### PR TITLE
Endurece los proveedores por suscripción y avisa del consumo de cuota

### DIFF
--- a/electron/ai/aiClient.ts
+++ b/electron/ai/aiClient.ts
@@ -9,7 +9,7 @@ import {
   isLocalProvider,
   localContextWindow,
 } from './providers';
-import { DEFAULT_EMBEDDING_MODELS, normalizeEmbeddingModel, PROVIDER_LABELS } from '@shared/providers';
+import { DEFAULT_EMBEDDING_MODELS, normalizeEmbeddingModel, PROVIDER_LABELS, supportsSamplingControls } from '@shared/providers';
 import type { AiProvider, CodexReasoningEffort, EmbeddingProvider, LocalProvider, ModelRef, PromptLanguage, ReasoningEffort } from '@shared/types';
 import { vaultTypePromptPack } from '@shared/vaultTypes';
 import { anthropicVisionContent, openAiVisionContent, type VisionImagePart } from '@shared/imageAnalysis';
@@ -25,6 +25,7 @@ import {
   deanonymizeDeep,
   findResidualNames,
 } from '@shared/studentPseudonyms';
+import { classifyProviderError } from './providerErrors';
 import { completeWithChatGptSubscription } from './codexSubscription';
 import { completeWithGitHubCopilotSubscription } from './githubCopilotSubscription';
 import { completeWithOpenCodeGo } from './openCodeGoCompletion';
@@ -39,6 +40,23 @@ export class AiError extends Error {
   constructor(message: string, public retriable = false, public config = false) {
     super(message);
   }
+}
+
+/** Subscription providers carry no HTTP status, so `wrapProviderError` cannot read
+ *  them. They classify themselves instead — see `providerErrors.ts`. */
+function subscriptionError(error: unknown): AiError {
+  const { message, retriable, config } = classifyProviderError(error);
+  return new AiError(message, retriable, config);
+}
+
+/**
+ * The subscription runtimes accept no `response_format`, so JSON mode can only be
+ * asked for in words. Without this `jsonMode` was silently inert for them and every
+ * structured call leaned entirely on the repair round-trip.
+ */
+function withJsonModeDirective(system: string, jsonMode: boolean): string {
+  if (!jsonMode) return system;
+  return `${system}\n\nReturn only a single valid JSON value. No prose, no explanation, no Markdown code fences.`;
 }
 
 /** Stored key for a provider, or a harmless placeholder for local providers
@@ -394,30 +412,28 @@ async function rawComplete(
     try {
       return await completeWithChatGptSubscription({
         model: model.model,
-        system: opts.system,
+        system: withJsonModeDirective(opts.system, jsonMode),
         user: opts.user,
         reasoning: codexReasoning === undefined ? reasoning : codexReasoning,
         timeoutMs: opts.timeoutMs,
         images: opts.images,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new AiError(message, /límite|limit|tempor|timeout|conexión/i.test(message), /conecta|suscripción|autentic/i.test(message));
+      throw subscriptionError(error);
     }
   }
   if (model.provider === 'github-copilot') {
     try {
       return await completeWithGitHubCopilotSubscription({
         model: model.model,
-        system: opts.system,
+        system: withJsonModeDirective(opts.system, jsonMode),
         user: opts.user,
         reasoning,
         timeoutMs: opts.timeoutMs,
         images: opts.images,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new AiError(message, /límite|limit|tempor|timeout|conexión|quota|credit/i.test(message), /conecta|suscripción|autentic|cuenta/i.test(message));
+      throw subscriptionError(error);
     }
   }
   const key = resolveProviderKey(model.provider);
@@ -661,11 +677,20 @@ export async function completeJson<T>(
   // JSON/structured calls (scans, extraction) default to reasoning off for speed.
   const reasoning = langOpts.reasoning ?? 'off';
   let lastErr: unknown;
-  const attempts = [
-    { temperature: langOpts.temperature ?? 0.15, jsonMode: true },
-    { temperature: 0, jsonMode: true },
-    { temperature: 0, jsonMode: false },
-  ];
+  // Each rung escalates by lowering temperature, then by dropping JSON mode. A
+  // provider that honours neither (the subscription runtimes) would send the exact
+  // same request three times and bill three turns for it, so it gets one retry —
+  // the only lever left there is a fresh sample — instead of two identical ones.
+  const attempts = supportsSamplingControls(resolved.provider)
+    ? [
+        { temperature: langOpts.temperature ?? 0.15, jsonMode: true },
+        { temperature: 0, jsonMode: true },
+        { temperature: 0, jsonMode: false },
+      ]
+    : [
+        { temperature: langOpts.temperature ?? 0.15, jsonMode: true },
+        { temperature: langOpts.temperature ?? 0.15, jsonMode: true },
+      ];
   for (let i = 0; i < attempts.length; i++) {
     const attempt = attempts[i];
     const retryDone = startPerf('JSON retry', langOpts.perf, { attempt: i + 1, jsonMode: attempt.jsonMode });
@@ -795,8 +820,7 @@ async function rawCompleteStream(
       return finish();
     } catch (error) {
       if (signal?.aborted) return finish();
-      const message = error instanceof Error ? error.message : String(error);
-      throw new AiError(message, /límite|limit|tempor|timeout|conexión/i.test(message), /conecta|suscripción|autentic/i.test(message));
+      throw subscriptionError(error);
     }
   }
 
@@ -817,8 +841,7 @@ async function rawCompleteStream(
       return finish();
     } catch (error) {
       if (signal?.aborted) return finish();
-      const message = error instanceof Error ? error.message : String(error);
-      throw new AiError(message, /límite|limit|tempor|timeout|conexión|quota|credit/i.test(message), /conecta|suscripción|autentic|cuenta/i.test(message));
+      throw subscriptionError(error);
     }
   }
 

--- a/electron/ai/codexAppServerClient.ts
+++ b/electron/ai/codexAppServerClient.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { createInterface } from 'node:readline';
+import { ProviderRuntimeError } from './providerErrors';
 
 type JsonRpcId = number;
 type JsonObject = Record<string, unknown>;
@@ -46,6 +47,12 @@ export class CodexAppServerClient {
     return this.sendRequest<T>(method, params, timeoutMs);
   }
 
+  /** Live child, without starting one. Lets callers skip best-effort teardown
+   *  instead of having `request()` respawn the runtime they are cleaning up after. */
+  isRunning(): boolean {
+    return this.child !== null && this.child.exitCode === null;
+  }
+
   async stop(): Promise<void> {
     this.stopping = true;
     const child = this.child;
@@ -55,7 +62,7 @@ export class CodexAppServerClient {
 
     for (const pending of this.pending.values()) {
       clearTimeout(pending.timer);
-      pending.reject(new Error('El runtime de ChatGPT se ha cerrado.'));
+      pending.reject(new ProviderRuntimeError('El runtime de ChatGPT se ha cerrado.', 'unavailable'));
     }
     this.pending.clear();
 
@@ -66,10 +73,35 @@ export class CodexAppServerClient {
     }, 1_500);
     await Promise.race([exited, new Promise<void>((resolve) => setTimeout(resolve, 2_500))]);
     clearTimeout(timer);
-    if (child.exitCode === null && !child.killed) {
+    // Escalate on liveness alone. `child.killed` only means "a signal was delivered
+    // to the OS", so the SIGTERM above sets it and testing it here would make this
+    // branch unreachable in exactly the case it exists for: a child that ignored
+    // SIGTERM and is still running.
+    if (child.exitCode === null) {
       try { child.kill('SIGKILL'); } catch { /* process already gone */ }
     }
     this.stopping = false;
+  }
+
+  /**
+   * Synchronous teardown for app shutdown. Electron's `before-quit` cannot await, so
+   * {@link stop}'s graceful drain — which only sends SIGTERM after a 1.5s timer —
+   * never gets to run there and the runtime survives as an orphan holding a keyring
+   * session. Killing outright is the only teardown that actually completes in a
+   * synchronous handler.
+   */
+  killNow(): void {
+    this.stopping = true;
+    const child = this.child;
+    this.child = null;
+    this.startPromise = null;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new ProviderRuntimeError('El runtime de ChatGPT se ha cerrado.', 'unavailable'));
+    }
+    this.pending.clear();
+    if (!child || child.exitCode !== null) return;
+    try { child.kill('SIGKILL'); } catch { /* process already gone */ }
   }
 
   private async ensureStarted(): Promise<void> {
@@ -115,6 +147,15 @@ export class CodexAppServerClient {
     );
     this.child = child;
 
+    // A dying child races every write: the `exitCode === null` guards below can pass
+    // and the pipe still be gone by the time the data lands, and an unhandled stream
+    // 'error' is an uncaught exception that takes down the whole main process. These
+    // listeners swallow it deliberately — the real failure is reported by the 'exit'
+    // handler, which rejects every pending request with a description of the exit.
+    child.stdin.on('error', () => { /* reported via 'exit' */ });
+    child.stdout.on('error', () => { /* reported via 'exit' */ });
+    child.stderr.on('error', () => { /* reported via 'exit' */ });
+
     const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
     lines.on('line', (line) => this.handleLine(line));
     child.stderr.setEncoding('utf8');
@@ -127,8 +168,9 @@ export class CodexAppServerClient {
       if (this.child === child) this.child = null;
       if (!this.stopping) {
         const detail = this.stderrTail.trim();
-        this.handleExit(new Error(
-          `El runtime oficial de Codex se cerró inesperadamente (${signal ?? code ?? 'sin código'}).${detail ? ` ${detail}` : ''}`
+        this.handleExit(new ProviderRuntimeError(
+          `El runtime oficial de Codex se cerró inesperadamente (${signal ?? code ?? 'sin código'}).${detail ? ` ${detail}` : ''}`,
+          'unavailable'
         ));
       }
     });
@@ -159,8 +201,13 @@ export class CodexAppServerClient {
     // The model has no execution tools, but do not pass unrelated credentials to
     // the child process in the first place. Keep ordinary runtime variables such
     // as PATH, HOME, locale and proxy configuration untouched.
+    // `SESSION` is deliberately absent: it matched DBUS_SESSION_BUS_ADDRESS,
+    // XDG_SESSION_* and macOS SECURITYSESSIONID, which are desktop-integration
+    // handles rather than credentials, and dropping them can stop the runtime from
+    // opening a browser or reaching the keyring during login. Genuine session
+    // credentials (AWS_SESSION_TOKEN, SESSION_SECRET, …) still match TOKEN/SECRET.
     for (const name of Object.keys(env)) {
-      if (/(?:API_?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|SESSION|AUTH_SOCK)/i.test(name)) delete env[name];
+      if (/(?:API_?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|AUTH_SOCK)/i.test(name)) delete env[name];
     }
     delete env.NODE_OPTIONS;
     env.CODEX_HOME = this.options.codexHome;
@@ -170,14 +217,16 @@ export class CodexAppServerClient {
   private sendRequest<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T> {
     const id = this.nextId++;
     const child = this.child;
-    if (!child || child.exitCode !== null) return Promise.reject(new Error('El runtime oficial de Codex no está disponible.'));
+    if (!child || child.exitCode !== null) {
+      return Promise.reject(new ProviderRuntimeError('El runtime oficial de Codex no está disponible.', 'unavailable'));
+    }
     const payload: JsonObject = { id, method };
     if (params !== undefined) payload.params = params;
 
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`Codex no respondió a «${method}» dentro del tiempo esperado.`));
+        reject(new ProviderRuntimeError(`Codex no respondió a «${method}» dentro del tiempo esperado.`, 'timeout'));
       }, timeoutMs ?? this.options.requestTimeoutMs ?? 30_000);
       this.pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timer });
       child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {

--- a/electron/ai/codexCompletion.ts
+++ b/electron/ai/codexCompletion.ts
@@ -2,10 +2,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { CodexReasoningEffort, ReasoningEffort } from '@shared/types';
 import type { VisionImagePart } from '@shared/imageAnalysis';
+import { ProviderRuntimeError } from './providerErrors';
 
 export interface CodexCompletionTransport {
   request<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
   onNotification(handler: (method: string, params: unknown) => void): () => void;
+  /** Whether the underlying runtime is live. Best-effort cleanup is skipped when it
+   *  is not, so tearing a turn down cannot respawn the process it belongs to. */
+  isRunning?(): boolean;
 }
 
 export interface IsolatedCodexCompletionOptions {
@@ -75,6 +79,17 @@ export async function runIsolatedCodexCompletion(
   let unsubscribe: () => void = () => undefined;
   let timeout: NodeJS.Timeout | null = null;
   let abortHandler: (() => void) | null = null;
+  let settleAborted: ((value: string) => void) | null = null;
+  const abortedEarly = new Promise<string>((resolve) => { settleAborted = resolve; });
+
+  // Teardown is best-effort and must never restart a dead runtime: every transport
+  // request goes through ensureStarted(), so an unguarded `turn/interrupt` or
+  // `thread/unsubscribe` after a crash would respawn the whole Codex process just to
+  // clean up a thread that no longer exists — and block for the request timeout.
+  const cleanupRequest = (method: string, params: unknown): Promise<unknown> => {
+    if (runtime.isRunning?.() === false) return Promise.resolve(undefined);
+    return runtime.request(method, params).catch(() => undefined);
+  };
 
   try {
     const input: any[] = [{ type: 'text', text: options.user, text_elements: [] }];
@@ -136,7 +151,7 @@ export async function runIsolatedCodexCompletion(
           'imageView',
           'imageGeneration',
         ].includes(params?.item?.type)) {
-          void runtime.request('turn/interrupt', { threadId, turnId: params.turnId }).catch(() => undefined);
+          void cleanupRequest('turn/interrupt', { threadId, turnId: params.turnId });
           reject(new Error('Codex intentó usar una herramienta deshabilitada; Nodus interrumpió la petición.'));
           return;
         }
@@ -153,14 +168,19 @@ export async function runIsolatedCodexCompletion(
           .find((item: any) => item?.type === 'agentMessage' && typeof item.text === 'string' && item.text.trim());
         if (turn?.status === 'interrupted') return resolve(full || final?.text || '');
         const answer = final?.text || full;
-        if (!answer.trim()) return reject(new Error('ChatGPT devolvió una respuesta vacía.'));
+        if (!answer.trim()) return reject(new ProviderRuntimeError('ChatGPT devolvió una respuesta vacía.', 'unavailable'));
         resolve(answer);
       });
     });
 
     abortHandler = () => {
       aborted = true;
-      if (threadId && turnId) void runtime.request('turn/interrupt', { threadId, turnId }).catch(() => undefined);
+      if (threadId && turnId) void cleanupRequest('turn/interrupt', { threadId, turnId });
+      // Settle on whatever already streamed instead of waiting for `turn/completed`.
+      // The runtime is not guaranteed to emit it after an interrupt, and the caller
+      // has already cancelled — holding them for the remaining timeout is the one
+      // outcome a cancel must never produce.
+      settleAborted?.(full);
     };
     options.signal?.addEventListener('abort', abortHandler, { once: true });
 
@@ -175,14 +195,21 @@ export async function runIsolatedCodexCompletion(
       summary: 'none',
     }, 60_000);
     turnId = started.turn.id;
-    if (aborted) await runtime.request('turn/interrupt', { threadId, turnId }).catch(() => undefined);
+    // Aborted before the turn id existed: the 'abort' event already fired, so the
+    // listener could not interrupt anything and will never fire again. Interrupt now
+    // and return directly rather than racing a promise that can no longer settle.
+    if (aborted) {
+      await cleanupRequest('turn/interrupt', { threadId, turnId });
+      return full;
+    }
 
     return await Promise.race([
       completed,
+      abortedEarly,
       new Promise<string>((_resolve, reject) => {
         timeout = setTimeout(() => {
-          if (threadId && turnId) void runtime.request('turn/interrupt', { threadId, turnId }).catch(() => undefined);
-          reject(new Error('ChatGPT no completó la petición dentro del tiempo esperado.'));
+          if (threadId && turnId) void cleanupRequest('turn/interrupt', { threadId, turnId });
+          reject(new ProviderRuntimeError('ChatGPT no completó la petición dentro del tiempo esperado.', 'timeout'));
         }, options.timeoutMs ?? 180_000);
       }),
     ]);
@@ -190,6 +217,6 @@ export async function runIsolatedCodexCompletion(
     if (timeout) clearTimeout(timeout);
     unsubscribe();
     if (abortHandler) options.signal?.removeEventListener('abort', abortHandler);
-    if (threadId) await runtime.request('thread/unsubscribe', { threadId }).catch(() => undefined);
+    if (threadId) await cleanupRequest('thread/unsubscribe', { threadId });
   }
 }

--- a/electron/ai/codexSubscription.ts
+++ b/electron/ai/codexSubscription.ts
@@ -14,6 +14,7 @@ import type {
 import type { VisionImagePart } from '@shared/imageAnalysis';
 import { CodexAppServerClient } from './codexAppServerClient';
 import { resolveCodexReasoningEffort, runIsolatedCodexCompletion } from './codexCompletion';
+import { ProviderRuntimeError } from './providerErrors';
 
 interface CodexAccountResponse {
   account: null | { type: 'apiKey' } | { type: 'chatgpt'; email: string | null; planType: string } | { type: 'amazonBedrock' };
@@ -222,6 +223,34 @@ async function readStatus(refreshToken = false): Promise<ChatGptSubscriptionStat
   }
 }
 
+// A connected account stays connected between calls, so re-reading it before every
+// single generation cost two extra round trips and a forced network token refresh
+// per completion — which a scan pipeline pays hundreds of times. Confirm at most
+// once per window instead, and drop the cache whenever the session may have changed.
+let connectedAt = 0;
+let connectedCached = false;
+const CONNECTED_TTL_MS = 60_000;
+
+function invalidateConnectedCache(): void {
+  connectedAt = 0;
+  connectedCached = false;
+}
+
+/** Gate a generation on a connected account, reusing a recent check. Keeps the
+ *  forced token refresh, but pays for it once per window rather than per call. */
+async function ensureConnectedForCompletion(): Promise<void> {
+  if (connectedCached && Date.now() - connectedAt < CONNECTED_TTL_MS) return;
+  const status = await readStatus(true);
+  connectedCached = status.connected;
+  connectedAt = Date.now();
+  if (!status.connected) {
+    throw new ProviderRuntimeError(
+      'La suscripción de ChatGPT no está conectada. Ábrela en Proveedores y modelos.',
+      'auth'
+    );
+  }
+}
+
 async function refreshAndEmitStatus(): Promise<ChatGptSubscriptionStatus> {
   const status = await readStatus(false);
   emitStatus(status);
@@ -259,6 +288,7 @@ export async function logoutChatGptSubscription(): Promise<ChatGptSubscriptionSt
   await getClient().request('account/logout');
   pendingLoginId = null;
   modelCatalog = new Map();
+  invalidateConnectedCache();
   return refreshAndEmitStatus();
 }
 
@@ -283,8 +313,13 @@ async function readModelCatalog(force = false): Promise<CodexModel[]> {
 
 export async function listChatGptSubscriptionModels(): Promise<ModelInfo[]> {
   const status = await readStatus(false);
-  if (!status.connected) throw new Error('Conecta primero una suscripción de ChatGPT en Proveedores y modelos.');
+  if (!status.connected) {
+    throw new ProviderRuntimeError('Conecta primero una suscripción de ChatGPT en Proveedores y modelos.', 'auth');
+  }
   const models = await readModelCatalog(true);
+  // Resolved once: finding it inside the comparator re-scanned the catalogue on
+  // every comparison.
+  const defaultId = models.find((model) => model.isDefault)?.id;
   return models
     .filter((model) => !model.hidden)
     .map((model) => ({
@@ -295,13 +330,12 @@ export async function listChatGptSubscriptionModels(): Promise<ModelInfo[]> {
       supportedReasoningEfforts: model.supportedReasoningEfforts,
       defaultReasoningEffort: model.defaultReasoningEffort,
     }))
-    .sort((a, b) => Number(b.id === models.find((m) => m.isDefault)?.id) - Number(a.id === models.find((m) => m.isDefault)?.id) || a.id.localeCompare(b.id));
+    .sort((a, b) => Number(b.id === defaultId) - Number(a.id === defaultId) || a.id.localeCompare(b.id));
 }
 
 /** Text/vision completion backed by an ephemeral, isolated Codex thread. */
 export async function completeWithChatGptSubscription(options: CodexCompletionOptions): Promise<string> {
-  const status = await readStatus(true);
-  if (!status.connected) throw new Error('La suscripción de ChatGPT no está conectada. Ábrela en Proveedores y modelos.');
+  await ensureConnectedForCompletion();
 
   const runtime = getClient();
   const catalog = await readModelCatalog(false);
@@ -315,15 +349,31 @@ export async function completeWithChatGptSubscription(options: CodexCompletionOp
 
   try {
     return await runIsolatedCodexCompletion(runtime, { ...options, reasoning, workdir });
+  } catch (error) {
+    // The cached check can outlive the session it vouched for (revoked, expired,
+    // signed out elsewhere). Any failure re-arms the full check for the next call
+    // so a stale "connected" cannot pin the provider in a broken state.
+    invalidateConnectedCache();
+    throw error;
   } finally {
     await fs.promises.rm(workdir, { recursive: true, force: true });
   }
 }
 
-export async function stopChatGptSubscriptionServer(): Promise<void> {
+/**
+ * Shut the runtime down from Electron's quit handlers.
+ *
+ * Synchronous on purpose: `before-quit` cannot await, so the graceful drain — which
+ * only escalates to a signal after a 1.5s timer — was abandoned half-way and left
+ * the runtime alive as an orphan holding a keyring session. Killing outright is the
+ * only teardown that actually completes in a synchronous handler, and nothing is
+ * lost by it: credentials are written at login, not at shutdown.
+ */
+export function killChatGptSubscriptionServer(): void {
   clientUnsubscribe?.();
   clientUnsubscribe = null;
+  invalidateConnectedCache();
   const current = client;
   client = null;
-  if (current) await current.stop();
+  current?.killNow();
 }

--- a/electron/ai/githubCopilotSubscription.ts
+++ b/electron/ai/githubCopilotSubscription.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { CopilotClient, RuntimeConnection, type ModelInfo as CopilotModelInfo } from '@github/copilot-sdk';
+import { ProviderRuntimeError } from './providerErrors';
 import type {
   GitHubCopilotSessionUsage,
   GitHubCopilotSubscriptionQuotaWindow,
@@ -46,6 +47,10 @@ let loginProcess: ChildProcessWithoutNullStreams | null = null;
 let loginDiagnostic = '';
 let lastSession: GitHubCopilotSessionUsage | null = null;
 let modelCache: CopilotModelInfo[] | null = null;
+let modelCacheAt = 0;
+/** The catalogue follows the GitHub plan, so a tier change or a newly released model
+ *  has to become visible without making the user sign out or restart Nodus. */
+const MODEL_CACHE_TTL_MS = 10 * 60_000;
 
 function copilotHome(): string {
   const dir = path.join(app.getPath('userData'), 'github-copilot-subscription');
@@ -92,7 +97,12 @@ function sanitizedEnv(): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [name, value] of Object.entries(process.env)) {
     if (value === undefined) continue;
-    if (/(?:API_?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|SESSION)/i.test(name)) continue;
+    // `SESSION` is deliberately absent: it matched DBUS_SESSION_BUS_ADDRESS,
+    // XDG_SESSION_* and macOS SECURITYSESSIONID, which are desktop-integration
+    // handles rather than credentials — and the CLI needs them to open a browser
+    // and reach the keyring during login. Real session credentials still match
+    // TOKEN/SECRET.
+    if (/(?:API_?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)/i.test(name)) continue;
     env[name] = value;
   }
   delete env.NODE_OPTIONS;
@@ -256,13 +266,17 @@ export async function logoutGitHubCopilotSubscription(): Promise<GitHubCopilotSu
 }
 
 async function copilotModels(): Promise<CopilotModelInfo[]> {
-  if (modelCache) return modelCache;
+  if (modelCache && Date.now() - modelCacheAt < MODEL_CACHE_TTL_MS) return modelCache;
   const runtime = getClient();
   await runtime.start();
   const auth = await runtime.getAuthStatus();
-  if (!auth.isAuthenticated) throw new Error('Conecta primero tu cuenta de GitHub Copilot en Proveedores y modelos.');
-  modelCache = await runtime.listModels();
-  return modelCache;
+  if (!auth.isAuthenticated) {
+    throw new ProviderRuntimeError('Conecta primero tu cuenta de GitHub Copilot en Proveedores y modelos.', 'auth');
+  }
+  const models = await runtime.listModels();
+  modelCache = models;
+  modelCacheAt = Date.now();
+  return models;
 }
 
 export async function listGitHubCopilotSubscriptionModels(): Promise<ModelInfo[]> {
@@ -303,6 +317,7 @@ async function stopClient(): Promise<void> {
   const current = client;
   client = null;
   modelCache = null;
+  modelCacheAt = 0;
   if (current) await current.stop();
 }
 

--- a/electron/ai/openCodeGoCompletion.ts
+++ b/electron/ai/openCodeGoCompletion.ts
@@ -53,6 +53,24 @@ function apiError(status: number, payload: unknown): Error & { status: number } 
   return Object.assign(new Error(`OpenCode Go rechazó la solicitud: ${detail}`), { status });
 }
 
+/**
+ * Status to attribute to an error delivered *inside* a 200 stream.
+ *
+ * `wrapProviderError` classifies by status, and the response status is 200 by the
+ * time these arrive — so passing it through marked every mid-stream overload or rate
+ * limit as permanent. Map the payload's own error type instead, and default to 502:
+ * the request was accepted and the upstream failed afterwards, which is transient.
+ */
+function streamErrorStatus(payload: unknown): number {
+  const body = payload as any;
+  const kind = String(body?.error?.type ?? body?.error?.code ?? body?.type ?? '').toLowerCase();
+  if (kind.includes('overload')) return 529;
+  if (kind.includes('rate_limit') || kind.includes('quota')) return 429;
+  if (kind.includes('authentication') || kind.includes('api_key') || kind.includes('permission')) return 401;
+  if (kind.includes('invalid_request') || kind.includes('not_found')) return 400;
+  return 502;
+}
+
 async function readError(response: Response): Promise<never> {
   const raw = await response.text();
   let payload: unknown = raw;
@@ -102,8 +120,47 @@ async function* sseEvents(response: Response): AsyncGenerator<{ event: string | 
       if (data.length) yield { event: null, data: data.join('\n') };
     }
   } finally {
+    // Releasing the lock alone leaves the body undrained when the consumer throws
+    // mid-stream (an inline error event), so the connection was leaked on exactly
+    // the path that fires most often under load. Cancel first, then release.
+    try { await reader.cancel(); } catch { /* already closed */ }
     reader.releaseLock();
   }
+}
+
+/**
+ * OpenCode Go's Chat Completions surface forwards OpenAI's `reasoning_effort` to the
+ * reasoning models in its catalogue — the streaming side already parses the
+ * `reasoning`/`reasoning_content` deltas they send back. This used to be accepted as
+ * an option and never read, so picking an effort silently did nothing.
+ */
+function reasoningExtras(reasoning: ReasoningEffort | undefined): Record<string, unknown> {
+  return !reasoning || reasoning === 'off' ? {} : { reasoning_effort: reasoning };
+}
+
+/**
+ * Send the optional params, and on a 400 retry once without them.
+ *
+ * The generic OpenAI path in `aiClient` has always done this, which is what makes it
+ * safe to be optimistic about `response_format` and `reasoning_effort` on a mixed
+ * catalogue. This branch returned before reaching that fallback, so a single model
+ * rejecting an optional field turned every structured call into a hard failure.
+ */
+async function postWithOptionalExtras(
+  url: string,
+  headers: Record<string, string>,
+  signal: AbortSignal,
+  body: Record<string, unknown>,
+  extras: Record<string, unknown>
+): Promise<Response> {
+  const send = (payload: Record<string, unknown>) =>
+    fetch(url, { method: 'POST', headers, signal, body: JSON.stringify(payload) });
+
+  const response = await send({ ...body, ...extras });
+  if (response.status !== 400 || Object.keys(extras).length === 0) return response;
+  // Discard the rejected body so the retry does not leak the connection.
+  try { await response.body?.cancel(); } catch { /* already closed */ }
+  return send(body);
 }
 
 function assertText(text: string): string {
@@ -136,23 +193,26 @@ function anthropicUsage(usage: any): OpenCodeGoNormalizedUsage | null {
 
 async function completeOpenAi(options: OpenCodeGoCompletionOptions, url: string, signal: AbortSignal): Promise<OpenCodeGoCompletionResult> {
   const streaming = Boolean(options.onDelta);
-  const response = await fetch(`${url}/v1/chat/completions`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${options.apiKey}`, 'Content-Type': 'application/json' },
+  const response = await postWithOptionalExtras(
+    `${url}/v1/chat/completions`,
+    { Authorization: `Bearer ${options.apiKey}`, 'Content-Type': 'application/json' },
     signal,
-    body: JSON.stringify({
+    {
       model: options.model,
       temperature: options.temperature ?? 0.15,
       max_tokens: options.maxTokens ?? 8_000,
       stream: streaming,
       ...(streaming ? { stream_options: { include_usage: true } } : {}),
-      ...(options.jsonMode ? { response_format: { type: 'json_object' } } : {}),
       messages: [
         { role: 'system', content: options.system },
         { role: 'user', content: options.user },
       ],
-    }),
-  });
+    },
+    {
+      ...reasoningExtras(options.reasoning),
+      ...(options.jsonMode ? { response_format: { type: 'json_object' } } : {}),
+    }
+  );
   if (!response.ok) return readError(response);
 
   if (!streaming) {
@@ -172,7 +232,7 @@ async function completeOpenAi(options: OpenCodeGoCompletionOptions, url: string,
     if (event.data === '[DONE]') continue;
     let chunk: any;
     try { chunk = JSON.parse(event.data); } catch { continue; }
-    if (chunk?.error) throw apiError(response.status, chunk);
+    if (chunk?.error) throw apiError(streamErrorStatus(chunk), chunk);
     const delta = chunk?.choices?.[0]?.delta;
     const reasoning = delta?.reasoning ?? delta?.reasoning_content;
     if (typeof reasoning === 'string') options.onReasoningDelta?.(reasoning);
@@ -201,7 +261,13 @@ async function completeAnthropic(options: OpenCodeGoCompletionOptions, url: stri
     signal,
     body: JSON.stringify({
       model: options.model,
-      system: options.system,
+      // The Messages surface has no `response_format`, so the only way to honour
+      // jsonMode on this route is to ask in words. Without it the flag was inert
+      // here while the Chat Completions route enforced it — the same request shape
+      // behaved differently depending on which model the caller happened to pick.
+      system: options.jsonMode
+        ? `${options.system}\n\nReturn only a single valid JSON value. No prose, no explanation, no Markdown code fences.`
+        : options.system,
       temperature: options.temperature ?? 0.15,
       max_tokens: options.maxTokens ?? 8_000,
       stream: streaming,
@@ -227,7 +293,7 @@ async function completeAnthropic(options: OpenCodeGoCompletionOptions, url: stri
   for await (const event of sseEvents(response)) {
     let chunk: any;
     try { chunk = JSON.parse(event.data); } catch { continue; }
-    if (chunk?.type === 'error' || chunk?.error) throw apiError(response.status, chunk);
+    if (chunk?.type === 'error' || chunk?.error) throw apiError(streamErrorStatus(chunk), chunk);
     if (chunk?.type === 'message_start') inputUsage = chunk.message?.usage ?? inputUsage;
     if (chunk?.type === 'message_delta') {
       outputUsage = chunk.usage ?? outputUsage;

--- a/electron/ai/providerErrors.ts
+++ b/electron/ai/providerErrors.ts
@@ -1,0 +1,84 @@
+/**
+ * Error classification for the subscription-backed providers.
+ *
+ * These providers do not return HTTP status codes — they speak JSON-RPC over stdio
+ * or come back through a vendor SDK — so `wrapProviderError`'s status-based mapping
+ * does not apply. Classification used to be four copies of a regex over the message
+ * text, which was wrong in both directions: the timeouts these runtimes actually
+ * emit matched no alternative and were reported as permanent, while the Spanish
+ * spelling `autentic` never matched an English `authentication` error, so genuine
+ * auth failures never pointed the user at Settings.
+ *
+ * The fix is for the provider modules to say what went wrong instead of describing
+ * it, by throwing {@link ProviderRuntimeError}. {@link classifyProviderError} keeps a
+ * bilingual heuristic for anything that arrives untyped from a vendor SDK.
+ */
+
+export type ProviderErrorKind =
+  /** Transient: the runtime did not answer in time. */
+  | 'timeout'
+  /** Transient: rate limit, quota window or exhausted plan credit. */
+  | 'rateLimit'
+  /** Transient: the runtime crashed, is starting, or the transport dropped. */
+  | 'unavailable'
+  /** Permanent until the user acts: not signed in, expired or rejected session. */
+  | 'auth'
+  /** Permanent: bad request, unsupported model, protocol violation. */
+  | 'invalid';
+
+export class ProviderRuntimeError extends Error {
+  constructor(message: string, readonly kind: ProviderErrorKind) {
+    super(message);
+    this.name = 'ProviderRuntimeError';
+  }
+
+  /** Worth another attempt without the user changing anything. */
+  get retriable(): boolean {
+    return this.kind === 'timeout' || this.kind === 'rateLimit' || this.kind === 'unavailable';
+  }
+
+  /** The user has to fix something in Settings before this can succeed. */
+  get config(): boolean {
+    return this.kind === 'auth';
+  }
+}
+
+// Bilingual fallbacks. Nodus writes its own messages in Spanish while the vendor
+// runtimes report in English, and both reach here, so every concept needs both
+// spellings — `autentic` (es) and `authentic` (en) share no common substring.
+const RETRIABLE = new RegExp([
+  'l[íi]mite', 'limit', 'quota', 'cuota', 'saldo',
+  'timeout', 'timed out', 'tiempo esperado', 'tempor',
+  'conexi[óo]n', 'connection', 'network', 'socket', 'econnre', 'epipe',
+  'overload', 'sobrecarg', 'unavailable', 'no est[áa] disponible', 'try again', 'int[ée]ntalo',
+  'se cerr[óo]', 'closed unexpectedly', 'crash',
+].join('|'), 'i');
+
+const CONFIG = new RegExp([
+  'autentic', 'authentic', 'unauthor', 'no autoriz', 'forbidden', 'prohibid',
+  'credencial', 'credential', 'inicia sesi[óo]n', 'sign in', 'signed in', 'log in', 'logged in',
+  'conecta', 'suscripci[óo]n', 'subscription', 'sesi[óo]n expirada', 'session expired',
+].join('|'), 'i');
+
+export interface ProviderErrorClassification {
+  message: string;
+  retriable: boolean;
+  config: boolean;
+}
+
+/**
+ * Map any thrown value into the retriable/config flags `AiError` expects. A
+ * {@link ProviderRuntimeError} is authoritative; anything else falls back to the
+ * bilingual heuristic, which is why an unrecognised failure defaults to retriable
+ * only when it actually looks transient.
+ */
+export function classifyProviderError(error: unknown): ProviderErrorClassification {
+  if (error instanceof ProviderRuntimeError) {
+    return { message: error.message, retriable: error.retriable, config: error.config };
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  // An auth failure is never worth an automatic retry, so it wins over a message
+  // that happens to mention both (e.g. "session expired, try again").
+  if (CONFIG.test(message)) return { message, retriable: false, config: true };
+  return { message, retriable: RETRIABLE.test(message), config: false };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,7 +23,7 @@ import { startStudyCalendarReminders, stopStudyCalendarReminders } from './study
 import { restorePersistedDockIcon } from './dockIcon';
 import { recoverLegacyApiKeys } from './secrets/legacySecretRecovery';
 import type { UpdateCheckResponse, UpdateProgressEvent } from '@shared/types';
-import { stopChatGptSubscriptionServer } from './ai/codexSubscription';
+import { killChatGptSubscriptionServer } from './ai/codexSubscription';
 import { stopGitHubCopilotSubscription } from './ai/githubCopilotSubscription';
 
 const require = createRequire(__filename);
@@ -500,7 +500,9 @@ app.on('before-quit', () => {
   interruptDecorativeImageGenerations();
   void stopMcpServer();
   void stopCopilotServer();
-  void stopChatGptSubscriptionServer();
+  // Kill synchronously: this handler cannot await, so the graceful stops below would
+  // be abandoned mid-drain and leave the vendor runtimes running as orphans.
+  killChatGptSubscriptionServer();
   void stopGitHubCopilotSubscription();
   closeDb();
 });
@@ -512,7 +514,9 @@ updateAwareApp.on('before-quit-for-update', () => {
   interruptDecorativeImageGenerations();
   void stopMcpServer();
   void stopCopilotServer();
-  void stopChatGptSubscriptionServer();
+  // Kill synchronously: this handler cannot await, so the graceful stops below would
+  // be abandoned mid-drain and leave the vendor runtimes running as orphans.
+  killChatGptSubscriptionServer();
   void stopGitHubCopilotSubscription();
   closeDb();
 });

--- a/scripts/test-subscription-failure-paths.mjs
+++ b/scripts/test-subscription-failure-paths.mjs
@@ -1,0 +1,474 @@
+// Failure paths of the subscription-backed providers.
+//
+// The happy paths are covered by test-codex-subscription.mjs and
+// test-subscription-providers.mjs, which is precisely why every defect these tests
+// pin down survived review: a crashed runtime, a timeout, an interrupted turn, an
+// error arriving inside a 200 stream. Each test here corresponds to a fix.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-subscription-failures-'));
+const bundle = path.join(outDir, 'failure-paths.cjs');
+const entry = path.join(outDir, 'entry.ts');
+fs.writeFileSync(entry, [
+  `export { CodexAppServerClient } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/codexAppServerClient.ts'))};`,
+  `export { runIsolatedCodexCompletion } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/codexCompletion.ts'))};`,
+  `export { classifyProviderError, ProviderRuntimeError } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/providerErrors.ts'))};`,
+  `export { completeWithOpenCodeGo } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/openCodeGoCompletion.ts'))};`,
+  `export { supportsSamplingControls } from ${JSON.stringify(path.join(repoRoot, 'shared/providers.ts'))};`,
+].join('\n'));
+execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
+  entry,
+  '--bundle',
+  '--platform=node',
+  '--format=cjs',
+  '--target=es2022',
+  `--outfile=${bundle}`,
+], { cwd: repoRoot, stdio: 'inherit' });
+const require = createRequire(import.meta.url);
+const {
+  CodexAppServerClient,
+  runIsolatedCodexCompletion,
+  classifyProviderError,
+  ProviderRuntimeError,
+  completeWithOpenCodeGo,
+  supportsSamplingControls,
+} = require(bundle);
+
+// Several tests deliberately leave a runtime wedged or respawned. Any survivor keeps
+// the event loop alive and the whole file would then die on the harness timeout
+// rather than reporting its results, so every client is force-killed at the end.
+const spawned = [];
+test.after(() => {
+  for (const runtime of spawned) {
+    try { runtime.killNow(); } catch { /* already gone */ }
+  }
+  fs.rmSync(outDir, { recursive: true, force: true });
+});
+
+/** Write an executable fake app server and return its path. */
+function fakeServer(name, body) {
+  const file = path.join(outDir, `${name}.mjs`);
+  fs.writeFileSync(file, `#!/usr/bin/env node\n${body}`);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+function client(binaryPath, requestTimeoutMs) {
+  const runtime = new CodexAppServerClient({
+    binaryPath,
+    codexHome: path.join(outDir, 'home'),
+    appVersion: '0.0.0-test',
+    requestTimeoutMs,
+    env: { ...process.env },
+  });
+  spawned.push(runtime);
+  return runtime;
+}
+
+const INITIALIZE = `
+import readline from 'node:readline';
+const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+const reply = (id, result) => process.stdout.write(JSON.stringify({ id, result }) + '\\n');
+`;
+
+test('an error message classifies the same in Spanish and in English', () => {
+  // The original regex used the Spanish spelling `autentic`, which shares no
+  // substring with the English `authentication` the vendor runtimes actually emit,
+  // so real auth failures were never flagged as configuration problems.
+  for (const message of [
+    'authentication failed for this account',
+    'Request was unauthorized',
+    'Conecta primero tu cuenta de GitHub Copilot en Proveedores y modelos.',
+    'La suscripción de ChatGPT no está conectada.',
+  ]) {
+    const verdict = classifyProviderError(new Error(message));
+    assert.equal(verdict.config, true, `should be a config error: ${message}`);
+    assert.equal(verdict.retriable, false, `auth is never worth an automatic retry: ${message}`);
+  }
+
+  for (const message of ['rate limit exceeded', 'Se alcanzó el límite del plan', 'connection reset by peer']) {
+    const verdict = classifyProviderError(new Error(message));
+    assert.equal(verdict.retriable, true, `should be retriable: ${message}`);
+    assert.equal(verdict.config, false);
+  }
+
+  const unknown = classifyProviderError(new Error('something entirely unexpected'));
+  assert.equal(unknown.retriable, false);
+  assert.equal(unknown.config, false);
+});
+
+test('a typed provider error outranks whatever its message happens to say', () => {
+  // The runtime's own timeout text mentions no keyword the heuristic would catch;
+  // before the type existed it was reported as permanent and never retried.
+  const timeout = classifyProviderError(
+    new ProviderRuntimeError('Codex no respondió a «turn/start».', 'timeout')
+  );
+  assert.deepEqual(timeout, {
+    message: 'Codex no respondió a «turn/start».',
+    retriable: true,
+    config: false,
+  });
+
+  const auth = classifyProviderError(new ProviderRuntimeError('nada reconocible', 'auth'));
+  assert.equal(auth.config, true);
+  assert.equal(auth.retriable, false);
+
+  const invalid = classifyProviderError(new ProviderRuntimeError('modelo no soportado', 'invalid'));
+  assert.equal(invalid.retriable, false);
+  assert.equal(invalid.config, false);
+});
+
+test('a runtime that dies mid-request rejects as retriable instead of hanging', async () => {
+  const server = fakeServer('crash-midway', `${INITIALIZE}
+for await (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') { reply(msg.id, {}); continue; }
+  if (msg.method === 'initialized') continue;
+  process.exit(9); // die while a request is in flight
+}`);
+  const runtime = client(server, 5_000);
+  await assert.rejects(
+    () => runtime.request('turn/start', {}),
+    (error) => {
+      const verdict = classifyProviderError(error);
+      assert.equal(verdict.retriable, true, 'a crashed runtime is a transient failure');
+      assert.match(error.message, /se cerró inesperadamente/);
+      return true;
+    }
+  );
+  await runtime.stop();
+});
+
+test('a silent runtime times out as retriable rather than as a permanent error', async () => {
+  const server = fakeServer('never-answers', `${INITIALIZE}
+for await (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') { reply(msg.id, {}); continue; }
+  // Everything else is swallowed on purpose.
+}`);
+  const runtime = client(server, 250);
+  await assert.rejects(
+    () => runtime.request('turn/start', {}),
+    (error) => {
+      assert.equal(classifyProviderError(error).retriable, true);
+      assert.match(error.message, /tiempo esperado/);
+      return true;
+    }
+  );
+  await runtime.stop();
+});
+
+test('a JSON-RPC response split across writes is still parsed', async () => {
+  // readline reassembles across chunk boundaries; a hand-rolled buffer would not.
+  const server = fakeServer('split-writes', `${INITIALIZE}
+for await (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialized') continue;
+  const payload = JSON.stringify({ id: msg.id, result: { ok: true, value: 'reassembled' } });
+  const cut = Math.floor(payload.length / 2);
+  process.stdout.write(payload.slice(0, cut));
+  await new Promise((r) => setTimeout(r, 20));
+  process.stdout.write(payload.slice(cut) + '\\n');
+}`);
+  const runtime = client(server, 5_000);
+  const result = await runtime.request('probe', {});
+  assert.deepEqual(result, { ok: true, value: 'reassembled' });
+  await runtime.stop();
+});
+
+test('a server-initiated request is refused without crashing the process', async () => {
+  // This reply is one of the writes that had no error handling on stdin.
+  // The probe reply is deferred until the refusal has actually arrived: the client
+  // sends its next request as soon as initialize resolves, so answering eagerly
+  // would race the refusal and report a false negative.
+  const server = fakeServer('asks-for-tools', `${INITIALIZE}
+let refusal = null;
+let pendingProbe = null;
+const flush = () => {
+  if (pendingProbe !== null && refusal !== null) { reply(pendingProbe, { refusal }); pendingProbe = null; }
+};
+for await (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') {
+    reply(msg.id, {});
+    process.stdout.write(JSON.stringify({ id: 9001, method: 'tool/execute', params: {} }) + '\\n');
+    continue;
+  }
+  if (msg.method === 'initialized') continue;
+  if (msg.id === 9001) { refusal = msg; flush(); continue; }
+  if (msg.method === 'probe') { pendingProbe = msg.id; flush(); }
+}`);
+  const runtime = client(server, 5_000);
+  const seen = await runtime.request('probe', {});
+  assert.equal(seen.refusal?.error?.code, -32601, 'the runtime is told tools are unavailable');
+  await runtime.stop();
+});
+
+test('writing to a runtime that already exited does not raise an uncaught error', async () => {
+  // Without a stdin 'error' listener this EPIPE is an uncaught exception, which in
+  // the real app takes down the whole Electron main process.
+  const server = fakeServer('exits-immediately', `${INITIALIZE}
+for await (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') { reply(msg.id, {}); continue; }
+}`);
+  const runtime = client(server, 200);
+  await runtime.request('initialize-probe', {}).catch(() => undefined);
+
+  const uncaught = [];
+  const onUncaught = (error) => uncaught.push(error);
+  process.on('uncaughtException', onUncaught);
+  try {
+    // Force the pipe shut underneath the client, then keep writing to it.
+    runtime.child?.kill?.('SIGKILL');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    for (let i = 0; i < 5; i++) await runtime.request('probe', {}).catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  } finally {
+    process.off('uncaughtException', onUncaught);
+  }
+  assert.deepEqual(uncaught, [], 'a dead pipe must never surface as an uncaught exception');
+  await runtime.stop();
+});
+
+test('stop() escalates to SIGKILL when the runtime ignores SIGTERM', async () => {
+  // `child.killed` means "a signal was sent", so testing it here made the escalation
+  // unreachable in exactly the case it exists for.
+  const server = fakeServer('ignores-sigterm', `${INITIALIZE}
+process.on('SIGTERM', () => { /* deliberately ignored */ });
+for await (const line of lines) {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') { reply(msg.id, {}); continue; }
+}
+await new Promise(() => {}); // never exit on its own`);
+  const runtime = client(server, 2_000);
+  await runtime.request('initialize-probe', {}).catch(() => undefined);
+  const child = runtime.child;
+  assert.ok(child?.pid, 'the runtime is live before stopping');
+
+  await runtime.stop();
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.equal(child.exitCode !== null || child.signalCode !== null, true, 'the runtime was actually terminated');
+});
+
+test('cancelling a turn settles immediately instead of waiting for the timeout', async () => {
+  // The runtime is not obliged to emit turn/completed after an interrupt. Waiting
+  // for one meant a cancel could hold the caller for the full 180s cap.
+  const calls = [];
+  const controller = new AbortController();
+  const transport = {
+    isRunning: () => true,
+    request: async (method, params) => {
+      calls.push(method);
+      if (method === 'thread/start') return { thread: { id: 'thread-1' } };
+      if (method === 'turn/start') return { turn: { id: 'turn-1' } };
+      return {};
+    },
+    onNotification: (handler) => {
+      // Stream a little, then go silent forever.
+      setTimeout(() => handler('item/agentMessage/delta', { threadId: 'thread-1', delta: 'parcial' }), 10);
+      setTimeout(() => controller.abort(), 30);
+      return () => undefined;
+    },
+  };
+
+  const started = Date.now();
+  const answer = await runIsolatedCodexCompletion(transport, {
+    model: 'gpt-test',
+    system: 'sys',
+    user: 'usr',
+    reasoning: null,
+    workdir: outDir,
+    timeoutMs: 10_000,
+    signal: controller.signal,
+  });
+  assert.equal(answer, 'parcial', 'the caller keeps whatever had already streamed');
+  assert.ok(Date.now() - started < 3_000, 'cancelling does not wait out the turn timeout');
+  assert.ok(calls.includes('turn/interrupt'), 'the runtime is told to stop working');
+});
+
+test('teardown of a dead runtime issues no requests that would respawn it', async () => {
+  // Every transport request goes through ensureStarted(), so an unguarded cleanup
+  // call after a crash restarts the entire Codex process to tidy up a dead thread.
+  const calls = [];
+  let alive = true;
+  const transport = {
+    isRunning: () => alive,
+    request: async (method) => {
+      calls.push(method);
+      if (method === 'thread/start') return { thread: { id: 'thread-1' } };
+      if (method === 'turn/start') { alive = false; throw new Error('el runtime murió'); }
+      return {};
+    },
+    onNotification: () => () => undefined,
+  };
+
+  await assert.rejects(() => runIsolatedCodexCompletion(transport, {
+    model: 'gpt-test',
+    system: 'sys',
+    user: 'usr',
+    reasoning: null,
+    workdir: outDir,
+    timeoutMs: 5_000,
+  }));
+  assert.equal(calls.includes('thread/unsubscribe'), false, 'no cleanup call revives a dead runtime');
+});
+
+test('the JSON retry ladder does not repeat identical requests on subscription providers', () => {
+  // The ladder escalates by lowering temperature and dropping JSON mode. Codex and
+  // Copilot honour neither, so every rung would bill an identical subscription turn.
+  assert.equal(supportsSamplingControls('openai'), true);
+  assert.equal(supportsSamplingControls('opencode-go'), true);
+  assert.equal(supportsSamplingControls('ollama'), true);
+  assert.equal(supportsSamplingControls('codex'), false);
+  assert.equal(supportsSamplingControls('github-copilot'), false);
+});
+
+/** Start a throwaway OpenCode Go stand-in on an ephemeral port. */
+async function openCodeServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise((r) => server.close(r)) };
+}
+
+test('an error inside a 200 stream is retriable, not permanent', async () => {
+  // response.status is 200 by the time an inline error arrives, so passing it
+  // through classified every mid-stream overload as a permanent failure.
+  const server = await openCodeServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    res.write('data: {"choices":[{"delta":{"content":"hola"}}]}\n\n');
+    res.write('data: {"error":{"type":"overloaded_error","message":"upstream saturado"}}\n\n');
+    res.end();
+  });
+  try {
+    await assert.rejects(
+      () => completeWithOpenCodeGo({
+        apiKey: 'k', model: 'gpt-test', system: 's', user: 'u',
+        baseUrl: server.url, onDelta: () => {},
+      }),
+      (error) => {
+        assert.equal(error.status, 529, 'an overload maps to a retriable status');
+        return true;
+      }
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test('a rate limit inside a 200 stream maps to 429', async () => {
+  const server = await openCodeServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    res.write('data: {"error":{"type":"rate_limit_error","message":"slow down"}}\n\n');
+    res.end();
+  });
+  try {
+    await assert.rejects(
+      () => completeWithOpenCodeGo({
+        apiKey: 'k', model: 'gpt-test', system: 's', user: 'u',
+        baseUrl: server.url, onDelta: () => {},
+      }),
+      (error) => { assert.equal(error.status, 429); return true; }
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test('the chosen reasoning effort actually reaches the request body', async () => {
+  // It was declared, threaded through aiClient, and then never read.
+  let seen = null;
+  const server = await openCodeServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => { raw += chunk; });
+    req.on('end', () => {
+      seen = JSON.parse(raw);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }));
+    });
+  });
+  try {
+    await completeWithOpenCodeGo({
+      apiKey: 'k', model: 'gpt-test', system: 's', user: 'u',
+      reasoning: 'high', baseUrl: server.url,
+    });
+    assert.equal(seen.reasoning_effort, 'high');
+
+    await completeWithOpenCodeGo({
+      apiKey: 'k', model: 'gpt-test', system: 's', user: 'u',
+      reasoning: 'off', baseUrl: server.url,
+    });
+    assert.equal('reasoning_effort' in seen, false, '`off` asks for no reasoning at all');
+  } finally {
+    await server.close();
+  }
+});
+
+test('a model that rejects the optional params is retried without them', async () => {
+  // Every other provider degrades this way; this branch returned before reaching
+  // the shared fallback, so one picky model turned into a hard failure.
+  const bodies = [];
+  const server = await openCodeServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => { raw += chunk; });
+    req.on('end', () => {
+      const body = JSON.parse(raw);
+      bodies.push(body);
+      if (body.response_format || body.reasoning_effort) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: { message: 'unsupported parameter' } }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }));
+    });
+  });
+  try {
+    const result = await completeWithOpenCodeGo({
+      apiKey: 'k', model: 'gpt-test', system: 's', user: 'u',
+      jsonMode: true, reasoning: 'high', baseUrl: server.url,
+    });
+    assert.equal(result.text, '{"ok":true}');
+    assert.equal(bodies.length, 2, 'exactly one retry');
+    assert.ok(bodies[0].response_format, 'the first attempt is optimistic');
+    assert.equal(bodies[1].response_format, undefined, 'the retry drops the optional params');
+    assert.equal(bodies[1].reasoning_effort, undefined);
+  } finally {
+    await server.close();
+  }
+});
+
+test('jsonMode is honoured on the Messages route instead of being ignored', async () => {
+  // minimax/qwen go over /v1/messages, which has no response_format — the flag was
+  // simply dropped there, so the same call behaved differently per model family.
+  let seen = null;
+  const server = await openCodeServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => { raw += chunk; });
+    req.on('end', () => {
+      seen = JSON.parse(raw);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ content: [{ type: 'text', text: '{"ok":true}' }] }));
+    });
+  });
+  try {
+    await completeWithOpenCodeGo({
+      apiKey: 'k', model: 'qwen3.5-plus', system: 'instrucciones', user: 'u',
+      jsonMode: true, baseUrl: server.url,
+    });
+    assert.match(seen.system, /valid JSON/, 'the JSON contract is stated in the prompt');
+    assert.match(seen.system, /^instrucciones/, 'the original system prompt is preserved');
+  } finally {
+    await server.close();
+  }
+});

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -78,6 +78,32 @@ export function isLocalProvider(provider: AiProvider): provider is LocalProvider
   return provider === 'ollama' || provider === 'lmstudio';
 }
 
+/**
+ * Providers billed against a personal ChatGPT / GitHub subscription instead of
+ * pay-per-use API credit. Their runtimes are agent protocols that accept a prompt, a
+ * model and a reasoning effort and nothing else — which is why the two predicates
+ * below both key off this one list rather than repeating it.
+ */
+export const SUBSCRIPTION_PROVIDERS: AiProvider[] = ['codex', 'github-copilot'];
+
+/** Usage lands on the user's plan quota (weekly/monthly caps), not on API credit. */
+export function isSubscriptionProvider(provider: AiProvider): boolean {
+  return SUBSCRIPTION_PROVIDERS.includes(provider);
+}
+
+/**
+ * Whether a provider honours per-request sampling controls (`temperature`,
+ * `max_tokens`, `response_format`).
+ *
+ * The subscription runtimes do not. That matters to `completeJson`, whose retry
+ * ladder escalates by lowering temperature and then dropping JSON mode — for these
+ * providers every rung is a byte-identical request, so the ladder must not spend
+ * three subscription turns discovering that.
+ */
+export function supportsSamplingControls(provider: AiProvider): boolean {
+  return !isSubscriptionProvider(provider);
+}
+
 /** Server base URL each local provider ships with (no trailing slash). */
 export const DEFAULT_LOCAL_BASE_URLS: Record<LocalProvider, string> = {
   ollama: 'http://localhost:11434',

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,8 +1,28 @@
 import { useEffect, useRef, useState } from 'react';
 import type { AppSettings, ModelRef } from '@shared/types';
+import { isSubscriptionProvider } from '@shared/providers';
 import { modelLabel, sameModel, sortModelRefs } from './ui';
 import { Icon } from './ui';
 import { t } from '../i18n';
+
+/**
+ * Shown next to the pickers that drive high-volume work (scans, extraction, vision,
+ * summaries, fusion). Those providers bill a personal plan with weekly and monthly
+ * caps instead of pay-per-use credit, so a single full-corpus run can exhaust the
+ * quota. This informs rather than blocks: the choice stays the user's.
+ */
+export function SubscriptionQuotaNotice({ model }: { model: ModelRef | null | undefined }) {
+  if (!model || !isSubscriptionProvider(model.provider)) return null;
+  return (
+    <p
+      role="note"
+      data-testid="subscription-quota-notice"
+      className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-200"
+    >
+      {t('Este modelo consume la cuota de tu suscripción, no crédito de API. Un análisis completo del corpus puede agotar el límite semanal o mensual de tu plan.')}
+    </p>
+  );
+}
 
 /**
  * Shared selector over favorite models plus the currently persisted value.

--- a/src/components/OnboardingModelStep.tsx
+++ b/src/components/OnboardingModelStep.tsx
@@ -16,6 +16,7 @@ import {
 } from '@shared/onboardingModels';
 import { t, tx } from '../i18n';
 import { SearchableModelSelect } from './SearchableModelSelect';
+import { SubscriptionQuotaNotice } from './ModelPicker';
 import { Icon } from './ui';
 
 const errorText = (cause: unknown) => (cause instanceof Error ? cause.message : String(cause));
@@ -168,6 +169,12 @@ export function OnboardingModelStep({
               emptyLabel={t('Ningún proveedor respondió todavía.')}
               noteFor={localNote}
             />
+          </div>
+          {/* Onboarding writes this choice to `synthesisModel` in basic mode, which
+              is the fallback for every batch pipeline — so the quota caveat belongs
+              here as much as in Settings. */}
+          <div className="mt-1.5">
+            <SubscriptionQuotaNotice model={aiModel} />
           </div>
         </label>
         <label className="block text-sm">

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -5083,6 +5083,8 @@ export const DE: Record<string, string> = {
   'Conversación, análisis, resúmenes y fallback de cualquier tarea sin modelo propio.':
     'Unterhaltung, Analyse, Zusammenfassungen und Fallback für jede Aufgabe ohne eigenes Modell.',
   'Conversación, análisis, resúmenes y demás tareas de texto.': 'Unterhaltung, Analyse, Zusammenfassungen und weitere Textaufgaben.',
+  'Este modelo consume la cuota de tu suscripción, no crédito de API. Un análisis completo del corpus puede agotar el límite semanal o mensual de tu plan.':
+    'Dieses Modell verbraucht das Kontingent Ihres Abonnements, kein API-Guthaben. Eine vollständige Korpusanalyse kann das Wochen- oder Monatslimit Ihres Tarifs aufbrauchen.',
   'Vault actual': 'Aktueller Arbeitsbereich',
   'Ajustes avanzados del vault {vault}': 'Erweiterte Einstellungen des Arbeitsbereichs {vault}',
   'Ajustes avanzados comunes': 'Gemeinsame erweiterte Einstellungen',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -5320,6 +5320,8 @@ export const EN: Record<string, string> = {
     'Conversation, analysis, summaries and fallback for any task without its own model.',
   'Conversación, análisis, resúmenes y demás tareas de texto.':
     'Conversation, analysis, summaries, and other text tasks.',
+  'Este modelo consume la cuota de tu suscripción, no crédito de API. Un análisis completo del corpus puede agotar el límite semanal o mensual de tu plan.':
+    'This model draws on your subscription quota, not on API credit. A full corpus analysis can exhaust your plan\'s weekly or monthly limit.',
   'Vault actual': 'Current vault',
   'Ajustes avanzados del vault {vault}': 'Advanced settings for the {vault} vault',
   'Ajustes avanzados comunes': 'Shared advanced settings',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -5077,6 +5077,8 @@ export const FR: Record<string, string> = {
   'Conversación, análisis, resúmenes y fallback de cualquier tarea sin modelo propio.':
     'Conversation, analyse, résumés et repli pour toute tâche sans modèle propre.',
   'Conversación, análisis, resúmenes y demás tareas de texto.': 'Conversation, analyse, résumés et autres tâches de texte.',
+  'Este modelo consume la cuota de tu suscripción, no crédito de API. Un análisis completo del corpus puede agotar el límite semanal o mensual de tu plan.':
+    "Ce modèle consomme le quota de votre abonnement, et non du crédit d'API. Une analyse complète du corpus peut épuiser la limite hebdomadaire ou mensuelle de votre offre.",
   'Vault actual': 'Espace actuel',
   'Ajustes avanzados del vault {vault}': 'Paramètres avancés de l\'espace {vault}',
   'Ajustes avanzados comunes': 'Paramètres avancés communs',

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -5041,6 +5041,8 @@ export const PT_BR: Record<string, string> = {
   'Conversación, análisis, resúmenes y fallback de cualquier tarea sin modelo propio.':
     'Conversas, análises, resumos e fallback de qualquer tarefa sem modelo próprio.',
   'Conversación, análisis, resúmenes y demás tareas de texto.': 'Conversas, análises, resumos e demais tarefas de texto.',
+  'Este modelo consume la cuota de tu suscripción, no crédito de API. Un análisis completo del corpus puede agotar el límite semanal o mensual de tu plan.':
+    'Este modelo consome a cota da sua assinatura, não crédito de API. Uma análise completa do corpus pode esgotar o limite semanal ou mensal do seu plano.',
   'Vault actual': 'Espaço atual',
   'Ajustes avanzados del vault {vault}': 'Configurações avançadas do espaço {vault}',
   'Ajustes avanzados comunes': 'Configurações avançadas comuns',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -5033,6 +5033,8 @@ export const PT: Record<string, string> = {
   'Conversación, análisis, resúmenes y fallback de cualquier tarea sin modelo propio.':
     'Conversa, análise, resumos e alternativa para qualquer tarefa sem modelo próprio.',
   'Conversación, análisis, resúmenes y demás tareas de texto.': 'Conversa, análise, resumos e restantes tarefas de texto.',
+  'Este modelo consume la cuota de tu suscripción, no crédito de API. Un análisis completo del corpus puede agotar el límite semanal o mensual de tu plan.':
+    'Este modelo consome a quota da sua subscrição, não crédito de API. Uma análise completa do corpus pode esgotar o limite semanal ou mensal do seu plano.',
   'Vault actual': 'Espaço atual',
   'Ajustes avanzados del vault {vault}': 'Definições avançadas do espaço {vault}',
   'Ajustes avanzados comunes': 'Definições avançadas comuns',

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -15,7 +15,7 @@ import { AudioGenerationSettings } from './AudioGenerationSettings';
 import { ConfirmModal } from '../components/ConfirmModal';
 import { confirm } from '../components/feedback';
 import { Icon, PROVIDER_LABELS } from '../components/ui';
-import { ModelPicker } from '../components/ModelPicker';
+import { ModelPicker, SubscriptionQuotaNotice } from '../components/ModelPicker';
 import { NodiStylePicker } from '../components/nodi/NodiStylePicker';
 import { vaultTypeLabel } from '../components/VaultSwitcher';
 import { SttSettings } from '../components/SttSettings';
@@ -1230,9 +1230,14 @@ export function Settings({
                 ? t('Un modelo general atiende conversación, análisis, resúmenes y las demás tareas de texto. Las capacidades especializadas se configuran debajo.')
                 : t('Cada tarea utiliza el modelo concreto seleccionado. Los modelos de las herramientas se guardan solo en el vault actual.')}
             </p>
-            {settings.modelSettingsMode === 'basic' && <Row label={t('Modelo general de texto')} hint={t('Conversación, análisis, resúmenes y demás tareas de texto.')}>
-              <ModelPicker settings={settings} value={settings.synthesisModel} onChange={(m) => patch({ synthesisModel: m })} />
-            </Row>}
+            {settings.modelSettingsMode === 'basic' && <>
+              <Row label={t('Modelo general de texto')} hint={t('Conversación, análisis, resúmenes y demás tareas de texto.')}>
+                <ModelPicker settings={settings} value={settings.synthesisModel} onChange={(m) => patch({ synthesisModel: m })} />
+              </Row>
+              {/* In basic mode this one model runs the scans too, so it is the single
+                  most expensive place to pick a subscription-billed provider. */}
+              <SubscriptionQuotaNotice model={settings.synthesisModel} />
+            </>}
             <Row label={t('Modelo de embeddings (similitud semántica multilingüe)')}>
               <EmbeddingModelControl
                 settings={settings}
@@ -1247,10 +1252,16 @@ export function Settings({
             {settings.modelSettingsMode === 'advanced' && <>
               <div className="mt-5 space-y-3 border-t border-neutral-800 pt-4" data-testid="common-model-overrides">
                 <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-neutral-500">{t('Ajustes avanzados comunes')}</h3>
+                {/* The four selectors below drive the scan pipeline: one run covers a
+                    whole corpus, so a subscription plan's quota is the real limit. */}
                 <Row label={t('Extracción de temas, ideas y evidencias')}><ModelPicker allowEmpty={false} settings={settings} value={settings.extractionModel} onChange={(extractionModel) => void patch({ extractionModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <SubscriptionQuotaNotice model={settings.extractionModel} />
                 <Row label={t('Visión y OCR de imágenes')}><ModelPicker allowEmpty={false} settings={settings} value={settings.visionModel} onChange={(visionModel) => void patch({ visionModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <SubscriptionQuotaNotice model={settings.visionModel} />
                 <Row label={t('Resúmenes de obras')}><ModelPicker allowEmpty={false} settings={settings} value={settings.summaryModel} onChange={(summaryModel) => void patch({ summaryModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <SubscriptionQuotaNotice model={settings.summaryModel} />
                 <Row label={t('Fusión y deduplicación')}><ModelPicker allowEmpty={false} settings={settings} value={settings.fusionModel} onChange={(fusionModel) => void patch({ fusionModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <SubscriptionQuotaNotice model={settings.fusionModel} />
                 <Row label={t('Asistente Nodi')}><ModelPicker allowEmpty={false} settings={settings} value={settings.nodiModel} onChange={(nodiModel) => void patch({ nodiModel })} emptyLabel="Seleccionar modelo" /></Row>
               </div>
               <VaultModelOverrides settings={settings} vaultType={activeVault?.type ?? 'academic'} vaultName={activeVault?.name ?? t('Vault actual')} patch={patch} />


### PR DESCRIPTION
Cierra #64.

Auditoría y corrección de la integración de proveedores por suscripción incorporada en #61. La arquitectura de base no se toca: sigue redistribuyendo los runtimes oficiales, delegando la autenticación en su propio OAuth y aislando cada petición en una sesión efímera sin herramientas. Lo que se corrige son las rutas de fallo, que era donde estaban concentrados todos los defectos porque son las que no tenían pruebas.

## Correcciones

**Caída del proceso principal.** Un `EPIPE` al escribir en un runtime recién muerto era una excepción sin manejador. Se añaden manejadores en `stdin`/`stdout`/`stderr`; el fallo real lo sigue reportando el manejador de `exit`.

**Clasificación de errores.** Nuevo `electron/ai/providerErrors.ts` con `ProviderRuntimeError` tipado, que sustituye cuatro expresiones regulares duplicadas y ya divergentes. Corrige dos casos concretos: los timeouts que estos runtimes emiten dejan de marcarse como permanentes, y un `authentication failed` en inglés pasa a clasificarse como error de configuración — antes no, porque `autentic` no aparece dentro de `authentic`.

**Gasto de cuota.** La escalera de `completeJson` variaba temperatura y modo JSON, que estos proveedores ignoran: tres turnos idénticos facturados. Pasan a dos, y `jsonMode` deja de ser inerte al pedirse por prompt, también en la ruta Messages de OpenCode que lo descartaba entera.

**Ciclo de vida.** El SIGKILL vuelve a ser alcanzable (`child.killed` significa «señal enviada», no «proceso muerto»); la limpieza deja de reactivar runtimes muertos; cancelar resuelve al instante con lo ya recibido en lugar de esperar los 180 s del turno; y el chequeo de cuenta pasa de dos RPC más refresco forzado de token por generación a uno por minuto, invalidado en logout, cierre y cualquier fallo.

**OpenCode Go.** `reasoning` llega al cuerpo de la petición; se añade el reintento sin parámetros opcionales ante un 400 que ya tenían los demás proveedores; los errores dentro de un stream 200 se mapean a 529/429/401/400/502 en lugar de heredar el 200 que los hacía permanentes; y se cancela el reader para no fugar el socket.

**Entorno y catálogo.** El barrido deja de eliminar variables de sesión del escritorio que el CLI necesita para el login. El catálogo de modelos de Copilot gana un TTL de 10 minutos: antes hacía falta cerrar sesión o reiniciar para ver un cambio de plan.

**Cierre de la app.** `before-quit` es síncrono y no espera promesas, así que el drenaje ordenado se abandonaba a medias y dejaba el runtime huérfano con una sesión del llavero abierta. Pasa a un cierre síncrono.

## Aviso de cuota

Nada impedía elegir Codex o Copilot como modelo de extracción o de scan, y una pasada completa sobre un corpus real puede agotar el límite semanal del plan. Se añade un aviso traducido a los cinco idiomas que informa sin bloquear: la decisión sigue siendo del usuario.

Aparece solo en los selectores de alto volumen — el modelo general del modo básico, del que dependen todos los scans; los cuatro del pipeline en modo avanzado; y el paso de onboarding, que escribe ese mismo ajuste. Se omite deliberadamente en Nodi y en los modelos por vault: son superficies de pocas peticiones donde repetir el aviso solo enseñaría a ignorarlo.

## Pruebas

16 pruebas nuevas en `scripts/test-subscription-failure-paths.mjs`, una por defecto corregido: caída a mitad de petición, timeout, JSON-RPC partido entre escrituras, petición del servidor rechazada, `EPIPE`, escalada de SIGKILL, cancelación, limpieza de runtime muerto y los cuatro de OpenCode.

## Verificación

- `npm run typecheck` limpio en ambos proyectos
- `npm test`: 547/547 (la base eran 531)
- `npm run test:e2e` completo, incluido `no renderer page errors`
- `npm run build` correcto
- Cobertura i18n 19/19

## Nota

Se revisó también un posible fallo en la resolución del binario de Copilot y resultó infundado: el paquete declara `exports: { ".": "./copilot" }`, así que `require.resolve` devuelve el ejecutable y no un punto de entrada JS. Se deja como estaba.