### PR TITLE
Add download and delete actions for database AI images

### DIFF
--- a/scripts/test-database-ai-image-actions.mjs
+++ b/scripts/test-database-ai-image-actions.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const source = await readFile(path.join(repoRoot, 'src/views/DatabasesView.tsx'), 'utf8');
+
+const between = (start, end) => source.slice(source.indexOf(start), source.indexOf(end, source.indexOf(start)));
+const aiCell = between('function AiImageCell(', 'function AiImageAttachmentActions(');
+const actions = between('function AiImageAttachmentActions(', 'function AiImageColumnConfig(');
+const preview = between('function AttachmentPreview(', 'function AttachmentCell(');
+const removal = between('async function removeStoredAttachment(', '/** Metadata panel');
+
+assert.match(aiCell, /<AiImageAttachmentActions/, 'AI image cells render explicit asset actions');
+assert.match(actions, /downloadStoredAttachment\(att\)/, 'the visible download action uses the stored attachment');
+assert.match(actions, /name="download"/, 'the download control has a recognizable icon');
+assert.match(actions, /name="trash"/, 'the delete control has a recognizable icon');
+assert.match(actions, /aria-label=\{t\('Descargar'\)\}/, 'download is accessible by name');
+assert.match(actions, /aria-label=\{t\('Eliminar'\)\}/, 'delete is accessible by name');
+
+assert.match(removal, /await confirm\(/, 'attachment deletion asks for confirmation');
+assert.match(removal, /danger: true/, 'the confirmation is marked destructive');
+assert.ok(
+  removal.indexOf('await confirm(') < removal.indexOf('deleteDatabaseAttachment(att.id)'),
+  'the attachment is deleted only after confirmation'
+);
+assert.doesNotMatch(preview, /deleteDatabaseAttachment/, 'the preview delegates removal instead of deleting twice');
+assert.match(preview, /onClick=\{onRemove\}/, 'the preview uses the same confirmed parent removal path');
+
+console.log('database AI image actions regression test passed');

--- a/src/views/DatabasesView.tsx
+++ b/src/views/DatabasesView.tsx
@@ -2292,14 +2292,16 @@ function AiImageCell({
     startDatabaseAiImageCellJob(rowId, column.id);
   };
   const remove = async (att: DatabaseAttachment) => {
-    await window.nodus.deleteDatabaseAttachment(att.id);
-    onChanged();
+    if (await removeStoredAttachment(att)) onChanged();
   };
   const btnBox = large ? 'w-24 h-24' : 'w-7 h-7';
   return (
     <div className={`w-full ${large ? 'flex-wrap py-1' : 'h-full overflow-x-auto'} px-1.5 flex items-center gap-1.5`}>
       {attachments.map((att) => (
-        <AttachmentThumb key={att.id} att={att} large={large} onRemove={() => void remove(att)} />
+        <div key={att.id} className="shrink-0 flex items-center gap-1">
+          <AttachmentThumb att={att} large={large} onRemove={() => void remove(att)} />
+          <AiImageAttachmentActions att={att} large={large} onRemove={() => void remove(att)} />
+        </div>
       ))}
       <button
         className={`shrink-0 ${btnBox} rounded flex items-center justify-center text-indigo-400 border border-dashed border-neutral-700 hover:bg-neutral-800 hover:text-indigo-300 disabled:opacity-40`}
@@ -2308,6 +2310,45 @@ function AiImageCell({
         disabled={busy || !hasPrompt}
       >
         <Icon name={busy ? 'sync' : attachments.length ? 'sync' : 'wand'} size={large ? 18 : 14} className={busy ? 'animate-spin' : ''} />
+      </button>
+    </div>
+  );
+}
+
+/** Visible asset management for generated images; preview actions remain available too. */
+function AiImageAttachmentActions({
+  att,
+  onRemove,
+  large,
+}: {
+  att: DatabaseAttachment;
+  onRemove: () => void;
+  large: boolean;
+}) {
+  const size = large ? 'w-9 h-9' : 'w-7 h-7';
+  return (
+    <div className={`shrink-0 flex ${large ? 'flex-col' : 'items-center'} gap-1`}>
+      <button
+        className={`btn btn-ghost ${size} p-0 text-indigo-400 hover:text-indigo-300`}
+        title={t('Descargar')}
+        aria-label={t('Descargar')}
+        onClick={(event) => {
+          event.stopPropagation();
+          void downloadStoredAttachment(att);
+        }}
+      >
+        <Icon name="download" size={large ? 15 : 13} />
+      </button>
+      <button
+        className={`btn btn-ghost ${size} p-0 text-red-400 hover:text-red-300`}
+        title={t('Eliminar')}
+        aria-label={t('Eliminar')}
+        onClick={(event) => {
+          event.stopPropagation();
+          onRemove();
+        }}
+      >
+        <Icon name="trash" size={large ? 15 : 13} />
       </button>
     </div>
   );
@@ -3334,6 +3375,25 @@ function formatBytes(bytes: number): string {
   return `${i === 0 ? n : Math.round(n * 10) / 10} ${units[i]}`;
 }
 
+async function downloadStoredAttachment(att: DatabaseAttachment): Promise<void> {
+  const result = await window.nodus.downloadDatabaseAttachment(att.id);
+  if (!result.canceled && result.path) toast(tx('Descargado en {p}', { p: result.path }));
+}
+
+/** One destructive path for both regular and AI-generated attachments. */
+async function removeStoredAttachment(att: DatabaseAttachment): Promise<boolean> {
+  const ok = await confirm({
+    title: t('Eliminar adjunto'),
+    message: att.fileName
+      ? tx('¿Eliminar «{name}»? Esta acción no se puede deshacer.', { name: att.fileName })
+      : t('¿Eliminar este adjunto? Esta acción no se puede deshacer.'),
+    danger: true,
+  });
+  if (!ok) return false;
+  await window.nodus.deleteDatabaseAttachment(att.id);
+  return true;
+}
+
 /** Metadata panel for one attachment: name, size, type, provenance, extracted text. */
 function AttachmentInfoModal({ att, onClose }: { att: DatabaseAttachment; onClose: () => void }) {
   const rows: { label: string; value: string }[] = [
@@ -3386,11 +3446,7 @@ function AttachmentInfoModal({ att, onClose }: { att: DatabaseAttachment; onClos
         <div className="flex justify-end gap-2 px-5 py-3 border-t border-neutral-800">
           <button
             className="btn btn-ghost gap-1.5"
-            onClick={() => {
-              void window.nodus.downloadDatabaseAttachment(att.id).then((r) => {
-                if (!r.canceled && r.path) toast(tx('Descargado en {p}', { p: r.path }));
-              });
-            }}
+            onClick={() => void downloadStoredAttachment(att)}
           >
             <Icon name="download" size={14} /> {t('Descargar')}
           </button>
@@ -3452,8 +3508,8 @@ function AttachmentThumb({ att, onRemove, large = false }: { att: DatabaseAttach
 }
 
 /**
- * Full-size preview of an attachment, and the only place its actions live. Everything is a
- * normal-sized button here, which is what the 14px hover chips could never be.
+ * Full-size preview of an attachment. Normal-sized actions remain here, while AI image
+ * cells also expose their essential actions directly beside the generated thumbnail.
  */
 function AttachmentPreview({ att, onClose, onRemove }: { att: DatabaseAttachment; onClose: () => void; onRemove: () => void }) {
   const url = useAttachmentImageUrl(att, true);
@@ -3466,15 +3522,6 @@ function AttachmentPreview({ att, onClose, onRemove }: { att: DatabaseAttachment
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
-  const download = async () => {
-    const r = await window.nodus.downloadDatabaseAttachment(att.id);
-    if (!r.canceled && r.path) toast(tx('Descargado en {p}', { p: r.path }));
-  };
-  const remove = async () => {
-    if (!(await confirm({ title: t('Quitar archivo'), message: tx('¿Quitar «{name}»?', { name: att.fileName ?? '' }), danger: true }))) return;
-    await window.nodus.deleteDatabaseAttachment(att.id);
-    onRemove();
-  };
   return createPortal(
     <div className="fixed inset-0 z-50 flex flex-col bg-black/80 p-6" onClick={onClose}>
       <div className="flex items-center gap-3 text-sm text-neutral-300 shrink-0" onClick={(e) => e.stopPropagation()}>
@@ -3484,10 +3531,10 @@ function AttachmentPreview({ att, onClose, onRemove }: { att: DatabaseAttachment
         <button className="btn btn-ghost gap-1.5 text-xs" onClick={() => setInfo(true)}>
           <Icon name="info" size={13} /> {t('Información')}
         </button>
-        <button className="btn btn-ghost gap-1.5 text-xs" onClick={() => void download()}>
+        <button className="btn btn-ghost gap-1.5 text-xs" onClick={() => void downloadStoredAttachment(att)}>
           <Icon name="download" size={13} /> {t('Descargar')}
         </button>
-        <button className="btn btn-ghost gap-1.5 text-xs text-red-400 hover:text-red-300" onClick={() => void remove()}>
+        <button className="btn btn-ghost gap-1.5 text-xs text-red-400 hover:text-red-300" onClick={onRemove}>
           <Icon name="trash" size={13} /> {t('Quitar')}
         </button>
         <button className="text-neutral-400 hover:text-neutral-200 ml-1" onClick={onClose} title={t('Cerrar')}>
@@ -3534,14 +3581,7 @@ function AttachmentCell({
     }
   };
   const remove = async (att: DatabaseAttachment) => {
-    const ok = await confirm({
-      title: t('Eliminar adjunto'),
-      message: att.fileName ? tx('¿Eliminar «{name}»? Esta acción no se puede deshacer.', { name: att.fileName }) : t('¿Eliminar este adjunto? Esta acción no se puede deshacer.'),
-      danger: true,
-    });
-    if (!ok) return;
-    await window.nodus.deleteDatabaseAttachment(att.id);
-    onChanged();
+    if (await removeStoredAttachment(att)) onChanged();
   };
   const addBox = large ? 'w-24 h-24' : 'w-7 h-7';
   return (


### PR DESCRIPTION
## Summary

- show persistent download and delete buttons next to every generated database AI image
- expose the same controls in compact grid cells and large record fields
- require the application's destructive confirmation modal before deleting
- keep thumbnail click-to-preview behavior intact
- centralize attachment download/delete helpers so preview and direct actions share one path
- remove the previous double-delete/double-confirmation behavior in attachment previews

## Root cause

AI image cells rendered only a thumbnail and the regenerate button. Download and removal existed only inside a full-screen preview reached through an unlabeled thumbnail click, so there was no visible way to manage the generated asset. The preview also deleted first and then invoked a parent callback that could attempt confirmation/deletion again.

## Validation

- `node --test scripts/test-database-ai-image-actions.mjs`
- `npm run typecheck`
- `npm run lint`
- `npm test` — 469 passing
- `npm run build`
- `npm run verify:database-records`

Closes #44