### PR TITLE
Fix Nodi model dropdown styling

### DIFF
--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -71,11 +71,12 @@ test('Nodi and the genealogy assistant receive tags relative to the persisted tr
 });
 
 test('Nodi chat keeps model selection inside settings and exposes deletable history and dedicated scrollbars', async () => {
-  const [component, css, settings, picker, globalCss] = await Promise.all([
+  const [component, css, settings, picker, pickerCss, globalCss] = await Promise.all([
     read('src/components/nodi/NodiCompanion.tsx'),
     read('src/components/nodi/companion.css'),
     read('src/views/Settings.tsx'),
     read('src/components/ModelPicker.tsx'),
+    read('src/components/modelPicker.css'),
     read('src/index.css'),
   ]);
   for (const tool of ['history', 'contexts', 'settings']) assert.match(component, new RegExp(`'${tool}'`));
@@ -101,7 +102,10 @@ test('Nodi chat keeps model selection inside settings and exposes deletable hist
   assert.match(settings, /settings\.nodiModel[^\n]* compact menu/);
   assert.match(picker, /if \(menu\)/);
   assert.match(picker, /model-picker-options/);
-  assert.match(globalCss, /\.model-picker-trigger/);
+  assert.match(picker, /import '\.\/modelPicker\.css'/);
+  assert.match(pickerCss, /\.model-picker-trigger/);
+  assert.match(pickerCss, /position:\s*absolute/);
+  assert.match(pickerCss, /font-family:\s*inherit/);
   assert.match(globalCss, /background-repeat: no-repeat/);
 });
 

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -4,6 +4,7 @@ import { isSubscriptionProvider } from '@shared/providers';
 import { modelLabel, sameModel, sortModelRefs } from './ui';
 import { Icon } from './ui';
 import { t } from '../i18n';
+import './modelPicker.css';
 
 /**
  * Shown next to the pickers that drive high-volume work (scans, extraction, vision,

--- a/src/components/modelPicker.css
+++ b/src/components/modelPicker.css
@@ -1,0 +1,34 @@
+.model-picker-menu { position: relative; width: 100%; }
+.model-picker-trigger {
+  display: flex; width: 100%; min-height: 38px; align-items: center; gap: .5rem;
+  border: 1px solid #404040; border-radius: .5rem; background: #171717; padding: .375rem .65rem;
+  color: #e5e5e5; text-align: left; font-family: inherit; font-size: .875rem; line-height: inherit;
+  outline: none; cursor: pointer;
+}
+.model-picker-menu.compact .model-picker-trigger { min-height: 31px; font-size: .75rem; }
+.model-picker-trigger:hover { border-color: #525252; background: #1f1f1f; }
+.model-picker-trigger:focus-visible { border-color: #6366f1; box-shadow: 0 0 0 2px rgba(99,102,241,.2); }
+.model-picker-trigger:disabled { cursor: default; opacity: .5; }
+.model-picker-trigger > span { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.model-picker-trigger > svg { flex: 0 0 auto; color: #a3a3a3; }
+.model-picker-options {
+  position: absolute; top: calc(100% + 5px); left: 0; right: 0; z-index: 30;
+  display: grid; max-height: 190px; gap: 2px; overflow-y: auto;
+  border: 1px solid #404040; border-radius: .6rem; background: #171717; padding: 4px;
+  box-shadow: 0 12px 30px rgba(0,0,0,.35);
+}
+.model-picker-options button {
+  display: flex; width: 100%; align-items: center; gap: .5rem; border: 0; border-radius: .4rem;
+  background: transparent; padding: .45rem .55rem; color: #d4d4d4; text-align: left;
+  font-family: inherit; font-size: .75rem; line-height: inherit; cursor: pointer;
+}
+.model-picker-options button > span { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.model-picker-options button:hover { background: #262626; color: #fff; }
+.model-picker-options button.selected { background: rgba(79,70,229,.2); color: #c7d2fe; }
+.model-picker-empty { padding: .6rem; color: #737373; font-size: .75rem; text-align: center; }
+.light .model-picker-trigger { border-color: #d4d4d4; background: #fff; color: #171717; }
+.light .model-picker-trigger:hover { border-color: #a3a3a3; background: #fafafa; }
+.light .model-picker-options { border-color: #d4d4d4; background: #fff; box-shadow: 0 12px 30px rgba(0,0,0,.15); }
+.light .model-picker-options button { color: #404040; }
+.light .model-picker-options button:hover { background: #f5f5f5; color: #171717; }
+.light .model-picker-options button.selected { background: #eef2ff; color: #4338ca; }

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -1,4 +1,8 @@
-.nodi-companion { font-family: inherit; }
+.nodi-companion {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.nodi-companion,
+.nodi-companion * { box-sizing: border-box; }
 .nodi-anchor { position: absolute; }
 
 .nodi-figure {
@@ -427,7 +431,7 @@
   font-size: 11px;
 }
 .nodi-chat-tool .model-picker-trigger:hover { border-color: rgba(212,175,55,.45); background: #151e2d; }
-.nodi-chat-tool .model-picker-options { max-height: 128px; border-color: rgba(255,255,255,.13); background: #111824; box-shadow: none; }
+.nodi-chat-tool .model-picker-options { max-height: 160px; border-color: rgba(255,255,255,.13); background: #111824; box-shadow: none; }
 .nodi-chat-tool .model-picker-options button { color: #cbd3df; font-size: 10px; }
 .nodi-chat-tool .model-picker-options button:hover { background: rgba(255,255,255,.06); color: #fff; }
 .nodi-chat-tool .model-picker-options button.selected { background: rgba(212,175,55,.12); color: #f3d67a; }

--- a/src/index.css
+++ b/src/index.css
@@ -1831,38 +1831,6 @@ select.input optgroup {
   color: #171717;
 }
 
-.model-picker-menu { position: relative; width: 100%; }
-.model-picker-trigger {
-  display: flex; width: 100%; min-height: 38px; align-items: center; gap: .5rem;
-  border: 1px solid #404040; border-radius: .5rem; background: #171717; padding: .375rem .65rem;
-  color: #e5e5e5; text-align: left; font-size: .875rem; outline: none;
-}
-.model-picker-menu.compact .model-picker-trigger { min-height: 31px; font-size: .75rem; }
-.model-picker-trigger:hover { border-color: #525252; background: #1f1f1f; }
-.model-picker-trigger:focus-visible { border-color: #6366f1; box-shadow: 0 0 0 2px rgba(99,102,241,.2); }
-.model-picker-trigger:disabled { cursor: default; opacity: .5; }
-.model-picker-trigger > span { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.model-picker-trigger > svg { flex: 0 0 auto; color: #a3a3a3; }
-.model-picker-options {
-  position: relative; z-index: 30; display: grid; max-height: 190px; gap: 2px; overflow-y: auto;
-  margin-top: 5px; border: 1px solid #404040; border-radius: .6rem; background: #171717; padding: 4px;
-  box-shadow: 0 12px 30px rgba(0,0,0,.35);
-}
-.model-picker-options button {
-  display: flex; width: 100%; align-items: center; gap: .5rem; border: 0; border-radius: .4rem;
-  background: transparent; padding: .45rem .55rem; color: #d4d4d4; text-align: left; font-size: .75rem;
-}
-.model-picker-options button > span { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.model-picker-options button:hover { background: #262626; color: #fff; }
-.model-picker-options button.selected { background: rgba(79,70,229,.2); color: #c7d2fe; }
-.model-picker-empty { padding: .6rem; color: #737373; font-size: .75rem; text-align: center; }
-.light .model-picker-trigger { border-color: #d4d4d4; background: #fff; color: #171717; }
-.light .model-picker-trigger:hover { border-color: #a3a3a3; background: #fafafa; }
-.light .model-picker-options { border-color: #d4d4d4; background: #fff; box-shadow: 0 12px 30px rgba(0,0,0,.15); }
-.light .model-picker-options button { color: #404040; }
-.light .model-picker-options button:hover { background: #f5f5f5; color: #171717; }
-.light .model-picker-options button.selected { background: #eef2ff; color: #4338ca; }
-
 .graph-detail-panel {
   font-size: var(--detail-font-size, 14px);
 }


### PR DESCRIPTION
Closes #94

## Summary

- move the shared model picker styles into a component-owned stylesheet so they load in both renderer entry points
- render the options list as an absolute popover instead of expanding the Nodi settings layout
- give the standalone Nodi surface an explicit UI font stack and consistent box sizing
- increase the compact Nodi menu height so the common favorites list fits cleanly
- add regression coverage for the component stylesheet and popover positioning

## Root cause

The reusable model picker styles lived in `src/index.css`, which is loaded by the main application entry point but not by the standalone floating Nodi window. The overlay therefore rendered the picker with incomplete styles and native-looking option buttons. The options container was also positioned in normal document flow, moving the rows below it when opened.

## Validation

- `node --test scripts/test-nodi-assistant.mjs` — 9 tests passed
- `npm run build` — passed, including both TypeScript checks
- visual verification in the standalone Nodi settings panel confirmed all five options render with the intended typography and borders
- layout measurement confirmed the visibility row keeps the same coordinates before and after opening the dropdown