### PR TITLE
Word copilot: footnotes, compose-over-selection, and citable passage search

### DIFF
--- a/electron/ai/liveRelations.ts
+++ b/electron/ai/liveRelations.ts
@@ -15,7 +15,7 @@ import {
 } from './chapterIdeas';
 import { getSettings } from '../db/settingsRepo';
 import { findSimilarIdeas, getIdeaDetail, getIdeaEdges, getIdeaSummary } from '../db/ideasRepo';
-import { getPassageDetail } from '../db/passagesRepo';
+import { embeddedPassageCount, findSimilarPassages, getPassageDetail } from '../db/passagesRepo';
 import { getWork } from '../db/worksRepo';
 import { getDb } from '../db/database';
 
@@ -808,4 +808,219 @@ export async function analyzeText(text: string, model?: ModelRef | null): Promis
   }).sort((a, b) => b.rankScore - a.rankScore || b.similarity - a.similarity);
 
   return { available: true, relations };
+}
+
+// ── Full-text passage search (citable source excerpts) ──────────────────────────
+const LIVE_PASSAGE_MIN_SIMILARITY = 0.18;
+
+export interface CopilotPassageSearchResult {
+  passageId: string;
+  nodusId: string;
+  similarity: number;
+  pageLabel: string | null;
+  /** Short excerpt for the card; `text` carries the full chunk for quoting. */
+  snippet: string;
+  text: string;
+  workTitle: string;
+  authors: string[];
+  year: number | null;
+  authorYear: string | null;
+  zoteroKey: string | null;
+  searchString: string | null;
+}
+
+export interface CopilotPassageSearchResponse {
+  /** False when no embedding provider/key is configured (cannot embed the query). */
+  available: boolean;
+  /** False when the corpus has no embedded passages for the current model. */
+  indexed: boolean;
+  passages: CopilotPassageSearchResult[];
+}
+
+function parseAuthorsJson(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json || '[]');
+    return Array.isArray(parsed) ? parsed.filter((a): a is string => typeof a === 'string' && a.length > 0) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Semantic search over the corpus full text. Returns citable passage excerpts —
+ * the writer's counterpart to searchCopilotIdeas, but over the underlying source
+ * text (what you actually quote) rather than derived claims.
+ */
+export async function searchCopilotPassages(query: string, limit = 20): Promise<CopilotPassageSearchResponse> {
+  const cleanLimit = Math.max(1, Math.min(50, Math.floor(limit)));
+  const trimmed = query.trim();
+  if (trimmed.length < 2) return { available: true, indexed: true, passages: [] };
+
+  // Embed first: with no provider we can report "not available" without touching
+  // the passage tables, which keeps the branch cheap and side-effect free.
+  const vector = await embed(trimmed);
+  if (!vector) return { available: false, indexed: false, passages: [] };
+
+  const indexed = embeddedPassageCount() > 0;
+  if (!indexed) return { available: true, indexed: false, passages: [] };
+
+  const hits = findSimilarPassages(vector, LIVE_PASSAGE_MIN_SIMILARITY, cleanLimit);
+  const passages = hits.map((hit) => {
+    const authors = parseAuthorsJson(hit.authors_json);
+    return {
+      passageId: hit.passage_id,
+      nodusId: hit.nodus_id,
+      similarity: hit.similarity,
+      pageLabel: hit.page_label,
+      snippet: clip(hit.text, 320),
+      text: hit.text,
+      workTitle: hit.title,
+      authors,
+      year: hit.year,
+      authorYear: authorYearLabel(authors, hit.year),
+      zoteroKey: hit.zotero_key || null,
+      searchString: searchString(authors, hit.year, hit.title),
+    };
+  });
+  return { available: true, indexed, passages };
+}
+
+// ── Compose over the user's selection (rewrite / expand / counter) ───────────────
+export type CopilotComposeMode = 'rewrite' | 'expand' | 'counter';
+
+export interface CopilotComposeCitation {
+  label: string;
+  authorYear: string | null;
+  zoteroKey: string | null;
+  searchString: string | null;
+}
+
+export interface CopilotComposeResult {
+  /** False when no embedding provider is configured (relations cannot be found). */
+  available: boolean;
+  mode: CopilotComposeMode;
+  text: string;
+  citations: CopilotComposeCitation[];
+}
+
+const COMPOSE_MAX_CONTEXT = 5;
+
+function composeSystemPrompt(mode: CopilotComposeMode): string {
+  const base = [
+    'Eres Nodus Copilot dentro de un procesador de texto académico.',
+    'Trabajas SOLO con el texto del usuario y las ideas de su biblioteca que se te pasan.',
+    'No inventes autores, años, páginas ni obras: usa únicamente las citas (autor, año) proporcionadas.',
+    'Escribe en el mismo idioma que el texto del usuario, con prosa académica natural.',
+    'Cuando te apoyes en una idea de la biblioteca, incorpora su cita parentética en texto plano, p. ej. (Autor, 2019).',
+    'Devuelve SOLO el texto resultante: sin Markdown, sin viñetas, sin comillas globales de apertura/cierre, sin explicación ni encabezados.',
+  ];
+  if (mode === 'rewrite') {
+    base.push(
+      'Tarea: REESCRIBE la selección con mejor prosa académica conservando su significado; integra 1-2 citas de apoyo solo si encajan con naturalidad. El resultado SUSTITUYE a la selección.'
+    );
+  } else if (mode === 'expand') {
+    base.push(
+      'Tarea: CONTINÚA y AMPLÍA la selección con 1-3 frases que desarrollen la idea apoyándose en la biblioteca y sus citas. El resultado se AÑADE tras la selección.'
+    );
+  } else {
+    base.push(
+      'Tarea: redacta un CONTRAARGUMENTO matizado a la selección basándote en las ideas de la biblioteca que la tensionan o contradicen, con sus citas. Empieza con una fórmula del tipo «Sin embargo,» o «No obstante,». El resultado se AÑADE tras la selección.'
+    );
+  }
+  return base.join('\n');
+}
+
+function composeOutputHint(mode: CopilotComposeMode): string {
+  if (mode === 'rewrite') return 'Versión reescrita de la selección (la sustituye).';
+  if (mode === 'expand') return '1-3 frases nuevas que continúan el texto (se añaden tras la selección).';
+  return '1-3 frases de contraargumento con su(s) cita(s) (se añaden tras la selección).';
+}
+
+function normalizeComposeText(raw: string): string {
+  return raw
+    .replace(/\[([^\]]+)\]\(nodus:\/\/[^)]+\)/g, '$1')
+    .replace(/[`*_#>]/g, '')
+    .replace(/\r?\n{2,}/g, '\n')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/^["“”«»]+|["“”«»]+$/g, '')
+    .trim();
+}
+
+/**
+ * Draft text FROM the user's selection, grounded in the library: rewrite it,
+ * expand it, or build a cited counterargument. Reuses analyzeText's typed
+ * relations so 'counter' can prefer the ideas that contradict/refine the claim.
+ */
+export async function composeFromSelection(input: {
+  mode: CopilotComposeMode;
+  selectionText: string;
+  paragraphText: string;
+  model?: ModelRef | null;
+}): Promise<CopilotComposeResult> {
+  const { mode } = input;
+  const selection = (input.selectionText ?? '').trim();
+  const paragraph = (input.paragraphText ?? '').trim();
+  const focus = selection || paragraph;
+  if (focus.length < 12) {
+    throw new Error('Selecciona (o sitúate en) un fragmento con algo más de texto para trabajarlo.');
+  }
+
+  const analysis = await analyzeText(focus, input.model ?? null);
+  if (!analysis.available) return { available: false, mode, text: '', citations: [] };
+
+  const relations = analysis.relations.slice();
+  let chosen: LiveRelation[];
+  if (mode === 'counter') {
+    const opposing = relations.filter((r) => r.relation === 'contradicts' || r.relation === 'refines');
+    chosen = (opposing.length ? opposing : relations).slice(0, COMPOSE_MAX_CONTEXT);
+  } else {
+    chosen = relations.slice(0, COMPOSE_MAX_CONTEXT);
+  }
+
+  const context = chosen.map((r) => ({
+    relacion: r.relation,
+    idea: r.targetLabel,
+    enunciado: clip(r.targetStatement ?? r.rationale ?? '', 320),
+    cita: r.authorYear,
+  }));
+
+  const model = input.model ?? getSettings().synthesisModel;
+  const raw = await completeText(
+    {
+      system: composeSystemPrompt(mode),
+      user: JSON.stringify(
+        {
+          seleccion: clip(selection, 1400),
+          parrafo: clip(paragraph, 2200),
+          ideas_de_la_biblioteca: context,
+          salida: composeOutputHint(mode),
+        },
+        null,
+        2
+      ),
+      temperature: 0.25,
+      maxTokens: 480,
+    },
+    model
+  );
+
+  const text = normalizeComposeText(raw);
+  if (!text) throw new Error('La IA no devolvió texto insertable.');
+
+  const citations: CopilotComposeCitation[] = [];
+  const seen = new Set<string>();
+  for (const r of chosen) {
+    if (!r.authorYear && !r.zoteroKey) continue;
+    const key = r.zoteroKey || r.authorYear || r.targetLabel;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    citations.push({
+      label: r.targetLabel,
+      authorYear: r.authorYear,
+      zoteroKey: r.zoteroKey,
+      searchString: r.searchString,
+    });
+  }
+
+  return { available: true, mode, text, citations };
 }

--- a/electron/copilot/server.ts
+++ b/electron/copilot/server.ts
@@ -12,7 +12,15 @@ import { app, BrowserWindow, shell } from 'electron';
 import type { CopilotServerStatus } from '@shared/types';
 import { getSettings, updateSettings } from '../db/settingsRepo';
 import { loadCopilotCert, loadCopilotCa, certReady, copilotStateDir, renewLeafIfNeeded } from './certs';
-import { analyzeText, composeCopilotIdeaInsertion, getCopilotIdeaDetail, searchCopilotIdeas } from '../ai/liveRelations';
+import {
+  analyzeText,
+  composeCopilotIdeaInsertion,
+  composeFromSelection,
+  getCopilotIdeaDetail,
+  searchCopilotIdeas,
+  searchCopilotPassages,
+  type CopilotComposeMode,
+} from '../ai/liveRelations';
 import { embeddedIdeaCount } from '../db/ideasRepo';
 import { getDb } from '../db/database';
 
@@ -28,12 +36,20 @@ interface EditorState {
   selectionText: string;
 }
 
+// One text to place in the external editor, with the same placement options the
+// Word pane uses: as a footnote, and/or replacing the current selection.
+interface EditorInsertion {
+  text: string;
+  asFootnote: boolean;
+  replace: boolean;
+}
+
 // Bridge state for external editors (LibreOffice Writer): the macro pushes the
 // current paragraph/selection here and long-polls for texts to insert, while the
 // standalone task pane reads the state and posts insertions. Single-slot state is
 // enough: this is a local, single-user bridge.
 const editorState: EditorState = { paragraphText: '', selectionText: '' };
-let pendingInsertionResolvers: ((text: string) => void)[] = [];
+let pendingInsertionResolvers: ((insertion: EditorInsertion) => void)[] = [];
 const EDITOR_POLL_TIMEOUT_MS = 30_000;
 
 function addinUrl(port: number): string {
@@ -209,6 +225,23 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
       sendJson(res, 200, { ideas });
       return;
     }
+    if (urlPath === '/api/passages' && req.method === 'POST') {
+      const body = (await readJsonBody(req)) as { query?: string; limit?: number };
+      const result = await searchCopilotPassages(String(body.query ?? ''), Number(body.limit ?? 20));
+      sendJson(res, 200, result);
+      return;
+    }
+    if (urlPath === '/api/compose' && req.method === 'POST') {
+      const body = (await readJsonBody(req)) as { mode?: string; selectionText?: string; paragraphText?: string };
+      const mode: CopilotComposeMode = body.mode === 'rewrite' || body.mode === 'counter' ? body.mode : 'expand';
+      const result = await composeFromSelection({
+        mode,
+        selectionText: String(body.selectionText ?? ''),
+        paragraphText: String(body.paragraphText ?? ''),
+      });
+      sendJson(res, 200, result);
+      return;
+    }
     if (urlPath === '/api/idea' && req.method === 'POST') {
       const body = (await readJsonBody(req)) as { ideaId?: string };
       if (!body.ideaId) {
@@ -280,10 +313,14 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
       return;
     }
     if (urlPath === '/api/editor/insert' && req.method === 'POST') {
-      const body = (await readJsonBody(req)) as { text?: string };
-      const text = String(body.text ?? '');
+      const body = (await readJsonBody(req)) as { text?: string; asFootnote?: boolean; replace?: boolean };
+      const insertion: EditorInsertion = {
+        text: String(body.text ?? ''),
+        asFootnote: Boolean(body.asFootnote),
+        replace: Boolean(body.replace),
+      };
       const resolver = pendingInsertionResolvers.shift();
-      if (resolver) resolver(text);
+      if (resolver) resolver(insertion);
       // delivered:false tells the pane no editor bridge is long-polling right now,
       // so it can surface "run the macro in Writer" instead of a silent no-op.
       sendJson(res, 200, { ok: true, delivered: Boolean(resolver) });
@@ -311,7 +348,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
           resolve();
         };
         const timeout = setTimeout(() => settle({ text: null }), EDITOR_POLL_TIMEOUT_MS);
-        const resolver = (text: string) => settle({ text });
+        const resolver = (insertion: EditorInsertion) => settle(insertion);
         // A dead poller must leave the queue immediately: otherwise a later
         // insert would be handed to it and the text silently lost. res 'close'
         // fires on premature termination (and, harmlessly for the idempotent

--- a/scripts/nodus_copilot.py
+++ b/scripts/nodus_copilot.py
@@ -166,14 +166,39 @@ class SelectionListener(unohelper.Base, uno.getClass("com.sun.star.view.XSelecti
         pass
 
 
-def _insert_at_cursor(doc, text_to_insert):
-    """Insert after the current selection (matching the Word pane: never replaces
-    the selected text) and leave the cursor at the end of the insertion.
-    Main-thread only."""
+def _insert_footnote(doc, view_cursor, text_to_insert):
+    """Attach a footnote at the end of the current selection and fill its text.
+    Raises on Writer builds that cannot place it, so the caller falls back inline."""
+    footnote = doc.createInstance("com.sun.star.text.Footnote")
+    view_text = view_cursor.getText()
+    view_text.insertTextContent(view_cursor.getEnd(), footnote, False)
+    fn_text = footnote.getText()
+    fn_cursor = fn_text.createTextCursor()
+    fn_text.insertString(fn_cursor, text_to_insert, False)
+
+
+def _insert_at_cursor(doc, text_to_insert, as_footnote=False, replace=False):
+    """Place AI text near the current selection. By default inserts after the
+    selection (matching the Word pane); `replace` overwrites the selected text and
+    `as_footnote` places the text in a footnote instead. Either option falls back
+    to a plain insertion so the text is never lost. Main-thread only."""
     controller = doc.getCurrentController()
     view_cursor = controller.getViewCursor() if controller else None
     if not view_cursor:
         return
+    if as_footnote:
+        try:
+            _insert_footnote(doc, view_cursor, text_to_insert)
+            return
+        except Exception as e:
+            print("[Nodus] No se pudo crear la nota al pie; se inserta en el texto: %s" % e)
+    if replace:
+        try:
+            view_cursor.setString(text_to_insert)
+            view_cursor.collapseToEnd()
+            return
+        except Exception as e:
+            print("[Nodus] No se pudo reemplazar la selección; se inserta al final: %s" % e)
     if text_to_insert and not text_to_insert[0].isspace():
         text_to_insert = " " + text_to_insert
     text = view_cursor.getText()
@@ -184,23 +209,25 @@ def _insert_at_cursor(doc, text_to_insert):
 class _InsertCallback(unohelper.Base, uno.getClass("com.sun.star.awt.XCallback")):
     """Runs one insertion on the main thread (posted via AsyncCallback)."""
 
-    def __init__(self, doc, text_to_insert):
+    def __init__(self, doc, text_to_insert, as_footnote=False, replace=False):
         self.doc = doc
         self.text_to_insert = text_to_insert
+        self.as_footnote = as_footnote
+        self.replace = replace
 
     def notify(self, data):
         try:
-            _insert_at_cursor(self.doc, self.text_to_insert)
+            _insert_at_cursor(self.doc, self.text_to_insert, self.as_footnote, self.replace)
         except Exception as e:
             print("[Nodus] Error al insertar el texto: %s" % e)
 
 
-def _schedule_insert(doc, text_to_insert):
+def _schedule_insert(doc, text_to_insert, as_footnote=False, replace=False):
     """Marshal a document mutation from a worker thread onto the main thread."""
     try:
         ctx = uno.getComponentContext()
         async_cb = ctx.ServiceManager.createInstanceWithContext("com.sun.star.awt.AsyncCallback", ctx)
-        async_cb.addCallback(_InsertCallback(doc, text_to_insert), None)
+        async_cb.addCallback(_InsertCallback(doc, text_to_insert, as_footnote, replace), None)
     except Exception as e:
         print("[Nodus] Error al programar la inserción: %s" % e)
 
@@ -238,7 +265,12 @@ def poll_insertions(doc):
                 continue
             result = _request("GET", "/api/editor/poll-insertion", timeout=POLL_TIMEOUT_S)
             if result and result.get("text") and running:
-                _schedule_insert(doc, result["text"])
+                _schedule_insert(
+                    doc,
+                    result["text"],
+                    bool(result.get("asFootnote")),
+                    bool(result.get("replace")),
+                )
         except urllib.error.URLError:
             time.sleep(5)  # server down/unreachable; back off and retry
         except Exception as e:

--- a/scripts/test-libreoffice-copilot.mjs
+++ b/scripts/test-libreoffice-copilot.mjs
@@ -119,6 +119,84 @@ try {
     );
   }
 
+  // Insert options (footnote / replace) travel through the bridge to the poller.
+  {
+    const pollRes = mockResponse();
+    const pollPromise = server.handleRequest(
+      mockRequest('GET', '/api/editor/poll-insertion', authHeaders()),
+      pollRes,
+      4320
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const insertRes = mockResponse();
+    await server.handleRequest(
+      mockRequest('POST', '/api/editor/insert', authHeaders(), {
+        text: 'Cita en nota al pie',
+        asFootnote: true,
+        replace: true,
+      }),
+      insertRes,
+      4320
+    );
+    assert.equal(JSON.parse(insertRes.getBody()).delivered, true);
+
+    await pollPromise;
+    const delivered = JSON.parse(pollRes.getBody());
+    assert.equal(delivered.text, 'Cita en nota al pie');
+    assert.equal(delivered.asFootnote, true, 'footnote flag must reach the poller');
+    assert.equal(delivered.replace, true, 'replace flag must reach the poller');
+  }
+
+  // Passage search with no embedding provider configured: available:false, no crash.
+  {
+    const res = mockResponse();
+    await server.handleRequest(
+      mockRequest('POST', '/api/passages', authHeaders(), { query: 'pobreza en el relato de viajes' }),
+      res,
+      4320
+    );
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.getBody());
+    assert.equal(body.available, false, 'no embeddings → passages unavailable');
+    assert.deepEqual(body.passages, [], 'no passages without embeddings');
+  }
+
+  // Compose over a selection with no embeddings: graceful available:false, no throw.
+  {
+    const res = mockResponse();
+    await server.handleRequest(
+      mockRequest('POST', '/api/compose', authHeaders(), {
+        mode: 'counter',
+        selectionText: 'El turismo documenta fielmente la realidad del país.',
+        paragraphText: 'El turismo documenta fielmente la realidad del país.',
+      }),
+      res,
+      4320
+    );
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.getBody());
+    assert.equal(body.available, false, 'no embeddings → compose unavailable');
+    assert.equal(body.mode, 'counter', 'compose echoes the requested mode');
+    assert.equal(body.text, '', 'no draft without embeddings');
+  }
+
+  // An unknown compose mode falls back to a valid default instead of erroring.
+  {
+    const res = mockResponse();
+    await server.handleRequest(
+      mockRequest('POST', '/api/compose', authHeaders(), {
+        mode: 'bogus',
+        selectionText: 'Una frase suficientemente larga para analizar.',
+        paragraphText: 'Una frase suficientemente larga para analizar.',
+      }),
+      res,
+      4320
+    );
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.getBody()).mode, 'expand', 'unknown mode defaults to expand');
+  }
+
   // Bridge discovery file: port + token for the LibreOffice macro.
   {
     const bridgeDir = path.join(root, 'bridge-state');

--- a/word-addin/README.md
+++ b/word-addin/README.md
@@ -6,8 +6,11 @@
 
 Un complemento (task pane) de Microsoft Word que, mientras escribes, muestra en el
 panel lateral cómo el **párrafo actual** se relaciona con tu biblioteca de Nodus,
-permite buscar ideas/autores/obras, ver cada idea con sus conexiones y pedir a la
-IA configurada en Nodus que inserte una idea parafraseada con cita autor-año.
+permite buscar ideas/autores/obras **y pasajes citables del texto completo**, ver
+cada idea con sus conexiones y pedir a la IA configurada en Nodus que inserte una
+idea parafraseada con cita autor-año. Sobre la **selección** puede además
+**reescribir**, **ampliar** o redactar un **contraargumento** citado, e insertar
+cualquier resultado **en el cuerpo o como nota al pie**.
 
 No reimplementa nada del cerebro de Nodus: el add-in es solo una segunda cara. El
 análisis (embeddings + relaciones tipadas) lo hace tu app de Nodus, que sirve el
@@ -46,9 +49,18 @@ complemento y una pequeña API JSON **en el mismo origen HTTPS local**
 - Abre Nodus (con el copiloto activado) y Word. En la pestaña **Nodus**, abre el
   panel **Nodus Copilot**.
 - Escribe. Al pausar, el panel muestra las ideas relacionadas del párrafo.
-- Usa el buscador para filtrar por idea, autor u obra indexada.
+- Usa el buscador para filtrar por idea, autor u obra indexada. Con el conmutador
+  **Ideas / Pasajes** cambias a la búsqueda semántica sobre el **texto completo**:
+  cada pasaje trae su cita y un botón **Insertar cita** (lo pega entre comillas con
+  el autor-año).
 - Abre **Detalles** para ver fuentes y conexiones; **Abrir en Nodus** enfoca la
   idea en el grafo; **Insertar con IA** añade una paráfrasis citada al texto.
+- Con texto seleccionado, la fila **Selección** ofrece **Reescribir** (sustituye la
+  selección), **Ampliar** (continúa el texto) y **Rebatir** (redacta un
+  contraargumento citado a partir de las ideas que la contradicen o matizan).
+- El selector **Insertar en** manda las inserciones y contraargumentos al **cuerpo**
+  o a una **nota al pie** (requiere Word con WordApi 1.5; si no, la opción se
+  desactiva). *Reescribir* siempre trabaja sobre el cuerpo.
 
 ## Requisitos
 - Nodus en marcha con un proveedor de **embeddings** configurado (la biblioteca debe

--- a/word-addin/manifest.xml
+++ b/word-addin/manifest.xml
@@ -6,7 +6,7 @@
   xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides"
   xsi:type="TaskPaneApp">
   <Id>E4352919-FFEC-4F77-8268-975BB4217FAD</Id>
-  <Version>0.7.20</Version>
+  <Version>2.4.0</Version>
   <ProviderName>Nodus</ProviderName>
   <DefaultLocale>es-ES</DefaultLocale>
   <DisplayName DefaultValue="Nodus Copilot" />

--- a/word-addin/taskpane.css
+++ b/word-addin/taskpane.css
@@ -201,6 +201,7 @@ main {
 .badge.refines { color: var(--amber); border-color: color-mix(in srgb, var(--amber) 42%, var(--border)); }
 .badge.extends { color: var(--cyan); border-color: color-mix(in srgb, var(--cyan) 42%, var(--border)); }
 .badge.idea { color: var(--primary); border-color: color-mix(in srgb, var(--primary) 42%, var(--border)); }
+.badge.passage { color: var(--cyan); border-color: color-mix(in srgb, var(--cyan) 42%, var(--border)); }
 
 .label {
   font-size: 13px;
@@ -285,3 +286,62 @@ main {
 .connection-head { display: flex; align-items: center; gap: 6px; }
 .spin { color: var(--muted); font-size: 12px; padding: 4px 0; }
 .copied { color: var(--green); font-size: 11px; align-self: center; }
+
+/* Segmented search mode (Ideas / Passages) */
+.segmented {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+}
+.seg {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  border-radius: 5px;
+  padding: 5px 8px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  min-height: 26px;
+}
+.seg:hover { color: var(--text); }
+.seg.active {
+  background: var(--panel);
+  color: var(--text);
+  font-weight: 620;
+  box-shadow: var(--shadow);
+}
+
+/* Selection actions (Rewrite / Expand / Counter) and insert target */
+.selection-actions,
+.insert-target {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.sa-label,
+.it-label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin-right: 2px;
+}
+.insert-target label {
+  font-size: 12px;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.insert-target label.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/word-addin/taskpane.html
+++ b/word-addin/taskpane.html
@@ -27,9 +27,24 @@
           <input id="searchBox" type="search" placeholder="Buscar ideas, autores u obras" autocomplete="off" />
           <button id="searchBtn" class="btn icon" type="button" title="Buscar">⌕</button>
         </div>
+        <div class="segmented" id="searchMode" role="tablist">
+          <button class="seg active" data-mode="ideas" type="button" role="tab">Ideas</button>
+          <button class="seg" data-mode="passages" type="button" role="tab">Pasajes</button>
+        </div>
         <div class="toolbar">
           <label class="auto"><input type="checkbox" id="autoToggle" checked /> Auto</label>
           <button id="analyzeBtn" class="btn primary" type="button">Analizar párrafo</button>
+        </div>
+        <div class="selection-actions" id="selectionActions">
+          <span class="sa-label">Selección</span>
+          <button class="btn small" data-compose="rewrite" type="button">Reescribir</button>
+          <button class="btn small" data-compose="expand" type="button">Ampliar</button>
+          <button class="btn small" data-compose="counter" type="button">Rebatir</button>
+        </div>
+        <div class="insert-target" id="insertTarget">
+          <span class="it-label">Insertar en</span>
+          <label><input type="radio" name="insTarget" value="body" checked /> <span data-it="body">Texto</span></label>
+          <label id="footnoteOption"><input type="radio" name="insTarget" value="footnote" id="footnoteRadio" /> <span data-it="footnote">Nota al pie</span></label>
         </div>
       </section>
 

--- a/word-addin/taskpane.js
+++ b/word-addin/taskpane.js
@@ -17,6 +17,9 @@
   var isWord = false;
   var currentParagraphText = '';
   var currentSelectionText = '';
+  var searchMode = 'ideas'; // 'ideas' | 'passages'
+  var insertTarget = 'body'; // 'body' | 'footnote'
+  var footnoteSupported = true;
 
   // The pane follows the Nodus UI language (injected by the copilot server).
   var STR = {
@@ -57,6 +60,28 @@
       editorNotListening: 'LibreOffice no está escuchando. Ejecuta la macro start_nodus_copilot en Writer.',
       wordOnly: 'Este complemento solo funciona en Word.',
       nodusError: 'Error de Nodus',
+      modeIdeas: 'Ideas',
+      modePassages: 'Pasajes',
+      selectionLabel: 'Selección',
+      composeRewrite: 'Reescribir',
+      composeExpand: 'Ampliar',
+      composeCounter: 'Rebatir',
+      insertInLabel: 'Insertar en',
+      targetBody: 'Texto',
+      targetFootnote: 'Nota al pie',
+      footnoteUnsupported: 'Tu versión de Word no admite notas al pie desde el complemento.',
+      working: 'Trabajando…',
+      needSelection: 'Selecciona el texto que quieres reescribir.',
+      composeEmpty: 'La IA no devolvió texto.',
+      rewriteDone: 'Reescrito',
+      expandDone: 'Ampliado',
+      counterDone: 'Contraargumento insertado',
+      citationsUsed: 'Citas usadas',
+      insertQuote: 'Insertar cita',
+      quoteInserted: 'Cita insertada',
+      searchingPassages: 'Buscando pasajes…',
+      noPassages: 'Sin pasajes para esa búsqueda.',
+      passagesNotIndexed: 'No hay texto completo indexado. Indexa la biblioteca en Nodus.',
       relation: { supports: 'apoya', contradicts: 'contradice', refines: 'matiza', extends: 'amplía', related: 'relacionada' },
       kind: { idea: 'idea', note: 'nota', passage: 'pasaje', work: 'obra' },
     },
@@ -97,6 +122,28 @@
       editorNotListening: 'LibreOffice is not listening. Run the start_nodus_copilot macro in Writer.',
       wordOnly: 'This add-in only works in Word.',
       nodusError: 'Nodus error',
+      modeIdeas: 'Ideas',
+      modePassages: 'Passages',
+      selectionLabel: 'Selection',
+      composeRewrite: 'Rewrite',
+      composeExpand: 'Expand',
+      composeCounter: 'Counter',
+      insertInLabel: 'Insert into',
+      targetBody: 'Body',
+      targetFootnote: 'Footnote',
+      footnoteUnsupported: 'Your Word version does not support add-in footnotes.',
+      working: 'Working…',
+      needSelection: 'Select the text you want to rewrite.',
+      composeEmpty: 'The AI returned no text.',
+      rewriteDone: 'Rewritten',
+      expandDone: 'Expanded',
+      counterDone: 'Counterargument inserted',
+      citationsUsed: 'Citations used',
+      insertQuote: 'Insert quote',
+      quoteInserted: 'Quote inserted',
+      searchingPassages: 'Searching passages…',
+      noPassages: 'No passages match that search.',
+      passagesNotIndexed: 'No full text indexed. Index your library in Nodus.',
       relation: { supports: 'supports', contradicts: 'contradicts', refines: 'refines', extends: 'extends', related: 'related' },
       kind: { idea: 'idea', note: 'note', passage: 'passage', work: 'work' },
     },
@@ -203,12 +250,15 @@
     });
   }
 
-  function insertAtCursor(text) {
+  function insertAtCursor(text, opts) {
+    opts = opts || {};
+    var asFootnote = !!opts.asFootnote && footnoteSupported;
+    var replace = !!opts.replace;
     if (!isWord) {
       return api('/api/editor/insert', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: text })
+        body: JSON.stringify({ text: text, asFootnote: !!opts.asFootnote, replace: replace })
       }).then(function (result) {
         // The server accepts the text but only a long-polling macro can place
         // it in the document; surface the miss instead of a silent no-op.
@@ -218,6 +268,16 @@
     }
     return Word.run(function (context) {
       var range = context.document.getSelection();
+      if (asFootnote) {
+        // A footnote is anchored at the end of the selection; its own text needs
+        // no leading space and never replaces the selected body text.
+        range.insertFootnote(text);
+        return context.sync();
+      }
+      if (replace) {
+        range.insertText(text, Word.InsertLocation.replace);
+        return context.sync();
+      }
       var prefix = text.charAt(0) === ' ' ? '' : ' ';
       range.insertText(prefix + text, Word.InsertLocation.end);
       return context.sync();
@@ -377,7 +437,7 @@
         });
       })
       .then(function (result) {
-        return insertAtCursor(result.text).then(function () {
+        return insertAtCursor(result.text, { asFootnote: insertTarget === 'footnote' }).then(function () {
           setStatus(T('ideaInserted'), 'ok');
         });
       })
@@ -477,10 +537,14 @@
     });
   }
 
-  function searchIdeas() {
+  function runSearch() {
     var query = els.searchBox.value.trim();
     if (query.length < 2) {
       analyze(true);
+      return;
+    }
+    if (searchMode === 'passages') {
+      searchPassages(query);
       return;
     }
     var seq = ++requestSeq;
@@ -504,6 +568,157 @@
       });
   }
 
+  function searchPassages(query) {
+    var seq = ++requestSeq;
+    els.paragraph.textContent = '';
+    els.empty.style.display = 'block';
+    els.empty.textContent = T('searchingPassages');
+    els.results.innerHTML = '';
+
+    api('/api/passages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: query, limit: 30 }),
+    })
+      .then(function (data) {
+        if (seq !== requestSeq) return;
+        if (!data.available) {
+          renderEmpty(T('needEmbeddings'));
+          return;
+        }
+        if (!data.indexed) {
+          renderEmpty(T('passagesNotIndexed'));
+          return;
+        }
+        renderPassages(data.passages || []);
+      })
+      .catch(function (e) {
+        if (seq !== requestSeq) return;
+        renderEmpty(T('searchError') + e.message);
+      });
+  }
+
+  function renderPassages(passages) {
+    els.results.innerHTML = '';
+    if (!passages.length) {
+      renderEmpty(T('noPassages'));
+      return;
+    }
+    els.empty.style.display = 'none';
+
+    passages.forEach(function (passage) {
+      var card = textEl('article', 'card', '');
+
+      var row = textEl('div', 'row', '');
+      row.appendChild(textEl('span', 'badge passage', KIND_LABEL.passage || 'passage'));
+      row.appendChild(textEl('span', 'label', passage.workTitle || T('untitled')));
+      if (passage.similarity) row.appendChild(textEl('span', 'pct', Math.round(passage.similarity * 100) + '%'));
+      card.appendChild(row);
+
+      var meta = [passage.authorYear, passage.pageLabel].filter(Boolean).join(' · ');
+      if (meta) card.appendChild(textEl('div', 'subtitle', meta));
+      if (passage.snippet) card.appendChild(textEl('p', 'rationale', passage.snippet));
+
+      var actions = textEl('div', 'actions', '');
+      actions.appendChild(button(T('insertQuote'), 'btn small primary', function () { insertPassageQuote(passage, this); }));
+      appendZoteroAction(actions, passage);
+      if (actions.childNodes.length) card.appendChild(actions);
+
+      els.results.appendChild(card);
+    });
+  }
+
+  function insertPassageQuote(passage, btn) {
+    var original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = T('inserting');
+    var body = (passage.text || passage.snippet || '').trim();
+    var quote = '«' + body + '»';
+    if (passage.authorYear) quote += ' (' + passage.authorYear + ')';
+    insertAtCursor(quote, { asFootnote: insertTarget === 'footnote' })
+      .then(function () { setStatus(T('quoteInserted'), 'ok'); })
+      .catch(function (e) { setStatus(e.message, 'err'); })
+      .finally(function () {
+        btn.disabled = false;
+        btn.textContent = original;
+      });
+  }
+
+  var COMPOSE_DONE = { rewrite: 'rewriteDone', expand: 'expandDone', counter: 'counterDone' };
+
+  function runCompose(mode, btn) {
+    var original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = T('working');
+    Promise.all([getCurrentParagraph(), getSelectionText()])
+      .then(function (values) {
+        var paragraphText = values[0];
+        var selectionText = values[1];
+        if (mode === 'rewrite' && !selectionText) {
+          setStatus(T('needSelection'), 'err');
+          return null;
+        }
+        return api('/api/compose', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mode: mode, selectionText: selectionText, paragraphText: paragraphText }),
+        });
+      })
+      .then(function (result) {
+        if (!result) return;
+        if (!result.available) {
+          setStatus(T('needEmbeddings'), 'err');
+          return;
+        }
+        if (!result.text) {
+          setStatus(T('composeEmpty'), 'err');
+          return;
+        }
+        // Rewrite replaces the selected body text; expand/counter append and may
+        // be routed to a footnote per the user's target choice.
+        var replace = mode === 'rewrite';
+        var asFootnote = mode !== 'rewrite' && insertTarget === 'footnote';
+        return insertAtCursor(result.text, { asFootnote: asFootnote, replace: replace }).then(function () {
+          setStatus(T(COMPOSE_DONE[mode] || 'ideaInserted'), 'ok');
+          renderComposeCitations(result.citations);
+        });
+      })
+      .catch(function (e) { setStatus((e && e.message) || String(e), 'err'); })
+      .finally(function () {
+        btn.disabled = false;
+        btn.textContent = original;
+      });
+  }
+
+  function renderComposeCitations(citations) {
+    if (!citations || !citations.length) return;
+    els.empty.style.display = 'none';
+    els.results.innerHTML = '';
+    els.results.appendChild(textEl('div', 'section-title', T('citationsUsed')));
+    citations.forEach(function (citation) {
+      var card = textEl('article', 'card', '');
+      var row = textEl('div', 'row', '');
+      row.appendChild(textEl('span', 'badge idea', KIND_LABEL.work || 'work'));
+      row.appendChild(textEl('span', 'label', citation.label || T('untitled')));
+      card.appendChild(row);
+      if (citation.authorYear) card.appendChild(textEl('div', 'subtitle', citation.authorYear));
+      var actions = textEl('div', 'actions', '');
+      appendZoteroAction(actions, citation);
+      if (actions.childNodes.length) card.appendChild(actions);
+      els.results.appendChild(card);
+    });
+  }
+
+  function setSearchMode(mode) {
+    if (mode === searchMode) return;
+    searchMode = mode;
+    var buttons = els.searchModeEl ? els.searchModeEl.querySelectorAll('.seg') : [];
+    for (var i = 0; i < buttons.length; i++) {
+      buttons[i].classList.toggle('active', buttons[i].getAttribute('data-mode') === mode);
+    }
+    if (els.searchBox.value.trim().length >= 2) runSearch();
+  }
+
   function onSelectionChanged() {
     if (!autoAnalyze || els.searchBox.value.trim()) return;
     if (debounceTimer) clearTimeout(debounceTimer);
@@ -512,7 +727,7 @@
 
   function onSearchInput() {
     if (searchTimer) clearTimeout(searchTimer);
-    searchTimer = setTimeout(searchIdeas, DEBOUNCE_MS);
+    searchTimer = setTimeout(runSearch, DEBOUNCE_MS);
   }
 
   function checkHealth() {
@@ -554,6 +769,11 @@
     els.autoToggle = document.getElementById('autoToggle');
     els.searchBox = document.getElementById('searchBox');
     els.searchBtn = document.getElementById('searchBtn');
+    els.searchModeEl = document.getElementById('searchMode');
+    els.selectionActions = document.getElementById('selectionActions');
+    els.insertTargetEl = document.getElementById('insertTarget');
+    els.footnoteOption = document.getElementById('footnoteOption');
+    els.footnoteRadio = document.getElementById('footnoteRadio');
 
     document.documentElement.lang = LANG;
     els.status.textContent = T('connecting');
@@ -561,6 +781,42 @@
     els.searchBtn.title = T('searchTitle');
     els.analyzeBtn.textContent = T('analyze');
     els.empty.textContent = T('emptyInitial');
+
+    // Localize the segmented search mode, selection actions and insert target.
+    var modeButtons = els.searchModeEl.querySelectorAll('.seg');
+    for (var mi = 0; mi < modeButtons.length; mi++) {
+      modeButtons[mi].textContent = modeButtons[mi].getAttribute('data-mode') === 'passages' ? T('modePassages') : T('modeIdeas');
+    }
+    var saLabel = els.selectionActions.querySelector('.sa-label');
+    if (saLabel) saLabel.textContent = T('selectionLabel');
+    var composeButtons = els.selectionActions.querySelectorAll('[data-compose]');
+    for (var ci = 0; ci < composeButtons.length; ci++) {
+      var cmode = composeButtons[ci].getAttribute('data-compose');
+      composeButtons[ci].textContent = cmode === 'rewrite' ? T('composeRewrite') : cmode === 'expand' ? T('composeExpand') : T('composeCounter');
+    }
+    var itLabel = els.insertTargetEl.querySelector('.it-label');
+    if (itLabel) itLabel.textContent = T('insertInLabel');
+    var bodySpan = els.insertTargetEl.querySelector('[data-it="body"]');
+    var footnoteSpan = els.insertTargetEl.querySelector('[data-it="footnote"]');
+    if (bodySpan) bodySpan.textContent = T('targetBody');
+    if (footnoteSpan) footnoteSpan.textContent = T('targetFootnote');
+
+    // Footnotes need WordApi 1.5. Standalone (LibreOffice) relies on the macro,
+    // which falls back to inline if its Writer build cannot place a footnote.
+    if (isWord) {
+      try {
+        footnoteSupported = !!(Office.context.requirements && Office.context.requirements.isSetSupported('WordApi', '1.5'));
+      } catch (e) {
+        footnoteSupported = false;
+      }
+    }
+    if (!footnoteSupported) {
+      if (els.footnoteRadio) els.footnoteRadio.disabled = true;
+      if (els.footnoteOption) {
+        els.footnoteOption.classList.add('disabled');
+        els.footnoteOption.title = T('footnoteUnsupported');
+      }
+    }
 
     if (!isWord) {
       var captionEl = document.querySelector('.head .caption');
@@ -585,16 +841,33 @@
       els.searchBox.value = '';
       analyze(true);
     };
-    els.searchBtn.onclick = searchIdeas;
+    els.searchBtn.onclick = runSearch;
     els.searchBox.oninput = onSearchInput;
     els.searchBox.onkeydown = function (event) {
-      if (event.key === 'Enter') searchIdeas();
+      if (event.key === 'Enter') runSearch();
       if (event.key === 'Escape') {
         els.searchBox.value = '';
         analyze(true);
       }
     };
     els.autoToggle.onchange = function () { autoAnalyze = els.autoToggle.checked; };
+
+    for (var mb = 0; mb < modeButtons.length; mb++) {
+      (function (btn) {
+        btn.onclick = function () { setSearchMode(btn.getAttribute('data-mode')); };
+      })(modeButtons[mb]);
+    }
+    for (var cbi = 0; cbi < composeButtons.length; cbi++) {
+      (function (btn) {
+        btn.onclick = function () { runCompose(btn.getAttribute('data-compose'), btn); };
+      })(composeButtons[cbi]);
+    }
+    var targetRadios = els.insertTargetEl.querySelectorAll('input[name="insTarget"]');
+    for (var ri = 0; ri < targetRadios.length; ri++) {
+      targetRadios[ri].onchange = function () {
+        if (this.checked) insertTarget = this.value;
+      };
+    }
 
     // The status chip doubles as a retry button when Nodus is unreachable.
     els.status.style.cursor = 'pointer';


### PR DESCRIPTION
Closes #129

Turns the Word task pane from a lookup tool into a writing assistant, reusing the existing engine (the pane stays a thin second face).

## What's new

### 1. Footnotes
An **Insert into: Body / Footnote** selector applies to idea insertion, passage quotes, and compose results.
- Word: `range.insertFootnote` gated on `isSetSupported('WordApi', '1.5')` — the option is disabled with a tooltip when unsupported.
- LibreOffice: the macro creates a `com.sun.star.text.Footnote` with a `try/except` fallback to inline, so text is never lost.
- The editor bridge payload now carries `{ text, asFootnote, replace }` (was a bare string).

### 2. Compose over the selection
A **Selection** row with **Rewrite / Expand / Counter**, served by `POST /api/compose` → `composeFromSelection`.
- Reuses `analyzeText`'s typed relations; **Counter** prefers ideas typed `contradicts`/`refines`.
- Rewrite replaces the selection; Expand/Counter append and can be routed to a footnote.
- The citations used are surfaced with Zotero buttons.

### 3. Citable passage search
An **Ideas / Passages** toggle. Passages run semantic search over the full text via `POST /api/passages` → `searchCopilotPassages`; each hit can be inserted as a verbatim quote (`«…» (Author, year)`) or cited in Zotero.

### Housekeeping
- Manifest `<Version>` bumped to `2.4.0` (cosmetic — `renderManifest` overrides it with the app version at install time).
- README updated.

## Verification
- `typecheck` (electron + root), `lint`, JS/Python syntax — green.
- Existing copilot manifest test — green.
- **Extended** `scripts/test-libreoffice-copilot.mjs`: the bridge forwards `asFootnote`/`replace`; `/api/passages` and `/api/compose` return `available: false` cleanly with no embedding provider; an unknown compose mode defaults to `expand`.
- i18n coverage 20/20.
- Rendered the pane at desktop and Word-pane widths (~340px): lays out cleanly, no console errors.

## Notes
AI output quality (compose text, passage ranking) is not unit-testable offline (needs a configured provider), matching the rest of the engine; routing, auth, the bridge, and the no-embeddings fallbacks are covered by the integration test.