### PR TITLE
Mark Genealogy and Study vaults as beta

### DIFF
--- a/scripts/test-vault-types.mjs
+++ b/scripts/test-vault-types.mjs
@@ -71,9 +71,8 @@ test('the vault picker derives selectable modes from the canonical registry', as
   assert.match(picker, /VAULT_TYPES\.filter\(\(type\) => type\.available\)/);
   assert.match(picker, /const CREATE_VAULT_TYPES: VaultType\[\] = \[\s*'academic', 'primary_sources', 'testimonios',\s*'databases', 'docencia', 'estudio',\s*'genealogy', 'worldbuilding',\s*\]/s);
   assert.doesNotMatch(picker, /COMING_SOON_VAULT_TYPES[^\n]*estudio/);
-  assert.match(picker, /type === 'estudio'\) return 'pre-alpha'/);
-  assert.match(picker, /type === 'genealogy'\) return 'alpha'/);
-  assert.match(picker, /type === 'databases'\) return 'beta'/);
+  assert.match(picker, /type === 'estudio' \|\| type === 'genealogy' \|\| type === 'databases'\) return 'beta'/);
+  assert.doesNotMatch(picker, /type === '(?:estudio|genealogy)'\) return '(?:pre-alpha|alpha)'/);
   assert.match(picker, /data-testid="vault-phase-notice"/);
   assert.match(picker, /data-testid="vault-preview-notice"/);
   assert.match(picker, />PREVIEW<\/span>/);

--- a/src/components/VaultSwitcher.tsx
+++ b/src/components/VaultSwitcher.tsx
@@ -84,9 +84,7 @@ export function vaultTypeIcon(type: VaultType): string {
 }
 
 function vaultTypePhase(type: VaultType): VaultPhase | null {
-  if (type === 'estudio') return 'pre-alpha';
-  if (type === 'genealogy') return 'alpha';
-  if (type === 'databases') return 'beta';
+  if (type === 'estudio' || type === 'genealogy' || type === 'databases') return 'beta';
   return null;
 }
 


### PR DESCRIPTION
## Summary

- update the centralized vault phase mapping so Study and Genealogy display `BETA`
- keep the existing beta label for Databases unchanged
- update regression coverage to prevent either mode from returning to the older PRE-ALPHA/ALPHA labels

## Validation

- `node --test scripts/test-vault-types.mjs`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` (469 tests)

Closes #46