### PR TITLE
Nest the toolkit tools under their sidebar section

### DIFF
--- a/scripts/test-basics-tutorial.mjs
+++ b/scripts/test-basics-tutorial.mjs
@@ -123,5 +123,9 @@ test('study analysis exposes chat, review and the question bank without obsolete
     assert.doesNotMatch(navigation, new RegExp(removed));
   }
   assert.doesNotMatch(app, /LOCKED_STUDY_VIEWS/);
-  assert.match(app, /group\.items\.map\(\(n\) => navButton\(n\)\)/);
+  // Every grouped section is a plain nav button — no route is filtered out or
+  // locked. (The toolkit is the one item that also renders nested tool buttons
+  // underneath, which is why the map is no longer a bare navButton call.)
+  assert.match(app, /group\.items\.map\(\(n\) => \(n\.id === 'toolkit' \? \(/);
+  assert.match(app, /\) : navButton\(n\)\)\)/);
 });

--- a/scripts/test-toolkit-ui.mjs
+++ b/scripts/test-toolkit-ui.mjs
@@ -90,26 +90,87 @@ test('the hub renders three tools and only Nodus Convert can be opened', async (
   assert.ok(view.includes('data-testid="toolkit-home"'), 'the hub is addressable');
   // The cards receive their testid as a prop; ToolCard is what stamps it onto the DOM.
   assert.match(view, /data-testid=\{testid\}/, 'ToolCard exposes its testid to the DOM');
-  for (const testid of ['toolkit-card-convert', 'toolkit-card-presenter', 'toolkit-card-aiocr']) {
-    assert.ok(view.includes(`testid="${testid}"`), `${testid} is rendered`);
-  }
-  for (const name of ['Nodus Convert', 'PDF Presenter', 'OCR Workspace']) {
-    assert.ok(view.includes(`name="${name}"`), `${name} keeps its brand name untranslated`);
-  }
-  // Honesty: the two unbuilt tools are inert, and the convert page never claims
-  // to convert anything yet.
-  assert.equal((view.match(/state="soon"/g) ?? []).length, 2, 'presenter and OCR workspace are marked coming soon');
-  assert.equal((view.match(/state="wip"/g) ?? []).length, 1, 'only Nodus Convert is openable');
+
+  // The catalogue is data, not markup: the hub cards and the nested sidebar
+  // buttons both render from TOOLKIT_TOOLS, so they cannot describe a different
+  // set of tools from each other.
+  assert.deepEqual(
+    navigation.TOOLKIT_TOOLS.map((tool) => `toolkit-card-${tool.testid}`),
+    ['toolkit-card-convert', 'toolkit-card-presenter', 'toolkit-card-aiocr']
+  );
+  assert.deepEqual(
+    navigation.TOOLKIT_TOOLS.map((tool) => tool.name),
+    ['Nodus Convert', 'PDF Presenter', 'OCR Workspace'],
+    'brand names stay untranslated'
+  );
+  assert.match(view, /name=\{tool\.name\}/, 'the card shows the brand name verbatim, never through t()');
+  assert.match(view, /description=\{t\(tool\.description\)\}/, 'only the description is translated');
+
+  // Honesty: the two unbuilt tools are inert, and only Convert has a page.
+  assert.deepEqual(
+    navigation.TOOLKIT_TOOLS.filter((tool) => tool.state === 'soon').map((tool) => tool.page),
+    ['presenter', 'ocr'],
+    'presenter and OCR workspace are marked coming soon'
+  );
+  assert.deepEqual(
+    navigation.TOOLKIT_TOOLS.filter((tool) => tool.state === 'wip').map((tool) => tool.page),
+    ['convert'],
+    'only Nodus Convert is openable'
+  );
   assert.match(view, /const disabled = state === 'soon'/);
   assert.match(view, /onClick=\{disabled \? undefined : onOpen\}/, 'a coming-soon card has no click handler');
   // The convert card now opens the real converter, not a placeholder.
   assert.match(view, /<ToolkitConvertView onBack=/, 'Nodus Convert renders the functional converter');
+  // Any page other than 'convert' falls back to the catalogue rather than
+  // rendering an empty pane.
+  assert.match(view, /\{page === 'convert' \? \(/, 'the converter is the only special-cased page');
+});
+
+test('the toolkit nests one sidebar button per tool under its section', async () => {
+  const app = await read('src/App.tsx');
+  // The tools are NOT views: they must never enter NAV_ITEMS, or they would show
+  // up in sidebarOrder, the reordering UI and the vault-type allow-lists.
+  const toolPages = new Set(navigation.TOOLKIT_TOOLS.map((tool) => tool.page));
+  assert.ok(
+    !navigation.NAV_ITEMS.some((n) => toolPages.has(n.id)),
+    'the tools stay out of the canonical nav table'
+  );
+  assert.match(app, /const toolkitSubNav = \(\) =>/, 'the sidebar renders the nested tool buttons');
+  assert.match(app, /TOOLKIT_TOOLS\.map\(\(tool\) => \{/, 'the buttons come from the shared catalogue');
+  assert.match(app, /data-testid=\{`nav-toolkit-\$\{tool\.testid\}`\}/, 'each nested button is addressable');
+  assert.match(app, /n\.id === 'toolkit' \? \(/, 'the nested list hangs off the toolkit item');
+  // Clicking a tool jumps straight to it; clicking the section always lands on
+  // the catalogue, which is the whole point of keeping both buttons.
+  assert.match(
+    app,
+    /setToolkitPage\(tool\.page\); setView\('toolkit'\)/,
+    'a nested button opens its tool directly'
+  );
+  assert.match(app, /if \(n\.id === 'toolkit'\) setToolkitPage\('home'\);/, 'the section button opens the catalogue');
+  // A coming-soon tool is inert in the sidebar too, not just on its card.
+  assert.match(app, /const disabled = tool\.state === 'soon';/, 'unbuilt tools are disabled in the sidebar');
+  // The full brand name does not fit the default 176px sidebar and used to
+  // render as "Nodus Con…"; the nested button drops the prefix the section
+  // already supplies and keeps the full name in its title.
+  assert.match(app, /\{tool\.shortName\}/, 'the nested button uses the short label');
+  assert.match(app, /title=\{disabled \? t\('Próximamente'\) : tool\.name\}/, 'hovering still gives the full brand name');
+  for (const tool of navigation.TOOLKIT_TOOLS) {
+    assert.ok(tool.shortName.length <= 10, `${tool.name} has a sidebar-sized label (${tool.shortName})`);
+    assert.ok(tool.name.includes(tool.shortName), `${tool.shortName} is part of the brand name, not a new word`);
+  }
+  // The section is only highlighted when the catalogue itself is on screen —
+  // otherwise both the parent and the open tool would read as active.
+  assert.match(
+    app,
+    /view === n\.id && \(n\.id !== 'toolkit' \|\| toolkitPage === 'home'\)/,
+    'the section and its open tool never highlight at once'
+  );
 });
 
 test('the hub cards share one shape: equal size, centred icons, pinned badges', async () => {
   const view = await read('src/views/ToolkitView.tsx');
   // One ToolCard component renders all three, so they cannot drift apart.
-  assert.equal((view.match(/<ToolCard\b/g) ?? []).length, 3);
+  assert.equal((view.match(/<ToolCard\b/g) ?? []).length, 1, 'a single ToolCard renders the whole catalogue');
   assert.match(view, /grid gap-4 sm:grid-cols-2 lg:grid-cols-3/, 'cards share a grid track');
   assert.match(view, /className=\{`flex h-full flex-col/, 'each card fills its grid cell');
   assert.match(view, /h-12 w-12 shrink-0 items-center justify-center/, 'the card icon sits in a fixed centred tile');
@@ -128,12 +189,16 @@ test('a tool page returns to the hub and keeps the header action row uniform', a
   assert.ok(convert.includes('data-testid="toolkit-back"'), 'the back control exists');
   assert.match(convert, /<Icon name="chevronLeft"/, 'back uses the shared chevron icon');
   assert.match(convert, /aria-label=\{t\('Volver a Herramientas'\)\}/, 'the back control is labelled for screen readers');
-  assert.match(view, /onBack=\{\(\) => setPage\('home'\)\}/, 'the hub passes a back handler to the tool');
+  assert.match(view, /onBack=\{\(\) => onNavigate\('home'\)\}/, 'the hub passes a back handler to the tool');
   // Header actions are icon-only buttons of one height; the toolkit must not be
   // the odd one out.
   assert.match(app, /icon="tools"\n\s+label=\{t\('Herramientas'\)\}/, 'the header exposes the toolkit');
   assert.match(app, /title=\{t\('Abrir Nodus Toolkit'\)\}/);
-  assert.match(app, /\{view === 'toolkit' && <ToolkitView \/>\}/, 'the view is rendered by the shell');
+  assert.match(
+    app,
+    /\{view === 'toolkit' && <ToolkitView page=\{toolkitPage\} onNavigate=\{setToolkitPage\} \/>\}/,
+    'the view is rendered by the shell, with the active page owned by App'
+  );
   assert.match(app, /const ToolkitView = lazy\(/, 'the view is code-split like its siblings');
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,8 @@ import type {
   PendingLibraryNavigationTarget,
   View,
 } from './navigation';
-import { groupedNav, NAV_ITEMS, NAV_GROUPS } from './navigation';
+import { groupedNav, NAV_ITEMS, NAV_GROUPS, TOOLKIT_TOOLS } from './navigation';
+import type { ToolkitPage } from './navigation';
 import { placeHeaderBadge, type HeaderBadgePlacement } from './headerLayout';
 import { effectiveSidebarHidden, isPreviewVaultType, isViewAllowedForVaultType, viewsDisallowedForType } from '@shared/vaultTypes';
 import { CommandPalette, type Command } from './components/CommandPalette';
@@ -187,6 +188,10 @@ export function App() {
     typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
   );
   const [view, setView] = useState<View>('home');
+  // Página activa dentro de Herramientas. Vive aquí (y no en ToolkitView) porque
+  // el sidebar navega directamente a una herramienta, y porque así salir de la
+  // sección y volver no pierde el sitio aunque la vista se desmonte.
+  const [toolkitPage, setToolkitPage] = useState<ToolkitPage>('home');
   const [navCollapsed, setNavCollapsed] = useState(() => localStorage.getItem('nodus.navCollapsed') === '1');
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     const stored = Number(localStorage.getItem('nodus.sidebarWidth'));
@@ -1055,9 +1060,19 @@ export function App() {
                   disabled={disabled}
                   aria-disabled={disabled}
                   title={disabled ? t('Próximamente') : undefined}
-                  onClick={() => { if (!disabled) setView(n.id); }}
+                  onClick={() => {
+                    if (disabled) return;
+                    // La sección Herramientas siempre entra por el catálogo; sus
+                    // herramientas tienen su propio botón anidado.
+                    if (n.id === 'toolkit') setToolkitPage('home');
+                    setView(n.id);
+                  }}
                   className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-left transition-colors ${
-                    disabled ? 'cursor-not-allowed text-neutral-700 opacity-65' : view === n.id ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:bg-neutral-900'
+                    disabled
+                      ? 'cursor-not-allowed text-neutral-700 opacity-65'
+                      : view === n.id && (n.id !== 'toolkit' || toolkitPage === 'home')
+                        ? 'bg-indigo-600 text-white'
+                        : 'text-neutral-400 hover:bg-neutral-900'
                   }`}
                 >
                   <Icon name={n.icon} className="opacity-70" />
@@ -1084,13 +1099,50 @@ export function App() {
                   {t(label)}
                 </button>
               );
+              // Las herramientas del toolkit se anidan bajo su sección: no son
+              // vistas propias (no entran en NAV_ITEMS ni en sidebarOrder), sólo
+              // atajos a una página del hub. Las que aún no existen se muestran
+              // deshabilitadas, igual que sus tarjetas en el catálogo.
+              const toolkitSubNav = () => (
+                <div className="ml-4 flex flex-col gap-1 border-l border-neutral-800 pl-2">
+                  {TOOLKIT_TOOLS.map((tool) => {
+                    const disabled = tool.state === 'soon';
+                    const active = view === 'toolkit' && toolkitPage === tool.page;
+                    return (
+                      <button
+                        key={tool.page}
+                        data-testid={`nav-toolkit-${tool.testid}`}
+                        disabled={disabled}
+                        aria-disabled={disabled}
+                        title={disabled ? t('Próximamente') : tool.name}
+                        onClick={() => { if (!disabled) { setToolkitPage(tool.page); setView('toolkit'); } }}
+                        className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition-colors ${
+                          disabled
+                            ? 'cursor-not-allowed text-neutral-700 opacity-65'
+                            : active
+                              ? 'bg-indigo-600 text-white'
+                              : 'text-neutral-400 hover:bg-neutral-900'
+                        }`}
+                      >
+                        <Icon name={tool.icon} size={14} className="shrink-0 opacity-70" />
+                        <span className="flex-1 truncate">{tool.shortName}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              );
               const renderGroup = (group: (typeof navGroups)[number]) => {
                 const collapsed = collapsedGroups.has(group.id);
                 const hasActive = group.items.some((n) => n.id === view);
                 return (
                   <div key={group.id} className="mt-2 flex flex-col gap-1">
                     <div className="flex items-center px-3">{groupHeaderButton(group.id, group.label, collapsed, hasActive)}</div>
-                    {!collapsed && group.items.map((n) => navButton(n))}
+                    {!collapsed && group.items.map((n) => (n.id === 'toolkit' ? (
+                      <div key={n.id} className="flex flex-col gap-1">
+                        {navButton(n)}
+                        {toolkitSubNav()}
+                      </div>
+                    ) : navButton(n)))}
                   </div>
                 );
               };
@@ -1423,7 +1475,7 @@ export function App() {
           {view === 'notes' && (
             <NotesView onOpenGraph={(target) => navigate('graph', target)} focusNote={noteTarget} />
           )}
-          {view === 'toolkit' && <ToolkitView />}
+          {view === 'toolkit' && <ToolkitView page={toolkitPage} onNavigate={setToolkitPage} />}
           {view === 'settings' && (
             <Settings
               settings={settings}

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -93,6 +93,63 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'settings', label: 'Ajustes', icon: 'settings' },
 ];
 
+/** Pages inside the Herramientas section. The toolkit keeps a SINGLE entry in the
+ * View union — its tools are addressed by this id instead — so that adding a tool
+ * never turns into a new top-level view (and never leaks into sidebarOrder, the
+ * per-vault-type allow-lists or the reordering UI). The sidebar nests one button
+ * per tool under the section, and 'home' is the catalogue. */
+export type ToolkitPage = 'home' | 'convert' | 'presenter' | 'ocr';
+
+export interface ToolkitToolDef {
+  page: Exclude<ToolkitPage, 'home'>;
+  /** Marca de la herramienta; NO se traduce. */
+  name: string;
+  /** Etiqueta del botón anidado del sidebar: la marca sin el prefijo que ya
+   * aporta la sección, porque el nombre completo no cabe en el ancho por
+   * defecto y se cortaba («Nodus Con…»). El nombre completo sigue en el title
+   * y en la tarjeta del catálogo. */
+  shortName: string;
+  /** Clave i18n (español) de la descripción de la tarjeta. */
+  description: string;
+  icon: string;
+  /** 'wip' = navegable pero en construcción; 'soon' = todavía no existe. */
+  state: 'wip' | 'soon';
+  /** Sufijo de los data-testid (tarjeta del hub y botón del sidebar). */
+  testid: string;
+}
+
+/** Single source of truth for the toolkit catalogue: the hub cards and the nested
+ * sidebar buttons render from this list, so they can never drift apart. */
+export const TOOLKIT_TOOLS: ToolkitToolDef[] = [
+  {
+    page: 'convert',
+    name: 'Nodus Convert',
+    shortName: 'Convert',
+    description: 'Convierte documentos, PDF e imágenes, con OCR ligero y utilidades de texto, de uno en uno o en lote.',
+    icon: 'swap',
+    state: 'wip',
+    testid: 'convert',
+  },
+  {
+    page: 'presenter',
+    name: 'PDF Presenter',
+    shortName: 'Presenter',
+    description: 'Presenta PDFs como diapositivas, con vista del presentador, notas del orador y anotaciones en directo.',
+    icon: 'presentation',
+    state: 'soon',
+    testid: 'presenter',
+  },
+  {
+    page: 'ocr',
+    name: 'OCR Workspace',
+    shortName: 'OCR',
+    description: 'OCR asistido por IA para escaneados difíciles, con revisión página a página e integración con tus bóvedas.',
+    icon: 'scanText',
+    state: 'soon',
+    testid: 'aiocr',
+  },
+];
+
 /**
  * Resolve the sidebar items for a user-defined order. Home is pinned first and
  * Settings is pinned last; neither is ever part of the saved order. Any sections

--- a/src/views/ToolkitView.tsx
+++ b/src/views/ToolkitView.tsx
@@ -1,18 +1,12 @@
 // Nodus Toolkit — el hub de Herramientas: utilidades locales de proceso de
 // archivos (conversión, presentación de PDFs, OCR asistido). La navegación
-// interna (hub ↔ herramienta) vive aquí y no añade ids a la union View: el
-// sidebar tiene una única entrada y cada herramienta se abre desde sus
-// tarjetas, con un botón para volver al hub.
-import { useState } from 'react';
+// interna (catálogo ↔ herramienta) no añade ids a la union View: el sidebar
+// tiene una única entrada de sección con las herramientas anidadas debajo, y la
+// página activa la controla App (así el estado sobrevive a salir de la sección).
 import { Icon } from '../components/ui';
 import { t } from '../i18n';
+import { TOOLKIT_TOOLS, type ToolkitPage } from '../navigation';
 import { ToolkitConvertView } from './ToolkitConvertView';
-
-type ToolkitPage = 'home' | 'convert';
-
-// Se recuerda la última página a nivel de módulo para que salir de la sección
-// y volver no pierda el sitio (mismo patrón que otras vistas con sub-estado).
-let lastToolkitPage: ToolkitPage = 'home';
 
 interface ToolCardProps {
   testid: string;
@@ -62,17 +56,20 @@ function ToolCard({ testid, icon, name, description, state, onOpen }: ToolCardPr
   );
 }
 
-export function ToolkitView() {
-  const [page, setPageState] = useState<ToolkitPage>(lastToolkitPage);
-  const setPage = (next: ToolkitPage) => {
-    lastToolkitPage = next;
-    setPageState(next);
-  };
-
+export function ToolkitView({
+  page,
+  onNavigate,
+}: {
+  page: ToolkitPage;
+  onNavigate: (page: ToolkitPage) => void;
+}) {
   return (
     <div className="h-full overflow-y-auto px-6 py-6 max-md:px-4">
+      {/* Sólo Convert tiene página propia; las otras dos herramientas están
+          deshabilitadas en el catálogo y en el sidebar, así que cualquier otra
+          página cae en el catálogo en lugar de dejar el panel en blanco. */}
       {page === 'convert' ? (
-        <ToolkitConvertView onBack={() => setPage('home')} />
+        <ToolkitConvertView onBack={() => onNavigate('home')} />
       ) : (
         <div data-testid="toolkit-home" className="mx-auto max-w-5xl space-y-6">
           <header className="flex items-start gap-3">
@@ -87,28 +84,17 @@ export function ToolkitView() {
             </div>
           </header>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <ToolCard
-              testid="toolkit-card-convert"
-              icon="swap"
-              name="Nodus Convert"
-              description={t('Convierte documentos, PDF e imágenes, con OCR ligero y utilidades de texto, de uno en uno o en lote.')}
-              state="wip"
-              onOpen={() => setPage('convert')}
-            />
-            <ToolCard
-              testid="toolkit-card-presenter"
-              icon="presentation"
-              name="PDF Presenter"
-              description={t('Presenta PDFs como diapositivas, con vista del presentador, notas del orador y anotaciones en directo.')}
-              state="soon"
-            />
-            <ToolCard
-              testid="toolkit-card-aiocr"
-              icon="scanText"
-              name="OCR Workspace"
-              description={t('OCR asistido por IA para escaneados difíciles, con revisión página a página e integración con tus bóvedas.')}
-              state="soon"
-            />
+            {TOOLKIT_TOOLS.map((tool) => (
+              <ToolCard
+                key={tool.page}
+                testid={`toolkit-card-${tool.testid}`}
+                icon={tool.icon}
+                name={tool.name}
+                description={t(tool.description)}
+                state={tool.state}
+                onOpen={() => onNavigate(tool.page)}
+              />
+            ))}
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #86.

## What changed

The Herramientas section now has a nested sidebar:

```
HERRAMIENTAS
  Nodus Toolkit        → always opens the catalogue
     Convert           → opens the converter directly
     Presenter         → disabled (Próximamente)
     OCR               → disabled (Próximamente)
```

## Design notes

- **The tools are not views.** They stay out of `NAV_ITEMS`, so they never reach `sidebarOrder`, the sidebar reordering UI or the per-vault-type allow-lists. They are pages inside the section, addressed by a `ToolkitPage` id.
- **The active page moved to `App`.** It used to be a module-level `let` inside `ToolkitView`; the sidebar has to navigate to a specific tool, and as a side effect leaving the section and returning no longer loses the open tool.
- **One catalogue, two renderings.** `TOOLKIT_TOOLS` drives both the hub cards and the nested buttons, so they cannot drift apart.
- **Short nested labels.** The full brand name did not fit the default 176px sidebar and truncated to "Nodus Con…". The full name stays on the card and in the button's `title`.
- The section is highlighted only when the catalogue is on screen, so the section and its open tool never read as active at once.

## Verification

Drove the real Electron app against a throwaway profile:

- the three nested buttons render, with Presenter and OCR disabled;
- **Nodus Toolkit** → catalogue; **Convert** → the converter without passing through the hub;
- leaving for another section and returning via **Convert** restores the converter;
- clicking Presenter does not navigate; no page errors.

`npm run typecheck`, `eslint` and the full unit suite (572/572) pass. Two assertions in `test-toolkit-ui.mjs` and one in `test-basics-tutorial.mjs` pinned the previous wiring and were updated; new assertions cover the nested navigation. `npm run test:e2e` was not run — the card testids it uses are unchanged.
