### PR TITLE
Match Nodi controls to the app theme and vault accent

### DIFF
--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -213,6 +213,12 @@ test('Nodi drags in absolute screen space and closes through an animated context
   assert.match(component, /window\.innerWidth - overlayPlacement\.x - figureW/, 'the overlay anchor follows the stable native-window edge during horizontal resize');
   assert.match(component, /window\.innerHeight - overlayPlacement\.y - figureH/, 'the overlay anchor follows the stable native-window edge during vertical resize');
   assert.doesNotMatch(ipc, /if \(expanded\) win\.focus\(\)/, 'opening radial controls must not explicitly focus Electron over the active desktop app');
+  assert.match(component, /vaultTypeColor\(vaultType\)/, 'every Nodi surface inherits the active vault accent');
+  assert.match(component, /nodi-theme-\$\{lightUi \? 'light' : 'dark'\}/, 'all Nodi controls resolve one shared app theme');
+  assert.doesNotMatch(component, /nodi-light/, 'quick notes must not carry a panel-only light theme');
+  assert.match(companionCss, /\.nodi-theme-light \.nodi-node\s*\{[^}]*var\(--nodi-vault-accent/s, 'light radial actions use the vault accent');
+  assert.match(companionCss, /\.nodi-theme-light \.nodi-panel\s*\{[^}]*background:\s*#ffffff/s, 'chat, notifications and notes share the light panel surface');
+  assert.match(companionCss, /\.nodi-theme-light \.nodi-msg\.user\s*\{[^}]*var\(--nodi-vault-accent/s, 'light chat messages use the vault accent');
   assert.match(figure, /closing-accessory-smoke/);
   assert.match(figure, /closing-body-smoke/);
   for (const animation of ['nodi-close-limb', 'nodi-close-accessory', 'nodi-close-face', 'nodi-close-core', 'nodi-close-smoke']) {

--- a/scripts/verify-nodi-notes.mjs
+++ b/scripts/verify-nodi-notes.mjs
@@ -196,21 +196,63 @@ try {
   await page.waitForFunction(() => document.querySelectorAll('.nodi-note-row').length === 1);
   log('note deleted -> 1 remaining');
 
-  // ── Light theme screenshot ──────────────────────────────────────────────────
+  // ── Shared light theme + active-vault accent ────────────────────────────────
+  await page.evaluate(async () => {
+    const active = await window.nodus.getActiveVault();
+    await window.nodus.setVaultType(active.id, 'databases');
+    const bridge = await window.nodus.createVault({ name: 'Accent bridge', type: 'academic' });
+    await window.nodus.switchVault(bridge.vault.id);
+    await window.nodus.switchVault(active.id);
+  });
+  await page.waitForFunction(() => {
+    const root = document.querySelector('.nodi-companion');
+    return root && getComputedStyle(root).getPropertyValue('--nodi-vault-accent').trim() === '#b30333';
+  }, undefined, { timeout: 10_000 });
   await applyTheme('light');
-  await page.waitForFunction(() => document.querySelector('.nodi-notes-panel')?.classList.contains('nodi-light') ?? false, undefined, { timeout: 10_000 });
+  await page.waitForFunction(() => {
+    const root = document.querySelector('.nodi-companion');
+    return root?.getAttribute('data-nodi-theme') === 'light';
+  }, undefined, { timeout: 10_000 });
   await page.locator('.nodi-note-row').first().waitFor();
+  const lightNotesTheme = await page.locator('.nodi-notes-panel').evaluate((panel) => ({
+    background: getComputedStyle(panel).backgroundColor,
+  }));
+  assert.equal(lightNotesTheme.background, 'rgb(255, 255, 255)');
   await page.screenshot({ path: `${shots}/notes-5-list-light.png` });
   // open editor in light mode
   await page.locator('.nodi-note-open').first().click();
   await ta.waitFor();
+  const lightSaveBackground = await page.locator('.nodi-note-save').evaluate((button) => getComputedStyle(button).backgroundColor);
+  assert.equal(lightSaveBackground, 'rgb(179, 3, 51)', 'quick notes must use the databases-vault accent');
   await page.screenshot({ path: `${shots}/notes-6-editor-light.png` });
-  log('light theme verified');
+  log('light notes theme verified:', JSON.stringify({ ...lightNotesTheme, save: lightSaveBackground }));
+
+  // Notifications and chat use the same white surface and vault accent; quick
+  // notes is no longer the only light panel.
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Cerrar"]').click();
+  await openMenu();
+  await page.locator('[data-nodi-action="ntf"]').click();
+  const notificationPanel = page.locator('.nodi-panel');
+  await notificationPanel.waitFor();
+  assert.equal(await notificationPanel.evaluate((panel) => getComputedStyle(panel).backgroundColor), 'rgb(255, 255, 255)');
+  await notificationPanel.locator('.nodi-panel-head button[aria-label="Cerrar"]').click();
+  await openMenu();
+  await page.locator('[data-nodi-action="chat"]').click();
+  const chatPanel = page.locator('.nodi-chat-panel');
+  await chatPanel.waitFor();
+  const lightChatTheme = await chatPanel.evaluate((panel) => ({
+    background: getComputedStyle(panel).backgroundColor,
+    send: getComputedStyle(panel.querySelector('.nodi-chat-send')).backgroundColor,
+  }));
+  assert.equal(lightChatTheme.background, 'rgb(255, 255, 255)');
+  assert.equal(lightChatTheme.send, 'rgb(179, 3, 51)', 'chat action must use the databases-vault accent');
+  await chatPanel.locator('.nodi-panel-head button[title="Cerrar"]').click();
+  log('notifications + chat share the light theme:', JSON.stringify(lightChatTheme));
 
   // ── Always-on-top overlay ─────────────────────────────────────────────────
   // The same persisted note must be reachable from Nodi's independent desktop
   // window, where the extra "Open Nodus" action brings the radial count to five.
-  await page.evaluate(() => window.nodus.updateSettings({ mascotAlwaysOnTop: true, theme: 'dark' }));
+  await page.evaluate(() => window.nodus.updateSettings({ mascotAlwaysOnTop: true, theme: 'light' }));
   let overlay = null;
   for (let i = 0; i < 40 && !overlay; i++) {
     overlay = app.windows().find((candidate) => candidate.url().includes('mascot'));
@@ -224,19 +266,29 @@ try {
   await overlayFigure.click();
   await overlay.waitForFunction(() => document.querySelectorAll('.nodi-node.open').length === 5);
   await overlay.waitForTimeout(450);
-  const overlayGaps = await overlay.evaluate(() => {
+  const overlayMetrics = await overlay.evaluate(() => {
     const centres = [...document.querySelectorAll('.nodi-node.open')].map((node) => {
       const rect = node.getBoundingClientRect();
       return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
     });
-    return centres.slice(1).map((point, i) => Math.hypot(point.x - centres[i].x, point.y - centres[i].y));
+    const styles = [...document.querySelectorAll('.nodi-node.open')].map((node) => ({
+      background: getComputedStyle(node).backgroundColor,
+      color: getComputedStyle(node).color,
+      border: getComputedStyle(node).borderColor,
+    }));
+    return { gaps: centres.slice(1).map((point, i) => Math.hypot(point.x - centres[i].x, point.y - centres[i].y)), styles };
   });
-  overlayGaps.forEach((gap) => assert.ok(gap >= 57 && gap <= 59, `overlay radial centre gap should be 58px, got ${gap}`));
+  overlayMetrics.gaps.forEach((gap) => assert.ok(gap >= 57 && gap <= 59, `overlay radial centre gap should be 58px, got ${gap}`));
+  overlayMetrics.styles.forEach((style) => {
+    assert.equal(style.background, 'rgb(255, 255, 255)', 'every light radial action must have a white surface');
+    assert.equal(style.color, 'rgb(179, 3, 51)', 'every light radial icon must use the vault accent');
+    assert.equal(style.border, 'rgb(179, 3, 51)', 'every light radial border must use the vault accent');
+  });
   await overlay.locator('[data-nodi-action="notes"]').click();
   await overlay.locator('.nodi-notes-panel').waitFor();
   assert.equal(await overlay.locator('.nodi-note-row').count(), 1, 'saved note should be shared with the overlay');
-  await overlay.screenshot({ path: `${shots}/notes-7-overlay-dark.png` });
-  log('always-on-top overlay verified ->', overlayGaps.map((gap) => gap.toFixed(1)).join(', '));
+  await overlay.screenshot({ path: `${shots}/notes-7-overlay-light.png` });
+  log('always-on-top overlay verified ->', overlayMetrics.gaps.map((gap) => gap.toFixed(1)).join(', '));
 
   log('ALL CHECKS PASSED. Shots in', shots);
 } finally {

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import type { AppSettings, ModelRef, NodiChatMessage, NodiContextKind, NodiConversation, NodiNote, NodiNotification, NodiOverlayPlacement, VaultType } from '@shared/types';
+import { vaultTypeColor } from '@shared/vaultTypes';
 import { type NodiRole, type NodiState } from './Nodi';
 import { NodiAvatar } from './NodiAvatar';
 import { Markdown } from '../Markdown';
@@ -172,8 +173,8 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const noteRef = useRef({ id: activeNoteId, draft: noteDraft, dirty: noteDirty });
   noteRef.current = { id: activeNoteId, draft: noteDraft, dirty: noteDirty };
 
-  // Light/dark for the notes panel is driven locally (self-contained modifier class)
-  // so it looks right in both the app and the theme-less always-on-top overlay.
+  // Resolve the app theme locally so the independent always-on-top renderer receives
+  // the same surface treatment as in-window Nodi.
   const [systemDark, setSystemDark] = useState(() =>
     typeof window !== 'undefined' && window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)').matches : true
   );
@@ -183,7 +184,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     mq.addEventListener('change', on);
     return () => mq.removeEventListener('change', on);
   }, []);
-  const notesLight = settings ? settings.theme === 'light' || (settings.theme === 'system' && !systemDark) : false;
+  const lightUi = settings ? settings.theme === 'light' || (settings.theme === 'system' && !systemDark) : false;
 
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const [overlayPlacement, setOverlayPlacement] = useState<NodiOverlayPlacement>(() => (
@@ -721,11 +722,17 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     }
   };
 
-  const rootStyle: CSSProperties = isOverlay
+  const rootPositionStyle: CSSProperties = isOverlay
     ? { position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 2147483000 }
     : pos
       ? { position: 'fixed', left: pos.x, top: pos.y, width: figureW, height: figureH, pointerEvents: 'none', zIndex: 45 }
       : { display: 'none' };
+  const rootStyle = {
+    ...rootPositionStyle,
+    // The vault registry is the same colour source used by the app shell, switcher,
+    // dock icon and orb. Keeping it on the root lets every Nodi surface inherit it.
+    ['--nodi-vault-accent' as string]: vaultTypeColor(vaultType),
+  } as CSSProperties;
 
   const anchorStyle: CSSProperties = isOverlay
     ? {
@@ -770,7 +777,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   };
 
   return (
-    <div className="nodi-companion" style={rootStyle}>
+    <div className={`nodi-companion nodi-theme-${lightUi ? 'light' : 'dark'}`} data-nodi-theme={lightUi ? 'light' : 'dark'} style={rootStyle}>
       <div className={`nodi-anchor open-${horizontal} open-${vertical}`} style={anchorStyle}>
         {helpOpen && (
           <div className="nodi-bubble" data-nodi-interactive>
@@ -903,7 +910,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
         )}
 
         {panel === 'notes' && (
-          <div className={`nodi-panel nodi-notes-panel${notesLight ? ' nodi-light' : ''}`} data-nodi-interactive style={{ height: 460 }}>
+          <div className="nodi-panel nodi-notes-panel" data-nodi-interactive style={{ height: 460 }}>
             <div className="nodi-panel-head">
               {noteView === 'editor' && (
                 <button className="nodi-head-icon" onClick={backToNotes} title={t('Volver')} aria-label={t('Volver')}><Icon name="arrowLeft" size={15} /></button>

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -728,67 +728,191 @@
 .nodi-note-textarea::-webkit-scrollbar-thumb,
 .nodi-note-preview::-webkit-scrollbar-thumb { background: #596579; border: 2px solid #111824; border-radius: 999px; }
 
-/* Light mode — self-contained so it also holds in the theme-less overlay window */
-.nodi-notes-panel.nodi-light {
+/* Shared light mode — driven by Nodus' resolved theme and the active vault accent.
+ * Dark mode deliberately keeps the original navy/gold Nodi identity above. */
+.nodi-theme-light .nodi-node {
+  border-color: var(--nodi-vault-accent, #6366f1);
+  background: #ffffff;
+  color: var(--nodi-vault-accent, #6366f1);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, .18), 0 0 14px color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 18%, transparent);
+}
+.nodi-theme-light .nodi-node:hover { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 8%, #ffffff); }
+.nodi-theme-light .nodi-node:focus-visible { outline-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 55%, #ffffff); }
+.nodi-theme-light .nodi-node-label {
+  color: var(--nodi-vault-accent, #6366f1);
+  background: rgba(255, 255, 255, .97);
+  border-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 42%, transparent);
+  box-shadow: 0 5px 16px rgba(15, 23, 42, .12);
+}
+.nodi-theme-light .nodi-node-badge { box-shadow: 0 0 0 2px #ffffff; }
+.nodi-theme-light .nodi-bubble {
+  border-color: var(--nodi-vault-accent, #6366f1);
+  color: #334155;
+  background: #ffffff;
+}
+.nodi-theme-light .nodi-bubble h4 { color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-bubble::after { border-left-color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-anchor.open-right .nodi-bubble::after { border-right-color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-bubble::before { border-left-color: #ffffff; }
+.nodi-theme-light .nodi-anchor.open-right .nodi-bubble::before { border-right-color: #ffffff; }
+
+.nodi-theme-light .nodi-panel {
   background: #ffffff;
   color: #1f2937;
-  border-color: rgba(15, 23, 42, 0.12);
+  border-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 38%, transparent);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, .18);
+}
+.nodi-theme-light .nodi-panel-head { border-bottom-color: rgba(15, 23, 42, .08); color: #1f2937; }
+.nodi-theme-light .nodi-panel-head button { color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-panel-head button:hover {
+  color: var(--nodi-vault-accent, #6366f1);
+  background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 10%, transparent);
+}
+.nodi-theme-light .nodi-panel-head button.nodi-head-icon.active {
+  color: var(--nodi-vault-accent, #6366f1);
+  background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 14%, transparent);
+}
+.nodi-theme-light .nodi-context-button > span { background: var(--nodi-vault-accent, #6366f1); color: #ffffff; }
+.nodi-theme-light .nodi-ntf.unread { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 9%, transparent); }
+.nodi-theme-light .nodi-ntf-body { color: #64748b; }
+.nodi-theme-light .nodi-ntf-time,
+.nodi-theme-light .nodi-empty,
+.nodi-theme-light .nodi-chat-status,
+.nodi-theme-light .nodi-typing { color: #94a3b8; }
+
+.nodi-theme-light .nodi-msg.user { background: var(--nodi-vault-accent, #6366f1); color: #ffffff; }
+.nodi-theme-light .nodi-msg.assistant { background: #f1f5f9; color: #1f2937; }
+.nodi-theme-light .nodi-msg .md h1,
+.nodi-theme-light .nodi-msg .md h2,
+.nodi-theme-light .nodi-msg .md h3,
+.nodi-theme-light .nodi-msg .md h4 { color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-msg .md blockquote { border-left-color: var(--nodi-vault-accent, #6366f1); color: #64748b; }
+.nodi-theme-light .nodi-msg .md code { background: #e2e8f0; color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-msg .md pre { border-color: rgba(15, 23, 42, .1); background: #f8fafc; }
+.nodi-theme-light .nodi-msg .md pre code { color: #1f2937; }
+.nodi-theme-light .nodi-msg .md th,
+.nodi-theme-light .nodi-msg .md td { border-color: rgba(15, 23, 42, .12); }
+.nodi-theme-light .nodi-msg .md th { color: #1f2937; background: #f1f5f9; }
+.nodi-theme-light .nodi-msg .md a { color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-chat-foot { border-top-color: rgba(15, 23, 42, .08); }
+.nodi-theme-light .nodi-chat-input {
+  background: #f8fafc;
+  color: #1f2937;
+  border-color: rgba(15, 23, 42, .14);
+}
+.nodi-theme-light .nodi-chat-input::placeholder { color: #94a3b8; }
+.nodi-theme-light .nodi-chat-input:focus { border-color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-chat-send { background: var(--nodi-vault-accent, #6366f1); color: #ffffff; }
+.nodi-theme-light .nodi-chat-send:hover:not(:disabled) { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 84%, #000000); }
+.nodi-theme-light .nodi-chat-tool { border-bottom-color: rgba(15, 23, 42, .08); background: #f8fafc; color: #1f2937; }
+.nodi-theme-light .nodi-tool-title { color: #64748b; }
+.nodi-theme-light .nodi-tool-empty { color: #94a3b8; }
+.nodi-theme-light .nodi-chat-tool .input,
+.nodi-theme-light .nodi-chat-tool select,
+.nodi-theme-light .nodi-chat-tool .model-picker-trigger {
+  border-color: rgba(15, 23, 42, .14);
+  background: #ffffff;
+  color: #1f2937;
+}
+.nodi-theme-light .nodi-chat-tool .model-picker-trigger:hover { border-color: var(--nodi-vault-accent, #6366f1); background: #ffffff; }
+.nodi-theme-light .nodi-chat-tool .model-picker-options { border-color: rgba(15, 23, 42, .14); background: #ffffff; }
+.nodi-theme-light .nodi-chat-tool .model-picker-options button { color: #475569; }
+.nodi-theme-light .nodi-chat-tool .model-picker-options button:hover { background: #f1f5f9; color: #1f2937; }
+.nodi-theme-light .nodi-chat-tool .model-picker-options button.selected {
+  background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 12%, transparent);
+  color: var(--nodi-vault-accent, #6366f1);
+}
+.nodi-theme-light .nodi-history-row { color: #64748b; }
+.nodi-theme-light .nodi-history-row:hover,
+.nodi-theme-light .nodi-history-row.active {
+  background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 10%, transparent);
+  color: var(--nodi-vault-accent, #6366f1);
+}
+.nodi-theme-light .nodi-history-copy small,
+.nodi-theme-light .nodi-context-grid small,
+.nodi-theme-light .nodi-visibility-row { color: #64748b; }
+.nodi-theme-light .nodi-context-grid b,
+.nodi-theme-light .nodi-visibility-row b { color: #1f2937; }
+.nodi-theme-light .nodi-context-grid label:hover { background: #f1f5f9; }
+.nodi-theme-light .nodi-context-grid input[type='checkbox'] {
+  border-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 65%, transparent);
+  background: #ffffff;
+}
+.nodi-theme-light .nodi-context-grid input[type='checkbox']:hover { border-color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-context-grid input[type='checkbox']:checked { background: var(--nodi-vault-accent, #6366f1); border-color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-context-grid input[type='checkbox']:checked::after { border-color: #ffffff; }
+.nodi-theme-light .nodi-open-settings {
+  border-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 35%, transparent);
+  background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 8%, transparent);
+  color: var(--nodi-vault-accent, #6366f1);
+}
+.nodi-theme-light .nodi-open-settings:hover { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 14%, transparent); }
+.nodi-theme-light .nodi-confirm-overlay { background: rgba(15, 23, 42, .28); }
+.nodi-theme-light .nodi-confirm-dialog {
+  background: #ffffff;
+  border-color: rgba(15, 23, 42, .12);
+  color: #1f2937;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .2);
+}
+.nodi-theme-light .nodi-confirm-dialog p { color: #64748b; }
+.nodi-theme-light .nodi-confirm-dialog button { border-color: rgba(15, 23, 42, .14); background: #f1f5f9; color: #1f2937; }
+.nodi-theme-light .nodi-confirm-dialog button:hover { background: #e2e8f0; }
+.nodi-theme-light .nodi-context-menu {
+  border-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 35%, transparent);
+  background: rgba(255, 255, 255, .98);
+  color: #1f2937;
+  box-shadow: 0 14px 36px rgba(15, 23, 42, .18);
+}
+.nodi-theme-light .nodi-context-menu small { color: #64748b; }
+
+/* Quick notes light details. They now inherit the same theme as every other Nodi panel. */
+.nodi-theme-light .nodi-notes-panel {
+  background: #ffffff;
+  color: #1f2937;
+  border-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 38%, transparent);
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.18);
 }
-.nodi-notes-panel.nodi-light .nodi-panel-head { border-bottom-color: rgba(15, 23, 42, 0.08); color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-panel-head button { color: #64748b; }
-.nodi-notes-panel.nodi-light .nodi-panel-head button:hover { color: #b8860b; background: rgba(15, 23, 42, 0.05); }
-.nodi-notes-panel.nodi-light .nodi-panel-head button.nodi-head-icon.active { color: #b8860b; background: rgba(184, 134, 11, 0.12); }
-.nodi-notes-panel.nodi-light .nodi-notes-search { border-bottom-color: rgba(15, 23, 42, 0.08); color: #64748b; }
-.nodi-notes-panel.nodi-light .nodi-notes-search input { color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-notes-search input::placeholder { color: #94a3b8; }
-.nodi-notes-panel.nodi-light .nodi-notes-search button { color: #94a3b8; }
-.nodi-notes-panel.nodi-light .nodi-notes-search button:hover { background: rgba(15, 23, 42, 0.06); color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-note-row:hover { background: rgba(184, 134, 11, 0.1); }
-.nodi-notes-panel.nodi-light .nodi-note-title { color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-note-snippet { color: #64748b; }
-.nodi-notes-panel.nodi-light .nodi-note-time { color: #94a3b8; }
-.nodi-notes-panel.nodi-light .nodi-note-delete { color: #94a3b8; }
-.nodi-notes-panel.nodi-light .nodi-note-delete:hover { background: rgba(239, 68, 68, 0.12); color: #dc2626; }
-.nodi-notes-panel.nodi-light .nodi-empty { color: #94a3b8; }
-.nodi-notes-panel.nodi-light .nodi-note-toolbar { background: #f8fafc; border-bottom-color: rgba(15, 23, 42, 0.08); }
-.nodi-notes-panel.nodi-light .nodi-note-tool { color: #64748b; }
-.nodi-notes-panel.nodi-light .nodi-note-tool:hover { background: rgba(184, 134, 11, 0.14); color: #92710f; }
-.nodi-notes-panel.nodi-light .nodi-note-textarea { background: #ffffff; color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-note-textarea::placeholder { color: #94a3b8; }
-.nodi-notes-panel.nodi-light .nodi-note-preview { color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-note-preview .md h1,
-.nodi-notes-panel.nodi-light .nodi-note-preview .md h2,
-.nodi-notes-panel.nodi-light .nodi-note-preview .md h3,
-.nodi-notes-panel.nodi-light .nodi-note-preview .md h4 { color: #92710f; }
-.nodi-notes-panel.nodi-light .nodi-note-preview .md blockquote { border-left-color: #b8860b; color: #64748b; }
-.nodi-notes-panel.nodi-light .nodi-note-preview .md code { background: #f1f5f9; color: #92710f; }
-.nodi-notes-panel.nodi-light .nodi-note-preview .md pre { background: #f1f5f9; border-color: rgba(15, 23, 42, 0.1); }
-.nodi-notes-panel.nodi-light .nodi-note-preview .md pre code { color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-note-preview .md a { color: #2563eb; }
-.nodi-notes-panel.nodi-light .nodi-note-foot { border-top-color: rgba(15, 23, 42, 0.08); }
-.nodi-notes-panel.nodi-light .nodi-note-state { color: #94a3b8; }
-.nodi-notes-panel.nodi-light .nodi-note-remove { border-color: rgba(239, 68, 68, 0.28); background: rgba(239, 68, 68, 0.08); color: #dc2626; }
-.nodi-notes-panel.nodi-light .nodi-note-remove:hover { background: rgba(239, 68, 68, 0.16); color: #b91c1c; }
-.nodi-notes-panel.nodi-light .nodi-note-save { background: #c79a2e; color: #ffffff; }
-.nodi-notes-panel.nodi-light .nodi-note-save:hover:not(:disabled) { background: #b8860b; }
-.nodi-notes-panel.nodi-light .nodi-notes-list,
-.nodi-notes-panel.nodi-light .nodi-note-textarea,
-.nodi-notes-panel.nodi-light .nodi-note-preview { scrollbar-color: #cbd5e1 #eef2f7; }
-.nodi-notes-panel.nodi-light .nodi-notes-list::-webkit-scrollbar-track,
-.nodi-notes-panel.nodi-light .nodi-note-textarea::-webkit-scrollbar-track,
-.nodi-notes-panel.nodi-light .nodi-note-preview::-webkit-scrollbar-track { background: #eef2f7; }
-.nodi-notes-panel.nodi-light .nodi-notes-list::-webkit-scrollbar-thumb,
-.nodi-notes-panel.nodi-light .nodi-note-textarea::-webkit-scrollbar-thumb,
-.nodi-notes-panel.nodi-light .nodi-note-preview::-webkit-scrollbar-thumb { background: #cbd5e1; border-color: #eef2f7; }
-.nodi-notes-panel.nodi-light .nodi-confirm-overlay { background: rgba(15, 23, 42, 0.28); }
-.nodi-notes-panel.nodi-light .nodi-confirm-dialog { background: #ffffff; border-color: rgba(15, 23, 42, 0.12); color: #1f2937; box-shadow: 0 18px 45px rgba(15, 23, 42, 0.2); }
-.nodi-notes-panel.nodi-light .nodi-confirm-dialog > svg { color: #dc2626; }
-.nodi-notes-panel.nodi-light .nodi-confirm-dialog p { color: #64748b; }
-.nodi-notes-panel.nodi-light .nodi-confirm-dialog button { border-color: rgba(15, 23, 42, 0.14); background: #f1f5f9; color: #1f2937; }
-.nodi-notes-panel.nodi-light .nodi-confirm-dialog button:hover { background: #e2e8f0; }
-.nodi-notes-panel.nodi-light .nodi-confirm-dialog button.danger { border-color: rgba(220, 38, 38, 0.35); background: rgba(220, 38, 38, 0.1); color: #b91c1c; }
-.nodi-notes-panel.nodi-light .nodi-confirm-dialog button.danger:hover { background: rgba(220, 38, 38, 0.18); }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-search { border-bottom-color: rgba(15, 23, 42, 0.08); color: #64748b; }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-search input { color: #1f2937; }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-search input::placeholder { color: #94a3b8; }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-search button { color: #94a3b8; }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-search button:hover { background: rgba(15, 23, 42, 0.06); color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-row:hover { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 10%, transparent); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-title { color: #1f2937; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-snippet { color: #64748b; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-time { color: #94a3b8; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-delete { color: #94a3b8; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-delete:hover { background: rgba(239, 68, 68, 0.12); color: #dc2626; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-toolbar { background: #f8fafc; border-bottom-color: rgba(15, 23, 42, 0.08); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-tool { color: #64748b; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-tool:hover { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 14%, transparent); color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-textarea { background: #ffffff; color: #1f2937; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-textarea::placeholder { color: #94a3b8; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview { color: #1f2937; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md h1,
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md h2,
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md h3,
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md h4 { color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md blockquote { border-left-color: var(--nodi-vault-accent, #6366f1); color: #64748b; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md code { background: #f1f5f9; color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md pre { background: #f1f5f9; border-color: rgba(15, 23, 42, 0.1); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md pre code { color: #1f2937; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview .md a { color: var(--nodi-vault-accent, #6366f1); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-foot { border-top-color: rgba(15, 23, 42, 0.08); }
+.nodi-theme-light .nodi-notes-panel .nodi-note-state { color: #94a3b8; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-remove { border-color: rgba(239, 68, 68, 0.28); background: rgba(239, 68, 68, 0.08); color: #dc2626; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-remove:hover { background: rgba(239, 68, 68, 0.16); color: #b91c1c; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-save { background: var(--nodi-vault-accent, #6366f1); color: #ffffff; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-save:hover:not(:disabled) { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 84%, #000000); }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-list,
+.nodi-theme-light .nodi-notes-panel .nodi-note-textarea,
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview { scrollbar-color: #cbd5e1 #eef2f7; }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-list::-webkit-scrollbar-track,
+.nodi-theme-light .nodi-notes-panel .nodi-note-textarea::-webkit-scrollbar-track,
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview::-webkit-scrollbar-track { background: #eef2f7; }
+.nodi-theme-light .nodi-notes-panel .nodi-notes-list::-webkit-scrollbar-thumb,
+.nodi-theme-light .nodi-notes-panel .nodi-note-textarea::-webkit-scrollbar-thumb,
+.nodi-theme-light .nodi-notes-panel .nodi-note-preview::-webkit-scrollbar-thumb { background: #cbd5e1; border-color: #eef2f7; }
 
 @keyframes nodi-badge-pop { 0% { transform: scale(0); } 70% { transform: scale(1.3); } 100% { transform: scale(1); } }
 @keyframes nodi-bubble-pop { 0% { opacity: 0; transform: scale(0.6) translateY(8px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }


### PR DESCRIPTION
Closes #33

## What changed

- Resolve one shared light/dark class for every Nodi surface in both the app and always-on-top renderer.
- Source `--nodi-vault-accent` from the shared vault-type colour registry.
- Give all radial actions white surfaces with vault-coloured icons and borders in light mode.
- Apply the same white/accent treatment to Quick Notes, Chat and Notifications.
- Preserve the existing navy/gold appearance in dark mode.
- Extend the visual verifier to exercise all three panels and all five always-on-top actions.

## Why

Quick Notes had its own panel-only light modifier and fixed gold values. Chat, Notifications and the radial actions remained dark regardless of the app theme, so Nodi mixed incompatible surfaces in the same interaction.

## Impact

Nodi now follows the selected app theme consistently. In light mode its primary controls immediately reflect the active vault (for example academic indigo, genealogy gold or databases crimson); dark mode is visually unchanged.

## Checks

- 457/457 repository tests passed
- Nodi regression tests passed
- ESLint passed
- TypeScript checks passed
- Production build passed
- Visual Electron verification passed for Notes, Chat, Notifications, four app actions and five always-on-top actions