### PR TITLE
Keep README installer links current

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,3 +125,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx electron-builder ${{ matrix.platform }} --publish always
+
+  verify-release-assets:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify stable installer assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          assets="$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+          for asset in \
+            Nodus-mac-arm64.dmg \
+            Nodus-win-x64.exe \
+            Nodus-linux-amd64.deb \
+            Nodus-linux-x86_64.AppImage
+          do
+            if ! grep -Fxq "$asset" <<< "$assets"; then
+              echo "::error::Missing release asset: $asset"
+              exit 1
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Download the installer for your computer and open it. There is no server to conf
 
 | Platform | Latest installer |
 | --- | --- |
-| macOS with Apple silicon | [Download DMG](https://github.com/Drakonis96/nodus/releases/download/v2.2.0/Nodus-2.2.0-mac-arm64.dmg) |
-| Windows 10 and 11 | [Download EXE](https://github.com/Drakonis96/nodus/releases/download/v2.2.0/Nodus-2.2.0-win-x64.exe) |
-| Ubuntu and Debian | [Download DEB](https://github.com/Drakonis96/nodus/releases/download/v2.2.0/Nodus-2.2.0-linux-amd64.deb) |
-| Other Linux distributions | [Download AppImage](https://github.com/Drakonis96/nodus/releases/download/v2.2.0/Nodus-2.2.0-linux-x86_64.AppImage) |
+| macOS with Apple silicon | [Download DMG](https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-mac-arm64.dmg) |
+| Windows 10 and 11 | [Download EXE](https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-win-x64.exe) |
+| Ubuntu and Debian | [Download DEB](https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-linux-amd64.deb) |
+| Other Linux distributions | [Download AppImage](https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-linux-x86_64.AppImage) |
 
 The [latest release page](https://github.com/Drakonis96/nodus/releases/latest) always contains the newest available installers and release notes.
 

--- a/package.json
+++ b/package.json
@@ -184,6 +184,6 @@
       "category": "Office",
       "maintainer": "Drakonis96 <Drakonis96@users.noreply.github.com>"
     },
-    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}"
+    "artifactName": "${productName}-${os}-${arch}.${ext}"
   }
 }


### PR DESCRIPTION
## Summary
- publish release installers with stable filenames
- point the README table at GitHub’s `releases/latest/download` redirects
- fail the release workflow if any expected installer asset is missing

## Validation
- `npm run typecheck`
- `npm test` (582 tests)
- resolved the electron-builder artifact pattern for every documented platform
- parsed `.github/workflows/release.yml` as YAML