### PR TITLE
Shorten landing page hero description

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -908,7 +908,7 @@
       <circle cx="46" cy="16" r="6.5" fill="#7c3aed"/>
     </svg>
     <h1 data-i18n="hero.h1"><span class="hw hw1">Research</span> deeper<br/><span class="hw hw2">Teach</span> smarter<br/><span class="hw hw3">Study</span> better</h1>
-    <p class="sub" data-i18n="hero.sub">A local-first desktop app for academic work. Every vault picks a mode. A research library that becomes a graph of ideas, a workspace for your courses and classes, an archive built from primary sources, or a set of your own structured data. All of it over one engine that never leaves your machine.</p>
+    <p class="sub" data-i18n="hero.sub">A local-first workspace for researchers, teachers, and students to connect sources, notes, data, ideas, and learning materials.</p>
     <div class="ctas">
       <a class="btn primary" href="demo/index.html">
         <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
@@ -2082,7 +2082,7 @@ const I18N = {
   es: {
     'nav.how': `Cómo funciona`, 'nav.views': `Vistas`, 'nav.listen': `Escuchar`, 'nav.demo': `Probar la demo`,
     'hero.h1': `<span class="hw hw1">Investiga</span> a fondo<br/><span class="hw hw2">Enseña</span> con criterio<br/><span class="hw hw3">Estudia</span> mejor`,
-    'hero.sub': `Una app de escritorio local para el trabajo académico. Cada vault elige un modo — una biblioteca de investigación que se convierte en un grafo de ideas, un espacio para tus asignaturas y tus clases, un archivo levantado desde fuentes primarias, tus propios datos estructurados — sobre un único motor que nunca sale de tu máquina.`,
+    'hero.sub': `Un espacio de trabajo local para que investigadores, docentes y estudiantes conecten fuentes, notas, datos, ideas y materiales de aprendizaje.`,
     'hero.demo': `Probar la demo`, 'hero.download': `Descargar para macOS, Windows y Linux`,
     'hero.meta': `<b>Totalmente gratis y de código abierto.</b> Sin cuentas, sin suscripciones, sin telemetría, y tu corpus nunca sale de tu máquina.`,
     'hero.scroll': `desplázate`,
@@ -2121,7 +2121,7 @@ const I18N = {
   fr: {
     'nav.how': `Comment ça marche`, 'nav.views': `Vues`, 'nav.listen': `Écouter`, 'nav.demo': `Essayer la démo`,
     'hero.h1': `<span class="hw hw1">Cherchez</span> plus loin<br/><span class="hw hw2">Enseignez</span> plus finement<br/><span class="hw hw3">Étudiez</span> mieux`,
-    'hero.sub': `Une application de bureau locale pour le travail académique. Chaque coffre choisit un mode — une bibliothèque de recherche qui devient un graphe d'idées, un espace pour vos cours et vos classes, une archive bâtie sur des sources primaires, vos propres données structurées — sur un moteur unique qui ne quitte jamais votre machine.`,
+    'hero.sub': `Un espace de travail local pour permettre aux chercheurs, aux enseignants et aux étudiants de relier sources, notes, données, idées et supports d'apprentissage.`,
     'hero.demo': `Essayer la démo`, 'hero.download': `Télécharger pour macOS, Windows et Linux`,
     'hero.meta': `<b>Entièrement gratuit et open source.</b> Sans compte, sans abonnement, sans télémétrie, et votre corpus ne quitte jamais votre machine.`,
     'hero.scroll': `défiler`,
@@ -2160,7 +2160,7 @@ const I18N = {
   it: {
     'nav.how': `Come funziona`, 'nav.views': `Viste`, 'nav.listen': `Ascolta`, 'nav.demo': `Prova la demo`,
     'hero.h1': `<span class="hw hw1">Ricerca</span> più a fondo<br/><span class="hw hw2">Insegna</span> meglio<br/><span class="hw hw3">Studia</span> meglio`,
-    'hero.sub': `Un'app desktop locale per il lavoro accademico. Ogni vault sceglie una modalità — una libreria di ricerca che diventa un grafo di idee, uno spazio per i tuoi corsi e le tue lezioni, un archivio costruito su fonti primarie, i tuoi dati strutturati — su un unico motore che non lascia mai la tua macchina.`,
+    'hero.sub': `Uno spazio di lavoro locale in cui ricercatori, docenti e studenti possono collegare fonti, note, dati, idee e materiali didattici.`,
     'hero.demo': `Prova la demo`, 'hero.download': `Scarica per macOS, Windows e Linux`,
     'hero.meta': `<b>Completamente gratuito e open source.</b> Nessun account, nessun abbonamento, nessuna telemetria, e il tuo corpus non lascia mai la tua macchina.`,
     'hero.scroll': `scorri`,
@@ -2199,7 +2199,7 @@ const I18N = {
   de: {
     'nav.how': `So funktioniert's`, 'nav.views': `Ansichten`, 'nav.listen': `Anhören`, 'nav.demo': `Live-Demo testen`,
     'hero.h1': `<span class="hw hw1">Forsche</span> tiefer<br/><span class="hw hw2">Lehre</span> klüger<br/><span class="hw hw3">Lerne</span> besser`,
-    'hero.sub': `Eine lokale Desktop-App für akademische Arbeit. Jeder Tresor wählt einen Modus — eine Forschungsbibliothek, die zu einem Graphen aus Ideen wird, ein Arbeitsplatz für deine Kurse und Vorlesungen, ein Archiv aus Primärquellen, deine eigenen strukturierten Daten — über einer Engine, die deinen Rechner nie verlässt.`,
+    'hero.sub': `Ein lokaler Arbeitsbereich, in dem Forschende, Lehrende und Studierende Quellen, Notizen, Daten, Ideen und Lernmaterialien miteinander verknüpfen.`,
     'hero.demo': `Live-Demo testen`, 'hero.download': `Für macOS, Windows & Linux herunterladen`,
     'hero.meta': `<b>Völlig kostenlos und quelloffen.</b> Keine Konten, keine Abos, keine Telemetrie, und dein Korpus verlässt nie deinen Rechner.`,
     'hero.scroll': `scrollen`,
@@ -2238,7 +2238,7 @@ const I18N = {
   pt: {
     'nav.how': `Como funciona`, 'nav.views': `Vistas`, 'nav.listen': `Ouvir`, 'nav.demo': `Testar a demo`,
     'hero.h1': `<span class="hw hw1">Investiga</span> a fundo<br/><span class="hw hw2">Ensina</span> com critério<br/><span class="hw hw3">Estuda</span> melhor`,
-    'hero.sub': `Uma app de desktop local para o trabalho acadêmico. Cada cofre escolhe um modo — uma biblioteca de investigação que se torna um grafo de ideias, um espaço para as tuas disciplinas e aulas, um arquivo levantado a partir de fontes primárias, os teus próprios dados estruturados — sobre um único motor que nunca sai da tua máquina.`,
+    'hero.sub': `Um espaço de trabalho local para investigadores, docentes e estudantes ligarem fontes, notas, dados, ideias e materiais de aprendizagem.`,
     'hero.demo': `Testar a demo`, 'hero.download': `Baixar para macOS, Windows e Linux`,
     'hero.meta': `<b>Totalmente gratuito e de código aberto.</b> Sem contas, sem assinaturas, sem telemetria, e o seu corpus nunca sai da sua máquina.`,
     'hero.scroll': `rolar`,
@@ -2277,7 +2277,7 @@ const I18N = {
   tr: {
     'nav.how': `Nasıl çalışır`, 'nav.views': `Görünümler`, 'nav.listen': `Dinle`, 'nav.demo': `Demoyu dene`,
     'hero.h1': `<span class="hw hw1">Araştır</span> daha derin<br/><span class="hw hw2">Öğret</span> daha akıllı<br/><span class="hw hw3">Çalış</span> daha iyi`,
-    'hero.sub': `Akademik çalışma için yerel bir masaüstü uygulaması. Her kasa bir mod seçer — fikirlerin grafiğine dönüşen bir araştırma kütüphanesi, dersleriniz için bir çalışma alanı, birincil kaynaklardan kurulmuş bir arşiv, kendi yapılandırılmış verileriniz — hepsi makinenizden hiç çıkmayan tek bir motorun üzerinde.`,
+    'hero.sub': `Araştırmacıların, öğretmenlerin ve öğrencilerin kaynakları, notları, verileri, fikirleri ve öğrenme materyallerini birbirine bağlayabildiği yerel bir çalışma alanı.`,
     'hero.demo': `Demoyu dene`, 'hero.download': `macOS, Windows ve Linux için indir`,
     'hero.meta': `<b>Tamamen ücretsiz ve açık kaynaklı.</b> Hesap yok, abonelik yok, telemetri yok; derleminiz makinenizden ayrılmaz.`,
     'hero.scroll': `aşağı kaydır`,
@@ -2316,7 +2316,7 @@ const I18N = {
   zh: {
     'nav.how': `工作原理`, 'nav.views': `视图`, 'nav.listen': `收听`, 'nav.demo': `试用演示`,
     'hero.h1': `<span class="hw hw1">研究</span>更深<br/><span class="hw hw2">教学</span>更巧<br/><span class="hw hw3">学习</span>更好`,
-    'hero.sub': `一款面向学术工作的本地桌面应用。每个保险库都会选择一种模式——一座变成观点图谱的研究书库、一个装下你课程与课堂的工作空间、一份由原始档案筑起的档案库、你自己的结构化数据——它们共用同一个引擎，而这一切从不离开你的电脑。`,
+    'hero.sub': `一个本地优先的工作空间，帮助研究人员、教师和学生连接资料来源、笔记、数据、观点与学习材料。`,
     'hero.demo': `试用演示`, 'hero.download': `下载 macOS、Windows 和 Linux 版`,
     'hero.meta': `<b>完全免费且开源。</b> 无需账户、无需订阅、无遥测，你的语料永远不会离开你的设备。`,
     'hero.scroll': `向下滚动`,
@@ -2911,7 +2911,7 @@ Object.assign(I18N, {
   ja: {
     'nav.vaults': `Vault`, 'nav.how': `仕組み`, 'nav.views': `画面`, 'nav.contrib': `参加する`, 'nav.demo': `ライブデモを試す`,
     'hero.h1': `<span class="hw hw1">研究</span>を深く<br/><span class="hw hw2">教育</span>を賢く<br/><span class="hw hw3">学習</span>をより良く`,
-    'hero.sub': `学術活動のためのローカルファーストなデスクトップアプリ。研究ライブラリ、授業と学習、一次資料のアーカイブ、構造化データを、端末から離れない一つのエンジンで扱います。`,
+    'hero.sub': `研究者、教員、学生が、資料、ノート、データ、アイデア、学習教材をつなげられるローカルファーストのワークスペースです。`,
     'hero.demo': `ライブデモを試す`, 'hero.download': `macOS・Windows・Linux版をダウンロード`,
     'hero.meta': `<b>完全無料・オープンソース。</b> アカウント、購読、テレメトリはなく、コーパスは端末の外に出ません。`, 'hero.scroll': `スクロール`,
     'vaults.kicker': `Vault`, 'vaults.title': `同じエンジンを、あなたの仕事の形に。`,
@@ -2965,7 +2965,7 @@ Object.assign(I18N, {
   uk: {
     'nav.vaults': `Сховища`, 'nav.how': `Як це працює`, 'nav.views': `Огляди`, 'nav.contrib': `Долучитися`, 'nav.demo': `Спробувати демо`,
     'hero.h1': `<span class="hw hw1">Досліджуйте</span> глибше<br/><span class="hw hw2">Викладайте</span> розумніше<br/><span class="hw hw3">Навчайтеся</span> краще`,
-    'hero.sub': `Локальний настільний застосунок для академічної роботи: досліджень, викладання, навчання, архівів первинних джерел і структурованих даних — на одному рушії, який не залишає ваш пристрій.`,
+    'hero.sub': `Локальний робочий простір, у якому дослідники, викладачі та студенти можуть пов’язувати джерела, нотатки, дані, ідеї та навчальні матеріали.`,
     'hero.demo': `Спробувати демо`, 'hero.download': `Завантажити для macOS, Windows і Linux`, 'hero.meta': `<b>Повністю безкоштовно й з відкритим кодом.</b> Без облікових записів, підписок і телеметрії; корпус не залишає ваш пристрій.`, 'hero.scroll': `гортайте`,
     'vaults.kicker': `Сховища`, 'vaults.title': `Один рушій, пристосований до вашої роботи.`, 'vaults.lead': `Сховище — це один файл проєкту на вашому пристрої. Режим визначає розділи та інструкції для ШІ-помічника. П’ять режимів доступні зараз; «Первинні джерела», «Свідчення» та «Просопографія» заплановані.`,
     'vaults.status.available': `Доступно зараз`, 'vaults.status.soon': `Незабаром`, 'vaults.roadmap': `У планах`,
@@ -2988,7 +2988,7 @@ Object.assign(I18N, {
   },
   ru: {
     'nav.vaults': `Хранилища`, 'nav.how': `Как это работает`, 'nav.views': `Обзоры`, 'nav.contrib': `Участвовать`, 'nav.demo': `Открыть демо`,
-    'hero.h1': `<span class="hw hw1">Исследуйте</span> глубже<br/><span class="hw hw2">Преподавайте</span> умнее<br/><span class="hw hw3">Учитесь</span> лучше`, 'hero.sub': `Локальное настольное приложение для академической работы: исследований, преподавания, учёбы, архивов первичных источников и структурированных данных — на одном движке, который не покидает ваше устройство.`, 'hero.demo': `Открыть демо`, 'hero.download': `Скачать для macOS, Windows и Linux`, 'hero.meta': `<b>Полностью бесплатно и с открытым исходным кодом.</b> Без аккаунтов, подписок и телеметрии; корпус не покидает ваш компьютер.`, 'hero.scroll': `листайте`,
+    'hero.h1': `<span class="hw hw1">Исследуйте</span> глубже<br/><span class="hw hw2">Преподавайте</span> умнее<br/><span class="hw hw3">Учитесь</span> лучше`, 'hero.sub': `Локальное рабочее пространство, где исследователи, преподаватели и студенты могут связывать источники, заметки, данные, идеи и учебные материалы.`, 'hero.demo': `Открыть демо`, 'hero.download': `Скачать для macOS, Windows и Linux`, 'hero.meta': `<b>Полностью бесплатно и с открытым исходным кодом.</b> Без аккаунтов, подписок и телеметрии; корпус не покидает ваш компьютер.`, 'hero.scroll': `листайте`,
     'vaults.kicker': `Хранилища`, 'vaults.title': `Один движок, настроенный под вашу работу.`, 'vaults.lead': `Хранилище — один файл проекта на вашем устройстве. Режим определяет разделы и инструкции для ИИ-помощника. Пять режимов доступны сейчас; «Первичные источники», «Свидетельства» и «Просопография» запланированы.`, 'vaults.status.available': `Доступно сейчас`, 'vaults.status.soon': `Скоро`, 'vaults.roadmap': `В планах`,
     'vaults.academic.t': `Академический`, 'vaults.academic.b': `Подключите библиотеку Zotero и превратите каждую работу в сеть утверждений, выводов и методов. Каждая идея сохраняет точный фрагмент и страницу, которые её подтверждают.`, 'vaults.academic.f1': `<b>Превратите библиотеку Zotero в граф идей</b>, связывая утверждения, выводы и методы с точными фрагментами и страницами.`, 'vaults.academic.f2': `<b>Находите дискуссии, противоречия и пробелы</b> с помощью семантического поиска, анализа охвата и маршрутов чтения.`, 'vaults.academic.f3': `<b>Исследуйте и пишите с проверяемыми ссылками</b> в Deep Research, мастерской письма и помощниках для Word и LibreOffice.`, 'vaults.academic.cta': `Открыть академическое демо →`,
     'vaults.study.t': `Учёба`, 'vaults.study.b': `Организуйте предметы, заметки и материалы в одном месте. Учитесь в своём темпе, готовьтесь к проверочным работам и следите за прогрессом без зависимости от Zotero и загрузки файлов.`, 'vaults.study.f1': `<b>Организуйте материалы по учебному году, курсу и предмету</b>, добавляя расписание, сроки и события с напоминаниями.`, 'vaults.study.f2': `<b>Записывайте и расшифровывайте занятия локально</b>, читайте PDF и EPUB и возвращайтесь от ответа к точной странице, заметке или секунде.`, 'vaults.study.f3': `<b>Создавайте из своих материалов банки вопросов, тесты, экзамены и карточки</b> с интервальным повторением и отслеживанием прогресса.`, 'vaults.study.cta': `Открыть демо учёбы →`,
@@ -3028,7 +3028,7 @@ function regionalisePortuguese(source, replacements) {
 }
 const PT_PT = {
   'hero.h1': `<span class="hw hw1">Investiga</span> a fundo<br/><span class="hw hw2">Ensina</span> com critério<br/><span class="hw hw3">Estuda</span> melhor`,
-  'hero.sub': `Uma aplicação de desktop local para o trabalho académico. Cada cofre escolhe um modo — uma biblioteca de investigação que se torna um grafo de ideias, um espaço para as tuas disciplinas e aulas, um arquivo criado a partir de fontes primárias, os teus próprios dados estruturados — sobre um único motor que nunca sai da tua máquina.`,
+  'hero.sub': `Um espaço de trabalho local para investigadores, docentes e estudantes ligarem fontes, notas, dados, ideias e materiais de aprendizagem.`,
   'hero.download': `Descarregar para macOS, Windows e Linux`,
   'hero.meta': `<b>Totalmente gratuito e de código aberto.</b> Sem contas, sem assinaturas, sem telemetria, e o teu corpus nunca sai da tua máquina.`,
   'vaults.kicker': `Os cofres`, 'vaults.title': `O mesmo motor, adaptado ao teu trabalho.`,
@@ -3066,7 +3066,7 @@ const PT_PT = {
 const PT_BR = {
   'nav.vaults': `Cofres`, 'nav.contrib': `Contribuir`,
   'hero.h1': `<span class="hw hw1">Pesquise</span> a fundo<br/><span class="hw hw2">Ensine</span> com critério<br/><span class="hw hw3">Estude</span> melhor`,
-  'hero.sub': `Um aplicativo de desktop local para o trabalho acadêmico. Cada cofre escolhe um modo — uma biblioteca de pesquisa que se torna um grafo de ideias, um espaço para suas disciplinas e aulas, um arquivo criado a partir de fontes primárias, seus próprios dados estruturados — sobre um único motor que nunca sai da sua máquina.`,
+  'hero.sub': `Um espaço de trabalho local para pesquisadores, professores e estudantes conectarem fontes, notas, dados, ideias e materiais de aprendizagem.`,
   'hero.download': `Baixar para macOS, Windows e Linux`,
   'hero.meta': `<b>Totalmente gratuito e de código aberto.</b> Sem contas, sem assinaturas, sem telemetria, e seu corpus nunca sai da sua máquina.`,
   'story.title': `Das suas fontes a ideias que você pode usar.`,


### PR DESCRIPTION
## What changed

- Replaced the long landing-page hero description with a concise statement of Nodus’s audience and value.
- Preserved the local-first positioning.
- Updated every maintained site translation so language switching keeps the new message consistent.

## Why

The previous hero copy explained the vault model in detail before visitors had the context for it. The new copy communicates who Nodus is for and what it connects at a glance; the vault explanation remains available further down the page.

## Impact

Visitors get a shorter, clearer introduction to Nodus without changing site behavior or removing the detailed product explanation elsewhere.

## Validation

- `git diff --check`
- `node --test scripts/test-teaching-web-demo.mjs`
- Parsed all three inline scripts in `docs/index.html` with Node