### PR TITLE
Autosave Nodi notes and derive concise fallback titles

### DIFF
--- a/electron/nodiNotes.ts
+++ b/electron/nodiNotes.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
+import { deriveNodiNoteTitle } from '@shared/nodiNotes';
 import type { NodiNote, NodiNoteInput } from '@shared/types';
 
 // Quick Markdown notes for the Nodi companion. Stored as a small JSON file in the
@@ -19,26 +20,13 @@ function storePath(): string {
   return path.join(app.getPath('userData'), 'nodi-notes.json');
 }
 
-/** The note's title is the first meaningful line, stripped of Markdown markers so
- *  the list reads as plain text. Empty when the note has no text yet; the renderer
- *  shows a localized "untitled" label in that case. */
-function deriveTitle(content: string): string {
-  for (const raw of content.split('\n')) {
-    const line = raw
-      .replace(/^\s{0,3}#{1,6}\s+/, '')
-      .replace(/^\s{0,3}[-*+>]\s+/, '')
-      .replace(/[*_`~]/g, '')
-      .trim();
-    if (line) return line.slice(0, 100);
-  }
-  return '';
-}
-
 function normalizeNote(value: NodiNote): NodiNote {
   const content = typeof value.content === 'string' ? value.content : '';
+  const explicitTitle = value.titleExplicit === true ? String(value.title || '').trim() : '';
   return {
     id: String(value.id || crypto.randomUUID()),
-    title: (String(value.title || '').trim() || deriveTitle(content)).slice(0, 100),
+    title: (explicitTitle || deriveNodiNoteTitle(content)).slice(0, 100),
+    titleExplicit: Boolean(explicitTitle),
     content,
     createdAt: Number(value.createdAt) || Date.now(),
     updatedAt: Number(value.updatedAt) || Date.now(),
@@ -75,9 +63,11 @@ export function saveNodiNote(input: NodiNoteInput): NodiNote {
   const existing = existingIndex >= 0 ? store.notes[existingIndex] : null;
   const now = Date.now();
   const content = typeof input.content === 'string' ? input.content : '';
+  const explicitTitle = String(input.title || '').trim();
   const note = normalizeNote({
     id: existing?.id ?? crypto.randomUUID(),
-    title: deriveTitle(content),
+    title: explicitTitle || deriveNodiNoteTitle(content),
+    titleExplicit: Boolean(explicitTitle),
     content,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,

--- a/scripts/test-nodi-notes.mjs
+++ b/scripts/test-nodi-notes.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = path.resolve(import.meta.dirname, '..');
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'nodus-nodi-notes-'));
+
+try {
+  const helperBundle = path.join(tmp, 'nodiNotes-helper.mjs');
+  await build({
+    entryPoints: [path.join(root, 'shared/nodiNotes.ts')],
+    outfile: helperBundle,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    logLevel: 'silent',
+  });
+  const helper = await import(pathToFileURL(helperBundle).href);
+  assert.equal(helper.deriveNodiNoteTitle('Una nota con muchas palabras'), 'Una nota con');
+  assert.equal(helper.deriveNodiNoteTitle('\n## **Plan de trabajo completo**\n- siguiente paso'), 'Plan de trabajo');
+  assert.equal(helper.deriveNodiNoteTitle(''), '');
+
+  const storeRoot = path.join(tmp, 'user-data');
+  const repositoryBundle = path.join(tmp, 'nodiNotes-repository.mjs');
+  await build({
+    entryPoints: [path.join(root, 'electron/nodiNotes.ts')],
+    outfile: repositoryBundle,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    tsconfig: path.join(root, 'tsconfig.json'),
+    logLevel: 'silent',
+    plugins: [{
+      name: 'electron-test-stub',
+      setup(buildApi) {
+        buildApi.onResolve({ filter: /^electron$/ }, () => ({ path: 'electron', namespace: 'nodi-notes-test' }));
+        buildApi.onLoad({ filter: /.*/, namespace: 'nodi-notes-test' }, () => ({
+          contents: `export const app = { getPath: () => ${JSON.stringify(storeRoot)} };`,
+          loader: 'js',
+        }));
+      },
+    }],
+  });
+  const repository = await import(pathToFileURL(repositoryBundle).href);
+  const derived = repository.saveNodiNote({ content: 'Primera nota guardada sin título manual' });
+  assert.equal(derived.title, 'Primera nota guardada');
+  assert.equal(derived.titleExplicit, false);
+  const explicit = repository.saveNodiNote({ title: 'Título elegido', content: 'Este contenido no manda' });
+  assert.equal(explicit.title, 'Título elegido');
+  assert.equal(explicit.titleExplicit, true);
+  const updated = repository.saveNodiNote({ id: derived.id, title: '', content: 'Nuevo comienzo para la nota' });
+  assert.equal(updated.id, derived.id);
+  assert.equal(updated.title, 'Nuevo comienzo para');
+  assert.equal(repository.listNodiNotes().length, 2);
+
+  const [component, css, types] = await Promise.all([
+    readFile(path.join(root, 'src/components/nodi/NodiCompanion.tsx'), 'utf8'),
+    readFile(path.join(root, 'src/components/nodi/companion.css'), 'utf8'),
+    readFile(path.join(root, 'shared/types.ts'), 'utf8'),
+  ]);
+  assert.match(types, /title\?: string;[\s\S]*first three content words/, 'the bridge accepts an optional explicit title');
+  assert.match(component, /const NOTE_AUTOSAVE_DELAY_MS = 600/, 'notes use a short autosave debounce');
+  assert.match(component, /window\.setTimeout\(\(\) => \{ void saveNote\(\); \}, NOTE_AUTOSAVE_DELAY_MS\)/, 'typing schedules autosave');
+  assert.match(component, /useEffect\(\(\) => \(\) => flushNote\(\)/, 'unmounting flushes the live note');
+  assert.match(component, /noteSaveChainRef/, 'overlapping autosaves are serialized');
+  assert.match(component, /deriveNodiNoteTitle\(noteDraft\)/, 'the editor previews the shared fallback title');
+  assert.match(component, /className="nodi-note-title-input"/, 'users can assign an explicit title');
+  assert.match(component, /t\('Guardado automáticamente'\)/, 'the footer communicates autosave');
+  assert.doesNotMatch(component, /className="nodi-note-save"/, 'the editor no longer requires a manual save action');
+  assert.match(css, /\.nodi-notes-list\s*\{[^}]*padding:\s*6px 10px/s, 'the list keeps a small lateral margin');
+
+  console.log('Nodi quick-note autosave tests passed!');
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/scripts/verify-nodi-notes.mjs
+++ b/scripts/verify-nodi-notes.mjs
@@ -1,5 +1,5 @@
 // End-to-end verification of the Nodi quick-notes panel against the real app:
-// create → format → save → search → preview → delete, in dark and light themes.
+// create → format → autosave → search → preview → delete, in dark and light themes.
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp } from 'node:fs/promises';
@@ -131,7 +131,7 @@ try {
   // Empty state
   assert.equal(await page.locator('.nodi-notes-panel .nodi-empty').count(), 1, 'expected empty-state copy');
 
-  // ── Create + format + save ─────────────────────────────────────────────────
+  // ── Create + format + autosave ─────────────────────────────────────────────
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Nueva nota"]').click();
   const ta = page.locator('.nodi-note-textarea');
   await ta.waitFor();
@@ -147,15 +147,14 @@ try {
   const afterBold = await ta.inputValue();
   assert.ok(afterBold.includes('**leche**'), `bold did not wrap selection: ${afterBold}`);
   log('bold formatting applied:', JSON.stringify(afterBold));
-  await page.locator('.nodi-note-save').click();
-  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado');
-  log('note saved');
+  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado automáticamente');
+  log('note autosaved');
 
   // ── Back to list: the note shows with derived title + snippet ───────────────
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Volver"]').click();
   await page.locator('.nodi-note-row').first().waitFor();
   const title = await page.locator('.nodi-note-title').first().innerText();
-  assert.equal(title, 'Lista de la compra', `unexpected list title: ${title}`);
+  assert.equal(title, 'Lista de la', `unexpected three-word fallback title: ${title}`);
   const snippet = await page.locator('.nodi-note-snippet').first().innerText();
   assert.ok(snippet.toLowerCase().includes('comprar leche'), `unexpected snippet: ${snippet}`);
   log('list shows note:', JSON.stringify({ title, snippet }));
@@ -163,9 +162,9 @@ try {
 
   // Add a second note so search has something to filter out.
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Nueva nota"]').click();
-  await ta.fill('Ideas para el proyecto\n\nProbar el modo oscuro');
-  await page.locator('.nodi-note-save').click();
-  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado');
+  await page.locator('.nodi-note-title-input').fill('Ideas para el proyecto');
+  await ta.fill('Probar el modo oscuro con un título manual');
+  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado automáticamente');
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Volver"]').click();
   assert.equal(await page.locator('.nodi-note-row').count(), 2, 'expected 2 notes');
 
@@ -179,7 +178,7 @@ try {
   await page.waitForFunction(() => document.querySelectorAll('.nodi-note-row').length === 2);
 
   // ── Preview a note ──────────────────────────────────────────────────────────
-  await page.locator('.nodi-note-row', { hasText: 'Lista de la compra' }).locator('.nodi-note-open').click();
+  await page.locator('.nodi-note-row', { hasText: 'Lista de la' }).locator('.nodi-note-open').click();
   await ta.waitFor();
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Vista previa"]').click();
   await page.locator('.nodi-note-preview').waitFor();
@@ -222,10 +221,12 @@ try {
   // open editor in light mode
   await page.locator('.nodi-note-open').first().click();
   await ta.waitFor();
-  const lightSaveBackground = await page.locator('.nodi-note-save').evaluate((button) => getComputedStyle(button).backgroundColor);
-  assert.equal(lightSaveBackground, 'rgb(179, 3, 51)', 'quick notes must use the databases-vault accent');
+  const titleInput = page.locator('.nodi-note-title-input');
+  await titleInput.focus();
+  const lightTitleAccent = await titleInput.evaluate((input) => getComputedStyle(input).borderBottomColor);
+  assert.equal(lightTitleAccent, 'rgb(179, 3, 51)', 'the optional title focus must use the databases-vault accent');
   await page.screenshot({ path: `${shots}/notes-6-editor-light.png` });
-  log('light notes theme verified:', JSON.stringify({ ...lightNotesTheme, save: lightSaveBackground }));
+  log('light notes theme verified:', JSON.stringify({ ...lightNotesTheme, titleAccent: lightTitleAccent }));
 
   // Notifications and chat use the same white surface and vault accent; quick
   // notes is no longer the only light panel.

--- a/shared/nodiNotes.ts
+++ b/shared/nodiNotes.ts
@@ -1,0 +1,17 @@
+/**
+ * Derive the concise fallback used when a Nodi quick note has no explicit title.
+ * Markdown decoration is ignored and words may span lines, but the stored title
+ * never grows beyond the first three meaningful words.
+ */
+export function deriveNodiNoteTitle(content: string): string {
+  const plain = String(content ?? '')
+    .split('\n')
+    .map((raw) => raw
+      .replace(/^\s{0,3}#{1,6}\s+/, '')
+      .replace(/^\s{0,3}[-*+>]\s+/, '')
+      .replace(/[*_`~]/g, '')
+      .trim())
+    .filter(Boolean)
+    .join(' ');
+  return plain.split(/\s+/u).filter(Boolean).slice(0, 3).join(' ').slice(0, 100);
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4768,11 +4768,12 @@ export interface NodiConversationInput {
   model?: ModelRef | null;
 }
 
-/** A quick Markdown note kept by the Nodi companion (local, per install). The
- *  title is derived from the first non-empty line when the note is saved. */
+/** A quick Markdown note kept by the Nodi companion (local, per install). */
 export interface NodiNote {
   id: string;
   title: string;
+  /** Distinguishes a user-assigned title from the three-word fallback. */
+  titleExplicit: boolean;
   content: string;
   createdAt: number;
   updatedAt: number;
@@ -4780,6 +4781,8 @@ export interface NodiNote {
 
 export interface NodiNoteInput {
   id?: string | null;
+  /** Optional explicit title; the first three content words are used when empty. */
+  title?: string;
   content: string;
 }
 

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { deriveNodiNoteTitle } from '@shared/nodiNotes';
 import type { AppSettings, ModelRef, NodiChatMessage, NodiContextKind, NodiConversation, NodiNote, NodiNotification, NodiOverlayPlacement, VaultType } from '@shared/types';
 import { vaultTypeColor } from '@shared/vaultTypes';
 import { type NodiRole, type NodiState } from './Nodi';
@@ -75,33 +76,15 @@ function IconNotes() {
   );
 }
 
-/** A quick note's title is its first meaningful line, stripped of Markdown markers.
- *  Derived live from the draft so the header updates as you type. */
-function deriveNoteTitle(content: string): string {
-  for (const raw of content.split('\n')) {
-    const line = raw
-      .replace(/^\s{0,3}#{1,6}\s+/, '')
-      .replace(/^\s{0,3}[-*+>]\s+/, '')
-      .replace(/[*_`~]/g, '')
-      .trim();
-    if (line) return line.slice(0, 80);
-  }
-  return '';
-}
-
-/** A one-line preview of everything after the title line, for the notes list. */
+/** A compact plain-text preview of the Markdown content for the notes list. */
 function noteSnippet(content: string): string {
-  const rest: string[] = [];
-  let started = false;
-  for (const raw of content.split('\n')) {
-    const line = raw.trim();
-    if (!started) {
-      if (line) started = true;
-      continue;
-    }
-    if (line) rest.push(line.replace(/^\s{0,3}[-*+>]\s+/, '').replace(/[*_`~#]/g, ''));
-  }
-  return rest.join(' ').trim().slice(0, 140);
+  return content
+    .split('\n')
+    .map((raw) => raw.trim().replace(/^\s{0,3}[-*+>]\s+/, '').replace(/[*_`~#]/g, ''))
+    .filter(Boolean)
+    .join(' ')
+    .trim()
+    .slice(0, 140);
 }
 
 function relTime(ts: number): string {
@@ -127,6 +110,7 @@ const RADIAL_MAX_SPAN_DEG = 88;
 // Normal clicks commonly move a few pixels between press and release. Keeping a
 // comfortable dead zone prevents those tiny movements from swallowing the click.
 const DRAG_THRESHOLD_PX = 7;
+const NOTE_AUTOSAVE_DELAY_MS = 600;
 
 export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: boolean }) {
   const isOverlay = context === 'overlay';
@@ -161,17 +145,22 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const [notes, setNotes] = useState<NodiNote[]>([]);
   const [noteView, setNoteView] = useState<'list' | 'editor'>('list');
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
+  const [noteTitle, setNoteTitle] = useState('');
   const [noteDraft, setNoteDraft] = useState('');
   const [noteDirty, setNoteDirty] = useState(false);
+  const [noteSaving, setNoteSaving] = useState(false);
   const [noteSearch, setNoteSearch] = useState('');
   const [notePreview, setNotePreview] = useState(false);
   const [deleteNoteTarget, setDeleteNoteTarget] = useState<NodiNote | null>(null);
   const noteEditorRef = useRef<HTMLTextAreaElement | null>(null);
+  const noteSessionRef = useRef(0);
+  const noteSaveChainRef = useRef<Promise<void>>(Promise.resolve());
+  const noteSavesInFlightRef = useRef(0);
   // Mirror the in-flight note so the leave-editor flush reads live values without a
   // stale closure (a lesson from the study-vault useMemo bug: closures over editor
   // state go stale between renders).
-  const noteRef = useRef({ id: activeNoteId, draft: noteDraft, dirty: noteDirty });
-  noteRef.current = { id: activeNoteId, draft: noteDraft, dirty: noteDirty };
+  const noteRef = useRef({ session: 0, id: activeNoteId, title: noteTitle, draft: noteDraft, dirty: noteDirty });
+  noteRef.current = { session: noteSessionRef.current, id: activeNoteId, title: noteTitle, draft: noteDraft, dirty: noteDirty };
 
   // Resolve the app theme locally so the independent always-on-top renderer receives
   // the same surface treatment as in-window Nodi.
@@ -240,54 +229,78 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   }, []);
   useEffect(() => { if (panel === 'notes') refreshNotes(); }, [panel, refreshNotes]);
 
-  const persistNote = useCallback(async (id: string | null, draft: string) => {
-    try {
-      const saved = await window.nodus.saveNodiNote({ id, content: draft });
-      setNotes((cur) => [saved, ...cur.filter((n) => n.id !== saved.id)]);
-      // A save may finish after the user has opened another note or continued
-      // typing. Only mark the editor clean when it still shows this exact snapshot.
-      const current = noteRef.current;
-      if (current.id === id && current.draft === draft) {
-        noteRef.current = { id: saved.id, draft, dirty: false };
-        setActiveNoteId(saved.id);
-        setNoteDirty(false);
+  const persistNote = useCallback((session: number, id: string | null, title: string, draft: string) => {
+    noteSavesInFlightRef.current += 1;
+    setNoteSaving(true);
+    const task = noteSaveChainRef.current.then(async () => {
+      // A second autosave may have been queued before the first one assigned its id.
+      // Reuse the live id for the same editor session instead of creating duplicates.
+      const before = noteRef.current;
+      const effectiveId = before.session === session ? before.id : id;
+      try {
+        const saved = await window.nodus.saveNodiNote({ id: effectiveId, title, content: draft });
+        setNotes((cur) => [saved, ...cur.filter((n) => n.id !== saved.id)]);
+        const current = noteRef.current;
+        if (current.session === session && (current.id === effectiveId || current.id === id)) {
+          const unchanged = current.title === title && current.draft === draft;
+          noteRef.current = { ...current, id: saved.id, dirty: !unchanged };
+          setActiveNoteId(saved.id);
+          setNoteDirty(!unchanged);
+        }
+      } catch {
+        const current = noteRef.current;
+        if (current.session === session && current.title === title && current.draft === draft) {
+          noteRef.current = { ...current, dirty: true };
+          setNoteDirty(true);
+        }
+      } finally {
+        noteSavesInFlightRef.current -= 1;
+        if (noteSavesInFlightRef.current === 0) setNoteSaving(false);
       }
-      return saved;
-    } catch {
-      const current = noteRef.current;
-      if (current.id === id && current.draft === draft) {
-        noteRef.current = { ...current, dirty: true };
-        setNoteDirty(true);
-      }
-      return null;
-    }
+    });
+    noteSaveChainRef.current = task.then(() => undefined, () => undefined);
+    return task;
   }, []);
 
   // Fire-and-forget save used when the editor is left by any route (panel closed,
   // switched, vault change, overlay dismissed). Mark the snapshot clean before the
   // IPC call so opening another note cannot enqueue the same save twice.
   const flushNote = useCallback(() => {
-    const { id, draft, dirty } = noteRef.current;
-    if (!dirty || !draft.trim()) return;
-    noteRef.current = { id, draft, dirty: false };
+    const { session, id, title, draft, dirty } = noteRef.current;
+    if (!dirty || (!title.trim() && !draft.trim() && !id)) return;
+    noteRef.current = { session, id, title, draft, dirty: false };
     setNoteDirty(false);
-    void persistNote(id, draft);
+    void persistNote(session, id, title, draft);
   }, [persistNote]);
   const leftEditor = panel !== 'notes' || noteView !== 'editor';
   useEffect(() => { if (leftEditor) flushNote(); }, [leftEditor, flushNote]);
 
   const saveNote = useCallback(async () => {
-    const { id, draft, dirty } = noteRef.current;
-    if (!dirty || !draft.trim()) return;
-    noteRef.current = { id, draft, dirty: false };
+    const { session, id, title, draft, dirty } = noteRef.current;
+    if (!dirty || (!title.trim() && !draft.trim() && !id)) return;
+    noteRef.current = { session, id, title, draft, dirty: false };
     setNoteDirty(false);
-    await persistNote(id, draft);
+    await persistNote(session, id, title, draft);
   }, [persistNote]);
+
+  useEffect(() => {
+    if (panel !== 'notes' || noteView !== 'editor' || !noteDirty) return;
+    const timer = window.setTimeout(() => { void saveNote(); }, NOTE_AUTOSAVE_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [noteDirty, noteDraft, noteTitle, noteView, panel, saveNote]);
+  useEffect(() => () => flushNote(), [flushNote]);
 
   const openNoteEditor = (note: NodiNote | null) => {
     flushNote();
-    setActiveNoteId(note?.id ?? null);
-    setNoteDraft(note?.content ?? '');
+    const session = noteSessionRef.current + 1;
+    const id = note?.id ?? null;
+    const title = note?.titleExplicit ? note.title : '';
+    const draft = note?.content ?? '';
+    noteSessionRef.current = session;
+    noteRef.current = { session, id, title, draft, dirty: false };
+    setActiveNoteId(id);
+    setNoteTitle(title);
+    setNoteDraft(draft);
     setNoteDirty(false);
     setNotePreview(false);
     setNoteView('editor');
@@ -304,11 +317,18 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const confirmDeleteNote = async () => {
     if (!deleteNoteTarget) return;
     const id = deleteNoteTarget.id;
+    if (activeNoteId === id) {
+      noteSessionRef.current += 1;
+      noteRef.current = { session: noteSessionRef.current, id: null, title: '', draft: '', dirty: false };
+      setNoteDirty(false);
+    }
+    await noteSaveChainRef.current;
     const deleted = await window.nodus.deleteNodiNote(id).then(() => true).catch(() => false);
     if (!deleted) return;
     setNotes((cur) => cur.filter((n) => n.id !== id));
     if (activeNoteId === id) {
       setActiveNoteId(null);
+      setNoteTitle('');
       setNoteDraft('');
       setNoteDirty(false);
       setNoteView('list');
@@ -915,8 +935,8 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
               {noteView === 'editor' && (
                 <button className="nodi-head-icon" onClick={backToNotes} title={t('Volver')} aria-label={t('Volver')}><Icon name="arrowLeft" size={15} /></button>
               )}
-              <span className="nodi-chat-title" title={noteView === 'editor' ? (deriveNoteTitle(noteDraft) || t('Nueva nota')) : t('Notas rápidas')}>
-                {noteView === 'editor' ? (deriveNoteTitle(noteDraft) || t('Nueva nota')) : t('Notas rápidas')}
+              <span className="nodi-chat-title" title={noteView === 'editor' ? (noteTitle.trim() || deriveNodiNoteTitle(noteDraft) || t('Nueva nota')) : t('Notas rápidas')}>
+                {noteView === 'editor' ? (noteTitle.trim() || deriveNodiNoteTitle(noteDraft) || t('Nueva nota')) : t('Notas rápidas')}
               </span>
               <span className="grow" />
               {noteView === 'list' && (
@@ -958,11 +978,23 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
             ) : (
               <>
                 {!notePreview && (
-                  <div className="nodi-note-toolbar">
-                    {noteFormats.map((f) => (
-                      <button key={f.id} type="button" className="nodi-note-tool" data-format={f.id} onMouseDown={(e) => e.preventDefault()} onClick={f.run} title={f.label} aria-label={f.label}><Icon name={f.icon} size={15} /></button>
-                    ))}
-                  </div>
+                  <>
+                    <div className="nodi-note-title-field">
+                      <input
+                        className="nodi-note-title-input"
+                        value={noteTitle}
+                        maxLength={100}
+                        placeholder={t('Título (opcional)')}
+                        aria-label={t('Título (opcional)')}
+                        onChange={(e) => { setNoteTitle(e.target.value); setNoteDirty(true); }}
+                      />
+                    </div>
+                    <div className="nodi-note-toolbar">
+                      {noteFormats.map((f) => (
+                        <button key={f.id} type="button" className="nodi-note-tool" data-format={f.id} onMouseDown={(e) => e.preventDefault()} onClick={f.run} title={f.label} aria-label={f.label}><Icon name={f.icon} size={15} /></button>
+                      ))}
+                    </div>
+                  </>
                 )}
                 <div className="nodi-note-body">
                   {notePreview ? (
@@ -992,9 +1024,8 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
                   {activeNoteId && (
                     <button className="nodi-note-remove" onClick={() => { const note = notes.find((n) => n.id === activeNoteId); if (note) setDeleteNoteTarget(note); }} title={t('Borrar nota')} aria-label={t('Borrar nota')}><Icon name="trash" size={13} /></button>
                   )}
-                  <span className="nodi-note-state">{noteDirty ? t('Sin guardar') : activeNoteId ? t('Guardado') : ''}</span>
+                  <span className="nodi-note-state">{noteSaving ? t('Guardando…') : noteDirty ? t('Sin guardar') : activeNoteId ? t('Guardado automáticamente') : ''}</span>
                   <span className="grow" />
-                  <button className="nodi-note-save" onClick={() => void saveNote()} disabled={!noteDraft.trim() || !noteDirty}><Icon name="save" size={14} /> {t('Guardar')}</button>
                 </div>
               </>
             )}

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -586,7 +586,7 @@
 }
 .nodi-notes-search button:hover { background: rgba(255, 255, 255, 0.06); color: #f3e6c2; }
 
-.nodi-notes-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 3px; }
+.nodi-notes-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px 10px; display: flex; flex-direction: column; gap: 3px; }
 .nodi-note-row { display: flex; align-items: stretch; gap: 3px; border-radius: 9px; background: transparent; }
 .nodi-note-row:hover { background: rgba(212, 175, 55, 0.08); }
 .nodi-note-open {
@@ -619,6 +619,21 @@
 .nodi-note-delete:hover { background: rgba(239, 68, 68, 0.12); color: #f28b8b; }
 
 /* Editor: toolbar + textarea/preview + footer */
+.nodi-note-title-field { flex: 0 0 auto; padding: 9px 10px 7px; }
+.nodi-note-title-input {
+  width: 100%;
+  border: 0;
+  border-bottom: 0.5px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  padding: 3px 2px 7px;
+  color: #e7ebf2;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  outline: none;
+}
+.nodi-note-title-input::placeholder { color: #6f7b8d; font-weight: 500; }
+.nodi-note-title-input:focus { border-bottom-color: var(--nodi-vault-accent, #d4af37); }
 .nodi-note-toolbar {
   display: flex;
   align-items: center;
@@ -696,24 +711,6 @@
 }
 .nodi-note-remove:hover { background: rgba(153, 27, 27, 0.4); color: #fecaca; }
 .nodi-note-state { font-size: 10px; color: #7a8598; }
-.nodi-note-save {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  border: 0;
-  border-radius: 9px;
-  background: #d4af37;
-  color: #14213a;
-  padding: 7px 12px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s, transform 0.1s;
-}
-.nodi-note-save svg { display: block; }
-.nodi-note-save:hover:not(:disabled) { background: #e6c257; }
-.nodi-note-save:active:not(:disabled) { transform: scale(0.96); }
-.nodi-note-save:disabled { opacity: 0.45; cursor: default; }
 
 .nodi-notes-list,
 .nodi-note-textarea,
@@ -883,6 +880,9 @@
 .nodi-theme-light .nodi-notes-panel .nodi-note-time { color: #94a3b8; }
 .nodi-theme-light .nodi-notes-panel .nodi-note-delete { color: #94a3b8; }
 .nodi-theme-light .nodi-notes-panel .nodi-note-delete:hover { background: rgba(239, 68, 68, 0.12); color: #dc2626; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-title-input { border-bottom-color: rgba(15, 23, 42, 0.1); color: #1f2937; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-title-input::placeholder { color: #94a3b8; }
+.nodi-theme-light .nodi-notes-panel .nodi-note-title-input:focus { border-bottom-color: var(--nodi-vault-accent, #6366f1); }
 .nodi-theme-light .nodi-notes-panel .nodi-note-toolbar { background: #f8fafc; border-bottom-color: rgba(15, 23, 42, 0.08); }
 .nodi-theme-light .nodi-notes-panel .nodi-note-tool { color: #64748b; }
 .nodi-theme-light .nodi-notes-panel .nodi-note-tool:hover { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 14%, transparent); color: var(--nodi-vault-accent, #6366f1); }
@@ -902,8 +902,6 @@
 .nodi-theme-light .nodi-notes-panel .nodi-note-state { color: #94a3b8; }
 .nodi-theme-light .nodi-notes-panel .nodi-note-remove { border-color: rgba(239, 68, 68, 0.28); background: rgba(239, 68, 68, 0.08); color: #dc2626; }
 .nodi-theme-light .nodi-notes-panel .nodi-note-remove:hover { background: rgba(239, 68, 68, 0.16); color: #b91c1c; }
-.nodi-theme-light .nodi-notes-panel .nodi-note-save { background: var(--nodi-vault-accent, #6366f1); color: #ffffff; }
-.nodi-theme-light .nodi-notes-panel .nodi-note-save:hover:not(:disabled) { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 84%, #000000); }
 .nodi-theme-light .nodi-notes-panel .nodi-notes-list,
 .nodi-theme-light .nodi-notes-panel .nodi-note-textarea,
 .nodi-theme-light .nodi-notes-panel .nodi-note-preview { scrollbar-color: #cbd5e1 #eef2f7; }

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -69,6 +69,7 @@ export const DE: Record<string, string> = {
   // ── Nodi: Schnellnotizen ─────────────────────────────────────────────────
   'Notas rápidas': 'Schnellnotizen',
   'Nueva nota': 'Neue Notiz',
+  'Título (opcional)': 'Titel (optional)',
   'Tachado': 'Durchgestrichen',
   'Borrar nota': 'Notiz löschen',
   'Escribe tu nota en Markdown…': 'Schreib deine Notiz in Markdown…',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -68,6 +68,7 @@ export const EN: Record<string, string> = {
   // ── Nodi: quick notes ────────────────────────────────────────────────────
   'Notas rápidas': 'Quick notes',
   'Nueva nota': 'New note',
+  'Título (opcional)': 'Title (optional)',
   'Tachado': 'Strikethrough',
   'Borrar nota': 'Delete note',
   'Escribe tu nota en Markdown…': 'Write your note in Markdown…',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -69,6 +69,7 @@ export const FR: Record<string, string> = {
   // ── Nodi : notes rapides ─────────────────────────────────────────────────
   'Notas rápidas': 'Notes rapides',
   'Nueva nota': 'Nouvelle note',
+  'Título (opcional)': 'Titre (facultatif)',
   'Tachado': 'Barré',
   'Borrar nota': 'Supprimer la note',
   'Escribe tu nota en Markdown…': 'Écris ta note en Markdown…',

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -69,6 +69,7 @@ export const PT_BR: Record<string, string> = {
   // ── Nodi: notas rápidas ──────────────────────────────────────────────────
   'Notas rápidas': 'Notas rápidas',
   'Nueva nota': 'Nova nota',
+  'Título (opcional)': 'Título (opcional)',
   'Tachado': 'Tachado',
   'Borrar nota': 'Excluir nota',
   'Escribe tu nota en Markdown…': 'Escreva sua nota em Markdown…',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -69,6 +69,7 @@ export const PT: Record<string, string> = {
   // ── Nodi: notas rápidas ──────────────────────────────────────────────────
   'Notas rápidas': 'Notas rápidas',
   'Nueva nota': 'Nova nota',
+  'Título (opcional)': 'Título (opcional)',
   'Tachado': 'Rasurado',
   'Borrar nota': 'Eliminar nota',
   'Escribe tu nota en Markdown…': 'Escreve a tua nota em Markdown…',


### PR DESCRIPTION
## Resumen
- autoguarda las notas rápidas de Nodi tras una pausa breve al escribir y fuerza el guardado al abandonar el editor
- permite un título manual opcional y, cuando falta, usa automáticamente las tres primeras palabras del contenido
- serializa los guardados para evitar notas duplicadas durante el primer autoguardado
- añade margen lateral al listado de notas y conserva el comportamiento en temas claro y oscuro

## Validación
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm test` (470/470)
- `node scripts/verify-nodi-notes.mjs`
- simulación local de merge limpia contra `origin/main`

Closes #50