### PR TITLE
Fix database cell fitting, AI editing, and record themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "verify:nodi-overlay": "npm run build && node scripts/verify-nodi-overlay.mjs",
     "verify:study-whisper": "node scripts/verify-study-whisper.mjs",
     "verify:study-improve-local": "node scripts/verify-study-improve-local.mjs",
+    "verify:database-records": "node scripts/verify-database-records.mjs",
     "verify:api-key-recovery-macos": "node scripts/verify-api-key-recovery-macos.mjs",
     "verify:toolkit-heic": "node scripts/verify-toolkit-heic.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p electron/tsconfig.json",

--- a/scripts/verify-database-records.mjs
+++ b/scripts/verify-database-records.mjs
@@ -1,0 +1,172 @@
+// Focused Electron regression for database fit-to-content rows, editable AI text,
+// and the full-record modal palette. Uses a throwaway profile and never touches the
+// user's vaults.
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const appVersion = require(path.join(repoRoot, 'package.json')).version;
+const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-db-records-'));
+const screenshotDir = process.env.SHOT_OUT || os.tmpdir();
+const longNote = 'Observación extensa del hábitat: la muestra crecía bajo un dosel muy cerrado, junto a un arroyo de corriente lenta y sobre un sustrato permanentemente húmedo.';
+const generatedSummary = 'Resumen generado por IA que el usuario debe poder revisar, corregir y guardar manualmente como cualquier otra celda de texto.';
+const editedSummary = 'Resumen de IA revisado manualmente y guardado por el usuario.';
+
+if (!existsSync(path.join(repoRoot, 'dist-electron/main.js')) || !existsSync(path.join(repoRoot, 'dist/index.html'))) {
+  throw new Error('Run `npm run build` before this focused verification.');
+}
+
+const childEnv = {
+  ...process.env,
+  NODUS_USERDATA: userData,
+  NODUS_DISABLE_AUTO_UPDATE: '1',
+  NODUS_E2E_UPDATE_STATUS: 'not-available',
+};
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+async function closeElectronApp(instance) {
+  if (!instance) return;
+  const child = instance.process();
+  let timeout;
+  const closed = instance.close().then(() => true, () => false);
+  const closedCleanly = await Promise.race([
+    closed,
+    new Promise((resolve) => { timeout = setTimeout(() => resolve(false), 5_000); }),
+  ]);
+  clearTimeout(timeout);
+  if (!closedCleanly && child.exitCode === null && !child.killed) child.kill('SIGKILL');
+}
+
+let app;
+try {
+  app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
+  console.log('[database-records] Electron launched');
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(20_000);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+  await page.evaluate((version) => {
+    localStorage.setItem('nodus.lastSeenVersion', version);
+    sessionStorage.setItem('nodus.startupUpdateChecked', '1');
+  }, appVersion);
+  await page.evaluate(async () => {
+    await window.nodus.seedDatabasesDemoData();
+    // Seeding deliberately re-enables the guided Databases tour for real demo
+    // users, so test preferences must be applied afterwards.
+    await window.nodus.updateSettings({
+      onboardingComplete: true,
+      basicsTutorialVersion: 3,
+      recoverySetupVersion: 1,
+      tourComplete: true,
+      advancedTourComplete: true,
+      databasesTourComplete: true,
+      mascotEnabled: false,
+      theme: 'light',
+      uiLanguage: 'es',
+    });
+  });
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor();
+  console.log('[database-records] Demo profile ready');
+
+  const ids = await page.evaluate(async ({ note, summary }) => {
+    const database = (await window.nodus.listDatabases()).find((item) => item.name === 'Muestras de campo');
+    if (!database) throw new Error('demo database does not exist');
+    const detail = await window.nodus.getDatabaseDetail(database.id);
+    const rows = await window.nodus.listDatabaseRows(database.id, { sort: 'position' });
+    const notes = detail.columns.find((column) => column.name === 'Notas');
+    const ai = detail.columns.find((column) => column.name === 'Resumen IA');
+    if (!notes || !ai || !rows[0]) throw new Error('demo row or target columns do not exist');
+    await window.nodus.setDatabaseCell(rows[0].id, notes.id, note);
+    await window.nodus.setDatabaseCell(rows[0].id, ai.id, summary);
+    return { databaseId: database.id, rowId: rows[0].id, notesId: notes.id, aiId: ai.id };
+  }, { note: longNote, summary: generatedSummary });
+
+  await page.getByText('Muestras de campo', { exact: true }).first().click();
+  await page.getByTitle(longNote).waitFor();
+  console.log('[database-records] Database table open');
+
+  // Fit via the real column menu, then verify the persisted flag and unclipped row.
+  await page.getByRole('main').getByRole('button', { name: 'Notas', exact: true }).click();
+  await page.getByText('Ajustar al contenido', { exact: true }).click();
+  await page.waitForFunction(async (columnId) => {
+    const databases = await window.nodus.listDatabases();
+    for (const database of databases) {
+      const detail = await window.nodus.getDatabaseDetail(database.id);
+      const column = detail?.columns.find((candidate) => candidate.id === columnId);
+      if (column) return column.config.fitContent === true;
+    }
+    return false;
+  }, ids.notesId);
+  const fittedCell = page.getByTitle(longNote);
+  const fittedLayout = await fittedCell.evaluate((element) => ({
+    height: element.getBoundingClientRect().height,
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    whiteSpace: getComputedStyle(element).whiteSpace,
+  }));
+  assert.ok(fittedLayout.height > 40, `fitted row grows beyond one line (${fittedLayout.height}px)`);
+  assert.ok(fittedLayout.scrollHeight <= fittedLayout.clientHeight + 1, 'fitted text is not vertically clipped');
+  assert.notEqual(fittedLayout.whiteSpace, 'nowrap', 'fitted text wraps');
+  console.log('[database-records] Fit-to-content verified');
+
+  // An AI value opens the same full-text editor and persists a manual revision.
+  await page.getByTitle(generatedSummary).click();
+  const aiEditor = page.locator('textarea');
+  await aiEditor.fill(editedSummary);
+  await page.getByRole('button', { name: 'Guardar', exact: true }).click();
+  await page.waitForFunction(async ({ rowId, columnId, expected }) => {
+    const row = await window.nodus.getDatabaseRow(rowId);
+    return row?.cells[columnId] === expected;
+  }, { rowId: ids.rowId, columnId: ids.aiId, expected: editedSummary });
+  console.log('[database-records] AI text editing verified');
+
+  // Open the full record and inspect the explicit light Databases palette.
+  await page.getByRole('button', { name: 'Galería', exact: true }).click();
+  await page.getByText('Musgo alpino', { exact: true }).click();
+  const modal = page.getByTestId('database-record-modal');
+  await modal.waitFor();
+  const lightPalette = await modal.evaluate((element) => ({
+    modal: getComputedStyle(element).backgroundColor,
+    header: getComputedStyle(element.querySelector('.database-record-header')).backgroundColor,
+    field: getComputedStyle(element.querySelector('.database-record-field')).backgroundColor,
+  }));
+  assert.equal(lightPalette.modal, 'rgb(255, 250, 251)');
+  assert.equal(lightPalette.header, 'rgb(255, 241, 244)');
+  assert.equal(lightPalette.field, 'rgb(255, 245, 247)');
+  await page.screenshot({ path: path.join(screenshotDir, 'database-record-light.png') });
+  console.log('[database-records] Light record palette verified');
+
+  // The same semantic surfaces must remain crimson in dark mode.
+  await page.evaluate(() => window.nodus.updateSettings({ theme: 'dark' }));
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor();
+  await page.getByText('Muestras de campo', { exact: true }).first().click();
+  await page.getByRole('button', { name: 'Galería', exact: true }).click();
+  await page.getByText('Musgo alpino', { exact: true }).click();
+  const darkModal = page.getByTestId('database-record-modal');
+  await darkModal.waitFor();
+  const darkPalette = await darkModal.evaluate((element) => ({
+    modal: getComputedStyle(element).backgroundColor,
+    header: getComputedStyle(element.querySelector('.database-record-header')).backgroundColor,
+  }));
+  assert.equal(darkPalette.modal, 'rgb(25, 7, 13)');
+  assert.notEqual(darkPalette.header, 'rgb(23, 23, 23)', 'header does not fall back to neutral grey');
+  await page.screenshot({ path: path.join(screenshotDir, 'database-record-dark.png') });
+
+  console.log(`Database record verification passed. Screenshots: ${screenshotDir}`);
+} finally {
+  await closeElectronApp(app);
+  await rm(userData, { recursive: true, force: true });
+}
+
+// Playwright can retain a closed transport handle on macOS after a forced Electron
+// shutdown; the focused verifier has no further asynchronous work at this point.
+process.exit(0);

--- a/shared/databases.ts
+++ b/shared/databases.ts
@@ -97,6 +97,8 @@ export interface DatabaseColumnConfig {
   numberFormat?: 'plain' | 'integer' | 'decimal';
   /** Column width in px (user-resized); falls back to a per-type default. */
   width?: number;
+  /** Show the complete cell value, wrapping it and growing the row when necessary. */
+  fitContent?: boolean;
   /** ai columns: the user prompt, whether it auto-recomputes, and an optional source. */
   aiPrompt?: string;
   aiAuto?: boolean;

--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -3,7 +3,7 @@ import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 interface VirtualListProps<T> {
   items: T[];
-  itemHeight: number;
+  itemHeight: number | ((item: T, index: number) => number);
   renderItem: (item: T, index: number) => React.ReactNode;
   getKey: (item: T, index: number) => React.Key;
   className?: string;
@@ -36,19 +36,50 @@ export function VirtualList<T>({
     return () => ro.disconnect();
   }, []);
 
+  const variableLayout = useMemo(() => {
+    if (typeof itemHeight === 'number') return null;
+    const count = items.length;
+    const heights = items.map((item, index) => Math.max(1, itemHeight(item, index)));
+    const offsets = new Array<number>(count + 1);
+    offsets[0] = 0;
+    for (let index = 0; index < count; index += 1) offsets[index + 1] = offsets[index] + heights[index];
+    return { heights, offsets };
+  }, [itemHeight, items]);
+
   const { start, end, offset, totalHeight } = useMemo(() => {
     const count = items.length;
-    const capacity = Math.ceil(viewportHeight / itemHeight) + overscan * 2;
-    const rawFirst = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
-    const first = Math.min(rawFirst, Math.max(0, count - capacity));
-    const last = Math.min(count, Math.ceil((scrollTop + viewportHeight) / itemHeight) + overscan);
+    if (!variableLayout) {
+      const fixedHeight = itemHeight as number;
+      const capacity = Math.ceil(viewportHeight / fixedHeight) + overscan * 2;
+      const rawFirst = Math.max(0, Math.floor(scrollTop / fixedHeight) - overscan);
+      const first = Math.min(rawFirst, Math.max(0, count - capacity));
+      const last = Math.min(count, Math.ceil((scrollTop + viewportHeight) / fixedHeight) + overscan);
+      return { start: first, end: last, offset: first * fixedHeight, totalHeight: count * fixedHeight };
+    }
+    const { offsets } = variableLayout;
+
+    // First item whose bottom is below the requested scroll position. This keeps
+    // virtualisation intact even when fitted database rows have different heights.
+    const indexAt = (position: number) => {
+      let low = 0;
+      let high = count;
+      while (low < high) {
+        const middle = Math.floor((low + high) / 2);
+        if (offsets[middle + 1] <= position) low = middle + 1;
+        else high = middle;
+      }
+      return Math.min(low, Math.max(0, count - 1));
+    };
+    const first = count === 0 ? 0 : Math.max(0, indexAt(scrollTop) - overscan);
+    const lastVisible = count === 0 ? 0 : indexAt(scrollTop + viewportHeight);
+    const last = Math.min(count, lastVisible + overscan + 1);
     return {
       start: first,
       end: last,
-      offset: first * itemHeight,
-      totalHeight: count * itemHeight,
+      offset: offsets[first],
+      totalHeight: offsets[count],
     };
-  }, [itemHeight, items.length, overscan, scrollTop, viewportHeight]);
+  }, [itemHeight, items.length, overscan, scrollTop, variableLayout, viewportHeight]);
 
   const visibleItems = items.slice(start, end);
 
@@ -67,7 +98,7 @@ export function VirtualList<T>({
             {visibleItems.map((item, localIndex) => {
               const index = start + localIndex;
               return (
-                <div key={getKey(item, index)} style={{ height: itemHeight }}>
+                <div key={getKey(item, index)} style={{ height: variableLayout?.heights[index] ?? (itemHeight as number) }}>
                   {renderItem(item, index)}
                 </div>
               );

--- a/src/components/dbGrid.tsx
+++ b/src/components/dbGrid.tsx
@@ -25,6 +25,20 @@ export const ADD_COLUMN_WIDTH = 44;
 export const MIN_COL_WIDTH = 80;
 export const MAX_COL_WIDTH = 640;
 
+/**
+ * Conservative height estimate for a wrapped grid cell. CSS does the final line
+ * breaking; this estimate deliberately allows slightly more room so proportional
+ * fonts and long words are never clipped by the virtual row container.
+ */
+export function wrappedCellHeight(value: string, width: number, reservedWidth = 0): number {
+  const available = Math.max(24, width - 16 - reservedWidth);
+  const charactersPerLine = Math.max(1, Math.floor(available / 7.5));
+  const lines = (value || ' ')
+    .split(/\r?\n/)
+    .reduce((total, line) => total + Math.max(1, Math.ceil(line.length / charactersPerLine)), 0);
+  return Math.max(ROW_HEIGHT, lines * 20 + 8);
+}
+
 /** Palette offered when creating/recoloring a select option or a chip. */
 export const OPTION_COLORS = ['#ef4444', '#f59e0b', '#eab308', '#10b981', '#3b82f6', '#8b5cf6', '#ec4899', '#14b8a6'];
 
@@ -141,11 +155,13 @@ export function TextCell({
   onChange,
   inputType,
   align = 'left',
+  wrap = false,
 }: {
   value: string | null;
   onChange: (raw: string | null) => void;
   inputType: 'text' | 'number' | 'date' | 'time';
   align?: 'left' | 'right';
+  wrap?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value ?? '');
@@ -179,7 +195,7 @@ export function TextCell({
   const display = inputType === 'number' && value != null ? String(decodeNumber(value) ?? value) : value ?? '';
   return (
     <button
-      className={`w-full h-full px-2 text-sm truncate text-left hover:bg-neutral-800/40 ${align === 'right' ? 'text-right' : ''} ${
+      className={`w-full h-full px-2 text-sm text-left hover:bg-neutral-800/40 ${wrap ? 'whitespace-normal break-words py-1' : 'truncate'} ${align === 'right' ? 'text-right' : ''} ${
         value == null ? 'text-neutral-600' : ''
       }`}
       onClick={() => setEditing(true)}
@@ -194,7 +210,19 @@ export function TextCell({
  * one line; clicking opens a popover with the FULL text in a growing textarea plus a
  * Markdown preview toggle. Commits on close.
  */
-export function LongTextCell({ value, onChange, markdown }: { value: string | null; onChange: (raw: string | null) => void; markdown: boolean }) {
+export function LongTextCell({
+  value,
+  onChange,
+  markdown,
+  wrap = false,
+  emptyLabel,
+}: {
+  value: string | null;
+  onChange: (raw: string | null) => void;
+  markdown: boolean;
+  wrap?: boolean;
+  emptyLabel?: string;
+}) {
   const [open, setOpen] = useState(false);
   const [preview, setPreview] = useState(false);
   const [draft, setDraft] = useState(value ?? '');
@@ -216,11 +244,11 @@ export function LongTextCell({ value, onChange, markdown }: { value: string | nu
     <div className="w-full h-full">
       <button
         ref={btnRef}
-        className={`w-full h-full px-2 text-sm truncate text-left hover:bg-neutral-800/40 ${value == null ? 'text-neutral-600' : ''}`}
+        className={`w-full h-full px-2 text-sm text-left hover:bg-neutral-800/40 ${wrap ? 'whitespace-pre-wrap break-words py-1' : 'truncate'} ${value == null ? 'text-neutral-600' : ''}`}
         onClick={() => setOpen(true)}
         title={value ?? ''}
       >
-        {value ? value.replace(/\s+/g, ' ') : ' '}
+        {value ? (wrap ? value : value.replace(/\s+/g, ' ')) : emptyLabel || ' '}
       </button>
       {open && coords &&
         createPortal(

--- a/src/index.css
+++ b/src/index.css
@@ -1447,6 +1447,55 @@ body {
 .light.databases .border-indigo-900\/70 { border-color: rgba(179, 3, 51, 0.28); }
 .light.databases .ring-indigo-600\/40 { --tw-ring-color: rgba(179, 3, 51, 0.35); }
 
+/* The full database record is rendered above the workspace, so neutral modal
+   utilities used to make it look like a grey/white form detached from the active
+   crimson vault. These semantic surfaces keep the record in the Databases theme
+   in both modes while retaining enough contrast for editable fields. */
+.databases .database-record-modal {
+  background: #19070d;
+  border-color: rgba(204, 10, 58, 0.55);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.58), 0 0 0 1px rgba(179, 3, 51, 0.12);
+}
+.databases .database-record-header {
+  background: rgba(77, 1, 22, 0.55);
+  border-color: rgba(204, 10, 58, 0.28);
+}
+.databases .database-record-row:hover {
+  background: rgba(77, 1, 22, 0.24);
+}
+.databases .database-record-field {
+  background: rgba(43, 0, 16, 0.72);
+  border-color: rgba(204, 10, 58, 0.3);
+}
+.databases .database-record-field:hover,
+.databases .database-record-field:focus-within {
+  border-color: rgba(226, 58, 99, 0.72);
+}
+.light.databases .database-record-backdrop {
+  background: rgba(56, 16, 29, 0.32);
+}
+.light.databases .database-record-modal {
+  background: #fffafb;
+  border-color: #efafc0;
+  box-shadow: 0 28px 80px rgba(77, 1, 22, 0.22), 0 0 0 1px rgba(179, 3, 51, 0.08);
+}
+.light.databases .database-record-header {
+  background: #fff1f4;
+  border-color: #f3c3cf;
+}
+.light.databases .database-record-row:hover {
+  background: #fff1f4;
+}
+.light.databases .database-record-field {
+  background: #fff5f7;
+  border-color: #efc2ce;
+}
+.light.databases .database-record-field:hover,
+.light.databases .database-record-field:focus-within {
+  background: #ffffff;
+  border-color: #cc0a3a;
+}
+
 .input {
   @apply bg-neutral-900 border border-neutral-700 rounded-lg px-3 py-1.5 text-sm outline-none focus:border-indigo-500;
 }

--- a/src/views/DatabasesView.tsx
+++ b/src/views/DatabasesView.tsx
@@ -17,6 +17,7 @@ import {
   TextCell,
   anchorStyle,
   useAnchoredCoords,
+  wrappedCellHeight,
 } from '../components/dbGrid';
 import { confirm, promptText, toast } from '../components/feedback';
 import { notifyDataChanged } from '../hooks';
@@ -86,6 +87,7 @@ function cellPreview(col: DatabaseColumn, row: DatabaseRow): string {
       .map((id) => col.options.find((o) => o.id === id)?.label ?? '')
       .join(' ');
   if (col.type === 'attachment' || col.type === 'ai_image') return (row.attachments?.[col.id] ?? []).map((a) => a.fileName ?? '').join(' ');
+  if (col.type === 'rollup') return row.rollups?.[col.id] ?? '';
   return raw ?? '';
 }
 
@@ -362,9 +364,11 @@ export function DatabasesView({ databaseId, onDatabasesChanged, onCreateDatabase
       const maxLen = rows.reduce((m, r) => Math.max(m, cellPreview(col, r).length), col.name.length);
       const w = Math.max(MIN_COL_WIDTH, Math.min(MAX_COL_WIDTH, maxLen * 8 + 48));
       setWidthOverrides((prev) => ({ ...prev, [col.id]: w }));
-      void persistWidth(col, w);
+      void window.nodus
+        .updateDatabaseColumn(col.id, { config: { ...col.config, width: w, fitContent: true } })
+        .then(reloadColumns);
     },
-    [rows, persistWidth]
+    [rows, reloadColumns]
   );
   /**
    * Forget a column's stored width so it falls back to the default for its type. Fitting to
@@ -378,11 +382,22 @@ export function DatabasesView({ databaseId, onDatabasesChanged, onCreateDatabase
         delete next[col.id];
         return next;
       });
-      const { width: _width, ...rest } = col.config;
+      const { width: _width, fitContent: _fitContent, ...rest } = col.config;
       await window.nodus.updateDatabaseColumn(col.id, { config: rest });
       await reloadColumns();
     },
     [reloadColumns]
+  );
+
+  const fittedColumns = useMemo(() => columns.filter((col) => Boolean(col.config.fitContent)), [columns]);
+  const rowHeightOf = useCallback(
+    (row: DatabaseRow) =>
+      fittedColumns.reduce(
+        (height, col) =>
+          Math.max(height, wrappedCellHeight(cellPreview(col, row), widthOf(col), col.type === 'ai' ? 30 : 0)),
+        ROW_HEIGHT
+      ),
+    [fittedColumns, widthOf]
   );
   const reorderColumn = useCallback(
     async (fromId: string, toId: string) => {
@@ -538,7 +553,7 @@ export function DatabasesView({ databaseId, onDatabasesChanged, onCreateDatabase
             <VirtualList
               className="flex-1 min-h-0 overflow-x-hidden"
               items={visibleRows}
-              itemHeight={ROW_HEIGHT}
+              itemHeight={fittedColumns.length > 0 ? rowHeightOf : ROW_HEIGHT}
               getKey={(r) => r.id}
               empty={
                 <div className="p-8 text-center text-sm text-neutral-500">
@@ -550,7 +565,7 @@ export function DatabasesView({ databaseId, onDatabasesChanged, onCreateDatabase
                 </div>
               }
               renderItem={(row) => (
-                <div className="flex border-b border-neutral-900 hover:bg-neutral-900/40 group" style={{ height: ROW_HEIGHT }}>
+                <div className="flex border-b border-neutral-900 hover:bg-neutral-900/40 group" style={{ minHeight: ROW_HEIGHT, height: '100%' }}>
                   <div style={{ width: GUTTER_WIDTH }} className="shrink-0 flex items-center justify-center gap-1">
                     <button
                       className="opacity-0 group-hover:opacity-100 text-neutral-500 hover:text-indigo-400 transition-opacity"
@@ -578,6 +593,7 @@ export function DatabasesView({ databaseId, onDatabasesChanged, onCreateDatabase
                       formulaError={row.formulaErrors?.[col.id]}
                       rowId={row.id}
                       attachments={row.attachments?.[col.id] ?? []}
+                      wrap={Boolean(col.config.fitContent)}
                       onChange={(raw) => void setCell(row.id, col.id, raw)}
                       onOptionsChanged={reloadColumns}
                       onAttachmentsChanged={() => void refreshRow(row.id)}
@@ -1331,12 +1347,16 @@ function RecordModal({
   const title = row ? rowTitle(row, columns) : '';
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+    <div className="database-record-backdrop fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
       <div
-        className="card-modal w-full max-w-2xl flex flex-col max-h-[90vh] overflow-hidden"
+        className="database-record-modal card-modal w-full max-w-2xl flex flex-col max-h-[90vh] overflow-hidden"
+        data-testid="database-record-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title || databaseName}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center gap-2 px-5 py-3 border-b border-neutral-800">
+        <div className="database-record-header flex items-center gap-2 px-5 py-3 border-b border-neutral-800">
           <span className="text-xs text-neutral-500">{databaseName}</span>
           <div className="flex-1" />
           <button className="text-neutral-500 hover:text-neutral-300" onClick={onClose} title={t('Cerrar')}>
@@ -1352,12 +1372,12 @@ function RecordModal({
               {columns.map((col) => {
                 const def = columnTypeDef(col.type);
                 return (
-                  <div key={col.id} className="flex items-start gap-4 rounded-lg px-2 py-1.5 hover:bg-neutral-900/40 transition-colors">
+                  <div key={col.id} className="database-record-row flex items-start gap-4 rounded-lg px-2 py-1.5 hover:bg-neutral-900/40 transition-colors">
                     <label className="w-36 shrink-0 pt-2 flex items-center gap-1.5 text-xs text-neutral-500">
                       <Icon name={def.icon} size={12} className="opacity-60 shrink-0" />
                       <span className="truncate">{col.name}</span>
                     </label>
-                    <div className="flex-1 min-w-0 rounded-md border border-neutral-800/70 bg-neutral-900/30 min-h-[2.25rem] flex items-center hover:border-neutral-700/80 focus-within:border-neutral-600 transition-colors">
+                    <div className="database-record-field flex-1 min-w-0 rounded-md border border-neutral-800/70 bg-neutral-900/30 min-h-[2.25rem] flex items-center hover:border-neutral-700/80 focus-within:border-neutral-600 transition-colors">
                       <RecordField
                         col={col}
                         row={row}
@@ -1411,7 +1431,7 @@ function RecordField({
   if (col.type === 'checkbox') return <CheckboxCell value={value} onChange={onChange} align="start" />;
   if (col.type === 'select') return <SelectCell column={col} value={value} onChange={onChange} onOptionsChanged={onOptionsChanged} multi={false} />;
   if (col.type === 'multi_select') return <SelectCell column={col} value={value} onChange={onChange} onOptionsChanged={onOptionsChanged} multi />;
-  if (col.type === 'ai') return <AiCell column={col} rowId={row.id} value={value} onRan={onAttachmentsChanged} />;
+  if (col.type === 'ai') return <AiCell column={col} rowId={row.id} value={value} onChange={onChange} onRan={onAttachmentsChanged} wrap />;
   if (col.type === 'relation') return <RelationCell column={col} rowId={row.id} />;
   if (col.type === 'rollup') return <RollupCell value={row.rollups?.[col.id] ?? ''} />;
   if (col.type === 'formula')
@@ -1774,6 +1794,7 @@ function Cell({
   formulaError,
   rowId,
   attachments,
+  wrap,
   onChange,
   onOptionsChanged,
   onAttachmentsChanged,
@@ -1786,38 +1807,39 @@ function Cell({
   formulaError?: string;
   rowId: string;
   attachments: DatabaseAttachment[];
+  wrap: boolean;
   onChange: (raw: string | null) => void;
   onOptionsChanged: () => void;
   onAttachmentsChanged: () => void;
 }) {
   return (
-    <div style={{ width }} className="shrink-0 border-r border-neutral-900 overflow-hidden">
+    <div style={{ width }} className="shrink-0 h-full border-r border-neutral-900 overflow-hidden">
       {column.type === 'formula' ? (
-        <FormulaCell column={column} value={value} color={formulaColor} error={formulaError} />
+        <FormulaCell column={column} value={value} color={formulaColor} error={formulaError} wrap={wrap} />
       ) : column.type === 'checkbox' ? (
         <CheckboxCell value={value} onChange={onChange} />
       ) : column.type === 'select' ? (
-        <SelectCell column={column} value={value} onChange={onChange} onOptionsChanged={onOptionsChanged} multi={false} />
+        <SelectCell column={column} value={value} onChange={onChange} onOptionsChanged={onOptionsChanged} multi={false} wrap={wrap} />
       ) : column.type === 'multi_select' ? (
-        <SelectCell column={column} value={value} onChange={onChange} onOptionsChanged={onOptionsChanged} multi />
+        <SelectCell column={column} value={value} onChange={onChange} onOptionsChanged={onOptionsChanged} multi wrap={wrap} />
       ) : column.type === 'attachment' ? (
         <AttachmentCell rowId={rowId} columnId={column.id} attachments={attachments} onChanged={onAttachmentsChanged} />
       ) : column.type === 'ai_image' ? (
         <AiImageCell column={column} rowId={rowId} attachments={attachments} onChanged={onAttachmentsChanged} />
       ) : column.type === 'ai' ? (
-        <AiCell column={column} rowId={rowId} value={value} onRan={onAttachmentsChanged} />
+        <AiCell column={column} rowId={rowId} value={value} onChange={onChange} onRan={onAttachmentsChanged} wrap={wrap} />
       ) : column.type === 'relation' ? (
         <RelationCell column={column} rowId={rowId} />
       ) : column.type === 'rollup' ? (
-        <RollupCell value={rollup ?? ''} />
+        <RollupCell value={rollup ?? ''} wrap={wrap} />
       ) : column.type === 'number' ? (
-        <TextCell value={value} onChange={onChange} inputType="number" align="right" />
+        <TextCell value={value} onChange={onChange} inputType="number" align="right" wrap={wrap} />
       ) : column.type === 'date' ? (
-        <TextCell value={value} onChange={onChange} inputType="date" />
+        <TextCell value={value} onChange={onChange} inputType="date" wrap={wrap} />
       ) : column.type === 'time' ? (
-        <TextCell value={value} onChange={onChange} inputType="time" />
+        <TextCell value={value} onChange={onChange} inputType="time" wrap={wrap} />
       ) : (
-        <LongTextCell value={value} onChange={onChange} markdown={column.type === 'text'} />
+        <LongTextCell value={value} onChange={onChange} markdown={column.type === 'text'} wrap={wrap} />
       )}
     </div>
   );
@@ -1923,12 +1945,14 @@ function SelectCell({
   onChange,
   onOptionsChanged,
   multi,
+  wrap = false,
 }: {
   column: DatabaseColumn;
   value: string | null;
   onChange: (raw: string | null) => void;
   onOptionsChanged: () => void;
   multi: boolean;
+  wrap?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -1990,7 +2014,7 @@ function SelectCell({
     <div className="w-full h-full">
       <button
         ref={btnRef}
-        className="w-full h-full px-2 flex items-center gap-1 overflow-hidden hover:bg-neutral-800/40"
+        className={`w-full h-full px-2 flex items-center gap-1 overflow-hidden hover:bg-neutral-800/40 ${wrap ? 'flex-wrap content-center py-1' : ''}`}
         onClick={() => setOpen((v) => !v)}
       >
         {selected.length === 0 ? (
@@ -2068,7 +2092,21 @@ function SelectCell({
 
 // ── AI columns ────────────────────────────────────────────────────────────────
 
-function AiCell({ column, rowId, value, onRan }: { column: DatabaseColumn; rowId: string; value: string | null; onRan: () => void }) {
+function AiCell({
+  column,
+  rowId,
+  value,
+  onChange,
+  onRan,
+  wrap = false,
+}: {
+  column: DatabaseColumn;
+  rowId: string;
+  value: string | null;
+  onChange: (raw: string | null) => void;
+  onRan: () => void;
+  wrap?: boolean;
+}) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const hasPrompt = Boolean(String(column.config.aiPrompt ?? '').trim());
@@ -2085,12 +2123,18 @@ function AiCell({ column, rowId, value, onRan }: { column: DatabaseColumn; rowId
     }
   };
   return (
-    <div className="w-full h-full flex items-center gap-1 px-2 group/ai">
-      <span className={`flex-1 truncate text-sm ${value == null ? 'text-neutral-600' : ''}`} title={error ?? value ?? ''}>
-        {value ? value.replace(/\s+/g, ' ') : hasPrompt ? '' : t('Configura el prompt →')}
-      </span>
+    <div className="w-full h-full flex items-center gap-1 group/ai">
+      <div className="flex-1 min-w-0 h-full">
+        <LongTextCell
+          value={value}
+          onChange={onChange}
+          markdown={false}
+          wrap={wrap}
+          emptyLabel={hasPrompt ? undefined : t('Configura el prompt →')}
+        />
+      </div>
       <button
-        className="shrink-0 opacity-60 group-hover/ai:opacity-100 text-indigo-400 hover:text-indigo-300 disabled:opacity-40"
+        className="shrink-0 mr-2 opacity-60 group-hover/ai:opacity-100 text-indigo-400 hover:text-indigo-300 disabled:opacity-40"
         title={error ?? t('Generar con IA')}
         onClick={() => void run()}
         disabled={busy || !hasPrompt}
@@ -2454,10 +2498,10 @@ function RelationCell({ column, rowId }: { column: DatabaseColumn; rowId: string
 // ── Rollup columns ─────────────────────────────────────────────────────────────
 
 /** Read-only cell showing a rollup's computed value (aggregated from related rows). */
-function RollupCell({ value }: { value: string }) {
+function RollupCell({ value, wrap = false }: { value: string; wrap?: boolean }) {
   return (
     <div className="w-full h-full px-2 flex items-center overflow-hidden text-sm text-neutral-300">
-      <span className="truncate" title={value}>
+      <span className={wrap ? 'whitespace-pre-wrap break-words py-1' : 'truncate'} title={value}>
         {value}
       </span>
     </div>
@@ -2475,12 +2519,14 @@ function FormulaCell({
   color,
   error,
   large = false,
+  wrap = false,
 }: {
   column: DatabaseColumn;
   value: string | null;
   color?: string;
   error?: string;
   large?: boolean;
+  wrap?: boolean;
 }) {
   const numeric = comparableType(column) === 'number';
   const text = value == null || value === '' ? '' : numeric ? formatFormulaNumber(value, column) : value;
@@ -2488,7 +2534,7 @@ function FormulaCell({
     return (
       <div className={`w-full ${large ? '' : 'h-full'} px-2 flex items-center gap-1 overflow-hidden text-xs text-amber-400`} title={error}>
         <Icon name="alert" size={12} className="shrink-0" />
-        <span className="truncate">{t(error)}</span>
+        <span className={wrap ? 'whitespace-pre-wrap break-words py-1' : 'truncate'}>{t(error)}</span>
       </div>
     );
   }
@@ -2498,14 +2544,14 @@ function FormulaCell({
     <div className={`w-full ${large ? '' : 'h-full'} px-2 flex items-center overflow-hidden text-sm ${numeric ? 'justify-end' : ''}`}>
       {color ? (
         <span
-          className="truncate rounded px-1.5 py-0.5 text-xs font-medium"
+          className={`${wrap ? 'whitespace-pre-wrap break-words' : 'truncate'} rounded px-1.5 py-0.5 text-xs font-medium`}
           style={{ backgroundColor: `${color}26`, color }}
           title={text}
         >
           {text || '—'}
         </span>
       ) : (
-        <span className="truncate text-neutral-300" title={text}>
+        <span className={wrap ? 'whitespace-pre-wrap break-words py-1 text-neutral-300' : 'truncate text-neutral-300'} title={text}>
           {text || <span className="text-neutral-600">—</span>}
         </span>
       )}


### PR DESCRIPTION
## Summary

- make **Fit to content** show complete cell values by wrapping text and growing virtualized rows
- make AI-generated text editable through the same full-text editor as normal text cells while retaining regeneration
- replace the full-record modal's neutral black/white surfaces with the Databases crimson palette in light and dark modes
- add a focused Electron interaction and visual regression verifier

## Root cause

Fit-to-content only changed column width while rows stayed fixed at 40 px and text remained truncated. AI cells rendered their value in a non-editable span. The record modal inherited generic neutral utility styles instead of database-theme surfaces.

## Validation

- `npm run lint`
- `npm run build`
- `npm test` — 468 passing
- `npm run verify:database-records` — fit wrapping, AI edit persistence, and light/dark modal palettes verified

Closes #40