### PR TITLE
fix(db): self-heal vaults whose schema version doesn't match their tables

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -3126,16 +3126,152 @@ export const migrations: Migration[] = [
   },
 ];
 
+/**
+ * A SQLite error that means the statement's object or column is ALREADY THERE. This is
+ * how a database built by a differently-numbered build announces itself: an object a
+ * migration wants to create already exists, or a column it wants to add is already
+ * present. It is never a reason to fail — the intent (that object should exist) is met —
+ * but it must be distinguished from a genuine migration error, which is not swallowed.
+ */
+function isAlreadyAppliedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /already exists|duplicate column name/i.test(message);
+}
+
+/**
+ * A migration body that only CREATEs objects — no ALTER, DROP, RENAME or data change.
+ * Only such a body is safe to replay to backfill a missing object: replaying one that
+ * transforms data or rebuilds a table (e.g. copy-into-new-then-drop-old) could destroy
+ * data on a database where it already ran. Comments are stripped first so prose that
+ * happens to mention "delete" or "update" does not disqualify a pure-CREATE migration.
+ */
+function isCreateOnly(sql: string): boolean {
+  const bare = stripSqlComments(sql);
+  return /\bCREATE\b/i.test(bare) && !/\b(ALTER|DROP|INSERT|UPDATE|DELETE|REPLACE)\b/i.test(bare);
+}
+
+function stripSqlComments(sql: string): string {
+  return sql.replace(/--[^\n]*/g, ' ').replace(/\/\*[\s\S]*?\*\//g, ' ');
+}
+
+/** The table/index/view/trigger names a CREATE-only body brings into being. */
+function objectNamesCreatedBy(sql: string): string[] {
+  const re = /CREATE\s+(?:UNIQUE\s+)?(?:TABLE|INDEX|VIEW|TRIGGER)\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?([A-Za-z_][A-Za-z0-9_]*)["'`]?/gi;
+  const names: string[] = [];
+  let match: RegExpExecArray | null;
+  const bare = stripSqlComments(sql);
+  while ((match = re.exec(bare)) !== null) names.push(match[1]);
+  return names;
+}
+
+/**
+ * Split a migration body into top-level statements, honouring single-quoted string
+ * literals ('' escapes included) and both comment styles so a ';' inside any of them
+ * never splits a statement. Migrations contain no triggers or BEGIN...END blocks — the
+ * only source of nested semicolons — which a test asserts stays true.
+ */
+function splitStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let current = '';
+  let i = 0;
+  while (i < sql.length) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+    if (ch === '-' && next === '-') {
+      while (i < sql.length && sql[i] !== '\n') { current += sql[i]; i++; }
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      current += '/*'; i += 2;
+      while (i < sql.length && !(sql[i] === '*' && sql[i + 1] === '/')) { current += sql[i]; i++; }
+      current += '*/'; i += 2;
+      continue;
+    }
+    if (ch === "'") {
+      current += ch; i++;
+      while (i < sql.length) {
+        current += sql[i];
+        if (sql[i] === "'") {
+          if (sql[i + 1] === "'") { current += sql[i + 1]; i += 2; continue; }
+          i++; break;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (ch === ';') { statements.push(current.trim()); current = ''; i++; continue; }
+    current += ch; i++;
+  }
+  if (current.trim()) statements.push(current.trim());
+  return statements.filter((s) => s.length > 0);
+}
+
+/** Run a body statement by statement, skipping only statements whose object/column is
+ *  already there. Any other error still aborts, so a real failure is never masked. */
+function execSkippingApplied(db: Database.Database, sql: string): void {
+  for (const statement of splitStatements(sql)) {
+    try {
+      db.exec(statement);
+    } catch (error) {
+      if (!isAlreadyAppliedError(error)) throw error;
+    }
+  }
+}
+
+/**
+ * Create any purely-additive table or index a database is MISSING even though its
+ * user_version is already at or past the migration that introduced it. This happens when
+ * a database was migrated by a build whose migration numbering differed (a pre-release,
+ * or a feature branch that was later reordered): that build's user_version can sit above
+ * an object it never created here, so the normal `version > current` loop skips the
+ * migration forever and the table is silently absent. Restricted to CREATE-only
+ * migrations and to those the database claims as applied, so a fresh database (nothing
+ * applied yet) and data-transforming rebuilds are both left untouched.
+ */
+function backfillMissingCreateOnly(db: Database.Database, current: number): void {
+  const existing = new Set(
+    (db.prepare("SELECT name FROM sqlite_master WHERE type IN ('table','index','view','trigger')").all() as { name: string }[])
+      .map((row) => row.name)
+  );
+  const applied = migrations.filter((m) => m.version <= current && isCreateOnly(m.up));
+  const tx = db.transaction(() => {
+    for (const m of applied) {
+      const names = objectNamesCreatedBy(m.up);
+      if (names.length > 0 && names.every((name) => existing.has(name))) continue;
+      execSkippingApplied(db, m.up);
+      for (const name of names) existing.add(name);
+    }
+  });
+  tx();
+}
+
 export function runMigrations(db: Database.Database): void {
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
   const current = db.pragma('user_version', { simple: true }) as number;
+  // Repair databases that a differently-numbered build left with a purely-additive table
+  // missing below the version line, then migrate forward. Both defend against the same
+  // cause: a user_version that does not match the objects actually present.
+  backfillMissingCreateOnly(db, current);
   const pending = migrations.filter((m) => m.version > current).sort((a, b) => a.version - b.version);
   for (const m of pending) {
-    const tx = db.transaction(() => {
-      db.exec(m.up);
-      db.pragma(`user_version = ${m.version}`);
-    });
-    tx();
+    try {
+      const tx = db.transaction(() => {
+        db.exec(m.up);
+        db.pragma(`user_version = ${m.version}`);
+      });
+      tx();
+    } catch (error) {
+      // A CREATE-only migration whose objects already exist was applied under another
+      // build's number. Re-apply only what is missing and record the version, instead of
+      // failing the vault switch with "table ... already exists". Anything else — or any
+      // migration that transforms data — is re-thrown rather than risked.
+      if (!isAlreadyAppliedError(error) || !isCreateOnly(m.up)) throw error;
+      const tx = db.transaction(() => {
+        execSkippingApplied(db, m.up);
+        db.pragma(`user_version = ${m.version}`);
+      });
+      tx();
+    }
   }
 }

--- a/scripts/test-migration-renumber-recovery.mjs
+++ b/scripts/test-migration-renumber-recovery.mjs
@@ -1,0 +1,156 @@
+// Verifies runMigrations() self-heals a database whose user_version does not match the
+// objects actually present — the state left behind when a vault was migrated by a build
+// whose migration numbering differed (a pre-release, or a feature branch later reordered
+// on main). Two symptoms are reproduced from the REAL migration list:
+//
+//   (a) a "future" CREATE-only migration's objects already exist while user_version sits
+//       one below it. The old runMigrations threw "table ... already exists" and the
+//       vault could not be opened (this is the reported bug).
+//   (b) a purely-additive table below the version line was never created here, because
+//       the differing numbering carried user_version past it. It stays silently absent.
+//
+// The fix must, in both cases, finish without throwing, reach SCHEMA_VERSION, create only
+// what is missing, and never duplicate an object. It must also leave a healthy database
+// completely untouched.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+if (!process.argv.includes('--electron-migration-test')) {
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/electron'),
+    [path.join(repoRoot, 'scripts/test-migration-renumber-recovery.mjs'), '--electron-migration-test'],
+    { cwd: repoRoot, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, stdio: 'inherit' }
+  );
+  process.exit(0);
+}
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-renumber-test-'));
+installTsHook();
+
+try {
+  const Database = require('better-sqlite3');
+  const { migrations, runMigrations, SCHEMA_VERSION } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
+
+  // The migrations that create the two tables the real corruption involved. Found by
+  // content, not by hard-coded version, so this test survives future append-only work.
+  const protectMig = migrations.find((m) => /CREATE\s+TABLE\s+protect_copies\b/i.test(m.up));
+  const supersededMig = migrations.find((m) => /CREATE\s+TABLE\s+sync_superseded\b/i.test(m.up));
+  assert.ok(protectMig, 'expected a migration that creates protect_copies');
+  assert.ok(supersededMig, 'expected a migration that creates sync_superseded');
+
+  // The splitter and CREATE-only recovery assume no migration body carries a trigger or a
+  // BEGIN...END block (the only source of nested semicolons). Guard that invariant here so
+  // a future migration that breaks it fails loudly rather than silently mis-splitting.
+  for (const m of migrations) {
+    assert.ok(!/CREATE\s+TRIGGER/i.test(m.up), `migration v${m.version} must not define a trigger`);
+  }
+
+  // -- Scenario (a): future CREATE-only migration's objects already present -------------
+  {
+    const dbPath = path.join(root, 'crash.sqlite');
+    const db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    for (const m of migrations.filter((x) => x.version < protectMig.version).sort((x, y) => x.version - y.version)) {
+      db.exec(m.up);
+      db.pragma(`user_version = ${m.version}`);
+    }
+    // The differing build already created this table; user_version stays one below it.
+    db.exec(protectMig.up);
+    assert.equal(hasTable(db, 'protect_copies'), true, 'setup: protect_copies pre-exists');
+    assert.equal(db.pragma('user_version', { simple: true }), protectMig.version - 1, 'setup: version is one below');
+
+    // Old code threw "table protect_copies already exists" here.
+    assert.doesNotThrow(() => runMigrations(db), 'switch must not crash when the table already exists');
+    assert.equal(db.pragma('user_version', { simple: true }), SCHEMA_VERSION, 'reaches current schema');
+    assert.equal(tableCount(db, 'protect_copies'), 1, 'protect_copies is not duplicated');
+    db.close();
+  }
+
+  // -- Scenario (b) ---------------------------------------------------------------------
+  {
+    const dbPath = path.join(root, 'skipped.sqlite');
+    const db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    runMigrations(db); // fully healthy at SCHEMA_VERSION
+    assert.equal(db.pragma('user_version', { simple: true }), SCHEMA_VERSION, 'setup: healthy DB');
+
+    // Simulate the additive table having been skipped by a differing numbering: it is gone
+    // yet user_version stays at the top, so the normal `version > current` loop never
+    // reconsiders it.
+    db.exec('DROP TABLE sync_superseded');
+    assert.equal(hasTable(db, 'sync_superseded'), false, 'setup: additive table missing');
+
+    runMigrations(db);
+    assert.equal(hasTable(db, 'sync_superseded'), true, 'missing additive table is backfilled');
+    assert.equal(db.pragma('user_version', { simple: true }), SCHEMA_VERSION, 'version unchanged');
+    db.close();
+  }
+
+  // -- Healthy database is untouched, and running twice is a no-op -----------------------
+  {
+    const db = new Database(path.join(root, 'healthy.sqlite'));
+    db.pragma('journal_mode = WAL');
+    runMigrations(db);
+    const before = objectFingerprint(db);
+    runMigrations(db);
+    const after = objectFingerprint(db);
+    assert.deepEqual(after, before, 'a second run changes nothing on a healthy DB');
+    assert.equal(tableCount(db, 'protect_copies'), 1, 'no duplicated objects on a healthy DB');
+    db.close();
+  }
+
+  console.log('Migration renumber recovery test passed!');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+function hasTable(db, name) {
+  return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?").get(name));
+}
+
+function tableCount(db, name) {
+  return db.prepare("SELECT COUNT(*) AS c FROM sqlite_master WHERE type='table' AND name = ?").get(name).c;
+}
+
+function objectFingerprint(db) {
+  return db
+    .prepare("SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name")
+    .all();
+}
+
+function installTsHook() {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) {
+      return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    }
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  require.extensions['.ts'] = function loadTs(module, filename) {
+    const source = fs.readFileSync(filename, 'utf8');
+    const output = ts.transpileModule(source, {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}


### PR DESCRIPTION
Closes #134.

## Problem

Switching to a vault could fail with `SqliteError: table protect_copies already exists`, leaving the vault unopenable. It happens on databases migrated by a build with **different migration numbering** (a pre-release, or a feature branch reordered on `main`), which leaves `user_version` out of step with the objects actually present:

- a **CREATE-only migration's table already exists** while `user_version` sits below it → the pending `CREATE TABLE` throws;
- a **lower additive migration was skipped** entirely and its table is silently absent.

Released builds alone never reach this (append-only numbering), but a user who ran betas/branch builds against real vaults can — and today the vault simply won't open.

## Fix

`runMigrations()` now reconciles the schema against what `user_version` claims, in both directions:

- **Backfill** purely-additive (CREATE-only) tables/indexes missing below the version line.
- On a pending **CREATE-only** migration whose objects already exist, re-apply only what is missing instead of throwing.

Safety properties:

- **Data-transforming / table-rebuild migrations are never replayed** — only CREATE-only bodies are, so no migration that copies or drops data can run twice. Anything else that errors is re-thrown, never swallowed.
- A **healthy database takes the unchanged fast path**; the reconciliation is a cheap `sqlite_master` lookup that no-ops when everything is present.
- The statement splitter relies on migrations having no triggers / `BEGIN…END` blocks; a test asserts that invariant holds.

## Testing

- New `scripts/test-migration-renumber-recovery.mjs` reproduces **both** symptoms from the real migration list (future table already present; additive table skipped) and asserts recovery, no duplication, and that a healthy DB is left byte-identical.
- `npm run test:e2e` passes (`database at schema v90`).
- Related migration/vault/sync/protect/databases/study tests pass; `typecheck` and `lint` clean.

No release bump — accumulating fixes for a later release.