### PR TITLE
What's new modal: dedicated icons for MCP, Nodi and language releases

### DIFF
--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -41,6 +41,10 @@ try {
     'testimonios',
     'worldbuilding',
     'docencia',
+    'mcp',
+    'nodi',
+    'toolkit',
+    'languages',
   ]);
   for (const note of RELEASE_NOTES) {
     for (const highlight of note.highlights) {

--- a/scripts/test-whats-new-support.mjs
+++ b/scripts/test-whats-new-support.mjs
@@ -29,6 +29,23 @@ assert.match(modal, /const scope = h\.scope;/);
 assert.match(modal, /data-testid=\{`whats-new-scope-\$\{scope\}`\}/);
 assert.match(modal, /genealogy: \{ icon: 'tree', color: '#ca8a04', label: 'Genealogía' \}/);
 assert.match(modal, /general: \{ icon: 'sparkles', color: '#64748b', label: 'General' \}/);
+// Cross-vault surfaces with an identity of their own get their own chip instead of
+// the anonymous 'general' sparkles.
+assert.match(modal, /mcp: \{ icon: 'plug', color: '#2563eb', label: 'Servidor MCP' \}/);
+assert.match(modal, /nodi: \{ icon: 'nodi', color: '#d4af37', label: 'Mascota Nodi' \}/);
+assert.match(modal, /toolkit: \{ icon: 'tools', color: '#059669', label: 'Herramientas' \}/);
+assert.match(modal, /languages: \{ icon: 'languages', color: '#db2777', label: 'Idiomas' \}/);
+assert.match(releaseNotes, /export type ReleaseNoteScope = 'general' \| VaultType \| 'mcp' \| 'nodi' \| 'toolkit' \| 'languages';/);
+assert.match(releaseNotes, /version: '2\.2\.0'[\s\S]*scope: 'nodi'/);
+assert.match(releaseNotes, /version: '2\.3\.8'[\s\S]*scope: 'languages'/);
+
+// Icon() renders nothing for an unknown name, so a typo here would ship an empty
+// coloured chip rather than fail. Every scope icon must exist in the catalogue.
+const scopeIcons = [...modal.matchAll(/icon: '([^']+)'/g)].map((m) => m[1]);
+assert.ok(scopeIcons.length >= 13, `expected every scope to declare an icon, got ${scopeIcons.length}`);
+for (const icon of scopeIcons) {
+  assert.match(icons, new RegExp(`^  ${icon}: '<`, 'm'), `scope icon "${icon}" is missing from ICON_PATHS`);
+}
 assert.match(modal, /role="tooltip" className="whats-new-scope-tooltip"/);
 assert.match(modal, /aria-label=\{scopeLabel\}/);
 assert.match(releaseNotes, /version: '2\.3\.7'[\s\S]*scope: 'genealogy'/);

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -6,7 +6,11 @@
 
 import type { VaultType } from './vaultTypes';
 
-export type ReleaseNoteScope = 'general' | VaultType;
+// Beyond the vault types, a highlight can belong to a cross-vault surface with an
+// identity of its own: the MCP server, the Nodi mascot, the tools hub or a new
+// interface language. They get their own icon and colour instead of dissolving
+// into 'general'.
+export type ReleaseNoteScope = 'general' | VaultType | 'mcp' | 'nodi' | 'toolkit' | 'languages';
 
 export interface ReleaseHighlight {
   es: string;
@@ -32,7 +36,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
     date: '2026-07-16',
     highlights: [
       {
-        scope: 'general',
+        scope: 'languages',
         es: 'Nodus ya está disponible por completo en francés, alemán, portugués de Portugal y portugués de Brasil. Cada interfaz conserva su vocabulario propio, cubre también taxonomías, parentescos y recuperación, y recurre al inglés de forma segura si falta alguna traducción.',
         en: 'Nodus is now fully available in French, German, European Portuguese and Brazilian Portuguese. Each interface keeps its own vocabulary, also covers taxonomies, kinship and recovery, and safely falls back to English if a translation is ever missing.',
         fr: 'Nodus est désormais entièrement disponible en français, allemand, portugais du Portugal et portugais du Brésil. Chaque interface conserve son propre vocabulaire, couvre également les taxonomies, les liens de parenté et la récupération, et revient à l’anglais en toute sécurité si une traduction manque.',
@@ -50,7 +54,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
         'pt-BR': 'O assistente de criação descobre automaticamente os modelos de IA e embeddings disponíveis em provedores locais e na nuvem. Ele combina os resultados em dois seletores pesquisáveis e claros, tolera provedores desconectados e baixa o modelo integrado somente ao concluir a configuração.',
       },
       {
-        scope: 'general',
+        scope: 'nodi',
         es: 'Los controles radiales de Nodi mantienen ahora una distribución equilibrada, siguen siendo pulsables en las esquinas superiores y permanecen visibles durante su despedida. El menú contextual conserva la acción de cerrar y las interacciones evitan aperturas o cierres accidentales.',
         en: 'Nodi’s radial controls now stay evenly balanced, remain clickable in the top corners and stay visible during its farewell. The context menu reliably keeps the close action and interactions avoid accidental opening or dismissal.',
         fr: 'Les commandes radiales de Nodi conservent désormais une disposition équilibrée, restent cliquables dans les coins supérieurs et demeurent visibles pendant ses adieux. Le menu contextuel garde fiablement l’action de fermeture et les interactions évitent les ouvertures ou fermetures accidentelles.',
@@ -128,7 +132,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
         'pt-BR': 'Os assistentes de criação de espaços Acadêmico, Genealogia, Estudo e Bases de dados permitem escolher separadamente o modelo de IA e o modelo de embeddings, tanto local quanto na nuvem, e baixam o modelo local quando necessário.',
       },
       {
-        scope: 'general',
+        scope: 'nodi',
         es: 'Nodi contrae y hace girar sus extremidades mientras piensa, cierra los ojos y recupera su postura con una animación fluida. También se puede arrastrar por toda la pantalla y cerrar desde su menú contextual con una despedida animada que respeta sus cosméticos.',
         en: 'Nodi contracts and spins its limbs while thinking, closes its eyes and smoothly returns to its normal pose. It can also be dragged across the full screen and dismissed from its context menu with an animated farewell that accounts for its cosmetics.',
         fr: 'Nodi contracte et fait tourner ses membres pendant qu\'il réfléchit, ferme les yeux et retrouve sa posture grâce à une animation fluide. Il peut également être déplacé sur tout l\'écran et fermé depuis son menu contextuel avec un adieu animé qui respecte ses cosmétiques.',
@@ -440,7 +444,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
         'pt-BR': 'As demos dos modos Acadêmico, Genealogia, Bases de dados e Estudo foram ampliadas para que nenhuma seção comece vazia: incluem pastas, notas, materiais, conversas, relatórios e exemplos conectados que você pode explorar e excluir depois.',
       },
       {
-        scope: 'general',
+        scope: 'nodi',
         es: 'Nodi cierra correctamente su menú, chat y paneles al hacer clic fuera. También mejoran la experiencia flotante, las animaciones del tutorial y el comportamiento del icono de la app, que conserva el aspecto de la bóveda y el tema activos al cerrar.',
         en: 'Nodi now closes its menu, chat and panels correctly when you click elsewhere. The floating experience and tutorial animations are improved too, and the app icon now keeps the active vault and theme appearance after quitting.',
         fr: 'Nodi ferme désormais correctement son menu, son chat et ses panneaux lors d\'un clic à l\'extérieur. L\'expérience flottante, les animations du tutoriel et le comportement de l\'icône de l\'application s\'améliorent également : elle conserve l\'apparence de l\'espace et du thème actifs à la fermeture.',
@@ -473,7 +477,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
     date: '2026-07-13',
     highlights: [
       {
-        scope: 'general',
+        scope: 'nodi',
         es: 'Te presentamos a Nodi, la nueva mascota de Nodus: un nodo de luz que te acompaña flotando abajo a la derecha. Puedes arrastrarlo por la ventana y activarlo o desactivarlo desde Ajustes → Interfaz.',
         en: 'Meet Nodi, Nodus’s new mascot: a little node of light that keeps you company, floating at the bottom right. Drag it around the window, and switch it on or off in Settings → Interface.',
         fr: 'Nous vous présentons Nodi, la nouvelle mascotte de Nodus : un nœud de lumière qui vous accompagne en flottant en bas à droite. Vous pouvez le faire glisser dans la fenêtre et l\'activer ou le désactiver depuis Paramètres → Interface.',
@@ -482,7 +486,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
         'pt-BR': 'Apresentamos o Nodi, a nova mascote do Nodus: um nó de luz que acompanha você flutuando no canto inferior direito. Você pode arrastá-lo pela janela e ativá-lo ou desativá-lo em Configurações → Interface.',
       },
       {
-        scope: 'general',
+        scope: 'nodi',
         es: 'Haz clic en Nodi para abrir su menú: un chat con la IA que conoce Nodus y tu configuración, un centro de notificaciones (te avisa con un punto rojo y levantando la mano) y una ayuda rápida. Además, Nodi cambia de traje según el modo de la bóveda (académico, genealogía, bases de datos), algo que puedes desactivar si prefieres el Nodi de siempre.',
         en: 'Click Nodi to open its menu: a chat with an AI that knows Nodus and your setup, a notification center (it flags unread items with a red dot and a raised hand) and quick help. Nodi even changes outfit to match the vault mode (academic, genealogy, databases) — which you can turn off if you prefer the plain Nodi.',
         fr: 'Cliquez sur Nodi pour ouvrir son menu : un chat avec l\'IA qui connaît Nodus et votre configuration, un centre de notifications (il vous prévient avec un point rouge et en levant la main) et une aide rapide. De plus, Nodi change de tenue selon le mode de l\'espace (académique, généalogie, bases de données), ce que vous pouvez désactiver si vous préférez le Nodi habituel.',
@@ -491,7 +495,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
         'pt-BR': 'Clique em Nodi para abrir seu menu: um chat com a IA que conhece o Nodus e sua configuração, uma central de notificações (ele avisa com um ponto vermelho e levantando a mão) e uma ajuda rápida. Além disso, Nodi troca de traje conforme o modo do espaço (acadêmico, genealogia, bases de dados), algo que você pode desativar se preferir o Nodi de sempre.',
       },
       {
-        scope: 'general',
+        scope: 'nodi',
         es: 'Si quieres, Nodi puede vivir en una pequeña ventana flotante del escritorio, siempre por encima del resto de aplicaciones —incluso a pantalla completa—, para tenerlo a mano sin cambiar de app.',
         en: 'If you like, Nodi can live in a small floating desktop window, always on top of your other apps — even in fullscreen — so it’s always within reach without switching apps.',
         fr: 'Si vous le souhaitez, Nodi peut vivre dans une petite fenêtre flottante du bureau, toujours au-dessus des autres applications — même en plein écran — pour l\'avoir à portée de main sans changer d\'application.',
@@ -689,7 +693,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
         'pt-BR': 'O Nodus chega ao Linux: cada release agora publica instaladores .deb e AppImage, e o app herda o tema do cursor do sistema no Wayland.',
       },
       {
-        scope: 'general',
+        scope: 'languages',
         es: 'Los idiomas de los prompts suman francés y turco: las ideas, los informes de Deep Research y los borradores del taller pueden generarse también en esos idiomas. Las citas literales siempre conservan el idioma original.',
         en: 'Prompt languages now include French and Turkish: ideas, Deep Research reports and workshop drafts can also be generated in those languages. Verbatim quotes always keep the source language.',
         fr: 'Les langues des prompts s\'enrichissent du français et du turc : les idées, les rapports de Deep Research et les brouillons de l\'atelier peuvent désormais être générés dans ces langues également. Les citations littérales conservent toujours la langue d\'origine.',

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -23,6 +23,10 @@ const RELEASE_SCOPE_META: Record<ReleaseNoteScope, { icon: string; color: string
   testimonios: { icon: 'microphone', color: '#0891b2', label: 'Testimonios' },
   worldbuilding: { icon: 'globe', color: '#7c3aed', label: 'Worldbuilding' },
   docencia: { icon: 'presentation', color: '#ea580c', label: 'Docencia' },
+  mcp: { icon: 'plug', color: '#2563eb', label: 'Servidor MCP' },
+  nodi: { icon: 'nodi', color: '#d4af37', label: 'Mascota Nodi' },
+  toolkit: { icon: 'tools', color: '#059669', label: 'Herramientas' },
+  languages: { icon: 'languages', color: '#db2777', label: 'Idiomas' },
 };
 
 function readLastSeen(): string | null {

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -148,6 +148,10 @@ const ICON_PATHS: Record<string, string> = {
   swap: '<polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/>',
   scanText: '<path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><path d="M7 8h8"/><path d="M7 12h10"/><path d="M7 16h6"/>',
   bug: '<path d="M8 2l1.5 1.5"/><path d="M16 2l-1.5 1.5"/><path d="M9 7a3 3 0 0 1 6 0v1H9V7Z"/><rect x="7" y="8" width="10" height="10" rx="5"/><path d="M12 12v6"/><path d="M7 12H3"/><path d="M21 12h-4"/><path d="M6.5 7 4 5"/><path d="M17.5 7 20 5"/><path d="M6.5 17 4 19"/><path d="M17.5 17 20 19"/>',
+  plug: '<path d="M9 2v6"/><path d="M15 2v6"/><path d="M6 8h12v3a6 6 0 0 1-12 0V8Z"/><path d="M12 17v5"/>',
+  // The mascot's face fills the circle: at the 13px the release chip renders, rays
+  // or satellite nodes turn it into a smudge.
+  nodi: '<circle cx="12" cy="12" r="8.5"/><path d="M9 10.5h.01"/><path d="M15 10.5h.01"/><path d="M9 14.5a4 4 0 0 0 6 0"/>',
 };
 
 /** Complete renderer-owned icon catalogue. Pickers should consume this list so

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -89,6 +89,7 @@ export const DE: Record<string, string> = {
   'Nueva versión': 'Neue Version',
   '¡Tenemos novedades!': 'Wir haben Neuigkeiten!',
   'Lo más destacado': 'Höhepunkte',
+  'Idiomas': 'Sprachen',
   'APOYO OPCIONAL': 'OPTIONALE UNTERSTÜTZUNG',
   'Explorar las novedades': 'Neuigkeiten entdecken',
   'El enlace se abrirá en tu navegador. Nodus no procesa pagos ni recibe información de pago.':

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -74,6 +74,7 @@ export const EN: Record<string, string> = {
   'Nueva versión': 'New version',
   '¡Tenemos novedades!': 'We have news!',
   'Lo más destacado': 'Highlights',
+  'Idiomas': 'Languages',
   'APOYO OPCIONAL': 'OPTIONAL SUPPORT',
   'Explorar las novedades': 'Explore what is new',
   'El enlace se abrirá en tu navegador. Nodus no procesa pagos ni recibe información de pago.': 'The link will open in your browser. Nodus does not process payments or receive payment information.',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -89,6 +89,7 @@ export const FR: Record<string, string> = {
   'Nueva versión': 'Nouvelle version',
   '¡Tenemos novedades!': 'Nous avons des nouveautés !',
   'Lo más destacado': 'Les temps forts',
+  'Idiomas': 'Langues',
   'APOYO OPCIONAL': 'SOUTIEN FACULTATIF',
   'Explorar las novedades': 'Découvrir les nouveautés',
   'El enlace se abrirá en tu navegador. Nodus no procesa pagos ni recibe información de pago.':

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -89,6 +89,7 @@ export const PT_BR: Record<string, string> = {
   'Nueva versión': 'Nova versão',
   '¡Tenemos novedades!': 'Temos novidades!',
   'Lo más destacado': 'Os destaques',
+  'Idiomas': 'Idiomas',
   'APOYO OPCIONAL': 'APOIO OPCIONAL',
   'Explorar las novedades': 'Explorar as novidades',
   'El enlace se abrirá en tu navegador. Nodus no procesa pagos ni recibe información de pago.':

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -89,6 +89,7 @@ export const PT: Record<string, string> = {
   'Nueva versión': 'Nova versão',
   '¡Tenemos novedades!': 'Temos novidades!',
   'Lo más destacado': 'Destaques',
+  'Idiomas': 'Idiomas',
   'APOYO OPCIONAL': 'APOIO OPCIONAL',
   'Explorar las novedades': 'Explorar as novidades',
   'El enlace se abrirá en tu navegador. Nodus no procesa pagos ni recibe información de pago.':


### PR DESCRIPTION
Fixes #22.

## Summary
- Extends `ReleaseNoteScope` with `mcp`, `nodi`, `languages` and `toolkit`, each with its own icon/colour/tooltip in `RELEASE_SCOPE_META`, so these cross-vault surfaces stop dissolving into the generic grey "General" chip.
- Reuses existing catalogue pieces where they already fit: the `tools` icon and the `Herramientas` i18n key (both already shipped by the Toolkit hub), so nothing is duplicated.
- Retags the historical release-note highlights whose actual subject is one of these surfaces (Nodi's various updates → `nodi`, the multi-language release → `languages`).
- Adds the new `Idiomas` translation key across all five language tables.

## Test plan
- [x] `node scripts/test-whats-new-support.mjs`
- [x] `node scripts/test-release-notes.mjs`
- [x] `node --test scripts/test-i18n-coverage.mjs` (12/12 passing)
- [x] `npx tsc --noEmit`
- [x] Rebased onto current `main`; verified no duplicate i18n keys or icon names after the rebase surfaced the (already-merged) Toolkit hub