### PR TITLE
Ad-hoc sign macOS build (fix Gatekeeper "damaged")

### DIFF
--- a/build/afterPack.cjs
+++ b/build/afterPack.cjs
@@ -1,0 +1,15 @@
+// electron-builder afterPack hook: ad-hoc sign the macOS .app so Gatekeeper does
+// not report it as "damaged" on Apple Silicon. Ad-hoc signing (codesign --sign -)
+// needs no certificate; it produces a valid (though un-notarized) signature, which
+// downgrades the block to the normal "unidentified developer" prompt.
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+  const appName = context.packager.appInfo.productFilename; // "Nodus"
+  const appPath = path.join(context.appOutDir, `${appName}.app`);
+  // --force replaces any existing signature; --deep covers nested frameworks/helpers.
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], { stdio: 'inherit' });
+  console.log(`[afterPack] Ad-hoc signed ${appPath}`);
+};

--- a/package.json
+++ b/package.json
@@ -72,8 +72,14 @@
         "releaseType": "release"
       }
     ],
+    "afterPack": "build/afterPack.cjs",
     "mac": {
-      "target": "dmg",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": ["arm64"]
+        }
+      ],
       "category": "public.app-category.education",
       "identity": null
     },


### PR DESCRIPTION
Fixes the macOS Gatekeeper "is damaged and can't be opened" error on Apple Silicon by ad-hoc signing the `.app` in an `afterPack` hook (`codesign --sign -`). An unsigned arm64 app triggers the "damaged" block; an ad-hoc signature downgrades it to the normal "unidentified developer" prompt.

Also pins the mac dmg target to `arm64` (the CI host arch) to avoid shipping wrong-arch native modules in an Intel build.

https://claude.ai/code/session_01NqpyCCfrDYLGCGmjPuvHA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqpyCCfrDYLGCGmjPuvHA5)_