### PR TITLE
Fix packaged app stuck on loading screen (CJS preload), v0.1.1

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -21,7 +21,7 @@ function createWindow(): void {
     backgroundColor: '#0a0a0a',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
-      preload: path.join(__dirname, 'preload.mjs'),
+      preload: path.join(__dirname, 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,13 +25,23 @@ export function App() {
   const [collectionsOpen, setCollectionsOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [lastSync, setLastSync] = useState<SyncLogEntry | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const reloadSettings = useCallback(async () => {
-    const s = await window.nodus.getSettings();
-    setSettings(s);
-    document.documentElement.classList.toggle('light', s.theme === 'light');
-    document.documentElement.classList.toggle('dark', s.theme === 'dark');
-    return s;
+    if (!window.nodus) {
+      setLoadError('El puente de Nodus (preload) no está disponible. La app no puede comunicarse con su backend.');
+      return undefined;
+    }
+    try {
+      const s = await window.nodus.getSettings();
+      setSettings(s);
+      document.documentElement.classList.toggle('light', s.theme === 'light');
+      document.documentElement.classList.toggle('dark', s.theme === 'dark');
+      return s;
+    } catch (e) {
+      setLoadError(`No se pudieron cargar los ajustes: ${(e as Error).message}`);
+      return undefined;
+    }
   }, []);
 
   useEffect(() => {
@@ -46,6 +56,18 @@ export function App() {
       setSyncing(false);
     }
   };
+
+  if (loadError) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center gap-3 p-8 text-center">
+        <div className="text-red-400 font-semibold">No se pudo iniciar Nodus</div>
+        <div className="text-neutral-400 text-sm max-w-md">{loadError}</div>
+        <button className="btn btn-primary" onClick={() => { setLoadError(null); void reloadSettings(); }}>
+          Reintentar
+        </button>
+      </div>
+    );
+  }
 
   if (!settings) {
     return <div className="h-full flex items-center justify-center text-neutral-500">Cargando Nodus…</div>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,12 @@ export default defineConfig({
         vite: {
           build: {
             outDir: 'dist-electron',
-            rollupOptions: { external: mainExternals },
+            rollupOptions: {
+              external: mainExternals,
+              // Emit a CommonJS .cjs preload: Electron loads it unambiguously as CJS,
+              // which is far more reliable in packaged apps than an ESM (.mjs) preload.
+              output: { format: 'cjs', entryFileNames: 'preload.cjs', inlineDynamicImports: true },
+            },
           },
         },
       },


### PR DESCRIPTION
Fixes the packaged app hanging on "Cargando Nodus…".

Root cause: the preload was emitted as ESM (`preload.mjs`). ESM preloads are unreliable in packaged Electron apps, so `window.nodus` ended up undefined and `getSettings()` never resolved — the UI sat on the loading screen forever.

- Emit the preload as CommonJS (`preload.cjs`) and load it from `main.ts`.
- `App.tsx` now shows a clear error + retry instead of an infinite spinner when the bridge/settings fail to load.
- Bump version to 0.1.1 for a fresh release.

https://claude.ai/code/session_01NqpyCCfrDYLGCGmjPuvHA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqpyCCfrDYLGCGmjPuvHA5)_