### PR TITLE
Añadir notas rápidas en Markdown a Nodi

### DIFF
--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -174,6 +174,7 @@ import {
 import { getNodiViewContext, setNodiViewContext, streamNodiChat } from './ai/nodiChat';
 import type { NodiChatRequest } from '@shared/types';
 import { clearNodiConversations, deleteNodiConversation, getNodiConversation, listNodiConversations, saveNodiConversation } from './nodiConversations';
+import { deleteNodiNote, listNodiNotes, saveNodiNote } from './nodiNotes';
 import { ensureCopilotCert } from './copilot/certs';
 import { installCopilotAddin, installLibreOfficeCopilot } from './copilot/install';
 import { setApiKey, clearApiKey, getApiKey, copyApiKeysBetweenVaults, listApiKeyProvidersForVault, setBackupPassword, clearBackupPassword, hasBackupPassword, getBackupPassword, getBackupRecoveryKey } from './secrets/secretStore';
@@ -729,6 +730,9 @@ export function registerIpc(
   h('nodi:conversations:save', async (_e, input) => saveNodiConversation(input));
   h('nodi:conversations:delete', async (_e, id: string) => deleteNodiConversation(id));
   h('nodi:conversations:clear', async () => clearNodiConversations());
+  h('nodi:notes:list', async () => listNodiNotes());
+  h('nodi:notes:save', async (_e, input) => saveNodiNote(input));
+  h('nodi:notes:delete', async (_e, id: string) => deleteNodiNote(id));
   h('nodi:chatStream', async (e, requestId: string, request: NodiChatRequest) => {
     const controller = new AbortController();
     nodiChatAborters.set(requestId, controller);

--- a/electron/nodiNotes.ts
+++ b/electron/nodiNotes.ts
@@ -1,0 +1,96 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import type { NodiNote, NodiNoteInput } from '@shared/types';
+
+// Quick Markdown notes for the Nodi companion. Stored as a small JSON file in the
+// user-data directory (install-wide, not per-vault) so a jot survives vault
+// switches and app restarts. Mirrors the atomic read/write of `nodiConversations`.
+
+interface Store {
+  version: 1;
+  notes: NodiNote[];
+}
+
+const MAX_NOTES = 500;
+
+function storePath(): string {
+  return path.join(app.getPath('userData'), 'nodi-notes.json');
+}
+
+/** The note's title is the first meaningful line, stripped of Markdown markers so
+ *  the list reads as plain text. Empty when the note has no text yet; the renderer
+ *  shows a localized "untitled" label in that case. */
+function deriveTitle(content: string): string {
+  for (const raw of content.split('\n')) {
+    const line = raw
+      .replace(/^\s{0,3}#{1,6}\s+/, '')
+      .replace(/^\s{0,3}[-*+>]\s+/, '')
+      .replace(/[*_`~]/g, '')
+      .trim();
+    if (line) return line.slice(0, 100);
+  }
+  return '';
+}
+
+function normalizeNote(value: NodiNote): NodiNote {
+  const content = typeof value.content === 'string' ? value.content : '';
+  return {
+    id: String(value.id || crypto.randomUUID()),
+    title: (String(value.title || '').trim() || deriveTitle(content)).slice(0, 100),
+    content,
+    createdAt: Number(value.createdAt) || Date.now(),
+    updatedAt: Number(value.updatedAt) || Date.now(),
+  };
+}
+
+function read(): Store {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storePath(), 'utf8')) as Partial<Store>;
+    return {
+      version: 1,
+      notes: Array.isArray(parsed.notes) ? parsed.notes.map(normalizeNote) : [],
+    };
+  } catch {
+    return { version: 1, notes: [] };
+  }
+}
+
+function write(store: Store): void {
+  const target = storePath();
+  const temporary = `${target}.tmp`;
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(temporary, JSON.stringify(store), 'utf8');
+  fs.renameSync(temporary, target);
+}
+
+export function listNodiNotes(): NodiNote[] {
+  return read().notes.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export function saveNodiNote(input: NodiNoteInput): NodiNote {
+  const store = read();
+  const existingIndex = input.id ? store.notes.findIndex((note) => note.id === input.id) : -1;
+  const existing = existingIndex >= 0 ? store.notes[existingIndex] : null;
+  const now = Date.now();
+  const content = typeof input.content === 'string' ? input.content : '';
+  const note = normalizeNote({
+    id: existing?.id ?? crypto.randomUUID(),
+    title: deriveTitle(content),
+    content,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  });
+  if (existingIndex >= 0) store.notes.splice(existingIndex, 1);
+  store.notes.unshift(note);
+  store.notes = store.notes.slice(0, MAX_NOTES);
+  write(store);
+  return note;
+}
+
+export function deleteNodiNote(id: string): void {
+  const store = read();
+  store.notes = store.notes.filter((note) => note.id !== id);
+  write(store);
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -35,6 +35,9 @@ const api: NodusApi = {
   saveNodiConversation: (input) => ipcRenderer.invoke('nodi:conversations:save', input),
   deleteNodiConversation: (id) => ipcRenderer.invoke('nodi:conversations:delete', id).then(() => undefined),
   clearNodiConversations: () => ipcRenderer.invoke('nodi:conversations:clear').then(() => undefined),
+  listNodiNotes: () => ipcRenderer.invoke('nodi:notes:list'),
+  saveNodiNote: (input) => ipcRenderer.invoke('nodi:notes:save', input),
+  deleteNodiNote: (id) => ipcRenderer.invoke('nodi:notes:delete', id).then(() => undefined),
   onNotificationsChanged: (cb) => {
     const listener = (_e: unknown, list: Parameters<typeof cb>[0]) => cb(list);
     ipcRenderer.on('nodi:notifications:changed', listener);

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -170,6 +170,9 @@ test('Nodi drags in absolute screen space and closes through an animated context
   assert.match(component, /Math\.hypot\(dx, dy\) < DRAG_THRESHOLD_PX/, 'small pointer jitter remains a click');
   assert.match(component, /onLostPointerCapture=\{onFigurePointerCaptureLost\}/, 'a lost capture cannot leave Nodi stuck dragging');
   assert.match(component, /vertical === 'down' \? Math\.round\(figureH \* 0\.12\)/, 'the downward radial arc clears Nodi’s longer lower limbs');
+  assert.match(component, /const RADIAL_NODE_GAP_PX = 58/, 'radial actions keep a deliberate 12px edge-to-edge gap');
+  assert.match(component, /RADIAL_NODE_GAP_PX \/ \(2 \* Math\.sin/, 'the radial radius grows when more actions are added');
+  assert.match(component, /Math\.asin\(Math\.min\(1, RADIAL_NODE_GAP_PX \/ \(2 \* radialRadius\)\)\)/, 'angular steps preserve the same centre spacing in every quadrant');
   assert.doesNotMatch(component, /e\.movement[XY]/, 'native-window movement must not distort the drag delta');
   for (const contract of ['nodiBeginWindowDrag', 'nodiDragWindow', 'nodiEndWindowDrag']) {
     assert.match(component, new RegExp(contract));

--- a/scripts/verify-nodi-notes.mjs
+++ b/scripts/verify-nodi-notes.mjs
@@ -1,0 +1,252 @@
+// End-to-end verification of the Nodi quick-notes panel against the real app:
+// create → format → save → search → preview → delete, in dark and light themes.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = process.env.NODUS_REPO_ROOT ?? path.resolve(import.meta.dirname, '..');
+const shots = process.env.NODUS_VERIFY_SHOTS ?? path.join(os.tmpdir(), 'nodus-notes-shots');
+const require = createRequire(import.meta.url);
+
+if (!process.argv.includes('--child')) {
+  execFileSync(require('electron'), [import.meta.filename, '--child'], {
+    cwd: repoRoot, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, stdio: 'inherit',
+  });
+  process.exit(0);
+}
+
+const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-notes-'));
+await mkdir(shots, { recursive: true });
+const childEnv = { ...process.env, NODUS_USERDATA: userData, NODUS_DISABLE_AUTO_UPDATE: '1', NODUS_E2E_UPDATE_STATUS: 'not-available' };
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+const app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
+const log = (...a) => console.log('[verify]', ...a);
+try {
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(30_000);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => !!document.getElementById('root')?.children.length, { timeout: 30_000 });
+  const applyTheme = async (theme) => {
+    await page.evaluate((t) => window.nodus.updateSettings({
+      onboardingComplete: true, recoverySetupVersion: 1, tourComplete: true, advancedTourComplete: true,
+      basicsTutorialVersion: 3, uiLanguage: 'es', mascotEnabled: true, mascotAlwaysOnTop: false,
+      mascotStyle: 'classic', reduceMotion: true, theme: t,
+    }), theme);
+  };
+  await applyTheme('dark');
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor();
+
+  // Fresh verification profiles can legitimately see the release/update startup
+  // sequence before Nodi. Dismiss it through the same controls a user sees.
+  const whatsNew = page.getByTestId('whats-new-cinematic-modal');
+  if (await whatsNew.isVisible().catch(() => false)) {
+    await whatsNew.getByRole('button', { name: /Explorar las novedades/ }).click();
+  }
+  const updateModal = page.getByTestId('startup-update-modal');
+  if (await updateModal.isVisible().catch(() => false)) {
+    await updateModal.getByRole('button', { name: /Entendido/ }).click();
+  }
+  const styleModal = page.getByTestId('nodi-style-modal');
+  if (await styleModal.isVisible().catch(() => false)) {
+    await page.getByTestId('nodi-style-classic').click();
+  }
+
+  const figure = page.locator('.nodi-figure');
+  await figure.waitFor({ timeout: 30_000 });
+
+  const openMenu = async () => {
+    if (await page.locator('.nodi-node.open').count() > 0) return;
+    await figure.click();
+    await page.waitForFunction(() => document.querySelector('.nodi-node')?.classList.contains('open') ?? false);
+  };
+
+  const dragFigureTo = async (x, y) => {
+    const box = await figure.boundingBox();
+    assert.ok(box, 'Nodi figure has no bounding box');
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(x, y, { steps: 6 });
+    await page.mouse.up();
+  };
+
+  const assertRadialGeometry = async (horizontal, vertical) => {
+    await page.waitForFunction(
+      ([h, v]) => document.querySelector('.nodi-anchor')?.classList.contains(`open-${h}`)
+        && document.querySelector('.nodi-anchor')?.classList.contains(`open-${v}`),
+      [horizontal, vertical],
+    );
+    await page.waitForTimeout(450);
+    const metrics = await page.evaluate(() => {
+      const nodes = [...document.querySelectorAll('.nodi-node.open')];
+      const centres = nodes.map((node) => {
+        const rect = node.getBoundingClientRect();
+        const style = getComputedStyle(node);
+        return {
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+          dx: Number.parseFloat(style.getPropertyValue('--dx')),
+          dy: Number.parseFloat(style.getPropertyValue('--dy')),
+        };
+      });
+      return {
+        centres,
+        gaps: centres.slice(1).map((point, i) => Math.hypot(point.x - centres[i].x, point.y - centres[i].y)),
+      };
+    });
+    assert.equal(metrics.centres.length, 4, 'main-window Nodi should expose four radial actions');
+    metrics.gaps.forEach((gap) => assert.ok(gap >= 57 && gap <= 59, `radial centre gap should be 58px, got ${gap}`));
+    metrics.centres.forEach(({ dx, dy }) => {
+      assert.ok(horizontal === 'left' ? dx <= 0 : dx >= 0, `wrong ${horizontal} radial direction`);
+      assert.ok(vertical === 'up' ? dy <= 0 : dy >= 0, `wrong ${vertical} radial direction`);
+    });
+    log(`radial ${horizontal}/${vertical} ->`, metrics.gaps.map((gap) => gap.toFixed(1)).join(', '));
+  };
+
+  // Exercise all four adaptive quadrants. This catches asymmetric spacing when the
+  // mascot is dragged to a different corner, not just the default bottom-right.
+  await openMenu();
+  const viewport = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
+  const corners = [
+    { x: 90, y: 100, horizontal: 'right', vertical: 'down' },
+    { x: viewport.width - 90, y: 100, horizontal: 'left', vertical: 'down' },
+    { x: 90, y: viewport.height - 100, horizontal: 'right', vertical: 'up' },
+    { x: viewport.width - 90, y: viewport.height - 100, horizontal: 'left', vertical: 'up' },
+  ];
+  for (const corner of corners) {
+    await dragFigureTo(corner.x, corner.y);
+    await assertRadialGeometry(corner.horizontal, corner.vertical);
+  }
+  await page.screenshot({ path: `${shots}/notes-0-radial-spacing.png` });
+
+  // ── Open the notes panel ───────────────────────────────────────────────────
+  await page.locator('[data-nodi-action="notes"]').click();
+  await page.locator('.nodi-notes-panel').waitFor();
+  log('notes panel open');
+  // Empty state
+  assert.equal(await page.locator('.nodi-notes-panel .nodi-empty').count(), 1, 'expected empty-state copy');
+
+  // ── Create + format + save ─────────────────────────────────────────────────
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Nueva nota"]').click();
+  const ta = page.locator('.nodi-note-textarea');
+  await ta.waitFor();
+  await ta.fill('Lista de la compra\n\nComprar leche y pan');
+  // Select the word "leche" and bold it via the toolbar.
+  await page.evaluate(() => {
+    const el = document.querySelector('.nodi-note-textarea');
+    const i = el.value.indexOf('leche');
+    el.focus();
+    el.setSelectionRange(i, i + 5);
+  });
+  await page.locator('.nodi-note-tool[data-format="bold"]').click();
+  const afterBold = await ta.inputValue();
+  assert.ok(afterBold.includes('**leche**'), `bold did not wrap selection: ${afterBold}`);
+  log('bold formatting applied:', JSON.stringify(afterBold));
+  await page.locator('.nodi-note-save').click();
+  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado');
+  log('note saved');
+
+  // ── Back to list: the note shows with derived title + snippet ───────────────
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Volver"]').click();
+  await page.locator('.nodi-note-row').first().waitFor();
+  const title = await page.locator('.nodi-note-title').first().innerText();
+  assert.equal(title, 'Lista de la compra', `unexpected list title: ${title}`);
+  const snippet = await page.locator('.nodi-note-snippet').first().innerText();
+  assert.ok(snippet.toLowerCase().includes('comprar leche'), `unexpected snippet: ${snippet}`);
+  log('list shows note:', JSON.stringify({ title, snippet }));
+  await page.screenshot({ path: `${shots}/notes-1-list-dark.png` });
+
+  // Add a second note so search has something to filter out.
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Nueva nota"]').click();
+  await ta.fill('Ideas para el proyecto\n\nProbar el modo oscuro');
+  await page.locator('.nodi-note-save').click();
+  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado');
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Volver"]').click();
+  assert.equal(await page.locator('.nodi-note-row').count(), 2, 'expected 2 notes');
+
+  // ── Search ──────────────────────────────────────────────────────────────────
+  await page.locator('.nodi-notes-search input').fill('proyecto');
+  await page.waitForFunction(() => document.querySelectorAll('.nodi-note-row').length === 1);
+  assert.equal(await page.locator('.nodi-note-title').first().innerText(), 'Ideas para el proyecto');
+  log('search "proyecto" -> 1 result');
+  await page.screenshot({ path: `${shots}/notes-2-search-dark.png` });
+  await page.locator('.nodi-notes-search input').fill('');
+  await page.waitForFunction(() => document.querySelectorAll('.nodi-note-row').length === 2);
+
+  // ── Preview a note ──────────────────────────────────────────────────────────
+  await page.locator('.nodi-note-row', { hasText: 'Lista de la compra' }).locator('.nodi-note-open').click();
+  await ta.waitFor();
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Vista previa"]').click();
+  await page.locator('.nodi-note-preview').waitFor();
+  assert.ok((await page.locator('.nodi-note-preview strong', { hasText: 'leche' }).count()) >= 1, 'preview should render bold');
+  log('preview renders markdown');
+  await page.screenshot({ path: `${shots}/notes-3-preview-dark.png` });
+
+  // ── Delete with confirmation ────────────────────────────────────────────────
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Editar"]').click(); // leave preview
+  await page.locator('.nodi-note-remove').click();
+  await page.locator('.nodi-confirm-dialog').waitFor();
+  await page.screenshot({ path: `${shots}/notes-4-confirm-dark.png` });
+  await page.locator('.nodi-confirm-dialog button.danger').click();
+  await page.waitForFunction(() => document.querySelectorAll('.nodi-note-row').length === 1);
+  log('note deleted -> 1 remaining');
+
+  // ── Light theme screenshot ──────────────────────────────────────────────────
+  await applyTheme('light');
+  await page.waitForFunction(() => document.querySelector('.nodi-notes-panel')?.classList.contains('nodi-light') ?? false, undefined, { timeout: 10_000 });
+  await page.locator('.nodi-note-row').first().waitFor();
+  await page.screenshot({ path: `${shots}/notes-5-list-light.png` });
+  // open editor in light mode
+  await page.locator('.nodi-note-open').first().click();
+  await ta.waitFor();
+  await page.screenshot({ path: `${shots}/notes-6-editor-light.png` });
+  log('light theme verified');
+
+  // ── Always-on-top overlay ─────────────────────────────────────────────────
+  // The same persisted note must be reachable from Nodi's independent desktop
+  // window, where the extra "Open Nodus" action brings the radial count to five.
+  await page.evaluate(() => window.nodus.updateSettings({ mascotAlwaysOnTop: true, theme: 'dark' }));
+  let overlay = null;
+  for (let i = 0; i < 40 && !overlay; i++) {
+    overlay = app.windows().find((candidate) => candidate.url().includes('mascot'));
+    if (!overlay) await page.waitForTimeout(250);
+  }
+  assert.ok(overlay, 'always-on-top Nodi window never appeared');
+  overlay.setDefaultTimeout(30_000);
+  await overlay.waitForLoadState('domcontentloaded');
+  const overlayFigure = overlay.locator('.nodi-figure');
+  await overlayFigure.waitFor();
+  await overlayFigure.click();
+  await overlay.waitForFunction(() => document.querySelectorAll('.nodi-node.open').length === 5);
+  await overlay.waitForTimeout(450);
+  const overlayGaps = await overlay.evaluate(() => {
+    const centres = [...document.querySelectorAll('.nodi-node.open')].map((node) => {
+      const rect = node.getBoundingClientRect();
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    });
+    return centres.slice(1).map((point, i) => Math.hypot(point.x - centres[i].x, point.y - centres[i].y));
+  });
+  overlayGaps.forEach((gap) => assert.ok(gap >= 57 && gap <= 59, `overlay radial centre gap should be 58px, got ${gap}`));
+  await overlay.locator('[data-nodi-action="notes"]').click();
+  await overlay.locator('.nodi-notes-panel').waitFor();
+  assert.equal(await overlay.locator('.nodi-note-row').count(), 1, 'saved note should be shared with the overlay');
+  await overlay.screenshot({ path: `${shots}/notes-7-overlay-dark.png` });
+  log('always-on-top overlay verified ->', overlayGaps.map((gap) => gap.toFixed(1)).join(', '));
+
+  log('ALL CHECKS PASSED. Shots in', shots);
+} finally {
+  const closed = await Promise.race([
+    app.close().then(() => true).catch(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 5_000)),
+  ]);
+  if (!closed) app.process().kill('SIGKILL');
+}
+// Electron may leave helper handles alive briefly after its last window closes.
+// This process owns only the disposable verification instance, so finish cleanly
+// once every assertion and teardown step above has completed.
+process.exit(0);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4739,6 +4739,21 @@ export interface NodiConversationInput {
   model?: ModelRef | null;
 }
 
+/** A quick Markdown note kept by the Nodi companion (local, per install). The
+ *  title is derived from the first non-empty line when the note is saved. */
+export interface NodiNote {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface NodiNoteInput {
+  id?: string | null;
+  content: string;
+}
+
 export interface NodiOverlayPlacement {
   x: number;
   y: number;
@@ -4765,6 +4780,9 @@ export interface NodusApi {
   saveNodiConversation(input: NodiConversationInput): Promise<NodiConversation>;
   deleteNodiConversation(id: string): Promise<void>;
   clearNodiConversations(): Promise<void>;
+  listNodiNotes(): Promise<NodiNote[]>;
+  saveNodiNote(input: NodiNoteInput): Promise<NodiNote>;
+  deleteNodiNote(id: string): Promise<void>;
   nodiChatStream(request: NodiChatRequest, handlers: { onDelta: (delta: string) => void }): Promise<string>;
   cancelNodiChat(): Promise<void>;
   setNodiViewContext(context: NodiViewContext): Promise<void>;

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
-import type { AppSettings, ModelRef, NodiChatMessage, NodiContextKind, NodiConversation, NodiNotification, NodiOverlayPlacement, VaultType } from '@shared/types';
+import type { AppSettings, ModelRef, NodiChatMessage, NodiContextKind, NodiConversation, NodiNote, NodiNotification, NodiOverlayPlacement, VaultType } from '@shared/types';
 import { type NodiRole, type NodiState } from './Nodi';
 import { NodiAvatar } from './NodiAvatar';
 import { Markdown } from '../Markdown';
 import { ModelPicker } from '../ModelPicker';
 import { Icon } from '../ui';
-import { setActiveLang, t } from '../../i18n';
+import { setActiveLang, t, tx } from '../../i18n';
 import './companion.css';
 
 /** Nodi wears a subtle accessory that reflects the active vault's mode. */
@@ -64,21 +64,65 @@ function IconSend() {
     </svg>
   );
 }
+function IconNotes() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+      <path d="M14 3v5h5" />
+      <path d="M9 13h6M9 16.5h4" />
+    </svg>
+  );
+}
+
+/** A quick note's title is its first meaningful line, stripped of Markdown markers.
+ *  Derived live from the draft so the header updates as you type. */
+function deriveNoteTitle(content: string): string {
+  for (const raw of content.split('\n')) {
+    const line = raw
+      .replace(/^\s{0,3}#{1,6}\s+/, '')
+      .replace(/^\s{0,3}[-*+>]\s+/, '')
+      .replace(/[*_`~]/g, '')
+      .trim();
+    if (line) return line.slice(0, 80);
+  }
+  return '';
+}
+
+/** A one-line preview of everything after the title line, for the notes list. */
+function noteSnippet(content: string): string {
+  const rest: string[] = [];
+  let started = false;
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!started) {
+      if (line) started = true;
+      continue;
+    }
+    if (line) rest.push(line.replace(/^\s{0,3}[-*+>]\s+/, '').replace(/[*_`~#]/g, ''));
+  }
+  return rest.join(' ').trim().slice(0, 140);
+}
 
 function relTime(ts: number): string {
   const s = Math.max(1, Math.round((Date.now() - ts) / 1000));
-  if (s < 60) return 'ahora';
+  if (s < 60) return t('ahora');
   const m = Math.round(s / 60);
-  if (m < 60) return `hace ${m} min`;
+  if (m < 60) return tx('hace {n} min', { n: m });
   const h = Math.round(m / 60);
-  if (h < 24) return `hace ${h} h`;
-  return `hace ${Math.round(h / 24)} d`;
+  if (h < 24) return tx('hace {n} h', { n: h });
+  return tx('hace {n} d', { n: Math.round(h / 24) });
 }
 
 const DOT: Record<NodiNotification['kind'], string> = { info: '#5b9bd5', success: '#3bb273', warning: '#e0a53b' };
 // Four overlay actions collapse over 340 ms with up to 90 ms of stagger.
 // Keep the roomy native window until every button has returned to its anchor.
 const RADIAL_COLLAPSE_MS = 450;
+// Each control is 46px wide. Keeping the centres 58px apart leaves a deliberate
+// 12px breathing space even after adding a fifth overlay action.
+const RADIAL_NODE_GAP_PX = 58;
+// Stay inside the original 180°–268° quadrant so every action opens away from the
+// nearest screen edges, including the first and last controls.
+const RADIAL_MAX_SPAN_DEG = 88;
 // Normal clicks commonly move a few pixels between press and release. Keeping a
 // comfortable dead zone prevents those tiny movements from swallowing the click.
 const DRAG_THRESHOLD_PX = 7;
@@ -92,7 +136,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const R = isOverlay ? 104 : 92;
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const [panel, setPanel] = useState<'none' | 'notifications' | 'chat'>('none');
+  const [panel, setPanel] = useState<'none' | 'notifications' | 'chat' | 'notes'>('none');
   const [helpOpen, setHelpOpen] = useState(false);
   const [ntfs, setNtfs] = useState<NodiNotification[]>([]);
   const unread = ntfs.reduce((n, x) => n + (x.read ? 0 : 1), 0);
@@ -111,6 +155,35 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const [closing, setClosing] = useState(false);
   const msgsRef = useRef<HTMLDivElement | null>(null);
   const hasOpenSurface = menuOpen || helpOpen || panel !== 'none' || contextMenuOpen || closing;
+
+  // ── Quick notes ────────────────────────────────────────────────────────────
+  const [notes, setNotes] = useState<NodiNote[]>([]);
+  const [noteView, setNoteView] = useState<'list' | 'editor'>('list');
+  const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
+  const [noteDraft, setNoteDraft] = useState('');
+  const [noteDirty, setNoteDirty] = useState(false);
+  const [noteSearch, setNoteSearch] = useState('');
+  const [notePreview, setNotePreview] = useState(false);
+  const [deleteNoteTarget, setDeleteNoteTarget] = useState<NodiNote | null>(null);
+  const noteEditorRef = useRef<HTMLTextAreaElement | null>(null);
+  // Mirror the in-flight note so the leave-editor flush reads live values without a
+  // stale closure (a lesson from the study-vault useMemo bug: closures over editor
+  // state go stale between renders).
+  const noteRef = useRef({ id: activeNoteId, draft: noteDraft, dirty: noteDirty });
+  noteRef.current = { id: activeNoteId, draft: noteDraft, dirty: noteDirty };
+
+  // Light/dark for the notes panel is driven locally (self-contained modifier class)
+  // so it looks right in both the app and the theme-less always-on-top overlay.
+  const [systemDark, setSystemDark] = useState(() =>
+    typeof window !== 'undefined' && window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)').matches : true
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const on = () => setSystemDark(mq.matches);
+    mq.addEventListener('change', on);
+    return () => mq.removeEventListener('change', on);
+  }, []);
+  const notesLight = settings ? settings.theme === 'light' || (settings.theme === 'system' && !systemDark) : false;
 
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const [overlayPlacement, setOverlayPlacement] = useState<NodiOverlayPlacement>({ x: 16, y: 16, horizontal: 'left', vertical: 'up' });
@@ -155,6 +228,148 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     void window.nodus.listNodiConversations().then(setConversations).catch(() => {});
   }, []);
   useEffect(() => { refreshConversations(); }, [refreshConversations]);
+
+  // ── Notes: load when the panel opens, persist on save / on leaving the editor ─
+  const refreshNotes = useCallback(() => {
+    void window.nodus.listNodiNotes().then(setNotes).catch(() => {});
+  }, []);
+  useEffect(() => { if (panel === 'notes') refreshNotes(); }, [panel, refreshNotes]);
+
+  const persistNote = useCallback(async (id: string | null, draft: string) => {
+    try {
+      const saved = await window.nodus.saveNodiNote({ id, content: draft });
+      setNotes((cur) => [saved, ...cur.filter((n) => n.id !== saved.id)]);
+      // A save may finish after the user has opened another note or continued
+      // typing. Only mark the editor clean when it still shows this exact snapshot.
+      const current = noteRef.current;
+      if (current.id === id && current.draft === draft) {
+        noteRef.current = { id: saved.id, draft, dirty: false };
+        setActiveNoteId(saved.id);
+        setNoteDirty(false);
+      }
+      return saved;
+    } catch {
+      const current = noteRef.current;
+      if (current.id === id && current.draft === draft) {
+        noteRef.current = { ...current, dirty: true };
+        setNoteDirty(true);
+      }
+      return null;
+    }
+  }, []);
+
+  // Fire-and-forget save used when the editor is left by any route (panel closed,
+  // switched, vault change, overlay dismissed). Mark the snapshot clean before the
+  // IPC call so opening another note cannot enqueue the same save twice.
+  const flushNote = useCallback(() => {
+    const { id, draft, dirty } = noteRef.current;
+    if (!dirty || !draft.trim()) return;
+    noteRef.current = { id, draft, dirty: false };
+    setNoteDirty(false);
+    void persistNote(id, draft);
+  }, [persistNote]);
+  const leftEditor = panel !== 'notes' || noteView !== 'editor';
+  useEffect(() => { if (leftEditor) flushNote(); }, [leftEditor, flushNote]);
+
+  const saveNote = useCallback(async () => {
+    const { id, draft, dirty } = noteRef.current;
+    if (!dirty || !draft.trim()) return;
+    noteRef.current = { id, draft, dirty: false };
+    setNoteDirty(false);
+    await persistNote(id, draft);
+  }, [persistNote]);
+
+  const openNoteEditor = (note: NodiNote | null) => {
+    flushNote();
+    setActiveNoteId(note?.id ?? null);
+    setNoteDraft(note?.content ?? '');
+    setNoteDirty(false);
+    setNotePreview(false);
+    setNoteView('editor');
+  };
+  const backToNotes = () => { setNoteView('list'); setNotePreview(false); };
+  const openNotes = () => {
+    setPanel((p) => (p === 'notes' ? 'none' : 'notes'));
+    setHelpOpen(false);
+    setNoteView('list');
+    setNoteSearch('');
+    setNotePreview(false);
+  };
+
+  const confirmDeleteNote = async () => {
+    if (!deleteNoteTarget) return;
+    const id = deleteNoteTarget.id;
+    const deleted = await window.nodus.deleteNodiNote(id).then(() => true).catch(() => false);
+    if (!deleted) return;
+    setNotes((cur) => cur.filter((n) => n.id !== id));
+    if (activeNoteId === id) {
+      setActiveNoteId(null);
+      setNoteDraft('');
+      setNoteDirty(false);
+      setNoteView('list');
+    }
+    setDeleteNoteTarget(null);
+  };
+
+  const filteredNotes = useMemo(() => {
+    const q = noteSearch.trim().toLowerCase();
+    if (!q) return notes;
+    return notes.filter((n) => n.title.toLowerCase().includes(q) || n.content.toLowerCase().includes(q));
+  }, [notes, noteSearch]);
+
+  // Markdown formatting acting on the textarea's current selection.
+  const wrapSelection = (marker: string) => {
+    const ta = noteEditorRef.current;
+    if (!ta) return;
+    const { selectionStart: s, selectionEnd: e, value } = ta;
+    const next = value.slice(0, s) + marker + value.slice(s, e) + marker + value.slice(e);
+    setNoteDraft(next);
+    setNoteDirty(true);
+    requestAnimationFrame(() => {
+      ta.focus();
+      ta.setSelectionRange(s + marker.length, e + marker.length);
+    });
+  };
+  const prefixLines = (prefix: string) => {
+    const ta = noteEditorRef.current;
+    if (!ta) return;
+    const { selectionStart: s, selectionEnd: e, value } = ta;
+    const lineStart = value.lastIndexOf('\n', s - 1) + 1;
+    const head = value.slice(0, lineStart);
+    const block = value.slice(lineStart, e);
+    const prefixed = block.split('\n').map((ln) => (ln.startsWith(prefix) ? ln : prefix + ln)).join('\n');
+    const next = head + prefixed + value.slice(e);
+    setNoteDraft(next);
+    setNoteDirty(true);
+    requestAnimationFrame(() => {
+      ta.focus();
+      ta.setSelectionRange(lineStart, head.length + prefixed.length);
+    });
+  };
+  const insertLink = () => {
+    const ta = noteEditorRef.current;
+    if (!ta) return;
+    const { selectionStart: s, selectionEnd: e, value } = ta;
+    const sel = value.slice(s, e);
+    const snippet = `[${sel}](url)`;
+    setNoteDraft(value.slice(0, s) + snippet + value.slice(e));
+    setNoteDirty(true);
+    requestAnimationFrame(() => {
+      ta.focus();
+      const urlStart = s + sel.length + 3; // past "[sel]("
+      ta.setSelectionRange(urlStart, urlStart + 3);
+    });
+  };
+  const noteFormats: Array<{ id: string; icon: string; label: string; run: () => void }> = [
+    { id: 'bold', icon: 'bold', label: t('Negrita'), run: () => wrapSelection('**') },
+    { id: 'italic', icon: 'italic', label: t('Cursiva'), run: () => wrapSelection('*') },
+    { id: 'strike', icon: 'strikethrough', label: t('Tachado'), run: () => wrapSelection('~~') },
+    { id: 'head', icon: 'heading', label: t('Encabezado'), run: () => prefixLines('## ') },
+    { id: 'list', icon: 'list', label: t('Lista'), run: () => prefixLines('- ') },
+    { id: 'quote', icon: 'quote', label: t('Cita'), run: () => prefixLines('> ') },
+    { id: 'code', icon: 'code', label: t('Código'), run: () => wrapSelection('`') },
+    { id: 'link', icon: 'link', label: t('Enlace'), run: insertLink },
+  ];
 
   // ── Notifications: load + live updates ────────────────────────────────────
   useEffect(() => {
@@ -379,6 +594,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
       { id: 'help', label: t('¿Quién soy?'), icon: <IconHelp />, onClick: () => { setHelpOpen((v) => !v); setPanel('none'); } },
       { id: 'ntf', label: t('Notificaciones'), icon: <IconBell />, onClick: openNotifications, badge: unread },
       { id: 'chat', label: t('Chat'), icon: <IconChat />, onClick: () => { setPanel((p) => (p === 'chat' ? 'none' : 'chat')); setHelpOpen(false); } },
+      { id: 'notes', label: t('Notas rápidas'), icon: <IconNotes />, onClick: openNotes },
     ];
     if (isOverlay) base.push({ id: 'open', label: t('Abrir Nodus'), icon: <IconOpen />, onClick: () => window.nodus.nodiOpenMainWindow() });
     return base;
@@ -485,13 +701,19 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     : pos && pos.y + figureH / 2 < window.innerHeight / 2 ? 'down' : 'up';
 
   const angleFor = (i: number, n: number) => {
-    // Nodi's body is centred in the figure, but its legs extend much farther below
-    // that centre than the hat/halo extend above it. A slightly wider downward arc
-    // keeps the controls visually as clear of the figure as the upward arc.
-    const radialRadius = R + (vertical === 'down' ? Math.round(figureH * 0.12) : 0);
-    const start = 180;
-    const end = 268;
-    const deg = n <= 1 ? 224 : start + (i * (end - start)) / (n - 1);
+    // Grow the radius only as much as needed to keep every pair of 46px controls
+    // exactly RADIAL_NODE_GAP_PX apart. The extra downward radius compensates for
+    // Nodi's longer lower silhouette, preserving the same visible mascot-to-button
+    // breathing room in every corner rather than merely mirroring centre points.
+    const halfSpan = (RADIAL_MAX_SPAN_DEG * Math.PI) / 360;
+    const crowdedRadius = n <= 1 ? R : RADIAL_NODE_GAP_PX / (2 * Math.sin(halfSpan / (n - 1)));
+    const spacingAdjustment = Math.max(0, crowdedRadius - R);
+    const silhouetteRadius = R + (vertical === 'down' ? Math.round(figureH * 0.12) : 0);
+    const radialRadius = silhouetteRadius + spacingAdjustment;
+    const step = n <= 1
+      ? 0
+      : (2 * Math.asin(Math.min(1, RADIAL_NODE_GAP_PX / (2 * radialRadius))) * 180) / Math.PI;
+    const deg = 224 + (i - (n - 1) / 2) * step;
     const rad = (deg * Math.PI) / 180;
     const dx = Math.round(radialRadius * Math.cos(rad));
     const dy = Math.round(radialRadius * Math.sin(rad));
@@ -508,6 +730,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
             {t('Soy el asistente integrado de Nodus. Puedo orientarte por la app y trabajar con los contextos que selecciones.')}
             <ul>
               <li><b>{t('Chat')}</b>: {t('respuestas fundamentadas en las fuentes activas.')}</li>
+              <li><b>{t('Notas')}</b>: {t('apuntes rápidos en Markdown, siempre a mano.')}</li>
               <li><b>{t('Contextos')}</b>: {t('documentación, vista actual y recuperación acotada del vault.')}</li>
               <li><b>{t('Notificaciones')}</b>: {t('avisos locales de la aplicación.')}</li>
             </ul>
@@ -630,6 +853,112 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
           </div>
         )}
 
+        {panel === 'notes' && (
+          <div className={`nodi-panel nodi-notes-panel${notesLight ? ' nodi-light' : ''}`} data-nodi-interactive style={{ height: 460 }}>
+            <div className="nodi-panel-head">
+              {noteView === 'editor' && (
+                <button className="nodi-head-icon" onClick={backToNotes} title={t('Volver')} aria-label={t('Volver')}><Icon name="arrowLeft" size={15} /></button>
+              )}
+              <span className="nodi-chat-title" title={noteView === 'editor' ? (deriveNoteTitle(noteDraft) || t('Nueva nota')) : t('Notas rápidas')}>
+                {noteView === 'editor' ? (deriveNoteTitle(noteDraft) || t('Nueva nota')) : t('Notas rápidas')}
+              </span>
+              <span className="grow" />
+              {noteView === 'list' && (
+                <button className="nodi-head-icon" onClick={() => openNoteEditor(null)} title={t('Nueva nota')} aria-label={t('Nueva nota')}><Icon name="plus" size={16} /></button>
+              )}
+              {noteView === 'editor' && (
+                <button className={`nodi-head-icon${notePreview ? ' active' : ''}`} disabled={!noteDraft.trim()} onClick={() => setNotePreview((v) => !v)} title={notePreview ? t('Editar') : t('Vista previa')} aria-label={notePreview ? t('Editar') : t('Vista previa')}><Icon name={notePreview ? 'edit' : 'eye'} size={15} /></button>
+              )}
+              <button className="nodi-head-icon" onClick={() => setPanel('none')} title={t('Cerrar')} aria-label={t('Cerrar')}><Icon name="x" size={15} /></button>
+            </div>
+
+            {noteView === 'list' ? (
+              <>
+                <div className="nodi-notes-search">
+                  <Icon name="search" size={13} />
+                  <input value={noteSearch} placeholder={t('Buscar en tus notas…')} onChange={(e) => setNoteSearch(e.target.value)} />
+                  {noteSearch && <button onClick={() => setNoteSearch('')} title={t('Limpiar')} aria-label={t('Limpiar')}><Icon name="x" size={12} /></button>}
+                </div>
+                <div className="nodi-notes-list">
+                  {filteredNotes.length === 0 ? (
+                    <div className="nodi-empty">{noteSearch.trim() ? t('Sin resultados.') : t('Aún no tienes notas. Crea la primera con el botón +.')}</div>
+                  ) : (
+                    filteredNotes.map((note) => {
+                      const snippet = noteSnippet(note.content);
+                      return (
+                        <div key={note.id} className="nodi-note-row">
+                          <button className="nodi-note-open" onClick={() => openNoteEditor(note)}>
+                            <span className="nodi-note-title">{note.title || t('Nota sin título')}</span>
+                            {snippet && <span className="nodi-note-snippet">{snippet}</span>}
+                            <span className="nodi-note-time">{relTime(note.updatedAt)}</span>
+                          </button>
+                          <button className="nodi-note-delete" onClick={() => setDeleteNoteTarget(note)} title={t('Borrar nota')} aria-label={`${t('Borrar nota')}: ${note.title || t('Nota sin título')}`}><Icon name="trash" size={13} /></button>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                {!notePreview && (
+                  <div className="nodi-note-toolbar">
+                    {noteFormats.map((f) => (
+                      <button key={f.id} type="button" className="nodi-note-tool" data-format={f.id} onMouseDown={(e) => e.preventDefault()} onClick={f.run} title={f.label} aria-label={f.label}><Icon name={f.icon} size={15} /></button>
+                    ))}
+                  </div>
+                )}
+                <div className="nodi-note-body">
+                  {notePreview ? (
+                    noteDraft.trim()
+                      ? <div className="nodi-note-preview"><Markdown content={noteDraft} verify={false} /></div>
+                      : <div className="nodi-empty">{t('Nada que previsualizar.')}</div>
+                  ) : (
+                    <textarea
+                      ref={noteEditorRef}
+                      className="nodi-note-textarea"
+                      value={noteDraft}
+                      placeholder={t('Escribe tu nota en Markdown…')}
+                      autoFocus
+                      onChange={(e) => { setNoteDraft(e.target.value); setNoteDirty(true); }}
+                      onKeyDown={(e) => {
+                        const mod = e.metaKey || e.ctrlKey;
+                        if (!mod) return;
+                        const key = e.key.toLowerCase();
+                        if (key === 'b') { e.preventDefault(); wrapSelection('**'); }
+                        else if (key === 'i') { e.preventDefault(); wrapSelection('*'); }
+                        else if (key === 's') { e.preventDefault(); void saveNote(); }
+                      }}
+                    />
+                  )}
+                </div>
+                <div className="nodi-note-foot">
+                  {activeNoteId && (
+                    <button className="nodi-note-remove" onClick={() => { const note = notes.find((n) => n.id === activeNoteId); if (note) setDeleteNoteTarget(note); }} title={t('Borrar nota')} aria-label={t('Borrar nota')}><Icon name="trash" size={13} /></button>
+                  )}
+                  <span className="nodi-note-state">{noteDirty ? t('Sin guardar') : activeNoteId ? t('Guardado') : ''}</span>
+                  <span className="grow" />
+                  <button className="nodi-note-save" onClick={() => void saveNote()} disabled={!noteDraft.trim() || !noteDirty}><Icon name="save" size={14} /> {t('Guardar')}</button>
+                </div>
+              </>
+            )}
+
+            {deleteNoteTarget && (
+              <div className="nodi-confirm-overlay">
+                <div className="nodi-confirm-dialog" role="dialog" aria-modal="true" aria-label={t('Borrar nota')}>
+                  <Icon name="trash" size={18} />
+                  <h3>{t('Borrar nota')}</h3>
+                  <p>{t('Se eliminará «{title}». Esta acción no se puede deshacer.').replace('{title}', deleteNoteTarget.title || t('Nota sin título'))}</p>
+                  <div>
+                    <button onClick={() => setDeleteNoteTarget(null)}>{t('Cancelar')}</button>
+                    <button className="danger" onClick={() => void confirmDeleteNote()}>{t('Borrar')}</button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         {contextMenuOpen && !closing && (
           <div className="nodi-context-menu" data-nodi-interactive role="menu" aria-label={t('Opciones de la mascota')}>
             <button type="button" role="menuitem" onClick={closeMascot}>
@@ -646,6 +975,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
               key={it.id}
               className={`nodi-node${menuOpen ? ' open' : ''}`}
               data-nodi-interactive
+              data-nodi-action={it.id}
               style={{
                 ['--dx' as string]: `${dx}px`,
                 ['--dy' as string]: `${dy}px`,

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -547,6 +547,249 @@
 .nodi-msg .md pre::-webkit-scrollbar-thumb:hover { background: #748198; }
 .nodi-typing { display: inline-block; color: #8b96a8; font-size: 12px; }
 
+/* Quick notes ───────────────────────────────────────────────────────────── */
+.nodi-panel.nodi-notes-panel { width: 372px; max-height: 480px; }
+
+/* List: search + rows */
+.nodi-notes-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 0 0 auto;
+  padding: 8px 10px;
+  border-bottom: 0.5px solid rgba(255, 255, 255, 0.08);
+  color: #8f9bad;
+}
+.nodi-notes-search > svg { flex: 0 0 auto; }
+.nodi-notes-search input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: #e7ebf2;
+  font: inherit;
+  font-size: 12px;
+  outline: none;
+}
+.nodi-notes-search input::placeholder { color: #6f7b8d; }
+.nodi-notes-search button {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #8f9bad;
+  cursor: pointer;
+}
+.nodi-notes-search button:hover { background: rgba(255, 255, 255, 0.06); color: #f3e6c2; }
+
+.nodi-notes-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 3px; }
+.nodi-note-row { display: flex; align-items: stretch; gap: 3px; border-radius: 9px; background: transparent; }
+.nodi-note-row:hover { background: rgba(212, 175, 55, 0.08); }
+.nodi-note-open {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 8px 8px 8px 10px;
+  text-align: left;
+  cursor: pointer;
+}
+.nodi-note-title { font-size: 12.5px; font-weight: 600; color: #e7ebf2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nodi-note-snippet { font-size: 11px; color: #98a3b4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nodi-note-time { font-size: 9.5px; color: #6b7688; margin-top: 1px; }
+.nodi-note-delete {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #687386;
+  cursor: pointer;
+}
+.nodi-note-delete:hover { background: rgba(239, 68, 68, 0.12); color: #f28b8b; }
+
+/* Editor: toolbar + textarea/preview + footer */
+.nodi-note-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-wrap: wrap;
+  flex: 0 0 auto;
+  padding: 6px 8px;
+  border-bottom: 0.5px solid rgba(255, 255, 255, 0.08);
+  background: #0d121b;
+}
+.nodi-note-tool {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: #b7c1d1;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.nodi-note-tool:hover { background: rgba(212, 175, 55, 0.14); color: #f3d67a; }
+.nodi-note-tool:active { background: rgba(212, 175, 55, 0.22); }
+
+.nodi-note-body { flex: 1; min-height: 0; display: flex; overflow: hidden; }
+.nodi-note-textarea {
+  flex: 1;
+  width: 100%;
+  resize: none;
+  border: 0;
+  outline: none;
+  background: #0b0f17;
+  color: #e7ebf2;
+  padding: 11px 12px;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.55;
+}
+.nodi-note-textarea::placeholder { color: #6f7b8d; }
+.nodi-note-preview { flex: 1; overflow-y: auto; padding: 11px 12px; font-size: 13px; line-height: 1.55; color: #e7ebf2; }
+.nodi-note-preview .md > :first-child { margin-top: 0; }
+.nodi-note-preview .md > :last-child { margin-bottom: 0; }
+.nodi-note-preview .md p { margin: 0 0 8px; }
+.nodi-note-preview .md h1,
+.nodi-note-preview .md h2,
+.nodi-note-preview .md h3,
+.nodi-note-preview .md h4 { margin: 12px 0 6px; color: #f3e6c2; line-height: 1.25; }
+.nodi-note-preview .md h1 { font-size: 17px; }
+.nodi-note-preview .md h2 { font-size: 15px; }
+.nodi-note-preview .md h3,
+.nodi-note-preview .md h4 { font-size: 14px; }
+.nodi-note-preview .md ul,
+.nodi-note-preview .md ol { margin: 6px 0 9px; padding-left: 20px; }
+.nodi-note-preview .md li { margin: 3px 0; }
+.nodi-note-preview .md blockquote { margin: 8px 0; padding-left: 10px; border-left: 2px solid #d4af37; color: #b8c1cf; }
+.nodi-note-preview .md code { border-radius: 4px; background: #0b0f17; padding: 1px 4px; color: #f3d67a; font-size: 12px; }
+.nodi-note-preview .md pre { margin: 8px 0; overflow-x: auto; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 8px; background: #090d14; padding: 9px; }
+.nodi-note-preview .md pre code { padding: 0; background: transparent; color: #dce3ed; }
+.nodi-note-preview .md a { color: #8ec5ff; text-decoration: underline; text-underline-offset: 2px; }
+
+.nodi-note-foot { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; padding: 8px; border-top: 0.5px solid rgba(255, 255, 255, 0.08); }
+.nodi-note-remove {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(239, 68, 68, 0.28);
+  border-radius: 9px;
+  background: rgba(127, 29, 29, 0.22);
+  color: #f0a3a3;
+  cursor: pointer;
+}
+.nodi-note-remove:hover { background: rgba(153, 27, 27, 0.4); color: #fecaca; }
+.nodi-note-state { font-size: 10px; color: #7a8598; }
+.nodi-note-save {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  border-radius: 9px;
+  background: #d4af37;
+  color: #14213a;
+  padding: 7px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+}
+.nodi-note-save svg { display: block; }
+.nodi-note-save:hover:not(:disabled) { background: #e6c257; }
+.nodi-note-save:active:not(:disabled) { transform: scale(0.96); }
+.nodi-note-save:disabled { opacity: 0.45; cursor: default; }
+
+.nodi-notes-list,
+.nodi-note-textarea,
+.nodi-note-preview { scrollbar-width: thin; scrollbar-color: #596579 #111824; }
+.nodi-notes-list::-webkit-scrollbar,
+.nodi-note-textarea::-webkit-scrollbar,
+.nodi-note-preview::-webkit-scrollbar { width: 8px; height: 8px; }
+.nodi-notes-list::-webkit-scrollbar-track,
+.nodi-note-textarea::-webkit-scrollbar-track,
+.nodi-note-preview::-webkit-scrollbar-track { background: #111824; border-radius: 999px; }
+.nodi-notes-list::-webkit-scrollbar-thumb,
+.nodi-note-textarea::-webkit-scrollbar-thumb,
+.nodi-note-preview::-webkit-scrollbar-thumb { background: #596579; border: 2px solid #111824; border-radius: 999px; }
+
+/* Light mode — self-contained so it also holds in the theme-less overlay window */
+.nodi-notes-panel.nodi-light {
+  background: #ffffff;
+  color: #1f2937;
+  border-color: rgba(15, 23, 42, 0.12);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.18);
+}
+.nodi-notes-panel.nodi-light .nodi-panel-head { border-bottom-color: rgba(15, 23, 42, 0.08); color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-panel-head button { color: #64748b; }
+.nodi-notes-panel.nodi-light .nodi-panel-head button:hover { color: #b8860b; background: rgba(15, 23, 42, 0.05); }
+.nodi-notes-panel.nodi-light .nodi-panel-head button.nodi-head-icon.active { color: #b8860b; background: rgba(184, 134, 11, 0.12); }
+.nodi-notes-panel.nodi-light .nodi-notes-search { border-bottom-color: rgba(15, 23, 42, 0.08); color: #64748b; }
+.nodi-notes-panel.nodi-light .nodi-notes-search input { color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-notes-search input::placeholder { color: #94a3b8; }
+.nodi-notes-panel.nodi-light .nodi-notes-search button { color: #94a3b8; }
+.nodi-notes-panel.nodi-light .nodi-notes-search button:hover { background: rgba(15, 23, 42, 0.06); color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-note-row:hover { background: rgba(184, 134, 11, 0.1); }
+.nodi-notes-panel.nodi-light .nodi-note-title { color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-note-snippet { color: #64748b; }
+.nodi-notes-panel.nodi-light .nodi-note-time { color: #94a3b8; }
+.nodi-notes-panel.nodi-light .nodi-note-delete { color: #94a3b8; }
+.nodi-notes-panel.nodi-light .nodi-note-delete:hover { background: rgba(239, 68, 68, 0.12); color: #dc2626; }
+.nodi-notes-panel.nodi-light .nodi-empty { color: #94a3b8; }
+.nodi-notes-panel.nodi-light .nodi-note-toolbar { background: #f8fafc; border-bottom-color: rgba(15, 23, 42, 0.08); }
+.nodi-notes-panel.nodi-light .nodi-note-tool { color: #64748b; }
+.nodi-notes-panel.nodi-light .nodi-note-tool:hover { background: rgba(184, 134, 11, 0.14); color: #92710f; }
+.nodi-notes-panel.nodi-light .nodi-note-textarea { background: #ffffff; color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-note-textarea::placeholder { color: #94a3b8; }
+.nodi-notes-panel.nodi-light .nodi-note-preview { color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-note-preview .md h1,
+.nodi-notes-panel.nodi-light .nodi-note-preview .md h2,
+.nodi-notes-panel.nodi-light .nodi-note-preview .md h3,
+.nodi-notes-panel.nodi-light .nodi-note-preview .md h4 { color: #92710f; }
+.nodi-notes-panel.nodi-light .nodi-note-preview .md blockquote { border-left-color: #b8860b; color: #64748b; }
+.nodi-notes-panel.nodi-light .nodi-note-preview .md code { background: #f1f5f9; color: #92710f; }
+.nodi-notes-panel.nodi-light .nodi-note-preview .md pre { background: #f1f5f9; border-color: rgba(15, 23, 42, 0.1); }
+.nodi-notes-panel.nodi-light .nodi-note-preview .md pre code { color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-note-preview .md a { color: #2563eb; }
+.nodi-notes-panel.nodi-light .nodi-note-foot { border-top-color: rgba(15, 23, 42, 0.08); }
+.nodi-notes-panel.nodi-light .nodi-note-state { color: #94a3b8; }
+.nodi-notes-panel.nodi-light .nodi-note-remove { border-color: rgba(239, 68, 68, 0.28); background: rgba(239, 68, 68, 0.08); color: #dc2626; }
+.nodi-notes-panel.nodi-light .nodi-note-remove:hover { background: rgba(239, 68, 68, 0.16); color: #b91c1c; }
+.nodi-notes-panel.nodi-light .nodi-note-save { background: #c79a2e; color: #ffffff; }
+.nodi-notes-panel.nodi-light .nodi-note-save:hover:not(:disabled) { background: #b8860b; }
+.nodi-notes-panel.nodi-light .nodi-notes-list,
+.nodi-notes-panel.nodi-light .nodi-note-textarea,
+.nodi-notes-panel.nodi-light .nodi-note-preview { scrollbar-color: #cbd5e1 #eef2f7; }
+.nodi-notes-panel.nodi-light .nodi-notes-list::-webkit-scrollbar-track,
+.nodi-notes-panel.nodi-light .nodi-note-textarea::-webkit-scrollbar-track,
+.nodi-notes-panel.nodi-light .nodi-note-preview::-webkit-scrollbar-track { background: #eef2f7; }
+.nodi-notes-panel.nodi-light .nodi-notes-list::-webkit-scrollbar-thumb,
+.nodi-notes-panel.nodi-light .nodi-note-textarea::-webkit-scrollbar-thumb,
+.nodi-notes-panel.nodi-light .nodi-note-preview::-webkit-scrollbar-thumb { background: #cbd5e1; border-color: #eef2f7; }
+.nodi-notes-panel.nodi-light .nodi-confirm-overlay { background: rgba(15, 23, 42, 0.28); }
+.nodi-notes-panel.nodi-light .nodi-confirm-dialog { background: #ffffff; border-color: rgba(15, 23, 42, 0.12); color: #1f2937; box-shadow: 0 18px 45px rgba(15, 23, 42, 0.2); }
+.nodi-notes-panel.nodi-light .nodi-confirm-dialog > svg { color: #dc2626; }
+.nodi-notes-panel.nodi-light .nodi-confirm-dialog p { color: #64748b; }
+.nodi-notes-panel.nodi-light .nodi-confirm-dialog button { border-color: rgba(15, 23, 42, 0.14); background: #f1f5f9; color: #1f2937; }
+.nodi-notes-panel.nodi-light .nodi-confirm-dialog button:hover { background: #e2e8f0; }
+.nodi-notes-panel.nodi-light .nodi-confirm-dialog button.danger { border-color: rgba(220, 38, 38, 0.35); background: rgba(220, 38, 38, 0.1); color: #b91c1c; }
+.nodi-notes-panel.nodi-light .nodi-confirm-dialog button.danger:hover { background: rgba(220, 38, 38, 0.18); }
+
 @keyframes nodi-badge-pop { 0% { transform: scale(0); } 70% { transform: scale(1.3); } 100% { transform: scale(1); } }
 @keyframes nodi-bubble-pop { 0% { opacity: 0; transform: scale(0.6) translateY(8px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
 @keyframes nodi-panel-pop { 0% { opacity: 0; transform: scale(0.85) translateY(8px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -120,6 +120,7 @@ const ICON_PATHS: Record<string, string> = {
   folderPlus: '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/><line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/>',
   bold: '<path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z"/><path d="M6 12h9a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z"/>',
   italic: '<line x1="19" y1="4" x2="10" y2="4"/><line x1="14" y1="20" x2="5" y2="20"/><line x1="15" y1="4" x2="9" y2="20"/>',
+  strikethrough: '<path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" y1="12" x2="20" y2="12"/>',
   heading: '<path d="M6 4v16"/><path d="M18 4v16"/><path d="M6 12h12"/>',
   list: '<line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/>',
   grid: '<rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>',

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -5,6 +5,17 @@
  * `scripts/test-i18n-coverage.mjs` requires every key the UI asks for to be here.
  */
 export const DE: Record<string, string> = {
+  // ── Nodi: Schnellnotizen ─────────────────────────────────────────────────
+  'Notas rápidas': 'Schnellnotizen',
+  'Nueva nota': 'Neue Notiz',
+  'Tachado': 'Durchgestrichen',
+  'Borrar nota': 'Notiz löschen',
+  'Escribe tu nota en Markdown…': 'Schreib deine Notiz in Markdown…',
+  'Nada que previsualizar.': 'Nichts zum Vorschauen.',
+  'Buscar en tus notas…': 'Notizen durchsuchen…',
+  'Aún no tienes notas. Crea la primera con el botón +.': 'Noch keine Notizen. Erstelle die erste mit der Schaltfläche +.',
+  'Sin guardar': 'Nicht gespeichert',
+  'apuntes rápidos en Markdown, siempre a mano.': 'schnelle Markdown-Notizen, immer griffbereit.',
   'Modelo de embeddings': 'Embeddings-Modell',
   'El modelo local seleccionado ya no está disponible.': 'Das ausgewählte lokale Modell ist nicht mehr verfügbar.',
   'Preparando el motor local…': 'Lokale Engine wird vorbereitet…',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -4,6 +4,17 @@
  * partial coverage never breaks the UI.
  */
 export const EN: Record<string, string> = {
+  // ── Nodi: quick notes ────────────────────────────────────────────────────
+  'Notas rápidas': 'Quick notes',
+  'Nueva nota': 'New note',
+  'Tachado': 'Strikethrough',
+  'Borrar nota': 'Delete note',
+  'Escribe tu nota en Markdown…': 'Write your note in Markdown…',
+  'Nada que previsualizar.': 'Nothing to preview.',
+  'Buscar en tus notas…': 'Search your notes…',
+  'Aún no tienes notas. Crea la primera con el botón +.': 'No notes yet. Create your first one with the + button.',
+  'Sin guardar': 'Unsaved',
+  'apuntes rápidos en Markdown, siempre a mano.': 'quick Markdown jottings, always within reach.',
   // ── Setup wizard: model discovery ────────────────────────────────────────
   'Modelo de embeddings': 'Embedding model',
   'El modelo local seleccionado ya no está disponible.': 'The selected local model is no longer available.',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -5,6 +5,17 @@
  * `scripts/test-i18n-coverage.mjs` requires every key the UI asks for to be here.
  */
 export const FR: Record<string, string> = {
+  // ── Nodi : notes rapides ─────────────────────────────────────────────────
+  'Notas rápidas': 'Notes rapides',
+  'Nueva nota': 'Nouvelle note',
+  'Tachado': 'Barré',
+  'Borrar nota': 'Supprimer la note',
+  'Escribe tu nota en Markdown…': 'Écris ta note en Markdown…',
+  'Nada que previsualizar.': 'Rien à prévisualiser.',
+  'Buscar en tus notas…': 'Rechercher dans tes notes…',
+  'Aún no tienes notas. Crea la primera con el botón +.': 'Pas encore de notes. Crée la première avec le bouton +.',
+  'Sin guardar': 'Non enregistré',
+  'apuntes rápidos en Markdown, siempre a mano.': 'des notes rapides en Markdown, toujours à portée de main.',
   'Modelo de embeddings': 'Modèle d\'embeddings',
   'El modelo local seleccionado ya no está disponible.': 'Le modèle local sélectionné n\'est plus disponible.',
   'Preparando el motor local…': 'Préparation du moteur local…',

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -5,6 +5,17 @@
  * `scripts/test-i18n-coverage.mjs` requires every key the UI asks for to be here.
  */
 export const PT_BR: Record<string, string> = {
+  // ── Nodi: notas rápidas ──────────────────────────────────────────────────
+  'Notas rápidas': 'Notas rápidas',
+  'Nueva nota': 'Nova nota',
+  'Tachado': 'Tachado',
+  'Borrar nota': 'Excluir nota',
+  'Escribe tu nota en Markdown…': 'Escreva sua nota em Markdown…',
+  'Nada que previsualizar.': 'Nada para pré-visualizar.',
+  'Buscar en tus notas…': 'Buscar nas suas notas…',
+  'Aún no tienes notas. Crea la primera con el botón +.': 'Você ainda não tem notas. Crie a primeira com o botão +.',
+  'Sin guardar': 'Não salvo',
+  'apuntes rápidos en Markdown, siempre a mano.': 'anotações rápidas em Markdown, sempre à mão.',
   'Modelo de embeddings': 'Modelo de embeddings',
   'El modelo local seleccionado ya no está disponible.': 'O modelo local selecionado não está mais disponível.',
   'Preparando el motor local…': 'Preparando o motor local…',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -5,6 +5,17 @@
  * `scripts/test-i18n-coverage.mjs` requires every key the UI asks for to be here.
  */
 export const PT: Record<string, string> = {
+  // ── Nodi: notas rápidas ──────────────────────────────────────────────────
+  'Notas rápidas': 'Notas rápidas',
+  'Nueva nota': 'Nova nota',
+  'Tachado': 'Rasurado',
+  'Borrar nota': 'Eliminar nota',
+  'Escribe tu nota en Markdown…': 'Escreve a tua nota em Markdown…',
+  'Nada que previsualizar.': 'Nada para pré-visualizar.',
+  'Buscar en tus notas…': 'Procurar nas tuas notas…',
+  'Aún no tienes notas. Crea la primera con el botón +.': 'Ainda não tens notas. Cria a primeira com o botão +.',
+  'Sin guardar': 'Por guardar',
+  'apuntes rápidos en Markdown, siempre a mano.': 'apontamentos rápidos em Markdown, sempre à mão.',
   'Modelo de embeddings': 'Modelo de embeddings',
   'El modelo local seleccionado ya no está disponible.': 'O modelo local selecionado já não está disponível.',
   'Preparando el motor local…': 'A preparar o motor local…',


### PR DESCRIPTION
## Resumen

- Añade notas rápidas en Markdown a Nodi con creación, edición, guardado y búsqueda.
- Incluye vista previa, formato básico y eliminación con confirmación.
- Mantiene la coherencia visual en modos claro y oscuro y en las cuatro esquinas.
- Persiste las notas localmente y funciona también en la ventana siempre visible.

## Verificación

- `npm run build`
- `npm test` — 418 pruebas superadas
- ESLint sobre los archivos modificados
- Prueba E2E de notas: guardado, búsqueda, formato, vista previa, borrado, temas, cuatro esquinas y overlay

Closes #24