### PR TITLE
Center orbital Nodi on the tutorial language screen

### DIFF
--- a/scripts/test-basics-tutorial.mjs
+++ b/scripts/test-basics-tutorial.mjs
@@ -36,6 +36,7 @@ test('essential tutorial is global, seen-once, skippable with confirmation and r
   assert.match(css, /\.tutorial-cinema\.tutorial-language-screen/);
   assert.match(css, /place-items: center/);
   assert.match(css, /\.tutorial-language-option/);
+  assert.match(css, /\.tutorial-language-card > \.nodi-svg,\s*\.tutorial-language-card > \.nodi-orb\s*\{[^}]*margin-inline: auto/s, 'classic and orbital Nodi are both centred on the language screen');
   assert.match(css, /grid-template-columns: repeat\(auto-fit, 145px\)/);
   assert.match(css, /height: 3\.5rem/);
   assert.match(css, /width: 100%/);

--- a/src/index.css
+++ b/src/index.css
@@ -920,7 +920,8 @@ body {
   backdrop-filter: blur(18px);
 }
 
-.tutorial-language-card .nodi-svg {
+.tutorial-language-card > .nodi-svg,
+.tutorial-language-card > .nodi-orb {
   margin-inline: auto;
 }
 


### PR DESCRIPTION
Closes #38

## What changed

- Center both direct Nodi avatar roots on the tutorial language card.
- Add a regression assertion covering classic `.nodi-svg` and orbital `.nodi-orb`.

## Root cause

The language card applied automatic inline margins only to the classic mascot class. The orbital SVG is a block with a different root class and therefore remained aligned to the start of the card.

## Impact

Classic and orbital Nodi now share the same horizontal center as the brand, heading and language grid.

## Checks

- Tutorial regression tests: 3/3 passed
- Diff whitespace check passed
- Verified visually in the running Electron app with orbital Nodi centered