### PR TITLE
Add interactive Nodi and Nodus Toolkit to website

### DIFF
--- a/docs/demo/databases.html
+++ b/docs/demo/databases.html
@@ -99,6 +99,6 @@
         });
     })();
   </script>
-  <script src="../nodi.js?v=20260717orb2"></script>
+  <script src="../nodi.js?v=20260720-menu1"></script>
 </body>
 </html>

--- a/docs/demo/demo.css
+++ b/docs/demo/demo.css
@@ -1228,6 +1228,7 @@ textarea.search-input { resize: vertical; min-height: 74px; line-height: 1.5; }
 .teach-head .view-sub { margin-bottom: 0; }
 .teach-mark { display: inline-grid; place-items: center; width: 34px; height: 34px; border-radius: 9px; flex-shrink: 0; color: var(--teach-2); background: var(--teach-soft); }
 .teach-mark svg { width: 17px; height: 17px; }
+.teach .list-row > svg { width: 16px; height: 16px; align-self: center; flex: 0 0 16px; color: var(--text-3); }
 .teach-section-title { margin: 22px 0 10px; font-size: 14px; }
 .teach-planned { border: 1px dashed rgba(251,146,60,.35); }
 .teach-planned small { margin-left: auto; color: #fdba74; font-size: 9px; text-transform: uppercase; }

--- a/docs/demo/genealogy.html
+++ b/docs/demo/genealogy.html
@@ -102,6 +102,6 @@
         });
     })();
   </script>
-  <script src="../nodi.js?v=20260717orb2"></script>
+  <script src="../nodi.js?v=20260720-menu1"></script>
 </body>
 </html>

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -109,6 +109,6 @@
         });
     })();
   </script>
-  <script src="../nodi.js?v=20260717orb2"></script>
+  <script src="../nodi.js?v=20260720-menu1"></script>
 </body>
 </html>

--- a/docs/demo/study.html
+++ b/docs/demo/study.html
@@ -99,6 +99,6 @@
         });
     })();
   </script>
-  <script src="../nodi.js?v=20260717orb2"></script>
+  <script src="../nodi.js?v=20260720-menu1"></script>
 </body>
 </html>

--- a/docs/demo/teaching.html
+++ b/docs/demo/teaching.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="demo.css?v=20260719-teaching1"/>
+  <link rel="stylesheet" href="demo.css?v=20260720-teaching-icons1"/>
 </head>
 <body class="demo-page teach">
   <nav class="site-nav">
@@ -67,6 +67,6 @@
       fetch('https://api.github.com/repos/Drakonis96/nodus', { cache: 'no-store' }).then(function (r) { return r.ok ? r.json() : null; }).then(function (j) { var n = j && Number(j.stargazers_count); if (Number.isFinite(n)) paintStars(n); }).catch(function () {});
     })();
   </script>
-  <script src="../nodi.js?v=20260717orb2"></script>
+  <script src="../nodi.js?v=20260720-menu1"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,19 +165,6 @@
   .scroll-hint svg { width: 18px; height: 18px; }
   @keyframes bob { 0%,100% { transform: translate(-50%,0); } 50% { transform: translate(-50%,8px); } }
 
-  /* floating back-to-top button */
-  #to-top {
-    position: fixed; right: 22px; bottom: 22px; z-index: 45; width: 46px; height: 46px;
-    border-radius: 50%; border: 1px solid var(--border); background: rgba(20,17,32,0.85);
-    color: var(--violet-2); display: grid; place-items: center; cursor: pointer;
-    backdrop-filter: blur(10px); box-shadow: 0 8px 26px rgba(0,0,0,0.5);
-    opacity: 0; visibility: hidden; transform: translateY(12px);
-    transition: opacity 0.25s ease, transform 0.25s ease, visibility 0.25s, border-color 0.2s, background 0.2s;
-  }
-  #to-top.show { opacity: 1; visibility: visible; transform: none; }
-  #to-top:hover { border-color: rgba(167,139,250,0.6); background: rgba(139,92,246,0.18); transform: translateY(-2px); }
-  #to-top svg { width: 20px; height: 20px; }
-
   .n-mark .stroke { stroke-dasharray: 130; stroke-dashoffset: 130; animation: draw 1.6s cubic-bezier(0.6,0,0.2,1) 0.35s forwards; }
   @keyframes draw { to { stroke-dashoffset: 0; } }
   .n-mark circle { opacity: 0; transform-origin: center; animation: pop 0.5s cubic-bezier(0.2,1.6,0.4,1) forwards; }
@@ -189,7 +176,7 @@
 
   /* ---------- sections ---------- */
   section { position: relative; padding: 110px 24px; }
-  #vaults { scroll-margin-top: 64px; }
+  #vaults, #toolkit { scroll-margin-top: 64px; }
   .wrap { max-width: 1080px; margin: 0 auto; }
   .kicker {
     display: inline-flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 700;
@@ -741,6 +728,109 @@
   }
   @media (prefers-reduced-motion: reduce) { .vault-panel { animation: none; } }
 
+  /* ---------- Nodus Toolkit ---------- */
+  .toolkit-head { display: grid; grid-template-columns: minmax(0,.9fr) minmax(320px,1.1fr); gap: 48px; align-items: end; }
+  .toolkit-head .title { max-width: 620px; }
+  .toolkit-head .lead { justify-self: end; }
+  .toolkit-presenter {
+    --tool:#22d3ee; position: relative; overflow: hidden; display: grid; grid-template-columns: minmax(0,.82fr) minmax(420px,1.18fr); gap: 42px;
+    margin-top: 44px; padding: clamp(28px,4vw,46px); border: 1px solid color-mix(in srgb, var(--tool) 34%, var(--border)); border-radius: 24px;
+    background: linear-gradient(135deg, color-mix(in srgb, var(--tool) 9%, var(--bg2)), rgba(14,12,23,.97) 46%, rgba(8,7,13,.98));
+    box-shadow: 0 28px 70px rgba(0,0,0,.28);
+  }
+  .toolkit-presenter::before { content: ''; position: absolute; inset: 0 auto 0 0; width: 3px; background: var(--tool); }
+  .toolkit-presenter::after { content: ''; position: absolute; width: 320px; height: 320px; left: -120px; bottom: -190px; border-radius: 50%; background: var(--tool); filter: blur(110px); opacity: .12; pointer-events: none; }
+  .toolkit-copy { position: relative; z-index: 1; display: flex; flex-direction: column; align-items: flex-start; }
+  .toolkit-label { display: inline-flex; align-items: center; gap: 8px; color: #67e8f9; font-size: 10px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+  .toolkit-label::before { content: ''; width: 7px; height: 7px; border-radius: 50%; background: var(--tool); box-shadow: 0 0 14px color-mix(in srgb, var(--tool) 70%, transparent); }
+  .toolkit-presenter h3 { margin: 14px 0 12px; font: 700 clamp(27px,3vw,36px)/1.08 var(--serif); }
+  .toolkit-presenter p { margin: 0; color: var(--text-2); font-size: 14.5px; line-height: 1.72; }
+  .toolkit-pills { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
+  .toolkit-pill { display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; border: 1px solid color-mix(in srgb, var(--tool) 28%, var(--border)); border-radius: 999px; background: color-mix(in srgb, var(--tool) 8%, transparent); color: color-mix(in srgb, var(--tool) 46%, white); font-size: 11px; font-weight: 650; }
+  .toolkit-pill svg { width: 12px; height: 12px; }
+  .presenter-stage { position: relative; z-index: 1; min-height: 340px; padding: 18px 154px 64px 18px; border: 1px solid rgba(255,255,255,.1); border-radius: 18px; background: #09090d; box-shadow: inset 0 0 0 1px rgba(34,211,238,.04), 0 20px 50px rgba(0,0,0,.34); }
+  .presenter-slide { position: relative; min-height: 254px; overflow: hidden; border-radius: 10px; background: #f5f4ef; color: #18181b; box-shadow: 0 14px 35px rgba(0,0,0,.32); isolation: isolate; }
+  .presenter-slide-content { position: absolute; inset: 0; z-index: 1; padding: 28px; transform-origin: var(--tool-x,50%) var(--tool-y,50%); transition: transform .22s ease; }
+  .presenter-slide-content small { color: #0e7490; font-size: 9px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+  .presenter-slide-content strong { display: block; max-width: 260px; margin: 22px 0 20px; font: 700 22px/1.17 var(--serif); }
+  .presenter-slide-content i { display: block; width: 86%; height: 5px; margin-top: 8px; border-radius: 4px; background: #d4d4d8; }
+  .presenter-slide-content i:nth-of-type(2) { width: 68%; }
+  .presenter-page { position: absolute; right: 14px; bottom: 11px; color: #71717a; font-size: 9px; }
+  .presenter-draw-canvas, .presenter-spotlight { position: absolute; inset: 0; width: 100%; height: 100%; }
+  .presenter-draw-canvas { z-index: 4; pointer-events: none; }
+  .presenter-stage[data-tool="draw"] .presenter-draw-canvas { pointer-events: auto; touch-action: none; cursor: crosshair; }
+  .presenter-spotlight { z-index: 3; opacity: 0; pointer-events: none; background: radial-gradient(circle 66px at var(--tool-x,50%) var(--tool-y,50%), transparent 0 52px, rgba(0,0,0,.16) 54px, rgba(0,0,0,.78) 76px); transition: opacity .16s; }
+  .presenter-stage[data-tool="spotlight"] .presenter-spotlight { opacity: 1; }
+  .presenter-laser { position: absolute; z-index: 5; left: var(--tool-x,50%); top: var(--tool-y,50%); width: 9px; height: 9px; border: 2px solid rgba(255,255,255,.85); border-radius: 50%; background: #ef4444; box-shadow: 0 0 4px #fff, 0 0 13px 5px rgba(239,68,68,.68); opacity: 0; pointer-events: none; transform: translate(-50%,-50%); transition: opacity .16s; }
+  .presenter-stage[data-tool="laser"] .presenter-laser { opacity: 1; }
+  .presenter-stage[data-tool="zoom"] .presenter-slide { cursor: zoom-in; }
+  .presenter-stage[data-tool="zoom"] .presenter-slide.zoomed { cursor: zoom-out; }
+  .presenter-slide.zoomed .presenter-slide-content { transform: scale(1.42); }
+  .presenter-tool-prompt { position: absolute; left: 36px; bottom: 62px; color: #67e8f9; font-size: 9px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; animation: presenter-prompt 1.15s ease-in-out infinite; }
+  .presenter-stage.tools-tried .presenter-tool-prompt { opacity: 0; animation: none; }
+  @keyframes presenter-prompt { 0%,100% { opacity: .55; transform: translateY(0); } 50% { opacity: 1; transform: translateY(-2px); } }
+  .presenter-toolbar { position: absolute; left: 36px; bottom: 16px; display: flex; gap: 5px; padding: 6px; border: 1px solid rgba(255,255,255,.12); border-radius: 10px; background: rgba(23,23,28,.95); box-shadow: 0 10px 30px rgba(0,0,0,.34); }
+  .presenter-toolbar button { position: relative; display: grid; width: 31px; height: 31px; padding: 0; place-items: center; border: 0; border-radius: 7px; background: transparent; color: #a1a1aa; cursor: pointer; }
+  .presenter-toolbar button:hover, .presenter-toolbar button:focus-visible { outline: none; color: #cffafe; background: rgba(34,211,238,.1); }
+  .presenter-toolbar button[aria-pressed="true"] { color: #cffafe; background: rgba(34,211,238,.18); box-shadow: inset 0 0 0 1px rgba(103,232,249,.24); }
+  .presenter-tool-name { position: absolute; left: 50%; bottom: calc(100% + 9px); width: max-content; max-width: 120px; padding: 5px 7px; border: 1px solid rgba(255,255,255,.12); border-radius: 6px; background: #18181d; color: #e4e4e7; box-shadow: 0 8px 22px rgba(0,0,0,.36); font-size: 8px; font-weight: 700; line-height: 1.2; opacity: 0; pointer-events: none; transform: translate(-50%,3px); transition: opacity .14s, transform .14s; }
+  .presenter-toolbar button:hover .presenter-tool-name, .presenter-toolbar button:focus-visible .presenter-tool-name { opacity: 1; transform: translate(-50%,0); }
+  .presenter-toolbar.is-inviting button { animation: presenter-tool-invite 1.8s ease-in-out 3; animation-delay: calc(var(--tool-order,0) * .14s); }
+  @keyframes presenter-tool-invite { 0%,42%,100% { box-shadow: none; } 18% { color: #ecfeff; background: rgba(34,211,238,.2); box-shadow: 0 0 0 4px rgba(34,211,238,.08), 0 0 14px rgba(34,211,238,.3); } }
+  .presenter-toolbar svg { width: 14px; height: 14px; }
+  .presenter-notes { position: absolute; right: 14px; bottom: 16px; width: 164px; padding: 13px; border: 1px solid rgba(255,255,255,.13); border-radius: 12px; background: #18181d; box-shadow: 0 12px 34px rgba(0,0,0,.48); }
+  .presenter-notes b { display: block; margin-bottom: 7px; color: #67e8f9; font-size: 9px; letter-spacing: .1em; text-transform: uppercase; }
+  .presenter-notes p { margin: 0; color: #d4d4d8; font-size: 10px; line-height: 1.45; }
+  .presenter-phone { position: absolute; top: 14px; right: 14px; width: 126px; height: 184px; padding: 9px 8px; border: 2px solid #3f3f46; border-radius: 19px; background: #101014; box-shadow: 0 16px 34px rgba(0,0,0,.5); }
+  .presenter-phone::before { content: ''; display: block; width: 28px; height: 3px; margin: 0 auto 7px; border-radius: 3px; background: #3f3f46; }
+  .presenter-phone-tabs { display: grid; grid-template-columns: 1fr 1fr; gap: 3px; padding: 3px; border-radius: 7px; background: #1c1c21; }
+  .presenter-phone-tabs button { min-width: 0; padding: 4px 2px; border: 0; border-radius: 5px; background: transparent; color: #71717a; font: 700 6.5px/1 var(--sans); cursor: pointer; }
+  .presenter-phone-tabs button[aria-selected="true"] { color: #cffafe; background: rgba(34,211,238,.14); }
+  .presenter-phone-view { padding-top: 8px; }
+  .presenter-phone-view[hidden] { display: none; }
+  .presenter-remote-label { display: block; color: #a1a1aa; font-size: 7px; text-align: center; }
+  .presenter-remote-grid { display: grid; grid-template-columns: repeat(2,1fr); gap: 5px; margin-top: 9px; }
+  .presenter-remote-grid i { display: grid; height: 29px; place-items: center; border-radius: 7px; background: rgba(34,211,238,.1); color: #67e8f9; font-size: 12px; font-style: normal; }
+  .presenter-phone-slide { height: 48px; padding: 7px; border-radius: 5px; background: #efeee9; color: #18181b; }
+  .presenter-phone-slide b { display: block; width: 72%; height: 5px; margin-bottom: 7px; border-radius: 3px; background: #155e75; }
+  .presenter-phone-slide i { display: block; width: 88%; height: 3px; margin-top: 4px; border-radius: 2px; background: #c4c4c8; }
+  .presenter-phone-note b { display: block; margin: 7px 0 3px; color: #67e8f9; font-size: 6.5px; letter-spacing: .06em; text-transform: uppercase; }
+  .presenter-phone-note p { margin: 0; color: #d4d4d8; font-size: 7px; line-height: 1.35; }
+  .toolkit-tools { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 16px; margin-top: 16px; }
+  .tool-card { --tool:var(--violet-2); position: relative; overflow: hidden; min-height: 286px; padding: 25px; border: 1px solid color-mix(in srgb, var(--tool) 28%, var(--border)); border-radius: 18px; background: linear-gradient(150deg, color-mix(in srgb, var(--tool) 7%, var(--bg2)), rgba(8,7,13,.96)); transition: transform .22s, border-color .22s, box-shadow .22s; }
+  .tool-card:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--tool) 52%, var(--border)); box-shadow: 0 18px 45px rgba(0,0,0,.27); }
+  .tool-card::after { content: ''; position: absolute; width: 150px; height: 150px; right: -75px; bottom: -90px; border-radius: 50%; background: var(--tool); filter: blur(65px); opacity: .1; }
+  .tool-icon { position: relative; z-index: 1; display: grid; width: 48px; height: 48px; place-items: center; margin-bottom: 24px; border: 1px solid color-mix(in srgb, var(--tool) 34%, var(--border)); border-radius: 14px; background: color-mix(in srgb, var(--tool) 12%, transparent); color: color-mix(in srgb, var(--tool) 58%, white); }
+  .tool-icon svg { width: 23px; height: 23px; }
+  .tool-card h3 { position: relative; z-index: 1; margin: 0 0 9px; font-size: 18px; }
+  .tool-card p { position: relative; z-index: 1; margin: 0; color: var(--text-2); font-size: 13.5px; line-height: 1.62; }
+  .tool-tags { position: relative; z-index: 1; display: flex; flex-wrap: wrap; gap: 7px; margin-top: 20px; }
+  .tool-tags span { padding: 4px 8px; border: 1px solid color-mix(in srgb, var(--tool) 24%, var(--border)); border-radius: 7px; color: color-mix(in srgb, var(--tool) 48%, white); background: color-mix(in srgb, var(--tool) 7%, transparent); font-size: 10px; font-weight: 700; }
+  @media (max-width: 900px) {
+    .toolkit-head, .toolkit-presenter { grid-template-columns: 1fr; }
+    .toolkit-head { gap: 18px; }
+    .toolkit-head .lead { justify-self: start; }
+    .toolkit-presenter { gap: 30px; }
+    .toolkit-tools { grid-template-columns: repeat(auto-fit,minmax(230px,1fr)); }
+  }
+  @media (max-width: 560px) {
+    .toolkit-presenter { padding: 25px 20px; border-radius: 19px; }
+    .presenter-stage { min-height: 454px; padding: 16px 16px 210px; }
+    .presenter-slide { min-height: 228px; }
+    .presenter-slide-content { padding: 22px; }
+    .presenter-slide-content strong { margin-top: 16px; font-size: 19px; }
+    .presenter-phone { top: auto; right: 16px; bottom: 13px; width: 126px; height: 184px; }
+    .presenter-notes { display: none; }
+    .presenter-toolbar { left: 24px; bottom: 206px; }
+    .presenter-tool-prompt { left: 24px; bottom: 252px; }
+    .toolkit-tools { grid-template-columns: 1fr; }
+    .tool-card { min-height: 0; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .presenter-toolbar.is-inviting button, .presenter-tool-prompt { animation: none; }
+    .presenter-slide-content { transition: none; }
+  }
+
   /* audience strip */
   .who { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-top: 44px; }
   .who-card { padding: 20px 22px; border-radius: 16px; border: 1px solid var(--border); background: var(--card); }
@@ -971,6 +1061,92 @@
         <h4><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m22 9-10-5L2 9l10 5 10-5Z"/><path d="M6 11.5V16c0 1.5 2.7 3 6 3s6-1.5 6-3v-4.5"/></svg> <span data-i18n="who.study.t">If you study</span></h4>
         <p data-i18n="who.study.b">Organise materials, schedules, practice and progress in <b>Study</b>. For advanced projects, <b>Academic</b>, <b>Genealogy</b> and <b>Databases</b> are available now; <b>Primary Sources</b>, <b>Testimony</b> and <b>Prosopography</b> will add specialist paths for archival and social research.</p>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- ---------- Nodus Toolkit ---------- -->
+<section id="toolkit" style="border-top:1px solid var(--border)">
+  <div class="wrap">
+    <div class="toolkit-head">
+      <div>
+        <span class="kicker" data-i18n="toolkit.kicker">Nodus Toolkit · Included</span>
+        <h2 class="title" data-i18n="toolkit.title">Four powerful tools. Already inside Nodus.</h2>
+      </div>
+      <p class="lead" data-i18n="toolkit.lead">Vaults give each project its structure. Nodus Toolkit handles the practical jobs before, during and after it, with focused utilities included in the same private desktop app.</p>
+    </div>
+
+    <article class="toolkit-presenter">
+      <div class="toolkit-copy">
+        <span class="toolkit-label" data-i18n="toolkit.presenter.label">Present differently</span>
+        <h3 id="toolkit-presenter-title" data-i18n="toolkit.presenter.title">PDF Presenter</h3>
+        <p data-i18n="toolkit.presenter.body">Turn any PDF into a lightweight presentation. Give every page its own speaker text, import existing presenter notes or write them in Nodus, and read them from your computer or phone while you present. Use the phone as a remote to change slides and control the live tools.</p>
+        <div class="toolkit-pills">
+          <span class="toolkit-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="2" width="10" height="20" rx="2"/><path d="M11 18h2"/></svg><span data-i18n="toolkit.presenter.remote">Phone remote</span></span>
+          <span class="toolkit-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/></svg><span data-i18n="toolkit.presenter.laser">Laser pointer</span></span>
+          <span class="toolkit-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a9 9 0 1 0 9 9"/><path d="M12 7a5 5 0 1 0 5 5"/></svg><span data-i18n="toolkit.presenter.spotlight">Spotlight</span></span>
+          <span class="toolkit-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m4 20 4.5-1 10-10a2.1 2.1 0 0 0-3-3l-10 10L4 20Z"/><path d="m13.5 8 3 3"/></svg><span data-i18n="toolkit.presenter.draw">Live drawing</span></span>
+          <span class="toolkit-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4M11 8v6M8 11h6"/></svg><span data-i18n="toolkit.presenter.zoom">Zoom</span></span>
+        </div>
+      </div>
+      <div class="presenter-stage" data-tool="none" role="group" aria-labelledby="toolkit-presenter-title">
+        <div class="presenter-slide" id="presenter-demo-slide">
+          <div class="presenter-slide-content">
+            <small data-i18n="toolkit.presenter.visual.kicker">PDF · presentation mode</small>
+            <strong data-i18n="toolkit.presenter.visual.title">Your document, page by page.</strong>
+            <i></i><i></i>
+            <span class="presenter-page" data-i18n="toolkit.presenter.visual.page">Page 12 of 24</span>
+          </div>
+          <canvas class="presenter-draw-canvas" aria-hidden="true"></canvas>
+          <div class="presenter-spotlight" aria-hidden="true"></div>
+          <span class="presenter-laser" aria-hidden="true"></span>
+        </div>
+        <div class="presenter-tool-prompt" data-i18n="toolkit.presenter.try">Try the live tools ↓</div>
+        <div class="presenter-toolbar is-inviting" role="toolbar" aria-label="Presentation tools">
+          <button type="button" data-presenter-tool="none" aria-pressed="true" style="--tool-order:0"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 3 12 9-6 1.5L9 20 5 3Z"/></svg><span class="presenter-tool-name" data-i18n="toolkit.presenter.tool.none">No tool</span></button>
+          <button type="button" data-presenter-tool="draw" aria-pressed="false" style="--tool-order:1"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m4 20 4.5-1 10-10a2.1 2.1 0 0 0-3-3l-10 10L4 20Z"/><path d="m13.5 8 3 3"/></svg><span class="presenter-tool-name" data-i18n="toolkit.presenter.tool.draw">Draw</span></button>
+          <button type="button" data-presenter-tool="spotlight" aria-pressed="false" style="--tool-order:2"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a9 9 0 1 0 9 9"/><path d="M12 7a5 5 0 1 0 5 5"/></svg><span class="presenter-tool-name" data-i18n="toolkit.presenter.tool.spotlight">Spotlight</span></button>
+          <button type="button" data-presenter-tool="laser" aria-pressed="false" style="--tool-order:3"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/></svg><span class="presenter-tool-name" data-i18n="toolkit.presenter.tool.laser">Laser pointer</span></button>
+          <button type="button" data-presenter-tool="zoom" aria-pressed="false" style="--tool-order:4"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4M11 8v6M8 11h6"/></svg><span class="presenter-tool-name" data-i18n="toolkit.presenter.tool.zoom">Zoom</span></button>
+        </div>
+        <div class="presenter-notes"><b data-i18n="toolkit.presenter.visual.notes">Your notes · page 12</b><p data-i18n="toolkit.presenter.visual.note">Pause here. Compare the two sources before revealing the next page.</p></div>
+        <div class="presenter-phone">
+          <div class="presenter-phone-tabs" role="tablist" aria-label="Phone preview">
+            <button type="button" role="tab" data-phone-preview="remote" aria-selected="false" data-i18n="toolkit.presenter.phone.remote">Remote</button>
+            <button type="button" role="tab" data-phone-preview="notes" aria-selected="true" data-i18n="toolkit.presenter.phone.notes">Notes</button>
+          </div>
+          <div class="presenter-phone-view" data-phone-view="remote" role="tabpanel" hidden>
+            <span class="presenter-remote-label" data-i18n="toolkit.presenter.visual.remote">Remote</span>
+            <div class="presenter-remote-grid"><i>‹</i><i>›</i><i>●</i><i>⌕</i></div>
+          </div>
+          <div class="presenter-phone-view presenter-phone-note" data-phone-view="notes" role="tabpanel">
+            <div class="presenter-phone-slide"><b></b><i></i><i></i></div>
+            <b data-i18n="toolkit.presenter.phone.page">Page 12 · notes</b>
+            <p data-i18n="toolkit.presenter.phone.note">Compare both sources before moving on.</p>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <div class="toolkit-tools">
+      <article class="tool-card" style="--tool:#a78bfa">
+        <span class="tool-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7h11l-3-3M17 17H6l3 3M18 7l-3 3M6 17l3-3"/></svg></span>
+        <h3 data-i18n="toolkit.converter.title">Nodus Converter</h3>
+        <p data-i18n="toolkit.converter.body">Change files into the format you need from one focused workspace, without bouncing between online services or losing track of the original.</p>
+        <div class="tool-tags"><span data-i18n="toolkit.converter.tag1">Format conversion</span><span data-i18n="toolkit.converter.tag2">Original preserved</span></div>
+      </article>
+      <article class="tool-card" style="--tool:#34d399">
+        <span class="tool-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V4h3M17 4h3v3M20 17v3h-3M7 20H4v-3M7 9h10M7 12h10M7 15h7"/></svg></span>
+        <h3 data-i18n="toolkit.ocr.title">Nodus OCR</h3>
+        <p data-i18n="toolkit.ocr.body">Choose the right extraction path for each document: visual AI for difficult layouts and images, or conventional OCR engines for fast, non-AI text recognition.</p>
+        <div class="tool-tags"><span data-i18n="toolkit.ocr.tag1">Visual AI</span><span data-i18n="toolkit.ocr.tag2">Conventional OCR</span></div>
+      </article>
+      <article class="tool-card" style="--tool:#f472b6">
+        <span class="tool-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 4.5 6v5.5c0 4.7 3.2 7.8 7.5 9.5 4.3-1.7 7.5-4.8 7.5-9.5V6L12 3Z"/><path d="m9 12 2 2 4-4"/></svg></span>
+        <h3 data-i18n="toolkit.protector.title">Nodus Protector</h3>
+        <p data-i18n="toolkit.protector.body">Create shareable copies with visible or invisible watermarks while keeping the untouched original safe in your workspace.</p>
+        <div class="tool-tags"><span data-i18n="toolkit.protector.tag1">Visible marks</span><span data-i18n="toolkit.protector.tag2">Invisible marks</span></div>
+      </article>
     </div>
   </div>
 </section>
@@ -1423,10 +1599,6 @@
   </div>
 </section>
 
-<button type="button" id="to-top" aria-label="Back to top">
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M6 11l6-6 6 6"/></svg>
-</button>
-
 <footer>
   <div>
     <a href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">GitHub</a> ·
@@ -1467,13 +1639,8 @@
 <script>
 // ---------- nav shadow ----------
 const nav = document.getElementById('nav');
-const toTop = document.getElementById('to-top');
-toTop.addEventListener('click', () => {
-  window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-});
 addEventListener('scroll', () => {
   nav.classList.toggle('scrolled', scrollY > 24);
-  toTop.classList.toggle('show', scrollY > 600);
 }, { passive: true });
 
 // ---------- vault tag selector ----------
@@ -1506,6 +1673,101 @@ addEventListener('scroll', () => {
       activate(next, true);
     });
   });
+})();
+
+// ---------- PDF Presenter interactive preview ----------
+(function () {
+  const stage = document.querySelector('.presenter-stage');
+  if (!stage) return;
+  const slide = stage.querySelector('.presenter-slide');
+  const canvas = stage.querySelector('.presenter-draw-canvas');
+  const ctx = canvas.getContext('2d');
+  const toolbar = stage.querySelector('.presenter-toolbar');
+  const toolButtons = [...stage.querySelectorAll('[data-presenter-tool]')];
+  const phoneTabs = [...stage.querySelectorAll('[data-phone-preview]')];
+  const phoneViews = [...stage.querySelectorAll('[data-phone-view]')];
+  let activeTool = 'none';
+  let drawing = false;
+
+  function resizeCanvas() {
+    const rect = slide.getBoundingClientRect();
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    canvas.width = Math.max(1, Math.round(rect.width * dpr));
+    canvas.height = Math.max(1, Math.round(rect.height * dpr));
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = '#ef4444';
+  }
+
+  function clearDrawing() { ctx.clearRect(0, 0, canvas.width, canvas.height); }
+
+  function pointFrom(event) {
+    const rect = slide.getBoundingClientRect();
+    const x = Math.max(0, Math.min(rect.width, event.clientX - rect.left));
+    const y = Math.max(0, Math.min(rect.height, event.clientY - rect.top));
+    stage.style.setProperty('--tool-x', (x / rect.width * 100).toFixed(2) + '%');
+    stage.style.setProperty('--tool-y', (y / rect.height * 100).toFixed(2) + '%');
+    return { x, y };
+  }
+
+  function resetPreview() {
+    drawing = false;
+    clearDrawing();
+    slide.classList.remove('zoomed');
+    stage.style.setProperty('--tool-x', '50%');
+    stage.style.setProperty('--tool-y', '50%');
+  }
+
+  function selectTool(tool) {
+    resetPreview();
+    activeTool = tool;
+    stage.dataset.tool = tool;
+    stage.classList.add('tools-tried');
+    toolbar.classList.remove('is-inviting');
+    toolButtons.forEach((button) => button.setAttribute('aria-pressed', String(button.dataset.presenterTool === tool)));
+  }
+
+  toolButtons.forEach((button) => button.addEventListener('click', () => selectTool(button.dataset.presenterTool)));
+
+  slide.addEventListener('pointermove', (event) => {
+    const point = pointFrom(event);
+    if (activeTool !== 'draw' || !drawing) return;
+    ctx.lineTo(point.x, point.y);
+    ctx.stroke();
+  });
+  slide.addEventListener('pointerdown', (event) => {
+    const point = pointFrom(event);
+    if (activeTool === 'draw') {
+      event.preventDefault();
+      drawing = true;
+      slide.setPointerCapture(event.pointerId);
+      ctx.beginPath();
+      ctx.moveTo(point.x, point.y);
+      ctx.lineTo(point.x + .01, point.y + .01);
+      ctx.stroke();
+    } else if (activeTool === 'zoom') {
+      event.preventDefault();
+      slide.classList.toggle('zoomed');
+    }
+  });
+  function endDrawing(event) {
+    drawing = false;
+    if (slide.hasPointerCapture && slide.hasPointerCapture(event.pointerId)) slide.releasePointerCapture(event.pointerId);
+  }
+  slide.addEventListener('pointerup', endDrawing);
+  slide.addEventListener('pointercancel', endDrawing);
+
+  phoneTabs.forEach((tab) => tab.addEventListener('click', () => {
+    const view = tab.dataset.phonePreview;
+    phoneTabs.forEach((item) => item.setAttribute('aria-selected', String(item === tab)));
+    phoneViews.forEach((panel) => { panel.hidden = panel.dataset.phoneView !== view; });
+  }));
+
+  resizeCanvas();
+  if ('ResizeObserver' in window) new ResizeObserver(resizeCanvas).observe(slide);
+  else window.addEventListener('resize', resizeCanvas);
 })();
 
 // ---------- hero constellation canvas ----------
@@ -2072,6 +2334,23 @@ const I18N_V2 = {
     'github.downloads': `{n} descargas`, 'github.downloads.tooltip': `Descargas de paquetes desde GitHub Releases · actualizado diariamente`,
     'vaults.kicker': `Los vaults`, 'vaults.title': `Cada proyecto, su propio espacio de trabajo.`,
     'vaults.lead': `Un vault es un único archivo en tu dispositivo con un proyecto dentro. Su modo decide qué secciones aparecen y cómo se instruye al asistente de IA. El motor, el almacenamiento privado y los ajustes son los mismos en todos los modos. Hoy hay cinco modos disponibles; Fuentes primarias, Testimonio y Prosopografía muestran lo que llegará después.`,
+    'toolkit.kicker': `Nodus Toolkit · Incluido`,
+    'toolkit.title': `Cuatro herramientas potentes. Ya dentro de Nodus.`,
+    'toolkit.lead': `Los vaults dan estructura a cada proyecto. Nodus Toolkit resuelve las tareas prácticas de antes, durante y después, con utilidades especializadas incluidas en la misma aplicación de escritorio privada.`,
+    'toolkit.presenter.label': `Otra forma de presentar`, 'toolkit.presenter.title': `PDF Presenter`,
+    'toolkit.presenter.body': `Convierte cualquier PDF en una presentación ligera. Asigna a cada página su propio texto, importa las notas del presentador o escríbelas en Nodus, y consúltalas desde el ordenador o el móvil mientras presentas. Usa el teléfono como mando para cambiar de diapositiva y controlar las herramientas en directo.`,
+    'toolkit.presenter.remote': `Mando desde el móvil`, 'toolkit.presenter.laser': `Puntero láser`, 'toolkit.presenter.spotlight': `Modo linterna`, 'toolkit.presenter.draw': `Dibujo en directo`, 'toolkit.presenter.zoom': `Zoom`,
+    'toolkit.presenter.visual.kicker': `PDF · modo presentación`, 'toolkit.presenter.visual.title': `Tu documento, página a página.`, 'toolkit.presenter.visual.page': `Página 12 de 24`,
+    'toolkit.presenter.visual.notes': `Tus notas · página 12`, 'toolkit.presenter.visual.note': `Haz una pausa aquí. Compara las dos fuentes antes de mostrar la página siguiente.`, 'toolkit.presenter.visual.remote': `Mando`,
+    'toolkit.presenter.try': `Prueba las herramientas ↓`,
+    'toolkit.presenter.tool.none': `Sin herramienta`, 'toolkit.presenter.tool.draw': `Dibujar`, 'toolkit.presenter.tool.spotlight': `Modo linterna`, 'toolkit.presenter.tool.laser': `Puntero láser`, 'toolkit.presenter.tool.zoom': `Zoom`,
+    'toolkit.presenter.phone.remote': `Mando`, 'toolkit.presenter.phone.notes': `Notas`, 'toolkit.presenter.phone.page': `Página 12 · notas`, 'toolkit.presenter.phone.note': `Compara las dos fuentes antes de continuar.`,
+    'toolkit.converter.title': `Nodus Converter`, 'toolkit.converter.body': `Convierte archivos al formato que necesites desde un único espacio, sin saltar entre servicios web ni perder de vista el original.`,
+    'toolkit.converter.tag1': `Conversión de formatos`, 'toolkit.converter.tag2': `Original conservado`,
+    'toolkit.ocr.title': `Nodus OCR`, 'toolkit.ocr.body': `Elige el método adecuado para cada documento: IA visual para imágenes y maquetaciones difíciles, o motores OCR convencionales para un reconocimiento de texto rápido y sin IA.`,
+    'toolkit.ocr.tag1': `IA visual`, 'toolkit.ocr.tag2': `OCR convencional`,
+    'toolkit.protector.title': `Nodus Protector`, 'toolkit.protector.body': `Crea copias listas para compartir con marcas de agua visibles o invisibles, mientras el original permanece intacto y seguro en tu espacio de trabajo.`,
+    'toolkit.protector.tag1': `Marcas visibles`, 'toolkit.protector.tag2': `Marcas invisibles`,
     'vaults.academic.t': `Académico`,
     'vaults.academic.b': `Conecta tu biblioteca de Zotero y convierte cada obra en una red de afirmaciones, hallazgos y métodos. Cada idea conserva el pasaje exacto y la página que la sustentan.`,
     'vaults.academic.f1': `<b>Convierte tu biblioteca de Zotero en un grafo de ideas</b>, conectando afirmaciones, hallazgos y métodos con su pasaje y página exactos.`,
@@ -3047,6 +3326,6 @@ function setLang(lang) {
   } else { start(); }
 })();
 </script>
-  <script src="nodi.js?v=20260717orb2"></script>
+  <script src="nodi.js?v=20260720-menu1"></script>
 </body>
 </html>

--- a/docs/nodi-widget.css
+++ b/docs/nodi-widget.css
@@ -1,0 +1,344 @@
+#nodi {
+  --nodi-accent: #22d3c5;
+  --nodi-surface: rgba(17, 15, 29, .97);
+  --nodi-surface-2: rgba(27, 23, 45, .98);
+  --nodi-border: rgba(94, 234, 212, .34);
+  --nodi-text: #f4f2fb;
+  --nodi-muted: #aaa5bd;
+  position: fixed;
+  right: max(14px, env(safe-area-inset-right));
+  bottom: max(8px, env(safe-area-inset-bottom));
+  z-index: 55;
+  width: 136px;
+  height: 144px;
+  display: block;
+  pointer-events: none;
+  color: var(--nodi-text);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+#nodi,
+#nodi * { box-sizing: border-box; }
+
+.nodi-btn {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 136px;
+  height: 144px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  background: none;
+  filter: drop-shadow(0 10px 26px rgba(0, 0, 0, .62));
+  cursor: pointer;
+  pointer-events: auto;
+  transform-origin: 62% 72%;
+  transition: transform .2s ease, filter .2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nodi-btn:hover { transform: scale(1.035); filter: drop-shadow(0 12px 30px rgba(0, 0, 0, .68)); }
+.nodi-btn:active { transform: scale(.97); }
+.nodi-btn:focus-visible { outline: 3px solid rgba(94, 234, 212, .78); outline-offset: -12px; border-radius: 50%; }
+.nodi-btn .nodi-orb { display: block; width: auto; height: 100%; }
+.nodi-btn.waving .nodi-orb .float { animation: nodiorb-web-wave .9s ease-in-out both; }
+
+@keyframes nodiorb-web-wave {
+  0%, 100% { transform: translateY(0) rotate(0); }
+  30% { transform: translateY(-5px) rotate(-4deg); }
+  65% { transform: translateY(-3px) rotate(4deg); }
+}
+
+.nodi-node {
+  position: absolute;
+  right: 47px;
+  bottom: 55px;
+  z-index: 2;
+  width: 50px;
+  height: 50px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1.5px solid var(--nodi-accent);
+  border-radius: 50%;
+  background: #f8fafc;
+  color: #0f8179;
+  box-shadow: 0 9px 24px rgba(0, 0, 0, .44), 0 0 18px rgba(45, 212, 191, .15);
+  cursor: pointer;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(0, 0) scale(.36);
+  transition:
+    transform .35s cubic-bezier(.2, 1.34, .42, 1),
+    opacity .18s ease,
+    background .16s ease,
+    color .16s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nodi-node.open {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translate(var(--dx), var(--dy)) scale(1);
+}
+
+.nodi-node.open:hover { color: #08675f; background: #ecfdfa; transform: translate(var(--dx), var(--dy)) scale(1.07); }
+.nodi-node.open:active { transform: translate(var(--dx), var(--dy)) scale(.94); }
+.nodi-node:focus-visible { outline: 3px solid rgba(94, 234, 212, .65); outline-offset: 3px; }
+.nodi-node svg { width: 24px; height: 24px; }
+.nodi-node-label {
+  position: absolute;
+  right: calc(100% + 8px);
+  top: 50%;
+  padding: 5px 8px;
+  border: 1px solid var(--nodi-border);
+  border-radius: 7px;
+  background: rgba(12, 11, 20, .96);
+  color: var(--nodi-text);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, .34);
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition: opacity .15s ease;
+}
+
+.nodi-node:hover .nodi-node-label,
+.nodi-node:focus-visible .nodi-node-label { opacity: 1; }
+
+.nodi-node-badge {
+  position: absolute;
+  right: -3px;
+  top: -3px;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 4px;
+  border: 2px solid #f8fafc;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 800;
+  line-height: 13px;
+  text-align: center;
+}
+
+.nodi-web-panel {
+  position: fixed;
+  right: 158px;
+  bottom: 22px;
+  z-index: 4;
+  width: min(382px, calc(100vw - 184px));
+  max-height: min(520px, calc(100dvh - 44px));
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--nodi-border);
+  border-radius: 18px;
+  background: linear-gradient(155deg, var(--nodi-surface-2), var(--nodi-surface));
+  color: var(--nodi-text);
+  box-shadow: 0 22px 64px rgba(0, 0, 0, .62), 0 0 0 1px rgba(255, 255, 255, .03) inset;
+  backdrop-filter: blur(18px);
+  pointer-events: auto;
+  transform-origin: bottom right;
+  animation: nodi-web-panel-in .24s cubic-bezier(.2, 1.2, .38, 1);
+}
+
+@keyframes nodi-web-panel-in {
+  from { opacity: 0; transform: translateY(10px) scale(.9); }
+  to { opacity: 1; transform: none; }
+}
+
+.nodi-web-head {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 11px 9px 15px;
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.nodi-web-head .grow { flex: 1; }
+.nodi-web-head button,
+.nodi-web-icon-btn {
+  min-width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--nodi-muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.nodi-web-head button:hover,
+.nodi-web-icon-btn:hover { background: rgba(94, 234, 212, .1); color: #99f6e4; }
+.nodi-web-head button:focus-visible,
+.nodi-web-icon-btn:focus-visible { outline: 2px solid rgba(94, 234, 212, .6); outline-offset: 1px; }
+.nodi-web-head svg,
+.nodi-web-icon-btn svg { width: 16px; height: 16px; }
+
+.nodi-web-body { min-height: 0; overflow-y: auto; padding: 12px; scrollbar-width: thin; scrollbar-color: rgba(94, 234, 212, .3) transparent; }
+.nodi-web-empty { padding: 30px 18px; color: var(--nodi-muted); font-size: 12px; line-height: 1.55; text-align: center; }
+
+.nodi-help { padding: 18px 20px 20px; }
+.nodi-help h3 { margin: 0 0 7px; color: #99f6e4; font-size: 17px; }
+.nodi-help p { margin: 0; color: #d5d1e2; font-size: 13px; line-height: 1.58; }
+.nodi-help ul { margin: 12px 0 0; padding: 0; display: grid; gap: 7px; list-style: none; }
+.nodi-help li { display: grid; grid-template-columns: 28px 1fr; gap: 9px; align-items: start; color: var(--nodi-muted); font-size: 12px; line-height: 1.45; }
+.nodi-help li > span:first-child { width: 27px; height: 27px; display: grid; place-items: center; border-radius: 8px; background: rgba(45, 212, 191, .1); color: #5eead4; }
+.nodi-help li svg { width: 15px; height: 15px; }
+.nodi-help b { color: var(--nodi-text); }
+
+.nodi-notification { display: grid; grid-template-columns: 9px 1fr; gap: 10px; padding: 11px; border-radius: 12px; }
+.nodi-notification + .nodi-notification { margin-top: 4px; }
+.nodi-notification:hover { background: rgba(255, 255, 255, .035); }
+.nodi-notification-dot { width: 7px; height: 7px; margin-top: 6px; border-radius: 50%; background: var(--nodi-accent); box-shadow: 0 0 10px rgba(45, 212, 191, .45); }
+.nodi-notification b { display: block; margin-bottom: 2px; font-size: 12.5px; }
+.nodi-notification p { margin: 0; color: var(--nodi-muted); font-size: 11.5px; line-height: 1.45; }
+
+.nodi-chat-messages {
+  min-height: 218px;
+  max-height: 330px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.nodi-chat-message {
+  max-width: 88%;
+  padding: 8px 10px;
+  border-radius: 12px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.nodi-chat-message.assistant { align-self: flex-start; border-bottom-left-radius: 4px; background: rgba(255, 255, 255, .065); color: #e9e6f1; }
+.nodi-chat-message.user { align-self: flex-end; border-bottom-right-radius: 4px; background: rgba(13, 148, 136, .34); color: #ecfeff; }
+.nodi-chat-suggestions { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 12px 10px; }
+.nodi-chat-suggestions button {
+  padding: 5px 9px;
+  border: 1px solid rgba(94, 234, 212, .25);
+  border-radius: 999px;
+  background: rgba(45, 212, 191, .06);
+  color: #b7eee8;
+  font: 600 10.5px/1.2 inherit;
+  cursor: pointer;
+}
+.nodi-chat-suggestions button:hover { background: rgba(45, 212, 191, .13); }
+.nodi-chat-form { display: grid; grid-template-columns: 1fr 36px; gap: 8px; padding: 10px; border-top: 1px solid rgba(255, 255, 255, .08); }
+.nodi-chat-form textarea {
+  min-height: 38px;
+  max-height: 88px;
+  resize: vertical;
+  padding: 9px 11px;
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: 11px;
+  outline: none;
+  background: rgba(0, 0, 0, .18);
+  color: var(--nodi-text);
+  font: 12px/1.45 inherit;
+}
+.nodi-chat-form textarea:focus { border-color: rgba(94, 234, 212, .55); box-shadow: 0 0 0 3px rgba(45, 212, 191, .08); }
+.nodi-chat-form button {
+  width: 36px;
+  height: 36px;
+  align-self: end;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #0d9488, #14b8a6);
+  color: white;
+  cursor: pointer;
+}
+.nodi-chat-form button:disabled { opacity: .4; cursor: default; }
+.nodi-chat-form button svg { width: 17px; height: 17px; }
+
+.nodi-notes-list { display: grid; gap: 6px; }
+.nodi-note-row { position: relative; display: grid; grid-template-columns: 1fr 30px; gap: 4px; border: 1px solid rgba(255, 255, 255, .08); border-radius: 11px; background: rgba(255, 255, 255, .025); }
+.nodi-note-row:hover { border-color: rgba(94, 234, 212, .28); }
+.nodi-note-open { min-width: 0; padding: 10px 8px 10px 11px; border: 0; background: transparent; color: inherit; text-align: left; cursor: pointer; }
+.nodi-note-open b,
+.nodi-note-open span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nodi-note-open b { font-size: 12.5px; }
+.nodi-note-open span { margin-top: 2px; color: var(--nodi-muted); font-size: 10.5px; }
+.nodi-note-delete { align-self: center; }
+.nodi-note-editor { display: flex; flex: 1; flex-direction: column; min-height: 310px; padding: 12px; }
+.nodi-note-editor input,
+.nodi-note-editor textarea {
+  width: 100%;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--nodi-text);
+  font-family: inherit;
+}
+.nodi-note-editor input { padding: 2px 2px 9px; border-bottom: 1px solid rgba(255, 255, 255, .08); font-size: 14px; font-weight: 700; }
+.nodi-note-editor textarea { flex: 1; min-height: 235px; resize: none; padding: 11px 2px; font-size: 12.5px; line-height: 1.55; }
+.nodi-note-foot { display: flex; align-items: center; gap: 7px; color: var(--nodi-muted); font-size: 10.5px; }
+.nodi-note-foot .grow { flex: 1; }
+.nodi-note-foot button { color: #fca5a5; }
+
+@media (max-width: 700px) {
+  #nodi {
+    right: max(7px, env(safe-area-inset-right));
+    bottom: max(5px, env(safe-area-inset-bottom));
+    width: 94px;
+    height: 100px;
+  }
+  .nodi-btn { width: 94px; height: 100px; }
+  .nodi-node { right: 31px; bottom: 36px; width: 44px; height: 44px; }
+  .nodi-node svg { width: 21px; height: 21px; }
+  .nodi-node.open { transform: translate(var(--mx), var(--my)) scale(1); }
+  .nodi-node.open:hover { transform: translate(var(--mx), var(--my)) scale(1.04); }
+  .nodi-node.open:active { transform: translate(var(--mx), var(--my)) scale(.94); }
+  .nodi-node-label { display: none; }
+  .nodi-web-panel {
+    left: max(8px, env(safe-area-inset-left));
+    right: max(8px, env(safe-area-inset-right));
+    bottom: max(108px, calc(env(safe-area-inset-bottom) + 103px));
+    width: auto;
+    max-height: calc(100dvh - max(124px, calc(env(safe-area-inset-bottom) + 119px)));
+    border-radius: 15px;
+  }
+  .nodi-chat-messages { min-height: 160px; max-height: 260px; }
+  .nodi-note-editor { min-height: 250px; }
+  .nodi-note-editor textarea { min-height: 175px; }
+}
+
+@media (max-width: 370px) {
+  #nodi { width: 84px; height: 90px; }
+  .nodi-btn { width: 84px; height: 90px; }
+  .nodi-node { right: 27px; bottom: 32px; width: 42px; height: 42px; }
+}
+
+@media (max-height: 540px) and (max-width: 900px) {
+  #nodi { width: 78px; height: 84px; }
+  .nodi-btn { width: 78px; height: 84px; }
+  .nodi-node { right: 25px; bottom: 29px; width: 40px; height: 40px; }
+  .nodi-web-panel { bottom: 8px; right: 96px; width: min(382px, calc(100vw - 112px)); max-height: calc(100dvh - 16px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nodi-btn,
+  .nodi-node,
+  .nodi-web-panel { animation: none !important; transition-duration: .001ms !important; }
+}

--- a/docs/nodi-widget.js
+++ b/docs/nodi-widget.js
@@ -1,0 +1,394 @@
+/* Website controls for Nodi. The animated orb stays in nodi.js; this file owns the
+   radial menu and the browser-safe versions of help, notifications, chat and notes. */
+(function () {
+  var ICONS = {
+    help: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9.5 9.5a2.5 2.5 0 0 1 4.5 1.5c0 1.6-2 2-2 3"/><circle cx="12" cy="17" r=".65" fill="currentColor"/></svg>',
+    bell: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6"/><path d="M10 20a2 2 0 0 0 4 0"/></svg>',
+    chat: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 5h16v11H8l-4 3z"/><path d="M8 9h8M8 12.5h5"/></svg>',
+    notes: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"/><path d="M14 3v5h5"/><path d="M9 13h6M9 16.5h4"/></svg>',
+    up: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6"/></svg>',
+    send: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 12l16-7-7 16-2.5-6.5L4 12z"/></svg>',
+    plus: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>',
+    back: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>',
+    trash: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16M9 7V4h6v3M7 7l1 13h8l1-13"/></svg>',
+    close: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18"/></svg>'
+  };
+
+  var EN = {
+    nodiLabel: 'Nodi, the Nodus companion', help: 'Who am I?', notifications: 'Notifications', chat: 'Chat', notes: 'Quick notes', top: 'Back to top', close: 'Close', clear: 'Clear',
+    helpTitle: "Hi! I'm Nodi", helpIntro: 'I am the Nodus companion. On the website I can guide you, keep local notes and help you explore the project.',
+    helpChat: '<b>Chat</b>: ask common questions about Nodus and this website.', helpNotes: '<b>Notes</b>: quick notes saved only in this browser.', helpNotifications: '<b>Notifications</b>: useful local updates from the website.', helpTop: '<b>Up arrow</b>: return smoothly to the top of the page.',
+    noNotifications: 'There are no notifications.', notification1Title: 'Explore the live demos', notification1Body: 'Try each vault mode in your browser from the interactive demo.', notification2Title: 'Free and open source', notification2Body: 'Nodus has no account system or telemetry, and your workspace remains local.', notification3Title: 'Your web notes are local', notification3Body: 'Quick notes created here stay in this browser and are not sent anywhere.',
+    chatTitle: 'Chat with Nodi', chatWelcome: "Hi! Here on the website I can answer common questions and point you to the right section. In the Nodus app, my chat also works with your selected AI model and contexts.", chatPlaceholder: 'Ask Nodi…', send: 'Send',
+    qWhat: 'What is Nodus?', qPrivacy: 'Is it private?', qDemo: 'Where is the demo?',
+    answerWhat: 'Nodus is a free, open-source, local-first desktop workspace for research, teaching and study. It connects your sources, ideas, notes and evidence inside specialized vaults.',
+    answerPrivacy: 'Your Nodus database, extracted text, graph, notes and drafts stay on your computer. If you choose a cloud AI provider, only the text needed for that request is sent under that provider’s terms.',
+    answerDemo: 'Use “Live demo” in the navigation or the main call to action. You can explore Academic, Study, Teaching, Genealogy and Databases vaults without installing anything.',
+    answerDownload: 'Use the “Download” button in the navigation. Nodus is available for macOS, Windows and Linux.',
+    answerZotero: 'Nodus can read your Zotero 7+ library locally. It does not write changes back to Zotero.',
+    answerFree: 'Nodus is free and open source. There are no paid features or Nodus subscription; optional cloud AI usage is billed by the provider you choose.',
+    answerModes: 'Nodus currently includes Academic, Study, Teaching, Genealogy and Databases vaults. Each mode changes the tools and context while sharing the same local engine.',
+    answerAi: 'Nodus can use cloud providers or local models through Ollama and LM Studio. You choose the model; the app does not hide where a request is sent.',
+    answerFallback: 'I can help with the demo, downloads, privacy, Zotero, AI setup and vault modes. For detailed answers, open the FAQ section on this page.',
+    notesTitle: 'Quick notes', newNote: 'New note', emptyNotes: 'You do not have any notes yet. Create the first one with the + button.', untitled: 'Untitled note', titlePlaceholder: 'Title (optional)', notePlaceholder: 'Write your note…', back: 'Back', deleteNote: 'Delete note', saved: 'Saved locally', saving: 'Saving…'
+  };
+
+  var UI = {
+    es: {
+      nodiLabel: 'Nodi, el compañero de Nodus', help: '¿Quién soy?', notifications: 'Notificaciones', chat: 'Chat', notes: 'Notas rápidas', top: 'Subir al inicio', close: 'Cerrar', clear: 'Limpiar',
+      helpTitle: '¡Hola! Soy Nodi', helpIntro: 'Soy el compañero de Nodus. En la web puedo orientarte, guardar notas locales y ayudarte a explorar el proyecto.',
+      helpChat: '<b>Chat</b>: pregúntame dudas habituales sobre Nodus y esta web.', helpNotes: '<b>Notas</b>: apuntes rápidos guardados solo en este navegador.', helpNotifications: '<b>Notificaciones</b>: avisos locales útiles de la web.', helpTop: '<b>Flecha hacia arriba</b>: vuelve suavemente al inicio de la página.',
+      noNotifications: 'No hay notificaciones.', notification1Title: 'Explora las demos interactivas', notification1Body: 'Prueba cada modo de bóveda en tu navegador desde la demo.', notification2Title: 'Gratis y de código abierto', notification2Body: 'Nodus no usa cuentas ni telemetría, y tu espacio de trabajo permanece local.', notification3Title: 'Tus notas web son locales', notification3Body: 'Las notas rápidas creadas aquí se quedan en este navegador y no se envían a ningún sitio.',
+      chatTitle: 'Chat con Nodi', chatWelcome: '¡Hola! En la web puedo responder preguntas habituales y llevarte a la sección adecuada. En la app de Nodus, mi chat también trabaja con el modelo de IA y los contextos que elijas.', chatPlaceholder: 'Escribe a Nodi…', send: 'Enviar',
+      qWhat: '¿Qué es Nodus?', qPrivacy: '¿Es privado?', qDemo: '¿Dónde está la demo?',
+      answerWhat: 'Nodus es un espacio de trabajo de escritorio gratuito, de código abierto y local-first para investigar, enseñar y estudiar. Conecta tus fuentes, ideas, notas y evidencias dentro de bóvedas especializadas.',
+      answerPrivacy: 'La base de datos de Nodus, el texto extraído, el grafo, las notas y los borradores permanecen en tu ordenador. Si eliges un proveedor de IA en la nube, solo se envía el texto necesario para esa petición bajo sus condiciones.',
+      answerDemo: 'Usa «Demo» en la navegación o el botón principal. Puedes explorar las bóvedas Académica, Estudio, Docencia, Genealogía y Bases de datos sin instalar nada.',
+      answerDownload: 'Usa el botón «Descargar» de la navegación. Nodus está disponible para macOS, Windows y Linux.',
+      answerZotero: 'Nodus puede leer localmente tu biblioteca de Zotero 7+. No escribe cambios de vuelta en Zotero.',
+      answerFree: 'Nodus es gratuito y de código abierto. No hay funciones de pago ni suscripción a Nodus; el uso opcional de IA en la nube lo factura el proveedor que elijas.',
+      answerModes: 'Nodus incluye actualmente bóvedas Académica, Estudio, Docencia, Genealogía y Bases de datos. Cada modo adapta las herramientas y el contexto sobre el mismo motor local.',
+      answerAi: 'Nodus puede usar proveedores en la nube o modelos locales mediante Ollama y LM Studio. Tú eliges el modelo; la app no oculta dónde se envía una petición.',
+      answerFallback: 'Puedo ayudarte con la demo, las descargas, la privacidad, Zotero, la configuración de IA y los modos de bóveda. Para respuestas detalladas, abre la sección de preguntas frecuentes de esta página.',
+      notesTitle: 'Notas rápidas', newNote: 'Nueva nota', emptyNotes: 'Aún no tienes notas. Crea la primera con el botón +.', untitled: 'Nota sin título', titlePlaceholder: 'Título (opcional)', notePlaceholder: 'Escribe tu nota…', back: 'Volver', deleteNote: 'Borrar nota', saved: 'Guardado localmente', saving: 'Guardando…'
+    },
+    fr: { help: 'Qui suis-je ?', notifications: 'Notifications', chat: 'Chat', notes: 'Notes rapides', top: 'Retour en haut', close: 'Fermer', clear: 'Effacer', helpTitle: 'Bonjour ! Je suis Nodi', chatTitle: 'Chat avec Nodi', chatPlaceholder: 'Écrivez à Nodi…', send: 'Envoyer', notesTitle: 'Notes rapides', newNote: 'Nouvelle note', emptyNotes: 'Vous n’avez encore aucune note.', untitled: 'Note sans titre', titlePlaceholder: 'Titre (facultatif)', notePlaceholder: 'Écrivez votre note…', back: 'Retour', deleteNote: 'Supprimer la note', saved: 'Enregistré localement', saving: 'Enregistrement…' },
+    it: { help: 'Chi sono?', notifications: 'Notifiche', chat: 'Chat', notes: 'Note rapide', top: 'Torna in alto', close: 'Chiudi', clear: 'Cancella', helpTitle: 'Ciao! Sono Nodi', chatTitle: 'Chat con Nodi', chatPlaceholder: 'Scrivi a Nodi…', send: 'Invia', notesTitle: 'Note rapide', newNote: 'Nuova nota', emptyNotes: 'Non hai ancora note.', untitled: 'Nota senza titolo', titlePlaceholder: 'Titolo (facoltativo)', notePlaceholder: 'Scrivi la tua nota…', back: 'Indietro', deleteNote: 'Elimina nota', saved: 'Salvato localmente', saving: 'Salvataggio…' },
+    de: { help: 'Wer bin ich?', notifications: 'Benachrichtigungen', chat: 'Chat', notes: 'Schnellnotizen', top: 'Nach oben', close: 'Schließen', clear: 'Leeren', helpTitle: 'Hallo! Ich bin Nodi', chatTitle: 'Chat mit Nodi', chatPlaceholder: 'Nodi fragen…', send: 'Senden', notesTitle: 'Schnellnotizen', newNote: 'Neue Notiz', emptyNotes: 'Du hast noch keine Notizen.', untitled: 'Unbenannte Notiz', titlePlaceholder: 'Titel (optional)', notePlaceholder: 'Notiz schreiben…', back: 'Zurück', deleteNote: 'Notiz löschen', saved: 'Lokal gespeichert', saving: 'Speichern…' },
+    pt: { help: 'Quem sou eu?', notifications: 'Notificações', chat: 'Chat', notes: 'Notas rápidas', top: 'Voltar ao topo', close: 'Fechar', clear: 'Limpar', helpTitle: 'Olá! Sou o Nodi', chatTitle: 'Chat com o Nodi', chatPlaceholder: 'Escreva ao Nodi…', send: 'Enviar', notesTitle: 'Notas rápidas', newNote: 'Nova nota', emptyNotes: 'Ainda não tem notas.', untitled: 'Nota sem título', titlePlaceholder: 'Título (opcional)', notePlaceholder: 'Escreva a sua nota…', back: 'Voltar', deleteNote: 'Eliminar nota', saved: 'Guardado localmente', saving: 'A guardar…' },
+    tr: { help: 'Ben kimim?', notifications: 'Bildirimler', chat: 'Sohbet', notes: 'Hızlı notlar', top: 'Başa dön', close: 'Kapat', clear: 'Temizle', helpTitle: 'Merhaba! Ben Nodi', chatTitle: 'Nodi ile sohbet', chatPlaceholder: 'Nodi’ye yaz…', send: 'Gönder', notesTitle: 'Hızlı notlar', newNote: 'Yeni not', emptyNotes: 'Henüz notunuz yok.', untitled: 'Başlıksız not', titlePlaceholder: 'Başlık (isteğe bağlı)', notePlaceholder: 'Notunuzu yazın…', back: 'Geri', deleteNote: 'Notu sil', saved: 'Yerel olarak kaydedildi', saving: 'Kaydediliyor…' },
+    zh: { help: '我是谁？', notifications: '通知', chat: '聊天', notes: '快速笔记', top: '返回顶部', close: '关闭', clear: '清除', helpTitle: '你好！我是 Nodi', chatTitle: '与 Nodi 聊天', chatPlaceholder: '问问 Nodi…', send: '发送', notesTitle: '快速笔记', newNote: '新建笔记', emptyNotes: '还没有笔记。', untitled: '无标题笔记', titlePlaceholder: '标题（可选）', notePlaceholder: '写下笔记…', back: '返回', deleteNote: '删除笔记', saved: '已保存在本地', saving: '正在保存…' },
+    ja: { help: '私は誰？', notifications: '通知', chat: 'チャット', notes: 'クイックノート', top: 'トップへ戻る', close: '閉じる', clear: '消去', helpTitle: 'こんにちは！Nodiです', chatTitle: 'Nodiとチャット', chatPlaceholder: 'Nodiに質問…', send: '送信', notesTitle: 'クイックノート', newNote: '新しいノート', emptyNotes: 'ノートはまだありません。', untitled: '無題のノート', titlePlaceholder: 'タイトル（任意）', notePlaceholder: 'ノートを書く…', back: '戻る', deleteNote: 'ノートを削除', saved: 'ローカルに保存済み', saving: '保存中…' },
+    uk: { help: 'Хто я?', notifications: 'Сповіщення', chat: 'Чат', notes: 'Швидкі нотатки', top: 'На початок', close: 'Закрити', clear: 'Очистити', helpTitle: 'Вітаю! Я Nodi', chatTitle: 'Чат із Nodi', chatPlaceholder: 'Запитайте Nodi…', send: 'Надіслати', notesTitle: 'Швидкі нотатки', newNote: 'Нова нотатка', emptyNotes: 'Нотаток ще немає.', untitled: 'Нотатка без назви', titlePlaceholder: 'Назва (необов’язково)', notePlaceholder: 'Напишіть нотатку…', back: 'Назад', deleteNote: 'Видалити нотатку', saved: 'Збережено локально', saving: 'Збереження…' },
+    ru: { help: 'Кто я?', notifications: 'Уведомления', chat: 'Чат', notes: 'Быстрые заметки', top: 'Наверх', close: 'Закрыть', clear: 'Очистить', helpTitle: 'Привет! Я Nodi', chatTitle: 'Чат с Nodi', chatPlaceholder: 'Спросите Nodi…', send: 'Отправить', notesTitle: 'Быстрые заметки', newNote: 'Новая заметка', emptyNotes: 'Заметок пока нет.', untitled: 'Заметка без названия', titlePlaceholder: 'Название (необязательно)', notePlaceholder: 'Напишите заметку…', back: 'Назад', deleteNote: 'Удалить заметку', saved: 'Сохранено локально', saving: 'Сохранение…' }
+  };
+
+  function escapeHtml(value) {
+    return String(value == null ? '' : value).replace(/[&<>'"]/g, function (char) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char];
+    });
+  }
+
+  window.mountNodiWebsite = function mountNodiWebsite(options) {
+    if (document.getElementById('nodi')) return;
+    var language = typeof options.language === 'function' ? options.language : function () { return document.documentElement.lang || navigator.language || 'en'; };
+    var root = document.createElement('div');
+    root.id = 'nodi';
+    var menuOpen = false;
+    var activeSurface = 'none';
+    var notificationRead = localGet('nodus.web.nodi.notifications.read') === '1';
+    var notificationsCleared = localGet('nodus.web.nodi.notifications.cleared') === '1';
+    var messages = [];
+    var notes = loadNotes();
+    var noteView = 'list';
+    var activeNoteId = null;
+    var saveTimer = 0;
+    var waveTimer = 0;
+    var radial = [
+      { id: 'help', icon: 'help', dx: -143, dy: -5, mx: -109, my: -2 },
+      { id: 'notifications', icon: 'bell', dx: -132, dy: -69, mx: -101, my: -47 },
+      { id: 'chat', icon: 'chat', dx: -96, dy: -120, mx: -73, my: -86 },
+      { id: 'notes', icon: 'notes', dx: -45, dy: -151, mx: -34, my: -110 },
+      { id: 'top', icon: 'up', dx: 11, dy: -155, mx: 7, my: -116 }
+    ];
+
+    root.innerHTML = '<div id="nodi-surface"></div>'
+      + radial.map(function (item, index) {
+        return '<button type="button" class="nodi-node" data-nodi-action="' + item.id + '" style="--dx:' + item.dx + 'px;--dy:' + item.dy + 'px;--mx:' + item.mx + 'px;--my:' + item.my + 'px;transition-delay:' + (index * .03) + 's" tabindex="-1" aria-hidden="true">'
+          + ICONS[item.icon] + '<span class="nodi-node-label"></span>'
+          + (item.id === 'notifications' ? '<span class="nodi-node-badge" hidden></span>' : '') + '</button>';
+      }).join('')
+      + '<button type="button" class="nodi-btn" id="nodi-btn" aria-haspopup="menu" aria-expanded="false">' + options.orbSvg + '</button>';
+    document.body.appendChild(root);
+
+    var btn = root.querySelector('#nodi-btn');
+    var surface = root.querySelector('#nodi-surface');
+    var nodes = Array.prototype.slice.call(root.querySelectorAll('.nodi-node'));
+    if (!messages.length) messages.push({ role: 'assistant', text: copy().chatWelcome });
+    updateLanguage();
+    updateNotificationBadge();
+
+    function languageCode() {
+      var raw = '';
+      try { raw = language() || document.documentElement.lang || navigator.language || 'en'; } catch (error) { raw = document.documentElement.lang || 'en'; }
+      raw = String(raw).replace('_', '-').toLowerCase();
+      if (raw.indexOf('pt') === 0) return 'pt';
+      if (raw.indexOf('zh') === 0) return 'zh';
+      return raw.slice(0, 2);
+    }
+
+    function copy() { return Object.assign({}, EN, UI[languageCode()] || {}); }
+    function localGet(key) { try { return localStorage.getItem(key); } catch (error) { return null; } }
+    function localSet(key, value) { try { localStorage.setItem(key, value); } catch (error) {} }
+
+    function loadNotes() {
+      try {
+        var parsed = JSON.parse(localStorage.getItem('nodus.web.nodi.notes') || '[]');
+        return Array.isArray(parsed) ? parsed.filter(function (note) { return note && typeof note.id === 'string'; }) : [];
+      } catch (error) { return []; }
+    }
+
+    function storeNotes() { localSet('nodus.web.nodi.notes', JSON.stringify(notes)); }
+
+    function updateLanguage() {
+      var t = copy();
+      btn.setAttribute('aria-label', t.nodiLabel);
+      nodes.forEach(function (node) {
+        var label = t[node.getAttribute('data-nodi-action')];
+        node.setAttribute('aria-label', label);
+        node.setAttribute('title', label);
+        node.querySelector('.nodi-node-label').textContent = label;
+      });
+      if (activeSurface !== 'none') renderSurface(activeSurface);
+    }
+
+    function setMenu(next) {
+      menuOpen = next;
+      btn.setAttribute('aria-expanded', String(next));
+      nodes.forEach(function (node, index) {
+        node.classList.toggle('open', next);
+        node.tabIndex = next ? 0 : -1;
+        node.setAttribute('aria-hidden', String(!next));
+        node.style.transitionDelay = ((next ? index : nodes.length - 1 - index) * .03) + 's';
+      });
+      if (next) {
+        btn.classList.add('waving');
+        clearTimeout(waveTimer);
+        waveTimer = setTimeout(function () { btn.classList.remove('waving'); }, 950);
+      }
+    }
+
+    function closeSurface() {
+      clearTimeout(saveTimer);
+      if (activeSurface === 'notes' && noteView === 'editor') saveCurrentNote();
+      activeSurface = 'none';
+      surface.innerHTML = '';
+    }
+
+    function closeAll() { closeSurface(); setMenu(false); }
+
+    function openSurface(kind) {
+      if (activeSurface === kind) { closeSurface(); return; }
+      closeSurface();
+      activeSurface = kind;
+      if (kind === 'notifications') {
+        notificationRead = true;
+        localSet('nodus.web.nodi.notifications.read', '1');
+        updateNotificationBadge();
+      }
+      if (kind === 'notes') { notes = loadNotes(); noteView = 'list'; activeNoteId = null; }
+      renderSurface(kind);
+    }
+
+    function panel(title, body, headActions, extraClass) {
+      return '<section class="nodi-web-panel ' + (extraClass || '') + '" role="dialog" aria-label="' + escapeHtml(title) + '">'
+        + '<header class="nodi-web-head"><span>' + escapeHtml(title) + '</span><span class="grow"></span>' + (headActions || '')
+        + '<button type="button" data-nodi-close aria-label="' + escapeHtml(copy().close) + '" title="' + escapeHtml(copy().close) + '">' + ICONS.close + '</button></header>'
+        + body + '</section>';
+    }
+
+    function renderSurface(kind) {
+      if (activeSurface !== kind) return;
+      if (kind === 'help') renderHelp();
+      else if (kind === 'notifications') renderNotifications();
+      else if (kind === 'chat') renderChat();
+      else if (kind === 'notes') renderNotes();
+      bindSharedPanelControls();
+    }
+
+    function bindSharedPanelControls() {
+      var close = surface.querySelector('[data-nodi-close]');
+      if (close) close.addEventListener('click', closeSurface);
+    }
+
+    function renderHelp() {
+      var t = copy();
+      var rows = [
+        [ICONS.chat, t.helpChat], [ICONS.notes, t.helpNotes], [ICONS.bell, t.helpNotifications], [ICONS.up, t.helpTop]
+      ].map(function (row) { return '<li><span>' + row[0] + '</span><span>' + row[1] + '</span></li>'; }).join('');
+      var body = '<div class="nodi-help"><h3>' + escapeHtml(t.helpTitle) + '</h3><p>' + escapeHtml(t.helpIntro) + '</p><ul>' + rows + '</ul></div>';
+      surface.innerHTML = panel(t.help, body, '', 'nodi-help-panel');
+    }
+
+    function webNotifications() {
+      var t = copy();
+      return [
+        { title: t.notification1Title, body: t.notification1Body },
+        { title: t.notification2Title, body: t.notification2Body },
+        { title: t.notification3Title, body: t.notification3Body }
+      ];
+    }
+
+    function renderNotifications() {
+      var t = copy();
+      var list = notificationsCleared ? [] : webNotifications();
+      var body = list.length
+        ? '<div class="nodi-web-body">' + list.map(function (item) { return '<article class="nodi-notification"><span class="nodi-notification-dot"></span><div><b>' + escapeHtml(item.title) + '</b><p>' + escapeHtml(item.body) + '</p></div></article>'; }).join('') + '</div>'
+        : '<div class="nodi-web-empty">' + escapeHtml(t.noNotifications) + '</div>';
+      var clear = list.length ? '<button type="button" data-clear-notifications>' + escapeHtml(t.clear) + '</button>' : '';
+      surface.innerHTML = panel(t.notifications, body, clear, 'nodi-notifications-panel');
+      var clearButton = surface.querySelector('[data-clear-notifications]');
+      if (clearButton) clearButton.addEventListener('click', function () {
+        notificationsCleared = true;
+        localSet('nodus.web.nodi.notifications.cleared', '1');
+        updateNotificationBadge();
+        renderSurface('notifications');
+      });
+    }
+
+    function updateNotificationBadge() {
+      var badge = root.querySelector('.nodi-node-badge');
+      var unread = notificationsCleared || notificationRead ? 0 : webNotifications().length;
+      badge.hidden = unread === 0;
+      badge.textContent = String(unread);
+    }
+
+    function renderChat() {
+      var t = copy();
+      var body = '<div class="nodi-chat-messages" aria-live="polite">' + messages.map(function (message) {
+        return '<div class="nodi-chat-message ' + message.role + '">' + escapeHtml(message.text) + '</div>';
+      }).join('') + '</div>'
+        + '<div class="nodi-chat-suggestions"><button type="button" data-question="' + escapeHtml(t.qWhat) + '">' + escapeHtml(t.qWhat) + '</button><button type="button" data-question="' + escapeHtml(t.qPrivacy) + '">' + escapeHtml(t.qPrivacy) + '</button><button type="button" data-question="' + escapeHtml(t.qDemo) + '">' + escapeHtml(t.qDemo) + '</button></div>'
+        + '<form class="nodi-chat-form"><textarea rows="1" aria-label="' + escapeHtml(t.chatPlaceholder) + '" placeholder="' + escapeHtml(t.chatPlaceholder) + '"></textarea><button type="submit" disabled aria-label="' + escapeHtml(t.send) + '" title="' + escapeHtml(t.send) + '">' + ICONS.send + '</button></form>';
+      surface.innerHTML = panel(t.chatTitle, body, '', 'nodi-chat-panel');
+      var form = surface.querySelector('.nodi-chat-form');
+      var input = form.querySelector('textarea');
+      var send = form.querySelector('button');
+      input.addEventListener('input', function () { send.disabled = !input.value.trim(); });
+      input.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); if (input.value.trim()) submitQuestion(input.value); }
+      });
+      form.addEventListener('submit', function (event) { event.preventDefault(); if (input.value.trim()) submitQuestion(input.value); });
+      Array.prototype.forEach.call(surface.querySelectorAll('[data-question]'), function (question) {
+        question.addEventListener('click', function () { submitQuestion(question.getAttribute('data-question')); });
+      });
+      requestAnimationFrame(function () {
+        var list = surface.querySelector('.nodi-chat-messages');
+        if (list) list.scrollTop = list.scrollHeight;
+      });
+    }
+
+    function submitQuestion(question) {
+      question = String(question || '').trim();
+      if (!question) return;
+      messages.push({ role: 'user', text: question });
+      messages.push({ role: 'assistant', text: '…' });
+      if (activeSurface === 'chat') renderSurface('chat');
+      var orb = btn.querySelector('.nodi-orb');
+      if (orb) orb.setAttribute('data-state', 'thinking');
+      setTimeout(function () {
+        messages[messages.length - 1] = { role: 'assistant', text: answerFor(question) };
+        if (orb) orb.setAttribute('data-state', 'idle');
+        if (activeSurface === 'chat') renderSurface('chat');
+      }, 480);
+    }
+
+    function answerFor(question) {
+      var t = copy();
+      var q = question.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+      if (/priv|local|telemetr|confiden|datos|data|云|プライバシ|конфиден/.test(q)) return t.answerPrivacy;
+      if (/demo|prueba|try|essai|prova|演示|デモ|демо/.test(q)) return t.answerDemo;
+      if (/download|descarg|baix|telecharg|herunter|indir|下载|ダウンロード|скач/.test(q)) return t.answerDownload;
+      if (/zotero/.test(q)) return t.answerZotero;
+      if (/grat|free|gratis|price|precio|cost|open source|kosten|ücretsiz|免费|無料|бесплат/.test(q)) return t.answerFree;
+      if (/vault|boved|cofre|mode|modo|tresor|kasa|保险库|モード|сховищ|хранилищ/.test(q)) return t.answerModes;
+      if (/(^|\s)(ai|ia|ki)(\s|$)|api|model|ollama|lm studio|intelig|人工智能|модел/.test(q)) return t.answerAi;
+      if (/nodus|que es|what is|cos'e|was ist|nedir|是什么|とは|що таке|что такое/.test(q)) return t.answerWhat;
+      return t.answerFallback;
+    }
+
+    function renderNotes() {
+      if (noteView === 'editor') renderNoteEditor();
+      else renderNoteList();
+    }
+
+    function renderNoteList() {
+      var t = copy();
+      var sorted = notes.slice().sort(function (a, b) { return (b.updatedAt || 0) - (a.updatedAt || 0); });
+      var body = sorted.length ? '<div class="nodi-web-body"><div class="nodi-notes-list">' + sorted.map(function (note) {
+        var summary = String(note.content || '').replace(/\s+/g, ' ').trim().slice(0, 80);
+        return '<article class="nodi-note-row"><button type="button" class="nodi-note-open" data-note-id="' + escapeHtml(note.id) + '"><b>' + escapeHtml(note.title || firstLine(note.content) || t.untitled) + '</b><span>' + escapeHtml(summary || t.saved) + '</span></button><button type="button" class="nodi-web-icon-btn nodi-note-delete" data-delete-note="' + escapeHtml(note.id) + '" aria-label="' + escapeHtml(t.deleteNote) + '" title="' + escapeHtml(t.deleteNote) + '">' + ICONS.trash + '</button></article>';
+      }).join('') + '</div></div>' : '<div class="nodi-web-empty">' + escapeHtml(t.emptyNotes) + '</div>';
+      var add = '<button type="button" data-new-note aria-label="' + escapeHtml(t.newNote) + '" title="' + escapeHtml(t.newNote) + '">' + ICONS.plus + '</button>';
+      surface.innerHTML = panel(t.notesTitle, body, add, 'nodi-notes-panel');
+      surface.querySelector('[data-new-note]').addEventListener('click', function () { openNote(null); });
+      Array.prototype.forEach.call(surface.querySelectorAll('[data-note-id]'), function (button) { button.addEventListener('click', function () { openNote(button.getAttribute('data-note-id')); }); });
+      Array.prototype.forEach.call(surface.querySelectorAll('[data-delete-note]'), function (button) { button.addEventListener('click', function () { deleteNote(button.getAttribute('data-delete-note')); }); });
+    }
+
+    function openNote(id) { activeNoteId = id; noteView = 'editor'; renderSurface('notes'); }
+
+    function renderNoteEditor() {
+      var t = copy();
+      var note = notes.find(function (item) { return item.id === activeNoteId; }) || { title: '', content: '' };
+      var back = '<button type="button" data-back-notes aria-label="' + escapeHtml(t.back) + '" title="' + escapeHtml(t.back) + '">' + ICONS.back + '</button>';
+      var body = '<div class="nodi-note-editor"><input type="text" maxlength="100" value="' + escapeHtml(note.title) + '" placeholder="' + escapeHtml(t.titlePlaceholder) + '" aria-label="' + escapeHtml(t.titlePlaceholder) + '"><textarea placeholder="' + escapeHtml(t.notePlaceholder) + '" aria-label="' + escapeHtml(t.notePlaceholder) + '">' + escapeHtml(note.content) + '</textarea><div class="nodi-note-foot"><span data-note-status>' + escapeHtml(activeNoteId ? t.saved : '') + '</span><span class="grow"></span>' + (activeNoteId ? '<button type="button" class="nodi-web-icon-btn" data-delete-current aria-label="' + escapeHtml(t.deleteNote) + '" title="' + escapeHtml(t.deleteNote) + '">' + ICONS.trash + '</button>' : '') + '</div></div>';
+      surface.innerHTML = panel(activeNoteId ? (note.title || firstLine(note.content) || t.untitled) : t.newNote, body, back, 'nodi-notes-panel');
+      var title = surface.querySelector('.nodi-note-editor input');
+      var content = surface.querySelector('.nodi-note-editor textarea');
+      var status = surface.querySelector('[data-note-status]');
+      function queueSave() {
+        status.textContent = t.saving;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(function () { saveCurrentNote(); status.textContent = t.saved; }, 420);
+      }
+      title.addEventListener('input', queueSave);
+      content.addEventListener('input', queueSave);
+      surface.querySelector('[data-back-notes]').addEventListener('click', function () { saveCurrentNote(); noteView = 'list'; renderSurface('notes'); });
+      var remove = surface.querySelector('[data-delete-current]');
+      if (remove) remove.addEventListener('click', function () { deleteNote(activeNoteId); });
+      requestAnimationFrame(function () { content.focus(); });
+    }
+
+    function saveCurrentNote() {
+      var editor = surface.querySelector('.nodi-note-editor');
+      if (!editor) return;
+      var title = editor.querySelector('input').value.trim();
+      var content = editor.querySelector('textarea').value;
+      if (!title && !content.trim() && !activeNoteId) return;
+      var now = Date.now();
+      var existing = notes.find(function (note) { return note.id === activeNoteId; });
+      if (existing) { existing.title = title; existing.content = content; existing.updatedAt = now; }
+      else {
+        activeNoteId = 'web-note-' + now + '-' + Math.random().toString(36).slice(2, 7);
+        notes.push({ id: activeNoteId, title: title, content: content, updatedAt: now });
+      }
+      storeNotes();
+    }
+
+    function deleteNote(id) {
+      notes = notes.filter(function (note) { return note.id !== id; });
+      storeNotes();
+      activeNoteId = null;
+      noteView = 'list';
+      renderSurface('notes');
+    }
+
+    function firstLine(value) { return String(value || '').split(/\r?\n/).map(function (line) { return line.trim(); }).filter(Boolean)[0] || ''; }
+
+    btn.addEventListener('click', function (event) {
+      event.stopPropagation();
+      if (menuOpen) closeAll();
+      else setMenu(true);
+    });
+
+    nodes.forEach(function (node) {
+      node.addEventListener('click', function (event) {
+        event.stopPropagation();
+        var action = node.getAttribute('data-nodi-action');
+        if (action === 'top') {
+          closeAll();
+          window.scrollTo({ top: 0, left: 0, behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth' });
+        } else openSurface(action);
+      });
+    });
+
+    document.addEventListener('pointerdown', function (event) { if ((menuOpen || activeSurface !== 'none') && !root.contains(event.target)) closeAll(); }, true);
+    document.addEventListener('keydown', function (event) {
+      if (event.key !== 'Escape') return;
+      if (activeSurface !== 'none') closeSurface();
+      else if (menuOpen) setMenu(false);
+    });
+    new MutationObserver(updateLanguage).observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] });
+  };
+})();

--- a/docs/nodi.js
+++ b/docs/nodi.js
@@ -1,8 +1,7 @@
-/* Nodi — the Nodus companion (orb style, ported from the app's NodiOrb) as a small
-   floating recreation for the website. Self-injecting: one <script src="nodi.js">
-   drops the orb into the bottom-right corner of every page. Click it and a speech
-   bubble pops out saying what it does. It shrinks on small screens and never covers
-   the page's own controls. The orb SVG + CSS are a faithful port of
+/* Nodi — the Nodus companion (orb style, ported from the app's NodiOrb) for the
+   website. One <script src="nodi.js"> injects the enlarged responsive orb; the
+   companion widget adds its radial help, notification, chat, notes and back-to-top
+   actions. The orb SVG + CSS are a faithful port of
    src/components/nodi/NodiOrb.tsx + nodiOrb.css. */
 (function () {
   if (window.__nodiMounted) return;
@@ -14,6 +13,10 @@
     try {
       var s = localStorage.getItem('nodus.lang');
       if (s && LINES[s]) return s;
+      var sb = (s || '').slice(0, 2).toLowerCase();
+      if (LINES[sb]) return sb;
+      var d = (document.documentElement.lang || '').slice(0, 2).toLowerCase();
+      if (LINES[d]) return d;
       var n = (navigator.language || 'en').slice(0, 2);
       if (LINES[n]) return n;
     } catch (e) {}
@@ -28,46 +31,22 @@
   style.textContent = WIDGET_CSS + '\n' + ORB_CSS;
   document.head.appendChild(style);
 
-  var root = document.createElement('div');
-  root.id = 'nodi';
-  root.innerHTML =
-    '<div class="nodi-bubble" id="nodi-bubble" role="status" aria-live="polite">'
-    + '<button class="nodi-x" id="nodi-x" aria-label="Close">\u00d7</button>'
-    + '<p class="nodi-p" id="nodi-p"></p>'
-    + '</div>'
-    + '<button class="nodi-btn" id="nodi-btn" aria-label="Nodi, the Nodus companion" aria-expanded="false">' + ORB_SVG + '</button>';
+  var currentScript = document.currentScript;
+  var widgetCss = document.createElement('link');
+  widgetCss.rel = 'stylesheet';
+  widgetCss.href = new URL('nodi-widget.css?v=20260720-menu1', currentScript && currentScript.src ? currentScript.src : location.href).href;
+  document.head.appendChild(widgetCss);
 
-  function mount() {
-    document.body.appendChild(root);
-    var btn = document.getElementById('nodi-btn');
-    var bubble = document.getElementById('nodi-bubble');
-    var p = document.getElementById('nodi-p');
-    var x = document.getElementById('nodi-x');
-    var i = 0, hideTimer = null, open = false;
-
-    function speak() {
-      var lines = LINES[lang()] || LINES.en;
-      p.textContent = lines[i % lines.length];
-      i += 1;
-      bubble.classList.add('open');
-      btn.setAttribute('aria-expanded', 'true');
-      open = true;
-      clearTimeout(hideTimer);
-      hideTimer = setTimeout(close, 7000);
-    }
-    function close() {
-      bubble.classList.remove('open');
-      btn.setAttribute('aria-expanded', 'false');
-      open = false;
-      clearTimeout(hideTimer);
-    }
-    btn.addEventListener('click', function (e) { e.stopPropagation(); speak(); });
-    x.addEventListener('click', function (e) { e.stopPropagation(); close(); });
-    bubble.addEventListener('click', function (e) { e.stopPropagation(); });
-    document.addEventListener('click', function () { if (open) close(); });
-    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && open) close(); });
+  function mountWebsiteControls() {
+    if (!window.mountNodiWebsite) return;
+    window.mountNodiWebsite({ orbSvg: ORB_SVG, language: lang });
   }
 
-  if (document.body) mount();
-  else document.addEventListener('DOMContentLoaded', mount);
+  var widgetScript = document.createElement('script');
+  widgetScript.src = new URL('nodi-widget.js?v=20260720-menu1', currentScript && currentScript.src ? currentScript.src : location.href).href;
+  widgetScript.onload = function () {
+    if (document.body) mountWebsiteControls();
+    else document.addEventListener('DOMContentLoaded', mountWebsiteControls, { once: true });
+  };
+  document.head.appendChild(widgetScript);
 })();


### PR DESCRIPTION
## What changed

- Rebuilds Nodi as a larger, responsive companion with working help, notifications, chat, notes and back-to-top controls across the website demos.
- Adds the Nodus Toolkit section to the homepage with Converter, AI/OCR extraction, PDF Presenter and document protection.
- Makes the PDF Presenter preview interactive: no-tool mode, draw, spotlight, laser and zoom, with exclusive tool state and a phone preview for remote controls and presenter notes.
- Normalizes oversized icons in the Teaching materials and question-bank sections.

## Why

The website should demonstrate the real Nodi and Toolkit value directly, while keeping the experience balanced and usable on desktop and mobile.

## Impact

Docs-site-only change. No application runtime, database or packaging code is modified.

## Validation

- npm run lint (0 errors; 2 pre-existing warnings outside docs)
- npm run build
- npm test (584/584 passing)
- git diff --check
- Manual desktop and 390px mobile interaction checks for Nodi, Toolkit and PDF Presenter