### PR TITLE
Show BETA badge on the Docencia vault type

### DIFF
--- a/scripts/test-vault-types.mjs
+++ b/scripts/test-vault-types.mjs
@@ -75,7 +75,7 @@ test('the vault picker derives selectable modes from the canonical registry', as
   assert.match(picker, /VAULT_TYPES\.filter\(\(type\) => type\.available\)/);
   assert.match(picker, /const CREATE_VAULT_TYPES: VaultType\[\] = \[\s*'academic', 'primary_sources', 'testimonios',\s*'databases', 'docencia', 'estudio',\s*'genealogy', 'worldbuilding',\s*\]/s);
   assert.doesNotMatch(picker, /COMING_SOON_VAULT_TYPES[^\n]*estudio/);
-  assert.match(picker, /type === 'estudio' \|\| type === 'genealogy' \|\| type === 'databases'\) return 'beta'/);
+  assert.match(picker, /type === 'estudio' \|\| type === 'genealogy' \|\| type === 'databases' \|\| type === 'docencia'\) return 'beta'/);
   assert.doesNotMatch(picker, /type === '(?:estudio|genealogy)'\) return '(?:pre-alpha|alpha)'/);
   assert.match(picker, /data-testid="vault-phase-notice"/);
   assert.match(picker, /data-testid="vault-preview-notice"/);

--- a/src/components/VaultSwitcher.tsx
+++ b/src/components/VaultSwitcher.tsx
@@ -84,7 +84,7 @@ export function vaultTypeIcon(type: VaultType): string {
 }
 
 function vaultTypePhase(type: VaultType): VaultPhase | null {
-  if (type === 'estudio' || type === 'genealogy' || type === 'databases') return 'beta';
+  if (type === 'estudio' || type === 'genealogy' || type === 'databases' || type === 'docencia') return 'beta';
   return null;
 }
 


### PR DESCRIPTION
## Summary
The **Docencia** (teaching) vault type now shows a **BETA** badge in the vault switcher, matching the other in-development modes (`estudio`, `genealogy`, `databases`). `academic` remains the only stable mode with no badge.

## Changes
- `src/components/VaultSwitcher.tsx`: add `docencia` to the `vaultTypePhase()` beta check.
- `scripts/test-vault-types.mjs`: update the invariant that pins the exact beta condition string.

## Verification
- `node --test scripts/test-vault-types.mjs` → 20/20 pass
- `npx tsc --noEmit` → clean

Closes #138