### PR TITLE
Recursive Zotero subcollections + multi-provider AI with dynamic models (v0.1.2)

### DIFF
--- a/electron/ai/aiClient.ts
+++ b/electron/ai/aiClient.ts
@@ -1,5 +1,7 @@
 import { getSettings } from '../db/settingsRepo';
 import { getApiKey } from '../secrets/secretStore';
+import { openAiCompatBase, supportsJsonMode } from './providers';
+import type { AiProvider, ModelRef } from '@shared/types';
 
 export class AiError extends Error {
   constructor(message: string, public retriable = false) {
@@ -14,18 +16,26 @@ interface CallOpts {
   maxTokens?: number;
 }
 
-/** Low-level chat completion returning raw text, provider-agnostic. */
-async function rawComplete(opts: CallOpts): Promise<string> {
-  const settings = getSettings();
-  const key = getApiKey();
-  if (!key) throw new AiError('Falta la clave de IA. Configúrala en Ajustes.', false);
+/** Resolve which model to use: explicit override, else the configured default. */
+function resolveModel(override?: ModelRef | null): ModelRef {
+  if (override?.provider && override.model) return override;
+  const def = getSettings().defaultModel;
+  if (!def?.provider || !def.model) {
+    throw new AiError('No hay un modelo de IA configurado. Elige uno en Ajustes.', false);
+  }
+  return def;
+}
 
-  if (settings.aiProvider === 'anthropic') {
+async function rawComplete(model: ModelRef, opts: CallOpts): Promise<string> {
+  const key = getApiKey(model.provider);
+  if (!key) throw new AiError(`Falta la clave de IA para ${model.provider}. Configúrala en Ajustes.`, false);
+
+  if (model.provider === 'anthropic') {
     const Anthropic = (await import('@anthropic-ai/sdk')).default;
     const client = new Anthropic({ apiKey: key });
     try {
       const res = await client.messages.create({
-        model: settings.aiModel,
+        model: model.model,
         max_tokens: opts.maxTokens ?? 8000,
         temperature: opts.temperature ?? 0.15,
         system: opts.system,
@@ -38,15 +48,16 @@ async function rawComplete(opts: CallOpts): Promise<string> {
     }
   }
 
-  // OpenAI
+  // OpenAI-compatible providers: openai, openrouter, deepseek, gemini.
+  const baseURL = openAiCompatBase(model.provider);
   const OpenAI = (await import('openai')).default;
-  const client = new OpenAI({ apiKey: key });
+  const client = new OpenAI({ apiKey: key, baseURL: baseURL ?? undefined });
   try {
     const res = await client.chat.completions.create({
-      model: settings.aiModel,
+      model: model.model,
       temperature: opts.temperature ?? 0.15,
       max_tokens: opts.maxTokens ?? 8000,
-      response_format: { type: 'json_object' },
+      ...(supportsJsonMode(model.provider) ? { response_format: { type: 'json_object' as const } } : {}),
       messages: [
         { role: 'system', content: opts.system },
         { role: 'user', content: opts.user },
@@ -62,7 +73,7 @@ function wrapProviderError(e: any): AiError {
   const status = e?.status ?? e?.response?.status;
   if (status === 429 || status === 529) return new AiError('Límite de tasa del proveedor de IA', true);
   if (status >= 500) return new AiError(`Error del proveedor (${status})`, true);
-  if (status === 401) return new AiError('Clave de IA inválida', false);
+  if (status === 401 || status === 403) return new AiError('Clave de IA inválida', false);
   return new AiError(e?.message ?? 'Error de IA', false);
 }
 
@@ -77,38 +88,55 @@ function extractJson(text: string): unknown {
 }
 
 /**
- * JSON completion with one retry at temperature 0 if parsing fails (per spec).
- * Validates with the provided guard before returning.
+ * JSON completion with one retry at temperature 0 if parsing fails.
+ * Uses the given model override or the configured default model.
  */
-export async function completeJson<T>(opts: CallOpts, guard: (v: unknown) => v is T): Promise<T> {
+export async function completeJson<T>(
+  opts: CallOpts,
+  guard: (v: unknown) => v is T,
+  model?: ModelRef | null
+): Promise<T> {
+  const resolved = resolveModel(model);
   let lastErr: unknown;
   for (const temperature of [opts.temperature ?? 0.15, 0]) {
     try {
-      const text = await rawComplete({ ...opts, temperature });
+      const text = await rawComplete(resolved, { ...opts, temperature });
       const parsed = extractJson(text);
       if (guard(parsed)) return parsed;
       lastErr = new AiError('El JSON no cumple el esquema esperado');
     } catch (e) {
       lastErr = e;
-      if (e instanceof AiError && e.retriable) throw e; // rate-limit: let the queue back off
+      if (e instanceof AiError && e.retriable) throw e;
     }
   }
   throw lastErr instanceof Error ? lastErr : new AiError('Fallo de parseo JSON');
 }
 
-/** Embeddings via OpenAI embeddings endpoint (works for both providers' keys when OpenAI selected). */
+const EMBED_MODELS: Partial<Record<AiProvider, string>> = {
+  openai: 'text-embedding-3-small',
+  gemini: 'text-embedding-004',
+};
+
+/**
+ * Embeddings for idea fusion. Uses whichever embedding-capable provider has a key
+ * (OpenAI or Gemini). Returns null when none is available — fusion then stays
+ * conservative (treats ideas as new).
+ */
 export async function embed(text: string): Promise<number[] | null> {
   const settings = getSettings();
-  const key = getApiKey();
-  if (!key) return null;
-  // Embeddings require an OpenAI-compatible endpoint; only attempt when using OpenAI.
-  if (settings.aiProvider !== 'openai') return null;
-  const OpenAI = (await import('openai')).default;
-  const client = new OpenAI({ apiKey: key });
-  try {
-    const res = await client.embeddings.create({ model: settings.embeddingModel, input: text.slice(0, 8000) });
-    return res.data[0]?.embedding ?? null;
-  } catch {
-    return null;
+  for (const provider of ['openai', 'gemini'] as AiProvider[]) {
+    const key = getApiKey(provider);
+    if (!key) continue;
+    const baseURL = openAiCompatBase(provider) ?? undefined;
+    const modelId = (provider === 'openai' && settings.embeddingModel) || EMBED_MODELS[provider]!;
+    try {
+      const OpenAI = (await import('openai')).default;
+      const client = new OpenAI({ apiKey: key, baseURL });
+      const res = await client.embeddings.create({ model: modelId, input: text.slice(0, 8000) });
+      return res.data[0]?.embedding ?? null;
+    } catch {
+      /* try next provider */
+    }
   }
+  return null;
 }

--- a/electron/ai/deepScan.ts
+++ b/electron/ai/deepScan.ts
@@ -11,7 +11,7 @@ import {
 import { addGap, addExternalRef } from '../db/gapsRepo';
 import { getOrCreateAuthor, linkWorkAuthor, recomputeAuthorRelations } from '../db/authorsRepo';
 import { setDeepResult } from '../db/worksRepo';
-import type { Work, IdeaType, EdgeType, EdgeBasis, EvidenceKind, GapKind } from '@shared/types';
+import type { Work, IdeaType, EdgeType, EdgeBasis, EvidenceKind, GapKind, ModelRef } from '@shared/types';
 import { chunkText, ExtractedDoc } from '../extraction/textExtractor';
 
 // ── Prompt 1 output shapes ────────────────────────────────────────────────────
@@ -97,7 +97,7 @@ function mergeByLabel(results: DeepResult[]): {
  * Deep scan: extract ideas per chunk, merge within the work, fuse against the
  * global graph, and persist all derived data with traceable evidence.
  */
-export async function runDeepScan(work: Work, doc: ExtractedDoc): Promise<void> {
+export async function runDeepScan(work: Work, doc: ExtractedDoc, model?: ModelRef | null): Promise<void> {
   const text = doc.text;
   const hash = crypto.createHash('sha1').update(text).digest('hex');
 
@@ -128,7 +128,8 @@ export async function runDeepScan(work: Work, doc: ExtractedDoc): Promise<void> 
     };
     const result = await completeJson<DeepResult>(
       { system: PROMPT_DEEP, user: JSON.stringify(input), temperature: 0.15, maxTokens: 8000 },
-      isDeepResult
+      isDeepResult,
+      model
     );
     results.push(result);
   }
@@ -147,7 +148,7 @@ export async function runDeepScan(work: Work, doc: ExtractedDoc): Promise<void> 
       label: idea.label,
       statement: idea.statement,
     };
-    const globalId = await fuseIdea(ext, work.nodus_id);
+    const globalId = await fuseIdea(ext, work.nodus_id, model);
     labelToGlobal.set(labelKey, globalId);
 
     upsertOccurrence(globalId, work.nodus_id, idea.role, idea.development, idea.confidence);

--- a/electron/ai/fusion.ts
+++ b/electron/ai/fusion.ts
@@ -7,7 +7,7 @@ import {
   addEdge,
   getIdea,
 } from '../db/ideasRepo';
-import type { IdeaType, EdgeType, EdgeBasis } from '@shared/types';
+import type { IdeaType, EdgeType, EdgeBasis, ModelRef } from '@shared/types';
 
 export interface ExtractedIdea {
   localId: string;
@@ -38,7 +38,7 @@ const MAX_CANDIDATES = 6;
  * Resolve one extracted idea against the global graph.
  * Returns the global_id this idea maps to (existing or newly created).
  */
-export async function fuseIdea(idea: ExtractedIdea, sourceWork: string): Promise<string> {
+export async function fuseIdea(idea: ExtractedIdea, sourceWork: string, model?: ModelRef | null): Promise<string> {
   const embedding = await embed(`${idea.label}. ${idea.statement}`);
 
   // Retrieve candidates by cosine similarity (in-memory fallback if no sqlite-vec).
@@ -77,7 +77,8 @@ export async function fuseIdea(idea: ExtractedIdea, sourceWork: string): Promise
   try {
     result = await completeJson<FusionResult>(
       { system: PROMPT_FUSION, user: JSON.stringify(input), temperature: 0.1, maxTokens: 800 },
-      isFusionResult
+      isFusionResult,
+      model
     );
   } catch {
     // On fusion failure, be conservative: treat as new (avoid wrong merges).

--- a/electron/ai/lightScan.ts
+++ b/electron/ai/lightScan.ts
@@ -2,7 +2,7 @@ import { completeJson } from './aiClient';
 import { PROMPT_LIGHT } from './prompts';
 import { setWorkThemes } from '../db/themesRepo';
 import { setLightResult } from '../db/worksRepo';
-import type { Work } from '@shared/types';
+import type { Work, ModelRef } from '@shared/types';
 import crypto from 'node:crypto';
 
 interface LightResult {
@@ -19,7 +19,7 @@ function isLightResult(v: unknown): v is LightResult {
 }
 
 /** Light scan: title + abstract only → coarse themes. Cheap, incremental, includes unread works. */
-export async function runLightScan(work: Work, abstract: string | null): Promise<void> {
+export async function runLightScan(work: Work, abstract: string | null, model?: ModelRef | null): Promise<void> {
   const hash = crypto
     .createHash('sha1')
     .update(`${work.title}\n${abstract ?? ''}`)
@@ -38,7 +38,8 @@ export async function runLightScan(work: Work, abstract: string | null): Promise
   try {
     const result = await completeJson<LightResult>(
       { system: PROMPT_LIGHT, user: JSON.stringify(input), temperature: 0.15, maxTokens: 1500 },
-      isLightResult
+      isLightResult,
+      model
     );
     const labels = result.themes.map((t) => t.label).filter(Boolean);
     setWorkThemes(work.nodus_id, labels);

--- a/electron/ai/providers.ts
+++ b/electron/ai/providers.ts
@@ -1,0 +1,110 @@
+import type { AiProvider, ModelInfo } from '@shared/types';
+
+export const PROVIDERS: AiProvider[] = ['anthropic', 'openai', 'openrouter', 'deepseek', 'gemini'];
+
+export const PROVIDER_LABELS: Record<AiProvider, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  openrouter: 'OpenRouter',
+  deepseek: 'DeepSeek',
+  gemini: 'Google Gemini',
+};
+
+/**
+ * OpenAI-compatible chat base URL for a provider, or null for providers with a
+ * native (non-OpenAI) API (Anthropic uses its own SDK).
+ */
+export function openAiCompatBase(provider: AiProvider): string | null {
+  switch (provider) {
+    case 'openai':
+      return 'https://api.openai.com/v1';
+    case 'openrouter':
+      return 'https://openrouter.ai/api/v1';
+    case 'deepseek':
+      return 'https://api.deepseek.com';
+    case 'gemini':
+      // Google exposes an OpenAI-compatible surface for chat + embeddings.
+      return 'https://generativelanguage.googleapis.com/v1beta/openai';
+    case 'anthropic':
+      return null;
+  }
+}
+
+/** Providers whose chat models reliably honor OpenAI's response_format: json_object. */
+export function supportsJsonMode(provider: AiProvider): boolean {
+  return provider === 'openai' || provider === 'deepseek';
+}
+
+function byId(a: ModelInfo, b: ModelInfo): number {
+  return a.id.localeCompare(b.id);
+}
+
+/**
+ * Fetch the live model list for a provider using its stored key. Sorted
+ * alphabetically; OpenRouter is additionally grouped/sorted by upstream provider.
+ */
+export async function listModels(provider: AiProvider, key: string | null): Promise<ModelInfo[]> {
+  switch (provider) {
+    case 'anthropic':
+      return listAnthropic(key);
+    case 'openai':
+      return listOpenAiStyle('https://api.openai.com/v1/models', key, true);
+    case 'deepseek':
+      return listOpenAiStyle('https://api.deepseek.com/models', key, false);
+    case 'openrouter':
+      return listOpenRouter();
+    case 'gemini':
+      return listGemini(key);
+  }
+}
+
+async function listAnthropic(key: string | null): Promise<ModelInfo[]> {
+  if (!key) throw new Error('Falta la clave de Anthropic.');
+  const res = await fetch('https://api.anthropic.com/v1/models?limit=1000', {
+    headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01' },
+  });
+  if (!res.ok) throw new Error(`Anthropic /models HTTP ${res.status}`);
+  const data = (await res.json()) as { data?: { id: string; display_name?: string }[] };
+  return (data.data ?? []).map((m) => ({ id: m.id, name: m.display_name })).sort(byId);
+}
+
+async function listOpenAiStyle(url: string, key: string | null, filterChat: boolean): Promise<ModelInfo[]> {
+  if (!key) throw new Error('Falta la clave del proveedor.');
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${key}` } });
+  if (!res.ok) throw new Error(`/models HTTP ${res.status}`);
+  const data = (await res.json()) as { data?: { id: string }[] };
+  let models = (data.data ?? []).map((m) => ({ id: m.id }) as ModelInfo);
+  if (filterChat) {
+    // Hide non-chat OpenAI models (embeddings, audio, image, moderation, legacy).
+    const exclude = /embedding|whisper|tts|dall-e|audio|realtime|moderation|image|davinci|babbage|computer-use|transcribe|search/i;
+    models = models.filter((m) => !exclude.test(m.id));
+  }
+  return models.sort(byId);
+}
+
+async function listOpenRouter(): Promise<ModelInfo[]> {
+  // OpenRouter's model list is public (no key required).
+  const res = await fetch('https://openrouter.ai/api/v1/models');
+  if (!res.ok) throw new Error(`OpenRouter /models HTTP ${res.status}`);
+  const data = (await res.json()) as { data?: { id: string; name?: string }[] };
+  const models: ModelInfo[] = (data.data ?? []).map((m) => ({
+    id: m.id,
+    name: m.name,
+    group: m.id.includes('/') ? m.id.split('/')[0] : 'other',
+  }));
+  // Sort by upstream provider, then model id.
+  return models.sort((a, b) => (a.group! === b.group! ? a.id.localeCompare(b.id) : a.group!.localeCompare(b.group!)));
+}
+
+async function listGemini(key: string | null): Promise<ModelInfo[]> {
+  if (!key) throw new Error('Falta la clave de Gemini.');
+  const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}&pageSize=1000`);
+  if (!res.ok) throw new Error(`Gemini /models HTTP ${res.status}`);
+  const data = (await res.json()) as {
+    models?: { name: string; displayName?: string; supportedGenerationMethods?: string[] }[];
+  };
+  return (data.models ?? [])
+    .filter((m) => (m.supportedGenerationMethods ?? []).includes('generateContent'))
+    .map((m) => ({ id: m.name.replace(/^models\//, ''), name: m.displayName }))
+    .sort(byId);
+}

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -1,11 +1,11 @@
 import { getDb } from './database';
 import type { AppSettings } from '@shared/types';
-import { hasApiKey } from '../secrets/secretStore';
+import { providerKeyMap } from '../secrets/secretStore';
 
-const DEFAULTS: Omit<AppSettings, 'hasApiKey'> = {
-  aiProvider: 'anthropic',
-  aiModel: 'claude-sonnet-4-6',
+const DEFAULTS: Omit<AppSettings, 'providerKeys'> = {
   embeddingModel: 'text-embedding-3-small',
+  favorites: [],
+  defaultModel: null,
   syncMode: 'manual',
   readTag: 'leído',
   zoteroUserId: '0',
@@ -43,13 +43,13 @@ export function getSettings(): AppSettings {
       parsed = {};
     }
   }
-  return { ...DEFAULTS, ...parsed, hasApiKey: hasApiKey() };
+  return { ...DEFAULTS, ...parsed, providerKeys: providerKeyMap() };
 }
 
 export function updateSettings(patch: Partial<AppSettings>): AppSettings {
   const current = getSettings();
-  // hasApiKey is derived, never persisted.
-  const { hasApiKey: _ignore, ...rest } = { ...current, ...patch };
+  // providerKeys is derived from the secret store, never persisted.
+  const { providerKeys: _ignore, ...rest } = { ...current, ...patch };
   writeRaw('app', JSON.stringify(rest));
   return getSettings();
 }

--- a/electron/export/exportImport.ts
+++ b/electron/export/exportImport.ts
@@ -34,7 +34,7 @@ export async function exportData(): Promise<{ path: string } | null> {
     date: new Date().toISOString(),
     zoteroUserId: settings.zoteroUserId,
   };
-  const { hasApiKey, ...nonSecret } = settings; // strip derived/secret flags
+  const { providerKeys, ...nonSecret } = settings; // strip derived key-presence flags
 
   const zip = new AdmZip();
   zip.addLocalFile(dbPath(), '', 'database.sqlite');

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -1,7 +1,8 @@
 import { ipcMain, shell, BrowserWindow } from 'electron';
-import type { AppSettings, QueueKind, WorkFilter } from '@shared/types';
+import type { AppSettings, QueueKind, WorkFilter, AiProvider, ModelRef } from '@shared/types';
 import { getSettings, updateSettings } from './db/settingsRepo';
-import { setApiKey, clearApiKey } from './secrets/secretStore';
+import { setApiKey, clearApiKey, getApiKey } from './secrets/secretStore';
+import { listModels } from './ai/providers';
 import * as zotero from './zotero/zoteroClient';
 import * as works from './db/worksRepo';
 import * as ideas from './db/ideasRepo';
@@ -30,8 +31,11 @@ export function registerIpc(getWindow: () => BrowserWindow | null): void {
     }
     return next;
   });
-  h('settings:setApiKey', async (_e, key: string) => setApiKey(key));
-  h('settings:clearApiKey', async () => clearApiKey());
+  h('settings:setApiKey', async (_e, provider: AiProvider, key: string) => setApiKey(provider, key));
+  h('settings:clearApiKey', async (_e, provider: AiProvider) => clearApiKey(provider));
+
+  // AI model discovery (OpenRouter needs no key; others use the stored key).
+  h('ai:listModels', async (_e, provider: AiProvider) => listModels(provider, getApiKey(provider)));
 
   // zotero
   h('zotero:ping', async () => {
@@ -48,42 +52,44 @@ export function registerIpc(getWindow: () => BrowserWindow | null): void {
     const { zoteroUserId } = getSettings();
     return zotero.childCollections(zoteroUserId, parentKey);
   });
-  h('zotero:collectionItems', async (_e, collectionKey: string, opts?: { query?: string }) => {
+  h('zotero:collectionItems', async (_e, collectionKey: string, opts?: { query?: string; recursive?: boolean }) => {
     const { zoteroUserId } = getSettings();
-    return zotero.collectionItems(zoteroUserId, collectionKey, opts);
+    return opts?.recursive
+      ? zotero.collectionItemsRecursive(zoteroUserId, collectionKey, opts)
+      : zotero.collectionItems(zoteroUserId, collectionKey, opts);
   });
 
   // works / library
   h('works:list', async (_e, filter?: WorkFilter) => works.listWorks(filter));
   h('works:get', async (_e, nodusId: string) => works.getWork(nodusId));
-  h('works:setManualDeep', async (_e, nodusId: string, value: boolean) => {
+  h('works:setManualDeep', async (_e, nodusId: string, value: boolean, model?: ModelRef | null) => {
     works.setManualDeep(nodusId, value);
     const w = works.getWork(nodusId);
     if (value && w) {
       markDeepPending(nodusId);
-      scanQueue.enqueue(nodusId, w.title, 'deep');
+      scanQueue.enqueue(nodusId, w.title, 'deep', model);
     }
   });
-  h('works:setManualDeepBulk', async (_e, nodusIds: string[], value: boolean) => {
+  h('works:setManualDeepBulk', async (_e, nodusIds: string[], value: boolean, model?: ModelRef | null) => {
     for (const id of nodusIds) {
       works.setManualDeep(id, value);
       if (value) {
         const w = works.getWork(id);
         if (w) {
           markDeepPending(id);
-          scanQueue.enqueue(id, w.title, 'deep');
+          scanQueue.enqueue(id, w.title, 'deep', model);
         }
       }
     }
   });
-  h('works:rescan', async (_e, nodusId: string, kind: QueueKind) => {
+  h('works:rescan', async (_e, nodusId: string, kind: QueueKind, model?: ModelRef | null) => {
     const w = works.getWork(nodusId);
     if (!w) return;
     if (kind === 'deep') {
       ideas.purgeDeepData(nodusId);
       markDeepPending(nodusId);
     }
-    scanQueue.enqueue(nodusId, w.title, kind);
+    scanQueue.enqueue(nodusId, w.title, kind, model);
   });
   h('works:openInZotero', async (_e, zoteroKey: string) => {
     const { zoteroUserId } = getSettings();

--- a/electron/pipeline/scanQueue.ts
+++ b/electron/pipeline/scanQueue.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import type { QueueItem, QueueKind, QueueProgress, Work } from '@shared/types';
+import type { QueueItem, QueueKind, QueueProgress, Work, ModelRef } from '@shared/types';
 import { getDb } from '../db/database';
 import { getWorkByZoteroKey } from '../db/worksRepo';
 import { getSettings } from '../db/settingsRepo';
@@ -44,7 +44,7 @@ class ScanQueue {
     };
   }
 
-  enqueue(nodusId: string, title: string, kind: QueueKind): void {
+  enqueue(nodusId: string, title: string, kind: QueueKind, model?: ModelRef | null): void {
     // Avoid duplicate pending/running jobs for the same work+kind.
     if (this.items.some((i) => i.nodus_id === nodusId && i.kind === kind && (i.state === 'queued' || i.state === 'running'))) {
       return;
@@ -57,6 +57,7 @@ class ScanQueue {
       state: 'queued',
       error: null,
       enqueued_at: new Date().toISOString(),
+      model: model ?? null,
     });
     this.sort();
     this.emit();
@@ -133,7 +134,7 @@ class ScanQueue {
     }
     try {
       if (item.kind === 'light') {
-        await this.doLight(work);
+        await this.doLight(work, item.model ?? null);
       } else {
         await this.doDeep(work, item);
       }
@@ -159,7 +160,7 @@ class ScanQueue {
     this.emit();
   }
 
-  private async doLight(work: Work): Promise<void> {
+  private async doLight(work: Work, model: ModelRef | null): Promise<void> {
     const settings = getSettings();
     let abstract: string | null = null;
     try {
@@ -168,7 +169,7 @@ class ScanQueue {
     } catch {
       abstract = null;
     }
-    await runLightScan(work, abstract);
+    await runLightScan(work, abstract, model);
   }
 
   private async doDeep(work: Work, queueItem: QueueItem): Promise<void> {
@@ -193,7 +194,7 @@ class ScanQueue {
     queueItem.detail = 'Analizando con IA…';
     queueItem.subPct = null;
     this.emit();
-    await runDeepScan(work, doc);
+    await runDeepScan(work, doc, queueItem.model ?? null);
   }
 
   /** Re-enqueue any work left in a pending state, so scans resume after restart. */

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,8 +5,10 @@ import type { NodusApi, QueueProgress } from '@shared/types';
 const api: NodusApi = {
   getSettings: () => ipcRenderer.invoke('settings:get'),
   updateSettings: (patch) => ipcRenderer.invoke('settings:update', patch),
-  setApiKey: (key) => ipcRenderer.invoke('settings:setApiKey', key),
-  clearApiKey: () => ipcRenderer.invoke('settings:clearApiKey'),
+  setApiKey: (provider, key) => ipcRenderer.invoke('settings:setApiKey', provider, key),
+  clearApiKey: (provider) => ipcRenderer.invoke('settings:clearApiKey', provider),
+
+  listModels: (provider) => ipcRenderer.invoke('ai:listModels', provider),
 
   zoteroPing: () => ipcRenderer.invoke('zotero:ping'),
   zoteroCollections: () => ipcRenderer.invoke('zotero:collections'),
@@ -16,9 +18,9 @@ const api: NodusApi = {
 
   listWorks: (filter) => ipcRenderer.invoke('works:list', filter),
   getWork: (nodusId) => ipcRenderer.invoke('works:get', nodusId),
-  setManualDeep: (nodusId, value) => ipcRenderer.invoke('works:setManualDeep', nodusId, value),
-  setManualDeepBulk: (nodusIds, value) => ipcRenderer.invoke('works:setManualDeepBulk', nodusIds, value),
-  rescan: (nodusId, kind) => ipcRenderer.invoke('works:rescan', nodusId, kind),
+  setManualDeep: (nodusId, value, model) => ipcRenderer.invoke('works:setManualDeep', nodusId, value, model),
+  setManualDeepBulk: (nodusIds, value, model) => ipcRenderer.invoke('works:setManualDeepBulk', nodusIds, value, model),
+  rescan: (nodusId, kind, model) => ipcRenderer.invoke('works:rescan', nodusId, kind, model),
   openInZotero: (zoteroKey) => ipcRenderer.invoke('works:openInZotero', zoteroKey).then(() => undefined),
   uploadText: (nodusId, filePath) => ipcRenderer.invoke('works:uploadText', nodusId, filePath),
 

--- a/electron/secrets/secretStore.ts
+++ b/electron/secrets/secretStore.ts
@@ -1,36 +1,36 @@
 import { app, safeStorage } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
+import type { AiProvider } from '@shared/types';
 
-// AI API key is stored encrypted-at-rest via Electron safeStorage, never in the
-// renderer and never in plaintext on disk. The key never crosses IPC to the UI.
+// AI API keys are stored per provider, encrypted-at-rest via Electron safeStorage,
+// never in the renderer and never in plaintext on disk. Keys never cross IPC to the UI.
 
-function keyFile(): string {
-  return path.join(app.getPath('userData'), 'ai_key.bin');
+const PROVIDERS: AiProvider[] = ['anthropic', 'openai', 'openrouter', 'deepseek', 'gemini'];
+
+function keyFile(provider: AiProvider): string {
+  return path.join(app.getPath('userData'), `ai_key_${provider}.bin`);
 }
 
-export function setApiKey(key: string): void {
+export function setApiKey(provider: AiProvider, key: string): void {
   if (!key) {
-    clearApiKey();
+    clearApiKey(provider);
     return;
   }
+  const file = keyFile(provider);
   if (!safeStorage.isEncryptionAvailable()) {
-    // Fallback: still avoid plaintext by base64; on most desktops encryption is available.
-    fs.writeFileSync(keyFile(), Buffer.from(`b64:${Buffer.from(key).toString('base64')}`));
+    fs.writeFileSync(file, Buffer.from(`b64:${Buffer.from(key).toString('base64')}`));
     return;
   }
-  const enc = safeStorage.encryptString(key);
-  fs.writeFileSync(keyFile(), enc);
+  fs.writeFileSync(file, safeStorage.encryptString(key));
 }
 
-export function getApiKey(): string | null {
-  const f = keyFile();
-  if (!fs.existsSync(f)) return null;
-  const buf = fs.readFileSync(f);
+export function getApiKey(provider: AiProvider): string | null {
+  const file = keyFile(provider);
+  if (!fs.existsSync(file)) return null;
+  const buf = fs.readFileSync(file);
   const asStr = buf.toString('utf8');
-  if (asStr.startsWith('b64:')) {
-    return Buffer.from(asStr.slice(4), 'base64').toString('utf8');
-  }
+  if (asStr.startsWith('b64:')) return Buffer.from(asStr.slice(4), 'base64').toString('utf8');
   if (!safeStorage.isEncryptionAvailable()) return null;
   try {
     return safeStorage.decryptString(buf);
@@ -39,11 +39,16 @@ export function getApiKey(): string | null {
   }
 }
 
-export function hasApiKey(): boolean {
-  return getApiKey() !== null;
+export function hasApiKey(provider: AiProvider): boolean {
+  return getApiKey(provider) !== null;
 }
 
-export function clearApiKey(): void {
-  const f = keyFile();
-  if (fs.existsSync(f)) fs.unlinkSync(f);
+export function clearApiKey(provider: AiProvider): void {
+  const file = keyFile(provider);
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+}
+
+/** Map of provider -> whether a key is stored, for the renderer (no keys exposed). */
+export function providerKeyMap(): Record<AiProvider, boolean> {
+  return Object.fromEntries(PROVIDERS.map((p) => [p, hasApiKey(p)])) as Record<AiProvider, boolean>;
 }

--- a/electron/sync/syncService.ts
+++ b/electron/sync/syncService.ts
@@ -9,7 +9,7 @@ import {
   setReadTag,
   recomputeDeepTrigger,
 } from '../db/worksRepo';
-import { collectionItems, libraryVersion, getItem } from '../zotero/zoteroClient';
+import { collectionItemsRecursive, libraryVersion } from '../zotero/zoteroClient';
 import { scanQueue } from '../pipeline/scanQueue';
 import type { SyncLogEntry, ZoteroItem } from '@shared/types';
 import { getDb } from '../db/database';
@@ -73,7 +73,8 @@ export async function fullSync(mode: 'manual' | 'realtime'): Promise<SyncLogEntr
   for (const collectionKey of settings.monitoredCollections) {
     let items: ZoteroItem[] = [];
     try {
-      items = await collectionItems(userId, collectionKey);
+      // Recurse into subcollections so monitoring a parent captures everything under it.
+      items = await collectionItemsRecursive(userId, collectionKey);
     } catch {
       continue; // collection unavailable; skip without aborting the whole sync
     }

--- a/electron/zotero/zoteroClient.ts
+++ b/electron/zotero/zoteroClient.ts
@@ -52,7 +52,9 @@ function mapCollection(raw: any): ZoteroCollection {
     key: raw.key ?? raw.data?.key,
     name: raw.data?.name ?? raw.name ?? '(sin nombre)',
     parentCollection: raw.data?.parentCollection ?? false,
+    // meta.numItems counts ONLY items directly in the collection (not subcollections).
     itemCount: raw.meta?.numItems ?? 0,
+    subCount: raw.meta?.numCollections ?? 0,
   };
 }
 
@@ -119,6 +121,29 @@ export async function collectionItems(
     if (data.length < limit || start >= total) break;
   }
   return out;
+}
+
+/**
+ * Items in a collection AND all its descendant subcollections, de-duplicated by key.
+ * The Zotero API has no reliable recursive parameter, so we traverse the tree.
+ */
+export async function collectionItemsRecursive(
+  userId: string,
+  collectionKey: string,
+  opts: { query?: string } = {}
+): Promise<ZoteroItem[]> {
+  const seen = new Map<string, ZoteroItem>();
+  const visited = new Set<string>();
+  const visit = async (key: string): Promise<void> => {
+    if (visited.has(key)) return;
+    visited.add(key);
+    const items = await collectionItems(userId, key, opts).catch(() => [] as ZoteroItem[]);
+    for (const it of items) if (!seen.has(it.key)) seen.set(it.key, it);
+    const children = await childCollections(userId, key).catch(() => [] as ZoteroCollection[]);
+    for (const c of children) await visit(c.key);
+  };
+  await visit(collectionKey);
+  return Array.from(seen.values());
 }
 
 export async function getItem(userId: string, itemKey: string): Promise<ZoteroItem | null> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -136,15 +136,31 @@ export interface ExternalRef {
 // Settings
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type AiProvider = 'anthropic' | 'openai';
+export type AiProvider = 'anthropic' | 'openai' | 'openrouter' | 'deepseek' | 'gemini';
 export type SyncMode = 'realtime' | 'manual';
 export type ThemeMode = 'dark' | 'light';
 
+/** A concrete model selection: which provider + which model id. */
+export interface ModelRef {
+  provider: AiProvider;
+  model: string;
+}
+
+/** One model as returned by a provider's model-list endpoint. */
+export interface ModelInfo {
+  id: string;
+  name?: string;
+  /** For OpenRouter: the upstream provider segment of the id (e.g. "anthropic"). */
+  group?: string;
+}
+
 export interface AppSettings {
-  aiProvider: AiProvider;
-  aiModel: string;
   embeddingModel: string;
-  hasApiKey: boolean; // never expose the key itself to the renderer
+  // Per-provider key presence (the keys themselves never cross IPC).
+  providerKeys: Record<AiProvider, boolean>;
+  // Favorite models the user pinned, and the one used by default for scans.
+  favorites: ModelRef[];
+  defaultModel: ModelRef | null;
   syncMode: SyncMode;
   readTag: string; // tag that triggers deep scan
   zoteroUserId: string;
@@ -156,10 +172,10 @@ export interface AppSettings {
   unpaywallEmail: string;
   onboardingComplete: boolean;
   // Large-PDF / extraction strategy
-  preferZoteroFulltext: boolean; // reuse Zotero's own indexed full text when available
-  ocrEnabled: boolean; // OCR scanned PDFs that lack a text layer
-  ocrLanguages: string; // Tesseract langs, e.g. "spa+eng"
-  ocrMaxPages: number; // safety cap on pages to OCR per work
+  preferZoteroFulltext: boolean;
+  ocrEnabled: boolean;
+  ocrLanguages: string;
+  ocrMaxPages: number;
 }
 
 export type ExtractStrategy = 'zotero_fulltext' | 'digital' | 'hybrid' | 'scanned' | 'empty';
@@ -181,7 +197,8 @@ export interface ZoteroCollection {
   key: string;
   name: string;
   parentCollection: string | false;
-  itemCount: number;
+  itemCount: number; // direct items only (Zotero meta.numItems)
+  subCount: number; // number of subcollections (Zotero meta.numCollections)
 }
 
 export interface ZoteroItem {
@@ -216,6 +233,8 @@ export interface QueueItem {
   detail?: string | null;
   /** 0..1 progress within the current item (extraction/OCR), when known. */
   subPct?: number | null;
+  /** Optional model override for this job; falls back to the default model when null. */
+  model?: ModelRef | null;
 }
 
 export interface QueueProgress {
@@ -304,8 +323,11 @@ export interface NodusApi {
   // settings + secrets
   getSettings(): Promise<AppSettings>;
   updateSettings(patch: Partial<AppSettings>): Promise<AppSettings>;
-  setApiKey(key: string): Promise<void>;
-  clearApiKey(): Promise<void>;
+  setApiKey(provider: AiProvider, key: string): Promise<void>;
+  clearApiKey(provider: AiProvider): Promise<void>;
+
+  // AI model discovery
+  listModels(provider: AiProvider): Promise<ModelInfo[]>;
 
   // zotero
   zoteroPing(): Promise<{ ok: boolean; userId?: string; message?: string }>;
@@ -313,15 +335,15 @@ export interface NodusApi {
   zoteroChildCollections(parentKey: string): Promise<ZoteroCollection[]>;
   zoteroCollectionItems(
     collectionKey: string,
-    opts?: { query?: string }
+    opts?: { query?: string; recursive?: boolean }
   ): Promise<ZoteroItem[]>;
 
   // works / library
   listWorks(filter?: WorkFilter): Promise<WorkView[]>;
   getWork(nodusId: string): Promise<WorkView | null>;
-  setManualDeep(nodusId: string, value: boolean): Promise<void>;
-  setManualDeepBulk(nodusIds: string[], value: boolean): Promise<void>;
-  rescan(nodusId: string, kind: QueueKind): Promise<void>;
+  setManualDeep(nodusId: string, value: boolean, model?: ModelRef | null): Promise<void>;
+  setManualDeepBulk(nodusIds: string[], value: boolean, model?: ModelRef | null): Promise<void>;
+  rescan(nodusId: string, kind: QueueKind, model?: ModelRef | null): Promise<void>;
   openInZotero(zoteroKey: string): Promise<void>;
   uploadText(nodusId: string, filePath: string): Promise<void>;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,9 +84,29 @@ export function App() {
         <div className="font-semibold text-lg tracking-tight">Nodus</div>
         <div className="flex-1" />
         {lastSync && <span className="text-xs text-neutral-500">{lastSync.summary}</span>}
-        {!settings.hasApiKey && (
+        {settings.favorites.length > 0 && (
+          <select
+            className="input text-xs py-1"
+            title="Modelo predeterminado para escaneos"
+            value={settings.defaultModel ? `${settings.defaultModel.provider}::${settings.defaultModel.model}` : ''}
+            onChange={async (e) => {
+              if (!e.target.value) return;
+              const [provider, model] = e.target.value.split('::');
+              await window.nodus.updateSettings({ defaultModel: { provider: provider as any, model } });
+              void reloadSettings();
+            }}
+          >
+            {!settings.defaultModel && <option value="">Modelo: sin configurar</option>}
+            {settings.favorites.map((m) => (
+              <option key={`${m.provider}::${m.model}`} value={`${m.provider}::${m.model}`}>
+                {m.provider} · {m.model}
+              </option>
+            ))}
+          </select>
+        )}
+        {!settings.defaultModel && (
           <button className="btn btn-ghost text-amber-400" onClick={() => setView('settings')}>
-            ⚠ Falta clave de IA
+            ⚠ Configura un modelo de IA
           </button>
         )}
         <button className="btn btn-ghost" onClick={() => setCollectionsOpen(true)}>
@@ -116,7 +136,7 @@ export function App() {
 
         {/* Main view */}
         <main className="flex-1 min-w-0 overflow-hidden">
-          {view === 'library' && <Library onOpenCollections={() => setCollectionsOpen(true)} />}
+          {view === 'library' && <Library settings={settings} onOpenCollections={() => setCollectionsOpen(true)} />}
           {view === 'graph' && <GraphView />}
           {view === 'gaps' && <GapsView />}
           {view === 'reading' && <ReadingPathView />}
@@ -126,9 +146,7 @@ export function App() {
 
       <QueueBar />
 
-      {collectionsOpen && (
-        <CollectionsModal readTag={settings.readTag} onClose={() => setCollectionsOpen(false)} />
-      )}
+      {collectionsOpen && <CollectionsModal settings={settings} onClose={() => setCollectionsOpen(false)} />}
     </div>
   );
 }

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,0 +1,43 @@
+import type { AppSettings, ModelRef } from '@shared/types';
+import { modelLabel, sameModel } from './ui';
+
+/**
+ * Lets the user pick which model a scan should use: the default, or any favorite.
+ * Returns null to mean "use the configured default model".
+ */
+export function ModelPicker({
+  settings,
+  value,
+  onChange,
+  compact,
+}: {
+  settings: AppSettings;
+  value: ModelRef | null;
+  onChange: (m: ModelRef | null) => void;
+  compact?: boolean;
+}) {
+  const favorites = settings.favorites ?? [];
+  const serialize = (m: ModelRef) => `${m.provider}::${m.model}`;
+
+  return (
+    <select
+      className={`input ${compact ? 'text-xs py-1' : ''}`}
+      value={value ? serialize(value) : ''}
+      onChange={(e) => {
+        if (!e.target.value) return onChange(null);
+        const [provider, model] = e.target.value.split('::');
+        onChange({ provider: provider as ModelRef['provider'], model });
+      }}
+      title="Modelo para el escaneo"
+    >
+      <option value="">
+        {settings.defaultModel ? `Predeterminado (${modelLabel(settings.defaultModel)})` : 'Predeterminado (sin configurar)'}
+      </option>
+      {favorites.map((m) => (
+        <option key={serialize(m)} value={serialize(m)} disabled={sameModel(m, settings.defaultModel)}>
+          {modelLabel(m)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,5 +1,23 @@
 import React from 'react';
-import type { IdeaType, EdgeType } from '@shared/types';
+import type { IdeaType, EdgeType, AiProvider, ModelRef } from '@shared/types';
+
+export const AI_PROVIDERS: AiProvider[] = ['anthropic', 'openai', 'openrouter', 'deepseek', 'gemini'];
+
+export const PROVIDER_LABELS: Record<AiProvider, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  openrouter: 'OpenRouter',
+  deepseek: 'DeepSeek',
+  gemini: 'Google Gemini',
+};
+
+export function modelLabel(m: ModelRef): string {
+  return `${PROVIDER_LABELS[m.provider]} · ${m.model}`;
+}
+
+export function sameModel(a: ModelRef | null | undefined, b: ModelRef | null | undefined): boolean {
+  return !!a && !!b && a.provider === b.provider && a.model === b.model;
+}
 
 export const NODE_COLORS: Record<IdeaType, string> = {
   claim: '#6366f1',

--- a/src/views/CollectionsModal.tsx
+++ b/src/views/CollectionsModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import type { ZoteroCollection, ZoteroItem, WorkView } from '@shared/types';
+import type { ZoteroCollection, ZoteroItem, WorkView, AppSettings, ModelRef } from '@shared/types';
 import { Badge } from '../components/ui';
+import { ModelPicker } from '../components/ModelPicker';
 
 const ITEM_TYPES = ['journalArticle', 'book', 'bookSection', 'conferencePaper', 'thesis', 'preprint', 'report'];
 
@@ -46,7 +47,10 @@ function CollectionNode({
         <span className="flex-1 truncate" onClick={() => onSelect(col)}>
           {col.name}
         </span>
-        <span className="text-[10px] text-neutral-600">{col.itemCount}</span>
+        <span className="text-[10px] text-neutral-600" title="ítems directos · subcolecciones">
+          {col.itemCount}
+          {col.subCount ? ` · ${col.subCount}▸` : ''}
+        </span>
       </div>
       {open &&
         children?.map((c) => (
@@ -56,12 +60,15 @@ function CollectionNode({
   );
 }
 
-export function CollectionsModal({ readTag, onClose }: { readTag: string; onClose: () => void }) {
+export function CollectionsModal({ settings, onClose }: { settings: AppSettings; onClose: () => void }) {
+  const readTag = settings.readTag;
   const [roots, setRoots] = useState<ZoteroCollection[]>([]);
   const [selected, setSelected] = useState<ZoteroCollection | null>(null);
   const [items, setItems] = useState<ZoteroItem[]>([]);
   const [loadingItems, setLoadingItems] = useState(false);
   const [worksByKey, setWorksByKey] = useState<Map<string, WorkView>>(new Map());
+  const [recursive, setRecursive] = useState(true);
+  const [scanModel, setScanModel] = useState<ModelRef | null>(null);
 
   // Filters
   const [search, setSearch] = useState('');
@@ -78,18 +85,29 @@ export function CollectionsModal({ readTag, onClose }: { readTag: string; onClos
     });
   }, []);
 
-  const loadItems = useCallback(async (col: ZoteroCollection, force = false) => {
-    setSelected(col);
-    if (!force && itemCache.has(col.key)) {
-      setItems(itemCache.get(col.key)!);
-      return;
-    }
-    setLoadingItems(true);
-    const data = await window.nodus.zoteroCollectionItems(col.key).catch(() => []);
-    itemCache.set(col.key, data);
-    setItems(data);
-    setLoadingItems(false);
-  }, []);
+  const loadItems = useCallback(
+    async (col: ZoteroCollection, force = false) => {
+      setSelected(col);
+      const cacheKey = `${col.key}:${recursive ? 'r' : 'd'}`;
+      if (!force && itemCache.has(cacheKey)) {
+        setItems(itemCache.get(cacheKey)!);
+        return;
+      }
+      setLoadingItems(true);
+      // Include subcollection items by default so a parent collection isn't shown empty.
+      const data = await window.nodus.zoteroCollectionItems(col.key, { recursive }).catch(() => []);
+      itemCache.set(cacheKey, data);
+      setItems(data);
+      setLoadingItems(false);
+    },
+    [recursive]
+  );
+
+  // Reload the selected collection's items when the recursive toggle changes.
+  useEffect(() => {
+    if (selected) void loadItems(selected, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recursive]);
 
   const statusOf = (key: string): 'unscanned' | 'light' | 'deep' => {
     const w = worksByKey.get(key);
@@ -124,7 +142,7 @@ export function CollectionsModal({ readTag, onClose }: { readTag: string; onClos
 
   const selectAllFiltered = async () => {
     const ids = filtered.map((it) => worksByKey.get(it.key)?.nodus_id).filter((x): x is string => !!x);
-    if (ids.length) await window.nodus.setManualDeepBulk(ids, true);
+    if (ids.length) await window.nodus.setManualDeepBulk(ids, true, scanModel);
     await refreshWorks();
   };
 
@@ -137,7 +155,7 @@ export function CollectionsModal({ readTag, onClose }: { readTag: string; onClos
   const toggleItem = async (it: ZoteroItem) => {
     const w = worksByKey.get(it.key);
     if (!w) return; // not yet ingested into Nodus
-    await window.nodus.setManualDeep(w.nodus_id, !w.manual_deep);
+    await window.nodus.setManualDeep(w.nodus_id, !w.manual_deep, scanModel);
     await refreshWorks();
   };
 
@@ -187,6 +205,11 @@ export function CollectionsModal({ readTag, onClose }: { readTag: string; onClos
                 <label className="text-xs flex items-center gap-1 text-neutral-400">
                   <input type="checkbox" checked={onlyTag} onChange={(e) => setOnlyTag(e.target.checked)} /> solo tag
                 </label>
+                <label className="text-xs flex items-center gap-1 text-neutral-400" title="Incluir ítems de subcolecciones">
+                  <input type="checkbox" checked={recursive} onChange={(e) => setRecursive(e.target.checked)} /> subcolecciones
+                </label>
+                <span className="text-xs text-neutral-500">Escanear con:</span>
+                <ModelPicker settings={settings} value={scanModel} onChange={setScanModel} compact />
               </div>
               <div className="flex gap-1 flex-wrap">
                 {ITEM_TYPES.map((t) => (

--- a/src/views/Library.tsx
+++ b/src/views/Library.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { WorkView, WorkFilter, DeepStatus, LightStatus } from '@shared/types';
+import type { WorkView, WorkFilter, DeepStatus, LightStatus, AppSettings, ModelRef } from '@shared/types';
 import { Badge } from '../components/ui';
+import { ModelPicker } from '../components/ModelPicker';
 
 function lightBadge(s: LightStatus) {
   if (s === 'done') return <Badge color="green">ligero ✓</Badge>;
@@ -34,10 +35,11 @@ function triggerBadge(w: WorkView) {
   );
 }
 
-export function Library({ onOpenCollections }: { onOpenCollections: () => void }) {
+export function Library({ settings, onOpenCollections }: { settings: AppSettings; onOpenCollections: () => void }) {
   const [works, setWorks] = useState<WorkView[]>([]);
   const [filter, setFilter] = useState<WorkFilter>({ lightStatus: 'all', deepStatus: 'all' });
   const [loading, setLoading] = useState(true);
+  const [scanModel, setScanModel] = useState<ModelRef | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -50,7 +52,7 @@ export function Library({ onOpenCollections }: { onOpenCollections: () => void }
   }, [load]);
 
   const toggleManual = async (w: WorkView) => {
-    await window.nodus.setManualDeep(w.nodus_id, !w.manual_deep);
+    await window.nodus.setManualDeep(w.nodus_id, !w.manual_deep, scanModel);
     await load();
   };
 
@@ -60,6 +62,8 @@ export function Library({ onOpenCollections }: { onOpenCollections: () => void }
         <h1 className="text-xl font-semibold">Biblioteca</h1>
         <span className="text-sm text-neutral-500">{works.length} obras</span>
         <div className="flex-1" />
+        <span className="text-xs text-neutral-500">Escanear con:</span>
+        <ModelPicker settings={settings} value={scanModel} onChange={setScanModel} compact />
         <button className="btn btn-ghost border border-neutral-700" onClick={onOpenCollections}>
           Modal de Colecciones
         </button>
@@ -143,7 +147,7 @@ export function Library({ onOpenCollections }: { onOpenCollections: () => void }
                     </button>
                     <button
                       className="text-xs text-neutral-400 hover:text-white mr-2"
-                      onClick={() => window.nodus.rescan(w.nodus_id, 'deep')}
+                      onClick={() => window.nodus.rescan(w.nodus_id, 'deep', scanModel)}
                     >
                       re-scan
                     </button>

--- a/src/views/Onboarding.tsx
+++ b/src/views/Onboarding.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import type { AiProvider, ZoteroCollection } from '@shared/types';
+import type { AiProvider, ZoteroCollection, ModelInfo } from '@shared/types';
+import { AI_PROVIDERS, PROVIDER_LABELS } from '../components/ui';
 
 export function Onboarding({ onDone }: { onDone: () => void }) {
   const [step, setStep] = useState(0);
@@ -9,8 +10,11 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [readTag, setReadTag] = useState('leído');
   const [provider, setProvider] = useState<AiProvider>('anthropic');
-  const [model, setModel] = useState('claude-sonnet-4-6');
   const [apiKey, setApiKey] = useState('');
+  const [models, setModels] = useState<ModelInfo[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [modelError, setModelError] = useState<string | null>(null);
+  const [loadingModels, setLoadingModels] = useState(false);
   const [storagePath, setStoragePath] = useState('');
 
   const checkZotero = async () => {
@@ -26,13 +30,30 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     void checkZotero();
   }, []);
 
+  const loadModels = async () => {
+    setLoadingModels(true);
+    setModelError(null);
+    try {
+      if (apiKey.trim()) await window.nodus.setApiKey(provider, apiKey.trim());
+      const list = await window.nodus.listModels(provider);
+      setModels(list);
+      if (list[0]) setSelectedModel(list[0].id);
+    } catch (e) {
+      setModelError((e as Error).message);
+      setModels([]);
+    } finally {
+      setLoadingModels(false);
+    }
+  };
+
   const finish = async () => {
-    if (apiKey.trim()) await window.nodus.setApiKey(apiKey.trim());
+    if (apiKey.trim()) await window.nodus.setApiKey(provider, apiKey.trim());
+    const ref = selectedModel ? { provider, model: selectedModel } : null;
     await window.nodus.updateSettings({
       monitoredCollections: Array.from(selected),
       readTag,
-      aiProvider: provider,
-      aiModel: model,
+      defaultModel: ref,
+      favorites: ref ? [ref] : [],
       zoteroStoragePath: storagePath,
       onboardingComplete: true,
     });
@@ -86,7 +107,9 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
 
         {step === 1 && (
           <div className="space-y-3">
-            <p className="text-sm text-neutral-400">Elige las colecciones a monitorizar (escaneo ligero).</p>
+            <p className="text-sm text-neutral-400">
+              Elige las colecciones a monitorizar (escaneo ligero). Se incluyen automáticamente sus subcolecciones.
+            </p>
             <div className="max-h-64 overflow-y-auto space-y-1">
               {collections.map((c) => (
                 <label key={c.key} className="flex items-center gap-2 text-sm py-1">
@@ -99,7 +122,10 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                       setSelected(next);
                     }}
                   />
-                  {c.name} <span className="text-neutral-600">({c.itemCount})</span>
+                  {c.name}{' '}
+                  <span className="text-neutral-600">
+                    ({c.itemCount} ítems{c.subCount ? `, ${c.subCount} subcol.` : ''})
+                  </span>
                 </label>
               ))}
               {collections.length === 0 && <div className="text-neutral-500 text-sm">No hay colecciones cargadas.</div>}
@@ -133,21 +159,23 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                 className="input w-full mt-1"
                 value={provider}
                 onChange={(e) => {
-                  const p = e.target.value as AiProvider;
-                  setProvider(p);
-                  setModel(p === 'anthropic' ? 'claude-sonnet-4-6' : 'gpt-4o');
+                  setProvider(e.target.value as AiProvider);
+                  setModels([]);
+                  setSelectedModel('');
                 }}
               >
-                <option value="anthropic">Anthropic</option>
-                <option value="openai">OpenAI</option>
+                {AI_PROVIDERS.map((p) => (
+                  <option key={p} value={p}>
+                    {PROVIDER_LABELS[p]}
+                  </option>
+                ))}
               </select>
             </label>
             <label className="block text-sm">
-              Modelo
-              <input className="input w-full mt-1" value={model} onChange={(e) => setModel(e.target.value)} />
-            </label>
-            <label className="block text-sm">
               Clave de IA (se guarda cifrada, nunca se exporta)
+              {provider === 'openrouter' && (
+                <span className="text-neutral-500"> — opcional para listar, necesaria para escanear</span>
+              )}
               <input
                 type="password"
                 className="input w-full mt-1"
@@ -155,6 +183,26 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
                 onChange={(e) => setApiKey(e.target.value)}
               />
             </label>
+            <button className="btn btn-ghost border border-neutral-700" onClick={loadModels} disabled={loadingModels}>
+              {loadingModels ? 'Cargando modelos…' : 'Cargar modelos'}
+            </button>
+            {modelError && <div className="text-sm text-red-400">{modelError}</div>}
+            {models.length > 0 && (
+              <label className="block text-sm">
+                Modelo predeterminado ({models.length} disponibles)
+                <select className="input w-full mt-1" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)}>
+                  {models.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.group ? `[${m.group}] ` : ''}
+                      {m.id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            <p className="text-xs text-neutral-500">
+              Podrás añadir más proveedores y marcar favoritos en Ajustes.
+            </p>
           </div>
         )}
 

--- a/src/views/ProvidersSettings.tsx
+++ b/src/views/ProvidersSettings.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react';
+import type { AiProvider, AppSettings, ModelInfo, ModelRef } from '@shared/types';
+import { AI_PROVIDERS, PROVIDER_LABELS, modelLabel, sameModel } from '../components/ui';
+
+export function ProvidersSettings({
+  settings,
+  onChange,
+}: {
+  settings: AppSettings;
+  onChange: () => Promise<unknown>;
+}) {
+  const [open, setOpen] = useState<AiProvider | null>(null);
+
+  const favorites = settings.favorites ?? [];
+  const isFav = (m: ModelRef) => favorites.some((f) => sameModel(f, m));
+
+  const toggleFav = async (m: ModelRef) => {
+    const currentlyFav = isFav(m);
+    const next = currentlyFav ? favorites.filter((f) => !sameModel(f, m)) : [...favorites, m];
+    const patch: Partial<AppSettings> = { favorites: next };
+    // Removing the model that is the current default clears the default too.
+    if (currentlyFav && sameModel(settings.defaultModel, m)) patch.defaultModel = null;
+    await window.nodus.updateSettings(patch);
+    await onChange();
+  };
+
+  const setDefault = async (m: ModelRef) => {
+    const next = isFav(m) ? favorites : [...favorites, m];
+    await window.nodus.updateSettings({ defaultModel: m, favorites: next });
+    await onChange();
+  };
+
+  return (
+    <section className="card p-4 mb-4">
+      <h2 className="text-sm font-semibold text-neutral-400 uppercase tracking-wide mb-3">Proveedores de IA y modelos</h2>
+
+      {/* Current default + favorites */}
+      <div className="mb-4 text-sm">
+        <div className="text-neutral-400">
+          Modelo predeterminado:{' '}
+          {settings.defaultModel ? (
+            <span className="text-neutral-100">📌 {modelLabel(settings.defaultModel)}</span>
+          ) : (
+            <span className="text-amber-400">sin configurar</span>
+          )}
+        </div>
+        {favorites.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {favorites.map((m) => (
+              <span
+                key={`${m.provider}::${m.model}`}
+                className={`text-xs px-2 py-0.5 rounded flex items-center gap-1 ${
+                  sameModel(m, settings.defaultModel) ? 'bg-indigo-800 text-indigo-100' : 'bg-neutral-800 text-neutral-300'
+                }`}
+              >
+                {sameModel(m, settings.defaultModel) ? '📌' : '⭐'} {modelLabel(m)}
+                {!sameModel(m, settings.defaultModel) && (
+                  <button className="text-neutral-500 hover:text-indigo-300" title="Marcar como predeterminado" onClick={() => setDefault(m)}>
+                    📌
+                  </button>
+                )}
+                <button className="text-neutral-500 hover:text-red-400" title="Quitar de favoritos" onClick={() => toggleFav(m)}>
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        {AI_PROVIDERS.map((p) => (
+          <ProviderRow
+            key={p}
+            provider={p}
+            settings={settings}
+            expanded={open === p}
+            onToggle={() => setOpen(open === p ? null : p)}
+            onChange={onChange}
+            isFav={isFav}
+            toggleFav={toggleFav}
+            setDefault={setDefault}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ProviderRow({
+  provider,
+  settings,
+  expanded,
+  onToggle,
+  onChange,
+  isFav,
+  toggleFav,
+  setDefault,
+}: {
+  provider: AiProvider;
+  settings: AppSettings;
+  expanded: boolean;
+  onToggle: () => void;
+  onChange: () => Promise<unknown>;
+  isFav: (m: ModelRef) => boolean;
+  toggleFav: (m: ModelRef) => Promise<void>;
+  setDefault: (m: ModelRef) => Promise<void>;
+}) {
+  const [keyInput, setKeyInput] = useState('');
+  const [models, setModels] = useState<ModelInfo[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const hasKey = settings.providerKeys?.[provider];
+
+  const saveKey = async () => {
+    if (!keyInput.trim()) return;
+    await window.nodus.setApiKey(provider, keyInput.trim());
+    setKeyInput('');
+    await onChange();
+  };
+
+  const loadModels = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setModels(await window.nodus.listModels(provider));
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filtered = (models ?? []).filter((m) => {
+    const q = search.toLowerCase();
+    return !q || m.id.toLowerCase().includes(q) || (m.name ?? '').toLowerCase().includes(q);
+  });
+  const shown = filtered.slice(0, 300);
+
+  return (
+    <div className="border border-neutral-800 rounded-lg">
+      <button className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm" onClick={onToggle}>
+        <span className="text-neutral-500">{expanded ? '▾' : '▸'}</span>
+        <span className="font-medium">{PROVIDER_LABELS[provider]}</span>
+        <span className={hasKey ? 'text-emerald-400 text-xs' : 'text-neutral-600 text-xs'}>
+          {hasKey ? '● clave guardada' : '○ sin clave'}
+        </span>
+        {provider === 'openrouter' && <span className="text-neutral-600 text-xs">(modelos públicos)</span>}
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2">
+          <div className="flex gap-2 items-center">
+            <input
+              type="password"
+              className="input flex-1"
+              placeholder={hasKey ? '•••••••• (guardada)' : 'clave del proveedor'}
+              value={keyInput}
+              onChange={(e) => setKeyInput(e.target.value)}
+            />
+            <button className="btn btn-primary" onClick={saveKey}>
+              Guardar
+            </button>
+            {hasKey && (
+              <button className="btn btn-ghost text-red-400" onClick={() => window.nodus.clearApiKey(provider).then(onChange)}>
+                Borrar
+              </button>
+            )}
+          </div>
+
+          <div className="flex gap-2 items-center">
+            <button className="btn btn-ghost border border-neutral-700" onClick={loadModels} disabled={loading}>
+              {loading ? 'Cargando…' : 'Cargar modelos'}
+            </button>
+            {models && (
+              <input className="input flex-1" placeholder="Buscar modelo…" value={search} onChange={(e) => setSearch(e.target.value)} />
+            )}
+            {models && <span className="text-xs text-neutral-500">{filtered.length}</span>}
+          </div>
+
+          {error && <div className="text-xs text-red-400">{error}</div>}
+
+          {models && (
+            <div className="max-h-64 overflow-y-auto border border-neutral-800 rounded">
+              <ModelList provider={provider} models={shown} isFav={isFav} toggleFav={toggleFav} setDefault={setDefault} settings={settings} />
+              {filtered.length > shown.length && (
+                <div className="text-xs text-neutral-600 p-2">Mostrando {shown.length}; refina la búsqueda para ver más.</div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ModelList({
+  provider,
+  models,
+  isFav,
+  toggleFav,
+  setDefault,
+  settings,
+}: {
+  provider: AiProvider;
+  models: ModelInfo[];
+  isFav: (m: ModelRef) => boolean;
+  toggleFav: (m: ModelRef) => Promise<void>;
+  setDefault: (m: ModelRef) => Promise<void>;
+  settings: AppSettings;
+}) {
+  // OpenRouter: render grouped by upstream provider.
+  const rows: JSX.Element[] = [];
+  let lastGroup: string | null = null;
+  for (const m of models) {
+    const ref: ModelRef = { provider, model: m.id };
+    if (provider === 'openrouter' && m.group && m.group !== lastGroup) {
+      lastGroup = m.group;
+      rows.push(
+        <div key={`g-${m.group}`} className="px-2 py-1 text-[10px] uppercase tracking-wide text-neutral-500 bg-neutral-900 sticky top-0">
+          {m.group}
+        </div>
+      );
+    }
+    const fav = isFav(ref);
+    const def = sameModel(ref, settings.defaultModel);
+    rows.push(
+      <div key={m.id} className="flex items-center gap-2 px-2 py-1 text-xs hover:bg-neutral-900/60">
+        <button className={fav ? 'text-amber-400' : 'text-neutral-600 hover:text-amber-300'} title="Favorito" onClick={() => toggleFav(ref)}>
+          {fav ? '⭐' : '☆'}
+        </button>
+        <button className={def ? 'text-indigo-400' : 'text-neutral-600 hover:text-indigo-300'} title="Predeterminado" onClick={() => setDefault(ref)}>
+          📌
+        </button>
+        <span className="flex-1 truncate" title={m.name ?? m.id}>
+          {m.name ? `${m.id}` : m.id}
+        </span>
+      </div>
+    );
+  }
+  return <div>{rows}</div>;
+}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1,22 +1,13 @@
 import { useState } from 'react';
 import type { AppSettings } from '@shared/types';
+import { ProvidersSettings } from './ProvidersSettings';
 
 export function Settings({ settings, onChange }: { settings: AppSettings; onChange: () => Promise<unknown> }) {
-  const [apiKey, setApiKey] = useState('');
   const [saved, setSaved] = useState<string | null>(null);
 
   const patch = async (p: Partial<AppSettings>) => {
     await window.nodus.updateSettings(p);
     await onChange();
-  };
-
-  const saveKey = async () => {
-    if (apiKey.trim()) {
-      await window.nodus.setApiKey(apiKey.trim());
-      setApiKey('');
-      await onChange();
-      flash('Clave guardada');
-    }
   };
 
   const flash = (m: string) => {
@@ -28,44 +19,11 @@ export function Settings({ settings, onChange }: { settings: AppSettings; onChan
     <div className="h-full overflow-y-auto p-6 max-w-2xl">
       <h1 className="text-xl font-semibold mb-6">Ajustes</h1>
 
-      <Section title="Proveedor de IA">
-        <Row label="Proveedor">
-          <select className="input" value={settings.aiProvider} onChange={(e) => patch({ aiProvider: e.target.value as any })}>
-            <option value="anthropic">Anthropic</option>
-            <option value="openai">OpenAI</option>
-          </select>
-        </Row>
-        <Row label="Modelo">
-          <input className="input" value={settings.aiModel} onChange={(e) => patch({ aiModel: e.target.value })} />
-        </Row>
-        <Row label="Modelo de embeddings">
-          <input
-            className="input"
-            value={settings.embeddingModel}
-            onChange={(e) => patch({ embeddingModel: e.target.value })}
-          />
-        </Row>
-        <Row label="Clave de IA">
-          <div className="flex gap-2 items-center">
-            <input
-              type="password"
-              className="input flex-1"
-              placeholder={settings.hasApiKey ? '•••••••• (guardada)' : 'introduce la clave'}
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-            />
-            <button className="btn btn-primary" onClick={saveKey}>
-              Guardar
-            </button>
-            {settings.hasApiKey && (
-              <button
-                className="btn btn-ghost text-red-400"
-                onClick={() => window.nodus.clearApiKey().then(onChange)}
-              >
-                Borrar
-              </button>
-            )}
-          </div>
+      <ProvidersSettings settings={settings} onChange={onChange} />
+
+      <Section title="IA (avanzado)">
+        <Row label="Modelo de embeddings (OpenAI)">
+          <input className="input" value={settings.embeddingModel} onChange={(e) => patch({ embeddingModel: e.target.value })} />
         </Row>
         <Row label="Llamadas simultáneas">
           <input
@@ -78,11 +36,7 @@ export function Settings({ settings, onChange }: { settings: AppSettings; onChan
           />
         </Row>
         <Row label="Email Unpaywall (fallback de texto)">
-          <input
-            className="input"
-            value={settings.unpaywallEmail}
-            onChange={(e) => patch({ unpaywallEmail: e.target.value })}
-          />
+          <input className="input" value={settings.unpaywallEmail} onChange={(e) => patch({ unpaywallEmail: e.target.value })} />
         </Row>
       </Section>
 


### PR DESCRIPTION
## Zotero fix (the `(0)` collections bug)
Parent collections showed `(0)` because Zotero's `meta.numItems` counts **only items directly in the collection** and the API has no recursive parameter. Sync now traverses subcollections (`collectionItemsRecursive`), and the UI shows item + subcollection counts plus a "subcolecciones" toggle in the Collections modal.

## Multi-provider AI with dynamic model loading
- Adds **OpenRouter, DeepSeek, Google Gemini** alongside Anthropic and OpenAI.
- **No hardcoded models**: each provider auto-loads its model list from its API, sorted alphabetically; OpenRouter additionally grouped by upstream provider.
- Per-provider encrypted API keys (safeStorage), never crossing IPC.
- **Favorites (⭐) + default (📌)**; scans use the default or a per-scan override (Library + modal pickers, top-bar switcher).
- `aiClient` routes Anthropic natively and OpenAI/OpenRouter/DeepSeek/Gemini via the OpenAI-compatible API; embeddings use OpenAI or Gemini when available.

Bump to 0.1.2.

https://claude.ai/code/session_01NqpyCCfrDYLGCGmjPuvHA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqpyCCfrDYLGCGmjPuvHA5)_