### PR TITLE
Fix Nodi quick-note delete overlap

### DIFF
--- a/scripts/test-nodi-notes.mjs
+++ b/scripts/test-nodi-notes.mjs
@@ -71,6 +71,8 @@ try {
   assert.match(component, /t\('Guardado automáticamente'\)/, 'the footer communicates autosave');
   assert.doesNotMatch(component, /className="nodi-note-save"/, 'the editor no longer requires a manual save action');
   assert.match(css, /\.nodi-notes-list\s*\{[^}]*padding:\s*6px 10px/s, 'the list keeps a small lateral margin');
+  assert.match(css, /\.nodi-note-row\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) 30px/s, 'each note reserves a fixed column for its delete action');
+  assert.match(css, /\.nodi-note-open\s*\{[^}]*overflow:\s*hidden/s, 'note text is clipped before the delete action');
 
   console.log('Nodi quick-note autosave tests passed!');
 } finally {

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -587,11 +587,20 @@
 .nodi-notes-search button:hover { background: rgba(255, 255, 255, 0.06); color: #f3e6c2; }
 
 .nodi-notes-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px 10px; display: flex; flex-direction: column; gap: 3px; }
-.nodi-note-row { display: flex; align-items: stretch; gap: 3px; border-radius: 9px; background: transparent; }
+.nodi-note-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 30px;
+  align-items: stretch;
+  gap: 3px;
+  overflow: hidden;
+  border-radius: 9px;
+  background: transparent;
+}
 .nodi-note-row:hover { background: rgba(212, 175, 55, 0.08); }
 .nodi-note-open {
-  flex: 1;
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -606,10 +615,9 @@
 .nodi-note-snippet { font-size: 11px; color: #98a3b4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .nodi-note-time { font-size: 9.5px; color: #6b7688; margin-top: 1px; }
 .nodi-note-delete {
-  flex: 0 0 auto;
   display: grid;
   place-items: center;
-  width: 30px;
+  width: 100%;
   border: 0;
   border-radius: 8px;
   background: transparent;


### PR DESCRIPTION
## Summary

- reserve a fixed column for the delete action in every Nodi quick-note row
- clip note content within its own column so long titles and snippets cannot render behind the action
- add regression assertions for the row layout and clipping behavior

## Root cause

The note content and delete action shared a flexible row. At increased interface scales, the content clipping boundary was not reliably constrained before the action.

## Validation

- `node scripts/test-nodi-notes.mjs`
- `npm run typecheck`
- `git diff --check`

Closes #62