### PR TITLE
About Nodus: localized in-app modals for Privacy/GDPR/Licenses + dedicated Updates section

### DIFF
--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -459,14 +459,25 @@ try {
   assert.ok(Math.max(...advancedPickerHeights) - Math.min(...advancedPickerHeights) <= 1, 'the Nodi model selector has the same height as adjacent advanced selectors');
   console.log('[e2e] image provider settings rendered');
   await page.getByRole('button', { name: 'Acerca de Nodus', exact: true }).click();
+  await page.getByTestId('about-privacy').waitFor();
+  assert.equal(await page.getByTestId('about-updates').count(), 0, 'Updates moved out of About Nodus into its own section');
+  // The privacy card opens a localized in-app modal instead of launching an external markdown file.
+  await page.getByTestId('open-privacy-policy').click();
+  await page.getByTestId('legal-doc-modal-privacy').waitFor();
+  await page.getByTestId('legal-doc-modal-privacy').getByText('Privacidad y control de datos', { exact: true }).waitFor();
+  await page.getByTestId('legal-doc-canonical-privacy').waitFor();
+  await page.getByTestId('legal-doc-close-privacy').click();
+  await page.getByTestId('legal-doc-modal-privacy').waitFor({ state: 'detached' });
+  console.log('[e2e] About legal cards open a localized in-app modal');
+
+  await page.getByRole('button', { name: 'Actualizaciones y novedades', exact: true }).click();
   await page.getByTestId('about-updates').waitFor();
-  assert.equal(await page.getByText('Guía esencial de Nodus e IA', { exact: true }).count(), 0, 'Updates is rendered under About Nodus, not Tutorials');
   await page.getByTestId('about-latest-changes').waitFor();
   const [latestChangesButtonBox, checkUpdatesButtonBox] = await Promise.all([
     page.getByTestId('open-latest-changes').boundingBox(),
     page.getByTestId('about-updates').getByRole('button', { name: 'Buscar actualización', exact: true }).boundingBox(),
   ]);
-  assert.ok(latestChangesButtonBox && checkUpdatesButtonBox, 'About Nodus renders both release-related actions');
+  assert.ok(latestChangesButtonBox && checkUpdatesButtonBox, 'The Updates section renders both release-related actions');
   assert.equal(latestChangesButtonBox.width, checkUpdatesButtonBox.width, 'Latest changes and Check for updates have the same width');
   assert.equal(latestChangesButtonBox.height, checkUpdatesButtonBox.height, 'Latest changes and Check for updates have the same height');
   await page.getByTestId('open-latest-changes').click();

--- a/scripts/test-license-compliance.mjs
+++ b/scripts/test-license-compliance.mjs
@@ -47,7 +47,8 @@ test('large upstream notices are immutable and fail-closed', () => {
 });
 
 test('licenses are visible in About and before local model downloads', () => {
-  assert.match(read('src/views/Settings.tsx'), /openThirdPartyNotices/);
+  assert.match(read('src/views/Settings.tsx'), /setOpenLegalDoc\('licenses'\)/);
+  assert.match(read('src/legalDocs.ts'), /blob\/main\/THIRD_PARTY_NOTICES\.md/);
   assert.match(read('src/components/LocalAiModelsSettings.tsx'), /model\.licenseLabel/);
   assert.match(read('src/views/AudioGenerationSettings.tsx'), /v\.licenseLabel/);
   assert.match(read('shared/localAiModels.ts'), /LFM Open License 1\.0/);

--- a/scripts/test-privacy-compliance.mjs
+++ b/scripts/test-privacy-compliance.mjs
@@ -33,12 +33,28 @@ test('the distributable contains the privacy policy and controller checklist', a
   assert.match(settings, /data-testid="about-gdpr"/);
   assert.match(settings, /data-testid="about-third-party-licenses"/);
   assert.match(settings, /data-testid="about-transparency-security"/);
-  assert.match(settings, /window\.nodus\.openPrivacyPolicy\(\)/);
+  // The privacy, GDPR and licenses cards open a localized in-app modal instead of
+  // launching an external markdown file (which only existed in Spanish).
+  assert.match(settings, /setOpenLegalDoc\('privacy'\)/);
+  assert.match(settings, /setOpenLegalDoc\('gdpr'\)/);
+  assert.match(settings, /setOpenLegalDoc\('licenses'\)/);
+  assert.match(settings, /<LegalDocModal/);
   assert.match(settings, /blob\/main\/PRIVACY\.md/);
-  assert.match(settings, /blob\/main\/legal\/RGPD_DEPLOYMENT_CHECKLIST\.md/);
   assert.match(settings, /blob\/main\/LICENSE/);
   assert.match(settings, /security\/advisories\/new/);
   assert.match(settings, /no es una certificación/);
+
+  // The in-app modal content links back to the authoritative documents and is
+  // authored per UI language (no Spanish leaks into a non-Spanish UI).
+  const legalDocs = await read('src/legalDocs.ts');
+  assert.match(legalDocs, /blob\/main\/PRIVACY\.md/);
+  assert.match(legalDocs, /blob\/main\/legal\/RGPD_DEPLOYMENT_CHECKLIST\.md/);
+  assert.match(legalDocs, /blob\/main\/THIRD_PARTY_NOTICES\.md/);
+  for (const key of ['es:', 'en:', 'fr:', 'de:', 'pt:', "'pt-BR':", 'it:']) {
+    assert.ok(legalDocs.includes(key), `legalDocs must cover the ${key} language`);
+  }
+  assert.match(legalDocs, /cannot grade, profile or evaluate students/);
+
   for (const source of await Promise.all(['electron/ipc.ts', 'electron/preload.ts', 'shared/types.ts'].map(read))) {
     assert.match(source, /openPrivacyPolicy/);
   }

--- a/scripts/test-settings-visual-regressions.mjs
+++ b/scripts/test-settings-visual-regressions.mjs
@@ -20,13 +20,15 @@ assert.match(
 
 const tutorialsSection = settings.indexOf("visibleSettingsSection('system', 'Ayuda'");
 const aboutSection = settings.indexOf("visibleSettingsSection('about', 'Acerca de Nodus'", tutorialsSection);
-const latestChangesControl = settings.indexOf('data-testid="about-latest-changes"', tutorialsSection);
-const updatesControl = settings.indexOf('data-testid="about-updates"', tutorialsSection);
+// Updates and Latest changes live in their own section, rendered right after About.
+const updatesSection = settings.indexOf("visibleSettingsSection('updates', 'Actualizaciones y novedades'", aboutSection);
+const latestChangesControl = settings.indexOf('data-testid="about-latest-changes"', updatesSection);
+const updatesControl = settings.indexOf('data-testid="about-updates"', updatesSection);
 assert.ok(tutorialsSection >= 0 && aboutSection > tutorialsSection, 'settings sections must be present in their expected order');
-assert.ok(latestChangesControl > aboutSection, 'the latest changes control must be rendered inside About Nodus');
+assert.ok(updatesSection > aboutSection, 'the Updates & what\'s new section must follow About Nodus');
+assert.ok(latestChangesControl > updatesSection, 'the latest changes control must be rendered in the Updates section');
 assert.ok(updatesControl > latestChangesControl, 'latest changes must be presented before the update checker');
-assert.ok(updatesControl > aboutSection, 'the updates control must be rendered inside About Nodus, after Tutorials');
-assert.equal(settings.slice(tutorialsSection, aboutSection).includes("t('Actualizaciones')"), false, 'Tutorials must not render the updates control');
+assert.equal(settings.slice(aboutSection, updatesSection).includes('data-testid="about-updates"'), false, 'About Nodus must not render the updates control anymore');
 assert.match(settings, /const ABOUT_ACTION_BUTTON_CLASS = 'btn btn-ghost w-full[^']+sm:w-56'/);
 assert.equal((settings.match(/className=\{ABOUT_ACTION_BUTTON_CLASS\}/g) ?? []).length, 10, 'About actions must use the same responsive button class');
 assert.match(settings, /data-testid="open-latest-changes"[\s\S]*onClick=\{onOpenWhatsNew\}/);

--- a/src/components/LegalDocModal.tsx
+++ b/src/components/LegalDocModal.tsx
@@ -1,0 +1,107 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { motion } from 'framer-motion';
+import type { AppLanguage } from '@shared/types';
+import { legalDocContent, type LegalDoc } from '../legalDocs';
+import { Icon } from './ui';
+import { t } from '../i18n';
+
+/**
+ * In-app viewer for the About "legal" cards (privacy, GDPR, licenses). Renders a
+ * localized summary — never opening an external markdown file — with a link to
+ * the authoritative full document on GitHub. Closes on Escape or backdrop click.
+ */
+export function LegalDocModal({
+  doc,
+  language,
+  onClose,
+}: {
+  doc: LegalDoc;
+  language: AppLanguage;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const content = legalDocContent(doc, language);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[130] flex items-center justify-center bg-black/60 p-4 sm:p-6"
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.97, y: 12 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ duration: 0.2 }}
+        className="card flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden p-0"
+        role="dialog"
+        aria-modal="true"
+        aria-label={content.title}
+        data-testid={`legal-doc-modal-${doc.id}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-start gap-3 border-b border-neutral-200 p-5 dark:border-neutral-800">
+          <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${doc.badgeClass}`}>
+            <Icon name={doc.icon} size={20} />
+          </div>
+          <h2 className="mt-1 flex-1 text-base font-semibold text-neutral-900 dark:text-neutral-100">
+            {content.title}
+          </h2>
+          <button
+            className="shrink-0 rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+            onClick={onClose}
+            aria-label={t('Cerrar')}
+          >
+            <Icon name="x" size={16} />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-5">
+          <p className="text-sm leading-6 text-neutral-700 dark:text-neutral-300">{content.intro}</p>
+          <div className="mt-5 space-y-5">
+            {content.sections.map((section, index) => (
+              <section key={index}>
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{section.heading}</h3>
+                <ul className="mt-2 space-y-1.5">
+                  {section.bullets.map((bullet, bulletIndex) => (
+                    <li
+                      key={bulletIndex}
+                      className="flex gap-2 text-sm leading-6 text-neutral-600 dark:text-neutral-400"
+                    >
+                      <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400 dark:bg-neutral-600" />
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+        </div>
+
+        <footer className="flex flex-col gap-2 border-t border-neutral-200 p-5 dark:border-neutral-800 sm:flex-row sm:justify-end">
+          <button
+            className="btn btn-ghost w-full justify-center border border-neutral-300 dark:border-neutral-700 sm:w-auto"
+            data-testid={`legal-doc-canonical-${doc.id}`}
+            onClick={() => void window.nodus.openExternal(doc.canonicalUrl)}
+          >
+            <Icon name="external" /> {content.canonicalLabel}
+          </button>
+          <button
+            className="btn btn-primary w-full justify-center sm:w-auto"
+            data-testid={`legal-doc-close-${doc.id}`}
+            onClick={onClose}
+          >
+            {t('Cerrar')}
+          </button>
+        </footer>
+      </motion.div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -1314,6 +1314,7 @@ export const DE: Record<string, string> = {
     'Der vollständige Ablauf: kritisch lesen, den Korpus verstehen, Ihren Beitrag finden und schreiben.',
   'Empezar': 'Starten',
   'Actualizaciones': 'Aktualisierungen',
+  'Actualizaciones y novedades': 'Updates und Neuigkeiten',
   'Últimos cambios': 'Neueste Änderungen',
   'Consulta las novedades de la versión actual cuando quieras.': 'Sehen Sie sich jederzeit die Neuerungen der aktuellen Version an.',
   'Ver últimos cambios': 'Neueste Änderungen ansehen',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -1325,6 +1325,7 @@ export const EN: Record<string, string> = {
     'The full flow: read critically, understand the corpus, find your contribution and write.',
   Empezar: 'Start',
   Actualizaciones: 'Updates',
+  'Actualizaciones y novedades': "Updates & what's new",
   'Últimos cambios': 'Latest changes',
   'Consulta las novedades de la versión actual cuando quieras.': 'Review what’s new in the current version whenever you like.',
   'Ver últimos cambios': 'View latest changes',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -1313,6 +1313,7 @@ export const FR: Record<string, string> = {
     'Le flux complet : lire avec discernement, comprendre le corpus, trouver votre contribution et écrire.',
   'Empezar': 'Commencer',
   'Actualizaciones': 'Mises à jour',
+  'Actualizaciones y novedades': 'Mises à jour et nouveautés',
   'Últimos cambios': 'Derniers changements',
   'Consulta las novedades de la versión actual cuando quieras.': 'Consultez les nouveautés de la version actuelle quand vous le souhaitez.',
   'Ver últimos cambios': 'Voir les derniers changements',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -1190,6 +1190,7 @@ export const IT: Record<string, string> = {
   "El flujo completo: leer con criterio, comprender el corpus, encontrar tu aportación y escribir.": "Il flusso completo: leggi in modo critico, comprendi il corpus, trova il tuo contributo e scrivi.",
   "Empezar": "Inizia",
   "Actualizaciones": "Aggiornamenti",
+  "Actualizaciones y novedades": "Aggiornamenti e novità",
   "Últimos cambios": "Ultime modifiche",
   "Consulta las novedades de la versión actual cuando quieras.": "Controlla le novità della versione corrente ogni volta che vuoi.",
   "Ver últimos cambios": "Visualizza le ultime modifiche",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -1302,6 +1302,7 @@ export const PT_BR: Record<string, string> = {
     'O fluxo completo: ler com critério, compreender o corpus, encontrar sua contribuição e escrever.',
   'Empezar': 'Começar',
   'Actualizaciones': 'Atualizações',
+  'Actualizaciones y novedades': 'Atualizações e novidades',
   'Últimos cambios': 'Últimas alterações',
   'Consulta las novedades de la versión actual cuando quieras.': 'Consulte as novidades da versão atual quando quiser.',
   'Ver últimos cambios': 'Ver últimas alterações',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -1300,6 +1300,7 @@ export const PT: Record<string, string> = {
     'O fluxo completo: ler com critério, compreender o corpus, encontrar o seu contributo e escrever.',
   'Empezar': 'Começar',
   'Actualizaciones': 'Atualizações',
+  'Actualizaciones y novedades': 'Atualizações e novidades',
   'Últimos cambios': 'Últimas alterações',
   'Consulta las novedades de la versión actual cuando quieras.': 'Consulte as novidades da versão atual quando quiser.',
   'Ver últimos cambios': 'Ver últimas alterações',

--- a/src/legalDocs.ts
+++ b/src/legalDocs.ts
@@ -1,0 +1,573 @@
+import type { AppLanguage } from '@shared/types';
+
+// Localized, in-app content for the About "legal" cards (privacy, GDPR, licenses).
+// These are self-contained summaries shown inside a modal — no external file is
+// opened — with a link to the authoritative full document on GitHub. The content
+// is authored per language (like WhatsNewModal's release notes) so it never falls
+// back to Spanish in a non-Spanish UI. Each record must cover every AppLanguage.
+
+export type LegalDocId = 'privacy' | 'gdpr' | 'licenses';
+
+export interface LegalDocSection {
+  heading: string;
+  bullets: string[];
+}
+
+export interface LegalDocContent {
+  title: string;
+  intro: string;
+  sections: LegalDocSection[];
+  canonicalLabel: string;
+}
+
+export interface LegalDoc {
+  id: LegalDocId;
+  icon: string;
+  /** Tailwind classes for the header icon badge. */
+  badgeClass: string;
+  canonicalUrl: string;
+  content: Record<AppLanguage, LegalDocContent>;
+}
+
+const NODUS_REPOSITORY_URL = 'https://github.com/Drakonis96/nodus';
+
+const PRIVACY: Record<AppLanguage, LegalDocContent> = {
+  es: {
+    title: 'Privacidad y control de datos',
+    intro:
+      'Nodus funciona principalmente en el dispositivo: no requiere una cuenta, no incluye publicidad, telemetría ni analítica remota y no opera un backend propio que reciba el contenido de tus vaults.',
+    sections: [
+      {
+        heading: 'Qué permanece en tu equipo',
+        bullets: [
+          'Bases de datos, archivos, grabaciones, transcripciones, notas, expedientes y resultados se guardan en tu dispositivo.',
+          'Seleccionar un archivo o iniciar una grabación no lo publica ni lo sube a Nodus.',
+        ],
+      },
+      {
+        heading: 'Cuándo salen datos del dispositivo',
+        bullets: [
+          'Solo las funciones opcionales que actives de forma expresa contactan con terceros: un proveedor de IA en la nube que elijas, Zotero, Unpaywall, GitHub (comprobar actualizaciones) o Hugging Face (descargar modelos).',
+          'Cada servicio externo queda identificado antes de usarse.',
+        ],
+      },
+      {
+        heading: 'Alumnado y datos docentes',
+        bullets: [
+          'La IA no recibe listados, notas ni respuestas del alumnado y no puede calificar, perfilar ni evaluar estudiantes.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Leer la política de privacidad completa en GitHub',
+  },
+  en: {
+    title: 'Privacy and data control',
+    intro:
+      'Nodus works primarily on the device: it requires no account, includes no advertising, telemetry or remote analytics, and operates no backend of its own that receives your vault content.',
+    sections: [
+      {
+        heading: 'What stays on your device',
+        bullets: [
+          'Databases, files, recordings, transcripts, notes, dossiers and results are stored on your device.',
+          'Selecting a file or starting a recording never publishes or uploads it to Nodus.',
+        ],
+      },
+      {
+        heading: 'When data leaves the device',
+        bullets: [
+          'Only optional features you explicitly enable contact third parties: a cloud AI provider you choose, Zotero, Unpaywall, GitHub (update checks) or Hugging Face (model downloads).',
+          'Each external service is identified before it is used.',
+        ],
+      },
+      {
+        heading: 'Students and teaching data',
+        bullets: [
+          'The AI never receives student rosters, notes or answers, and cannot grade, profile or evaluate students.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Read the full privacy policy on GitHub',
+  },
+  fr: {
+    title: 'Confidentialité et contrôle des données',
+    intro:
+      "Nodus fonctionne principalement sur l'appareil : aucun compte requis, ni publicité, ni télémétrie ou analyse à distance, et aucun serveur propre ne reçoit le contenu de vos coffres.",
+    sections: [
+      {
+        heading: "Ce qui reste sur votre appareil",
+        bullets: [
+          'Bases de données, fichiers, enregistrements, transcriptions, notes, dossiers et résultats sont stockés sur votre appareil.',
+          "Sélectionner un fichier ou lancer un enregistrement ne le publie ni ne l'envoie à Nodus.",
+        ],
+      },
+      {
+        heading: "Quand les données quittent l'appareil",
+        bullets: [
+          "Seules les fonctions optionnelles que vous activez expressément contactent des tiers : un fournisseur d'IA cloud de votre choix, Zotero, Unpaywall, GitHub (vérification des mises à jour) ou Hugging Face (téléchargement de modèles).",
+          'Chaque service externe est identifié avant utilisation.',
+        ],
+      },
+      {
+        heading: 'Élèves et données pédagogiques',
+        bullets: [
+          "L'IA ne reçoit jamais de listes, de notes ni de réponses des élèves et ne peut ni noter, ni profiler, ni évaluer les élèves.",
+        ],
+      },
+    ],
+    canonicalLabel: 'Lire la politique de confidentialité complète sur GitHub',
+  },
+  de: {
+    title: 'Datenschutz und Datenkontrolle',
+    intro:
+      'Nodus arbeitet hauptsächlich auf dem Gerät: kein Konto erforderlich, keine Werbung, keine Telemetrie oder Ferndatenanalyse und kein eigenes Backend, das die Inhalte deiner Tresore empfängt.',
+    sections: [
+      {
+        heading: 'Was auf deinem Gerät bleibt',
+        bullets: [
+          'Datenbanken, Dateien, Aufnahmen, Transkripte, Notizen, Dossiers und Ergebnisse werden auf deinem Gerät gespeichert.',
+          'Das Auswählen einer Datei oder das Starten einer Aufnahme veröffentlicht sie nicht und lädt sie nicht zu Nodus hoch.',
+        ],
+      },
+      {
+        heading: 'Wann Daten das Gerät verlassen',
+        bullets: [
+          'Nur optionale Funktionen, die du ausdrücklich aktivierst, kontaktieren Dritte: einen von dir gewählten Cloud-KI-Anbieter, Zotero, Unpaywall, GitHub (Update-Prüfung) oder Hugging Face (Modell-Downloads).',
+          'Jeder externe Dienst wird vor der Nutzung benannt.',
+        ],
+      },
+      {
+        heading: 'Lernende und Unterrichtsdaten',
+        bullets: [
+          'Die KI erhält niemals Listen, Noten oder Antworten der Lernenden und kann Schülerinnen und Schüler weder benoten noch profilieren oder bewerten.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Die vollständige Datenschutzerklärung auf GitHub lesen',
+  },
+  pt: {
+    title: 'Privacidade e controlo de dados',
+    intro:
+      'O Nodus funciona principalmente no dispositivo: não exige conta, não inclui publicidade, telemetria ou análise remota e não opera um backend próprio que receba o conteúdo dos teus cofres.',
+    sections: [
+      {
+        heading: 'O que permanece no teu dispositivo',
+        bullets: [
+          'Bases de dados, ficheiros, gravações, transcrições, notas, processos e resultados são guardados no teu dispositivo.',
+          'Selecionar um ficheiro ou iniciar uma gravação não o publica nem o envia para o Nodus.',
+        ],
+      },
+      {
+        heading: 'Quando os dados saem do dispositivo',
+        bullets: [
+          'Apenas as funções opcionais que ativas expressamente contactam terceiros: um fornecedor de IA na nuvem à tua escolha, Zotero, Unpaywall, GitHub (verificar atualizações) ou Hugging Face (transferir modelos).',
+          'Cada serviço externo é identificado antes de ser usado.',
+        ],
+      },
+      {
+        heading: 'Alunos e dados pedagógicos',
+        bullets: [
+          'A IA nunca recebe listas, notas ou respostas dos alunos e não pode classificar, criar perfis nem avaliar estudantes.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Ler a política de privacidade completa no GitHub',
+  },
+  'pt-BR': {
+    title: 'Privacidade e controle de dados',
+    intro:
+      'O Nodus funciona principalmente no dispositivo: não exige conta, não inclui publicidade, telemetria ou análise remota e não opera um backend próprio que receba o conteúdo dos seus cofres.',
+    sections: [
+      {
+        heading: 'O que permanece no seu dispositivo',
+        bullets: [
+          'Bancos de dados, arquivos, gravações, transcrições, notas, dossiês e resultados são armazenados no seu dispositivo.',
+          'Selecionar um arquivo ou iniciar uma gravação não o publica nem o envia para o Nodus.',
+        ],
+      },
+      {
+        heading: 'Quando os dados saem do dispositivo',
+        bullets: [
+          'Apenas os recursos opcionais que você ativa expressamente contatam terceiros: um provedor de IA na nuvem de sua escolha, Zotero, Unpaywall, GitHub (verificar atualizações) ou Hugging Face (baixar modelos).',
+          'Cada serviço externo é identificado antes de ser usado.',
+        ],
+      },
+      {
+        heading: 'Alunos e dados pedagógicos',
+        bullets: [
+          'A IA nunca recebe listas, notas ou respostas dos alunos e não pode dar notas, traçar perfis nem avaliar estudantes.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Ler a política de privacidade completa no GitHub',
+  },
+  it: {
+    title: 'Privacy e controllo dei dati',
+    intro:
+      'Nodus funziona principalmente sul dispositivo: non richiede un account, non include pubblicità, telemetria o analisi remota e non gestisce un backend proprio che riceva il contenuto dei tuoi vault.',
+    sections: [
+      {
+        heading: 'Cosa resta sul tuo dispositivo',
+        bullets: [
+          'Database, file, registrazioni, trascrizioni, note, fascicoli e risultati sono salvati sul tuo dispositivo.',
+          'Selezionare un file o avviare una registrazione non lo pubblica né lo carica su Nodus.',
+        ],
+      },
+      {
+        heading: 'Quando i dati lasciano il dispositivo',
+        bullets: [
+          "Solo le funzioni opzionali che attivi espressamente contattano terze parti: un fornitore di IA nel cloud a tua scelta, Zotero, Unpaywall, GitHub (verifica aggiornamenti) o Hugging Face (download dei modelli).",
+          'Ogni servizio esterno è identificato prima di essere usato.',
+        ],
+      },
+      {
+        heading: 'Studenti e dati didattici',
+        bullets: [
+          "L'IA non riceve mai elenchi, voti o risposte degli studenti e non può valutare, profilare o giudicare gli studenti.",
+        ],
+      },
+    ],
+    canonicalLabel: 'Leggi l’informativa sulla privacy completa su GitHub',
+  },
+};
+
+const GDPR: Record<AppLanguage, LegalDocContent> = {
+  es: {
+    title: 'Cómo facilita Nodus el cumplimiento del RGPD',
+    intro:
+      'El diseño aplica minimización de datos, privacidad por defecto y avisos justo antes de grabar. Esto facilita el cumplimiento del RGPD, pero no es una certificación: el responsable decide la base jurídica, la conservación, el acceso y los proveedores.',
+    sections: [
+      {
+        heading: 'Privacidad desde el diseño',
+        bullets: [
+          'El tratamiento local se distingue claramente de las conexiones externas opcionales.',
+          'Aparecen avisos breves justo antes de acciones sensibles como grabar.',
+        ],
+      },
+      {
+        heading: 'Qué sigue siendo tu responsabilidad',
+        bullets: [
+          'Documentar cada finalidad, base jurídica, plazo de conservación y destinatario.',
+          'Facilitar el aviso completo de los artículos 13/14 a las personas afectadas.',
+          'Completar la lista de implantación para tu organización.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Abrir la lista de implantación del RGPD en GitHub',
+  },
+  en: {
+    title: 'How Nodus supports GDPR compliance',
+    intro:
+      'The design applies data minimisation, privacy by default and just-in-time notices before recording. This helps you comply with the GDPR, but it is not a certification: the controller decides the lawful basis, retention, access and providers.',
+    sections: [
+      {
+        heading: 'Privacy by design',
+        bullets: [
+          'Local processing is clearly separated from optional external connections.',
+          'Short notices appear just before sensitive actions such as recording.',
+        ],
+      },
+      {
+        heading: 'What remains your responsibility',
+        bullets: [
+          'Document each purpose, lawful basis, retention period and recipient.',
+          'Provide the complete Articles 13/14 notice to the people involved.',
+          'Complete the deployment checklist for your organisation.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Open the GDPR deployment checklist on GitHub',
+  },
+  fr: {
+    title: 'Comment Nodus facilite la conformité au RGPD',
+    intro:
+      "La conception applique la minimisation des données, la confidentialité par défaut et des avis affichés juste avant l'enregistrement. Cela facilite la conformité au RGPD, mais ne constitue pas une certification : le responsable décide de la base légale, de la conservation, de l'accès et des prestataires.",
+    sections: [
+      {
+        heading: 'Protection dès la conception',
+        bullets: [
+          'Le traitement local est clairement distingué des connexions externes optionnelles.',
+          "De brefs avis apparaissent juste avant les actions sensibles comme l'enregistrement.",
+        ],
+      },
+      {
+        heading: 'Ce qui reste de votre responsabilité',
+        bullets: [
+          'Documenter chaque finalité, base légale, durée de conservation et destinataire.',
+          "Fournir l'information complète des articles 13/14 aux personnes concernées.",
+          'Compléter la liste de déploiement pour votre organisation.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Ouvrir la liste de déploiement RGPD sur GitHub',
+  },
+  de: {
+    title: 'Wie Nodus die DSGVO-Konformität unterstützt',
+    intro:
+      'Das Design setzt auf Datenminimierung, Datenschutz durch Voreinstellung und Hinweise direkt vor der Aufnahme. Das erleichtert die DSGVO-Konformität, ist aber keine Zertifizierung: Der Verantwortliche entscheidet über Rechtsgrundlage, Aufbewahrung, Zugriff und Anbieter.',
+    sections: [
+      {
+        heading: 'Datenschutz durch Technikgestaltung',
+        bullets: [
+          'Die lokale Verarbeitung ist klar von optionalen externen Verbindungen getrennt.',
+          'Kurze Hinweise erscheinen direkt vor sensiblen Aktionen wie dem Aufnehmen.',
+        ],
+      },
+      {
+        heading: 'Was in deiner Verantwortung bleibt',
+        bullets: [
+          'Jeden Zweck, jede Rechtsgrundlage, Aufbewahrungsfrist und jeden Empfänger dokumentieren.',
+          'Den vollständigen Hinweis nach Artikel 13/14 den betroffenen Personen bereitstellen.',
+          'Die Bereitstellungs-Checkliste für deine Organisation ausfüllen.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Die DSGVO-Bereitstellungs-Checkliste auf GitHub öffnen',
+  },
+  pt: {
+    title: 'Como o Nodus facilita a conformidade com o RGPD',
+    intro:
+      'O design aplica minimização de dados, privacidade por predefinição e avisos mesmo antes de gravar. Isto facilita a conformidade com o RGPD, mas não é uma certificação: o responsável decide a base jurídica, a conservação, o acesso e os fornecedores.',
+    sections: [
+      {
+        heading: 'Privacidade desde a conceção',
+        bullets: [
+          'O tratamento local distingue-se claramente das ligações externas opcionais.',
+          'Surgem avisos breves mesmo antes de ações sensíveis como gravar.',
+        ],
+      },
+      {
+        heading: 'O que continua a ser da tua responsabilidade',
+        bullets: [
+          'Documentar cada finalidade, base jurídica, prazo de conservação e destinatário.',
+          'Fornecer o aviso completo dos artigos 13.º/14.º às pessoas envolvidas.',
+          'Completar a lista de implementação para a tua organização.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Abrir a lista de implementação do RGPD no GitHub',
+  },
+  'pt-BR': {
+    title: 'Como o Nodus facilita a conformidade com a LGPD/GDPR',
+    intro:
+      'O design aplica minimização de dados, privacidade por padrão e avisos logo antes de gravar. Isso facilita a conformidade com o GDPR, mas não é uma certificação: o controlador decide a base legal, a retenção, o acesso e os fornecedores.',
+    sections: [
+      {
+        heading: 'Privacidade desde a concepção',
+        bullets: [
+          'O tratamento local é claramente separado das conexões externas opcionais.',
+          'Avisos curtos aparecem logo antes de ações sensíveis, como gravar.',
+        ],
+      },
+      {
+        heading: 'O que continua sendo sua responsabilidade',
+        bullets: [
+          'Documentar cada finalidade, base legal, prazo de retenção e destinatário.',
+          'Fornecer o aviso completo dos artigos 13/14 às pessoas envolvidas.',
+          'Concluir a lista de implantação para a sua organização.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Abrir a lista de implantação do GDPR no GitHub',
+  },
+  it: {
+    title: 'Come Nodus facilita la conformità al GDPR',
+    intro:
+      "Il design applica la minimizzazione dei dati, la privacy per impostazione predefinita e avvisi appena prima della registrazione. Questo facilita la conformità al GDPR, ma non è una certificazione: il titolare decide la base giuridica, la conservazione, l'accesso e i fornitori.",
+    sections: [
+      {
+        heading: 'Privacy fin dalla progettazione',
+        bullets: [
+          'Il trattamento locale è chiaramente distinto dalle connessioni esterne opzionali.',
+          'Brevi avvisi compaiono appena prima di azioni sensibili come la registrazione.',
+        ],
+      },
+      {
+        heading: 'Cosa resta sotto la tua responsabilità',
+        bullets: [
+          'Documentare ogni finalità, base giuridica, periodo di conservazione e destinatario.',
+          "Fornire l'informativa completa degli articoli 13/14 alle persone interessate.",
+          'Completare la lista di implementazione per la tua organizzazione.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Aprire la lista di implementazione GDPR su GitHub',
+  },
+};
+
+const LICENSES: Record<AppLanguage, LegalDocContent> = {
+  es: {
+    title: 'Licencias y atribuciones',
+    intro:
+      'Nodus se publica con licencia MIT. Las licencias, atribuciones y textos exigidos por cada componente, modelo, voz o conjunto de datos de terceros se incluyen con cada versión.',
+    sections: [
+      {
+        heading: 'Código abierto',
+        bullets: [
+          'El código, el historial y los documentos legales de Nodus son públicos y auditables.',
+        ],
+      },
+      {
+        heading: 'Avisos de terceros',
+        bullets: [
+          'Cada aplicación empaquetada incluye un directorio legal con la licencia MIT, el inventario generado completo de las dependencias de producción y los avisos exigidos (ONNX Runtime, sharp/libvips, Electron, Chromium y textos GPL/LGPL y Creative Commons).',
+          'Se incluyen instrucciones para reconstruir o reemplazar los componentes LGPL.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Ver los avisos de terceros en GitHub',
+  },
+  en: {
+    title: 'Licenses and attributions',
+    intro:
+      'Nodus is released under the MIT License. The licenses, attributions and notices required by each third-party component, model, voice or dataset ship with every release.',
+    sections: [
+      {
+        heading: 'Open source',
+        bullets: [
+          "Nodus's source, history and legal documents are public and auditable.",
+        ],
+      },
+      {
+        heading: 'Third-party notices',
+        bullets: [
+          'Each packaged app includes a legal directory with the MIT license, the full generated inventory of production dependencies, and the required upstream notices (ONNX Runtime, sharp/libvips, Electron, Chromium, and GPL/LGPL and Creative Commons texts).',
+          'Rebuild or replacement instructions for LGPL components are included.',
+        ],
+      },
+    ],
+    canonicalLabel: 'View the third-party notices on GitHub',
+  },
+  fr: {
+    title: 'Licences et attributions',
+    intro:
+      "Nodus est publié sous licence MIT. Les licences, attributions et textes exigés par chaque composant, modèle, voix ou jeu de données tiers sont inclus dans chaque version.",
+    sections: [
+      {
+        heading: 'Open source',
+        bullets: [
+          'Le code, l’historique et les documents juridiques de Nodus sont publics et auditables.',
+        ],
+      },
+      {
+        heading: 'Avis de tiers',
+        bullets: [
+          "Chaque application packagée inclut un répertoire légal avec la licence MIT, l'inventaire généré complet des dépendances de production et les avis requis (ONNX Runtime, sharp/libvips, Electron, Chromium, ainsi que les textes GPL/LGPL et Creative Commons).",
+          'Des instructions pour reconstruire ou remplacer les composants LGPL sont incluses.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Voir les avis de tiers sur GitHub',
+  },
+  de: {
+    title: 'Lizenzen und Namensnennungen',
+    intro:
+      'Nodus wird unter der MIT-Lizenz veröffentlicht. Die Lizenzen, Namensnennungen und geforderten Texte jeder Drittkomponente, jedes Modells, jeder Stimme oder jedes Datensatzes liegen jeder Version bei.',
+    sections: [
+      {
+        heading: 'Open Source',
+        bullets: [
+          'Quellcode, Verlauf und Rechtsdokumente von Nodus sind öffentlich und prüfbar.',
+        ],
+      },
+      {
+        heading: 'Hinweise zu Drittanbietern',
+        bullets: [
+          'Jede paketierte App enthält ein Rechtsverzeichnis mit der MIT-Lizenz, dem vollständigen generierten Inventar der Produktionsabhängigkeiten und den erforderlichen Hinweisen (ONNX Runtime, sharp/libvips, Electron, Chromium sowie GPL/LGPL- und Creative-Commons-Texte).',
+          'Anleitungen zum Neu-Erstellen oder Ersetzen der LGPL-Komponenten sind enthalten.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Die Drittanbieter-Hinweise auf GitHub ansehen',
+  },
+  pt: {
+    title: 'Licenças e atribuições',
+    intro:
+      'O Nodus é publicado sob a licença MIT. As licenças, atribuições e textos exigidos por cada componente, modelo, voz ou conjunto de dados de terceiros são incluídos em cada versão.',
+    sections: [
+      {
+        heading: 'Código aberto',
+        bullets: [
+          'O código, o histórico e os documentos legais do Nodus são públicos e auditáveis.',
+        ],
+      },
+      {
+        heading: 'Avisos de terceiros',
+        bullets: [
+          'Cada aplicação empacotada inclui um diretório legal com a licença MIT, o inventário gerado completo das dependências de produção e os avisos exigidos (ONNX Runtime, sharp/libvips, Electron, Chromium e textos GPL/LGPL e Creative Commons).',
+          'São incluídas instruções para reconstruir ou substituir os componentes LGPL.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Ver os avisos de terceiros no GitHub',
+  },
+  'pt-BR': {
+    title: 'Licenças e atribuições',
+    intro:
+      'O Nodus é publicado sob a licença MIT. As licenças, atribuições e textos exigidos por cada componente, modelo, voz ou conjunto de dados de terceiros são incluídos em cada versão.',
+    sections: [
+      {
+        heading: 'Código aberto',
+        bullets: [
+          'O código, o histórico e os documentos legais do Nodus são públicos e auditáveis.',
+        ],
+      },
+      {
+        heading: 'Avisos de terceiros',
+        bullets: [
+          'Cada aplicativo empacotado inclui um diretório legal com a licença MIT, o inventário gerado completo das dependências de produção e os avisos exigidos (ONNX Runtime, sharp/libvips, Electron, Chromium e textos GPL/LGPL e Creative Commons).',
+          'São incluídas instruções para reconstruir ou substituir os componentes LGPL.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Ver os avisos de terceiros no GitHub',
+  },
+  it: {
+    title: 'Licenze e attribuzioni',
+    intro:
+      'Nodus è pubblicato con licenza MIT. Le licenze, le attribuzioni e i testi richiesti da ogni componente, modello, voce o set di dati di terze parti sono inclusi in ogni versione.',
+    sections: [
+      {
+        heading: 'Open source',
+        bullets: [
+          'Il codice, la cronologia e i documenti legali di Nodus sono pubblici e verificabili.',
+        ],
+      },
+      {
+        heading: 'Avvisi di terze parti',
+        bullets: [
+          "Ogni app pacchettizzata include una cartella legale con la licenza MIT, l'inventario generato completo delle dipendenze di produzione e gli avvisi richiesti (ONNX Runtime, sharp/libvips, Electron, Chromium e i testi GPL/LGPL e Creative Commons).",
+          'Sono incluse istruzioni per ricostruire o sostituire i componenti LGPL.',
+        ],
+      },
+    ],
+    canonicalLabel: 'Visualizza gli avvisi di terze parti su GitHub',
+  },
+};
+
+export const LEGAL_DOCS: Record<LegalDocId, LegalDoc> = {
+  privacy: {
+    id: 'privacy',
+    icon: 'shield',
+    badgeClass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300',
+    canonicalUrl: `${NODUS_REPOSITORY_URL}/blob/main/PRIVACY.md`,
+    content: PRIVACY,
+  },
+  gdpr: {
+    id: 'gdpr',
+    icon: 'globe',
+    badgeClass: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300',
+    canonicalUrl: `${NODUS_REPOSITORY_URL}/blob/main/legal/RGPD_DEPLOYMENT_CHECKLIST.md`,
+    content: GDPR,
+  },
+  licenses: {
+    id: 'licenses',
+    icon: 'book',
+    badgeClass: 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300',
+    canonicalUrl: `${NODUS_REPOSITORY_URL}/blob/main/THIRD_PARTY_NOTICES.md`,
+    content: LICENSES,
+  },
+};
+
+export function legalDocContent(doc: LegalDoc, language: AppLanguage): LegalDocContent {
+  return doc.content[language] ?? doc.content.en;
+}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -16,6 +16,8 @@ import { recoveryHealthAdvice, recoveryHealthAge, recoveryHealthHeadline } from 
 import { ImageGenerationSettings, ProvidersSettings } from './ProvidersSettings';
 import { AudioGenerationSettings } from './AudioGenerationSettings';
 import { ConfirmModal } from '../components/ConfirmModal';
+import { LegalDocModal } from '../components/LegalDocModal';
+import { LEGAL_DOCS, type LegalDocId } from '../legalDocs';
 import { confirm } from '../components/feedback';
 import { Icon, PROVIDER_LABELS } from '../components/ui';
 import { ModelPicker, SubscriptionQuotaNotice, ExtractionCapabilityNotice } from '../components/ModelPicker';
@@ -30,7 +32,7 @@ import { DEFAULT_EMBEDDING_MODELS, EMBEDDING_PROVIDERS } from '@shared/providers
 import { ORB_COLOR_CHOICES, orbHue } from '@shared/nodiOrb';
 import { effectiveSidebarHidden, isViewAllowedForVaultType } from '@shared/vaultTypes';
 
-type SettingsTabId = 'providers' | 'models' | 'library' | 'extraction' | 'interface' | 'integrations' | 'system' | 'data' | 'about';
+type SettingsTabId = 'providers' | 'models' | 'library' | 'extraction' | 'interface' | 'integrations' | 'system' | 'data' | 'about' | 'updates';
 
 const SETTINGS_TABS: { id: SettingsTabId; label: string; icon: string; keywords: string }[] = [
   { id: 'providers', label: 'Proveedores', icon: 'key', keywords: 'api key keys claves proveedores provider providers modelos favoritos default openai anthropic deepseek gemini google openrouter xiaomi lm studio ollama vault boveda' },
@@ -41,14 +43,14 @@ const SETTINGS_TABS: { id: SettingsTabId; label: string; icon: string; keywords:
   { id: 'integrations', label: 'Integraciones', icon: 'link', keywords: 'mcp servidor token puerto word copilot certificado addin' },
   { id: 'system', label: 'Tutoriales', icon: 'graduation', keywords: 'sistema ayuda tutorial' },
   { id: 'data', label: 'Backup / copia de seguridad', icon: 'download', keywords: 'datos backup exportar importar demo copia cifrada peligro reinicializar grafo borrar' },
-  { id: 'about', label: 'Acerca de Nodus', icon: 'info', keywords: 'acerca proyecto codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado inteligencia artificial licencia terceros legal actualizaciones update version novedades' },
+  { id: 'about', label: 'Acerca de Nodus', icon: 'info', keywords: 'acerca proyecto codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado inteligencia artificial licencia terceros legal' },
+  { id: 'updates', label: 'Actualizaciones y novedades', icon: 'sync', keywords: 'actualizaciones update actualizar version novedades ultimos cambios latest changes changelog buscar instalar reiniciar' },
 ];
 
 const ABOUT_ACTION_BUTTON_CLASS = 'btn btn-ghost w-full shrink-0 justify-center border border-neutral-300 dark:border-neutral-700 sm:w-56';
 const ABOUT_CARD_CLASS = 'rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/50';
 const NODUS_REPOSITORY_URL = 'https://github.com/Drakonis96/nodus';
 const NODUS_PRIVACY_URL = `${NODUS_REPOSITORY_URL}/blob/main/PRIVACY.md`;
-const NODUS_GDPR_CHECKLIST_URL = `${NODUS_REPOSITORY_URL}/blob/main/legal/RGPD_DEPLOYMENT_CHECKLIST.md`;
 const NODUS_LICENSE_URL = `${NODUS_REPOSITORY_URL}/blob/main/LICENSE`;
 const NODUS_SECURITY_REPORT_URL = `${NODUS_REPOSITORY_URL}/security/advisories/new`;
 
@@ -85,6 +87,7 @@ export function Settings({
   const [importSyncPromptOpen, setImportSyncPromptOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTabId>('providers');
   const [settingsQuery, setSettingsQuery] = useState('');
+  const [openLegalDoc, setOpenLegalDoc] = useState<LegalDocId | null>(null);
   // Reset-graph flow: a confirm() dialog, then a modal that requires typing a
   // freshly generated 4-digit code so it can't be triggered by accident.
   const [resetCode, setResetCode] = useState<string | null>(null);
@@ -328,7 +331,8 @@ export function Settings({
     visibleSettingsSection('models', 'Modelos de IA', 'basico avanzado modelo general extraccion sintesis tutor resumen fusion embeddings transcripcion voz imagen'),
     visibleSettingsSection('extraction', 'Extracción de texto PDFs grandes', 'pdf texto zotero ocr tesseract paginas idiomas'),
     visibleSettingsSection('data', 'Zona de peligro', 'reinicializar grafo borrar ideas temas conexiones autores huecos'),
-    visibleSettingsSection('about', 'Acerca de Nodus', 'proyecto independiente codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado licencia actualizaciones update version'),
+    visibleSettingsSection('about', 'Acerca de Nodus', 'proyecto independiente codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado licencia'),
+    visibleSettingsSection('updates', 'Actualizaciones y novedades', 'actualizaciones update version novedades ultimos cambios latest changes changelog buscar instalar reiniciar'),
   ].filter(Boolean).length;
 
   return (
@@ -815,7 +819,7 @@ export function Settings({
               <button
                 data-testid="open-privacy-policy"
                 className={ABOUT_ACTION_BUTTON_CLASS}
-                onClick={() => void window.nodus.openPrivacyPolicy()}
+                onClick={() => setOpenLegalDoc('privacy')}
               >
                 <Icon name="book" /> {t('Leer política de privacidad')}
               </button>
@@ -848,7 +852,7 @@ export function Settings({
               <button
                 data-testid="open-gdpr-checklist"
                 className={ABOUT_ACTION_BUTTON_CLASS}
-                onClick={() => void window.nodus.openExternal(NODUS_GDPR_CHECKLIST_URL)}
+                onClick={() => setOpenLegalDoc('gdpr')}
               >
                 <Icon name="check" /> {t('Ver lista RGPD')}
               </button>
@@ -878,7 +882,7 @@ export function Settings({
               <button
                 data-testid="open-third-party-licenses"
                 className={ABOUT_ACTION_BUTTON_CLASS}
-                onClick={() => void window.nodus.openThirdPartyNotices()}
+                onClick={() => setOpenLegalDoc('licenses')}
               >
                 <Icon name="book" /> {t('Ver licencias')}
               </button>
@@ -925,6 +929,11 @@ export function Settings({
             </div>
           </div>
 
+        </Section>
+      )}
+
+      {visibleSettingsSection('updates', 'Actualizaciones y novedades', 'actualizaciones update version novedades ultimos cambios latest changes changelog buscar instalar reiniciar') && (
+        <Section title={t('Actualizaciones y novedades')}>
           <div data-testid="about-latest-changes" className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/50 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <label className="text-sm text-neutral-700 dark:text-neutral-300">{t('Últimos cambios')}</label>
@@ -1803,6 +1812,13 @@ export function Settings({
             void patch({ embeddingProvider: next.provider, embeddingModel: next.model });
           }}
           onCancel={() => setPendingEmbeddingChange(null)}
+        />
+      )}
+      {openLegalDoc && (
+        <LegalDocModal
+          doc={LEGAL_DOCS[openLegalDoc]}
+          language={settings.uiLanguage}
+          onClose={() => setOpenLegalDoc(null)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

In **Settings → About Nodus**, the *Privacy and data control*, *How Nodus supports GDPR compliance* and *Licenses and attributions* cards opened the underlying local markdown file (`PRIVACY.md`, `THIRD_PARTY_NOTICES.md`) in an external app, or a GitHub page. `PRIVACY.md` only exists in Spanish, so a non‑Spanish UI showed Spanish content — and outside the app.

This PR makes those cards open a **localized in‑app modal**, and moves **Updates** / **Latest changes** into their own settings section.

## Changes

- **`src/legalDocs.ts`** (new) — per‑language content (es, en, fr, de, pt, pt‑BR, it) for the three legal documents: a self‑contained summary plus the canonical GitHub URL. The full documents remain the source of truth.
- **`src/components/LegalDocModal.tsx`** (new) — accessible in‑app viewer (portal + Escape/backdrop close) that renders the localized summary and a "view full document on GitHub" action. Never opens an external markdown file.
- **`src/views/Settings.tsx`**
  - Privacy / GDPR / Licenses cards now open the modal (`setOpenLegalDoc(...)`) instead of `openPrivacyPolicy()` / `openThirdPartyNotices()` / a GitHub link.
  - New **"Actualizaciones y novedades"** section/tab holding *Updates* and *Latest changes*, rendered right after *About Nodus*.
- **i18n** — added `Actualizaciones y novedades` to all six translation tables.
- **Tests** — updated `test-privacy-compliance.mjs`, `test-license-compliance.mjs`, `test-settings-visual-regressions.mjs` and the `e2e-smoke.mjs` About flow to assert the new in‑app modal and section layout.

## Verification

- `npm test` → 683/683 pass
- `tsc --noEmit` (renderer + electron) → clean
- `eslint` on changed files → clean
- `npm run test:e2e` → passed, including the new `[e2e] About legal cards open a localized in-app modal` assertion

Closes #140
