### PR TITLE
Fix Nodi overlay flicker across apps

### DIFF
--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -166,6 +166,7 @@ import {
   beginMascotWindowDrag,
   dragMascotWindow,
   endMascotWindowDrag,
+  getMascotWindowPlacement,
   setMascotTutorialVisible,
   setMascotWindowExpanded,
 } from './mascotWindow';
@@ -761,8 +762,17 @@ export function registerIpc(
   });
   h('nodi:viewContext:set', async (_e, context) => setNodiViewContext(context));
   h('nodi:viewContext:get', async () => getNodiViewContext());
-  // Retained for compatibility with older renderers; the current compact overlay is
-  // kept interactive so a first click cannot be lost during an IPC round-trip.
+  ipcMain.on('nodi:setMouseIgnoreSync', (e, ignore: boolean) => {
+    const win = BrowserWindow.fromWebContents(e.sender);
+    win?.setIgnoreMouseEvents(Boolean(ignore), { forward: true });
+    // sendSync is intentional here: a forwarded mousemove must make Nodi interactive
+    // before a following physical mouse-down can pass through to the app underneath.
+    e.returnValue = true;
+  });
+  ipcMain.on('nodi:getOverlayPlacementSync', (e) => {
+    e.returnValue = getMascotWindowPlacement();
+  });
+  // Retained for compatibility with older preload bundles.
   h('nodi:setMouseIgnore', async (e, ignore: boolean) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     win?.setIgnoreMouseEvents(Boolean(ignore), { forward: true });
@@ -771,7 +781,6 @@ export function registerIpc(
     const win = BrowserWindow.fromWebContents(e.sender);
     if (!win) return { x: 16, y: 16, horizontal: 'left', vertical: 'up' };
     const nextPlacement = setMascotWindowExpanded(win, Boolean(expanded));
-    if (expanded) win.focus();
     return nextPlacement;
   });
   h('nodi:openMainWindow', async () => {

--- a/electron/mascotWindow.ts
+++ b/electron/mascotWindow.ts
@@ -10,26 +10,25 @@ import { getSettings } from './db/settingsRepo';
 
 const VITE_DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL;
 const RENDERER_DIST = path.join(__dirname, '../dist');
-// Roomy enough for Nodi plus its radial menu and a compact panel. The window is
-// transparent. Its compact bounds hug Nodi; the larger bounds are used only while a
-// menu or panel is open.
+// Roomy enough for Nodi plus its radial menu and panels. Keep these native bounds
+// stable: on macOS, resizing a visible transparent NSPanel briefly stretches its old
+// backing surface from the new origin before Chromium submits the next frame. That
+// exact transient is the diagonal jump seen when Nodi opens outside the main app.
 const EXPANDED_WIDTH = 600;
 const EXPANDED_HEIGHT = 520;
 const FIGURE_WIDTH = 180;
 const FIGURE_HEIGHT = 200;
 const MARGIN = 16;
-const COMPACT_WIDTH = FIGURE_WIDTH + MARGIN * 2;
-const COMPACT_HEIGHT = FIGURE_HEIGHT + MARGIN * 2;
 
 let mascotWindow: BrowserWindow | null = null;
 let tutorialVisible = false;
 let placement: NodiOverlayPlacement = { x: MARGIN, y: MARGIN, horizontal: 'left', vertical: 'up' };
-let windowDrag: { cursorX: number; cursorY: number; nodiX: number; nodiY: number; expanded: boolean } | null = null;
+let windowDrag: { cursorX: number; cursorY: number; nodiX: number; nodiY: number } | null = null;
 let requestedBounds: { x: number; y: number; width: number; height: number } | null = null;
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(min, value), Math.max(min, max));
 
-function placeWindowAroundNodi(win: BrowserWindow, desiredX: number, desiredY: number, expanded: boolean): NodiOverlayPlacement {
+function placeWindowAroundNodi(win: BrowserWindow, desiredX: number, desiredY: number): NodiOverlayPlacement {
   const display = screen.getDisplayNearestPoint({
     x: Math.round(desiredX + FIGURE_WIDTH / 2),
     y: Math.round(desiredY + FIGURE_HEIGHT / 2),
@@ -39,10 +38,10 @@ function placeWindowAroundNodi(win: BrowserWindow, desiredX: number, desiredY: n
   const nodiY = clamp(desiredY, workArea.y, workArea.y + workArea.height - FIGURE_HEIGHT);
   const horizontal: NodiOverlayPlacement['horizontal'] = nodiX + FIGURE_WIDTH / 2 >= workArea.x + workArea.width / 2 ? 'left' : 'right';
   const vertical: NodiOverlayPlacement['vertical'] = nodiY + FIGURE_HEIGHT / 2 >= workArea.y + workArea.height / 2 ? 'up' : 'down';
-  const width = expanded ? Math.min(EXPANDED_WIDTH, workArea.width) : COMPACT_WIDTH;
-  const height = expanded ? Math.min(EXPANDED_HEIGHT, workArea.height) : COMPACT_HEIGHT;
-  const idealX = expanded && horizontal === 'left' ? nodiX - (width - FIGURE_WIDTH - MARGIN) : nodiX - MARGIN;
-  const idealY = expanded && vertical === 'up' ? nodiY - (height - FIGURE_HEIGHT - MARGIN) : nodiY - MARGIN;
+  const width = Math.min(EXPANDED_WIDTH, workArea.width);
+  const height = Math.min(EXPANDED_HEIGHT, workArea.height);
+  const idealX = horizontal === 'left' ? nodiX - (width - FIGURE_WIDTH - MARGIN) : nodiX - MARGIN;
+  const idealY = vertical === 'up' ? nodiY - (height - FIGURE_HEIGHT - MARGIN) : nodiY - MARGIN;
   const x = clamp(idealX, workArea.x, workArea.x + workArea.width - width);
   const y = clamp(idealY, workArea.y, workArea.y + workArea.height - height);
 
@@ -63,7 +62,7 @@ function placeWindowAroundNodi(win: BrowserWindow, desiredX: number, desiredY: n
       win.setBounds(nextBounds, false);
     }
     // Keep the requested rectangle as well as the applied one. AppKit may inset a
-    // compact NSPanel at a screen edge; comparing only against getBounds() would
+    // transparent NSPanel at a screen edge; comparing only against getBounds() would
     // resend the rejected x=0 request on every pointermove and make the panel rock.
     requestedBounds = nextBounds;
   }
@@ -85,21 +84,36 @@ function currentNodiPosition(win: BrowserWindow): { x: number; y: number } {
   return { x: bounds.x + placement.x, y: bounds.y + placement.y };
 }
 
+function cursorIsOverNodi(win: BrowserWindow): boolean {
+  const cursor = screen.getCursorScreenPoint();
+  const nodi = currentNodiPosition(win);
+  return cursor.x >= nodi.x
+    && cursor.x < nodi.x + FIGURE_WIDTH
+    && cursor.y >= nodi.y
+    && cursor.y < nodi.y + FIGURE_HEIGHT;
+}
+
+function applyClosedMousePassthrough(win: BrowserWindow): void {
+  // The host stays large to avoid a native resize flash. Its transparent area must
+  // therefore pass through to the app below, while a stationary pointer already on
+  // Nodi must remain clickable without requiring a preparatory mouse movement.
+  win.setIgnoreMouseEvents(!cursorIsOverNodi(win), { forward: true });
+}
+
 function positionBottomRight(win: BrowserWindow): void {
   const { workArea } = screen.getPrimaryDisplay();
   placeWindowAroundNodi(
     win,
     workArea.x + workArea.width - FIGURE_WIDTH - MARGIN,
-    workArea.y + workArea.height - FIGURE_HEIGHT - MARGIN,
-    false
+    workArea.y + workArea.height - FIGURE_HEIGHT - MARGIN
   );
 }
 
 function createMascotWindow(): BrowserWindow {
   const isMac = process.platform === 'darwin';
   const win = new BrowserWindow({
-    width: COMPACT_WIDTH,
-    height: COMPACT_HEIGHT,
+    width: EXPANDED_WIDTH,
+    height: EXPANDED_HEIGHT,
     show: false,
     useContentSize: true,
     frame: false,
@@ -107,9 +121,8 @@ function createMascotWindow(): BrowserWindow {
     backgroundColor: '#00000000',
     resizable: false,
     // Movement is implemented below in absolute screen space. Letting AppKit also
-    // treat this panel as user-movable makes macOS constrain a compact window 43px
-    // away from the left edge while the expanded one can reach x=0, so changing
-    // size or dragging at that edge visibly bounces Nodi between both positions.
+    // treat this panel as user-movable makes macOS apply a second edge constraint,
+    // so pointer movement at the left wall visibly rebounds between two positions.
     movable: false,
     minimizable: false,
     maximizable: false,
@@ -127,6 +140,11 @@ function createMascotWindow(): BrowserWindow {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      // Nodi is an animated desktop overlay and remains visible while another app
+      // owns the active window. Chromium's default background throttling suspends
+      // its compositor in that exact state; the first click would otherwise resume
+      // with a stale frame. Keep this one tiny renderer compositing continuously.
+      backgroundThrottling: false,
     },
   });
 
@@ -141,18 +159,19 @@ function createMascotWindow(): BrowserWindow {
     win.setMovable(false);
   };
   applyLevels();
-  // Keep the compact host interactive. Enabling it from a forwarded mousemove races
-  // a fast click, which makes Nodi appear unresponsive. The compact window is only a
-  // 16px margin larger than the figure, so it remains a tightly scoped hit target.
-  win.setIgnoreMouseEvents(false, { forward: true });
   positionBottomRight(win);
+  applyClosedMousePassthrough(win);
 
   win.on('show', applyLevels);
   win.on('blur', () => {
-    if (!win.isDestroyed()) win.webContents.send('nodi:dismiss');
+    if (!win.isDestroyed()) {
+      win.webContents.send('nodi:dismiss');
+      applyClosedMousePassthrough(win);
+    }
   });
   win.once('ready-to-show', () => {
     applyLevels();
+    applyClosedMousePassthrough(win);
     if (!tutorialVisible) win.showInactive();
   });
 
@@ -173,21 +192,29 @@ function createMascotWindow(): BrowserWindow {
   return win;
 }
 
-/** Resize the transparent host around the mascot without moving Nodi itself. */
+/** Toggle full-host interactivity without moving or resizing Nodi. */
 export function setMascotWindowExpanded(win: BrowserWindow, expanded: boolean): NodiOverlayPlacement {
   const nodi = currentNodiPosition(win);
   windowDrag = null;
-  return placeWindowAroundNodi(win, nodi.x, nodi.y, expanded);
+  if (expanded) win.setIgnoreMouseEvents(false, { forward: true });
+  else applyClosedMousePassthrough(win);
+  // Deliberately keep the native window expanded. Only its mouse passthrough state
+  // changes; stable bounds mean AppKit never has an old compact surface to flash.
+  return placeWindowAroundNodi(win, nodi.x, nodi.y);
+}
+
+/** Placement already computed before mascot.html loads, for its very first frame. */
+export function getMascotWindowPlacement(): NodiOverlayPlacement {
+  return { ...placement };
 }
 
 /** Start an absolute screen-space drag. This is stable while the native window moves. */
 export function beginMascotWindowDrag(win: BrowserWindow, screenX: number, screenY: number): NodiOverlayPlacement {
   const nodi = currentNodiPosition(win);
-  const bounds = win.getBounds();
-  const expanded = bounds.width > COMPACT_WIDTH || bounds.height > COMPACT_HEIGHT;
-  placement = placeWindowAroundNodi(win, nodi.x, nodi.y, expanded);
+  win.setIgnoreMouseEvents(false, { forward: true });
+  placement = placeWindowAroundNodi(win, nodi.x, nodi.y);
   const placedNodi = currentNodiPosition(win);
-  windowDrag = { cursorX: screenX, cursorY: screenY, nodiX: placedNodi.x, nodiY: placedNodi.y, expanded };
+  windowDrag = { cursorX: screenX, cursorY: screenY, nodiX: placedNodi.x, nodiY: placedNodi.y };
   return placement;
 }
 
@@ -196,8 +223,7 @@ export function dragMascotWindow(win: BrowserWindow, screenX: number, screenY: n
   return placeWindowAroundNodi(
     win,
     windowDrag.nodiX + screenX - windowDrag.cursorX,
-    windowDrag.nodiY + screenY - windowDrag.cursorY,
-    windowDrag.expanded
+    windowDrag.nodiY + screenY - windowDrag.cursorY
   );
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -64,7 +64,10 @@ const api: NodusApi = {
   setNodiViewContext: (context) => ipcRenderer.invoke('nodi:viewContext:set', context).then(() => undefined),
   getNodiViewContext: () => ipcRenderer.invoke('nodi:viewContext:get'),
   setNodiTutorialVisible: (visible) => ipcRenderer.invoke('nodi:tutorialVisible', visible).then(() => undefined),
-  nodiSetMouseIgnore: (ignore) => ipcRenderer.invoke('nodi:setMouseIgnore', ignore),
+  nodiSetMouseIgnore: async (ignore) => {
+    ipcRenderer.sendSync('nodi:setMouseIgnoreSync', ignore);
+  },
+  nodiGetOverlayPlacement: () => ipcRenderer.sendSync('nodi:getOverlayPlacementSync'),
   nodiSetExpanded: (expanded) => ipcRenderer.invoke('nodi:setExpanded', expanded),
   onNodiDismiss: (cb) => {
     const listener = () => cb();

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -134,22 +134,27 @@ test('floating Nodi dismisses every open surface on an outside click or window b
   assert.match(mascot, /win\.on\('blur'/, 'clicking another application dismisses the overlay');
   assert.match(mascot, /webContents\.send\('nodi:dismiss'\)/);
   assert.match(ipc, /nodi:setExpanded/);
-  assert.match(mascot, /setIgnoreMouseEvents\(false/, 'the compact host is immediately clickable');
-  assert.doesNotMatch(ipc, /setIgnoreMouseEvents\(!expanded/, 'resizing must not reintroduce the first-click race');
-  assert.doesNotMatch(component, /addEventListener\('mousemove'/, 'interactivity must not depend on a prior hover event');
+  assert.match(mascot, /width: EXPANDED_WIDTH/, 'opening controls must not resize a visible transparent NSPanel');
+  assert.match(mascot, /applyClosedMousePassthrough/, 'closed transparent regions pass clicks to the app underneath');
+  assert.match(component, /addEventListener\('mousemove'/, 'forwarded movement performs transparent-region hit testing');
+  assert.match(ipc, /nodi:setMouseIgnoreSync/);
+  assert.match(ipc, /e\.returnValue = true/, 'the native hit target changes before a following physical mouse-down');
+  assert.match(preload, /sendSync\('nodi:setMouseIgnoreSync'/);
+  assert.match(component, /nodiGetOverlayPlacement\(\)/, 'the first renderer frame uses the native placement rather than a provisional anchor');
+  assert.match(preload, /sendSync\('nodi:getOverlayPlacementSync'/);
   assert.match(preload, /onNodiDismiss/);
   assert.match(types, /onNodiDismiss\(cb: \(\) => void\)/);
 });
 
-test('floating Nodi stays expanded until its radial buttons finish collapsing', async () => {
+test('floating Nodi restores mouse passthrough after its radial buttons finish collapsing', async () => {
   const component = await read('src/components/nodi/NodiCompanion.tsx');
   assert.match(component, /const RADIAL_COLLAPSE_MS = 450/);
   assert.match(
     component,
     /setTimeout\(\(\) => \{\s*void window\.nodus\.nodiSetExpanded\(false\)[\s\S]*?\}, RADIAL_COLLAPSE_MS\)/,
-    'the native overlay must not shrink while the radial transition is still visible',
+    'transparent-area passthrough waits until the radial transition finishes',
   );
-  assert.match(component, /window\.clearTimeout\(shrink\)/, 'reopening Nodi cancels a pending shrink');
+  assert.match(component, /window\.clearTimeout\(releasePassthrough\)/, 'reopening Nodi cancels a pending passthrough hand-off');
 });
 
 test('Nodi drags in absolute screen space and closes through an animated context action', async () => {
@@ -188,13 +193,15 @@ test('Nodi drags in absolute screen space and closes through an animated context
   }
   assert.match(ipc, /nodi:windowDrag:begin/);
   assert.match(ipc, /nodi:windowDrag:move/);
-  assert.match(mascot, /COMPACT_WIDTH = FIGURE_WIDTH \+ MARGIN \* 2/);
+  assert.doesNotMatch(mascot, /COMPACT_WIDTH/, 'the native host has no compact size to flash during menu opening');
+  assert.match(mascot, /width: EXPANDED_WIDTH/);
   assert.match(mascot, /movable:\s*false/, 'AppKit must not apply a second, conflicting drag constraint at screen edges');
+  assert.match(mascot, /backgroundThrottling:\s*false/, 'the desktop overlay compositor must keep drawing while another macOS app is active');
   assert.match(mascot, /placeWindowAroundNodi/);
   assert.match(mascot, /const isRepeatedRequest = requestedBounds/, 'clamped pointer movement must not repeatedly invalidate a native edge constraint');
   assert.match(mascot, /const appliedBounds = win\.getBounds\(\)/, 'renderer placement follows the bounds actually applied by the window manager');
-  assert.match(mascot, /const expanded = bounds\.width > COMPACT_WIDTH \|\| bounds\.height > COMPACT_HEIGHT/);
-  assert.match(mascot, /windowDrag\.expanded/, 'pressing Nodi must not compact an open radial menu before it closes');
+  assert.match(mascot, /return placeWindowAroundNodi\(win, nodi\.x, nodi\.y\)/, 'menu state changes never resize the native host');
+  assert.doesNotMatch(mascot, /windowDrag\.expanded/, 'dragging never switches the native host to a compact size');
   assert.match(mascot, /screen\.getDisplayNearestPoint/);
   assert.match(types, /horizontal: 'left' \| 'right'/);
   assert.match(component, /onContextMenu=\{onFigureContextMenu\}/);
@@ -205,6 +212,7 @@ test('Nodi drags in absolute screen space and closes through an animated context
   assert.match(component, /settings\?\.mascotStyle !== 'orb'\) wave\(\)/, 'opening the orb menu cannot replace its continuous float with a snapping rock animation');
   assert.match(component, /window\.innerWidth - overlayPlacement\.x - figureW/, 'the overlay anchor follows the stable native-window edge during horizontal resize');
   assert.match(component, /window\.innerHeight - overlayPlacement\.y - figureH/, 'the overlay anchor follows the stable native-window edge during vertical resize');
+  assert.doesNotMatch(ipc, /if \(expanded\) win\.focus\(\)/, 'opening radial controls must not explicitly focus Electron over the active desktop app');
   assert.match(figure, /closing-accessory-smoke/);
   assert.match(figure, /closing-body-smoke/);
   for (const animation of ['nodi-close-limb', 'nodi-close-accessory', 'nodi-close-face', 'nodi-close-core', 'nodi-close-smoke']) {

--- a/scripts/verify-nodi-overlay.mjs
+++ b/scripts/verify-nodi-overlay.mjs
@@ -47,8 +47,25 @@ try {
   if (!overlay) throw new Error('overlay window never appeared');
   await overlay.waitForLoadState('domcontentloaded');
   const nativeOverlay = await app.browserWindow(overlay);
+  assert.equal(
+    await nativeOverlay.evaluate((win) => win.webContents.getBackgroundThrottling()),
+    false,
+    'Nodi overlay must keep compositing while another macOS app is active',
+  );
+  // Playwright's synthetic click does not perform AppKit's real mouse-window
+  // activation. A physical click does, so reproduce that native precondition before
+  // exercising the menu; otherwise the overlay's blur dismissal immediately wins.
+  await nativeOverlay.evaluate((win) => win.focus());
   const figure = overlay.locator('.nodi-figure');
   await figure.waitFor({ timeout: 30_000 });
+  const figureScreenPosition = async () => {
+    const [bounds, box] = await Promise.all([
+      nativeOverlay.evaluate((win) => win.getBounds()),
+      figure.boundingBox(),
+    ]);
+    if (!box) throw new Error('Nodi figure has no bounding box');
+    return { x: Math.round(bounds.x + box.x), y: Math.round(bounds.y + box.y) };
+  };
   const setMenuOpen = async (open) => {
     const current = await overlay.locator('.nodi-node.open').count() > 0;
     if (current === open) return;
@@ -60,9 +77,7 @@ try {
 
   /** How far the radial buttons stick out of the window, in px. */
   const overflow = () => overlay.evaluate(() => {
-    // Include Nodi itself: the old numeric anchor briefly remained at (404,304)
-    // after the host had already shrunk to 212x232, making the mascot disappear for
-    // exactly one compositor frame even though the returning buttons were in bounds.
+    // Include Nodi itself as well as every radial action.
     const nodes = [...document.querySelectorAll('.nodi-node, .nodi-figure')];
     let worst = 0;
     for (const n of nodes) {
@@ -72,7 +87,10 @@ try {
     return { viewport: [window.innerWidth, window.innerHeight], clippedBy: Math.round(worst) };
   });
 
+  const beforeOpenPosition = await figureScreenPosition();
   await setMenuOpen(true);
+  const afterOpenPosition = await figureScreenPosition();
+  assert.deepEqual(afterOpenPosition, beforeOpenPosition, 'opening the radial menu moved Nodi on screen');
   await overlay.waitForTimeout(700);
   assert.equal(await overlay.locator('.nodi-orb').getAttribute('data-state'), 'idle', 'opening the orb menu must not replace its continuous float animation');
   const open = await overflow();
@@ -89,18 +107,13 @@ try {
     const o = await overflow();
     console.log(`[verify] +${ms}ms after collapse ->`, JSON.stringify(o));
     assert.equal(o.clippedBy, 0, `a radial button was clipped at ${ms} ms`);
+    assert.deepEqual(await figureScreenPosition(), beforeOpenPosition, `closing the radial menu moved Nodi at ${ms} ms`);
     await overlay.screenshot({ path: `${shots}/overlay-2-collapse-${ms}.png` });
   }
-  // Electron may throttle background renderer timers, so allow the delayed compact
-  // resize more time than the CSS transition itself before testing another position.
-  await overlay.waitForFunction(
-    () => window.innerWidth === 212 && window.innerHeight === 232,
-    undefined,
-    { timeout: 3_000 },
-  );
+  assert.deepEqual((await overflow()).viewport, [600, 520], 'the native host resized after collapse');
 
   // A little hand jitter must still produce a click instead of being mistaken for a
-  // drag. This also exercises clicking the compact native window with no prior hover.
+  // drag. This also exercises reactivating Nodi from transparent-area passthrough.
   const figureBox = await figure.boundingBox();
   if (!figureBox) throw new Error('Nodi figure has no bounding box');
   const clickX = figureBox.x + figureBox.width / 2;
@@ -110,9 +123,9 @@ try {
   await overlay.mouse.move(clickX + 4, clickY + 2);
   await overlay.mouse.up();
   await overlay.waitForFunction(() => document.querySelector('.nodi-node')?.classList.contains('open') ?? false);
-  console.log('[verify] compact first click + pointer jitter -> menu open');
+  console.log('[verify] passthrough first click + pointer jitter -> menu open');
   await setMenuOpen(false);
-  await overlay.waitForFunction(() => window.innerWidth === 212 && window.innerHeight === 232, undefined, { timeout: 3_000 });
+  await overlay.waitForTimeout(700);
 
   const moveNodi = async (screenX, screenY) => {
     await overlay.evaluate(async ([x, y]) => {
@@ -173,7 +186,7 @@ try {
   }
   await overlay.evaluate(async () => window.nodus.nodiEndWindowDrag());
   console.log('[verify] lower-left native bounds ->', JSON.stringify(lowerLeftSamples));
-  assert.equal(new Set(lowerLeftSamples.map(({ x }) => x)).size, 1, 'the compact panel rebounds horizontally at the left edge');
+  assert.equal(new Set(lowerLeftSamples.map(({ x }) => x)).size, 1, 'the stable panel rebounds horizontally at the left edge');
   console.log('[verify] shots in', shots);
 } finally {
   await app.close().catch(() => {});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4820,6 +4820,7 @@ export interface NodusApi {
   nodiOpenSettings(): Promise<void>;
   onNodiNavigate(cb: (view: 'settings') => void): () => void;
   nodiSetMouseIgnore(ignore: boolean): Promise<void>;
+  nodiGetOverlayPlacement(): NodiOverlayPlacement;
   nodiSetExpanded(expanded: boolean): Promise<NodiOverlayPlacement>;
   onNodiDismiss(cb: () => void): () => void;
   nodiOpenMainWindow(): Promise<void>;

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -186,7 +186,11 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const notesLight = settings ? settings.theme === 'light' || (settings.theme === 'system' && !systemDark) : false;
 
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-  const [overlayPlacement, setOverlayPlacement] = useState<NodiOverlayPlacement>({ x: 16, y: 16, horizontal: 'left', vertical: 'up' });
+  const [overlayPlacement, setOverlayPlacement] = useState<NodiOverlayPlacement>(() => (
+    isOverlay
+      ? window.nodus.nodiGetOverlayPlacement()
+      : { x: 16, y: 16, horizontal: 'left', vertical: 'up' }
+  ));
   const [dragging, setDragging] = useState(false);
   const [greet, setGreet] = useState(false);
   const draggingRef = useRef(false);
@@ -432,27 +436,22 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     return () => window.removeEventListener('resize', place);
   }, [isOverlay, clamp, figureW, figureH]);
 
-  // ── Overlay: resize the native window around open surfaces ──────────────────
-  // The compact host is deliberately interactive. Toggling Electron's mouse-ignore
-  // mode from forwarded mousemove events creates a race in which a quick first click
-  // reaches the app behind Nodi before the IPC round-trip can enable this window.
+  // ── Overlay: switch full-host interactivity around open surfaces ────────────
   useEffect(() => {
     if (!isOverlay) return;
-    let shrink: number | undefined;
+    let releasePassthrough: number | undefined;
     if (hasOpenSurface) {
-      // Grow first, then let the surface animate open inside the new bounds.
+      // The host already has its full, stable bounds; make all controls interactive.
       void window.nodus.nodiSetExpanded(true).then(setOverlayPlacement).catch(() => {});
     } else {
-      // Shrinking is the opposite: the radial buttons are still flying home, and the
-      // overlay body is overflow:hidden, so a window this small would slice them
-      // mid-flight. Wait for them to land. Reopening clears the timer below, so a
-      // quick open/close/open never shrinks behind the surface's back.
-      shrink = window.setTimeout(() => {
+      // Keep the host interactive while the radial buttons fly home, then restore
+      // transparent-area passthrough. Reopening clears this pending hand-off.
+      releasePassthrough = window.setTimeout(() => {
         void window.nodus.nodiSetExpanded(false).then(setOverlayPlacement).catch(() => {});
       }, RADIAL_COLLAPSE_MS);
     }
     return () => {
-      window.clearTimeout(shrink);
+      window.clearTimeout(releasePassthrough);
     };
   }, [hasOpenSurface, isOverlay]);
 
@@ -472,6 +471,38 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     if (!isOverlay) return;
     return window.nodus.onNodiDismiss(closeAll);
   }, [closeAll, isOverlay]);
+
+  // The native overlay keeps its full bounds so macOS never stretches a compact
+  // backing surface while the radial menu opens. When no surface is open, make the
+  // transparent area click-through and reactivate only the figure itself. The
+  // preload uses synchronous IPC for this one mouse hit-test transition, preventing
+  // a fast first click from racing ahead of BrowserWindow.setIgnoreMouseEvents().
+  useEffect(() => {
+    if (!isOverlay) return;
+    let lastIgnore: boolean | null = null;
+    const setIgnore = (ignore: boolean) => {
+      if (lastIgnore === ignore) return;
+      lastIgnore = ignore;
+      void window.nodus.nodiSetMouseIgnore(ignore).catch(() => {});
+    };
+    const onMove = (event: MouseEvent) => {
+      if (hasOpenSurface || dragging) {
+        setIgnore(false);
+        return;
+      }
+      const figure = document.querySelector<HTMLElement>('.nodi-figure');
+      if (!figure) return;
+      const rect = figure.getBoundingClientRect();
+      const overFigure = event.clientX >= rect.left
+        && event.clientX < rect.right
+        && event.clientY >= rect.top
+        && event.clientY < rect.bottom;
+      setIgnore(!overFigure);
+    };
+    if (hasOpenSurface || dragging) setIgnore(false);
+    document.addEventListener('mousemove', onMove, true);
+    return () => document.removeEventListener('mousemove', onMove, true);
+  }, [dragging, hasOpenSurface, isOverlay]);
 
   // Click anywhere outside Nodi or its controls closes the menu/panels/bubble.
   useEffect(() => {
@@ -698,11 +729,8 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
 
   const anchorStyle: CSSProperties = isOverlay
     ? {
-        // Anchor to the window edges that stay next to Nodi while the transparent
-        // host grows and shrinks. Numeric left/top coordinates require a second
-        // React update after Electron changes the native bounds; for one compositor
-        // frame that left Nodi at (404,304) inside a 212x232 window, clipping the orb
-        // completely on close and making it jump diagonally on open.
+        // Preserve Nodi's screen-edge relationship while the stable native host is
+        // dragged between quadrants. The host itself never resizes when controls open.
         ...(overlayPlacement.horizontal === 'left'
           ? { right: Math.max(0, window.innerWidth - overlayPlacement.x - figureW) }
           : { left: overlayPlacement.x }),


### PR DESCRIPTION
Closes #31

## What changed

- Keep Nodi's transparent native host at stable 600×520 bounds while radial controls open and close.
- Use transparent-region mouse passthrough while Nodi is collapsed.
- Re-enable the native hit target synchronously on forwarded mouse movement so the first physical click cannot race the IPC round trip.
- Initialize the renderer from the native overlay placement before its first frame.
- Keep the desktop overlay compositor active when another macOS application owns focus.
- Remove the explicit Electron focus change when the radial controls open.
- Extend the regression and native overlay verification scripts.

## Root cause

The panel previously resized from 212×232 to 600×520. On macOS, AppKit could briefly present the compact backing surface from the expanded window origin before Chromium submitted its next frame. The resulting 388×288 delta exactly matched the diagonal/vertical displacement captured over the desktop and other applications.

## Impact

Nodi remains at the same screen coordinate with no native resize flash when controls open or close. This applies to orbital and classic modes and also preserves stable dragging at the left screen edge.

## Checks

- Rebased cleanly onto current `origin/main`
- 457/457 tests passed
- ESLint passed
- TypeScript checks passed
- Production build passed
- Native overlay verifier keeps the viewport at 600×520 and asserts unchanged screen position throughout open/collapse samples