### PR TITLE
Keep database AI generation alive across navigation

### DIFF
--- a/scripts/test-background-jobs.mjs
+++ b/scripts/test-background-jobs.mjs
@@ -38,6 +38,16 @@ try {
   let immersionCalls = 0;
   let deepCalls = 0;
   let saveCalls = 0;
+  let databaseTextCalls = 0;
+  let databaseImageCalls = 0;
+  let releaseDatabaseText;
+  let releaseDatabaseImage;
+  const databaseTextGate = new Promise((resolve) => {
+    releaseDatabaseText = resolve;
+  });
+  const databaseImageGate = new Promise((resolve) => {
+    releaseDatabaseImage = resolve;
+  });
   const fakeSession = { id: 'imm-1', topic: 'Tema recuperable' };
   const fakeReport = {
     draft: { title: 'Informe recuperable', brief: { kind: 'deep_research' } },
@@ -63,6 +73,17 @@ try {
       saveWritingWorkshopDraft: async () => {
         saveCalls += 1;
         return fakeSaved;
+      },
+      runDatabaseAiCell: async (rowId, columnId) => {
+        databaseTextCalls += 1;
+        if (rowId === 'row-fail') throw new Error('provider unavailable');
+        await databaseTextGate;
+        return `generated:${rowId}:${columnId}`;
+      },
+      generateDatabaseAiImage: async (rowId, columnId) => {
+        databaseImageCalls += 1;
+        await databaseImageGate;
+        return { id: 'image-1', rowId, columnId, fileName: 'generated.png' };
       },
     },
   };
@@ -131,6 +152,45 @@ try {
   assert.equal(jobs.getBackgroundJob(jobs.DEEP_RESEARCH_MAIN_JOB_KEY).request.objective, 'Pregunta principal');
   assert.equal(jobs.getBackgroundJob(dossierKey).request.objective, 'Dossier');
   assert.equal(saveCalls, 2, 'the immersion dossier is also saved automatically');
+
+  // Database cell jobs survive the initiating cell's unmount. A remounted cell
+  // immediately receives the running snapshot, then the retained result, and a
+  // repeated click never creates a second provider call for that same cell.
+  const textKey = jobs.databaseAiTextCellJobKey('row-1', 'column-1');
+  const textJob = jobs.startDatabaseAiTextCellJob('row-1', 'column-1');
+  const duplicateTextJob = jobs.startDatabaseAiTextCellJob('row-1', 'column-1');
+  assert.equal(duplicateTextJob.id, textJob.id, 'duplicate database text generation reuses the running job');
+  await waitFor(() => databaseTextCalls === 1, 'database text request start');
+  let textBeforeUnmount = null;
+  const unsubscribeText = jobs.subscribeBackgroundJob(textKey, (job) => {
+    textBeforeUnmount = job;
+  });
+  assert.equal(textBeforeUnmount.status, 'running');
+  unsubscribeText();
+  releaseDatabaseText();
+  await waitFor(() => jobs.getBackgroundJob(textKey)?.status === 'completed', 'database text completion after unmount');
+  let recoveredText = null;
+  const unsubscribeRecoveredText = jobs.subscribeBackgroundJob(textKey, (job) => {
+    recoveredText = job;
+  });
+  assert.equal(recoveredText.status, 'completed', 'remounted text cell receives completion');
+  assert.equal(recoveredText.result, 'generated:row-1:column-1');
+  assert.equal(databaseTextCalls, 1, 'only one database text provider call runs');
+  unsubscribeRecoveredText();
+
+  const imageKey = jobs.databaseAiImageCellJobKey('row-2', 'column-2');
+  jobs.startDatabaseAiImageCellJob('row-2', 'column-2');
+  await waitFor(() => databaseImageCalls === 1, 'database image request start');
+  const unsubscribeImage = jobs.subscribeBackgroundJob(imageKey, () => {});
+  unsubscribeImage();
+  releaseDatabaseImage();
+  await waitFor(() => jobs.getBackgroundJob(imageKey)?.status === 'completed', 'database image completion after unmount');
+  assert.equal(jobs.getBackgroundJob(imageKey).result.fileName, 'generated.png');
+
+  const failedKey = jobs.databaseAiTextCellJobKey('row-fail', 'column-3');
+  jobs.startDatabaseAiTextCellJob('row-fail', 'column-3');
+  await waitFor(() => jobs.getBackgroundJob(failedKey)?.status === 'failed', 'database text failure retention');
+  assert.equal(jobs.getBackgroundJob(failedKey).error, 'provider unavailable');
 
   console.log('background generation jobs test passed');
 } finally {

--- a/src/backgroundJobs.ts
+++ b/src/backgroundJobs.ts
@@ -11,6 +11,7 @@ import type {
   ToolkitJobProgress,
   ToolkitJobResult,
 } from '@shared/types';
+import type { DatabaseAttachment } from '@shared/databases';
 
 export type BackgroundJobStatus = 'running' | 'completed' | 'failed';
 
@@ -170,6 +171,41 @@ export type ToolkitConvertJob = BackgroundJob<ToolkitJobRequest, ToolkitJobProgr
 export function startToolkitJob(request: ToolkitJobRequest): ToolkitConvertJob {
   return startBackgroundJob(TOOLKIT_JOB_KEY, request, (currentRequest, onProgress) =>
     window.nodus.runToolkitJob(currentRequest, { onProgress }),
+  );
+}
+
+// ── Database AI cells ───────────────────────────────────────────────────────
+// Each cell has its own renderer-wide key. The actual generation runs through
+// Electron's main process; keeping the promise snapshot here lets any remounted
+// database view re-attach without starting the request again.
+
+export interface DatabaseAiCellJobRequest {
+  rowId: string;
+  columnId: string;
+}
+
+export function databaseAiTextCellJobKey(rowId: string, columnId: string): string {
+  return `database:ai:text:${rowId}:${columnId}`;
+}
+
+export function databaseAiImageCellJobKey(rowId: string, columnId: string): string {
+  return `database:ai:image:${rowId}:${columnId}`;
+}
+
+export type DatabaseAiTextCellJob = BackgroundJob<DatabaseAiCellJobRequest, never, string>;
+export type DatabaseAiImageCellJob = BackgroundJob<DatabaseAiCellJobRequest, never, DatabaseAttachment>;
+
+export function startDatabaseAiTextCellJob(rowId: string, columnId: string): DatabaseAiTextCellJob {
+  const request = { rowId, columnId };
+  return startBackgroundJob(databaseAiTextCellJobKey(rowId, columnId), request, (current) =>
+    window.nodus.runDatabaseAiCell(current.rowId, current.columnId)
+  );
+}
+
+export function startDatabaseAiImageCellJob(rowId: string, columnId: string): DatabaseAiImageCellJob {
+  const request = { rowId, columnId };
+  return startBackgroundJob(databaseAiImageCellJobKey(rowId, columnId), request, (current) =>
+    window.nodus.generateDatabaseAiImage(current.rowId, current.columnId)
   );
 }
 

--- a/src/views/DatabasesView.tsx
+++ b/src/views/DatabasesView.tsx
@@ -23,6 +23,17 @@ import { confirm, promptText, toast } from '../components/feedback';
 import { notifyDataChanged } from '../hooks';
 import { t, tx } from '../i18n';
 import {
+  clearBackgroundJob,
+  databaseAiImageCellJobKey,
+  databaseAiTextCellJobKey,
+  getBackgroundJob,
+  startDatabaseAiImageCellJob,
+  startDatabaseAiTextCellJob,
+  subscribeBackgroundJob,
+  type DatabaseAiImageCellJob,
+  type DatabaseAiTextCellJob,
+} from '../backgroundJobs';
+import {
   attachmentKind,
   availableColumnTypes,
   columnTypeDef,
@@ -2107,20 +2118,25 @@ function AiCell({
   onRan: () => void;
   wrap?: boolean;
 }) {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const jobKey = databaseAiTextCellJobKey(rowId, column.id);
+  const [job, setJob] = useState<DatabaseAiTextCellJob | null>(() => getBackgroundJob(jobKey));
   const hasPrompt = Boolean(String(column.config.aiPrompt ?? '').trim());
-  const run = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await window.nodus.runDatabaseAiCell(rowId, column.id);
-      onRan();
-    } catch (e) {
-      setError((e as Error).message);
-    } finally {
-      setBusy(false);
-    }
+  const busy = job?.status === 'running';
+  const error = job?.status === 'failed' ? job.error : null;
+
+  useEffect(
+    () => subscribeBackgroundJob(jobKey, (current) => setJob(current as DatabaseAiTextCellJob | null)),
+    [jobKey]
+  );
+  useEffect(() => {
+    if (job?.status !== 'completed') return;
+    onRan();
+    clearBackgroundJob(jobKey, job.id);
+  }, [job, jobKey, onRan]);
+
+  const run = () => {
+    clearBackgroundJob(jobKey);
+    startDatabaseAiTextCellJob(rowId, column.id);
   };
   return (
     <div className="w-full h-full flex items-center gap-1 group/ai">
@@ -2136,7 +2152,7 @@ function AiCell({
       <button
         className="shrink-0 mr-2 opacity-60 group-hover/ai:opacity-100 text-indigo-400 hover:text-indigo-300 disabled:opacity-40"
         title={error ?? t('Generar con IA')}
-        onClick={() => void run()}
+        onClick={run}
         disabled={busy || !hasPrompt}
       >
         <Icon name={busy ? 'sync' : 'wand'} size={14} className={busy ? 'animate-spin' : ''} />
@@ -2255,20 +2271,25 @@ function AiImageCell({
   onChanged: () => void;
   large?: boolean;
 }) {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const jobKey = databaseAiImageCellJobKey(rowId, column.id);
+  const [job, setJob] = useState<DatabaseAiImageCellJob | null>(() => getBackgroundJob(jobKey));
   const hasPrompt = Boolean(String(column.config.aiPrompt ?? '').trim());
-  const generate = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await window.nodus.generateDatabaseAiImage(rowId, column.id);
-      onChanged();
-    } catch (e) {
-      setError((e as Error).message);
-    } finally {
-      setBusy(false);
-    }
+  const busy = job?.status === 'running';
+  const error = job?.status === 'failed' ? job.error : null;
+
+  useEffect(
+    () => subscribeBackgroundJob(jobKey, (current) => setJob(current as DatabaseAiImageCellJob | null)),
+    [jobKey]
+  );
+  useEffect(() => {
+    if (job?.status !== 'completed') return;
+    onChanged();
+    clearBackgroundJob(jobKey, job.id);
+  }, [job, jobKey, onChanged]);
+
+  const generate = () => {
+    clearBackgroundJob(jobKey);
+    startDatabaseAiImageCellJob(rowId, column.id);
   };
   const remove = async (att: DatabaseAttachment) => {
     await window.nodus.deleteDatabaseAttachment(att.id);
@@ -2283,7 +2304,7 @@ function AiImageCell({
       <button
         className={`shrink-0 ${btnBox} rounded flex items-center justify-center text-indigo-400 border border-dashed border-neutral-700 hover:bg-neutral-800 hover:text-indigo-300 disabled:opacity-40`}
         title={error ?? (hasPrompt ? (attachments.length ? t('Regenerar imagen') : t('Generar imagen con IA')) : t('Configura el prompt primero'))}
-        onClick={() => void generate()}
+        onClick={generate}
         disabled={busy || !hasPrompt}
       >
         <Icon name={busy ? 'sync' : attachments.length ? 'sync' : 'wand'} size={large ? 18 : 14} className={busy ? 'animate-spin' : ''} />


### PR DESCRIPTION
## Summary

- move individual database AI text generations into the renderer-wide background job store
- apply the same persistent lifecycle to AI image cells
- re-subscribe when a database cell remounts so its spinner, completion, and errors survive navigation
- refresh the persisted row after a remounted job completes
- deduplicate repeated generation attempts for the same row and column

## Root cause

The Electron request continued independently, but `AiCell` and `AiImageCell` kept their busy state and completion callback inside component-local React state. Navigating away unmounted those components. Returning before completion therefore showed an idle icon, and the new view never refreshed when the old request persisted its result.

## Validation

- `node --test scripts/test-background-jobs.mjs`
- `npm run typecheck`
- `npm run lint`
- `npm test` — 468 passing
- `npm run build`
- `npm run verify:database-records`

The focused regression unsubscribes during delayed text and image generations, verifies the underlying work completes, re-subscribes to the retained result, confirms failures survive remounting, and checks duplicate starts reuse one provider request.

Closes #42