### PR TITLE
Keep local model downloads running across navigation

### DIFF
--- a/electron/ai/nodusLocalAi.ts
+++ b/electron/ai/nodusLocalAi.ts
@@ -17,7 +17,14 @@ import {
 import type { ModelInfo } from '@shared/types';
 
 const LLAMA_CPP_VERSION = 'b10002';
-const activeDownloads = new Map<string, Promise<NodusLocalAiStatus>>();
+interface ActiveLocalAiDownload {
+  progress: number;
+  promise: Promise<NodusLocalAiStatus>;
+  listeners: Set<(fraction: number) => void>;
+}
+
+const activeDownloads = new Map<string, ActiveLocalAiDownload>();
+let activeRuntimeDownload: ActiveLocalAiDownload | null = null;
 const embeddingPipelines = new Map<string, Promise<any>>();
 
 interface RuntimeAsset {
@@ -123,25 +130,54 @@ async function modelStatus(model: NodusLocalModelDefinition) {
   let downloaded = true;
   for (const asset of model.assets) {
     const stat = await fsp.stat(path.join(directory, asset.file)).catch(() => null);
-    downloadedBytes += stat?.isFile() ? Math.min(stat.size, asset.bytes) : 0;
+    const partial = stat?.isFile() ? null : await fsp.stat(`${path.join(directory, asset.file)}.download`).catch(() => null);
+    downloadedBytes += stat?.isFile()
+      ? Math.min(stat.size, asset.bytes)
+      : partial?.isFile() ? Math.min(partial.size, asset.bytes) : 0;
     if (!stat?.isFile() || stat.size !== asset.bytes) downloaded = false;
   }
+  const active = activeDownloads.get(model.id);
   return {
     id: model.id,
     downloaded,
     downloadedBytes,
     totalBytes: nodusLocalModelBytes(model),
     path: directory,
+    downloading: Boolean(active),
+    progress: active?.progress ?? (downloaded ? 1 : 0),
   };
 }
 
 export async function getNodusLocalAiStatus(): Promise<NodusLocalAiStatus> {
   const executablePath = await llamaServerPath();
   return {
-    runtime: { version: LLAMA_CPP_VERSION, ready: Boolean(executablePath), executablePath },
+    runtime: {
+      version: LLAMA_CPP_VERSION,
+      ready: Boolean(executablePath),
+      executablePath,
+      downloading: Boolean(activeRuntimeDownload),
+      progress: activeRuntimeDownload?.progress ?? (executablePath ? 1 : 0),
+    },
     models: await Promise.all(NODUS_LOCAL_MODELS.map(modelStatus)),
     activeModelId: activeServer?.modelId ?? null,
   };
+}
+
+function reportDownloadProgress(job: ActiveLocalAiDownload, fraction: number): void {
+  job.progress = Math.max(0, Math.min(1, fraction));
+  for (const listener of job.listeners) {
+    try { listener(job.progress); } catch { /* Progress observers never own the transfer. */ }
+  }
+}
+
+function followDownload(
+  job: ActiveLocalAiDownload,
+  onProgress?: (fraction: number) => void
+): Promise<NodusLocalAiStatus> {
+  if (!onProgress) return job.promise;
+  job.listeners.add(onProgress);
+  onProgress(job.progress);
+  return job.promise.finally(() => job.listeners.delete(onProgress));
 }
 
 async function downloadFile(
@@ -201,28 +237,41 @@ function run(command: string, args: string[], cwd?: string): Promise<void> {
 export async function installNodusLocalRuntime(onProgress?: (fraction: number) => void): Promise<NodusLocalAiStatus> {
   const existing = await llamaServerPath();
   if (existing) return getNodusLocalAiStatus();
-  const asset = runtimeAsset();
-  const root = runtimeDirectory();
-  const archive = path.join(rootDirectory(), `${asset.name}.download`);
-  await fsp.rm(root, { recursive: true, force: true });
-  await fsp.mkdir(rootDirectory(), { recursive: true });
-  let downloaded = 0;
-  await downloadFile(asset.url, archive, asset.bytes, asset.sha256, (bytes) => {
-    downloaded += bytes;
-    onProgress?.(Math.min(0.9, (downloaded / asset.bytes) * 0.9));
-  });
-  await fsp.mkdir(root, { recursive: true });
-  if (asset.archive === 'zip') {
-    new AdmZip(archive).extractAllTo(root, true);
-  } else {
-    await run('tar', ['-xzf', archive, '-C', root]);
-  }
-  await fsp.rm(archive, { force: true });
-  const executable = await llamaServerPath();
-  if (!executable) throw new Error('El runtime se descargó, pero no contiene llama-server.');
-  if (process.platform !== 'win32') await fsp.chmod(executable, 0o755);
-  onProgress?.(1);
-  return getNodusLocalAiStatus();
+  if (activeRuntimeDownload) return followDownload(activeRuntimeDownload, onProgress);
+
+  const job: ActiveLocalAiDownload = {
+    progress: 0,
+    promise: null as unknown as Promise<NodusLocalAiStatus>,
+    listeners: new Set(),
+  };
+  activeRuntimeDownload = job;
+  job.promise = (async () => {
+    const asset = runtimeAsset();
+    const root = runtimeDirectory();
+    const archive = path.join(rootDirectory(), `${asset.name}.download`);
+    await fsp.rm(root, { recursive: true, force: true });
+    await fsp.mkdir(rootDirectory(), { recursive: true });
+    let downloaded = 0;
+    await downloadFile(asset.url, archive, asset.bytes, asset.sha256, (bytes) => {
+      downloaded += bytes;
+      reportDownloadProgress(job, Math.min(0.9, (downloaded / asset.bytes) * 0.9));
+    });
+    await fsp.mkdir(root, { recursive: true });
+    if (asset.archive === 'zip') {
+      new AdmZip(archive).extractAllTo(root, true);
+    } else {
+      await run('tar', ['-xzf', archive, '-C', root]);
+    }
+    await fsp.rm(archive, { force: true });
+    const executable = await llamaServerPath();
+    if (!executable) throw new Error('El runtime se descargó, pero no contiene llama-server.');
+    if (process.platform !== 'win32') await fsp.chmod(executable, 0o755);
+    reportDownloadProgress(job, 1);
+    return getNodusLocalAiStatus();
+  })().finally(() => {
+    if (activeRuntimeDownload === job) activeRuntimeDownload = null;
+  }).then(() => getNodusLocalAiStatus());
+  return followDownload(job, onProgress);
 }
 
 async function downloadModelAssets(
@@ -259,16 +308,23 @@ export async function downloadNodusLocalModel(
   const model = getNodusLocalModel(modelId);
   if (!model) throw new Error(`Modelo local no soportado: ${modelId}`);
   const running = activeDownloads.get(modelId);
-  if (running) return running;
-  const promise = (async () => {
+  if (running) return followDownload(running, onProgress);
+  const job: ActiveLocalAiDownload = {
+    progress: 0,
+    promise: null as unknown as Promise<NodusLocalAiStatus>,
+    listeners: new Set(),
+  };
+  activeDownloads.set(modelId, job);
+  job.promise = (async () => {
     if (model.runtime === 'llama_cpp' && !(await llamaServerPath())) {
-      await installNodusLocalRuntime((fraction) => onProgress?.(fraction * 0.2));
-      return downloadModelAssets(model, (fraction) => onProgress?.(0.2 + fraction * 0.8));
+      await installNodusLocalRuntime((fraction) => reportDownloadProgress(job, fraction * 0.2));
+      return downloadModelAssets(model, (fraction) => reportDownloadProgress(job, 0.2 + fraction * 0.8));
     }
-    return downloadModelAssets(model, onProgress);
-  })().finally(() => activeDownloads.delete(modelId));
-  activeDownloads.set(modelId, promise);
-  return promise;
+    return downloadModelAssets(model, (fraction) => reportDownloadProgress(job, fraction));
+  })().finally(() => {
+    if (activeDownloads.get(modelId) === job) activeDownloads.delete(modelId);
+  }).then(() => getNodusLocalAiStatus());
+  return followDownload(job, onProgress);
 }
 
 export async function deleteNodusLocalModel(modelId: string): Promise<NodusLocalAiStatus> {

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -1668,9 +1668,13 @@ export function registerIpc(
   h('ai:listImageModels', async () => listImageModels());
   h('ai:nodusLocal:status', async () => getNodusLocalAiStatus());
   h('ai:nodusLocal:installRuntime', async (event, requestId: string) =>
-    installNodusLocalRuntime((fraction) => event.sender.send('ai:nodusLocal:progress', requestId, fraction)));
+    installNodusLocalRuntime((fraction) => {
+      if (!event.sender.isDestroyed()) event.sender.send('ai:nodusLocal:progress', requestId, fraction);
+    }));
   h('ai:nodusLocal:downloadModel', async (event, requestId: string, model: string) =>
-    downloadNodusLocalModel(model, (fraction) => event.sender.send('ai:nodusLocal:progress', requestId, fraction)));
+    downloadNodusLocalModel(model, (fraction) => {
+      if (!event.sender.isDestroyed()) event.sender.send('ai:nodusLocal:progress', requestId, fraction);
+    }));
   h('ai:nodusLocal:deleteModel', async (_event, model: string) => deleteNodusLocalModel(model));
   h('images:get', async (_e, entityKind: DecorativeImageEntityKind, entityId: string) =>
     getDecorativeImage(entityKind, entityId)

--- a/scripts/test-local-ai-models.mjs
+++ b/scripts/test-local-ai-models.mjs
@@ -42,15 +42,20 @@ try {
     readFile(path.join(root, 'shared/studyAi.ts'), 'utf8'),
   ]);
   assert.match(manager, /\.download/, 'downloads use partial files before atomic rename');
+  assert.match(manager, /fsp\.stat\(`\$\{path\.join\(directory, asset\.file\)\}\.download`\)/, 'status includes bytes from an in-progress partial asset');
   assert.match(manager, /createHash\('sha256'\)/, 'downloads verify SHA-256');
   assert.match(manager, /'--mmproj'/, 'llama-server receives the multimodal projector');
   assert.match(manager, /'--embedding', '--pooling', 'mean'/, 'BGE runs through llama.cpp embedding mode');
   assert.match(manager, /pipeline\('feature-extraction'/, 'INT8 ONNX models run through Transformers.js');
   assert.match(manager, /model\.runtime === 'llama_cpp'.*llamaServerPath/s, 'llama.cpp is installed automatically before a dependent model download');
   assert.match(manager, /installNodusLocalRuntime.*downloadModelAssets/s, 'runtime installation continues immediately into the requested model download');
+  assert.match(manager, /activeRuntimeDownload.*ActiveLocalAiDownload/s, 'runtime downloads persist in main-process state');
+  assert.match(manager, /activeDownloads\.get\(model\.id\)/, 'model status reconnects to a main-process download job');
+  assert.match(manager, /return followDownload\(running, onProgress\)/, 'duplicate requests follow the existing download');
   assert.match(aiClient, /ensureNodusLocalServer\(model\.model, 'chat'\)/, 'chat completions start the managed local server');
   assert.match(aiClient, /embedWithNodusLocal/, 'embedding calls route to the integrated runtime');
   assert.match(ipc, /ai:nodusLocal:downloadModel/, 'main IPC exposes model downloads');
+  assert.match(ipc, /if \(!event\.sender\.isDestroyed\(\)\) event\.sender\.send\('ai:nodusLocal:progress'/, 'progress cannot abort a download after its renderer is destroyed');
   assert.match(preload, /ai:nodusLocal:progress/, 'preload forwards download progress safely');
   assert.match(settings, /Cambiar modelo de embeddings/, 'embedding changes require an explicit compatibility confirmation');
   assert.match(ui, /ConfirmModal/, 'deleting a local model uses the styled confirmation modal');
@@ -58,6 +63,11 @@ try {
   assert.match(ui, /nodus-local-embedding-list/, 'embedding models use the shared settings list pattern');
   assert.match(ui, /nodus-local-chat-list/, 'chat models use the shared settings list pattern');
   assert.match(ui, /Preparando motor…/, 'the UI explains the automatic dependency stage');
+  assert.match(ui, /status\?\.runtime\.downloading \|\| status\?\.models\.some\(\(model\) => model\.downloading\)/, 'the UI restores active transfers from the status snapshot');
+  assert.match(ui, /window\.setInterval\(\(\) => \{[\s\S]*refresh\(\)/, 'a remounted settings view follows the persistent download through completion');
+  assert.match(ui, /await window\.nodus\.downloadNodusLocalModel\(model\.id, setProgress\)/, 'one main-process request owns runtime preparation and model download');
+  assert.doesNotMatch(ui, /await window\.nodus\.installNodusLocalRuntime\([\s\S]{0,300}await window\.nodus\.downloadNodusLocalModel/, 'the renderer does not split a model transfer into dependent stages');
+  assert.match(ui, /nodus-local-download-progress/, 'rehydrated progress has a stable UI hook');
   assert.match(ui, /exposeDownloadedChatModels/, 'downloaded local chat models are exposed to the shared dropdowns');
   assert.doesNotMatch(ui, /SettingsModelDot|selectedEmbedding|selectedGeneral|selectedVision/, 'the download catalog must not present models as active selections');
   assert.doesNotMatch(ui, /onSelectEmbedding|selectChat|Usar para embeddings|Usar como general|Usar para visión|Modelo general|Modelo de visión/, 'model assignment belongs exclusively to the shared dropdowns');

--- a/shared/localAiModels.ts
+++ b/shared/localAiModels.ts
@@ -30,12 +30,18 @@ export interface NodusLocalModelStatus {
   downloadedBytes: number;
   totalBytes: number;
   path: string;
+  /** Main-process transfer state, retained while renderer views mount/unmount. */
+  downloading: boolean;
+  progress: number;
 }
 
 export interface NodusLocalRuntimeStatus {
   version: string;
   ready: boolean;
   executablePath: string | null;
+  /** Main-process transfer state, retained while renderer views mount/unmount. */
+  downloading: boolean;
+  progress: number;
 }
 
 export interface NodusLocalAiStatus {

--- a/src/components/LocalAiModelsSettings.tsx
+++ b/src/components/LocalAiModelsSettings.tsx
@@ -48,6 +48,15 @@ export function LocalAiModelsSettings({
   };
   useEffect(() => { void refresh().catch((cause) => setError(cause instanceof Error ? cause.message : String(cause))); }, []);
 
+  const activeTransfer = Boolean(status?.runtime.downloading || status?.models.some((model) => model.downloading));
+  useEffect(() => {
+    if (!activeTransfer) return;
+    const timer = window.setInterval(() => {
+      void refresh().catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)));
+    }, 500);
+    return () => window.clearInterval(timer);
+  }, [activeTransfer]);
+
   const installed = useMemo(() => new Map(status?.models.map((model) => [model.id, model]) ?? []), [status]);
 
   const installRuntime = async () => {
@@ -58,15 +67,11 @@ export function LocalAiModelsSettings({
   };
 
   const download = async (model: NodusLocalModelDefinition) => {
-    const needsRuntime = model.runtime === 'llama_cpp' && !status?.runtime.ready;
-    setBusy(needsRuntime ? `runtime:${model.id}` : model.id); setProgress(0); setError('');
+    setBusy(model.id); setProgress(0); setError('');
     try {
-      if (needsRuntime) {
-        const prepared = await window.nodus.installNodusLocalRuntime((fraction) => setProgress(fraction * 0.2));
-        setStatus(prepared);
-        setBusy(model.id);
-      }
-      const nextStatus = await window.nodus.downloadNodusLocalModel(model.id, (fraction) => setProgress(needsRuntime ? 0.2 + fraction * 0.8 : fraction));
+      // One main-process request owns the runtime dependency and every model asset,
+      // so navigation cannot strand the operation between renderer-side awaits.
+      const nextStatus = await window.nodus.downloadNodusLocalModel(model.id, setProgress);
       setStatus(nextStatus);
       await exposeDownloadedChatModels(nextStatus);
     }
@@ -86,6 +91,11 @@ export function LocalAiModelsSettings({
     } catch (cause) { setError(cause instanceof Error ? cause.message : String(cause)); }
     finally { setBusy(''); }
   };
+
+  const activeModelTransfer = status?.models.find((model) => model.downloading);
+  const transferProgress = activeModelTransfer?.progress
+    ?? (status?.runtime.downloading ? status.runtime.progress : progress);
+  const transferBusy = Boolean(busy || activeTransfer);
 
   const renderModelList = (kind: NodusLocalModelDefinition['kind']) => (
     <SettingsModelList
@@ -110,8 +120,8 @@ export function LocalAiModelsSettings({
               {downloaded ? t('Descargado') : local?.downloadedBytes ? `${formatBytes(local.downloadedBytes)} / ${formatBytes(local.totalBytes)}` : t('No descargado')}
             </span>
             {downloaded
-              ? <button className="btn btn-ghost h-7 px-2 text-[10px] text-red-400" disabled={Boolean(busy)} onClick={() => setDeleting(model)}><Icon name="trash" size={10} />{t('Eliminar')}</button>
-              : <button className="btn btn-ghost h-7 px-2 text-[10px]" disabled={Boolean(busy)} onClick={() => void download(model)}><Icon name="download" size={10} />{busy === `runtime:${model.id}` ? t('Preparando motor…') : busy === model.id ? t('Descargando…') : t('Descargar')}</button>}
+              ? <button className="btn btn-ghost h-7 px-2 text-[10px] text-red-400" disabled={transferBusy} onClick={() => setDeleting(model)}><Icon name="trash" size={10} />{t('Eliminar')}</button>
+              : <button className="btn btn-ghost h-7 px-2 text-[10px]" disabled={transferBusy} onClick={() => void download(model)}><Icon name={local?.downloading || busy === model.id ? 'sync' : 'download'} className={local?.downloading || busy === model.id ? 'animate-spin' : ''} size={10} />{local?.downloading && status?.runtime.downloading ? t('Preparando motor…') : local?.downloading || busy === model.id ? t('Descargando…') : t('Descargar')}</button>}
             {downloaded && !runtimeReady && <span className="w-full text-right text-[10px] text-amber-600 dark:text-amber-400">{t('Instala el motor local para poder usar este modelo.')}</span>}
           </div>
         </article>;
@@ -128,7 +138,7 @@ export function LocalAiModelsSettings({
       <div className={`rounded-lg border px-3 py-2 text-xs ${status?.runtime.ready ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-900/60 dark:bg-emerald-950/20 dark:text-emerald-300' : 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-300'}`}>
         {status?.runtime.ready
           ? `${t('Motor local listo')} · llama.cpp ${status.runtime.version}`
-          : <button className="inline-flex items-center gap-1" disabled={Boolean(busy)} onClick={() => void installRuntime()}><Icon name="download" size={12} />{busy === 'runtime' ? t('Instalando motor…') : t('Instalar motor local')}</button>}
+          : <button className="inline-flex items-center gap-1" disabled={transferBusy} onClick={() => void installRuntime()}><Icon name={status?.runtime.downloading || busy === 'runtime' ? 'sync' : 'download'} className={status?.runtime.downloading || busy === 'runtime' ? 'animate-spin' : ''} size={12} />{status?.runtime.downloading || busy === 'runtime' ? t('Instalando motor…') : t('Instalar motor local')}</button>}
       </div>
     </div>
 
@@ -146,7 +156,7 @@ export function LocalAiModelsSettings({
       {renderModelList('chat')}
     </div>
 
-    {busy && progress > 0 && <div className="mt-4 h-1.5 overflow-hidden rounded bg-neutral-800"><div className="h-full bg-indigo-500 transition-all" style={{ width: `${Math.max(3, progress * 100)}%` }} /></div>}
+    {transferBusy && transferProgress > 0 && <div className="mt-4 h-1.5 overflow-hidden rounded bg-neutral-800" data-testid="nodus-local-download-progress"><div className="h-full bg-indigo-500 transition-all" style={{ width: `${Math.max(3, transferProgress * 100)}%` }} /></div>}
     {error && <p className="mt-3 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-300">{error}</p>}
     {deleting && <ConfirmModal
       title={t('Eliminar modelo local')}


### PR DESCRIPTION
## Summary

- move runtime and model transfer ownership into persistent main-process jobs
- expose active download state and progress through the Local AI status snapshot
- include partial-file bytes while a model asset is downloading
- reconnect the Local AI settings view to active transfers after navigation and keep polling through completion
- attach duplicate requests to the existing transfer and protect downloads from destroyed renderer progress targets

## Root cause

The download itself lived in Electron, but progress and the runtime-to-model sequence were tied to the renderer call that started it. A remounted Settings view could only see completed files, so it looked stopped and could not follow completion. The UI also split runtime installation and model download into separate awaits.

## Validation

- `node scripts/test-local-ai-models.mjs`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` (469 tests)

Closes #48