### PR TITLE
Integrar proveedores por suscripción y razonamiento de Codex

### DIFF
--- a/electron/ai/aiClient.ts
+++ b/electron/ai/aiClient.ts
@@ -10,7 +10,7 @@ import {
   localContextWindow,
 } from './providers';
 import { DEFAULT_EMBEDDING_MODELS, normalizeEmbeddingModel, PROVIDER_LABELS } from '@shared/providers';
-import type { AiProvider, EmbeddingProvider, LocalProvider, ModelRef, PromptLanguage, ReasoningEffort } from '@shared/types';
+import type { AiProvider, CodexReasoningEffort, EmbeddingProvider, LocalProvider, ModelRef, PromptLanguage, ReasoningEffort } from '@shared/types';
 import { vaultTypePromptPack } from '@shared/vaultTypes';
 import { anthropicVisionContent, openAiVisionContent, type VisionImagePart } from '@shared/imageAnalysis';
 import { getActiveVault } from '../vaults/vaultRegistry';
@@ -25,6 +25,10 @@ import {
   deanonymizeDeep,
   findResidualNames,
 } from '@shared/studentPseudonyms';
+import { completeWithChatGptSubscription } from './codexSubscription';
+import { completeWithGitHubCopilotSubscription } from './githubCopilotSubscription';
+import { completeWithOpenCodeGo } from './openCodeGoCompletion';
+import { recordOpenCodeGoUsage } from './openCodeGoUsage';
 
 export class AiError extends Error {
   /**
@@ -162,6 +166,9 @@ interface CallOpts {
   /** Reasoning effort. Defaults to `off` for JSON/scan calls and to the configured
    *  `chatReasoning` for conversational calls. */
   reasoning?: ReasoningEffort;
+  /** Let Codex use its per-model setting while retaining an explicit portable effort
+   * for other providers (used by latency-sensitive conversational surfaces). */
+  useConfiguredCodexReasoning?: boolean;
   /** Disable SDK/compatibility retries for explicitly single-attempt workflows. */
   noRetry?: boolean;
   /** Per-request transport timeout override. */
@@ -375,16 +382,67 @@ async function rawComplete(
   model: ModelRef,
   opts: CallOpts,
   jsonMode = true,
-  reasoning: ReasoningEffort = 'off'
+  reasoning: ReasoningEffort = 'off',
+  codexReasoning?: CodexReasoningEffort | null
 ): Promise<string> {
+  // Student names must leave before any provider-specific branch. Subscription
+  // providers do not use API keys, so this deliberately precedes key resolution.
+  // The public entry points map the opaque codes back after parsing/repair.
+  opts = anonymizeCallOpts(opts).sent;
+
+  if (model.provider === 'codex') {
+    try {
+      return await completeWithChatGptSubscription({
+        model: model.model,
+        system: opts.system,
+        user: opts.user,
+        reasoning: codexReasoning === undefined ? reasoning : codexReasoning,
+        timeoutMs: opts.timeoutMs,
+        images: opts.images,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AiError(message, /límite|limit|tempor|timeout|conexión/i.test(message), /conecta|suscripción|autentic/i.test(message));
+    }
+  }
+  if (model.provider === 'github-copilot') {
+    try {
+      return await completeWithGitHubCopilotSubscription({
+        model: model.model,
+        system: opts.system,
+        user: opts.user,
+        reasoning,
+        timeoutMs: opts.timeoutMs,
+        images: opts.images,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AiError(message, /límite|limit|tempor|timeout|conexión|quota|credit/i.test(message), /conecta|suscripción|autentic|cuenta/i.test(message));
+    }
+  }
   const key = resolveProviderKey(model.provider);
   if (!key) throw new AiError(`Falta la clave de IA para ${model.provider}. Configúrala en Ajustes.`, false, true);
 
-  // Student names out. Note the asymmetry: what we RETURN stays in code space, because
-  // parseOrRepair may feed this very text back to the model and a repair round-trip
-  // must never re-encounter a real name. The mapping back happens in the public
-  // entry points (completeJson / completeText / completeTextNeutral).
-  opts = anonymizeCallOpts(opts).sent;
+  if (model.provider === 'opencode-go') {
+    try {
+      const result = await completeWithOpenCodeGo({
+        apiKey: key,
+        model: model.model,
+        system: opts.system,
+        user: opts.user,
+        temperature: opts.temperature,
+        maxTokens: opts.maxTokens,
+        reasoning,
+        jsonMode,
+        timeoutMs: opts.timeoutMs,
+        images: opts.images,
+      });
+      await recordOpenCodeGoUsage(model.model, result.usage);
+      return result.text;
+    } catch (error: any) {
+      throw wrapProviderError(error);
+    }
+  }
 
   if (model.provider === 'anthropic') {
     const Anthropic = (await import('@anthropic-ai/sdk')).default;
@@ -638,7 +696,10 @@ export async function completeJson<T>(
 export async function completeText(opts: CallOpts, model?: ModelRef | null): Promise<string> {
   const resolved = resolveModel(model);
   const reasoning = opts.reasoning ?? getSettings().chatReasoning ?? 'off';
-  return deanonymizeResult(await rawComplete(resolved, withPromptContext(opts), false, reasoning));
+  const codexReasoning = resolved.provider === 'codex' && (opts.reasoning === undefined || opts.useConfiguredCodexReasoning)
+    ? getSettings().codexReasoningEfforts?.[resolved.model] ?? null
+    : undefined;
+  return deanonymizeResult(await rawComplete(resolved, withPromptContext(opts), false, reasoning, codexReasoning));
 }
 
 /**
@@ -661,7 +722,10 @@ export async function completeTextStream(
 ): Promise<string> {
   const resolved = resolveModel(model);
   const reasoning = opts.reasoning ?? getSettings().chatReasoning ?? 'off';
-  return rawCompleteStream(resolved, withPromptContext(opts), onDelta, reasoning, signal);
+  const codexReasoning = resolved.provider === 'codex' && (opts.reasoning === undefined || opts.useConfiguredCodexReasoning)
+    ? getSettings().codexReasoningEfforts?.[resolved.model] ?? null
+    : undefined;
+  return rawCompleteStream(resolved, withPromptContext(opts), onDelta, reasoning, signal, codexReasoning);
 }
 
 async function rawCompleteStream(
@@ -669,11 +733,9 @@ async function rawCompleteStream(
   opts: CallOpts,
   onDelta: TextDeltaHandler,
   reasoning: ReasoningEffort = 'off',
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  codexReasoning?: CodexReasoningEffort | null
 ): Promise<string> {
-  const key = resolveProviderKey(model.provider);
-  if (!key) throw new AiError(`Falta la clave de IA para ${model.provider}. Configúrala en Ajustes.`, false, true);
-
   const { sent, privacy } = anonymizeCallOpts(opts);
   opts = sent;
 
@@ -716,6 +778,78 @@ async function rawCompleteStream(
     if (restReasoning) onDelta(restReasoning, 'reasoning');
     return full;
   };
+
+  if (model.provider === 'codex') {
+    try {
+      const answer = await completeWithChatGptSubscription({
+        model: model.model,
+        system: opts.system,
+        user: opts.user,
+        reasoning: codexReasoning === undefined ? reasoning : codexReasoning,
+        timeoutMs: opts.timeoutMs,
+        images: opts.images,
+        signal,
+        onDelta: emitContent,
+      });
+      if (!full && answer) emitContent(answer);
+      return finish();
+    } catch (error) {
+      if (signal?.aborted) return finish();
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AiError(message, /límite|limit|tempor|timeout|conexión/i.test(message), /conecta|suscripción|autentic/i.test(message));
+    }
+  }
+
+  if (model.provider === 'github-copilot') {
+    try {
+      const answer = await completeWithGitHubCopilotSubscription({
+        model: model.model,
+        system: opts.system,
+        user: opts.user,
+        reasoning,
+        timeoutMs: opts.timeoutMs,
+        images: opts.images,
+        signal,
+        onDelta: emitContent,
+        onReasoningDelta: emitReasoning,
+      });
+      if (!full && answer) emitContent(answer);
+      return finish();
+    } catch (error) {
+      if (signal?.aborted) return finish();
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AiError(message, /límite|limit|tempor|timeout|conexión|quota|credit/i.test(message), /conecta|suscripción|autentic|cuenta/i.test(message));
+    }
+  }
+
+  const key = resolveProviderKey(model.provider);
+  if (!key) throw new AiError(`Falta la clave de IA para ${model.provider}. Configúrala en Ajustes.`, false, true);
+
+  if (model.provider === 'opencode-go') {
+    try {
+      const result = await completeWithOpenCodeGo({
+        apiKey: key,
+        model: model.model,
+        system: opts.system,
+        user: opts.user,
+        temperature: opts.temperature,
+        maxTokens: opts.maxTokens,
+        reasoning,
+        jsonMode: false,
+        timeoutMs: opts.timeoutMs,
+        images: opts.images,
+        signal,
+        onDelta: emitContent,
+        onReasoningDelta: emitReasoning,
+      });
+      await recordOpenCodeGoUsage(model.model, result.usage);
+      if (!full && result.text) emitContent(result.text);
+      return finish();
+    } catch (error: any) {
+      if (signal?.aborted) return finish();
+      throw wrapProviderError(error);
+    }
+  }
 
   if (model.provider === 'anthropic') {
     const Anthropic = (await import('@anthropic-ai/sdk')).default;

--- a/electron/ai/codexAppServerClient.ts
+++ b/electron/ai/codexAppServerClient.ts
@@ -1,0 +1,247 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+type JsonRpcId = number;
+type JsonObject = Record<string, unknown>;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export interface CodexAppServerClientOptions {
+  binaryPath: string;
+  codexHome: string;
+  appVersion: string;
+  requestTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+export type CodexNotificationHandler = (method: string, params: unknown) => void;
+
+/**
+ * Minimal JSONL client for the official Codex App Server. Authentication is
+ * deliberately forced to managed ChatGPT OAuth; API-key environment variables
+ * are stripped before the child process starts.
+ */
+export class CodexAppServerClient {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private startPromise: Promise<void> | null = null;
+  private stopping = false;
+  private nextId = 1;
+  private pending = new Map<JsonRpcId, PendingRequest>();
+  private notificationHandlers = new Set<CodexNotificationHandler>();
+  private stderrTail = '';
+
+  constructor(private readonly options: CodexAppServerClientOptions) {}
+
+  onNotification(handler: CodexNotificationHandler): () => void {
+    this.notificationHandlers.add(handler);
+    return () => this.notificationHandlers.delete(handler);
+  }
+
+  async request<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T> {
+    await this.ensureStarted();
+    return this.sendRequest<T>(method, params, timeoutMs);
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    const child = this.child;
+    this.child = null;
+    this.startPromise = null;
+    if (!child) return;
+
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('El runtime de ChatGPT se ha cerrado.'));
+    }
+    this.pending.clear();
+
+    const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    try { child.stdin.end(); } catch { /* process already gone */ }
+    const timer = setTimeout(() => {
+      try { child.kill('SIGTERM'); } catch { /* process already gone */ }
+    }, 1_500);
+    await Promise.race([exited, new Promise<void>((resolve) => setTimeout(resolve, 2_500))]);
+    clearTimeout(timer);
+    if (child.exitCode === null && !child.killed) {
+      try { child.kill('SIGKILL'); } catch { /* process already gone */ }
+    }
+    this.stopping = false;
+  }
+
+  private async ensureStarted(): Promise<void> {
+    if (this.child && this.child.exitCode === null) return;
+    if (!this.startPromise) {
+      this.startPromise = this.start().finally(() => { this.startPromise = null; });
+    }
+    return this.startPromise;
+  }
+
+  private async start(): Promise<void> {
+    this.stopping = false;
+    this.stderrTail = '';
+    const child = spawn(
+      this.options.binaryPath,
+      [
+        '--config', 'forced_login_method="chatgpt"',
+        '--config', 'cli_auth_credentials_store="keyring"',
+        '--config', 'model_provider="openai"',
+        '--config', 'web_search="disabled"',
+        '--config', 'mcp_servers={}',
+        '--config', 'features.apps=false',
+        '--config', 'features.browser_use=false',
+        '--config', 'features.code_mode_host=false',
+        '--config', 'features.computer_use=false',
+        '--config', 'features.goals=false',
+        '--config', 'features.hooks=false',
+        '--config', 'features.image_generation=false',
+        '--config', 'features.in_app_browser=false',
+        '--config', 'features.multi_agent=false',
+        '--config', 'features.plugins=false',
+        '--config', 'features.shell_tool=false',
+        '--config', 'features.tool_suggest=false',
+        '--config', 'features.unified_exec=false',
+        '--config', 'features.workspace_dependencies=false',
+        'app-server', '--listen', 'stdio://',
+      ],
+      {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+        env: this.sanitizedEnv(),
+      }
+    );
+    this.child = child;
+
+    const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+    lines.on('line', (line) => this.handleLine(line));
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      // Retain only a small, redacted diagnostic tail. Never log auth output.
+      this.stderrTail = redactSecrets(`${this.stderrTail}${chunk}`).slice(-4_000);
+    });
+    child.once('error', (error) => this.handleExit(error));
+    child.once('exit', (code, signal) => {
+      if (this.child === child) this.child = null;
+      if (!this.stopping) {
+        const detail = this.stderrTail.trim();
+        this.handleExit(new Error(
+          `El runtime oficial de Codex se cerró inesperadamente (${signal ?? code ?? 'sin código'}).${detail ? ` ${detail}` : ''}`
+        ));
+      }
+    });
+
+    await this.sendRequest('initialize', {
+      clientInfo: {
+        name: 'nodus_desktop',
+        title: 'Nodus',
+        version: this.options.appVersion,
+      },
+      capabilities: { experimentalApi: false },
+    }, 60_000);
+    this.sendNotification('initialized');
+  }
+
+  private sanitizedEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...(this.options.env ?? process.env), CODEX_HOME: this.options.codexHome };
+    // Managed ChatGPT auth only. Prevent an ambient developer credential or custom
+    // endpoint from silently changing which account/billing surface Nodus uses.
+    for (const name of [
+      'OPENAI_API_KEY',
+      'CODEX_API_KEY',
+      'CODEX_ACCESS_TOKEN',
+      'AZURE_OPENAI_API_KEY',
+      'OPENAI_BASE_URL',
+      'OPENAI_API_BASE',
+    ]) delete env[name];
+    // The model has no execution tools, but do not pass unrelated credentials to
+    // the child process in the first place. Keep ordinary runtime variables such
+    // as PATH, HOME, locale and proxy configuration untouched.
+    for (const name of Object.keys(env)) {
+      if (/(?:API_?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|SESSION|AUTH_SOCK)/i.test(name)) delete env[name];
+    }
+    delete env.NODE_OPTIONS;
+    env.CODEX_HOME = this.options.codexHome;
+    return env;
+  }
+
+  private sendRequest<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T> {
+    const id = this.nextId++;
+    const child = this.child;
+    if (!child || child.exitCode !== null) return Promise.reject(new Error('El runtime oficial de Codex no está disponible.'));
+    const payload: JsonObject = { id, method };
+    if (params !== undefined) payload.params = params;
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Codex no respondió a «${method}» dentro del tiempo esperado.`));
+      }, timeoutMs ?? this.options.requestTimeoutMs ?? 30_000);
+      this.pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timer });
+      child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
+        if (!error) return;
+        const pending = this.pending.get(id);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+        reject(error);
+      });
+    });
+  }
+
+  private sendNotification(method: string, params?: unknown): void {
+    const child = this.child;
+    if (!child || child.exitCode !== null) return;
+    const payload: JsonObject = { method };
+    if (params !== undefined) payload.params = params;
+    child.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  private handleLine(line: string): void {
+    let message: any;
+    try { message = JSON.parse(line); } catch { return; }
+
+    if (typeof message?.id === 'number' && ('result' in message || 'error' in message)) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(new Error(message.error.message ?? 'Codex devolvió un error de protocolo.'));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    if (typeof message?.method === 'string' && message.id !== undefined) {
+      // Nodus never grants tool or approval requests to the runtime. In normal text
+      // generation this path is unreachable because approvals are set to `never`.
+      this.child?.stdin.write(`${JSON.stringify({
+        id: message.id,
+        error: { code: -32601, message: 'Nodus no expone herramientas interactivas a este runtime.' },
+      })}\n`);
+      return;
+    }
+
+    if (typeof message?.method === 'string') {
+      for (const handler of this.notificationHandlers) handler(message.method, message.params);
+    }
+  }
+
+  private handleExit(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+function redactSecrets(value: string): string {
+  return value
+    .replace(/(?:Bearer\s+|sk-[A-Za-z0-9_-]{8})[A-Za-z0-9._-]*/gi, '[credencial ocultada]')
+    .replace(/([?&](?:code|token|state)=)[^\s&]+/gi, '$1[oculto]');
+}

--- a/electron/ai/codexCompletion.ts
+++ b/electron/ai/codexCompletion.ts
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { CodexReasoningEffort, ReasoningEffort } from '@shared/types';
+import type { VisionImagePart } from '@shared/imageAnalysis';
+
+export interface CodexCompletionTransport {
+  request<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
+  onNotification(handler: (method: string, params: unknown) => void): () => void;
+}
+
+export interface IsolatedCodexCompletionOptions {
+  model: string;
+  system: string;
+  user: string;
+  /** Already validated against the selected model's catalog. Null uses its default. */
+  reasoning: CodexReasoningEffort | null;
+  workdir: string;
+  timeoutMs?: number;
+  images?: VisionImagePart[];
+  onDelta?: (delta: string) => void;
+  signal?: AbortSignal;
+}
+
+export interface CodexReasoningModelCapabilities {
+  supportedReasoningEfforts?: Array<{ reasoningEffort: CodexReasoningEffort; description?: string }>;
+  defaultReasoningEffort?: CodexReasoningEffort;
+}
+
+/**
+ * Resolve portable Nodus reasoning into the exact per-model Codex catalog. A saved
+ * option that disappeared after a catalog update safely falls back to the model
+ * default (null); `off` selects the least expensive advertised effort.
+ */
+export function resolveCodexReasoningEffort(
+  model: CodexReasoningModelCapabilities | null,
+  requested: ReasoningEffort | CodexReasoningEffort | null
+): CodexReasoningEffort | null {
+  if (requested === null) return null;
+  const supported = model?.supportedReasoningEfforts?.map((option) => option.reasoningEffort) ?? [];
+  if (supported.length === 0) {
+    if (requested === 'off') return 'low';
+    return (['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as readonly string[])
+      .includes(requested) ? requested : null;
+  }
+  if (requested === 'off') {
+    return (['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const)
+      .find((effort) => supported.includes(effort)) ?? supported[0] ?? null;
+  }
+  return supported.includes(requested) ? requested : null;
+}
+
+function imageExtension(mediaType: string): string {
+  switch (mediaType.toLowerCase()) {
+    case 'image/jpeg': return '.jpg';
+    case 'image/webp': return '.webp';
+    case 'image/gif': return '.gif';
+    default: return '.png';
+  }
+}
+
+function completionError(turn: any): Error {
+  const message = turn?.error?.message ?? turn?.error?.additionalDetails;
+  return new Error(message || `La ejecución de Codex terminó con estado «${turn?.status ?? 'desconocido'}».`);
+}
+
+/** Protocol-level completion kept independent from Electron so isolation can be tested. */
+export async function runIsolatedCodexCompletion(
+  runtime: CodexCompletionTransport,
+  options: IsolatedCodexCompletionOptions
+): Promise<string> {
+  let threadId: string | null = null;
+  let turnId: string | null = null;
+  let full = '';
+  let aborted = options.signal?.aborted ?? false;
+  let unsubscribe: () => void = () => undefined;
+  let timeout: NodeJS.Timeout | null = null;
+  let abortHandler: (() => void) | null = null;
+
+  try {
+    const input: any[] = [{ type: 'text', text: options.user, text_elements: [] }];
+    for (const [index, image] of (options.images ?? []).entries()) {
+      const imagePath = path.join(options.workdir, `image-${index + 1}${imageExtension(image.mediaType)}`);
+      await fs.promises.writeFile(imagePath, Buffer.from(image.base64, 'base64'), { mode: 0o600 });
+      input.push({ type: 'localImage', path: imagePath });
+    }
+
+    const thread = await runtime.request<{ thread: { id: string } }>('thread/start', {
+      model: options.model,
+      modelProvider: 'openai',
+      cwd: options.workdir,
+      approvalPolicy: 'never',
+      sandbox: 'read-only',
+      serviceName: 'nodus_desktop',
+      ephemeral: true,
+      config: {
+        web_search: 'disabled',
+        mcp_servers: {},
+        features: {
+          apps: false,
+          browser_use: false,
+          code_mode_host: false,
+          computer_use: false,
+          goals: false,
+          hooks: false,
+          image_generation: false,
+          in_app_browser: false,
+          multi_agent: false,
+          plugins: false,
+          shell_tool: false,
+          tool_suggest: false,
+          unified_exec: false,
+          workspace_dependencies: false,
+        },
+      },
+      baseInstructions: [
+        'You are a constrained text-generation runtime embedded in Nodus.',
+        'Answer the user request directly and return only the requested content.',
+        'Never invoke shell commands, tools, MCP servers, plugins, skills, subagents, file operations, or web search.',
+        'All context required for the answer is included in the request.',
+      ].join(' '),
+      developerInstructions: options.system,
+    }, 60_000);
+    threadId = thread.thread.id;
+
+    const completed = new Promise<string>((resolve, reject) => {
+      unsubscribe = runtime.onNotification((method, params: any) => {
+        if (params?.threadId !== threadId) return;
+        if (method === 'item/started' && [
+          'commandExecution',
+          'fileChange',
+          'mcpToolCall',
+          'dynamicToolCall',
+          'collabAgentToolCall',
+          'subAgentActivity',
+          'webSearch',
+          'imageView',
+          'imageGeneration',
+        ].includes(params?.item?.type)) {
+          void runtime.request('turn/interrupt', { threadId, turnId: params.turnId }).catch(() => undefined);
+          reject(new Error('Codex intentó usar una herramienta deshabilitada; Nodus interrumpió la petición.'));
+          return;
+        }
+        if (method === 'item/agentMessage/delta' && typeof params.delta === 'string') {
+          full += params.delta;
+          options.onDelta?.(params.delta);
+          return;
+        }
+        if (method !== 'turn/completed') return;
+        const turn = params.turn;
+        if (turn?.status === 'failed') return reject(completionError(turn));
+        const final = [...(turn?.items ?? [])]
+          .reverse()
+          .find((item: any) => item?.type === 'agentMessage' && typeof item.text === 'string' && item.text.trim());
+        if (turn?.status === 'interrupted') return resolve(full || final?.text || '');
+        const answer = final?.text || full;
+        if (!answer.trim()) return reject(new Error('ChatGPT devolvió una respuesta vacía.'));
+        resolve(answer);
+      });
+    });
+
+    abortHandler = () => {
+      aborted = true;
+      if (threadId && turnId) void runtime.request('turn/interrupt', { threadId, turnId }).catch(() => undefined);
+    };
+    options.signal?.addEventListener('abort', abortHandler, { once: true });
+
+    const started = await runtime.request<{ turn: { id: string } }>('turn/start', {
+      threadId,
+      input,
+      cwd: options.workdir,
+      approvalPolicy: 'never',
+      sandboxPolicy: { type: 'readOnly', networkAccess: false },
+      model: options.model,
+      ...(options.reasoning ? { effort: options.reasoning } : {}),
+      summary: 'none',
+    }, 60_000);
+    turnId = started.turn.id;
+    if (aborted) await runtime.request('turn/interrupt', { threadId, turnId }).catch(() => undefined);
+
+    return await Promise.race([
+      completed,
+      new Promise<string>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          if (threadId && turnId) void runtime.request('turn/interrupt', { threadId, turnId }).catch(() => undefined);
+          reject(new Error('ChatGPT no completó la petición dentro del tiempo esperado.'));
+        }, options.timeoutMs ?? 180_000);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    unsubscribe();
+    if (abortHandler) options.signal?.removeEventListener('abort', abortHandler);
+    if (threadId) await runtime.request('thread/unsubscribe', { threadId }).catch(() => undefined);
+  }
+}

--- a/electron/ai/codexSubscription.ts
+++ b/electron/ai/codexSubscription.ts
@@ -1,0 +1,329 @@
+import { app } from 'electron';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type {
+  ChatGptSubscriptionLogin,
+  ChatGptSubscriptionRateLimits,
+  ChatGptSubscriptionStatus,
+  CodexReasoningEffort,
+  ModelInfo,
+  ReasoningEffort,
+} from '@shared/types';
+import type { VisionImagePart } from '@shared/imageAnalysis';
+import { CodexAppServerClient } from './codexAppServerClient';
+import { resolveCodexReasoningEffort, runIsolatedCodexCompletion } from './codexCompletion';
+
+interface CodexAccountResponse {
+  account: null | { type: 'apiKey' } | { type: 'chatgpt'; email: string | null; planType: string } | { type: 'amazonBedrock' };
+  requiresOpenaiAuth: boolean;
+}
+
+interface CodexRateLimitWindow {
+  usedPercent: number;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+interface CodexRateLimitSnapshot {
+  primary: CodexRateLimitWindow | null;
+  secondary: CodexRateLimitWindow | null;
+  credits: { hasCredits: boolean; unlimited: boolean; balance: string | null } | null;
+}
+
+interface CodexRateLimitsResponse {
+  rateLimits: CodexRateLimitSnapshot;
+  rateLimitsByLimitId: Record<string, CodexRateLimitSnapshot> | null;
+}
+
+interface CodexModel {
+  id: string;
+  displayName: string;
+  description: string;
+  hidden: boolean;
+  inputModalities?: string[];
+  isDefault: boolean;
+  supportedReasoningEfforts?: Array<{
+    reasoningEffort: CodexReasoningEffort;
+    description: string;
+  }>;
+  defaultReasoningEffort?: CodexReasoningEffort;
+}
+
+interface CodexCompletionOptions {
+  model: string;
+  system: string;
+  user: string;
+  reasoning: ReasoningEffort | CodexReasoningEffort | null;
+  timeoutMs?: number;
+  images?: VisionImagePart[];
+  onDelta?: (delta: string) => void;
+  signal?: AbortSignal;
+}
+
+const STATUS_UNAVAILABLE: ChatGptSubscriptionStatus = {
+  available: false,
+  connected: false,
+  loginPending: false,
+  email: null,
+  planType: null,
+  rateLimits: null,
+  error: null,
+};
+
+const statusListeners = new Set<(status: ChatGptSubscriptionStatus) => void>();
+let client: CodexAppServerClient | null = null;
+let clientUnsubscribe: (() => void) | null = null;
+let pendingLoginId: string | null = null;
+let lastStatus: ChatGptSubscriptionStatus = STATUS_UNAVAILABLE;
+let modelCatalog = new Map<string, CodexModel>();
+
+export function onChatGptSubscriptionStatusChanged(
+  listener: (status: ChatGptSubscriptionStatus) => void
+): () => void {
+  statusListeners.add(listener);
+  return () => statusListeners.delete(listener);
+}
+
+function emitStatus(status: ChatGptSubscriptionStatus): void {
+  lastStatus = status;
+  for (const listener of statusListeners) listener(status);
+}
+
+function codexHome(): string {
+  const dir = path.join(app.getPath('userData'), 'codex-subscription');
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(dir, 0o700); } catch { /* Windows and restrictive filesystems */ }
+  return dir;
+}
+
+function unpackedAsarPath(file: string): string {
+  const marker = `${path.sep}app.asar${path.sep}`;
+  return file.includes(marker) ? file.replace(marker, `${path.sep}app.asar.unpacked${path.sep}`) : file;
+}
+
+export function resolveCodexBinaryPath(): string {
+  const target = (() => {
+    if (process.platform === 'darwin' && process.arch === 'arm64') return ['@openai/codex-darwin-arm64', 'aarch64-apple-darwin'];
+    if (process.platform === 'darwin' && process.arch === 'x64') return ['@openai/codex-darwin-x64', 'x86_64-apple-darwin'];
+    if (process.platform === 'linux' && process.arch === 'arm64') return ['@openai/codex-linux-arm64', 'aarch64-unknown-linux-musl'];
+    if (process.platform === 'linux' && process.arch === 'x64') return ['@openai/codex-linux-x64', 'x86_64-unknown-linux-musl'];
+    if (process.platform === 'win32' && process.arch === 'arm64') return ['@openai/codex-win32-arm64', 'aarch64-pc-windows-msvc'];
+    if (process.platform === 'win32' && process.arch === 'x64') return ['@openai/codex-win32-x64', 'x86_64-pc-windows-msvc'];
+    return null;
+  })();
+  if (!target) throw new Error(`Codex no es compatible con ${process.platform}/${process.arch}.`);
+
+  // The Electron bundle recreates __filename in its banner; using it also keeps
+  // the repository's CommonJS-based TS test harness compatible with this module.
+  const require = createRequire(__filename);
+  let packageJson: string;
+  try {
+    packageJson = require.resolve(`${target[0]}/package.json`);
+  } catch {
+    // electron-builder may keep optional dependencies nested under their
+    // parent package instead of hoisting them. Resolve the signed Codex loader
+    // first and accept only its own pinned optional runtime.
+    try {
+      const codexPackageJson = require.resolve('@openai/codex/package.json');
+      packageJson = path.join(
+        path.dirname(codexPackageJson),
+        'node_modules',
+        ...target[0].split('/'),
+        'package.json'
+      );
+      if (!fs.existsSync(packageJson)) throw new Error('nested runtime missing');
+    } catch {
+      throw new Error('No se encontró el runtime oficial de Codex incluido con Nodus.');
+    }
+  }
+  const executable = unpackedAsarPath(path.join(
+    path.dirname(packageJson),
+    'vendor',
+    target[1],
+    'bin',
+    process.platform === 'win32' ? 'codex.exe' : 'codex'
+  ));
+  if (!fs.existsSync(executable)) throw new Error('El ejecutable oficial de Codex no está disponible en esta instalación.');
+  return executable;
+}
+
+function getClient(): CodexAppServerClient {
+  if (client) return client;
+  client = new CodexAppServerClient({
+    binaryPath: resolveCodexBinaryPath(),
+    codexHome: codexHome(),
+    appVersion: app.getVersion(),
+  });
+  clientUnsubscribe = client.onNotification((method) => {
+    if (method === 'account/login/completed') pendingLoginId = null;
+    if (method === 'account/login/completed' || method === 'account/updated') modelCatalog = new Map();
+    if (
+      method === 'account/login/completed' ||
+      method === 'account/updated' ||
+      method === 'account/rateLimits/updated'
+    ) {
+      void refreshAndEmitStatus();
+    }
+  });
+  return client;
+}
+
+function mapRateLimits(snapshot: CodexRateLimitSnapshot | null): ChatGptSubscriptionRateLimits | null {
+  if (!snapshot) return null;
+  return {
+    primary: snapshot.primary,
+    secondary: snapshot.secondary,
+    credits: snapshot.credits,
+  };
+}
+
+async function readStatus(refreshToken = false): Promise<ChatGptSubscriptionStatus> {
+  try {
+    const runtime = getClient();
+    const response = await runtime.request<CodexAccountResponse>('account/read', { refreshToken });
+    if (response.account?.type !== 'chatgpt') {
+      return {
+        available: true,
+        connected: false,
+        loginPending: pendingLoginId !== null,
+        email: null,
+        planType: null,
+        rateLimits: null,
+        error: response.account
+          ? 'Codex está autenticado con un método no permitido. Nodus solo admite el acceso gestionado con ChatGPT.'
+          : null,
+      };
+    }
+
+    let rateLimits: ChatGptSubscriptionRateLimits | null = null;
+    try {
+      const limits = await runtime.request<CodexRateLimitsResponse>('account/rateLimits/read');
+      const codexBucket = limits.rateLimitsByLimitId?.codex ?? limits.rateLimits;
+      rateLimits = mapRateLimits(codexBucket);
+    } catch {
+      // Account status remains useful if a plan has no rate-limit snapshot.
+    }
+    return {
+      available: true,
+      connected: true,
+      loginPending: pendingLoginId !== null,
+      email: response.account.email,
+      planType: response.account.planType,
+      rateLimits,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      ...STATUS_UNAVAILABLE,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function refreshAndEmitStatus(): Promise<ChatGptSubscriptionStatus> {
+  const status = await readStatus(false);
+  emitStatus(status);
+  return status;
+}
+
+export async function getChatGptSubscriptionStatus(): Promise<ChatGptSubscriptionStatus> {
+  return refreshAndEmitStatus();
+}
+
+export async function startChatGptSubscriptionLogin(): Promise<ChatGptSubscriptionLogin> {
+  const response = await getClient().request<
+    { type: 'chatgpt'; loginId: string; authUrl: string } | { type: string }
+  >('account/login/start', {
+    type: 'chatgpt',
+    appBrand: 'chatgpt',
+    useHostedLoginSuccessPage: true,
+  });
+  if (response.type !== 'chatgpt' || !('loginId' in response) || !('authUrl' in response)) {
+    throw new Error('Codex no inició el acceso gestionado con ChatGPT.');
+  }
+  pendingLoginId = response.loginId;
+  emitStatus({ ...lastStatus, available: true, loginPending: true, error: null });
+  return { loginId: response.loginId, authUrl: response.authUrl };
+}
+
+export async function cancelChatGptSubscriptionLogin(loginId: string): Promise<ChatGptSubscriptionStatus> {
+  if (pendingLoginId && pendingLoginId !== loginId) throw new Error('El identificador de acceso ya no está activo.');
+  await getClient().request('account/login/cancel', { loginId });
+  pendingLoginId = null;
+  return refreshAndEmitStatus();
+}
+
+export async function logoutChatGptSubscription(): Promise<ChatGptSubscriptionStatus> {
+  await getClient().request('account/logout');
+  pendingLoginId = null;
+  modelCatalog = new Map();
+  return refreshAndEmitStatus();
+}
+
+async function readModelCatalog(force = false): Promise<CodexModel[]> {
+  if (!force && modelCatalog.size > 0) return [...modelCatalog.values()];
+  const models: CodexModel[] = [];
+  let cursor: string | null = null;
+  do {
+    const page: { data: CodexModel[]; nextCursor: string | null } = await getClient().request('model/list', {
+      cursor,
+      limit: 100,
+      // Keep the full capability catalog for validating an older saved model; the
+      // renderer still filters hidden entries out of the visible picker below.
+      includeHidden: true,
+    });
+    models.push(...page.data);
+    cursor = page.nextCursor;
+  } while (cursor);
+  modelCatalog = new Map(models.map((model) => [model.id, model]));
+  return models;
+}
+
+export async function listChatGptSubscriptionModels(): Promise<ModelInfo[]> {
+  const status = await readStatus(false);
+  if (!status.connected) throw new Error('Conecta primero una suscripción de ChatGPT en Proveedores y modelos.');
+  const models = await readModelCatalog(true);
+  return models
+    .filter((model) => !model.hidden)
+    .map((model) => ({
+      id: model.id,
+      name: model.displayName || model.id,
+      vision: (model.inputModalities ?? ['text', 'image']).includes('image'),
+      reasoning: (model.supportedReasoningEfforts?.length ?? 0) > 0,
+      supportedReasoningEfforts: model.supportedReasoningEfforts,
+      defaultReasoningEffort: model.defaultReasoningEffort,
+    }))
+    .sort((a, b) => Number(b.id === models.find((m) => m.isDefault)?.id) - Number(a.id === models.find((m) => m.isDefault)?.id) || a.id.localeCompare(b.id));
+}
+
+/** Text/vision completion backed by an ephemeral, isolated Codex thread. */
+export async function completeWithChatGptSubscription(options: CodexCompletionOptions): Promise<string> {
+  const status = await readStatus(true);
+  if (!status.connected) throw new Error('La suscripción de ChatGPT no está conectada. Ábrela en Proveedores y modelos.');
+
+  const runtime = getClient();
+  const catalog = await readModelCatalog(false);
+  const reasoning = resolveCodexReasoningEffort(
+    catalog.find((model) => model.id === options.model) ?? null,
+    options.reasoning
+  );
+  const tempRoot = path.join(app.getPath('temp') || os.tmpdir(), 'nodus-codex-');
+  const workdir = await fs.promises.mkdtemp(tempRoot);
+  try { await fs.promises.chmod(workdir, 0o700); } catch { /* Windows */ }
+
+  try {
+    return await runIsolatedCodexCompletion(runtime, { ...options, reasoning, workdir });
+  } finally {
+    await fs.promises.rm(workdir, { recursive: true, force: true });
+  }
+}
+
+export async function stopChatGptSubscriptionServer(): Promise<void> {
+  clientUnsubscribe?.();
+  clientUnsubscribe = null;
+  const current = client;
+  client = null;
+  if (current) await current.stop();
+}

--- a/electron/ai/githubCopilotCompletion.ts
+++ b/electron/ai/githubCopilotCompletion.ts
@@ -1,0 +1,169 @@
+import type { ReasoningEffort } from '@shared/types';
+import type { VisionImagePart } from '@shared/imageAnalysis';
+
+interface CopilotSessionLike {
+  sessionId: string;
+  rpc?: { usage?: { getMetrics?: () => Promise<any> } };
+  on(handler: (event: any) => void): () => void;
+  sendAndWait(options: any, timeout?: number): Promise<any>;
+  abort(): Promise<void>;
+  disconnect(): Promise<void>;
+}
+
+export interface CopilotClientLike {
+  createSession(config: any): Promise<CopilotSessionLike>;
+  deleteSession(sessionId: string): Promise<void>;
+}
+
+export interface GitHubCopilotCompletionOptions {
+  model: string;
+  system: string;
+  user: string;
+  reasoning: ReasoningEffort;
+  supportsReasoning: boolean;
+  workdir: string;
+  timeoutMs?: number;
+  images?: VisionImagePart[];
+  signal?: AbortSignal;
+  onDelta?: (delta: string) => void;
+  onReasoningDelta?: (delta: string) => void;
+}
+
+export interface GitHubCopilotCompletionUsage {
+  model: string;
+  premiumRequestCost: number;
+  userRequests: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface GitHubCopilotCompletionResult {
+  text: string;
+  usage: GitHubCopilotCompletionUsage | null;
+}
+
+function messageContent(response: any): string {
+  return typeof response?.data?.content === 'string' ? response.data.content : '';
+}
+
+function usageFrom(metrics: any, model: string): GitHubCopilotCompletionUsage | null {
+  if (!metrics) return null;
+  return {
+    model: metrics.currentModel ?? model,
+    premiumRequestCost: Number(metrics.totalPremiumRequestCost ?? 0),
+    userRequests: Number(metrics.totalUserRequests ?? 0),
+    inputTokens: Number(metrics.lastCallInputTokens ?? 0),
+    outputTokens: Number(metrics.lastCallOutputTokens ?? 0),
+  };
+}
+
+/** One ephemeral no-tools session. The empty SDK mode disables ambient CLI
+ * features; the explicit filters and rejection handler are a second fail-closed
+ * layer, while the empty workdir prevents instruction-file discovery. */
+export async function runIsolatedGitHubCopilotCompletion(
+  client: CopilotClientLike,
+  options: GitHubCopilotCompletionOptions
+): Promise<GitHubCopilotCompletionResult> {
+  let session: CopilotSessionLike | null = null;
+  let unsubscribe: () => void = () => undefined;
+  let abortHandler: (() => void) | null = null;
+  let partial = '';
+  let eventError: ((error: Error) => void) | null = null;
+  let eventFailure: Error | null = null;
+
+  try {
+    session = await client.createSession({
+      clientName: 'nodus-desktop',
+      model: options.model,
+      ...(options.supportsReasoning && options.reasoning !== 'off'
+        ? { reasoningEffort: options.reasoning }
+        : {}),
+      workingDirectory: options.workdir,
+      streaming: Boolean(options.onDelta || options.onReasoningDelta),
+      systemMessage: {
+        mode: 'append',
+        content: [
+          'You are a constrained text-generation runtime embedded in Nodus.',
+          'Answer the supplied request directly and return only the requested content.',
+          'Never use tools, shell commands, files, URLs, MCP servers, plugins, skills, memory, subagents, or GitHub context.',
+          'All context required for the answer is included in this request.',
+          options.system,
+        ].join(' '),
+      },
+      tools: [],
+      availableTools: [],
+      excludedTools: ['builtin:*', 'mcp:*', 'custom:*'],
+      mcpServers: {},
+      enableConfigDiscovery: false,
+      skillDirectories: [],
+      instructionDirectories: [],
+      enableSkills: false,
+      infiniteSessions: { enabled: false },
+      memory: { enabled: false },
+      skipEmbeddingRetrieval: true,
+      embeddingCacheStorage: 'in-memory',
+      enableOnDemandInstructionDiscovery: false,
+      enableFileHooks: false,
+      enableHostGitOperations: false,
+      enableSessionStore: false,
+      remoteSession: 'off',
+      enableSessionTelemetry: false,
+      onPermissionRequest: () => ({ kind: 'reject', feedback: 'Nodus does not expose tools for text generation.' }),
+    });
+
+    const unexpectedExecution = new Promise<never>((_resolve, reject) => { eventError = reject; });
+    unsubscribe = session.on((event) => {
+      if (event?.agentId) return;
+      if (event?.type === 'assistant.message_delta' && typeof event.data?.deltaContent === 'string') {
+        partial += event.data.deltaContent;
+        options.onDelta?.(event.data.deltaContent);
+        return;
+      }
+      if (event?.type === 'assistant.reasoning_delta' && typeof event.data?.deltaContent === 'string') {
+        options.onReasoningDelta?.(event.data.deltaContent);
+        return;
+      }
+      if (['tool.execution_start', 'permission.requested', 'external_tool.requested'].includes(event?.type)) {
+        eventFailure = new Error('GitHub Copilot intentó usar una herramienta deshabilitada; Nodus interrumpió la petición.');
+        void session?.abort().catch(() => undefined);
+        eventError?.(eventFailure);
+        return;
+      }
+      if (event?.type === 'session.error') {
+        const message = event.data?.message ?? event.data?.error ?? 'GitHub Copilot devolvió un error de sesión.';
+        eventFailure = new Error(message);
+        eventError?.(eventFailure);
+      }
+    });
+
+    abortHandler = () => { void session?.abort().catch(() => undefined); };
+    if (options.signal?.aborted) abortHandler();
+    else options.signal?.addEventListener('abort', abortHandler, { once: true });
+
+    const attachments = (options.images ?? []).map((image, index) => ({
+      type: 'blob' as const,
+      data: image.base64,
+      mimeType: image.mediaType,
+      displayName: `nodus-image-${index + 1}`,
+    }));
+    const response = await Promise.race([
+      session.sendAndWait({ prompt: options.user, ...(attachments.length ? { attachments } : {}) }, options.timeoutMs ?? 180_000),
+      unexpectedExecution,
+    ]);
+    if (eventFailure) throw eventFailure;
+    const text = messageContent(response) || partial;
+    if (!text.trim() && !options.signal?.aborted) throw new Error('GitHub Copilot devolvió una respuesta vacía.');
+
+    let metrics: any = null;
+    try { metrics = await session.rpc?.usage?.getMetrics?.(); } catch { /* completion remains valid */ }
+    return { text, usage: usageFrom(metrics, options.model) };
+  } finally {
+    unsubscribe();
+    if (abortHandler) options.signal?.removeEventListener('abort', abortHandler);
+    if (session) {
+      const id = session.sessionId;
+      try { await session.disconnect(); } catch { /* delete is the definitive cleanup */ }
+      await client.deleteSession(id).catch(() => undefined);
+    }
+  }
+}

--- a/electron/ai/githubCopilotSubscription.ts
+++ b/electron/ai/githubCopilotSubscription.ts
@@ -1,0 +1,316 @@
+import { app } from 'electron';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CopilotClient, RuntimeConnection, type ModelInfo as CopilotModelInfo } from '@github/copilot-sdk';
+import type {
+  GitHubCopilotSessionUsage,
+  GitHubCopilotSubscriptionQuotaWindow,
+  GitHubCopilotSubscriptionStatus,
+  ModelInfo,
+  ReasoningEffort,
+} from '@shared/types';
+import type { VisionImagePart } from '@shared/imageAnalysis';
+import { runIsolatedGitHubCopilotCompletion } from './githubCopilotCompletion';
+
+interface CompletionOptions {
+  model: string;
+  system: string;
+  user: string;
+  reasoning: ReasoningEffort;
+  timeoutMs?: number;
+  images?: VisionImagePart[];
+  onDelta?: (delta: string) => void;
+  onReasoningDelta?: (delta: string) => void;
+  signal?: AbortSignal;
+}
+
+const EMPTY_STATUS: GitHubCopilotSubscriptionStatus = {
+  available: false,
+  connected: false,
+  loginPending: false,
+  login: null,
+  authType: null,
+  statusMessage: null,
+  canLogout: false,
+  quota: [],
+  lastSession: null,
+  error: null,
+};
+
+const listeners = new Set<(status: GitHubCopilotSubscriptionStatus) => void>();
+let client: CopilotClient | null = null;
+let loginProcess: ChildProcessWithoutNullStreams | null = null;
+let loginDiagnostic = '';
+let lastSession: GitHubCopilotSessionUsage | null = null;
+let modelCache: CopilotModelInfo[] | null = null;
+
+function copilotHome(): string {
+  const dir = path.join(app.getPath('userData'), 'github-copilot-subscription');
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(dir, 0o700); } catch { /* Windows */ }
+  return dir;
+}
+
+function unpackedAsarPath(file: string): string {
+  const marker = `${path.sep}app.asar${path.sep}`;
+  return file.includes(marker) ? file.replace(marker, `${path.sep}app.asar.unpacked${path.sep}`) : file;
+}
+
+export function resolveGitHubCopilotBinaryPath(): string {
+  const packageName = (() => {
+    if (process.platform === 'darwin' && process.arch === 'arm64') return '@github/copilot-darwin-arm64';
+    if (process.platform === 'darwin' && process.arch === 'x64') return '@github/copilot-darwin-x64';
+    if (process.platform === 'linux' && process.arch === 'arm64') return '@github/copilot-linux-arm64';
+    if (process.platform === 'linux' && process.arch === 'x64') return '@github/copilot-linux-x64';
+    if (process.platform === 'win32' && process.arch === 'arm64') return '@github/copilot-win32-arm64';
+    if (process.platform === 'win32' && process.arch === 'x64') return '@github/copilot-win32-x64';
+    return null;
+  })();
+  if (!packageName) throw new Error(`GitHub Copilot no es compatible con ${process.platform}/${process.arch}.`);
+
+  const require = createRequire(__filename);
+  let executable: string;
+  try {
+    executable = require.resolve(packageName);
+  } catch {
+    try {
+      const loader = require.resolve('@github/copilot/package.json');
+      executable = path.join(path.dirname(loader), 'node_modules', ...packageName.split('/'), process.platform === 'win32' ? 'copilot.exe' : 'copilot');
+    } catch {
+      throw new Error('No se encontró el runtime oficial de GitHub Copilot incluido con Nodus.');
+    }
+  }
+  executable = unpackedAsarPath(executable);
+  if (!fs.existsSync(executable)) throw new Error('El ejecutable oficial de GitHub Copilot no está disponible en esta instalación.');
+  return executable;
+}
+
+function sanitizedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (/(?:API_?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|SESSION)/i.test(name)) continue;
+    env[name] = value;
+  }
+  delete env.NODE_OPTIONS;
+  env.COPILOT_HOME = copilotHome();
+  return env;
+}
+
+function getClient(): CopilotClient {
+  if (client) return client;
+  const home = copilotHome();
+  client = new CopilotClient({
+    connection: RuntimeConnection.forStdio({ path: resolveGitHubCopilotBinaryPath(), env: sanitizedEnv() }),
+    mode: 'empty',
+    baseDirectory: home,
+    workingDirectory: home,
+    useLoggedInUser: true,
+    logLevel: 'none',
+  });
+  return client;
+}
+
+function emit(status: GitHubCopilotSubscriptionStatus): void {
+  for (const listener of listeners) listener(status);
+}
+
+export function onGitHubCopilotSubscriptionStatusChanged(
+  listener: (status: GitHubCopilotSubscriptionStatus) => void
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function mapQuota(id: string, raw: any): GitHubCopilotSubscriptionQuotaWindow {
+  const entitlement = Number(raw?.entitlementRequests ?? 0);
+  const used = Number(raw?.usedRequests ?? 0);
+  const unlimited = Boolean(raw?.isUnlimitedEntitlement);
+  return {
+    id,
+    unlimited,
+    entitlementRequests: entitlement,
+    usedRequests: used,
+    remainingRequests: unlimited ? null : Math.max(0, entitlement - used),
+    remainingPercentage: Math.max(0, Math.min(100, Number(raw?.remainingPercentage ?? 0))),
+    overage: Number(raw?.overage ?? 0),
+    overageAllowed: Boolean(raw?.overageAllowedWithExhaustedQuota),
+    usageAllowedAfterExhaustion: Boolean(raw?.usageAllowedWithExhaustedQuota),
+    resetDate: typeof raw?.resetDate === 'string' ? raw.resetDate : null,
+    tokenBasedBilling: Boolean(raw?.tokenBasedBilling),
+    hasQuota: raw?.hasQuota === undefined ? unlimited || entitlement > used : Boolean(raw.hasQuota),
+  };
+}
+
+async function readStatus(): Promise<GitHubCopilotSubscriptionStatus> {
+  try {
+    const runtime = getClient();
+    await runtime.start();
+    const auth = await runtime.getAuthStatus();
+    if (!auth.isAuthenticated) {
+      return {
+        ...EMPTY_STATUS,
+        available: true,
+        loginPending: loginProcess !== null,
+        statusMessage: auth.statusMessage ?? null,
+        lastSession,
+        error: loginDiagnostic || null,
+      };
+    }
+    let quota: GitHubCopilotSubscriptionQuotaWindow[] = [];
+    try {
+      const response = await runtime.rpc.account.getQuota({});
+      quota = Object.entries(response.quotaSnapshots ?? {})
+        .flatMap(([id, value]) => value ? [mapQuota(id, value)] : [])
+        .sort((a, b) => Number(b.id === 'premium_interactions') - Number(a.id === 'premium_interactions') || a.id.localeCompare(b.id));
+    } catch { /* authentication/catalogue still useful without a quota snapshot */ }
+    return {
+      available: true,
+      connected: true,
+      loginPending: loginProcess !== null,
+      login: auth.login ?? null,
+      authType: auth.authType ?? null,
+      statusMessage: auth.statusMessage ?? null,
+      // Never log the user out of GitHub CLI or revoke environment credentials.
+      canLogout: auth.authType === 'user',
+      quota,
+      lastSession,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      ...EMPTY_STATUS,
+      loginPending: loginProcess !== null,
+      lastSession,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function refresh(): Promise<GitHubCopilotSubscriptionStatus> {
+  const status = await readStatus();
+  emit(status);
+  return status;
+}
+
+export async function getGitHubCopilotSubscriptionStatus(): Promise<GitHubCopilotSubscriptionStatus> {
+  return refresh();
+}
+
+export async function startGitHubCopilotSubscriptionLogin(): Promise<GitHubCopilotSubscriptionStatus> {
+  const current = await readStatus();
+  if (current.connected || loginProcess) return current;
+  loginDiagnostic = '';
+  const child = spawn(resolveGitHubCopilotBinaryPath(), ['login', '--host', 'https://github.com'], {
+    env: sanitizedEnv(),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  loginProcess = child;
+  child.stdin.end();
+  const capture = (chunk: Buffer | string) => {
+    loginDiagnostic = `${loginDiagnostic}${String(chunk)}`
+      .replace(/(?:gh[oupsr]_|github_pat_)[A-Za-z0-9_]+/g, '[credencial ocultada]')
+      .slice(-2_000);
+  };
+  child.stdout.on('data', capture);
+  child.stderr.on('data', capture);
+  child.once('error', (error) => {
+    loginDiagnostic = error.message;
+    if (loginProcess === child) loginProcess = null;
+    void refresh();
+  });
+  child.once('exit', (code) => {
+    if (loginProcess === child) loginProcess = null;
+    if (code === 0) loginDiagnostic = '';
+    void stopClient().finally(() => refresh());
+  });
+  emit({ ...current, available: true, loginPending: true, error: null });
+  return { ...current, available: true, loginPending: true, error: null };
+}
+
+export async function cancelGitHubCopilotSubscriptionLogin(): Promise<GitHubCopilotSubscriptionStatus> {
+  const child = loginProcess;
+  loginProcess = null;
+  if (child && child.exitCode === null) {
+    try { child.kill('SIGTERM'); } catch { /* already exited */ }
+  }
+  loginDiagnostic = '';
+  return refresh();
+}
+
+export async function logoutGitHubCopilotSubscription(): Promise<GitHubCopilotSubscriptionStatus> {
+  const runtime = getClient();
+  await runtime.start();
+  const auth = await runtime.getAuthStatus();
+  if (auth.authType !== 'user') {
+    throw new Error('Esta conexión procede de GitHub CLI o del entorno. Nodus no cerrará una sesión global de GitHub; gestiónala en GitHub CLI.');
+  }
+  const current = await runtime.rpc.account.getCurrentAuth();
+  if (current.authInfo) await runtime.rpc.account.logout({ authInfo: current.authInfo });
+  await stopClient();
+  return refresh();
+}
+
+async function copilotModels(): Promise<CopilotModelInfo[]> {
+  if (modelCache) return modelCache;
+  const runtime = getClient();
+  await runtime.start();
+  const auth = await runtime.getAuthStatus();
+  if (!auth.isAuthenticated) throw new Error('Conecta primero tu cuenta de GitHub Copilot en Proveedores y modelos.');
+  modelCache = await runtime.listModels();
+  return modelCache;
+}
+
+export async function listGitHubCopilotSubscriptionModels(): Promise<ModelInfo[]> {
+  return (await copilotModels()).map((model) => ({
+    id: model.id,
+    name: model.name || model.id,
+    contextLength: model.capabilities?.limits?.max_context_window_tokens,
+    vision: model.capabilities?.supports?.vision,
+    reasoning: model.capabilities?.supports?.reasoningEffort,
+  }));
+}
+
+export async function completeWithGitHubCopilotSubscription(options: CompletionOptions): Promise<string> {
+  const models = await copilotModels();
+  const selected = models.find((model) => model.id === options.model);
+  if (!selected) throw new Error(`El modelo «${options.model}» no está disponible en tu suscripción de GitHub Copilot.`);
+  if (options.images?.length && !selected.capabilities?.supports?.vision) {
+    throw new Error(`El modelo «${options.model}» de GitHub Copilot no admite imágenes.`);
+  }
+
+  const workdir = await fs.promises.mkdtemp(path.join(app.getPath('temp') || os.tmpdir(), 'nodus-github-copilot-'));
+  try { await fs.promises.chmod(workdir, 0o700); } catch { /* Windows */ }
+  try {
+    const result = await runIsolatedGitHubCopilotCompletion(getClient(), {
+      ...options,
+      supportsReasoning: Boolean(selected.capabilities?.supports?.reasoningEffort),
+      workdir,
+    });
+    if (result.usage) lastSession = result.usage;
+    void refresh();
+    return result.text;
+  } finally {
+    await fs.promises.rm(workdir, { recursive: true, force: true });
+  }
+}
+
+async function stopClient(): Promise<void> {
+  const current = client;
+  client = null;
+  modelCache = null;
+  if (current) await current.stop();
+}
+
+export async function stopGitHubCopilotSubscription(): Promise<void> {
+  const child = loginProcess;
+  loginProcess = null;
+  if (child && child.exitCode === null) {
+    try { child.kill('SIGTERM'); } catch { /* already exited */ }
+  }
+  await stopClient();
+}

--- a/electron/ai/nodiChat.ts
+++ b/electron/ai/nodiChat.ts
@@ -151,7 +151,7 @@ export async function streamNodiChat(
   ].filter(Boolean).join('\n\n');
   const settings = getSettings();
   return completeTextStream(
-    { system: buildSystemPrompt(request, context.sources), user, maxTokens: 1_200, temperature: 0.2, reasoning: 'off', plainContext: true },
+    { system: buildSystemPrompt(request, context.sources), user, maxTokens: 1_200, temperature: 0.2, reasoning: 'off', useConfiguredCodexReasoning: true, plainContext: true },
     (delta, kind) => { if (kind === 'content') onDelta(delta); },
     request.model ?? settings.nodiModel ?? settings.chatModel,
     signal

--- a/electron/ai/openCodeGoCompletion.ts
+++ b/electron/ai/openCodeGoCompletion.ts
@@ -1,0 +1,270 @@
+import type { ReasoningEffort } from '@shared/types';
+import type { VisionImagePart } from '@shared/imageAnalysis';
+
+export type OpenCodeGoProtocol = 'openai' | 'anthropic';
+
+export interface OpenCodeGoNormalizedUsage {
+  uncachedInputTokens: number;
+  outputTokens: number;
+  cachedReadTokens: number;
+  cachedWriteTokens: number;
+}
+
+export interface OpenCodeGoCompletionOptions {
+  apiKey: string;
+  model: string;
+  system: string;
+  user: string;
+  temperature?: number;
+  maxTokens?: number;
+  reasoning?: ReasoningEffort;
+  jsonMode?: boolean;
+  timeoutMs?: number;
+  images?: VisionImagePart[];
+  signal?: AbortSignal;
+  onDelta?: (delta: string) => void;
+  onReasoningDelta?: (delta: string) => void;
+  /** Test seam; production always uses the documented OpenCode Go endpoint. */
+  baseUrl?: string;
+}
+
+export interface OpenCodeGoCompletionResult {
+  text: string;
+  usage: OpenCodeGoNormalizedUsage | null;
+}
+
+const ANTHROPIC_MODEL_PREFIXES = ['minimax-', 'qwen'];
+
+/** The official Go catalogue documents MiniMax/Qwen on Messages and the rest on
+ * Chat Completions. Unknown future models use the OpenAI-compatible route unless
+ * their family is explicitly one of the Messages families. */
+export function openCodeGoProtocol(model: string): OpenCodeGoProtocol {
+  return ANTHROPIC_MODEL_PREFIXES.some((prefix) => model.toLowerCase().startsWith(prefix))
+    ? 'anthropic'
+    : 'openai';
+}
+
+function apiError(status: number, payload: unknown): Error & { status: number } {
+  const detail = (() => {
+    if (typeof payload === 'string') return payload;
+    const body = payload as any;
+    return body?.error?.message ?? body?.message ?? body?.error?.type ?? `HTTP ${status}`;
+  })();
+  return Object.assign(new Error(`OpenCode Go rechazó la solicitud: ${detail}`), { status });
+}
+
+async function readError(response: Response): Promise<never> {
+  const raw = await response.text();
+  let payload: unknown = raw;
+  try { payload = JSON.parse(raw); } catch { /* retain readable text */ }
+  throw apiError(response.status, payload);
+}
+
+function linkedSignal(signal: AbortSignal | undefined, timeoutMs: number): { signal: AbortSignal; dispose: () => void } {
+  const controller = new AbortController();
+  const abort = () => controller.abort(signal?.reason);
+  if (signal?.aborted) abort();
+  else signal?.addEventListener('abort', abort, { once: true });
+  const timer = setTimeout(() => controller.abort(new Error('timeout')), timeoutMs);
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', abort);
+    },
+  };
+}
+
+async function* sseEvents(response: Response): AsyncGenerator<{ event: string | null; data: string }> {
+  if (!response.body) throw new Error('OpenCode Go devolvió un stream vacío.');
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+      const blocks = buffer.split(/\r?\n\r?\n/);
+      buffer = blocks.pop() ?? '';
+      for (const block of blocks) {
+        let event: string | null = null;
+        const data: string[] = [];
+        for (const line of block.split(/\r?\n/)) {
+          if (line.startsWith('event:')) event = line.slice(6).trim();
+          else if (line.startsWith('data:')) data.push(line.slice(5).trimStart());
+        }
+        if (data.length) yield { event, data: data.join('\n') };
+      }
+      if (done) break;
+    }
+    if (buffer.trim()) {
+      const data = buffer.split(/\r?\n/).filter((line) => line.startsWith('data:')).map((line) => line.slice(5).trimStart());
+      if (data.length) yield { event: null, data: data.join('\n') };
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function assertText(text: string): string {
+  if (!text.trim()) throw new Error('OpenCode Go devolvió una respuesta vacía.');
+  return text;
+}
+
+function openAiUsage(usage: any): OpenCodeGoNormalizedUsage | null {
+  if (!usage) return null;
+  const totalInput = Number(usage.prompt_tokens ?? usage.input_tokens ?? 0);
+  const cachedRead = Number(usage.prompt_tokens_details?.cached_tokens ?? usage.input_tokens_details?.cached_tokens ?? 0);
+  return {
+    uncachedInputTokens: Math.max(0, totalInput - cachedRead),
+    outputTokens: Math.max(0, Number(usage.completion_tokens ?? usage.output_tokens ?? 0)),
+    cachedReadTokens: Math.max(0, cachedRead),
+    cachedWriteTokens: 0,
+  };
+}
+
+function anthropicUsage(usage: any): OpenCodeGoNormalizedUsage | null {
+  if (!usage) return null;
+  return {
+    // Anthropic's input_tokens excludes cache read/creation tokens.
+    uncachedInputTokens: Math.max(0, Number(usage.input_tokens ?? 0)),
+    outputTokens: Math.max(0, Number(usage.output_tokens ?? 0)),
+    cachedReadTokens: Math.max(0, Number(usage.cache_read_input_tokens ?? 0)),
+    cachedWriteTokens: Math.max(0, Number(usage.cache_creation_input_tokens ?? 0)),
+  };
+}
+
+async function completeOpenAi(options: OpenCodeGoCompletionOptions, url: string, signal: AbortSignal): Promise<OpenCodeGoCompletionResult> {
+  const streaming = Boolean(options.onDelta);
+  const response = await fetch(`${url}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${options.apiKey}`, 'Content-Type': 'application/json' },
+    signal,
+    body: JSON.stringify({
+      model: options.model,
+      temperature: options.temperature ?? 0.15,
+      max_tokens: options.maxTokens ?? 8_000,
+      stream: streaming,
+      ...(streaming ? { stream_options: { include_usage: true } } : {}),
+      ...(options.jsonMode ? { response_format: { type: 'json_object' } } : {}),
+      messages: [
+        { role: 'system', content: options.system },
+        { role: 'user', content: options.user },
+      ],
+    }),
+  });
+  if (!response.ok) return readError(response);
+
+  if (!streaming) {
+    const body = await response.json() as any;
+    if (body?.error) throw apiError(response.status, body);
+    const choice = body?.choices?.[0];
+    if (options.jsonMode && choice?.finish_reason === 'length') {
+      throw new Error('OpenCode Go cortó la respuesta al alcanzar el límite de salida y el JSON quedó incompleto.');
+    }
+    return { text: assertText(choice?.message?.content ?? ''), usage: openAiUsage(body?.usage) };
+  }
+
+  let text = '';
+  let usage: OpenCodeGoNormalizedUsage | null = null;
+  let finishReason: string | null = null;
+  for await (const event of sseEvents(response)) {
+    if (event.data === '[DONE]') continue;
+    let chunk: any;
+    try { chunk = JSON.parse(event.data); } catch { continue; }
+    if (chunk?.error) throw apiError(response.status, chunk);
+    const delta = chunk?.choices?.[0]?.delta;
+    const reasoning = delta?.reasoning ?? delta?.reasoning_content;
+    if (typeof reasoning === 'string') options.onReasoningDelta?.(reasoning);
+    if (typeof delta?.content === 'string' && delta.content) {
+      text += delta.content;
+      options.onDelta?.(delta.content);
+    }
+    finishReason = chunk?.choices?.[0]?.finish_reason ?? finishReason;
+    usage = openAiUsage(chunk?.usage) ?? usage;
+  }
+  if (options.jsonMode && finishReason === 'length') {
+    throw new Error('OpenCode Go cortó la respuesta al alcanzar el límite de salida y el JSON quedó incompleto.');
+  }
+  return { text: assertText(text), usage };
+}
+
+async function completeAnthropic(options: OpenCodeGoCompletionOptions, url: string, signal: AbortSignal): Promise<OpenCodeGoCompletionResult> {
+  const streaming = Boolean(options.onDelta);
+  const response = await fetch(`${url}/v1/messages`, {
+    method: 'POST',
+    headers: {
+      'x-api-key': options.apiKey,
+      'anthropic-version': '2023-06-01',
+      'Content-Type': 'application/json',
+    },
+    signal,
+    body: JSON.stringify({
+      model: options.model,
+      system: options.system,
+      temperature: options.temperature ?? 0.15,
+      max_tokens: options.maxTokens ?? 8_000,
+      stream: streaming,
+      messages: [{ role: 'user', content: options.user }],
+    }),
+  });
+  if (!response.ok) return readError(response);
+
+  if (!streaming) {
+    const body = await response.json() as any;
+    if (body?.error) throw apiError(response.status, body);
+    if (options.jsonMode && body?.stop_reason === 'max_tokens') {
+      throw new Error('OpenCode Go cortó la respuesta al alcanzar el límite de salida y el JSON quedó incompleto.');
+    }
+    const text = (body?.content ?? []).filter((block: any) => block?.type === 'text').map((block: any) => block.text ?? '').join('');
+    return { text: assertText(text), usage: anthropicUsage(body?.usage) };
+  }
+
+  let text = '';
+  let inputUsage: any = null;
+  let outputUsage: any = null;
+  let stopReason: string | null = null;
+  for await (const event of sseEvents(response)) {
+    let chunk: any;
+    try { chunk = JSON.parse(event.data); } catch { continue; }
+    if (chunk?.type === 'error' || chunk?.error) throw apiError(response.status, chunk);
+    if (chunk?.type === 'message_start') inputUsage = chunk.message?.usage ?? inputUsage;
+    if (chunk?.type === 'message_delta') {
+      outputUsage = chunk.usage ?? outputUsage;
+      stopReason = chunk.delta?.stop_reason ?? stopReason;
+    }
+    if (chunk?.type === 'content_block_delta' && chunk.delta?.type === 'thinking_delta') {
+      options.onReasoningDelta?.(chunk.delta.thinking ?? '');
+    }
+    if (chunk?.type === 'content_block_delta' && chunk.delta?.type === 'text_delta' && chunk.delta.text) {
+      text += chunk.delta.text;
+      options.onDelta?.(chunk.delta.text);
+    }
+  }
+  if (options.jsonMode && stopReason === 'max_tokens') {
+    throw new Error('OpenCode Go cortó la respuesta al alcanzar el límite de salida y el JSON quedó incompleto.');
+  }
+  return { text: assertText(text), usage: anthropicUsage({ ...(inputUsage ?? {}), ...(outputUsage ?? {}) }) };
+}
+
+/** Direct use of OpenCode's documented Go endpoints. No OpenCode CLI, browser
+ * session or private Console cookie is involved. */
+export async function completeWithOpenCodeGo(options: OpenCodeGoCompletionOptions): Promise<OpenCodeGoCompletionResult> {
+  if (options.images?.length) {
+    throw new Error('El catálogo público de OpenCode Go no anuncia entrada de imágenes para estos modelos.');
+  }
+  const linked = linkedSignal(options.signal, options.timeoutMs ?? 180_000);
+  const baseUrl = (options.baseUrl ?? 'https://opencode.ai/zen/go').replace(/\/+$/, '');
+  try {
+    return openCodeGoProtocol(options.model) === 'anthropic'
+      ? await completeAnthropic(options, baseUrl, linked.signal)
+      : await completeOpenAi(options, baseUrl, linked.signal);
+  } catch (error) {
+    if (linked.signal.aborted && !options.signal?.aborted) {
+      throw new Error('OpenCode Go no completó la petición dentro del tiempo esperado.');
+    }
+    throw error;
+  } finally {
+    linked.dispose();
+  }
+}

--- a/electron/ai/openCodeGoPricing.ts
+++ b/electron/ai/openCodeGoPricing.ts
@@ -1,0 +1,52 @@
+import type { OpenCodeGoNormalizedUsage } from './openCodeGoCompletion';
+
+interface PricingUsdPerMillion {
+  input: number;
+  output: number;
+  cachedRead?: number;
+  cachedWrite?: number;
+}
+
+/** Prices published in the OpenCode Go documentation on 2026-07-17. Unknown
+ * catalogue entries remain unpriced instead of receiving a guess. */
+const PRICING: Record<string, PricingUsdPerMillion> = {
+  'grok-4.5': { input: 2, output: 6, cachedRead: 0.5 },
+  'glm-5.2': { input: 1.4, output: 4.4, cachedRead: 0.26 },
+  'glm-5.1': { input: 1.4, output: 4.4, cachedRead: 0.26 },
+  'kimi-k3': { input: 3, output: 15, cachedRead: 0.3 },
+  'kimi-k2.7-code': { input: 0.95, output: 4, cachedRead: 0.19 },
+  'kimi-k2.6': { input: 0.95, output: 4, cachedRead: 0.16 },
+  'deepseek-v4-pro': { input: 0.435, output: 0.87, cachedRead: 0.003625 },
+  'deepseek-v4-flash': { input: 0.14, output: 0.28, cachedRead: 0.0028 },
+  'mimo-v2.5': { input: 0.14, output: 0.28, cachedRead: 0.0028 },
+  'mimo-v2.5-pro': { input: 0.435, output: 0.87, cachedRead: 0.003625 },
+  'minimax-m3': { input: 0.3, output: 1.2, cachedRead: 0.06 },
+  'minimax-m2.7': { input: 0.3, output: 1.2, cachedRead: 0.06, cachedWrite: 0.375 },
+  'minimax-m2.5': { input: 0.3, output: 1.2, cachedRead: 0.06, cachedWrite: 0.375 },
+  'qwen3.7-max': { input: 2.5, output: 7.5, cachedRead: 0.5, cachedWrite: 3.125 },
+  'qwen3.7-plus': { input: 0.4, output: 1.6, cachedRead: 0.04, cachedWrite: 0.5 },
+  'qwen3.6-plus': { input: 0.5, output: 3, cachedRead: 0.05, cachedWrite: 0.625 },
+};
+
+const LONG_CONTEXT_PRICING: Partial<Record<string, PricingUsdPerMillion>> = {
+  'qwen3.7-plus': { input: 1.2, output: 4.8, cachedRead: 0.12, cachedWrite: 1.5 },
+  'qwen3.6-plus': { input: 2, output: 6, cachedRead: 0.2, cachedWrite: 2.5 },
+};
+
+/** Local estimate only. OpenCode Console remains authoritative because this
+ * meter cannot observe requests from other clients or provider-side rounding. */
+export function estimateOpenCodeGoCostUsd(
+  model: string,
+  usage: OpenCodeGoNormalizedUsage | null
+): number | null {
+  if (!usage) return null;
+  const totalInput = usage.uncachedInputTokens + usage.cachedReadTokens + usage.cachedWriteTokens;
+  const price = totalInput > 256_000 ? LONG_CONTEXT_PRICING[model] ?? PRICING[model] : PRICING[model];
+  if (!price) return null;
+  const cost =
+    usage.uncachedInputTokens * price.input +
+    usage.outputTokens * price.output +
+    usage.cachedReadTokens * (price.cachedRead ?? price.input) +
+    usage.cachedWriteTokens * (price.cachedWrite ?? price.input);
+  return cost / 1_000_000;
+}

--- a/electron/ai/openCodeGoUsage.ts
+++ b/electron/ai/openCodeGoUsage.ts
@@ -1,0 +1,89 @@
+import { app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { OpenCodeGoUsagePeriod, OpenCodeGoUsageStatus } from '@shared/types';
+import type { OpenCodeGoNormalizedUsage } from './openCodeGoCompletion';
+import { estimateOpenCodeGoCostUsd } from './openCodeGoPricing';
+
+interface UsageEvent {
+  at: string;
+  model: string;
+  estimatedCostUsd: number | null;
+}
+
+interface UsageFile {
+  version: 1;
+  events: UsageEvent[];
+}
+
+const LIMITS = { fiveHours: 12, week: 30, month: 60 } as const;
+const OFFICIAL_USAGE_URL = 'https://opencode.ai/auth';
+const listeners = new Set<(status: OpenCodeGoUsageStatus) => void>();
+let writeQueue = Promise.resolve();
+
+function usageFile(): string {
+  return path.join(app.getPath('userData'), 'opencode-go-usage.json');
+}
+
+function readEvents(): UsageEvent[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(usageFile(), 'utf8')) as UsageFile;
+    if (parsed.version !== 1 || !Array.isArray(parsed.events)) return [];
+    return parsed.events.filter((event) => Number.isFinite(Date.parse(event.at)) && typeof event.model === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function observed(events: UsageEvent[], cutoff: number): OpenCodeGoUsagePeriod {
+  const selected = events.filter((event) => Date.parse(event.at) >= cutoff);
+  return {
+    requests: selected.length,
+    estimatedCostUsd: selected.reduce((sum, event) => sum + (event.estimatedCostUsd ?? 0), 0),
+    unpricedRequests: selected.filter((event) => event.estimatedCostUsd === null).length,
+  };
+}
+
+function statusFrom(events: UsageEvent[]): OpenCodeGoUsageStatus {
+  const now = Date.now();
+  return {
+    officialUsageUrl: OFFICIAL_USAGE_URL,
+    limitsUsd: LIMITS,
+    observed: {
+      fiveHours: observed(events, now - 5 * 60 * 60 * 1_000),
+      week: observed(events, now - 7 * 24 * 60 * 60 * 1_000),
+      month: observed(events, now - 30 * 24 * 60 * 60 * 1_000),
+    },
+    lastUpdatedAt: events.at(-1)?.at ?? null,
+  };
+}
+
+export function getOpenCodeGoUsageStatus(): OpenCodeGoUsageStatus {
+  return statusFrom(readEvents());
+}
+
+export function onOpenCodeGoUsageStatusChanged(listener: (status: OpenCodeGoUsageStatus) => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Stores only timestamp/model/cost—never prompts, responses, credentials or raw
+ * token payloads. The local meter is deliberately labelled non-authoritative. */
+export async function recordOpenCodeGoUsage(model: string, usage: OpenCodeGoNormalizedUsage | null): Promise<void> {
+  const run = async () => {
+    const cutoff = Date.now() - 32 * 24 * 60 * 60 * 1_000;
+    const events = readEvents().filter((event) => Date.parse(event.at) >= cutoff);
+    events.push({ at: new Date().toISOString(), model, estimatedCostUsd: estimateOpenCodeGoCostUsd(model, usage) });
+    const file = usageFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const temporary = `${file}.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(temporary, JSON.stringify({ version: 1, events } satisfies UsageFile), { mode: 0o600 });
+    fs.renameSync(temporary, file);
+    try { fs.chmodSync(file, 0o600); } catch { /* best effort on Windows */ }
+    const status = statusFrom(events);
+    for (const listener of listeners) listener(status);
+  };
+  const pending = writeQueue.then(run, run);
+  writeQueue = pending.then(() => undefined, () => undefined);
+  await pending;
+}

--- a/electron/ai/providers.ts
+++ b/electron/ai/providers.ts
@@ -49,6 +49,9 @@ export function openAiCompatBase(provider: AiProvider): string | null {
       // Local servers expose an OpenAI-compatible surface under {baseUrl}/v1.
       return `${localBaseUrl(provider)}/v1`;
     case 'anthropic':
+    case 'codex':
+    case 'github-copilot':
+    case 'opencode-go':
     case 'nodus':
       return null;
   }
@@ -122,6 +125,15 @@ export function reasoningBody(provider: AiProvider, effort: ReasoningEffort): Re
     case 'anthropic':
       // Anthropic uses its own SDK path, not this OpenAI-compat reasoning knob.
       return {};
+    case 'codex':
+      // The App Server receives effort as a first-class turn parameter.
+      return {};
+    case 'github-copilot':
+      // The official SDK receives effort as a first-class session parameter.
+      return {};
+    case 'opencode-go':
+      // Go serves a mixed OpenAI/Anthropic catalogue through dedicated paths.
+      return {};
   }
 }
 
@@ -150,6 +162,12 @@ export async function listModels(provider: AiProvider, key: string | null): Prom
       return listAnthropic(key);
     case 'openai':
       return listOpenAiStyle('https://api.openai.com/v1/models', key, true);
+    case 'codex':
+      throw new Error('Los modelos de Codex se consultan mediante el runtime de suscripción gestionado.');
+    case 'github-copilot':
+      throw new Error('Los modelos de GitHub Copilot se consultan mediante su runtime oficial.');
+    case 'opencode-go':
+      return listOpenCodeGo();
     case 'deepseek':
       return listOpenAiStyle('https://api.deepseek.com/models', key, false);
     case 'openrouter':
@@ -169,6 +187,43 @@ export async function listModels(provider: AiProvider, key: string | null): Prom
     case 'nodus':
       return listNodusLocalChatModels();
   }
+}
+
+const OPENCODE_GO_MODEL_NAMES: Record<string, string> = {
+  'grok-4.5': 'Grok 4.5',
+  'glm-5.2': 'GLM-5.2',
+  'glm-5.1': 'GLM-5.1',
+  'glm-5': 'GLM-5',
+  'kimi-k3': 'Kimi K3',
+  'kimi-k2.7-code': 'Kimi K2.7 Code',
+  'kimi-k2.6': 'Kimi K2.6',
+  'kimi-k2.5': 'Kimi K2.5',
+  'deepseek-v4-pro': 'DeepSeek V4 Pro',
+  'deepseek-v4-flash': 'DeepSeek V4 Flash',
+  'mimo-v2.5': 'MiMo-V2.5',
+  'mimo-v2.5-pro': 'MiMo-V2.5-Pro',
+  'mimo-v2-pro': 'MiMo-V2-Pro',
+  'mimo-v2-omni': 'MiMo-V2-Omni',
+  'minimax-m3': 'MiniMax M3',
+  'minimax-m2.7': 'MiniMax M2.7',
+  'minimax-m2.5': 'MiniMax M2.5',
+  'qwen3.7-max': 'Qwen3.7 Max',
+  'qwen3.7-plus': 'Qwen3.7 Plus',
+  'qwen3.6-plus': 'Qwen3.6 Plus',
+  'qwen3.5-plus': 'Qwen3.5 Plus',
+  'hy3-preview': 'HY 3 Preview',
+};
+
+/** Public catalogue documented by OpenCode Go. Authentication is required only
+ * for inference, so Settings can show what the subscription offers before a key
+ * is pasted. The response intentionally carries no inferred vision capability. */
+async function listOpenCodeGo(): Promise<ModelInfo[]> {
+  const res = await fetch('https://opencode.ai/zen/go/v1/models');
+  if (!res.ok) throw new Error(`OpenCode Go /models HTTP ${res.status}`);
+  const data = (await res.json()) as { data?: { id?: string }[] };
+  return (data.data ?? [])
+    .flatMap((model) => model.id ? [{ id: model.id, name: OPENCODE_GO_MODEL_NAMES[model.id] ?? model.id }] : [])
+    .sort(byId);
 }
 
 /** Fetch embedding-capable models for the configured embedding provider. */

--- a/electron/assets/THIRD_PARTY_NOTICES.md
+++ b/electron/assets/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,216 @@
+# Third-party notices for managed AI subscription runtimes
+
+Nodus redistributes the following official, unmodified runtimes as optional
+parts of its AI-provider integration:
+
+- OpenAI Codex CLI (`@openai/codex`), Apache License 2.0.
+- GitHub Copilot SDK (`@github/copilot-sdk`), MIT License.
+- GitHub Copilot CLI (`@github/copilot`), under the GitHub Copilot CLI
+  License distributed alongside that package as `LICENSE.md`.
+
+Nodus is licensed independently from these components. OpenAI, ChatGPT,
+Codex, GitHub and Copilot are trademarks of their respective owners. Their
+inclusion does not imply affiliation, certification or endorsement.
+
+## GitHub Copilot SDK — MIT License
+
+Copyright GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## OpenAI Codex — Apache License 2.0
+
+Copyright 2025 OpenAI
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/electron/db/appPrefs.ts
+++ b/electron/db/appPrefs.ts
@@ -56,6 +56,7 @@ export type GlobalPrefKey = (typeof GLOBAL_PREF_KEYS)[number];
 
 export const SHARED_MODEL_KEYS = [
   'favorites',
+  'codexReasoningEfforts',
   'localProviders',
   'extractionModel',
   'visionModel',

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -19,6 +19,16 @@ const DEFAULT_LOCAL_PROVIDERS: AppSettings['localProviders'] = {
   lmstudio: { baseUrl: DEFAULT_LOCAL_BASE_URLS.lmstudio },
 };
 
+function sanitizeCodexReasoningEfforts(value: unknown): AppSettings['codexReasoningEfforts'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value)
+      // The official protocol intentionally leaves effort extensible. Accept a small,
+      // identifier-shaped value here; the live model catalog validates support again.
+      .filter(([model, effort]) => model.trim().length > 0 && /^[a-z][a-z0-9_-]{0,31}$/.test(String(effort)))
+  ) as AppSettings['codexReasoningEfforts'];
+}
+
 const DEFAULTS: Omit<AppSettings, 'providerKeys' | 'lockedProviderKeys'> = {
   embeddingProvider: 'openai',
   embeddingModel: DEFAULT_EMBEDDING_MODELS.openai,
@@ -105,6 +115,7 @@ const DEFAULTS: Omit<AppSettings, 'providerKeys' | 'lockedProviderKeys'> = {
   mascotOrbColor: NODI_ORB_DEFAULT_COLOR,
   concurrency: 1,
   chatReasoning: 'off',
+  codexReasoningEfforts: {},
   openRouterThroughput: true,
   unpaywallEmail: '',
   onboardingComplete: false,
@@ -189,6 +200,7 @@ export function getSettings(): AppSettings {
     }
   }
   const merged = { ...DEFAULTS, ...parsed };
+  merged.codexReasoningEfforts = sanitizeCodexReasoningEfforts(parsed.codexReasoningEfforts);
   merged.studyImproveToolbarStyleIds = [...new Set((Array.isArray(merged.studyImproveToolbarStyleIds) ? merged.studyImproveToolbarStyleIds : [])
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0))].slice(0, 4);
   // Pre-2.3 builds called the Transformers.js worker simply "local".
@@ -238,6 +250,7 @@ export function getSettings(): AppSettings {
       seed[key] = merged[key];
     }
   }
+  merged.codexReasoningEfforts = sanitizeCodexReasoningEfforts(merged.codexReasoningEfforts);
   if ((merged.sttProvider as string) === 'local') {
     merged.sttProvider = 'transformers';
     seed.sttProvider = 'transformers';
@@ -276,6 +289,9 @@ export function getSettings(): AppSettings {
 }
 
 export function updateSettings(patch: Partial<AppSettings>): AppSettings {
+  if (patch.codexReasoningEfforts !== undefined) {
+    patch = { ...patch, codexReasoningEfforts: sanitizeCodexReasoningEfforts(patch.codexReasoningEfforts) };
+  }
   if (patch.studyImproveToolbarStyleIds) {
     patch = { ...patch, studyImproveToolbarStyleIds: [...new Set(patch.studyImproveToolbarStyleIds.filter((value) => typeof value === 'string' && value.trim()))].slice(0, 4) };
   }

--- a/electron/export/exportImport.ts
+++ b/electron/export/exportImport.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { dialog, app } from 'electron';
 import type { AiProvider, AppSettings, BackupSelection } from '@shared/types';
-import { AI_PROVIDERS } from '@shared/providers';
+import { SECRET_PROVIDERS } from '@shared/providers';
 import { closeDb, getDb, replaceDbFile, SCHEMA_VERSION } from '../db/database';
 import { getSettings } from '../db/settingsRepo';
 import { listVaults, getActiveVault, restoreVaultDatabase, setActiveVault } from '../vaults/vaultRegistry';
@@ -85,7 +85,7 @@ interface BackupInventory {
   };
   modelSettings: Pick<
     AppSettings,
-    | 'embeddingProvider' | 'embeddingModel' | 'favorites' | 'defaultModel' | 'modelSettingsMode' | 'modelSettingsVersion'
+    | 'embeddingProvider' | 'embeddingModel' | 'favorites' | 'codexReasoningEfforts' | 'defaultModel' | 'modelSettingsMode' | 'modelSettingsVersion'
     | 'extractionModel' | 'synthesisModel' | 'summaryModel' | 'fusionModel'
     | 'chatModel' | 'nodiModel' | 'deepResearchModel' | 'immersionModel' | 'writingModel'
     | 'argumentMapModel' | 'authorModel' | 'studyModel' | 'tutorModel' | 'hypothesisModel'
@@ -766,7 +766,7 @@ function settingsMatchInventory(
 function modelSettings(
   settings: Pick<
     AppSettings,
-    | 'embeddingProvider' | 'embeddingModel' | 'favorites' | 'defaultModel' | 'modelSettingsMode' | 'modelSettingsVersion'
+    | 'embeddingProvider' | 'embeddingModel' | 'favorites' | 'codexReasoningEfforts' | 'defaultModel' | 'modelSettingsMode' | 'modelSettingsVersion'
     | 'extractionModel' | 'synthesisModel' | 'summaryModel' | 'fusionModel'
     | 'chatModel' | 'nodiModel' | 'deepResearchModel' | 'immersionModel' | 'writingModel'
     | 'argumentMapModel' | 'authorModel' | 'studyModel' | 'tutorModel' | 'hypothesisModel'
@@ -779,6 +779,7 @@ function modelSettings(
     embeddingProvider: settings.embeddingProvider,
     embeddingModel: settings.embeddingModel,
     favorites: settings.favorites,
+    codexReasoningEfforts: settings.codexReasoningEfforts,
     defaultModel: settings.defaultModel,
     modelSettingsMode: settings.modelSettingsMode,
     modelSettingsVersion: settings.modelSettingsVersion,
@@ -824,7 +825,7 @@ function quoteIdentifier(value: string): string {
 
 function readApiKeys(): Partial<Record<AiProvider, string>> {
   return Object.fromEntries(
-    AI_PROVIDERS.flatMap((provider) => {
+    SECRET_PROVIDERS.flatMap((provider) => {
       const key = getApiKey(provider);
       return key ? [[provider, key]] : [];
     })
@@ -832,7 +833,7 @@ function readApiKeys(): Partial<Record<AiProvider, string>> {
 }
 
 function restoreApiKeys(keys: Partial<Record<AiProvider, string>>): void {
-  for (const provider of AI_PROVIDERS) {
+  for (const provider of SECRET_PROVIDERS) {
     const key = keys[provider];
     // Merge-only recovery: an absent provider can mean that the source snapshot
     // was created while its OS keychain was temporarily unavailable. Never erase

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -187,6 +187,23 @@ import { recoverLegacyApiKeys } from './secrets/legacySecretRecovery';
 import { runAutoBackupNow } from './export/autoBackup';
 import { MIN_BACKUP_PASSWORD_LENGTH } from './export/backupCrypto';
 import { listEmbeddingModels, listModels, testLocalProvider } from './ai/providers';
+import {
+  cancelChatGptSubscriptionLogin,
+  getChatGptSubscriptionStatus,
+  listChatGptSubscriptionModels,
+  logoutChatGptSubscription,
+  onChatGptSubscriptionStatusChanged,
+  startChatGptSubscriptionLogin,
+} from './ai/codexSubscription';
+import {
+  cancelGitHubCopilotSubscriptionLogin,
+  getGitHubCopilotSubscriptionStatus,
+  listGitHubCopilotSubscriptionModels,
+  logoutGitHubCopilotSubscription,
+  onGitHubCopilotSubscriptionStatusChanged,
+  startGitHubCopilotSubscriptionLogin,
+} from './ai/githubCopilotSubscription';
+import { getOpenCodeGoUsageStatus, onOpenCodeGoUsageStatusChanged } from './ai/openCodeGoUsage';
 import { listImageModels } from './ai/imageModels';
 import {
   applyDecorativeImageOption,
@@ -655,6 +672,22 @@ export function registerIpc(
   const studyImproveAborters = new Map<string, AbortController>();
   const studyAssistantAborters = new Map<string, AbortController>();
   const studyGradingAborters = new Map<string, AbortController>();
+
+  onChatGptSubscriptionStatusChanged((status) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('ai:chatgptSubscription:statusChanged', status);
+    }
+  });
+  onGitHubCopilotSubscriptionStatusChanged((status) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('ai:githubCopilotSubscription:statusChanged', status);
+    }
+  });
+  onOpenCodeGoUsageStatusChanged((status) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('ai:openCodeGo:usageChanged', status);
+    }
+  });
 
   const emitVaultChanged = () => {
     const payload = withVaultKeyProviders(getActiveVault());
@@ -1688,8 +1721,24 @@ export function registerIpc(
     return result;
   });
 
+  h('ai:chatgptSubscription:status', async () => getChatGptSubscriptionStatus());
+  h('ai:chatgptSubscription:login', async () => startChatGptSubscriptionLogin());
+  h('ai:chatgptSubscription:cancelLogin', async (_event, loginId: string) =>
+    cancelChatGptSubscriptionLogin(loginId)
+  );
+  h('ai:chatgptSubscription:logout', async () => logoutChatGptSubscription());
+  h('ai:githubCopilotSubscription:status', async () => getGitHubCopilotSubscriptionStatus());
+  h('ai:githubCopilotSubscription:login', async () => startGitHubCopilotSubscriptionLogin());
+  h('ai:githubCopilotSubscription:cancelLogin', async () => cancelGitHubCopilotSubscriptionLogin());
+  h('ai:githubCopilotSubscription:logout', async () => logoutGitHubCopilotSubscription());
+  h('ai:openCodeGo:usage', async () => getOpenCodeGoUsageStatus());
+
   // AI model discovery (OpenRouter needs no key; others use the stored key).
-  h('ai:listModels', async (_e, provider: AiProvider) => listModels(provider, getApiKey(provider)));
+  h('ai:listModels', async (_e, provider: AiProvider) => {
+    if (provider === 'codex') return listChatGptSubscriptionModels();
+    if (provider === 'github-copilot') return listGitHubCopilotSubscriptionModels();
+    return listModels(provider, getApiKey(provider));
+  });
   h('ai:listEmbeddingModels', async (_e, provider: EmbeddingProvider) =>
     listEmbeddingModels(provider, getApiKey(provider))
   );

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,6 +23,8 @@ import { startStudyCalendarReminders, stopStudyCalendarReminders } from './study
 import { restorePersistedDockIcon } from './dockIcon';
 import { recoverLegacyApiKeys } from './secrets/legacySecretRecovery';
 import type { UpdateCheckResponse, UpdateProgressEvent } from '@shared/types';
+import { stopChatGptSubscriptionServer } from './ai/codexSubscription';
+import { stopGitHubCopilotSubscription } from './ai/githubCopilotSubscription';
 
 const require = createRequire(__filename);
 const { autoUpdater } = require('electron-updater') as typeof import('electron-updater');
@@ -498,6 +500,8 @@ app.on('before-quit', () => {
   interruptDecorativeImageGenerations();
   void stopMcpServer();
   void stopCopilotServer();
+  void stopChatGptSubscriptionServer();
+  void stopGitHubCopilotSubscription();
   closeDb();
 });
 
@@ -508,5 +512,7 @@ updateAwareApp.on('before-quit-for-update', () => {
   interruptDecorativeImageGenerations();
   void stopMcpServer();
   void stopCopilotServer();
+  void stopChatGptSubscriptionServer();
+  void stopGitHubCopilotSubscription();
   closeDb();
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -330,6 +330,31 @@ const api: NodusApi = {
     return () => ipcRenderer.removeListener('settings:apiKeysRecovered', listener);
   },
 
+  getChatGptSubscriptionStatus: () => ipcRenderer.invoke('ai:chatgptSubscription:status'),
+  startChatGptSubscriptionLogin: () => ipcRenderer.invoke('ai:chatgptSubscription:login'),
+  cancelChatGptSubscriptionLogin: (loginId) => ipcRenderer.invoke('ai:chatgptSubscription:cancelLogin', loginId),
+  logoutChatGptSubscription: () => ipcRenderer.invoke('ai:chatgptSubscription:logout'),
+  onChatGptSubscriptionStatusChanged: (cb) => {
+    const listener = (_e: unknown, status: Parameters<typeof cb>[0]) => cb(status);
+    ipcRenderer.on('ai:chatgptSubscription:statusChanged', listener);
+    return () => ipcRenderer.removeListener('ai:chatgptSubscription:statusChanged', listener);
+  },
+  getGitHubCopilotSubscriptionStatus: () => ipcRenderer.invoke('ai:githubCopilotSubscription:status'),
+  startGitHubCopilotSubscriptionLogin: () => ipcRenderer.invoke('ai:githubCopilotSubscription:login'),
+  cancelGitHubCopilotSubscriptionLogin: () => ipcRenderer.invoke('ai:githubCopilotSubscription:cancelLogin'),
+  logoutGitHubCopilotSubscription: () => ipcRenderer.invoke('ai:githubCopilotSubscription:logout'),
+  onGitHubCopilotSubscriptionStatusChanged: (cb) => {
+    const listener = (_e: unknown, status: Parameters<typeof cb>[0]) => cb(status);
+    ipcRenderer.on('ai:githubCopilotSubscription:statusChanged', listener);
+    return () => ipcRenderer.removeListener('ai:githubCopilotSubscription:statusChanged', listener);
+  },
+  getOpenCodeGoUsageStatus: () => ipcRenderer.invoke('ai:openCodeGo:usage'),
+  onOpenCodeGoUsageStatusChanged: (cb) => {
+    const listener = (_e: unknown, status: Parameters<typeof cb>[0]) => cb(status);
+    ipcRenderer.on('ai:openCodeGo:usageChanged', listener);
+    return () => ipcRenderer.removeListener('ai:openCodeGo:usageChanged', listener);
+  },
+
   listModels: (provider) => ipcRenderer.invoke('ai:listModels', provider),
   listEmbeddingModels: (provider) => ipcRenderer.invoke('ai:listEmbeddingModels', provider),
   testLocalProvider: (provider) => ipcRenderer.invoke('ai:testLocalProvider', provider),

--- a/electron/secrets/secretStore.ts
+++ b/electron/secrets/secretStore.ts
@@ -2,7 +2,7 @@ import { app, safeStorage } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { AiProvider } from '@shared/types';
-import { AI_PROVIDERS as PROVIDERS } from '@shared/providers';
+import { AI_PROVIDERS, SECRET_PROVIDERS as PROVIDERS } from '@shared/providers';
 import { activeVaultDir, listVaults } from '../vaults/vaultRegistry';
 
 // AI API keys are stored per provider, encrypted-at-rest via Electron safeStorage,
@@ -81,6 +81,8 @@ function readKeyFile(file: string): string | null {
 }
 
 export function setApiKey(provider: AiProvider, key: string): void {
+  if (provider === 'codex') throw new Error('ChatGPT usa acceso gestionado; Nodus no almacena una clave para este proveedor.');
+  if (provider === 'github-copilot') throw new Error('GitHub Copilot usa el acceso oficial de GitHub; Nodus no almacena una clave para este proveedor.');
   if (!key) {
     clearApiKey(provider);
     return;
@@ -101,6 +103,7 @@ export function setApiKey(provider: AiProvider, key: string): void {
 }
 
 export function getApiKey(provider: AiProvider): string | null {
+  if (provider === 'codex' || provider === 'github-copilot') return null;
   const canonical = keyFile(provider);
   const fromGlobal = readKeyFile(canonical);
   if (fromGlobal !== null) return fromGlobal;
@@ -123,6 +126,7 @@ export function hasApiKey(provider: AiProvider): boolean {
 }
 
 export function clearApiKey(provider: AiProvider): void {
+  if (provider === 'codex' || provider === 'github-copilot') return;
   // An explicit delete applies to every released storage location; otherwise an
   // old per-vault copy could silently recreate the key on the next read.
   for (const file of apiKeyCandidateFiles(provider)) {
@@ -307,7 +311,7 @@ export function clearBackupRecoveryKey(): void {
 
 /** Map of provider -> whether a key is stored, for the renderer (no keys exposed). */
 export function providerKeyMap(): Record<AiProvider, boolean> {
-  return Object.fromEntries(PROVIDERS.map((p) => [p, hasApiKey(p)])) as Record<AiProvider, boolean>;
+  return Object.fromEntries(AI_PROVIDERS.map((p) => [p, p === 'codex' || p === 'github-copilot' ? false : hasApiKey(p)])) as Record<AiProvider, boolean>;
 }
 
 /** Providers with a configured key. Keys are shared globally, so the vault id is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "nodus",
-  "version": "2.3.8",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "2.3.8",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@diffusionstudio/vits-web": "^1.0.3",
+        "@github/copilot-sdk": "1.0.7",
         "@google/genai": "^2.11.0",
         "@huggingface/transformers": "^3.8.1",
         "@milkdown/core": "^7.21.3",
@@ -26,6 +27,7 @@
         "@milkdown/utils": "^7.21.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@napi-rs/canvas": "^0.1.65",
+        "@openai/codex": "0.144.6",
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^11.5.0",
         "cytoscape": "^3.30.2",
@@ -1768,6 +1770,180 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@github/copilot": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.71.tgz",
+      "integrity": "sha512-F3axBi+sXSLYDJbxCBW36bM6MYKNC2rlyAf3Ivo/MjiHKKJW7j5AmaR1IRYS9Gt8r9mxOwWFM1cJFA+CuLaR8g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.71",
+        "@github/copilot-darwin-x64": "1.0.71",
+        "@github/copilot-linux-arm64": "1.0.71",
+        "@github/copilot-linux-x64": "1.0.71",
+        "@github/copilot-linuxmusl-arm64": "1.0.71",
+        "@github/copilot-linuxmusl-x64": "1.0.71",
+        "@github/copilot-win32-arm64": "1.0.71",
+        "@github/copilot-win32-x64": "1.0.71"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.71.tgz",
+      "integrity": "sha512-mEWzyqbqRAWgyU7i2uuSRoVPx/TwaFQX0nZmw0bc30aJ0BnO7cy2kYQyCHw8ykmf/tfxT0xauZ6k0BOFmWizzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.71.tgz",
+      "integrity": "sha512-Md9yEg406OBVBx3w4PeEj62TubulVLBcHleqmCoOoUmPgUxPZotUbrqz3rtbzADbXfrrD7JWvVsbd2UiNL194w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.71.tgz",
+      "integrity": "sha512-ykLJYOqBj3jRB5IJCDugLClAqbr7DmtTbUjlNY7+Jdq/n6i+d7xUQGclf1IWL5gnxbGQVAf+zkToD+sRM389Kg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.71.tgz",
+      "integrity": "sha512-pC0FNHG+BBwZd6yZlM85kkAGN+uJhM6o+THi76N2GnnSxmw7+remb1mvYxdgRVbdCm+LBUIbCKRWJLuMwrfb6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.71.tgz",
+      "integrity": "sha512-hBmDljFTjacxqZTasCEy43H8EIzuXB/hHEBBCMFjhB9J00nIxsO6Dh0woTifKpx7knTYZdpTjjca3D0pAoZlUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.71.tgz",
+      "integrity": "sha512-CfTXU8pa5dxRz22xQzoi3TiG1PJo9+WR8PRDiPSdkIBSyPJ1NvX87DJmfXjTgeAfR+wkjt/p0keDCaBBVhNmUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.7.tgz",
+      "integrity": "sha512-dgCFCPfxWUkrgclQbrm7WCFzTf5RnJHsK1Lqsc3KjPBbDLPutJT0qIGg3xJ0ZELLyX0icg3TOmVczhR4HdwHxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.71",
+        "koffi": "^3.1.0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.71.tgz",
+      "integrity": "sha512-+HI1DokixXhHUahj06Fw67ZAigBuXKC58BFma4UJOGrQsDgwOSbqeTQHCw6vuymzjKlg3sactfsCUTaefkjscQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.71.tgz",
+      "integrity": "sha512-02kXOBd9CwBbCaztuf71WYWn+uGapCuiaasomN4tcMH3HBVZ4gi3J0ZUoRcgcS80xh81uQyeBHbnUKzb/RE/9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.11.0.tgz",
@@ -2556,6 +2732,246 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.1.tgz",
+      "integrity": "sha512-+Dl0zQDh1Wb55AWOn9hp7K30qgkODvrvN+ZNkFOh81Q0oFX/rpJQtocgjAuYk2zFAcajSeVDumkcHMPwnKSXzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.1.tgz",
+      "integrity": "sha512-cDFAKn1qdZBFLrp7dAc9QUDw3l4xAhTJbOdPWWb0LxssVicUdHcRCLZGrDsmPW2tpH6LGNNeLgqRpAoD2Mo8iA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.1.tgz",
+      "integrity": "sha512-zaP7FJISI/scQW9Wa5QicY3a09WmtKBWSbmC+5nfCqPzwWe7Hx2so74Er7mPsDfCiMMR0Ya+evKbJQDkfyXicg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.1.tgz",
+      "integrity": "sha512-7GejVb688TLM8rbjfc0oezJrATxZc0dn801xWEDJekN2DgmRXu7HquGqWQ6z3NeSq7ZxEggz4T3xtlbCysQapA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.1.tgz",
+      "integrity": "sha512-XLiCFP9OFCyOoGTjAimtDKLhzhfo34WcP1ShVWxRzNCWDGjfz8BYjwd69cp/cDSUXZbxamqs4+/6vmkePq9wxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.1.tgz",
+      "integrity": "sha512-HA9xINK7G4dRAkpfnBWD9VfuyIBgW1SuK+KPHjksUwRMOnhgqP8J/JqgrAzdzcDiefGBkqEacIP776OUwz7knQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.1.tgz",
+      "integrity": "sha512-jG7IFytmP8K5Qtbx0ro0ZeuX3JjSsLxmYhq+nmXDdrtOAlxIsWGynuiDLS6Jk3vOchVii2m6Y2f/L3GLG2fG5A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.1.tgz",
+      "integrity": "sha512-CIsT1cNnih8FuU52Me/IVlJBpH28SQfoDeYPctJswgJzaARktusF7m4MUbtR1PBDjuquCVM4/vFyNdOzfPonvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.1.tgz",
+      "integrity": "sha512-9D6RmqeKsSvs3U6jILJU9PcAjMwKKyn7yLxNBb5k6z9PCoUoGJ3/BrhXAX0qjrLLwEiIpP/hS/40RuXvH8Lc3Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.1.tgz",
+      "integrity": "sha512-pyTcX5fePeYbt7TZAwRby69wdlRx3PT+g15ra5IYdat/Pgh3qAKEYeZ+uu7WpPGOy43p/oSRqqZoa2kORzozlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.1.tgz",
+      "integrity": "sha512-iPnPzvG2HOfdzaiG1drdkt86sAqmTPDv9mAf+5gL7mRzkeeQC88EVGboRy7eXwdXn7R+v0ntA3iQxdHrBn6yXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.1.tgz",
+      "integrity": "sha512-/Xqc3R0SVoMCYjMPZnJ9bULtRo364+dKmnQhfDrI83tSpxUHRw7HRNf12vBeL+hPgKxSBjtMpWfQ/ZIyVyLFag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.1.tgz",
+      "integrity": "sha512-JhqHauEwQvdcWUERxrV5HH/DT9W7hY1A1eU6/o8tB+yck+D3kt5elpRDBt9KjpW6h+vHPy3V0sjDvO0CXyabTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.1.tgz",
+      "integrity": "sha512-ZRuyYmlGS/rCc966qqs0qREXDW4FRdul7rDF1VgSWHbVmdc196PUgUT+blq/GjZgTwqzeEXtMRgM+cU8krHjvA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.1.tgz",
+      "integrity": "sha512-KqHPmvj6QILhNyI/To8QSihHsijeVGIYYPBOUnXEpcnH2LuLbargY4Hd6dDeTN3Z90uUUxN+1FWz1UnhVzFOiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/@lezer/common": {
@@ -3610,6 +4026,128 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ocavue"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.144.6",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6.tgz",
+      "integrity": "sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.6-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.6-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.6-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.6-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.6-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.6-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.144.6-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-arm64.tgz",
+      "integrity": "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.144.6-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-x64.tgz",
+      "integrity": "sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.144.6-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
+      "integrity": "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.144.6-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
+      "integrity": "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.144.6-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-arm64.tgz",
+      "integrity": "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.144.6-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
+      "integrity": "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@pdf-lib/standard-fonts": {
@@ -9783,6 +10321,33 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/koffi": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.1.tgz",
+      "integrity": "sha512-mRX6AMeeKCxSOeOopqAcLAl5jcNvge7NAG8l7rF/8gGJATI0tdHFYjteIdE0mGOtWdsrJOij+PjnP8Q9c1gwgA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.1",
+        "@koromix/koffi-darwin-x64": "3.1.1",
+        "@koromix/koffi-freebsd-arm64": "3.1.1",
+        "@koromix/koffi-freebsd-ia32": "3.1.1",
+        "@koromix/koffi-freebsd-x64": "3.1.1",
+        "@koromix/koffi-linux-arm64": "3.1.1",
+        "@koromix/koffi-linux-ia32": "3.1.1",
+        "@koromix/koffi-linux-loong64": "3.1.1",
+        "@koromix/koffi-linux-riscv64": "3.1.1",
+        "@koromix/koffi-linux-x64": "3.1.1",
+        "@koromix/koffi-openbsd-ia32": "3.1.1",
+        "@koromix/koffi-openbsd-x64": "3.1.1",
+        "@koromix/koffi-win32-arm64": "3.1.1",
+        "@koromix/koffi-win32-ia32": "3.1.1",
+        "@koromix/koffi-win32-x64": "3.1.1"
+      }
+    },
     "node_modules/kokoro-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/kokoro-js/-/kokoro-js-1.2.1.tgz",
@@ -15190,6 +15755,15 @@
       "integrity": "sha512-hHBMKuZ24MB2SIxG7U7ix+DDEnvxou7Bgy/TdhYxNz3S5N3Yh7Hjvj9blfMeGEJ0oaZJn7y5z0V/RyDmJ5OuCA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/vue": {
       "version": "3.5.39",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
     "@diffusionstudio/vits-web": "^1.0.3",
+    "@github/copilot-sdk": "1.0.7",
     "@google/genai": "^2.11.0",
     "@huggingface/transformers": "^3.8.1",
     "@milkdown/core": "^7.21.3",
@@ -48,6 +49,7 @@
     "@milkdown/utils": "^7.21.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.65",
+    "@openai/codex": "0.144.6",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^11.5.0",
     "cytoscape": "^3.30.2",
@@ -130,6 +132,10 @@
     ],
     "beforePack": "build/beforePack.cjs",
     "afterPack": "build/afterPack.cjs",
+    "asarUnpack": [
+      "node_modules/@openai/codex-*/vendor/**/*",
+      "node_modules/@github/copilot-*/**/*"
+    ],
     "mac": {
       "extraFiles": [
         {

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -134,6 +134,9 @@ try {
     hasStudyAiPolicy: typeof window.nodus?.getStudyAiUsageSummary === 'function' && typeof window.nodus?.clearStudyAiUsage === 'function',
     hasStudyDemo: typeof window.nodus?.seedStudyDemoData === 'function',
     hasNodusLocalAi: typeof window.nodus?.getNodusLocalAiStatus === 'function' && typeof window.nodus?.downloadNodusLocalModel === 'function' && typeof window.nodus?.deleteNodusLocalModel === 'function',
+    hasChatGptSubscription: typeof window.nodus?.getChatGptSubscriptionStatus === 'function' && typeof window.nodus?.startChatGptSubscriptionLogin === 'function' && typeof window.nodus?.logoutChatGptSubscription === 'function',
+    hasGitHubCopilotSubscription: typeof window.nodus?.getGitHubCopilotSubscriptionStatus === 'function' && typeof window.nodus?.startGitHubCopilotSubscriptionLogin === 'function' && typeof window.nodus?.logoutGitHubCopilotSubscription === 'function',
+    hasOpenCodeGoUsage: typeof window.nodus?.getOpenCodeGoUsageStatus === 'function' && typeof window.nodus?.onOpenCodeGoUsageStatusChanged === 'function',
   }));
   assert.equal(bridge.hasNodus, true, 'window.nodus bridge exposed');
   assert.equal(bridge.hasGetGraph, true, 'getGraph available');
@@ -151,6 +154,13 @@ try {
   assert.equal(bridge.hasStudyAiPolicy, true, 'study AI policy and usage bridge available');
   assert.equal(bridge.hasStudyDemo, true, 'study sample-data bridge available');
   assert.equal(bridge.hasNodusLocalAi, true, 'integrated local AI model manager bridge available');
+  assert.equal(bridge.hasChatGptSubscription, true, 'managed ChatGPT subscription bridge available');
+  assert.equal(bridge.hasGitHubCopilotSubscription, true, 'managed GitHub Copilot subscription bridge available');
+  assert.equal(bridge.hasOpenCodeGoUsage, true, 'OpenCode Go usage bridge available');
+  const signedOutChatGpt = await page.evaluate(() => window.nodus.getChatGptSubscriptionStatus());
+  assert.equal(signedOutChatGpt.available, true, `official Codex runtime is available: ${signedOutChatGpt.error ?? 'ok'}`);
+  assert.equal(signedOutChatGpt.connected, false, 'throwaway profile starts without a ChatGPT account');
+  assert.equal(signedOutChatGpt.loginPending, false, 'throwaway profile has no pending OAuth flow');
   console.log('[e2e] preload bridge ok');
 
   // ── Essential tutorial: first screen, language preferences, seen-once gate ──
@@ -374,6 +384,55 @@ try {
   await page.waitForFunction(() => document.querySelector('header'));
   assert.equal(await page.locator('header select[data-tour="model"]').count(), 0, 'global header model selector removed');
   await page.locator('[data-tour="nav-settings"]').click();
+  await page.getByRole('button', { name: 'Proveedores', exact: true }).click();
+  const chatGptProvider = page.getByTestId('chatgpt-subscription-provider');
+  await chatGptProvider.waitFor();
+  await chatGptProvider.locator('button').first().click();
+  await chatGptProvider.getByRole('button', { name: 'Conectar suscripción de ChatGPT', exact: true }).waitFor();
+  await chatGptProvider.getByText('El uso consume la cuota o los créditos de Codex incluidos en tu plan de ChatGPT; no consume saldo de la API de OpenAI.', { exact: true }).waitFor();
+  const githubCopilotProvider = page.getByTestId('github-copilot-subscription-provider');
+  await githubCopilotProvider.waitFor();
+  await githubCopilotProvider.locator('button').first().click();
+  await githubCopilotProvider.getByText('Nodus usa el SDK y el runtime oficiales de GitHub Copilot. Cada petición se factura a la suscripción de GitHub del usuario; no requiere claves de los modelos.', { exact: true }).waitFor();
+  await githubCopilotProvider.getByText('Cada petición se ejecuta en una sesión efímera sin herramientas, MCP, memoria, acceso a archivos, GitHub ni instrucciones del proyecto.', { exact: true }).waitFor();
+  await page.getByRole('button', { name: /OpenCode Go/ }).first().click();
+  const openCodeUsage = page.getByTestId('opencode-go-usage');
+  await openCodeUsage.waitFor();
+  await openCodeUsage.getByText('Límites generales publicados: 12 USD cada 5 horas, 30 USD por semana y 60 USD por mes. Algunos modelos tienen un límite mensual efectivo inferior (15 USD); el número de peticiones depende del modelo y puede cambiar.', { exact: true }).waitFor();
+  await openCodeUsage.getByText('Saldo restante oficial: OpenCode solo lo publica en Console; no ofrece una API de cuota compatible con la clave de usuario. Nodus no usa cookies ni endpoints privados.', { exact: true }).waitFor();
+  const providerThemeStyles = await page.evaluate(() => {
+    const root = document.documentElement;
+    const github = document.querySelector('[data-testid="github-copilot-subscription-provider"]');
+    const openCode = document.querySelector('[data-testid="provider-opencode-go"]');
+    const openCodeUsage = document.querySelector('[data-testid="opencode-go-usage"]');
+    if (!github || !openCode || !openCodeUsage) throw new Error('provider theme surfaces are missing');
+    const original = { light: root.classList.contains('light'), dark: root.classList.contains('dark') };
+    const read = () => ({
+      githubBackground: getComputedStyle(github).backgroundColor,
+      githubBorder: getComputedStyle(github).borderTopColor,
+      openCodeBorder: getComputedStyle(openCode).borderTopColor,
+      openCodeUsageBackground: getComputedStyle(openCodeUsage).backgroundColor,
+      openCodeUsageText: getComputedStyle(openCodeUsage).color,
+    });
+    root.classList.add('light');
+    root.classList.remove('dark');
+    const light = read();
+    root.classList.remove('light');
+    root.classList.add('dark');
+    const dark = read();
+    root.classList.toggle('light', original.light);
+    root.classList.toggle('dark', original.dark);
+    return { light, dark };
+  });
+  const colorBrightness = (color) => (color.match(/[\d.]+/g) ?? []).slice(0, 3).reduce((sum, channel) => sum + Number(channel), 0);
+  assert.ok(colorBrightness(providerThemeStyles.light.githubBackground) > colorBrightness(providerThemeStyles.dark.githubBackground) + 300, 'Copilot uses a genuinely light surface in light mode');
+  assert.ok(colorBrightness(providerThemeStyles.light.openCodeUsageBackground) > colorBrightness(providerThemeStyles.dark.openCodeUsageBackground) + 300, 'OpenCode Go uses a genuinely light surface in light mode');
+  assert.notEqual(providerThemeStyles.light.githubBorder, providerThemeStyles.dark.githubBorder, 'Copilot border follows the active theme');
+  assert.notEqual(providerThemeStyles.light.openCodeBorder, providerThemeStyles.dark.openCodeBorder, 'OpenCode Go provider border follows the active theme');
+  assert.notEqual(providerThemeStyles.light.openCodeUsageText, providerThemeStyles.dark.openCodeUsageText, 'OpenCode Go body text follows the active theme');
+  await page.getByRole('button', { name: /Anthropic/ }).click();
+  await page.getByText(/Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude\.ai/).waitFor();
+  console.log('[e2e] provider UI exposes subscriptions, usage limits and real light/dark surfaces');
   await page.getByRole('button', { name: 'Modelos IA', exact: true }).click();
   await page.getByText('Generación de imágenes', { exact: true }).waitFor({ timeout: 30_000 });
   assert.equal(await page.getByText('gemini-3.1-flash-lite-image', { exact: false }).count() > 0, true, 'image settings render selected verified model');
@@ -1250,12 +1309,12 @@ try {
   await annotationCanvas.click({ position: { x: 180, y: 160 } });
   await page.getByTestId('study-pdf-sticky-dialog').locator('textarea').fill('Sticker smoke');
   await page.getByRole('button', { name: 'Guardar sticker', exact: true }).click();
-  await page.getByText('Sticker smoke', { exact: true }).waitFor();
+  await page.getByTestId('study-material-annotations-sidebar').getByText('Sticker smoke', { exact: true }).waitFor();
   await page.getByTestId('study-pdf-tool-comment').click();
   await annotationCanvas.click({ position: { x: 220, y: 210 } });
   await page.getByTestId('study-pdf-inline-comment').locator('textarea').fill('Comentario smoke');
   await page.getByTestId('study-pdf-inline-comment').getByRole('button', { name: 'Guardar', exact: true }).click();
-  await page.getByTestId('study-material-annotations-sidebar').getByText('Comentario smoke', { exact: true }).waitFor();
+  await page.getByTestId('study-material-annotations-sidebar').getByText('Comentario smoke', { exact: true }).last().waitFor();
   await page.getByText('Crear apunte', { exact: true }).last().click();
   await waitForCondition('apunte creado desde material', () => page.evaluate(async () => (await window.nodus.getStudyWorkspace()).documents.some((document) => document.title.includes('fuente-smoke'))));
   assert.ok(await page.evaluate(async () => (await window.nodus.getStudyWorkspace()).documents.some((document) => document.contentMarkdown.includes('nodus://study/material/'))), 'highlight creates a note with a durable source link');

--- a/scripts/test-codex-subscription.mjs
+++ b/scripts/test-codex-subscription.mjs
@@ -1,0 +1,286 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-codex-test-'));
+const bundle = path.join(outDir, 'codex-test.cjs');
+const entry = path.join(outDir, 'entry.ts');
+fs.writeFileSync(entry, [
+  `export { CodexAppServerClient } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/codexAppServerClient.ts'))};`,
+  `export { resolveCodexReasoningEffort, runIsolatedCodexCompletion } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/codexCompletion.ts'))};`,
+].join('\n'));
+execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
+  entry,
+  '--bundle',
+  '--platform=node',
+  '--format=cjs',
+  '--target=es2022',
+  `--outfile=${bundle}`,
+], { cwd: repoRoot, stdio: 'inherit' });
+const require = createRequire(import.meta.url);
+const { CodexAppServerClient, resolveCodexReasoningEffort, runIsolatedCodexCompletion } = require(bundle);
+
+test.after(() => fs.rmSync(outDir, { recursive: true, force: true }));
+
+function fakeAppServer() {
+  const file = path.join(outDir, 'fake-codex.mjs');
+  fs.writeFileSync(file, `#!/usr/bin/env node
+import readline from 'node:readline';
+const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+const reply = (id, result) => process.stdout.write(JSON.stringify({ id, result }) + '\\n');
+for await (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialized') continue;
+  if (msg.method === 'initialize') {
+    reply(msg.id, { serverInfo: { name: 'fake', version: '1' } });
+  } else if (msg.method === 'probe') {
+    reply(msg.id, {
+      argv: process.argv.slice(2),
+      codexHome: process.env.CODEX_HOME,
+      secrets: {
+        openai: process.env.OPENAI_API_KEY ?? null,
+        codex: process.env.CODEX_API_KEY ?? null,
+        access: process.env.CODEX_ACCESS_TOKEN ?? null,
+        azure: process.env.AZURE_OPENAI_API_KEY ?? null,
+        base: process.env.OPENAI_BASE_URL ?? null,
+        github: process.env.GITHUB_TOKEN ?? null,
+      },
+    });
+  } else if (msg.method === 'emit') {
+    reply(msg.id, {});
+    process.stdout.write(JSON.stringify({ method: 'account/updated', params: { authMode: 'chatgpt' } }) + '\\n');
+  }
+}`);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+test('Codex App Server is forced to managed ChatGPT auth and receives no ambient API credentials', async () => {
+  const home = path.join(outDir, 'codex-home');
+  fs.mkdirSync(home);
+  const client = new CodexAppServerClient({
+    binaryPath: fakeAppServer(),
+    codexHome: home,
+    appVersion: 'test',
+    env: {
+      ...process.env,
+      OPENAI_API_KEY: 'sk-openai-secret',
+      CODEX_API_KEY: 'codex-secret',
+      CODEX_ACCESS_TOKEN: 'access-secret',
+      AZURE_OPENAI_API_KEY: 'azure-secret',
+      OPENAI_BASE_URL: 'https://attacker.invalid',
+      GITHUB_TOKEN: 'github-secret',
+    },
+  });
+  try {
+    const probe = await client.request('probe');
+    assert.deepEqual(probe.secrets, { openai: null, codex: null, access: null, azure: null, base: null, github: null });
+    assert.equal(probe.codexHome, home);
+    assert.deepEqual(probe.argv, [
+      '--config', 'forced_login_method="chatgpt"',
+      '--config', 'cli_auth_credentials_store="keyring"',
+      '--config', 'model_provider="openai"',
+      '--config', 'web_search="disabled"',
+      '--config', 'mcp_servers={}',
+      '--config', 'features.apps=false',
+      '--config', 'features.browser_use=false',
+      '--config', 'features.code_mode_host=false',
+      '--config', 'features.computer_use=false',
+      '--config', 'features.goals=false',
+      '--config', 'features.hooks=false',
+      '--config', 'features.image_generation=false',
+      '--config', 'features.in_app_browser=false',
+      '--config', 'features.multi_agent=false',
+      '--config', 'features.plugins=false',
+      '--config', 'features.shell_tool=false',
+      '--config', 'features.tool_suggest=false',
+      '--config', 'features.unified_exec=false',
+      '--config', 'features.workspace_dependencies=false',
+      'app-server', '--listen', 'stdio://',
+    ]);
+
+    const notification = new Promise((resolve) => {
+      const off = client.onNotification((method, params) => {
+        if (method === 'account/updated') {
+          off();
+          resolve(params);
+        }
+      });
+    });
+    await client.request('emit');
+    assert.deepEqual(await notification, { authMode: 'chatgpt' });
+  } finally {
+    await client.stop();
+  }
+});
+
+class CompletionTransport {
+  handlers = new Set();
+  calls = [];
+  request(method, params) {
+    this.calls.push({ method, params });
+    if (method === 'thread/start') return Promise.resolve({ thread: { id: 'thread-1' } });
+    if (method === 'turn/start') {
+      setTimeout(() => {
+        for (const handler of this.handlers) {
+          handler('item/agentMessage/delta', { threadId: 'thread-1', turnId: 'turn-1', delta: 'Hola ' });
+          handler('item/agentMessage/delta', { threadId: 'thread-1', turnId: 'turn-1', delta: 'mundo' });
+          handler('turn/completed', {
+            threadId: 'thread-1',
+            turn: { status: 'completed', items: [{ type: 'agentMessage', text: 'Hola mundo' }] },
+          });
+        }
+      }, 0);
+      return Promise.resolve({ turn: { id: 'turn-1' } });
+    }
+    return Promise.resolve({});
+  }
+  onNotification(handler) {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+}
+
+test('Nodus completions are ephemeral, read-only, tool-isolated, streamable and multimodal', async () => {
+  const workdir = fs.mkdtempSync(path.join(outDir, 'completion-'));
+  const runtime = new CompletionTransport();
+  const deltas = [];
+  try {
+    const answer = await runIsolatedCodexCompletion(runtime, {
+      model: 'gpt-test',
+      system: 'Devuelve solo la respuesta.',
+      user: 'Saluda.',
+      reasoning: 'xhigh',
+      workdir,
+      images: [{ mediaType: 'image/png', base64: Buffer.from('image-bytes').toString('base64') }],
+      onDelta: (delta) => deltas.push(delta),
+    });
+    assert.equal(answer, 'Hola mundo');
+    assert.deepEqual(deltas, ['Hola ', 'mundo']);
+
+    const thread = runtime.calls.find((call) => call.method === 'thread/start').params;
+    assert.equal(thread.modelProvider, 'openai');
+    assert.equal(thread.approvalPolicy, 'never');
+    assert.equal(thread.sandbox, 'read-only');
+    assert.equal(thread.ephemeral, true);
+    assert.equal(thread.config.web_search, 'disabled');
+    assert.deepEqual(thread.config.mcp_servers, {});
+    assert.ok(Object.values(thread.config.features).every((enabled) => enabled === false));
+    assert.equal(thread.cwd, workdir);
+    assert.equal(thread.developerInstructions, 'Devuelve solo la respuesta.');
+    assert.match(thread.baseInstructions, /Never invoke shell commands, tools, MCP servers, plugins/);
+
+    const turn = runtime.calls.find((call) => call.method === 'turn/start').params;
+    assert.equal(turn.approvalPolicy, 'never');
+    assert.deepEqual(turn.sandboxPolicy, { type: 'readOnly', networkAccess: false });
+    assert.equal(turn.effort, 'xhigh');
+    assert.equal(turn.summary, 'none');
+    assert.deepEqual(turn.input[0], { type: 'text', text: 'Saluda.', text_elements: [] });
+    assert.equal(turn.input[1].type, 'localImage');
+    assert.equal(path.dirname(turn.input[1].path), workdir);
+    assert.equal(fs.readFileSync(turn.input[1].path, 'utf8'), 'image-bytes');
+    if (process.platform !== 'win32') assert.equal(fs.statSync(turn.input[1].path).mode & 0o777, 0o600);
+    assert.ok(runtime.calls.some((call) => call.method === 'thread/unsubscribe'));
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test('Codex reasoning follows each model catalog and safely handles stale choices', () => {
+  const model = {
+    defaultReasoningEffort: 'medium',
+    supportedReasoningEfforts: [
+      { reasoningEffort: 'minimal', description: 'Fastest' },
+      { reasoningEffort: 'medium', description: 'Balanced' },
+      { reasoningEffort: 'xhigh', description: 'Deepest' },
+      { reasoningEffort: 'ultra', description: 'Maximum current catalog setting' },
+    ],
+  };
+  assert.equal(resolveCodexReasoningEffort(model, 'minimal'), 'minimal');
+  assert.equal(resolveCodexReasoningEffort(model, 'xhigh'), 'xhigh');
+  assert.equal(resolveCodexReasoningEffort(model, 'ultra'), 'ultra');
+  assert.equal(resolveCodexReasoningEffort(model, 'off'), 'minimal');
+  assert.equal(resolveCodexReasoningEffort(model, 'max'), null, 'a removed catalog option falls back to the model default');
+  assert.equal(resolveCodexReasoningEffort(model, null), null, 'no override leaves Codex on its advertised default');
+});
+
+test('an aborted Codex completion interrupts its exact turn and returns safely', async () => {
+  const workdir = fs.mkdtempSync(path.join(outDir, 'abort-'));
+  const controller = new AbortController();
+  const runtime = new CompletionTransport();
+  runtime.request = function (method, params) {
+    this.calls.push({ method, params });
+    if (method === 'thread/start') return Promise.resolve({ thread: { id: 'thread-1' } });
+    if (method === 'turn/start') {
+      setTimeout(() => controller.abort(), 0);
+      return Promise.resolve({ turn: { id: 'turn-1' } });
+    }
+    if (method === 'turn/interrupt') {
+      setTimeout(() => {
+        for (const handler of this.handlers) {
+          handler('turn/completed', { threadId: 'thread-1', turn: { status: 'interrupted', items: [] } });
+        }
+      }, 0);
+    }
+    return Promise.resolve({});
+  };
+  try {
+    assert.equal(await runIsolatedCodexCompletion(runtime, {
+      model: 'gpt-test',
+      system: 'test',
+      user: 'test',
+      reasoning: 'low',
+      workdir,
+      signal: controller.signal,
+    }), '');
+    assert.deepEqual(runtime.calls.find((call) => call.method === 'turn/interrupt').params, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    });
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test('any unexpected tool start is interrupted and never becomes an answer', async () => {
+  const workdir = fs.mkdtempSync(path.join(outDir, 'tool-guard-'));
+  const runtime = new CompletionTransport();
+  runtime.request = function (method, params) {
+    this.calls.push({ method, params });
+    if (method === 'thread/start') return Promise.resolve({ thread: { id: 'thread-1' } });
+    if (method === 'turn/start') {
+      setTimeout(() => {
+        for (const handler of this.handlers) {
+          handler('item/started', {
+            threadId: 'thread-1',
+            turnId: 'turn-1',
+            item: { type: 'commandExecution', command: 'cat private.txt' },
+          });
+        }
+      }, 0);
+      return Promise.resolve({ turn: { id: 'turn-1' } });
+    }
+    return Promise.resolve({});
+  };
+  try {
+    await assert.rejects(() => runIsolatedCodexCompletion(runtime, {
+      model: 'gpt-test',
+      system: 'test',
+      user: 'test',
+      reasoning: 'low',
+      workdir,
+    }), /herramienta deshabilitada/i);
+    assert.deepEqual(runtime.calls.find((call) => call.method === 'turn/interrupt').params, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    });
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});

--- a/scripts/test-model-prefs-recovery.mjs
+++ b/scripts/test-model-prefs-recovery.mjs
@@ -112,6 +112,12 @@ const prefs = JSON.parse(readFileSync(path.join(userData, 'app-prefs.json'), 'ut
 assert.equal(prefs.v23ModelPrefsRecoveryVersion, 1, 'the repair is marked as one-shot');
 settingsRepo.updateSettings({ embeddingProvider: 'openai', embeddingModel: 'text-embedding-3-small' });
 assert.equal(settingsRepo.getSettings().embeddingProvider, 'openai', 'a later intentional change is not reverted');
+settingsRepo.updateSettings({ codexReasoningEfforts: { 'gpt-test': 'xhigh', 'stale-model': '../turbo' } });
+assert.deepEqual(
+  settingsRepo.getSettings().codexReasoningEfforts,
+  { 'gpt-test': 'xhigh' },
+  'Codex reasoning preferences reject unsafe values outside the protocol identifier shape'
+);
 
 database.closeDb();
 registry.setActiveVault(secondary.id);
@@ -124,6 +130,7 @@ db.prepare(`INSERT INTO ideas (
 const secondarySettings = settingsRepo.getSettings();
 assert.equal(secondarySettings.embeddingProvider, 'openai', 'each vault recovers against its own independent index');
 assert.equal(secondarySettings.embeddingModel, 'text-embedding-3-small');
+assert.deepEqual(secondarySettings.codexReasoningEfforts, { 'gpt-test': 'xhigh' }, 'Codex reasoning preferences are shared across vaults');
 
 database.closeDb();
 console.log('2.3 model preference recovery tests passed');

--- a/scripts/test-subscription-providers.mjs
+++ b/scripts/test-subscription-providers.mjs
@@ -1,0 +1,250 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-subscription-providers-'));
+const bundle = path.join(outDir, 'subscription-providers.cjs');
+const entry = path.join(outDir, 'entry.ts');
+fs.writeFileSync(entry, [
+  `export * from ${JSON.stringify(path.join(repoRoot, 'electron/ai/openCodeGoCompletion.ts'))};`,
+  `export * from ${JSON.stringify(path.join(repoRoot, 'electron/ai/openCodeGoPricing.ts'))};`,
+  `export * from ${JSON.stringify(path.join(repoRoot, 'electron/ai/githubCopilotCompletion.ts'))};`,
+].join('\n'));
+execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
+  entry,
+  '--bundle',
+  '--platform=node',
+  '--format=cjs',
+  '--target=es2022',
+  `--outfile=${bundle}`,
+], { cwd: repoRoot, stdio: 'inherit' });
+const require = createRequire(import.meta.url);
+const {
+  completeWithOpenCodeGo,
+  estimateOpenCodeGoCostUsd,
+  openCodeGoProtocol,
+  runIsolatedGitHubCopilotCompletion,
+} = require(bundle);
+
+test.after(() => fs.rmSync(outDir, { recursive: true, force: true }));
+
+test('redistributed official runtimes retain the required license notices', () => {
+  const notices = fs.readFileSync(path.join(repoRoot, 'electron/assets/THIRD_PARTY_NOTICES.md'), 'utf8');
+  const copilotCliLicense = fs.readFileSync(path.join(repoRoot, 'node_modules/@github/copilot/LICENSE.md'), 'utf8');
+  assert.match(notices, /GitHub Copilot SDK — MIT License/);
+  assert.match(notices, /Copyright GitHub, Inc\./);
+  assert.match(notices, /OpenAI Codex — Apache License 2\.0/);
+  assert.match(notices, /TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION/);
+  assert.match(copilotCliLicense, /right to reproduce and redistribute unmodified copies/);
+});
+
+async function body(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+async function fakeOpenCodeGo() {
+  const calls = [];
+  const server = http.createServer(async (request, response) => {
+    const payload = await body(request);
+    calls.push({ url: request.url, headers: request.headers, payload });
+    if (request.headers.authorization === 'Bearer rejected') {
+      response.writeHead(401, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ type: 'error', error: { type: 'AuthError', message: 'Invalid API key.' } }));
+      return;
+    }
+    if (request.url === '/v1/chat/completions') {
+      if (!payload.stream) {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({
+          choices: [{ message: { content: 'respuesta openai' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 10, completion_tokens: 4, prompt_tokens_details: { cached_tokens: 3 } },
+        }));
+        return;
+      }
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.write(`data: ${JSON.stringify({ choices: [{ delta: { reasoning_content: 'piensa' } }] })}\n\n`);
+      response.write(`data: ${JSON.stringify({ choices: [{ delta: { content: 'hola ' } }] })}\n\n`);
+      response.write(`data: ${JSON.stringify({ choices: [{ delta: { content: 'go' }, finish_reason: 'stop' }], usage: { prompt_tokens: 8, completion_tokens: 2 } })}\n\n`);
+      response.end('data: [DONE]\n\n');
+      return;
+    }
+    if (request.url === '/v1/messages') {
+      if (!payload.stream) {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({
+          content: [{ type: 'text', text: 'respuesta anthropic' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 7, output_tokens: 5, cache_read_input_tokens: 2, cache_creation_input_tokens: 1 },
+        }));
+        return;
+      }
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.write(`event: message_start\ndata: ${JSON.stringify({ type: 'message_start', message: { usage: { input_tokens: 6, cache_read_input_tokens: 2 } } })}\n\n`);
+      response.write(`event: content_block_delta\ndata: ${JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'hola mini' } })}\n\n`);
+      response.end(`event: message_delta\ndata: ${JSON.stringify({ type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 3 } })}\n\n`);
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    calls,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+test('OpenCode Go selects its two documented protocols and normalizes usage', async () => {
+  const fake = await fakeOpenCodeGo();
+  try {
+    assert.equal(openCodeGoProtocol('kimi-k3'), 'openai');
+    assert.equal(openCodeGoProtocol('minimax-m3'), 'anthropic');
+    assert.equal(openCodeGoProtocol('qwen3.7-plus'), 'anthropic');
+
+    const openai = await completeWithOpenCodeGo({
+      apiKey: 'go-key', model: 'kimi-k3', system: 'system', user: 'user', jsonMode: true, baseUrl: fake.baseUrl,
+    });
+    assert.equal(openai.text, 'respuesta openai');
+    assert.deepEqual(openai.usage, { uncachedInputTokens: 7, outputTokens: 4, cachedReadTokens: 3, cachedWriteTokens: 0 });
+    const openaiCall = fake.calls[0];
+    assert.equal(openaiCall.url, '/v1/chat/completions');
+    assert.equal(openaiCall.headers.authorization, 'Bearer go-key');
+    assert.deepEqual(openaiCall.payload.response_format, { type: 'json_object' });
+
+    const anthropic = await completeWithOpenCodeGo({
+      apiKey: 'go-key', model: 'minimax-m3', system: 'system', user: 'user', jsonMode: true, baseUrl: fake.baseUrl,
+    });
+    assert.equal(anthropic.text, 'respuesta anthropic');
+    assert.deepEqual(anthropic.usage, { uncachedInputTokens: 7, outputTokens: 5, cachedReadTokens: 2, cachedWriteTokens: 1 });
+    const anthropicCall = fake.calls[1];
+    assert.equal(anthropicCall.url, '/v1/messages');
+    assert.equal(anthropicCall.headers['x-api-key'], 'go-key');
+    assert.equal(anthropicCall.headers['anthropic-version'], '2023-06-01');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('OpenCode Go local metering uses official cache and long-context prices without guessing', () => {
+  assert.equal(estimateOpenCodeGoCostUsd('qwen3.7-plus', {
+    uncachedInputTokens: 100_000, outputTokens: 10_000, cachedReadTokens: 0, cachedWriteTokens: 0,
+  }), 0.056);
+  assert.equal(estimateOpenCodeGoCostUsd('qwen3.7-plus', {
+    uncachedInputTokens: 300_000, outputTokens: 10_000, cachedReadTokens: 0, cachedWriteTokens: 0,
+  }), 0.408);
+  assert.equal(estimateOpenCodeGoCostUsd('future-unpriced-model', {
+    uncachedInputTokens: 1, outputTokens: 1, cachedReadTokens: 0, cachedWriteTokens: 0,
+  }), null);
+});
+
+test('OpenCode Go streams both protocols, separates reasoning, and surfaces auth errors', async () => {
+  const fake = await fakeOpenCodeGo();
+  try {
+    const text = [];
+    const reasoning = [];
+    const openai = await completeWithOpenCodeGo({
+      apiKey: 'go-key', model: 'kimi-k3', system: 's', user: 'u', baseUrl: fake.baseUrl,
+      onDelta: (delta) => text.push(delta), onReasoningDelta: (delta) => reasoning.push(delta),
+    });
+    assert.equal(openai.text, 'hola go');
+    assert.deepEqual(text, ['hola ', 'go']);
+    assert.deepEqual(reasoning, ['piensa']);
+
+    const mini = [];
+    const anthropic = await completeWithOpenCodeGo({
+      apiKey: 'go-key', model: 'minimax-m3', system: 's', user: 'u', baseUrl: fake.baseUrl,
+      onDelta: (delta) => mini.push(delta),
+    });
+    assert.equal(anthropic.text, 'hola mini');
+    assert.deepEqual(mini, ['hola mini']);
+    assert.deepEqual(anthropic.usage, { uncachedInputTokens: 6, outputTokens: 3, cachedReadTokens: 2, cachedWriteTokens: 0 });
+
+    await assert.rejects(() => completeWithOpenCodeGo({
+      apiKey: 'rejected', model: 'kimi-k3', system: 's', user: 'u', baseUrl: fake.baseUrl,
+    }), (error) => error.status === 401 && /Invalid API key/i.test(error.message));
+  } finally {
+    await fake.close();
+  }
+});
+
+class FakeCopilotSession {
+  sessionId = 'ephemeral-session';
+  handlers = new Set();
+  aborted = false;
+  disconnected = false;
+  rpc = { usage: { getMetrics: async () => ({
+    currentModel: 'gpt-test', totalPremiumRequestCost: 0.5, totalUserRequests: 1,
+    lastCallInputTokens: 12, lastCallOutputTokens: 4,
+  }) } };
+  on(handler) { this.handlers.add(handler); return () => this.handlers.delete(handler); }
+  async sendAndWait(options) {
+    this.message = options;
+    for (const handler of this.handlers) handler({ type: 'assistant.message_delta', data: { deltaContent: 'hola ' } });
+    for (const handler of this.handlers) handler({ type: 'assistant.message_delta', data: { deltaContent: 'copilot' } });
+    return { data: { content: 'hola copilot' } };
+  }
+  async abort() { this.aborted = true; }
+  async disconnect() { this.disconnected = true; }
+}
+
+class FakeCopilotClient {
+  session = new FakeCopilotSession();
+  deleted = [];
+  async createSession(config) { this.config = config; return this.session; }
+  async deleteSession(id) { this.deleted.push(id); }
+}
+
+test('GitHub Copilot completion is ephemeral, no-tools, multimodal, streamable, and metered', async () => {
+  const client = new FakeCopilotClient();
+  const deltas = [];
+  const result = await runIsolatedGitHubCopilotCompletion(client, {
+    model: 'gpt-test', system: 'Return only text.', user: 'hello', reasoning: 'high', supportsReasoning: true,
+    workdir: outDir, images: [{ mediaType: 'image/png', base64: Buffer.from('image').toString('base64') }],
+    onDelta: (delta) => deltas.push(delta),
+  });
+  assert.equal(result.text, 'hola copilot');
+  assert.deepEqual(deltas, ['hola ', 'copilot']);
+  assert.deepEqual(result.usage, { model: 'gpt-test', premiumRequestCost: 0.5, userRequests: 1, inputTokens: 12, outputTokens: 4 });
+  assert.equal(client.config.model, 'gpt-test');
+  assert.equal(client.config.reasoningEffort, 'high');
+  assert.deepEqual(client.config.availableTools, []);
+  assert.deepEqual(client.config.tools, []);
+  assert.deepEqual(client.config.mcpServers, {});
+  assert.equal(client.config.enableConfigDiscovery, false);
+  assert.equal(client.config.enableSkills, false);
+  assert.equal(client.config.enableHostGitOperations, false);
+  assert.equal(client.config.enableSessionStore, false);
+  assert.equal(client.config.remoteSession, 'off');
+  assert.equal(client.config.enableSessionTelemetry, false);
+  assert.deepEqual(client.config.onPermissionRequest(), { kind: 'reject', feedback: 'Nodus does not expose tools for text generation.' });
+  assert.match(client.config.systemMessage.content, /Never use tools, shell commands, files, URLs, MCP servers/);
+  assert.equal(client.session.message.attachments[0].type, 'blob');
+  assert.equal(client.session.message.attachments[0].data, Buffer.from('image').toString('base64'));
+  assert.equal(client.session.disconnected, true);
+  assert.deepEqual(client.deleted, ['ephemeral-session']);
+});
+
+test('GitHub Copilot aborts and rejects any unexpected tool execution', async () => {
+  const client = new FakeCopilotClient();
+  client.session.sendAndWait = async function () {
+    for (const handler of this.handlers) handler({ type: 'tool.execution_start', data: { toolName: 'shell' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return { data: { content: 'must not escape' } };
+  };
+  await assert.rejects(() => runIsolatedGitHubCopilotCompletion(client, {
+    model: 'gpt-test', system: 's', user: 'u', reasoning: 'off', supportsReasoning: false, workdir: outDir,
+  }), /herramienta deshabilitada/i);
+  assert.equal(client.session.aborted, true);
+  assert.equal(client.session.disconnected, true);
+  assert.deepEqual(client.deleted, ['ephemeral-session']);
+});

--- a/shared/onboardingModels.ts
+++ b/shared/onboardingModels.ts
@@ -1,5 +1,5 @@
 import type { AiProvider, EmbeddingProvider, ModelInfo, ModelRef } from './types';
-import { AI_PROVIDERS, EMBEDDING_PROVIDERS, PROVIDER_LABELS, isLocalProvider } from './providers';
+import { AI_PROVIDERS, EMBEDDING_PROVIDERS, PROVIDER_LABELS, SECRET_PROVIDERS, isLocalProvider } from './providers';
 
 // Pure helpers behind the setup wizard's provider step. The wizard asks the user
 // for nothing it can find out on its own: it queries every provider that already
@@ -35,12 +35,12 @@ export function autoDiscoverableEmbeddingProviders(keys: ProviderKeyMap): Embedd
 /** Cloud providers with no key yet — the only ones worth offering in the "add a
  *  key" prompt, since local ones are already reachable without one. */
 export function providersMissingKey(keys: ProviderKeyMap): AiProvider[] {
-  return AI_PROVIDERS.filter((provider) => !isLocalProvider(provider) && !keys[provider]);
+  return SECRET_PROVIDERS.filter((provider) => !isLocalProvider(provider) && !keys[provider]);
 }
 
 /** Cloud providers whose key is already stored, in picker order. */
 export function configuredKeyProviders(keys: ProviderKeyMap): AiProvider[] {
-  return AI_PROVIDERS.filter((provider) => !isLocalProvider(provider) && Boolean(keys[provider]));
+  return SECRET_PROVIDERS.filter((provider) => !isLocalProvider(provider) && Boolean(keys[provider]));
 }
 
 export interface ModelChoice {

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -9,6 +9,25 @@ import type { AiProvider, EmbeddingProvider, LocalProvider, ModelRef } from './t
 export const AI_PROVIDERS: AiProvider[] = [
   'anthropic',
   'openai',
+  'codex',
+  'github-copilot',
+  'opencode-go',
+  'openrouter',
+  'groq',
+  'cerebras',
+  'deepseek',
+  'gemini',
+  'xiaomi',
+  'ollama',
+  'lmstudio',
+];
+
+/** Providers whose credentials are Nodus-managed API keys/tokens. ChatGPT's
+ * managed OAuth session belongs to Codex and must never enter backup/recovery. */
+export const SECRET_PROVIDERS: Exclude<AiProvider, 'codex' | 'github-copilot' | 'nodus'>[] = [
+  'anthropic',
+  'openai',
+  'opencode-go',
   'openrouter',
   'groq',
   'cerebras',
@@ -22,6 +41,9 @@ export const AI_PROVIDERS: AiProvider[] = [
 export const PROVIDER_LABELS: Record<AiProvider, string> = {
   anthropic: 'Anthropic',
   openai: 'OpenAI',
+  codex: 'ChatGPT · Codex',
+  'github-copilot': 'GitHub Copilot',
+  'opencode-go': 'OpenCode Go',
   openrouter: 'OpenRouter',
   groq: 'Groq',
   cerebras: 'Cerebras',

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -780,6 +780,9 @@ export interface ExternalRef {
 export type AiProvider =
   | 'anthropic'
   | 'openai'
+  | 'codex'
+  | 'github-copilot'
+  | 'opencode-go'
   | 'openrouter'
   | 'groq'
   | 'cerebras'
@@ -810,6 +813,94 @@ export interface LocalProviderTestResult {
   modelCount?: number;
   /** Human-readable error when `ok` is false. */
   message?: string;
+}
+
+/** A rolling usage window reported by the official Codex App Server. */
+export interface ChatGptSubscriptionRateLimitWindow {
+  usedPercent: number;
+  windowDurationMins: number | null;
+  /** Unix timestamp (seconds), as returned by Codex. */
+  resetsAt: number | null;
+}
+
+/** ChatGPT-plan quota exposed by Codex. This is separate from OpenAI API billing. */
+export interface ChatGptSubscriptionRateLimits {
+  primary: ChatGptSubscriptionRateLimitWindow | null;
+  secondary: ChatGptSubscriptionRateLimitWindow | null;
+  credits: { hasCredits: boolean; unlimited: boolean; balance: string | null } | null;
+}
+
+/** Renderer-safe view of the managed ChatGPT login. OAuth tokens never cross IPC. */
+export interface ChatGptSubscriptionStatus {
+  available: boolean;
+  connected: boolean;
+  loginPending: boolean;
+  email: string | null;
+  planType: string | null;
+  rateLimits: ChatGptSubscriptionRateLimits | null;
+  error: string | null;
+}
+
+export interface ChatGptSubscriptionLogin {
+  loginId: string;
+  authUrl: string;
+}
+
+/** One account-level quota bucket returned by the official GitHub Copilot runtime. */
+export interface GitHubCopilotSubscriptionQuotaWindow {
+  id: string;
+  unlimited: boolean;
+  entitlementRequests: number;
+  usedRequests: number;
+  remainingRequests: number | null;
+  remainingPercentage: number;
+  overage: number;
+  overageAllowed: boolean;
+  usageAllowedAfterExhaustion: boolean;
+  resetDate: string | null;
+  tokenBasedBilling: boolean;
+  hasQuota: boolean;
+}
+
+export interface GitHubCopilotSessionUsage {
+  model: string;
+  premiumRequestCost: number;
+  userRequests: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** Renderer-safe status. GitHub tokens and keychain records never cross IPC. */
+export interface GitHubCopilotSubscriptionStatus {
+  available: boolean;
+  connected: boolean;
+  loginPending: boolean;
+  login: string | null;
+  authType: string | null;
+  statusMessage: string | null;
+  canLogout: boolean;
+  quota: GitHubCopilotSubscriptionQuotaWindow[];
+  lastSession: GitHubCopilotSessionUsage | null;
+  error: string | null;
+}
+
+/** Usage Nodus can observe locally for OpenCode Go. The authoritative balance
+ * remains in OpenCode Console because no supported user-key quota API exists. */
+export interface OpenCodeGoUsagePeriod {
+  requests: number;
+  estimatedCostUsd: number;
+  unpricedRequests: number;
+}
+
+export interface OpenCodeGoUsageStatus {
+  officialUsageUrl: string;
+  limitsUsd: { fiveHours: number; week: number; month: number };
+  observed: {
+    fiveHours: OpenCodeGoUsagePeriod;
+    week: OpenCodeGoUsagePeriod;
+    month: OpenCodeGoUsagePeriod;
+  };
+  lastUpdatedAt: string | null;
 }
 export type DecorativeImageEntityKind = 'immersion' | 'deep_research';
 export type DecorativeImageStatus = 'not_requested' | 'pending' | 'ready' | 'failed';
@@ -909,6 +1000,13 @@ export interface ModelInfo {
   group?: string;
   /** For OpenRouter: true when the model is a reasoning model (slower for scans). */
   reasoning?: boolean;
+  /** Codex App Server: exact effort choices advertised for this model. */
+  supportedReasoningEfforts?: Array<{
+    reasoningEffort: CodexReasoningEffort;
+    description: string;
+  }>;
+  /** Codex App Server's recommended effort when the user leaves the model on default. */
+  defaultReasoningEffort?: CodexReasoningEffort;
   // ── Local-provider metadata (Ollama / LM Studio). All optional; other
   //    providers omit them and the UI only renders what is present. ────────────
   /** On-disk size in bytes (Ollama). */
@@ -931,6 +1029,12 @@ export interface ModelInfo {
 /** How hard a model should "think" before answering. `off` skips the chain-of-thought
  *  on reasoning models where the provider supports it (much faster for scanning). */
 export type ReasoningEffort = 'off' | 'low' | 'medium' | 'high';
+
+/** Codex deliberately types effort as an extensible string. The literals preserve
+ * autocomplete for current catalogs; availability still comes from each ModelInfo. */
+export type CodexReasoningEffort =
+  | 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
+  | (string & {});
 
 // ── Audio / text-to-speech ───────────────────────────────────────────────────
 /** Audio (text-to-speech) backends. Both current providers run fully local in the
@@ -1249,6 +1353,8 @@ export interface AppSettings {
   // Reasoning effort for interactive long-form calls (chat, tutor, debate, writing).
   // Scans always run with reasoning off for speed, regardless of this value.
   chatReasoning: ReasoningEffort;
+  /** Per-model Codex reasoning overrides. Missing means use that model's advertised default. */
+  codexReasoningEfforts: Record<string, CodexReasoningEffort>;
   // When using OpenRouter, bias routing toward the fastest upstream provider.
   openRouterThroughput: boolean;
   unpaywallEmail: string;
@@ -5143,6 +5249,25 @@ export interface NodusApi {
   onApiKeysRecovered(
     cb: (result: { recoveredProviders: AiProvider[]; remainingLockedProviders: AiProvider[] }) => void
   ): () => void;
+
+  // Managed ChatGPT subscription login through the official Codex App Server.
+  // Credentials remain in Codex's OS-keychain-backed store and never cross IPC.
+  getChatGptSubscriptionStatus(): Promise<ChatGptSubscriptionStatus>;
+  startChatGptSubscriptionLogin(): Promise<ChatGptSubscriptionLogin>;
+  cancelChatGptSubscriptionLogin(loginId: string): Promise<ChatGptSubscriptionStatus>;
+  logoutChatGptSubscription(): Promise<ChatGptSubscriptionStatus>;
+  onChatGptSubscriptionStatusChanged(cb: (status: ChatGptSubscriptionStatus) => void): () => void;
+
+  // GitHub Copilot subscription access through GitHub's official SDK/CLI.
+  getGitHubCopilotSubscriptionStatus(): Promise<GitHubCopilotSubscriptionStatus>;
+  startGitHubCopilotSubscriptionLogin(): Promise<GitHubCopilotSubscriptionStatus>;
+  cancelGitHubCopilotSubscriptionLogin(): Promise<GitHubCopilotSubscriptionStatus>;
+  logoutGitHubCopilotSubscription(): Promise<GitHubCopilotSubscriptionStatus>;
+  onGitHubCopilotSubscriptionStatusChanged(cb: (status: GitHubCopilotSubscriptionStatus) => void): () => void;
+
+  // OpenCode Go exposes inference/models by API key, but live remaining quota in Console.
+  getOpenCodeGoUsageStatus(): Promise<OpenCodeGoUsageStatus>;
+  onOpenCodeGoUsageStatusChanged(cb: (status: OpenCodeGoUsageStatus) => void): () => void;
 
   // AI model discovery
   listModels(provider: AiProvider): Promise<ModelInfo[]>;

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -1088,6 +1088,84 @@ export const DE: Record<string, string> = {
   'sin claves': 'keine Schlüssel',
   'Las claves de API y los modelos configurados se comparten entre todas tus bóvedas.':
     'API-Schlüssel und die konfigurierten Modelle werden von allen Ihren Arbeitsbereichen gemeinsam genutzt.',
+  'comprobando…': 'wird geprüft…',
+  'suscripción conectada': 'Abonnement verbunden',
+  'sin conectar': 'nicht verbunden',
+  'Conexión mediante el protocolo oficial Codex App Server y el acceso gestionado de ChatGPT. Nodus no lee ni almacena tus credenciales.':
+    'Verbindung über das offizielle Codex-App-Server-Protokoll und die verwaltete ChatGPT-Anmeldung. Nodus liest oder speichert Ihre Zugangsdaten nicht.',
+  'Nodus es una aplicación independiente y no está afiliada, certificada ni respaldada por OpenAI.':
+    'Nodus ist eine unabhängige Anwendung und weder mit OpenAI verbunden noch von OpenAI zertifiziert oder unterstützt.',
+  'El uso consume la cuota o los créditos de Codex incluidos en tu plan de ChatGPT; no consume saldo de la API de OpenAI.':
+    'Die Nutzung verbraucht das in Ihrem ChatGPT-Tarif enthaltene Codex-Kontingent bzw. Guthaben, nicht das OpenAI-API-Guthaben.',
+  'Funciona como motor de Nodi, análisis y Deep Research de Nodus. No es el producto Deep Research de la web de ChatGPT.':
+    'Die Laufzeit betreibt Nodi, Analysen und Nodus Deep Research. Sie ist nicht das Deep-Research-Produkt der ChatGPT-Webseite.',
+  'Cada petición usa un hilo efímero aislado, sin acceso de escritura, sin red de herramientas y sin cargar tus MCP, plugins o instrucciones personales.':
+    'Jede Anfrage nutzt einen isolierten, flüchtigen Thread ohne Schreibzugriff, ohne Werkzeugnetzwerk und ohne Ihre MCP-Server, Plugins oder persönlichen Anweisungen zu laden.',
+  'Documentación oficial de Codex App Server ↗': 'Offizielle Dokumentation zu Codex App Server ↗',
+  'Conectado': 'Verbunden',
+  'Actualizar estado': 'Status aktualisieren',
+  'Cerrar sesión': 'Abmelden',
+  'Límite principal': 'Primäres Limit',
+  'Límite secundario': 'Sekundäres Limit',
+  'Cargar modelos de Codex': 'Codex-Modelle laden',
+  'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
+    'Jedes Modell zeigt nur die von Codex veröffentlichten Reasoning-Stufen. „Standard“ verwendet die vom Modell empfohlene Stufe.',
+  'Razonamiento de {model}': 'Reasoning für {model}',
+  '{level} (predeterminado)': '{level} (Standard)',
+  Ninguno: 'Keines',
+  Alto: 'Hoch',
+  'Muy alto': 'Sehr hoch',
+  Ultra: 'Ultra',
+  'Esperando acceso en el navegador…': 'Warten auf die Anmeldung im Browser…',
+  'Conectar suscripción de ChatGPT': 'ChatGPT-Abonnement verbinden',
+  'Cancelar acceso': 'Anmeldung abbrechen',
+  'Comprobar estado': 'Status prüfen',
+  'Se restablece: {time}': 'Zurücksetzung: {time}',
+  'Créditos adicionales': 'Zusätzliche Credits',
+  'Ilimitados': 'Unbegrenzt',
+  'Disponibles': 'Verfügbar',
+  'Sin créditos': 'Keine Credits',
+  '{n}% restante': '{n} % verbleibend',
+  '{n}% usado': '{n} % verwendet',
+  'SDK oficial · preview': 'Offizielles SDK · Vorschau',
+  'Nodus usa el SDK y el runtime oficiales de GitHub Copilot. Cada petición se factura a la suscripción de GitHub del usuario; no requiere claves de los modelos.':
+    'Nodus verwendet das offizielle GitHub-Copilot-SDK und die offizielle Laufzeit. Jede Anfrage wird dem GitHub-Abonnement des Benutzers angerechnet; Modell-API-Schlüssel sind nicht erforderlich.',
+  'La integración oficial está en public preview. Nodus es independiente y no está afiliada, certificada ni respaldada por GitHub.':
+    'Die offizielle Integration befindet sich in der öffentlichen Vorschau. Nodus ist unabhängig und weder mit GitHub verbunden noch von GitHub zertifiziert oder unterstützt.',
+  'Cada petición se ejecuta en una sesión efímera sin herramientas, MCP, memoria, acceso a archivos, GitHub ni instrucciones del proyecto.':
+    'Jede Anfrage läuft in einer flüchtigen Sitzung ohne Tools, MCP, Speicher, Datei- oder GitHub-Zugriff und ohne Projektanweisungen.',
+  'Documentación oficial del SDK de Copilot ↗': 'Offizielle Copilot-SDK-Dokumentation ↗',
+  'Actualizar cuota': 'Kontingent aktualisieren',
+  'GitHub no devolvió un contador de cuota para esta cuenta.': 'GitHub hat für dieses Konto keinen Kontingentzähler zurückgegeben.',
+  'Última petición en Nodus: {cost} créditos/solicitudes premium · {input} tokens de entrada · {output} de salida':
+    'Letzte Nodus-Anfrage: {cost} Credits/Premium-Anfragen · {input} Eingabe-Token · {output} Ausgabe-Token',
+  'Cargar modelos de Copilot': 'Copilot-Modelle laden',
+  'Esperando acceso de GitHub en el navegador…': 'Warten auf die GitHub-Anmeldung im Browser…',
+  'Conectar GitHub Copilot': 'GitHub Copilot verbinden',
+  'El runtime oficial abre el flujo OAuth de dispositivo y guarda su credencial en el almacén seguro del sistema. Si ya usas GitHub CLI, puede reutilizar esa sesión sin modificarla.':
+    'Die offizielle Laufzeit öffnet den OAuth-Gerätefluss und speichert die Anmeldedaten im sicheren Systemspeicher. Eine vorhandene GitHub-CLI-Sitzung kann unverändert wiederverwendet werden.',
+  'Créditos / solicitudes premium': 'Credits / Premium-Anfragen',
+  'Ilimitado según GitHub': 'Laut GitHub unbegrenzt',
+  '{remaining} de {total} restantes · {used} usadas': '{remaining} von {total} verbleibend · {used} verwendet',
+  '{n} de uso adicional': '{n} zusätzliche Nutzung',
+  'OpenCode documenta el uso directo de la suscripción Go mediante esta clave y sus endpoints oficiales. Nodus es independiente y no está afiliada, certificada ni respaldada por OpenCode.':
+    'OpenCode dokumentiert die direkte Nutzung des Go-Abonnements über diesen Schlüssel und seine offiziellen Endpunkte. Nodus ist unabhängig und weder mit OpenCode verbunden noch zertifiziert oder unterstützt.',
+  'Límites generales publicados: 12 USD cada 5 horas, 30 USD por semana y 60 USD por mes. Algunos modelos tienen un límite mensual efectivo inferior (15 USD); el número de peticiones depende del modelo y puede cambiar.':
+    'Veröffentlichte allgemeine Limits: 12 USD je 5 Stunden, 30 USD pro Woche und 60 USD pro Monat. Einige Modelle haben ein niedrigeres effektives Monatslimit (15 USD); die Anzahl der Anfragen hängt vom Modell ab und kann sich ändern.',
+  'Saldo restante oficial: OpenCode solo lo publica en Console; no ofrece una API de cuota compatible con la clave de usuario. Nodus no usa cookies ni endpoints privados.':
+    'Offizieller Restsaldo: OpenCode veröffentlicht ihn nur in Console und bietet keine mit dem Benutzerschlüssel kompatible Kontingent-API. Nodus verwendet weder Cookies noch private Endpunkte.',
+  'Últimas 5 horas': 'Letzte 5 Stunden',
+  'Últimos 7 días': 'Letzte 7 Tage',
+  'Últimos 30 días': 'Letzte 30 Tage',
+  'El gasto observado es una estimación local de las peticiones hechas por Nodus con precios oficiales; no incluye otros clientes y no equivale al saldo restante.':
+    'Die beobachteten Ausgaben sind eine lokale Schätzung der von Nodus gestellten Anfragen zu offiziellen Preisen; andere Clients sind nicht enthalten und sie entsprechen nicht dem Restsaldo.',
+  'Ver saldo restante oficial en OpenCode Console ↗': 'Offiziellen Restsaldo in OpenCode Console anzeigen ↗',
+  'Documentación oficial de OpenCode Go ↗': 'Offizielle OpenCode-Go-Dokumentation ↗',
+  '{requests} peticiones · ~${spent} observados · ${cap} de tope general de referencia': '{requests} Anfragen · ~${spent} beobachtet · ${cap} allgemeines Referenzlimit',
+  '{n} sin precio estimable': '{n} ohne schätzbaren Preis',
+  'Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude.ai ni utilicen credenciales de suscripciones Free, Pro o Max. Por ello Claude se conecta aquí únicamente mediante la API oficial.':
+    'Anthropic gestattet Drittanbieter-Apps weder die Claude.ai-Anmeldung noch die Nutzung von Zugangsdaten für Free-, Pro- oder Max-Abonnements. Claude wird hier daher ausschließlich über die offizielle API verbunden.',
+  'Política oficial de Anthropic ↗': 'Offizielle Anthropic-Richtlinie ↗',
   'Nodus ha encontrado claves de API cifradas que todavía no puede leer.': 'Nodus hat verschlüsselte API-Schlüssel gefunden, die es noch nicht lesen kann.',
   'No se han borrado. Pulsa recuperar y autoriza el acceso al Llavero de macOS si el sistema lo solicita.':
     'Sie wurden nicht gelöscht. Wählen Sie „Wiederherstellen“ und autorisieren Sie den Zugriff auf den macOS-Schlüsselbund, falls das System danach fragt.',
@@ -1327,8 +1405,8 @@ export const DE: Record<string, string> = {
   'Reindexar todo': 'Alles neu indexieren',
   'Llamadas simultáneas': 'Gleichzeitige Aufrufe',
   'Razonamiento (chat/tutor/escritura)': 'Reasoning (Chat/Tutor/Schreiben)',
-  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales.':
-    'Scans laufen zur Beschleunigung immer mit deaktiviertem Reasoning. Dies betrifft nur die Chat-Antworten.',
+  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales. En Codex se configura por modelo dentro de Proveedores.':
+    'Scans laufen zur Beschleunigung immer mit deaktiviertem Reasoning. Dies betrifft nur die Chat-Antworten. Für Codex wird es pro Modell unter Anbieter eingestellt.',
   'Desactivado (más rápido)': 'Deaktiviert (schneller)',
   'Bajo': 'Niedrig',
   'Medio': 'Mittel',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -1096,6 +1096,84 @@ export const EN: Record<string, string> = {
   'sin claves': 'no keys',
   'Las claves de API y los modelos configurados se comparten entre todas tus bóvedas.':
     'API keys and the models you configure are shared across all your vaults.',
+  'comprobando…': 'checking…',
+  'suscripción conectada': 'subscription connected',
+  'sin conectar': 'not connected',
+  'Conexión mediante el protocolo oficial Codex App Server y el acceso gestionado de ChatGPT. Nodus no lee ni almacena tus credenciales.':
+    'Connection through the official Codex App Server protocol and managed ChatGPT sign-in. Nodus does not read or store your credentials.',
+  'Nodus es una aplicación independiente y no está afiliada, certificada ni respaldada por OpenAI.':
+    'Nodus is an independent application and is not affiliated with, certified by, or endorsed by OpenAI.',
+  'El uso consume la cuota o los créditos de Codex incluidos en tu plan de ChatGPT; no consume saldo de la API de OpenAI.':
+    'Usage consumes the Codex quota or credits included in your ChatGPT plan; it does not consume OpenAI API balance.',
+  'Funciona como motor de Nodi, análisis y Deep Research de Nodus. No es el producto Deep Research de la web de ChatGPT.':
+    'It powers Nodi, analysis and Nodus Deep Research. It is not the Deep Research product on the ChatGPT website.',
+  'Cada petición usa un hilo efímero aislado, sin acceso de escritura, sin red de herramientas y sin cargar tus MCP, plugins o instrucciones personales.':
+    'Each request uses an isolated ephemeral thread, with no write access, no tool network, and without loading your MCP servers, plugins or personal instructions.',
+  'Documentación oficial de Codex App Server ↗': 'Official Codex App Server documentation ↗',
+  'Conectado': 'Connected',
+  'Actualizar estado': 'Refresh status',
+  'Cerrar sesión': 'Sign out',
+  'Límite principal': 'Primary limit',
+  'Límite secundario': 'Secondary limit',
+  'Cargar modelos de Codex': 'Load Codex models',
+  'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
+    'Each model shows only the reasoning levels published by Codex. “Default” uses the model’s recommended level.',
+  'Razonamiento de {model}': 'Reasoning for {model}',
+  '{level} (predeterminado)': '{level} (default)',
+  Ninguno: 'None',
+  Alto: 'High',
+  'Muy alto': 'Very high',
+  Ultra: 'Ultra',
+  'Esperando acceso en el navegador…': 'Waiting for browser sign-in…',
+  'Conectar suscripción de ChatGPT': 'Connect ChatGPT subscription',
+  'Cancelar acceso': 'Cancel sign-in',
+  'Comprobar estado': 'Check status',
+  'Se restablece: {time}': 'Resets: {time}',
+  'Créditos adicionales': 'Additional credits',
+  'Ilimitados': 'Unlimited',
+  'Disponibles': 'Available',
+  'Sin créditos': 'No credits',
+  '{n}% restante': '{n}% remaining',
+  '{n}% usado': '{n}% used',
+  'SDK oficial · preview': 'Official SDK · preview',
+  'Nodus usa el SDK y el runtime oficiales de GitHub Copilot. Cada petición se factura a la suscripción de GitHub del usuario; no requiere claves de los modelos.':
+    "Nodus uses the official GitHub Copilot SDK and runtime. Each request is billed to the user's GitHub subscription; model API keys are not required.",
+  'La integración oficial está en public preview. Nodus es independiente y no está afiliada, certificada ni respaldada por GitHub.':
+    'The official integration is in public preview. Nodus is independent and is not affiliated with, certified by, or endorsed by GitHub.',
+  'Cada petición se ejecuta en una sesión efímera sin herramientas, MCP, memoria, acceso a archivos, GitHub ni instrucciones del proyecto.':
+    'Each request runs in an ephemeral session with no tools, MCP, memory, file or GitHub access, or project instructions.',
+  'Documentación oficial del SDK de Copilot ↗': 'Official Copilot SDK documentation ↗',
+  'Actualizar cuota': 'Refresh quota',
+  'GitHub no devolvió un contador de cuota para esta cuenta.': 'GitHub did not return a quota meter for this account.',
+  'Última petición en Nodus: {cost} créditos/solicitudes premium · {input} tokens de entrada · {output} de salida':
+    'Last Nodus request: {cost} AI credits/premium requests · {input} input tokens · {output} output tokens',
+  'Cargar modelos de Copilot': 'Load Copilot models',
+  'Esperando acceso de GitHub en el navegador…': 'Waiting for GitHub sign-in in the browser…',
+  'Conectar GitHub Copilot': 'Connect GitHub Copilot',
+  'El runtime oficial abre el flujo OAuth de dispositivo y guarda su credencial en el almacén seguro del sistema. Si ya usas GitHub CLI, puede reutilizar esa sesión sin modificarla.':
+    'The official runtime opens the OAuth device flow and stores its credential in the system secure store. If you already use GitHub CLI, it can reuse that session without changing it.',
+  'Créditos / solicitudes premium': 'AI credits / premium requests',
+  'Ilimitado según GitHub': 'Unlimited according to GitHub',
+  '{remaining} de {total} restantes · {used} usadas': '{remaining} of {total} remaining · {used} used',
+  '{n} de uso adicional': '{n} additional usage',
+  'OpenCode documenta el uso directo de la suscripción Go mediante esta clave y sus endpoints oficiales. Nodus es independiente y no está afiliada, certificada ni respaldada por OpenCode.':
+    'OpenCode documents direct use of the Go subscription through this key and its official endpoints. Nodus is independent and is not affiliated with, certified by, or endorsed by OpenCode.',
+  'Límites generales publicados: 12 USD cada 5 horas, 30 USD por semana y 60 USD por mes. Algunos modelos tienen un límite mensual efectivo inferior (15 USD); el número de peticiones depende del modelo y puede cambiar.':
+    'Published general limits: USD 12 every 5 hours, USD 30 per week, and USD 60 per month. Some models have a lower effective monthly limit (USD 15); request counts depend on the model and may change.',
+  'Saldo restante oficial: OpenCode solo lo publica en Console; no ofrece una API de cuota compatible con la clave de usuario. Nodus no usa cookies ni endpoints privados.':
+    'Official remaining balance: OpenCode only publishes it in Console and does not offer a quota API compatible with the user key. Nodus does not use cookies or private endpoints.',
+  'Últimas 5 horas': 'Last 5 hours',
+  'Últimos 7 días': 'Last 7 days',
+  'Últimos 30 días': 'Last 30 days',
+  'El gasto observado es una estimación local de las peticiones hechas por Nodus con precios oficiales; no incluye otros clientes y no equivale al saldo restante.':
+    'Observed spend is a local estimate of requests made by Nodus using official prices; it excludes other clients and is not the remaining balance.',
+  'Ver saldo restante oficial en OpenCode Console ↗': 'View official remaining balance in OpenCode Console ↗',
+  'Documentación oficial de OpenCode Go ↗': 'Official OpenCode Go documentation ↗',
+  '{requests} peticiones · ~${spent} observados · ${cap} de tope general de referencia': '{requests} requests · ~${spent} observed · ${cap} general reference cap',
+  '{n} sin precio estimable': '{n} without an estimable price',
+  'Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude.ai ni utilicen credenciales de suscripciones Free, Pro o Max. Por ello Claude se conecta aquí únicamente mediante la API oficial.':
+    'Anthropic does not allow third-party apps to offer Claude.ai sign-in or use Free, Pro or Max subscription credentials. Claude therefore connects here only through the official API.',
+  'Política oficial de Anthropic ↗': 'Official Anthropic policy ↗',
   'Nodus ha encontrado claves de API cifradas que todavía no puede leer.':
     'Nodus found encrypted API keys that it cannot read yet.',
   'No se han borrado. Pulsa recuperar y autoriza el acceso al Llavero de macOS si el sistema lo solicita.':
@@ -1338,8 +1416,8 @@ export const EN: Record<string, string> = {
   'Reindexar todo': 'Reindex all',
   'Llamadas simultáneas': 'Concurrent calls',
   'Razonamiento (chat/tutor/escritura)': 'Reasoning (chat/tutor/writing)',
-  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales.':
-    'Scans always run with reasoning off for speed. This only affects conversational responses.',
+  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales. En Codex se configura por modelo dentro de Proveedores.':
+    'Scans always run with reasoning off for speed. This only affects conversational responses. For Codex, configure it per model under Providers.',
   'Desactivado (más rápido)': 'Off (faster)',
   Bajo: 'Low',
   Medio: 'Medium',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -1088,6 +1088,84 @@ export const FR: Record<string, string> = {
   'sin claves': 'sans clés',
   'Las claves de API y los modelos configurados se comparten entre todas tus bóvedas.':
     'Les clés API et les modèles configurés sont partagés entre tous vos espaces.',
+  'comprobando…': 'vérification…',
+  'suscripción conectada': 'abonnement connecté',
+  'sin conectar': 'non connecté',
+  'Conexión mediante el protocolo oficial Codex App Server y el acceso gestionado de ChatGPT. Nodus no lee ni almacena tus credenciales.':
+    'Connexion via le protocole officiel Codex App Server et la connexion gérée de ChatGPT. Nodus ne lit ni ne stocke vos identifiants.',
+  'Nodus es una aplicación independiente y no está afiliada, certificada ni respaldada por OpenAI.':
+    'Nodus est une application indépendante, ni affiliée, ni certifiée, ni soutenue par OpenAI.',
+  'El uso consume la cuota o los créditos de Codex incluidos en tu plan de ChatGPT; no consume saldo de la API de OpenAI.':
+    'L’utilisation consomme le quota ou les crédits Codex inclus dans votre offre ChatGPT, pas le solde de l’API OpenAI.',
+  'Funciona como motor de Nodi, análisis y Deep Research de Nodus. No es el producto Deep Research de la web de ChatGPT.':
+    'Ce moteur alimente Nodi, les analyses et Deep Research de Nodus. Il ne s’agit pas du produit Deep Research du site ChatGPT.',
+  'Cada petición usa un hilo efímero aislado, sin acceso de escritura, sin red de herramientas y sin cargar tus MCP, plugins o instrucciones personales.':
+    'Chaque requête utilise un fil éphémère isolé, sans accès en écriture, sans réseau d’outils et sans charger vos MCP, plugins ou instructions personnelles.',
+  'Documentación oficial de Codex App Server ↗': 'Documentation officielle de Codex App Server ↗',
+  'Conectado': 'Connecté',
+  'Actualizar estado': 'Actualiser l’état',
+  'Cerrar sesión': 'Se déconnecter',
+  'Límite principal': 'Limite principale',
+  'Límite secundario': 'Limite secondaire',
+  'Cargar modelos de Codex': 'Charger les modèles Codex',
+  'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
+    'Chaque modèle affiche uniquement les niveaux de raisonnement publiés par Codex. « Par défaut » utilise le niveau recommandé par le modèle.',
+  'Razonamiento de {model}': 'Raisonnement pour {model}',
+  '{level} (predeterminado)': '{level} (par défaut)',
+  Ninguno: 'Aucun',
+  Alto: 'Élevé',
+  'Muy alto': 'Très élevé',
+  Ultra: 'Ultra',
+  'Esperando acceso en el navegador…': 'En attente de la connexion dans le navigateur…',
+  'Conectar suscripción de ChatGPT': 'Connecter l’abonnement ChatGPT',
+  'Cancelar acceso': 'Annuler la connexion',
+  'Comprobar estado': 'Vérifier l’état',
+  'Se restablece: {time}': 'Réinitialisation : {time}',
+  'Créditos adicionales': 'Crédits supplémentaires',
+  'Ilimitados': 'Illimités',
+  'Disponibles': 'Disponibles',
+  'Sin créditos': 'Aucun crédit',
+  '{n}% restante': '{n} % restant',
+  '{n}% usado': '{n} % utilisé',
+  'SDK oficial · preview': 'SDK officiel · aperçu',
+  'Nodus usa el SDK y el runtime oficiales de GitHub Copilot. Cada petición se factura a la suscripción de GitHub del usuario; no requiere claves de los modelos.':
+    "Nodus utilise le SDK et le runtime officiels de GitHub Copilot. Chaque requête est facturée à l’abonnement GitHub de l’utilisateur ; aucune clé de modèle n’est nécessaire.",
+  'La integración oficial está en public preview. Nodus es independiente y no está afiliada, certificada ni respaldada por GitHub.':
+    'L’intégration officielle est en aperçu public. Nodus est indépendant et n’est ni affilié, ni certifié, ni approuvé par GitHub.',
+  'Cada petición se ejecuta en una sesión efímera sin herramientas, MCP, memoria, acceso a archivos, GitHub ni instrucciones del proyecto.':
+    'Chaque requête s’exécute dans une session éphémère sans outils, MCP, mémoire, accès aux fichiers ou à GitHub, ni instructions du projet.',
+  'Documentación oficial del SDK de Copilot ↗': 'Documentation officielle du SDK Copilot ↗',
+  'Actualizar cuota': 'Actualiser le quota',
+  'GitHub no devolvió un contador de cuota para esta cuenta.': 'GitHub n’a renvoyé aucun compteur de quota pour ce compte.',
+  'Última petición en Nodus: {cost} créditos/solicitudes premium · {input} tokens de entrada · {output} de salida':
+    'Dernière requête Nodus : {cost} crédits/requêtes premium · {input} jetons en entrée · {output} en sortie',
+  'Cargar modelos de Copilot': 'Charger les modèles Copilot',
+  'Esperando acceso de GitHub en el navegador…': 'En attente de la connexion GitHub dans le navigateur…',
+  'Conectar GitHub Copilot': 'Connecter GitHub Copilot',
+  'El runtime oficial abre el flujo OAuth de dispositivo y guarda su credencial en el almacén seguro del sistema. Si ya usas GitHub CLI, puede reutilizar esa sesión sin modificarla.':
+    'Le runtime officiel ouvre le flux OAuth de l’appareil et stocke ses identifiants dans le magasin sécurisé du système. Si vous utilisez déjà GitHub CLI, il peut réutiliser cette session sans la modifier.',
+  'Créditos / solicitudes premium': 'Crédits / requêtes premium',
+  'Ilimitado según GitHub': 'Illimité selon GitHub',
+  '{remaining} de {total} restantes · {used} usadas': '{remaining} sur {total} restantes · {used} utilisées',
+  '{n} de uso adicional': '{n} d’utilisation supplémentaire',
+  'OpenCode documenta el uso directo de la suscripción Go mediante esta clave y sus endpoints oficiales. Nodus es independiente y no está afiliada, certificada ni respaldada por OpenCode.':
+    'OpenCode documente l’utilisation directe de l’abonnement Go via cette clé et ses endpoints officiels. Nodus est indépendant et n’est ni affilié, ni certifié, ni approuvé par OpenCode.',
+  'Límites generales publicados: 12 USD cada 5 horas, 30 USD por semana y 60 USD por mes. Algunos modelos tienen un límite mensual efectivo inferior (15 USD); el número de peticiones depende del modelo y puede cambiar.':
+    'Limites générales publiées : 12 USD toutes les 5 heures, 30 USD par semaine et 60 USD par mois. Certains modèles ont une limite mensuelle effective inférieure (15 USD) ; le nombre de requêtes dépend du modèle et peut changer.',
+  'Saldo restante oficial: OpenCode solo lo publica en Console; no ofrece una API de cuota compatible con la clave de usuario. Nodus no usa cookies ni endpoints privados.':
+    'Solde restant officiel : OpenCode ne le publie que dans Console et ne propose aucune API de quota compatible avec la clé utilisateur. Nodus n’utilise ni cookies ni endpoints privés.',
+  'Últimas 5 horas': '5 dernières heures',
+  'Últimos 7 días': '7 derniers jours',
+  'Últimos 30 días': '30 derniers jours',
+  'El gasto observado es una estimación local de las peticiones hechas por Nodus con precios oficiales; no incluye otros clientes y no equivale al saldo restante.':
+    'La dépense observée est une estimation locale des requêtes faites par Nodus avec les prix officiels ; elle exclut les autres clients et ne correspond pas au solde restant.',
+  'Ver saldo restante oficial en OpenCode Console ↗': 'Voir le solde restant officiel dans OpenCode Console ↗',
+  'Documentación oficial de OpenCode Go ↗': 'Documentation officielle d’OpenCode Go ↗',
+  '{requests} peticiones · ~${spent} observados · ${cap} de tope general de referencia': '{requests} requêtes · ~${spent} observés · plafond général de référence de ${cap}',
+  '{n} sin precio estimable': '{n} sans prix estimable',
+  'Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude.ai ni utilicen credenciales de suscripciones Free, Pro o Max. Por ello Claude se conecta aquí únicamente mediante la API oficial.':
+    'Anthropic n’autorise pas les applications tierces à proposer la connexion Claude.ai ni à utiliser les identifiants des abonnements Free, Pro ou Max. Claude se connecte donc ici uniquement via l’API officielle.',
+  'Política oficial de Anthropic ↗': 'Politique officielle d’Anthropic ↗',
   'Nodus ha encontrado claves de API cifradas que todavía no puede leer.': 'Nodus a trouvé des clés API chiffrées qu\'il ne peut pas encore lire.',
   'No se han borrado. Pulsa recuperar y autoriza el acceso al Llavero de macOS si el sistema lo solicita.':
     'Elles n\'ont pas été supprimées. Cliquez sur récupérer et autorisez l\'accès au Trousseau macOS si le système le demande.',
@@ -1326,8 +1404,8 @@ export const FR: Record<string, string> = {
   'Reindexar todo': 'Tout réindexer',
   'Llamadas simultáneas': 'Appels simultanés',
   'Razonamiento (chat/tutor/escritura)': 'Raisonnement (chat/tuteur/écriture)',
-  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales.':
-    'Les analyses désactivent toujours le raisonnement pour aller plus vite. Cela n\'affecte que les réponses conversationnelles.',
+  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales. En Codex se configura por modelo dentro de Proveedores.':
+    'Les analyses désactivent toujours le raisonnement pour aller plus vite. Cela n\'affecte que les réponses conversationnelles. Pour Codex, réglez-le par modèle dans Fournisseurs.',
   'Desactivado (más rápido)': 'Désactivé (plus rapide)',
   'Bajo': 'Bas',
   'Medio': 'Moyen',

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -1078,6 +1078,84 @@ export const PT_BR: Record<string, string> = {
   'sin claves': 'sem chaves',
   'Las claves de API y los modelos configurados se comparten entre todas tus bóvedas.':
     'As chaves de API e os modelos configurados são compartilhados entre todos os seus espaços.',
+  'comprobando…': 'verificando…',
+  'suscripción conectada': 'assinatura conectada',
+  'sin conectar': 'não conectado',
+  'Conexión mediante el protocolo oficial Codex App Server y el acceso gestionado de ChatGPT. Nodus no lee ni almacena tus credenciales.':
+    'Conexão pelo protocolo oficial Codex App Server e pelo login gerenciado do ChatGPT. O Nodus não lê nem armazena suas credenciais.',
+  'Nodus es una aplicación independiente y no está afiliada, certificada ni respaldada por OpenAI.':
+    'O Nodus é um aplicativo independente e não é afiliado, certificado ou endossado pela OpenAI.',
+  'El uso consume la cuota o los créditos de Codex incluidos en tu plan de ChatGPT; no consume saldo de la API de OpenAI.':
+    'O uso consome a cota ou os créditos do Codex incluídos no seu plano ChatGPT; não consome o saldo da API da OpenAI.',
+  'Funciona como motor de Nodi, análisis y Deep Research de Nodus. No es el producto Deep Research de la web de ChatGPT.':
+    'Ele alimenta o Nodi, as análises e o Deep Research do Nodus. Não é o produto Deep Research do site do ChatGPT.',
+  'Cada petición usa un hilo efímero aislado, sin acceso de escritura, sin red de herramientas y sin cargar tus MCP, plugins o instrucciones personales.':
+    'Cada solicitação usa uma conversa efêmera isolada, sem acesso de gravação, sem rede de ferramentas e sem carregar seus MCPs, plugins ou instruções pessoais.',
+  'Documentación oficial de Codex App Server ↗': 'Documentação oficial do Codex App Server ↗',
+  'Conectado': 'Conectado',
+  'Actualizar estado': 'Atualizar status',
+  'Cerrar sesión': 'Sair',
+  'Límite principal': 'Limite principal',
+  'Límite secundario': 'Limite secundário',
+  'Cargar modelos de Codex': 'Carregar modelos do Codex',
+  'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
+    'Cada modelo mostra apenas os níveis de raciocínio publicados pelo Codex. “Padrão” usa o nível recomendado pelo modelo.',
+  'Razonamiento de {model}': 'Raciocínio para {model}',
+  '{level} (predeterminado)': '{level} (padrão)',
+  Ninguno: 'Nenhum',
+  Alto: 'Alto',
+  'Muy alto': 'Muito alto',
+  Ultra: 'Ultra',
+  'Esperando acceso en el navegador…': 'Aguardando o login no navegador…',
+  'Conectar suscripción de ChatGPT': 'Conectar assinatura do ChatGPT',
+  'Cancelar acceso': 'Cancelar login',
+  'Comprobar estado': 'Verificar status',
+  'Se restablece: {time}': 'Redefine em: {time}',
+  'Créditos adicionales': 'Créditos adicionais',
+  'Ilimitados': 'Ilimitados',
+  'Disponibles': 'Disponíveis',
+  'Sin créditos': 'Sem créditos',
+  '{n}% restante': '{n}% restante',
+  '{n}% usado': '{n}% usado',
+  'SDK oficial · preview': 'SDK oficial · prévia',
+  'Nodus usa el SDK y el runtime oficiales de GitHub Copilot. Cada petición se factura a la suscripción de GitHub del usuario; no requiere claves de los modelos.':
+    'O Nodus usa o SDK e o runtime oficiais do GitHub Copilot. Cada solicitação é contabilizada na assinatura GitHub do usuário; não requer chaves dos modelos.',
+  'La integración oficial está en public preview. Nodus es independiente y no está afiliada, certificada ni respaldada por GitHub.':
+    'A integração oficial está em prévia pública. O Nodus é independente e não é afiliado, certificado nem endossado pelo GitHub.',
+  'Cada petición se ejecuta en una sesión efímera sin herramientas, MCP, memoria, acceso a archivos, GitHub ni instrucciones del proyecto.':
+    'Cada solicitação é executada em uma sessão efêmera sem ferramentas, MCP, memória, acesso a arquivos ou ao GitHub, nem instruções do projeto.',
+  'Documentación oficial del SDK de Copilot ↗': 'Documentação oficial do SDK do Copilot ↗',
+  'Actualizar cuota': 'Atualizar cota',
+  'GitHub no devolvió un contador de cuota para esta cuenta.': 'O GitHub não retornou um medidor de cota para esta conta.',
+  'Última petición en Nodus: {cost} créditos/solicitudes premium · {input} tokens de entrada · {output} de salida':
+    'Última solicitação no Nodus: {cost} créditos/solicitações premium · {input} tokens de entrada · {output} de saída',
+  'Cargar modelos de Copilot': 'Carregar modelos do Copilot',
+  'Esperando acceso de GitHub en el navegador…': 'Aguardando o login do GitHub no navegador…',
+  'Conectar GitHub Copilot': 'Conectar GitHub Copilot',
+  'El runtime oficial abre el flujo OAuth de dispositivo y guarda su credencial en el almacén seguro del sistema. Si ya usas GitHub CLI, puede reutilizar esa sesión sin modificarla.':
+    'O runtime oficial abre o fluxo OAuth do dispositivo e armazena a credencial no armazenamento seguro do sistema. Se você já usa o GitHub CLI, ele pode reutilizar essa sessão sem alterá-la.',
+  'Créditos / solicitudes premium': 'Créditos / solicitações premium',
+  'Ilimitado según GitHub': 'Ilimitado segundo o GitHub',
+  '{remaining} de {total} restantes · {used} usadas': '{remaining} de {total} restantes · {used} usadas',
+  '{n} de uso adicional': '{n} de uso adicional',
+  'OpenCode documenta el uso directo de la suscripción Go mediante esta clave y sus endpoints oficiales. Nodus es independiente y no está afiliada, certificada ni respaldada por OpenCode.':
+    'O OpenCode documenta o uso direto da assinatura Go por meio desta chave e dos endpoints oficiais. O Nodus é independente e não é afiliado, certificado nem endossado pelo OpenCode.',
+  'Límites generales publicados: 12 USD cada 5 horas, 30 USD por semana y 60 USD por mes. Algunos modelos tienen un límite mensual efectivo inferior (15 USD); el número de peticiones depende del modelo y puede cambiar.':
+    'Limites gerais publicados: US$ 12 a cada 5 horas, US$ 30 por semana e US$ 60 por mês. Alguns modelos têm um limite mensal efetivo menor (US$ 15); o número de solicitações depende do modelo e pode mudar.',
+  'Saldo restante oficial: OpenCode solo lo publica en Console; no ofrece una API de cuota compatible con la clave de usuario. Nodus no usa cookies ni endpoints privados.':
+    'Saldo restante oficial: o OpenCode só o publica no Console e não oferece uma API de cota compatível com a chave do usuário. O Nodus não usa cookies nem endpoints privados.',
+  'Últimas 5 horas': 'Últimas 5 horas',
+  'Últimos 7 días': 'Últimos 7 dias',
+  'Últimos 30 días': 'Últimos 30 dias',
+  'El gasto observado es una estimación local de las peticiones hechas por Nodus con precios oficiales; no incluye otros clientes y no equivale al saldo restante.':
+    'O gasto observado é uma estimativa local das solicitações feitas pelo Nodus com preços oficiais; não inclui outros clientes e não equivale ao saldo restante.',
+  'Ver saldo restante oficial en OpenCode Console ↗': 'Ver saldo restante oficial no OpenCode Console ↗',
+  'Documentación oficial de OpenCode Go ↗': 'Documentação oficial do OpenCode Go ↗',
+  '{requests} peticiones · ~${spent} observados · ${cap} de tope general de referencia': '{requests} solicitações · ~${spent} observados · teto geral de referência de ${cap}',
+  '{n} sin precio estimable': '{n} sem preço estimável',
+  'Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude.ai ni utilicen credenciales de suscripciones Free, Pro o Max. Por ello Claude se conecta aquí únicamente mediante la API oficial.':
+    'A Anthropic não permite que aplicativos de terceiros ofereçam login do Claude.ai nem usem credenciais de assinaturas Free, Pro ou Max. Por isso, o Claude se conecta aqui somente pela API oficial.',
+  'Política oficial de Anthropic ↗': 'Política oficial da Anthropic ↗',
   'Nodus ha encontrado claves de API cifradas que todavía no puede leer.': 'O Nodus encontrou chaves de API criptografadas que ainda não consegue ler.',
   'No se han borrado. Pulsa recuperar y autoriza el acceso al Llavero de macOS si el sistema lo solicita.':
     'Elas não foram apagadas. Clique em recuperar e autorize o acesso ao Chaveiro do macOS se o sistema solicitar.',
@@ -1313,8 +1391,8 @@ export const PT_BR: Record<string, string> = {
   'Reindexar todo': 'Reindexar tudo',
   'Llamadas simultáneas': 'Chamadas simultâneas',
   'Razonamiento (chat/tutor/escritura)': 'Raciocínio (chat/tutor/escrita)',
-  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales.':
-    'Os escaneamentos sempre usam raciocínio desativado para ir mais rápido. Isso afeta somente as respostas conversacionais.',
+  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales. En Codex se configura por modelo dentro de Proveedores.':
+    'Os escaneamentos sempre usam raciocínio desativado para ir mais rápido. Isso afeta somente as respostas conversacionais. No Codex, configure por modelo em Provedores.',
   'Desactivado (más rápido)': 'Desativado (mais rápido)',
   'Bajo': 'Baixo',
   'Medio': 'Médio',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -1076,6 +1076,84 @@ export const PT: Record<string, string> = {
   'sin claves': 'sem chaves',
   'Las claves de API y los modelos configurados se comparten entre todas tus bóvedas.':
     'As chaves de API e os modelos configurados são partilhados entre todos os seus espaços.',
+  'comprobando…': 'a verificar…',
+  'suscripción conectada': 'subscrição ligada',
+  'sin conectar': 'não ligado',
+  'Conexión mediante el protocolo oficial Codex App Server y el acceso gestionado de ChatGPT. Nodus no lee ni almacena tus credenciales.':
+    'Ligação através do protocolo oficial Codex App Server e do início de sessão gerido do ChatGPT. O Nodus não lê nem guarda as suas credenciais.',
+  'Nodus es una aplicación independiente y no está afiliada, certificada ni respaldada por OpenAI.':
+    'O Nodus é uma aplicação independente e não é afiliado, certificado ou apoiado pela OpenAI.',
+  'El uso consume la cuota o los créditos de Codex incluidos en tu plan de ChatGPT; no consume saldo de la API de OpenAI.':
+    'A utilização consome a quota ou os créditos Codex incluídos no seu plano ChatGPT; não consome o saldo da API OpenAI.',
+  'Funciona como motor de Nodi, análisis y Deep Research de Nodus. No es el producto Deep Research de la web de ChatGPT.':
+    'É o motor do Nodi, das análises e do Deep Research do Nodus. Não é o produto Deep Research do site ChatGPT.',
+  'Cada petición usa un hilo efímero aislado, sin acceso de escritura, sin red de herramientas y sin cargar tus MCP, plugins o instrucciones personales.':
+    'Cada pedido utiliza um fio efémero isolado, sem acesso de escrita, sem rede de ferramentas e sem carregar os seus MCP, plugins ou instruções pessoais.',
+  'Documentación oficial de Codex App Server ↗': 'Documentação oficial do Codex App Server ↗',
+  'Conectado': 'Ligado',
+  'Actualizar estado': 'Atualizar estado',
+  'Cerrar sesión': 'Terminar sessão',
+  'Límite principal': 'Limite principal',
+  'Límite secundario': 'Limite secundário',
+  'Cargar modelos de Codex': 'Carregar modelos Codex',
+  'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
+    'Cada modelo mostra apenas os níveis de raciocínio publicados pelo Codex. «Predefinido» utiliza o nível recomendado pelo modelo.',
+  'Razonamiento de {model}': 'Raciocínio para {model}',
+  '{level} (predeterminado)': '{level} (predefinido)',
+  Ninguno: 'Nenhum',
+  Alto: 'Alto',
+  'Muy alto': 'Muito alto',
+  Ultra: 'Ultra',
+  'Esperando acceso en el navegador…': 'A aguardar o início de sessão no navegador…',
+  'Conectar suscripción de ChatGPT': 'Ligar subscrição do ChatGPT',
+  'Cancelar acceso': 'Cancelar início de sessão',
+  'Comprobar estado': 'Verificar estado',
+  'Se restablece: {time}': 'Reinicia: {time}',
+  'Créditos adicionales': 'Créditos adicionais',
+  'Ilimitados': 'Ilimitados',
+  'Disponibles': 'Disponíveis',
+  'Sin créditos': 'Sem créditos',
+  '{n}% restante': '{n}% restante',
+  '{n}% usado': '{n}% utilizado',
+  'SDK oficial · preview': 'SDK oficial · pré-visualização',
+  'Nodus usa el SDK y el runtime oficiales de GitHub Copilot. Cada petición se factura a la suscripción de GitHub del usuario; no requiere claves de los modelos.':
+    'O Nodus utiliza o SDK e o runtime oficiais do GitHub Copilot. Cada pedido é contabilizado na subscrição GitHub do utilizador; não requer chaves dos modelos.',
+  'La integración oficial está en public preview. Nodus es independiente y no está afiliada, certificada ni respaldada por GitHub.':
+    'A integração oficial está em pré-visualização pública. O Nodus é independente e não é afiliado, certificado nem apoiado pelo GitHub.',
+  'Cada petición se ejecuta en una sesión efímera sin herramientas, MCP, memoria, acceso a archivos, GitHub ni instrucciones del proyecto.':
+    'Cada pedido é executado numa sessão efémera sem ferramentas, MCP, memória, acesso a ficheiros ou ao GitHub, nem instruções do projeto.',
+  'Documentación oficial del SDK de Copilot ↗': 'Documentação oficial do SDK do Copilot ↗',
+  'Actualizar cuota': 'Atualizar quota',
+  'GitHub no devolvió un contador de cuota para esta cuenta.': 'O GitHub não devolveu um contador de quota para esta conta.',
+  'Última petición en Nodus: {cost} créditos/solicitudes premium · {input} tokens de entrada · {output} de salida':
+    'Último pedido no Nodus: {cost} créditos/pedidos premium · {input} tokens de entrada · {output} de saída',
+  'Cargar modelos de Copilot': 'Carregar modelos do Copilot',
+  'Esperando acceso de GitHub en el navegador…': 'A aguardar o início de sessão do GitHub no navegador…',
+  'Conectar GitHub Copilot': 'Ligar GitHub Copilot',
+  'El runtime oficial abre el flujo OAuth de dispositivo y guarda su credencial en el almacén seguro del sistema. Si ya usas GitHub CLI, puede reutilizar esa sesión sin modificarla.':
+    'O runtime oficial abre o fluxo OAuth do dispositivo e guarda a credencial no armazenamento seguro do sistema. Se já utiliza o GitHub CLI, pode reutilizar essa sessão sem a modificar.',
+  'Créditos / solicitudes premium': 'Créditos / pedidos premium',
+  'Ilimitado según GitHub': 'Ilimitado segundo o GitHub',
+  '{remaining} de {total} restantes · {used} usadas': '{remaining} de {total} restantes · {used} utilizados',
+  '{n} de uso adicional': '{n} de utilização adicional',
+  'OpenCode documenta el uso directo de la suscripción Go mediante esta clave y sus endpoints oficiales. Nodus es independiente y no está afiliada, certificada ni respaldada por OpenCode.':
+    'O OpenCode documenta a utilização direta da subscrição Go através desta chave e dos endpoints oficiais. O Nodus é independente e não é afiliado, certificado nem apoiado pelo OpenCode.',
+  'Límites generales publicados: 12 USD cada 5 horas, 30 USD por semana y 60 USD por mes. Algunos modelos tienen un límite mensual efectivo inferior (15 USD); el número de peticiones depende del modelo y puede cambiar.':
+    'Limites gerais publicados: 12 USD a cada 5 horas, 30 USD por semana e 60 USD por mês. Alguns modelos têm um limite mensal efetivo inferior (15 USD); o número de pedidos depende do modelo e pode mudar.',
+  'Saldo restante oficial: OpenCode solo lo publica en Console; no ofrece una API de cuota compatible con la clave de usuario. Nodus no usa cookies ni endpoints privados.':
+    'Saldo restante oficial: o OpenCode só o publica na Console e não disponibiliza uma API de quota compatível com a chave do utilizador. O Nodus não utiliza cookies nem endpoints privados.',
+  'Últimas 5 horas': 'Últimas 5 horas',
+  'Últimos 7 días': 'Últimos 7 dias',
+  'Últimos 30 días': 'Últimos 30 dias',
+  'El gasto observado es una estimación local de las peticiones hechas por Nodus con precios oficiales; no incluye otros clientes y no equivale al saldo restante.':
+    'O gasto observado é uma estimativa local dos pedidos efetuados pelo Nodus com preços oficiais; não inclui outros clientes e não corresponde ao saldo restante.',
+  'Ver saldo restante oficial en OpenCode Console ↗': 'Ver saldo restante oficial na OpenCode Console ↗',
+  'Documentación oficial de OpenCode Go ↗': 'Documentação oficial do OpenCode Go ↗',
+  '{requests} peticiones · ~${spent} observados · ${cap} de tope general de referencia': '{requests} pedidos · ~${spent} observados · limite geral de referência de ${cap}',
+  '{n} sin precio estimable': '{n} sem preço estimável',
+  'Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude.ai ni utilicen credenciales de suscripciones Free, Pro o Max. Por ello Claude se conecta aquí únicamente mediante la API oficial.':
+    'A Anthropic não permite que aplicações de terceiros ofereçam o início de sessão Claude.ai nem utilizem credenciais de subscrições Free, Pro ou Max. Por isso, o Claude liga-se aqui apenas através da API oficial.',
+  'Política oficial de Anthropic ↗': 'Política oficial da Anthropic ↗',
   'Nodus ha encontrado claves de API cifradas que todavía no puede leer.': 'O Nodus encontrou chaves de API encriptadas que ainda não consegue ler.',
   'No se han borrado. Pulsa recuperar y autoriza el acceso al Llavero de macOS si el sistema lo solicita.':
     'Não foram apagadas. Prima recuperar e autorize o acesso ao Chaveiro do macOS se o sistema o solicitar.',
@@ -1311,8 +1389,8 @@ export const PT: Record<string, string> = {
   'Reindexar todo': 'Reindexar tudo',
   'Llamadas simultáneas': 'Chamadas simultâneas',
   'Razonamiento (chat/tutor/escritura)': 'Raciocínio (chat/tutor/escrita)',
-  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales.':
-    'As análises usam sempre o raciocínio desativado para serem mais rápidas. Isto afeta apenas as respostas conversacionais.',
+  'Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales. En Codex se configura por modelo dentro de Proveedores.':
+    'As análises usam sempre o raciocínio desativado para serem mais rápidas. Isto afeta apenas as respostas conversacionais. No Codex, configure-o por modelo em Fornecedores.',
   'Desactivado (más rápido)': 'Desativado (mais rápido)',
   'Bajo': 'Baixo',
   'Medio': 'Médio',

--- a/src/views/ProvidersSettings.tsx
+++ b/src/views/ProvidersSettings.tsx
@@ -2,11 +2,17 @@ import { useEffect, useMemo, useState } from 'react';
 import type {
   AiProvider,
   AppSettings,
+  ChatGptSubscriptionRateLimitWindow,
+  ChatGptSubscriptionStatus,
+  CodexReasoningEffort,
+  GitHubCopilotSubscriptionQuotaWindow,
+  GitHubCopilotSubscriptionStatus,
   ImageModelInfo,
   LocalProvider,
   LocalProviderTestResult,
   ModelInfo,
   ModelRef,
+  OpenCodeGoUsageStatus,
 } from '@shared/types';
 import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
 import { DEFAULT_LOCAL_BASE_URLS } from '@shared/providers';
@@ -100,7 +106,25 @@ export function ProvidersSettings({
 
       <div className="space-y-2">
         {AI_PROVIDERS.map((p) =>
-          isLocalAiProvider(p) ? (
+          p === 'codex' ? (
+            <ChatGptSubscriptionRow
+              key={p}
+              settings={settings}
+              expanded={open === p}
+              onToggle={() => setOpen(open === p ? null : p)}
+              onChange={onChange}
+              isFav={isFav}
+              toggleFav={toggleFav}
+            />
+          ) : p === 'github-copilot' ? (
+            <GitHubCopilotSubscriptionRow
+              key={p}
+              expanded={open === p}
+              onToggle={() => setOpen(open === p ? null : p)}
+              isFav={isFav}
+              toggleFav={toggleFav}
+            />
+          ) : isLocalAiProvider(p) ? (
             <LocalProviderRow
               key={p}
               provider={p as LocalProvider}
@@ -127,6 +151,375 @@ export function ProvidersSettings({
       </div>
     </section>
     </>
+  );
+}
+
+function ChatGptSubscriptionRow({
+  settings,
+  expanded,
+  onToggle,
+  onChange,
+  isFav,
+  toggleFav,
+}: {
+  settings: AppSettings;
+  expanded: boolean;
+  onToggle: () => void;
+  onChange: () => Promise<unknown>;
+  isFav: (m: ModelRef) => boolean;
+  toggleFav: (m: ModelRef) => Promise<void>;
+}) {
+  const [status, setStatus] = useState<ChatGptSubscriptionStatus | null>(null);
+  const [loginId, setLoginId] = useState<string | null>(null);
+  const [models, setModels] = useState<ModelInfo[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try { setStatus(await window.nodus.getChatGptSubscriptionStatus()); }
+    catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+    finally { setLoading(false); }
+  };
+
+  useEffect(() => {
+    void refresh();
+    return window.nodus.onChatGptSubscriptionStatusChanged((next) => {
+      setStatus(next);
+      if (!next.loginPending) setLoginId(null);
+    });
+  }, []);
+
+  const connect = async () => {
+    setError(null);
+    try {
+      const login = await window.nodus.startChatGptSubscriptionLogin();
+      setLoginId(login.loginId);
+      await window.nodus.openExternal(login.authUrl);
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+  };
+
+  const cancelLogin = async () => {
+    if (!loginId) return;
+    setError(null);
+    try { setStatus(await window.nodus.cancelChatGptSubscriptionLogin(loginId)); }
+    catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+    finally { setLoginId(null); }
+  };
+
+  const logout = async () => {
+    setError(null);
+    try {
+      setStatus(await window.nodus.logoutChatGptSubscription());
+      setModels(null);
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+  };
+
+  const loadModels = async () => {
+    setLoadingModels(true);
+    setError(null);
+    try { setModels(await window.nodus.listModels('codex')); }
+    catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+    finally { setLoadingModels(false); }
+  };
+
+  const setReasoning = async (model: string, effort: CodexReasoningEffort | null) => {
+    const next = { ...(settings.codexReasoningEfforts ?? {}) };
+    if (effort) next[model] = effort;
+    else delete next[model];
+    await window.nodus.updateSettings({ codexReasoningEfforts: next });
+    await onChange();
+  };
+
+  const filtered = (models ?? []).filter((model) => {
+    const query = search.toLowerCase();
+    return !query || model.id.toLowerCase().includes(query) || (model.name ?? '').toLowerCase().includes(query);
+  });
+
+  return (
+    <div className="rounded-lg border border-indigo-200 bg-indigo-50/60 dark:border-indigo-700/50 dark:bg-indigo-950/10" data-testid="chatgpt-subscription-provider">
+      <button className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm" onClick={onToggle}>
+        <span className="text-neutral-500">{expanded ? '▾' : '▸'}</span>
+        <span className="font-medium">{PROVIDER_LABELS.codex}</span>
+        {loading ? (
+          <span className="text-xs text-neutral-600">{t('comprobando…')}</span>
+        ) : (
+          <span className={status?.connected ? 'text-emerald-400 text-xs' : 'text-neutral-600 text-xs'}>
+            {status?.connected ? `● ${t('suscripción conectada')}` : `○ ${t('sin conectar')}`}
+          </span>
+        )}
+        {status?.planType && <span className="ml-auto text-[10px] uppercase tracking-wide text-indigo-700 dark:text-indigo-300">{status.planType}</span>}
+      </button>
+
+      {expanded && (
+        <div className="space-y-3 px-3 pb-3">
+          <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-3 text-xs leading-5 text-neutral-600 dark:border-indigo-800/60 dark:bg-indigo-950/20 dark:text-neutral-400">
+            <p>{t('Conexión mediante el protocolo oficial Codex App Server y el acceso gestionado de ChatGPT. Nodus no lee ni almacena tus credenciales.')}</p>
+            <p className="mt-1">{t('Nodus es una aplicación independiente y no está afiliada, certificada ni respaldada por OpenAI.')}</p>
+            <p className="mt-1">{t('El uso consume la cuota o los créditos de Codex incluidos en tu plan de ChatGPT; no consume saldo de la API de OpenAI.')}</p>
+            <p className="mt-1">{t('Funciona como motor de Nodi, análisis y Deep Research de Nodus. No es el producto Deep Research de la web de ChatGPT.')}</p>
+            <p className="mt-1">{t('Cada petición usa un hilo efímero aislado, sin acceso de escritura, sin red de herramientas y sin cargar tus MCP, plugins o instrucciones personales.')}</p>
+            <button className="mt-1 text-indigo-700 hover:text-indigo-800 dark:text-indigo-300 dark:hover:text-indigo-200" onClick={() => window.nodus.openExternal('https://learn.chatgpt.com/docs/app-server')}>
+              {t('Documentación oficial de Codex App Server ↗')}
+            </button>
+          </div>
+
+          {status?.connected ? (
+            <>
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="text-emerald-600 dark:text-emerald-400">{t('Conectado')}</span>
+                {status.email && <span className="text-neutral-600 dark:text-neutral-400">{status.email}</span>}
+                <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void refresh()} disabled={loading}>
+                  {t('Actualizar estado')}
+                </button>
+                <button className="btn btn-ghost text-red-600 dark:text-red-400" onClick={() => void logout()}>{t('Cerrar sesión')}</button>
+              </div>
+              {status.rateLimits && (
+                <>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <RateLimitCard label={t('Límite principal')} window={status.rateLimits.primary} />
+                    <RateLimitCard label={t('Límite secundario')} window={status.rateLimits.secondary} />
+                  </div>
+                  {status.rateLimits.credits && (
+                    <div className="rounded-lg border border-neutral-200 p-2 text-[11px] text-neutral-500 dark:border-neutral-800">
+                      <div className="flex justify-between gap-3">
+                        <span>{t('Créditos adicionales')}</span>
+                        <span className="text-neutral-700 dark:text-neutral-300">
+                          {status.rateLimits.credits.unlimited
+                            ? t('Ilimitados')
+                            : status.rateLimits.credits.balance ?? (status.rateLimits.credits.hasCredits ? t('Disponibles') : t('Sin créditos'))}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+              <div className="flex gap-2 items-center">
+                <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void loadModels()} disabled={loadingModels}>
+                  {loadingModels ? t('Cargando…') : t('Cargar modelos de Codex')}
+                </button>
+                {models && <input className="input flex-1" placeholder={t('Buscar modelo…')} value={search} onChange={(e) => setSearch(e.target.value)} />}
+                {models && <span className="text-xs text-neutral-500">{filtered.length}</span>}
+              </div>
+              {models && (
+                <>
+                  <p className="text-[11px] leading-5 text-neutral-500">
+                    {t('Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.')}
+                  </p>
+                  <SettingsModelList className="max-h-72 overflow-y-auto" data-testid="provider-model-list-codex">
+                    <ModelList
+                      provider="codex"
+                      models={filtered.slice(0, 300)}
+                      isFav={isFav}
+                      toggleFav={toggleFav}
+                      codexReasoningEfforts={settings.codexReasoningEfforts}
+                      onCodexReasoningChange={setReasoning}
+                    />
+                  </SettingsModelList>
+                </>
+              )}
+            </>
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              <button className="btn btn-primary" onClick={() => void connect()} disabled={status?.loginPending}>
+                {status?.loginPending ? t('Esperando acceso en el navegador…') : t('Conectar suscripción de ChatGPT')}
+              </button>
+              {status?.loginPending && loginId && (
+                <button className="btn btn-ghost" onClick={() => void cancelLogin()}>{t('Cancelar acceso')}</button>
+              )}
+              <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void refresh()} disabled={loading}>{t('Comprobar estado')}</button>
+            </div>
+          )}
+
+          {(error || status?.error) && <div className="text-xs text-red-600 dark:text-red-400">{error || status?.error}</div>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RateLimitCard({ label, window }: { label: string; window: ChatGptSubscriptionRateLimitWindow | null }) {
+  if (!window) return null;
+  const used = Math.max(0, Math.min(100, Math.round(window.usedPercent)));
+  const remaining = 100 - used;
+  const reset = window.resetsAt ? new Date(window.resetsAt * 1_000).toLocaleString() : null;
+  return (
+    <div className="rounded-lg border border-neutral-200 p-2 text-[11px] text-neutral-500 dark:border-neutral-800">
+      <div className="flex justify-between"><span>{label}</span><span>{tx('{n}% restante', { n: remaining })}</span></div>
+      <div className="mt-1 h-1.5 overflow-hidden rounded bg-neutral-200 dark:bg-neutral-800"><div className="h-full bg-emerald-500" style={{ width: `${remaining}%` }} /></div>
+      <div className="mt-1">{tx('{n}% usado', { n: used })}</div>
+      {reset && <div className="mt-1">{tx('Se restablece: {time}', { time: reset })}</div>}
+    </div>
+  );
+}
+
+function GitHubCopilotSubscriptionRow({
+  expanded,
+  onToggle,
+  isFav,
+  toggleFav,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  isFav: (m: ModelRef) => boolean;
+  toggleFav: (m: ModelRef) => Promise<void>;
+}) {
+  const [status, setStatus] = useState<GitHubCopilotSubscriptionStatus | null>(null);
+  const [models, setModels] = useState<ModelInfo[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try { setStatus(await window.nodus.getGitHubCopilotSubscriptionStatus()); }
+    catch (reason) { setError(reason instanceof Error ? reason.message : String(reason)); }
+    finally { setLoading(false); }
+  };
+
+  useEffect(() => {
+    void refresh();
+    return window.nodus.onGitHubCopilotSubscriptionStatusChanged(setStatus);
+  }, []);
+
+  const connect = async () => {
+    setError(null);
+    try { setStatus(await window.nodus.startGitHubCopilotSubscriptionLogin()); }
+    catch (reason) { setError(reason instanceof Error ? reason.message : String(reason)); }
+  };
+
+  const cancel = async () => {
+    setError(null);
+    try { setStatus(await window.nodus.cancelGitHubCopilotSubscriptionLogin()); }
+    catch (reason) { setError(reason instanceof Error ? reason.message : String(reason)); }
+  };
+
+  const logout = async () => {
+    setError(null);
+    try {
+      setStatus(await window.nodus.logoutGitHubCopilotSubscription());
+      setModels(null);
+    } catch (reason) { setError(reason instanceof Error ? reason.message : String(reason)); }
+  };
+
+  const loadModels = async () => {
+    setLoadingModels(true);
+    setError(null);
+    try { setModels(await window.nodus.listModels('github-copilot')); }
+    catch (reason) { setError(reason instanceof Error ? reason.message : String(reason)); }
+    finally { setLoadingModels(false); }
+  };
+
+  const filtered = (models ?? []).filter((model) => {
+    const query = search.toLowerCase();
+    return !query || model.id.toLowerCase().includes(query) || (model.name ?? '').toLowerCase().includes(query);
+  });
+
+  return (
+    <div className="rounded-lg border border-sky-200 bg-sky-50/60 dark:border-sky-700/50 dark:bg-sky-950/10" data-testid="github-copilot-subscription-provider">
+      <button className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm" onClick={onToggle}>
+        <span className="text-neutral-500">{expanded ? '▾' : '▸'}</span>
+        <span className="font-medium">{PROVIDER_LABELS['github-copilot']}</span>
+        {loading ? <span className="text-xs text-neutral-600">{t('comprobando…')}</span> : (
+          <span className={status?.connected ? 'text-emerald-400 text-xs' : 'text-neutral-600 text-xs'}>
+            {status?.connected ? `● ${t('suscripción conectada')}` : `○ ${t('sin conectar')}`}
+          </span>
+        )}
+        <span className="ml-auto text-[10px] uppercase tracking-wide text-sky-700 dark:text-sky-300">{t('SDK oficial · preview')}</span>
+      </button>
+
+      {expanded && (
+        <div className="space-y-3 px-3 pb-3">
+          <div className="rounded-lg border border-sky-200 bg-sky-50 p-3 text-xs leading-5 text-neutral-600 dark:border-sky-800/60 dark:bg-sky-950/20 dark:text-neutral-400">
+            <p>{t('Nodus usa el SDK y el runtime oficiales de GitHub Copilot. Cada petición se factura a la suscripción de GitHub del usuario; no requiere claves de los modelos.')}</p>
+            <p className="mt-1">{t('La integración oficial está en public preview. Nodus es independiente y no está afiliada, certificada ni respaldada por GitHub.')}</p>
+            <p className="mt-1">{t('Cada petición se ejecuta en una sesión efímera sin herramientas, MCP, memoria, acceso a archivos, GitHub ni instrucciones del proyecto.')}</p>
+            <button className="mt-1 text-sky-700 hover:text-sky-800 dark:text-sky-300 dark:hover:text-sky-200" onClick={() => window.nodus.openExternal('https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/authenticate')}>
+              {t('Documentación oficial del SDK de Copilot ↗')}
+            </button>
+          </div>
+
+          {status?.connected ? (
+            <>
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="text-emerald-600 dark:text-emerald-400">{t('Conectado')}</span>
+                {status.login && <span className="text-neutral-700 dark:text-neutral-300">@{status.login}</span>}
+                {status.authType && <span className="text-neutral-500">{status.authType}</span>}
+                <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void refresh()} disabled={loading}>{t('Actualizar cuota')}</button>
+                {status.canLogout && <button className="btn btn-ghost text-red-600 dark:text-red-400" onClick={() => void logout()}>{t('Cerrar sesión')}</button>}
+              </div>
+              {status.quota.length > 0 ? (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {status.quota.map((quota) => <GitHubQuotaCard key={quota.id} quota={quota} />)}
+                </div>
+              ) : <div className="text-xs text-neutral-500">{t('GitHub no devolvió un contador de cuota para esta cuenta.')}</div>}
+              {status.lastSession && (
+                <div className="rounded-lg border border-neutral-200 p-2 text-[11px] text-neutral-500 dark:border-neutral-800">
+                  {tx('Última petición en Nodus: {cost} créditos/solicitudes premium · {input} tokens de entrada · {output} de salida', {
+                    cost: status.lastSession.premiumRequestCost.toLocaleString(),
+                    input: status.lastSession.inputTokens.toLocaleString(),
+                    output: status.lastSession.outputTokens.toLocaleString(),
+                  })}
+                </div>
+              )}
+              <div className="flex gap-2 items-center">
+                <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void loadModels()} disabled={loadingModels}>
+                  {loadingModels ? t('Cargando…') : t('Cargar modelos de Copilot')}
+                </button>
+                {models && <input className="input flex-1" placeholder={t('Buscar modelo…')} value={search} onChange={(event) => setSearch(event.target.value)} />}
+                {models && <span className="text-xs text-neutral-500">{filtered.length}</span>}
+              </div>
+              {models && (
+                <SettingsModelList className="max-h-64 overflow-y-auto" data-testid="provider-model-list-github-copilot">
+                  <ModelList provider="github-copilot" models={filtered.slice(0, 300)} isFav={isFav} toggleFav={toggleFav} />
+                </SettingsModelList>
+              )}
+            </>
+          ) : (
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <button className="btn btn-primary" onClick={() => void connect()} disabled={status?.loginPending}>
+                  {status?.loginPending ? t('Esperando acceso de GitHub en el navegador…') : t('Conectar GitHub Copilot')}
+                </button>
+                {status?.loginPending && <button className="btn btn-ghost" onClick={() => void cancel()}>{t('Cancelar acceso')}</button>}
+                <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void refresh()} disabled={loading}>{t('Comprobar estado')}</button>
+              </div>
+              <p className="text-[11px] leading-4 text-neutral-500">{t('El runtime oficial abre el flujo OAuth de dispositivo y guarda su credencial en el almacén seguro del sistema. Si ya usas GitHub CLI, puede reutilizar esa sesión sin modificarla.')}</p>
+            </div>
+          )}
+          {(error || status?.error) && <div className="text-xs whitespace-pre-wrap text-red-600 dark:text-red-400">{error || status?.error}</div>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GitHubQuotaCard({ quota }: { quota: GitHubCopilotSubscriptionQuotaWindow }) {
+  const label = quota.id === 'premium_interactions'
+    ? t('Créditos / solicitudes premium')
+    : quota.id === 'chat' ? t('Chat') : quota.id === 'completions' ? t('Completado') : quota.id;
+  const remaining = Math.max(0, Math.min(100, Math.round(quota.remainingPercentage)));
+  const reset = quota.resetDate ? new Date(quota.resetDate).toLocaleString() : null;
+  const detail = quota.unlimited
+    ? t('Ilimitado según GitHub')
+    : tx('{remaining} de {total} restantes · {used} usadas', {
+        remaining: (quota.remainingRequests ?? 0).toLocaleString(),
+        total: quota.entitlementRequests.toLocaleString(),
+        used: quota.usedRequests.toLocaleString(),
+      });
+  return (
+    <div className="rounded-lg border border-neutral-200 p-2 text-[11px] text-neutral-500 dark:border-neutral-800">
+      <div className="flex justify-between gap-2"><span>{label}</span><span className="text-neutral-700 dark:text-neutral-300">{quota.unlimited ? '∞' : tx('{n}% restante', { n: remaining })}</span></div>
+      <div className="mt-1 h-1.5 overflow-hidden rounded bg-neutral-200 dark:bg-neutral-800"><div className="h-full bg-emerald-500" style={{ width: `${quota.unlimited ? 100 : remaining}%` }} /></div>
+      <div className="mt-1">{detail}</div>
+      {quota.overage > 0 && <div className="mt-1 text-amber-700 dark:text-amber-400">{tx('{n} de uso adicional', { n: quota.overage })}</div>}
+      {reset && <div className="mt-1">{tx('Se restablece: {time}', { time: reset })}</div>}
+    </div>
   );
 }
 
@@ -331,11 +724,11 @@ function ProviderRow({
   const shown = filtered.slice(0, 300);
 
   return (
-    <div className="border border-neutral-800 rounded-lg">
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800" data-testid={`provider-${provider}`}>
       <button className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm" onClick={onToggle}>
         <span className="text-neutral-500">{expanded ? '▾' : '▸'}</span>
         <span className="font-medium">{PROVIDER_LABELS[provider]}</span>
-        <span className={hasKey ? 'text-emerald-400 text-xs' : 'text-neutral-600 text-xs'}>
+        <span className={hasKey ? 'text-xs text-emerald-600 dark:text-emerald-400' : 'text-xs text-neutral-500 dark:text-neutral-600'}>
           {hasKey ? `● ${t('clave guardada')}` : `○ ${t('sin clave')}`}
         </span>
         {provider === 'openrouter' && <span className="text-neutral-600 text-xs">{t('(modelos públicos)')}</span>}
@@ -355,14 +748,25 @@ function ProviderRow({
               {t('Guardar')}
             </button>
             {hasKey && (
-              <button className="btn btn-ghost text-red-400" onClick={() => window.nodus.clearApiKey(provider).then(onChange)}>
+              <button className="btn btn-ghost text-red-600 dark:text-red-400" onClick={() => window.nodus.clearApiKey(provider).then(onChange)}>
                 {t('Borrar')}
               </button>
             )}
           </div>
 
+          {provider === 'opencode-go' && <OpenCodeGoUsagePanel />}
+
+          {provider === 'anthropic' && (
+            <div className="rounded-lg border border-amber-800/60 bg-amber-950/20 p-3 text-xs leading-5 text-neutral-400">
+              <p>{t('Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude.ai ni utilicen credenciales de suscripciones Free, Pro o Max. Por ello Claude se conecta aquí únicamente mediante la API oficial.')}</p>
+              <button className="mt-1 text-amber-300 hover:text-amber-200" onClick={() => window.nodus.openExternal('https://code.claude.com/docs/en/legal-and-compliance')}>
+                {t('Política oficial de Anthropic ↗')}
+              </button>
+            </div>
+          )}
+
           <div className="flex gap-2 items-center">
-            <button className="btn btn-ghost border border-neutral-700" onClick={loadModels} disabled={loading}>
+            <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={loadModels} disabled={loading}>
               {loading ? t('Cargando…') : t('Cargar modelos')}
             </button>
             {models && (
@@ -371,7 +775,7 @@ function ProviderRow({
             {models && <span className="text-xs text-neutral-500">{filtered.length}</span>}
           </div>
 
-          {error && <div className="text-xs text-red-400">{error}</div>}
+          {error && <div className="text-xs text-red-600 dark:text-red-400">{error}</div>}
 
           {models && (
             <SettingsModelList className="max-h-64 overflow-y-auto" data-testid={`provider-model-list-${provider}`}>
@@ -383,6 +787,61 @@ function ProviderRow({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function OpenCodeGoUsagePanel() {
+  const [usage, setUsage] = useState<OpenCodeGoUsageStatus | null>(null);
+  useEffect(() => {
+    void window.nodus.getOpenCodeGoUsageStatus().then(setUsage);
+    return window.nodus.onOpenCodeGoUsageStatusChanged(setUsage);
+  }, []);
+
+  return (
+    <div className="rounded-lg border border-violet-200 bg-violet-50 p-3 text-xs leading-5 text-neutral-600 dark:border-violet-800/60 dark:bg-violet-950/20 dark:text-neutral-400" data-testid="opencode-go-usage">
+      <p>{t('OpenCode documenta el uso directo de la suscripción Go mediante esta clave y sus endpoints oficiales. Nodus es independiente y no está afiliada, certificada ni respaldada por OpenCode.')}</p>
+      <p className="mt-1">{t('Límites generales publicados: 12 USD cada 5 horas, 30 USD por semana y 60 USD por mes. Algunos modelos tienen un límite mensual efectivo inferior (15 USD); el número de peticiones depende del modelo y puede cambiar.')}</p>
+      <p className="mt-1 text-amber-700 dark:text-amber-300">{t('Saldo restante oficial: OpenCode solo lo publica en Console; no ofrece una API de cuota compatible con la clave de usuario. Nodus no usa cookies ni endpoints privados.')}</p>
+      {usage && (
+        <div className="mt-2 grid gap-2 sm:grid-cols-3">
+          <OpenCodeObservedCard label={t('Últimas 5 horas')} period={usage.observed.fiveHours} cap={usage.limitsUsd.fiveHours} />
+          <OpenCodeObservedCard label={t('Últimos 7 días')} period={usage.observed.week} cap={usage.limitsUsd.week} />
+          <OpenCodeObservedCard label={t('Últimos 30 días')} period={usage.observed.month} cap={usage.limitsUsd.month} />
+        </div>
+      )}
+      <p className="mt-2 text-[11px] text-neutral-500">{t('El gasto observado es una estimación local de las peticiones hechas por Nodus con precios oficiales; no incluye otros clientes y no equivale al saldo restante.')}</p>
+      <div className="mt-2 flex flex-wrap gap-3">
+        <button className="text-violet-700 hover:text-violet-800 dark:text-violet-300 dark:hover:text-violet-200" onClick={() => window.nodus.openExternal(usage?.officialUsageUrl ?? 'https://opencode.ai/auth')}>
+          {t('Ver saldo restante oficial en OpenCode Console ↗')}
+        </button>
+        <button className="text-violet-700 hover:text-violet-800 dark:text-violet-300 dark:hover:text-violet-200" onClick={() => window.nodus.openExternal('https://opencode.ai/docs/go/')}>
+          {t('Documentación oficial de OpenCode Go ↗')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function OpenCodeObservedCard({
+  label,
+  period,
+  cap,
+}: {
+  label: string;
+  period: OpenCodeGoUsageStatus['observed']['fiveHours'];
+  cap: number;
+}) {
+  const spend = period.estimatedCostUsd;
+  return (
+    <div className="rounded border border-neutral-200 p-2 text-[11px] dark:border-neutral-800">
+      <div className="text-neutral-700 dark:text-neutral-300">{label}</div>
+      <div>{tx('{requests} peticiones · ~${spent} observados · ${cap} de tope general de referencia', {
+        requests: period.requests,
+        spent: spend.toFixed(spend < 0.01 ? 4 : 2),
+        cap: cap.toFixed(0),
+      })}</div>
+      {period.unpricedRequests > 0 && <div className="text-amber-700 dark:text-amber-400">{tx('{n} sin precio estimable', { n: period.unpricedRequests })}</div>}
     </div>
   );
 }
@@ -581,11 +1040,15 @@ function ModelList({
   models,
   isFav,
   toggleFav,
+  codexReasoningEfforts,
+  onCodexReasoningChange,
 }: {
   provider: AiProvider;
   models: ModelInfo[];
   isFav: (m: ModelRef) => boolean;
   toggleFav: (m: ModelRef) => Promise<void>;
+  codexReasoningEfforts?: Record<string, CodexReasoningEffort>;
+  onCodexReasoningChange?: (model: string, effort: CodexReasoningEffort | null) => Promise<void>;
 }) {
   // OpenRouter: render grouped by upstream provider.
   const rows: JSX.Element[] = [];
@@ -630,8 +1093,45 @@ function ModelList({
             {t('razona')}
           </span>
         )}
+        {provider === 'codex' && (m.supportedReasoningEfforts?.length ?? 0) > 0 && (
+          <select
+            className="input h-7 w-36 shrink-0 py-0 text-[10px]"
+            data-testid={`codex-reasoning-${m.id}`}
+            aria-label={tx('Razonamiento de {model}', { model: m.name ?? m.id })}
+            value={codexReasoningEfforts?.[m.id] ?? ''}
+            onChange={(event) => void onCodexReasoningChange?.(
+              m.id,
+              event.target.value ? event.target.value as CodexReasoningEffort : null
+            )}
+          >
+            <option value="">
+              {m.defaultReasoningEffort
+                ? tx('{level} (predeterminado)', { level: codexReasoningLabel(m.defaultReasoningEffort) })
+                : t('Predeterminado')}
+            </option>
+            {(m.supportedReasoningEfforts ?? []).map((option) => (
+              <option key={option.reasoningEffort} value={option.reasoningEffort} title={option.description}>
+                {codexReasoningLabel(option.reasoningEffort)}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
     );
   }
   return <div>{rows}</div>;
+}
+
+function codexReasoningLabel(effort: CodexReasoningEffort): string {
+  switch (effort) {
+    case 'none': return t('Ninguno');
+    case 'minimal': return t('Mínimo');
+    case 'low': return t('Bajo');
+    case 'medium': return t('Medio');
+    case 'high': return t('Alto');
+    case 'xhigh': return t('Muy alto');
+    case 'max': return t('Máximo');
+    case 'ultra': return t('Ultra');
+    default: return effort.replace(/[_-]+/g, ' ').replace(/^./, (letter) => letter.toUpperCase());
+  }
 }

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1287,7 +1287,7 @@ export function Settings({
             </Row>
             <Row
               label={t('Razonamiento (chat/tutor/escritura)')}
-              hint={t('Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales.')}
+              hint={t('Los escaneos siempre usan razonamiento desactivado para ir más rápido. Esto solo afecta a las respuestas conversacionales. En Codex se configura por modelo dentro de Proveedores.')}
             >
               <select
                 className="input"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,7 @@ const mainExternals = [
   '@modelcontextprotocol/sdk/server/mcp.js',
   '@modelcontextprotocol/sdk/server/streamableHttp.js',
   '@modelcontextprotocol/sdk/types.js',
+  '@github/copilot-sdk',
   'openai',
   'electron-updater',
 ];


### PR DESCRIPTION
Closes #60

## Qué cambia

- Integra las suscripciones de ChatGPT/Codex y GitHub Copilot mediante sus runtimes oficiales.
- Integra OpenCode Go mediante sus endpoints y credenciales documentados.
- Añade autenticación, catálogo de modelos, estado de conexión y visibilidad de cuota/uso.
- Cablea los proveedores con Chat, Nodi, Deep Research y las superficies compatibles.
- Añade selección dinámica del esfuerzo de razonamiento por modelo Codex.
- Comparte las preferencias de razonamiento entre vaults y las incluye en exportación/importación.
- Completa los estilos claro y oscuro en Proveedores y modelos.
- Aísla las ejecuciones, deshabilita herramientas y limpia procesos, sesiones y credenciales.
- Conserva la seudonimización docente de extremo a extremo, incluido el streaming.
- Incluye avisos de terceros y pruebas específicas de los nuevos proveedores.

## Cumplimiento

La implementación utiliza los mecanismos oficialmente documentados por OpenAI/Codex, GitHub Copilot y OpenCode Go. No automatiza sesiones web privadas ni reutiliza cookies del navegador.

## Validación

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`
- `npm test` — 531/531
- `npm run test:e2e` — Electron E2E completo, esquema v87
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD` — sin conflictos

La rama está basada en el último `origin/main`.