### PR TITLE
Add resilient database processing properties

### DIFF
--- a/electron/ai/databaseAiColumn.ts
+++ b/electron/ai/databaseAiColumn.ts
@@ -16,6 +16,7 @@ import {
 import { AI_COLUMN_SYSTEM, buildAiCellPrompt, buildAiRowContext } from '@shared/databaseAi';
 import { attachmentKind } from '@shared/databases';
 import { isVisionMime } from '@shared/imageAnalysis';
+import { AI_PROVIDERS } from '@shared/providers';
 import type { ModelRef } from '@shared/types';
 import type { VisionImagePart } from '@shared/imageAnalysis';
 
@@ -31,6 +32,16 @@ export interface AiCellDeps {
   }, model?: ModelRef | null) => Promise<string>;
   model?: ModelRef | null;
   visionModel?: ModelRef | null;
+}
+
+const VALID_MODEL_PROVIDERS = new Set<string>([...AI_PROVIDERS, 'nodus']);
+
+function configuredModel(value: unknown): ModelRef | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<ModelRef>;
+  if (!candidate.provider || !VALID_MODEL_PROVIDERS.has(candidate.provider)) return null;
+  if (typeof candidate.model !== 'string' || !candidate.model.trim()) return null;
+  return { provider: candidate.provider, model: candidate.model.trim() };
 }
 
 /** Collect up to `limit` images from the AI column's configured source attachment column. */
@@ -62,8 +73,9 @@ export async function runAiCell(rowId: string, columnId: string, deps: AiCellDep
   const images = sourceImages(rowId, col.config.aiSourceColumnId as string | undefined);
 
   const settings = getSettings();
-  const model = deps.model ?? settings.chatModel ?? settings.synthesisModel ?? null;
-  const visionModel = deps.visionModel ?? settings.visionModel ?? settings.extractionModel ?? settings.synthesisModel ?? model;
+  const columnModel = configuredModel(col.config.aiModel);
+  const model = deps.model ?? columnModel ?? settings.chatModel ?? settings.synthesisModel ?? null;
+  const visionModel = deps.visionModel ?? columnModel ?? settings.visionModel ?? settings.extractionModel ?? settings.synthesisModel ?? model;
   if (!deps.complete && images.length === 0 && !model) {
     throw new Error('No hay un modelo de IA configurado. Elígelo en Ajustes.');
   }

--- a/electron/ai/databaseAiImageColumn.ts
+++ b/electron/ai/databaseAiImageColumn.ts
@@ -15,10 +15,26 @@ import {
 } from '../db/databasesRepo';
 import { buildAiImagePrompt, buildAiRowContext } from '@shared/databaseAi';
 import type { DatabaseAttachment } from '@shared/databases';
+import type { ImageProvider } from '@shared/types';
+
+interface AiImageModelRef {
+  provider: ImageProvider;
+  model: string;
+}
 
 export interface AiImageDeps {
   /** Injectable image generation (defaults to the real multi-provider pipeline). */
-  generate?: (prompt: string) => Promise<{ image: Buffer; mimeType: string }>;
+  generate?: (prompt: string, model: AiImageModelRef | null) => Promise<{ image: Buffer; mimeType: string }>;
+}
+
+const IMAGE_PROVIDERS = new Set<ImageProvider>(['google', 'openai', 'openrouter']);
+
+function configuredImageModel(value: unknown): AiImageModelRef | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<AiImageModelRef>;
+  if (!candidate.provider || !IMAGE_PROVIDERS.has(candidate.provider)) return null;
+  if (typeof candidate.model !== 'string' || !candidate.model.trim()) return null;
+  return { provider: candidate.provider, model: candidate.model.trim() };
 }
 
 /** Generate one AI image for a cell and persist it as its (single) attachment. */
@@ -36,7 +52,7 @@ export async function runAiImageCell(rowId: string, columnId: string, deps: AiIm
   const fullPrompt = buildAiImagePrompt(prompt, context);
 
   const generate = deps.generate ?? realGenerate;
-  const { image, mimeType } = await generate(fullPrompt);
+  const { image, mimeType } = await generate(fullPrompt, configuredImageModel(col.config.aiImageModel));
   if (!image?.length) throw new Error('El proveedor no devolvió una imagen.');
 
   // An AI-image cell holds a single current image: replace whatever was there.
@@ -55,13 +71,15 @@ export async function runAiImageCell(rowId: string, columnId: string, deps: AiIm
 }
 
 /** Real generation: lazy-loaded so tests never pull the image SDKs. */
-async function realGenerate(prompt: string): Promise<{ image: Buffer; mimeType: string }> {
+async function realGenerate(prompt: string, columnModel: AiImageModelRef | null): Promise<{ image: Buffer; mimeType: string }> {
   const settings = getSettings();
-  if (!settings.imageProvider || !settings.imageModel) {
+  const provider = columnModel?.provider ?? settings.imageProvider;
+  const model = columnModel?.model ?? settings.imageModel;
+  if (!provider || !model) {
     throw new Error('Configura un proveedor y modelo de imagen en Ajustes → Proveedores.');
   }
   const { callImageProvider, optimizedJpegs } = await import('./decorativeImages');
-  const generated = await callImageProvider(settings.imageProvider, settings.imageModel, prompt);
+  const generated = await callImageProvider(provider, model, prompt);
   const optimized = await optimizedJpegs(generated);
   return { image: optimized.image, mimeType: 'image/jpeg' };
 }

--- a/electron/db/database.ts
+++ b/electron/db/database.ts
@@ -1,11 +1,13 @@
 import Database from 'better-sqlite3';
 import path from 'node:path';
 import fs from 'node:fs';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { runMigrations, SCHEMA_VERSION } from './migrations';
 import { ensureTombstoneTriggers, pruneTombstones } from './tombstones';
-import { activeVaultDbPath } from '../vaults/vaultRegistry';
+import { activeVaultDbPath, getVault } from '../vaults/vaultRegistry';
 
 let db: Database.Database | null = null;
+const jobDatabase = new AsyncLocalStorage<Database.Database>();
 
 export function dbPath(): string {
   return activeVaultDbPath();
@@ -56,6 +58,8 @@ function openDatabase(file: string): Database.Database {
 }
 
 export function getDb(): Database.Database {
+  const scoped = jobDatabase.getStore();
+  if (scoped) return scoped;
   if (!db) {
     const target = dbPath();
     const dir = path.dirname(target);
@@ -63,6 +67,25 @@ export function getDb(): Database.Database {
     db = openDatabase(target);
   }
   return db;
+}
+
+/**
+ * Run a long-lived task against its originating vault, independently of the live UI
+ * connection. AsyncLocalStorage keeps every repository call on this dedicated connection
+ * across provider awaits, while the user remains free to close/switch the active vault.
+ */
+export async function withVaultDatabase<T>(vaultId: string, work: () => Promise<T> | T): Promise<T> {
+  const vault = getVault(vaultId);
+  if (!vault) throw new Error('Bóveda no encontrada.');
+  const existing = jobDatabase.getStore();
+  if (existing?.name === vault.path) return work();
+
+  const scoped = openDatabase(vault.path);
+  try {
+    return await jobDatabase.run(scoped, work);
+  } finally {
+    if (scoped.open) scoped.close();
+  }
 }
 
 /**

--- a/electron/db/databasesRepo.ts
+++ b/electron/db/databasesRepo.ts
@@ -17,6 +17,7 @@ import {
   type RollupFunction,
 } from '@shared/databases';
 import { splitMultiValue, normalizeCsvValue, typeStoresImportedText } from '@shared/databaseCsv';
+import { comparisonMajorityValue, comparisonSourceColumns } from '@shared/databaseComparison';
 import { computeFormulas } from '@shared/databaseFormulaEval';
 import type { FormulaSpec } from '@shared/databaseFormula';
 import type { DatabaseFilterState, DatabaseSavedView, SavedViewInput, SortRule } from '@shared/databaseFilters';
@@ -691,6 +692,60 @@ export function setCell(rowId: string, columnId: string, raw: string | null): Da
   touchRow(rowId);
   touchDatabase(col.databaseId);
   return getRow(rowId);
+}
+
+// ── Comparison cells ────────────────────────────────────────────────────────
+
+/** Recompute one comparison cell from the configured source columns. */
+export function runComparisonCell(rowId: string, columnId: string): DatabaseRow | null {
+  const column = getColumn(columnId);
+  const row = getRow(rowId);
+  if (!column || column.type !== 'comparison' || !row || row.databaseId !== column.databaseId) return row;
+  const columns = getColumns(column.databaseId);
+  if (comparisonSourceColumns(column, columns).length < 2) return row;
+  return setCell(rowId, columnId, comparisonMajorityValue(column, columns, row));
+}
+
+/**
+ * Recompute a complete comparison column in bounded transactions. Unlike calling setCell
+ * for every row, this avoids reloading formulas and rollups N times; yielding between batches
+ * keeps navigation and vault switching responsive on large databases.
+ */
+export async function runComparisonColumn(
+  databaseId: string,
+  columnId: string,
+  onProgress?: (done: number, total: number) => void
+): Promise<{ done: number }> {
+  const column = getColumn(columnId);
+  if (!column || column.type !== 'comparison' || column.databaseId !== databaseId) return { done: 0 };
+  const columns = getColumns(databaseId);
+  if (comparisonSourceColumns(column, columns).length < 2) return { done: 0 };
+  const rows = listRows(databaseId, { sort: 'position' });
+  const db = getDb();
+  const upsert = db.prepare(
+    'INSERT INTO db_cells (row_id, column_id, value_text) VALUES (?, ?, ?) ON CONFLICT(row_id, column_id) DO UPDATE SET value_text = excluded.value_text'
+  );
+  const clear = db.prepare('DELETE FROM db_cells WHERE row_id = ? AND column_id = ?');
+  const touch = db.prepare('UPDATE db_rows SET updated_at = ? WHERE id = ?');
+  const batchSize = 250;
+  for (let start = 0; start < rows.length; start += batchSize) {
+    const batch = rows.slice(start, start + batchSize);
+    const ts = now();
+    db.transaction(() => {
+      for (const row of batch) {
+        const result = comparisonMajorityValue(column, columns, row);
+        if (result == null) clear.run(row.id, columnId);
+        else upsert.run(row.id, columnId, result);
+        touch.run(ts, row.id);
+      }
+    })();
+    onProgress?.(Math.min(start + batch.length, rows.length), rows.length);
+    // Let navigation and a vault switch be handled between batches. The scoped database
+    // remains pinned to this job's source vault across the yield.
+    if (start + batch.length < rows.length) await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  touchDatabase(databaseId);
+  return { done: rows.length };
 }
 
 // ── Attachments ──────────────────────────────────────────────────────────────

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -447,7 +447,7 @@ import { TRANSLATION_LANGUAGES } from '@shared/types';
 import { translateMarkdown, titleFromMarkdown } from './ai/translate';
 import * as workSummaries from './db/workSummariesRepo';
 import * as projects from './db/projectsRepo';
-import { closeDb, getDb } from './db/database';
+import { closeDb, getDb, withVaultDatabase } from './db/database';
 import { exportWritingWorkshopDraft } from './export/writingWorkshopExport';
 import { generateProjectSuggestions } from './ai/projectInsertion';
 import { exportProject, exportProjectChapter } from './export/projectExport';
@@ -1476,6 +1476,18 @@ export function registerIpc(
     dbMode.deleteRow(id);
   });
   h('db:setCell', async (_e, rowId: string, columnId: string, raw: string | null) => dbMode.setCell(rowId, columnId, raw));
+  h('db:runComparisonCell', async (_e, rowId: string, columnId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () => dbMode.runComparisonCell(rowId, columnId));
+  });
+  h('db:runComparisonColumn', async (_e, databaseId: string, columnId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () =>
+      dbMode.runComparisonColumn(databaseId, columnId, (done, total) =>
+        getWindow()?.webContents.send('db:comparisonProgress', { vaultId, databaseId, columnId, done, total })
+      )
+    );
+  });
   h('db:listAttachments', async (_e, rowId: string, columnId: string) => dbMode.listAttachments(rowId, columnId));
   h('db:getAttachmentBlob', async (_e, id: string) => dbMode.getAttachmentBlob(id));
   h('db:getAttachmentThumb', async (_e, id: string) => dbMode.getAttachmentThumb(id));
@@ -1495,18 +1507,30 @@ export function registerIpc(
     fs.writeFileSync(picked.filePath, blob);
     return { canceled: false, path: picked.filePath };
   });
-  h('db:runAiCell', async (_e, rowId: string, columnId: string) => runAiCell(rowId, columnId));
-  h('db:runAiColumn', async (_e, databaseId: string, columnId: string) =>
-    runAiColumn(databaseId, columnId, (done, total) =>
-      getWindow()?.webContents.send('db:aiProgress', { columnId, done, total })
-    )
-  );
-  h('db:generateAiImage', async (_e, rowId: string, columnId: string) => runAiImageCell(rowId, columnId));
-  h('db:generateAiImageColumn', async (_e, databaseId: string, columnId: string) =>
-    runAiImageColumn(databaseId, columnId, (done, total) =>
-      getWindow()?.webContents.send('db:aiProgress', { columnId, done, total })
-    )
-  );
+  h('db:runAiCell', async (_e, rowId: string, columnId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () => runAiCell(rowId, columnId));
+  });
+  h('db:runAiColumn', async (_e, databaseId: string, columnId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () =>
+      runAiColumn(databaseId, columnId, (done, total) =>
+        getWindow()?.webContents.send('db:aiProgress', { vaultId, databaseId, columnId, done, total })
+      )
+    );
+  });
+  h('db:generateAiImage', async (_e, rowId: string, columnId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () => runAiImageCell(rowId, columnId));
+  });
+  h('db:generateAiImageColumn', async (_e, databaseId: string, columnId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () =>
+      runAiImageColumn(databaseId, columnId, (done, total) =>
+        getWindow()?.webContents.send('db:aiProgress', { vaultId, databaseId, columnId, done, total })
+      )
+    );
+  });
   h('db:pickBulkFiles', async (_e, mode: 'files' | 'folder' = 'files') => {
     const win = getWindow();
     const picked = await showImportOpenDialog(win ?? undefined!, {
@@ -1676,10 +1700,19 @@ export function registerIpc(
     return { canceled: false, path: picked.filePath };
   });
   h('db:profile', async (_e, databaseId: string) => getDatabaseProfile(databaseId));
-  h('db:analyzeReport', async (_e, databaseId: string) => generateAnalysisReport(databaseId));
-  h('db:suggestAnalyses', async (_e, databaseId: string) => suggestDatabaseAnalyses(databaseId));
+  h('db:analyzeReport', async (_e, databaseId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () => generateAnalysisReport(databaseId));
+  });
+  h('db:suggestAnalyses', async (_e, databaseId: string) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () => suggestDatabaseAnalyses(databaseId));
+  });
   h('db:runAnalysis', async (_e, databaseId: string, request: AnalysisRequest) => runDatabaseAnalysis(databaseId, request));
-  h('db:narrateAnalysis', async (_e, result: AnalysisResult) => narrateAnalysisResult(result));
+  h('db:narrateAnalysis', async (_e, result: AnalysisResult) => {
+    const vaultId = getActiveVault().id;
+    return withVaultDatabase(vaultId, () => narrateAnalysisResult(result));
+  });
   h('db:chatStream', async (e, requestId: string, request: DatabaseChatRequest) => {
     const controller = new AbortController();
     chatAborters.set(requestId, controller);

--- a/electron/mcp/tools.ts
+++ b/electron/mcp/tools.ts
@@ -2167,7 +2167,7 @@ export function registerTools(server: McpServer): void {
     {
       title: 'Get database schema',
       description:
-        'Gets a database\'s columns: each column\'s id, name and type (title|text|number|date|time|select|multi_select|checkbox|attachment|ai|ai_image|relation|rollup|formula) plus the option labels for select/multi-select columns. A formula column also reports `computes` (number|text — what its values behave as, since "formula" says nothing on its own) and `formula`, a plain-language description of the recipe. Read-only.',
+        'Gets a database\'s columns: each column\'s id, name and type (title|text|number|date|time|select|multi_select|checkbox|attachment|ai|ai_image|relation|rollup|formula|comparison) plus the option labels for select/multi-select columns. A formula column also reports `computes` (number|text — what its values behave as, since "formula" says nothing on its own) and `formula`, a plain-language description of the recipe. Read-only.',
       inputSchema: { databaseId: z.string().trim().min(1) },
       annotations: { readOnlyHint: true, openWorldHint: false },
     },

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -236,6 +236,16 @@ const api: NodusApi = {
   createDatabaseRow: (databaseId) => ipcRenderer.invoke('db:createRow', databaseId),
   deleteDatabaseRow: (id) => ipcRenderer.invoke('db:deleteRow', id).then(() => undefined),
   setDatabaseCell: (rowId, columnId, raw) => ipcRenderer.invoke('db:setCell', rowId, columnId, raw),
+  runDatabaseComparisonCell: (rowId, columnId) => ipcRenderer.invoke('db:runComparisonCell', rowId, columnId),
+  runDatabaseComparisonColumn: (databaseId, columnId) => ipcRenderer.invoke('db:runComparisonColumn', databaseId, columnId),
+  onDatabaseComparisonProgress: (cb) => {
+    const listener = (
+      _e: unknown,
+      payload: { vaultId: string; databaseId: string; columnId: string; done: number; total: number }
+    ) => cb(payload);
+    ipcRenderer.on('db:comparisonProgress', listener);
+    return () => ipcRenderer.removeListener('db:comparisonProgress', listener);
+  },
   listDatabaseAttachments: (rowId, columnId) => ipcRenderer.invoke('db:listAttachments', rowId, columnId),
   getDatabaseAttachmentBlob: (id) => ipcRenderer.invoke('db:getAttachmentBlob', id),
   getDatabaseAttachmentThumb: (id) => ipcRenderer.invoke('db:getAttachmentThumb', id),
@@ -247,7 +257,10 @@ const api: NodusApi = {
   generateDatabaseAiImage: (rowId, columnId) => ipcRenderer.invoke('db:generateAiImage', rowId, columnId),
   generateDatabaseAiImageColumn: (databaseId, columnId) => ipcRenderer.invoke('db:generateAiImageColumn', databaseId, columnId),
   onDatabaseAiProgress: (cb) => {
-    const listener = (_e: unknown, payload: { columnId: string; done: number; total: number }) => cb(payload);
+    const listener = (
+      _e: unknown,
+      payload: { vaultId: string; databaseId: string; columnId: string; done: number; total: number }
+    ) => cb(payload);
     ipcRenderer.on('db:aiProgress', listener);
     return () => ipcRenderer.removeListener('db:aiProgress', listener);
   },

--- a/scripts/test-background-jobs.mjs
+++ b/scripts/test-background-jobs.mjs
@@ -40,6 +40,9 @@ try {
   let saveCalls = 0;
   let databaseTextCalls = 0;
   let databaseImageCalls = 0;
+  let databaseTextColumnCalls = 0;
+  let databaseImageColumnCalls = 0;
+  let comparisonColumnCalls = 0;
   let releaseDatabaseText;
   let releaseDatabaseImage;
   const databaseTextGate = new Promise((resolve) => {
@@ -48,6 +51,8 @@ try {
   const databaseImageGate = new Promise((resolve) => {
     releaseDatabaseImage = resolve;
   });
+  const aiProgressListeners = new Set();
+  const comparisonProgressListeners = new Set();
   const fakeSession = { id: 'imm-1', topic: 'Tema recuperable' };
   const fakeReport = {
     draft: { title: 'Informe recuperable', brief: { kind: 'deep_research' } },
@@ -84,6 +89,32 @@ try {
         databaseImageCalls += 1;
         await databaseImageGate;
         return { id: 'image-1', rowId, columnId, fileName: 'generated.png' };
+      },
+      onDatabaseAiProgress: (listener) => {
+        aiProgressListeners.add(listener);
+        return () => aiProgressListeners.delete(listener);
+      },
+      onDatabaseComparisonProgress: (listener) => {
+        comparisonProgressListeners.add(listener);
+        return () => comparisonProgressListeners.delete(listener);
+      },
+      runDatabaseAiColumn: async (databaseId, columnId) => {
+        databaseTextColumnCalls += 1;
+        for (const listener of aiProgressListeners) listener({ databaseId, columnId, done: 2, total: 5 });
+        await Promise.resolve();
+        return { done: 5, failed: 0 };
+      },
+      generateDatabaseAiImageColumn: async (databaseId, columnId) => {
+        databaseImageColumnCalls += 1;
+        for (const listener of aiProgressListeners) listener({ databaseId, columnId, done: 1, total: 3 });
+        await Promise.resolve();
+        return { done: 3, failed: 0 };
+      },
+      runDatabaseComparisonColumn: async (databaseId, columnId) => {
+        comparisonColumnCalls += 1;
+        for (const listener of comparisonProgressListeners) listener({ databaseId, columnId, done: 4, total: 8 });
+        await Promise.resolve();
+        return { done: 8 };
       },
     },
   };
@@ -191,6 +222,28 @@ try {
   jobs.startDatabaseAiTextCellJob('row-fail', 'column-3');
   await waitFor(() => jobs.getBackgroundJob(failedKey)?.status === 'failed', 'database text failure retention');
   assert.equal(jobs.getBackgroundJob(failedKey).error, 'provider unavailable');
+
+  // Whole-column processing also lives outside the view and retains progress. This is the
+  // path used when the user leaves the database, opens another section, or switches vaults.
+  const textColumnKey = jobs.databaseAiTextColumnJobKey('db-1', 'text-column');
+  const textColumn = jobs.startDatabaseAiTextColumnJob('db-1', 'text-column');
+  const duplicateTextColumn = jobs.startDatabaseAiTextColumnJob('db-1', 'text-column');
+  assert.equal(duplicateTextColumn.id, textColumn.id, 'a running AI column cannot be launched twice');
+  await waitFor(() => jobs.getBackgroundJob(textColumnKey)?.status === 'completed', 'AI text column completion');
+  assert.deepEqual(jobs.getBackgroundJob(textColumnKey).progress, { done: 2, total: 5 });
+  assert.equal(databaseTextColumnCalls, 1);
+
+  const imageColumnKey = jobs.databaseAiImageColumnJobKey('db-1', 'image-column');
+  jobs.startDatabaseAiImageColumnJob('db-1', 'image-column');
+  await waitFor(() => jobs.getBackgroundJob(imageColumnKey)?.status === 'completed', 'AI image column completion');
+  assert.deepEqual(jobs.getBackgroundJob(imageColumnKey).progress, { done: 1, total: 3 });
+  assert.equal(databaseImageColumnCalls, 1);
+
+  const comparisonKey = jobs.databaseComparisonColumnJobKey('db-1', 'comparison-column');
+  jobs.startDatabaseComparisonColumnJob('db-1', 'comparison-column');
+  await waitFor(() => jobs.getBackgroundJob(comparisonKey)?.status === 'completed', 'comparison column completion');
+  assert.deepEqual(jobs.getBackgroundJob(comparisonKey).progress, { done: 4, total: 8 });
+  assert.equal(comparisonColumnCalls, 1);
 
   console.log('background generation jobs test passed');
 } finally {

--- a/scripts/test-databases.mjs
+++ b/scripts/test-databases.mjs
@@ -36,6 +36,7 @@ try {
   const filters = require(path.join(repoRoot, 'shared/databaseFilters.ts'));
   const formulaShared = require(path.join(repoRoot, 'shared/databaseFormula.ts'));
   const formulaEval = require(path.join(repoRoot, 'shared/databaseFormulaEval.ts'));
+  const comparison = require(path.join(repoRoot, 'shared/databaseComparison.ts'));
   const profile = require(path.join(repoRoot, 'shared/dataProfile.ts'));
   const chart = require(path.join(repoRoot, 'shared/chartSpec.ts'));
   const exportShared = require(path.join(repoRoot, 'shared/databaseExport.ts'));
@@ -70,6 +71,28 @@ try {
   assert.equal(shared.normalizeCellValue('number', 'abc'), null, 'invalid number normalizes to null');
   assert.equal(shared.normalizeCellValue('checkbox', 'true'), '1');
   assert.equal(shared.normalizeCellValue('text', ''), null, 'empty text normalizes to null');
+
+  const comparisonColumns = [
+    { id: 'a', databaseId: 'db', name: 'A', type: 'text', position: 0, config: {}, options: [] },
+    { id: 'b', databaseId: 'db', name: 'B', type: 'text', position: 1, config: {}, options: [] },
+    { id: 'c', databaseId: 'db', name: 'C', type: 'text', position: 2, config: {}, options: [] },
+    {
+      id: 'result', databaseId: 'db', name: 'Resultado', type: 'comparison', position: 3,
+      config: { comparisonSourceColumnIds: ['a', 'b', 'c'] }, options: [],
+    },
+  ];
+  const comparisonRow = { id: 'row', databaseId: 'db', position: 0, cells: { a: 'sol', b: 'sol', c: 'luna' } };
+  assert.equal(
+    comparison.comparisonMajorityValue(comparisonColumns[3], comparisonColumns, comparisonRow),
+    'sol',
+    'comparison returns the unique most frequent exact term'
+  );
+  comparisonRow.cells.b = 'Sol';
+  assert.equal(
+    comparison.comparisonMajorityValue(comparisonColumns[3], comparisonColumns, comparisonRow),
+    null,
+    'comparison is case-sensitive and returns no arbitrary winner on a tie'
+  );
 
   // ── Databases + unique short ids ───────────────────────────────────────────
   const db1 = dbmode.createDatabase('Fotos');
@@ -178,6 +201,29 @@ try {
   s = dbmode.databaseStats(db1.id);
   assert.equal(s.vaultTotal, 3, 'vault total spans every database');
   assert.equal(s.percent, 67, '2 of 3 rows rounds to 67%');
+
+  // ── Comparison property: one cell and the complete column ─────────────────
+  const comparisonDb = dbmode.createDatabase('Comparaciones');
+  const sourceA = dbmode.createColumn(comparisonDb.id, 'A', 'text');
+  const sourceB = dbmode.createColumn(comparisonDb.id, 'B', 'text');
+  const sourceC = dbmode.createColumn(comparisonDb.id, 'C', 'text');
+  const resultCol = dbmode.createColumn(comparisonDb.id, 'Mayoría', 'comparison', {
+    comparisonSourceColumnIds: [sourceA.id, sourceB.id, sourceC.id],
+  });
+  const comparisonRow1 = dbmode.createRow(comparisonDb.id);
+  dbmode.setCell(comparisonRow1.id, sourceA.id, 'sol');
+  dbmode.setCell(comparisonRow1.id, sourceB.id, 'sol');
+  dbmode.setCell(comparisonRow1.id, sourceC.id, 'luna');
+  assert.equal(dbmode.runComparisonCell(comparisonRow1.id, resultCol.id).cells[resultCol.id], 'sol');
+  const comparisonRow2 = dbmode.createRow(comparisonDb.id);
+  dbmode.setCell(comparisonRow2.id, sourceA.id, 'mar');
+  dbmode.setCell(comparisonRow2.id, sourceB.id, 'tierra');
+  dbmode.setCell(comparisonRow2.id, sourceC.id, 'mar');
+  assert.deepEqual(await dbmode.runComparisonColumn(comparisonDb.id, resultCol.id), { done: 2 });
+  const comparedRows = dbmode.listRows(comparisonDb.id, { sort: 'position' });
+  assert.equal(comparedRows[0].cells[resultCol.id], 'sol');
+  assert.equal(comparedRows[1].cells[resultCol.id], 'mar');
+  dbmode.deleteDatabase(comparisonDb.id);
 
   // ── Deleting an option purges it from cells ────────────────────────────────
   dbmode.deleteOption(optA.id);
@@ -351,6 +397,16 @@ try {
   });
   assert.equal(produced, 'RESUMEN: ok');
   assert.equal(dbmode.getRow(aiRow.id).cells[aiCol.id], 'RESUMEN: ok', 'AI result persisted to the cell');
+  const textColumnModel = { provider: 'openai', model: 'gpt-column-specific' };
+  dbmode.updateColumn(aiCol.id, { config: { ...aiCol.config, aiModel: textColumnModel } });
+  let seenTextModel = null;
+  await runAiCell(aiRow.id, aiCol.id, {
+    complete: async (_opts, model) => {
+      seenTextModel = model;
+      return 'MODELO PROPIO';
+    },
+  });
+  assert.deepEqual(seenTextModel, textColumnModel, 'a text AI column uses its own persisted model');
   // Batch: runAiColumn fills every row.
   const aiRow2 = dbmode.createRow(aiDb.id);
   dbmode.setCell(aiRow2.id, aiTitle.id, 'Liquen');
@@ -361,18 +417,25 @@ try {
   // ── AI image columns: generate → stored as an AI-flagged attachment ─────────
   const imgDb = dbmode.createDatabase('Retratos');
   const imgTitle = dbmode.createColumn(imgDb.id, 'Nombre', 'title');
-  const imgCol = dbmode.createColumn(imgDb.id, 'Retrato', 'ai_image', { aiPrompt: 'Retrato ilustrado de {Nombre}.' });
+  const imageColumnModel = { provider: 'openai', model: 'gpt-image-column-specific' };
+  const imgCol = dbmode.createColumn(imgDb.id, 'Retrato', 'ai_image', {
+    aiPrompt: 'Retrato ilustrado de {Nombre}.',
+    aiImageModel: imageColumnModel,
+  });
   const imgRow = dbmode.createRow(imgDb.id);
   dbmode.setCell(imgRow.id, imgTitle.id, 'Ada');
   let seenPrompt = '';
+  let seenImageModel = null;
   const genAtt = await runAiImageCell(imgRow.id, imgCol.id, {
-    generate: async (prompt) => {
+    generate: async (prompt, model) => {
       seenPrompt = prompt;
+      seenImageModel = model;
       return { image: Buffer.from('JPEGBYTES'), mimeType: 'image/jpeg' };
     },
   });
   assert.match(seenPrompt, /Retrato ilustrado/, 'image prompt carries the column instruction');
   assert.match(seenPrompt, /Ada/, 'image prompt is enriched with the row context');
+  assert.deepEqual(seenImageModel, imageColumnModel, 'an image AI column uses its own persisted model');
   assert.equal(genAtt.aiGenerated, true, 'generated attachment flagged aiGenerated');
   assert.equal(genAtt.aiPrompt, seenPrompt, 'the exact prompt is stored on the attachment');
   assert.equal(genAtt.mimeType, 'image/jpeg');

--- a/scripts/test-vaults.mjs
+++ b/scripts/test-vaults.mjs
@@ -79,6 +79,30 @@ const researchVault = registry.createVault('Investigación separada');
 assert.equal(researchVault.type, 'academic', 'createVault defaults to academic when no type is given');
 assert.equal(registry.listVaults().length, 2);
 
+// A long job keeps a dedicated connection to its source vault while the live app switches.
+// This models an AI/image/comparison column yielding to a provider and finishing afterwards.
+const scopedWrite = database.withVaultDatabase('default', async () => {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  database.getDb().prepare('INSERT INTO settings (key, value) VALUES (?, ?)').run('background-vault-test', 'source');
+});
+registry.setActiveVault(researchVault.id);
+db = database.getDb();
+await scopedWrite;
+assert.equal(
+  db.prepare('SELECT value FROM settings WHERE key = ?').get('background-vault-test'),
+  undefined,
+  'a background write never leaks into the newly active vault'
+);
+database.closeDb();
+registry.setActiveVault('default');
+db = database.getDb();
+assert.equal(
+  db.prepare('SELECT value FROM settings WHERE key = ?').get('background-vault-test').value,
+  'source',
+  'the background write lands in its originating vault after the switch'
+);
+database.closeDb();
+
 // ── Vault types ────────────────────────────────────────────────────────────
 const studyVault = registry.createVault('Estudio de oposición', 'estudio');
 assert.equal(studyVault.type, 'estudio', 'createVault honours an explicit type');

--- a/shared/databaseComparison.ts
+++ b/shared/databaseComparison.ts
@@ -1,0 +1,64 @@
+/**
+ * Exact majority comparison for database cells.
+ *
+ * A comparison column is manually runnable for one row or the whole column. It writes the
+ * unique most frequent non-empty visible value into its cell. Matching is intentionally
+ * exact (case, accents and whitespace all matter); a tie has no arbitrary winner.
+ */
+
+import { cellDisplayValue } from './databaseFormulaEval';
+import type { DatabaseColumn, DatabaseRow } from './databases';
+
+/** Types whose value is meaningful as one comparable term. */
+export function isComparisonSource(column: DatabaseColumn): boolean {
+  return !['attachment', 'ai_image', 'relation', 'comparison'].includes(column.type);
+}
+
+/** Valid, de-duplicated source columns from a comparison column's current configuration. */
+export function comparisonSourceColumns(column: DatabaseColumn, columns: DatabaseColumn[]): DatabaseColumn[] {
+  const ids = Array.isArray(column.config.comparisonSourceColumnIds)
+    ? column.config.comparisonSourceColumnIds.filter((id): id is string => typeof id === 'string')
+    : [];
+  const wanted = new Set(ids);
+  return columns.filter((candidate) => wanted.has(candidate.id) && candidate.id !== column.id && isComparisonSource(candidate));
+}
+
+/** The exact text a source cell contributes. Selects resolve to the label the user sees. */
+export function comparisonCellValue(column: DatabaseColumn, row: DatabaseRow): string {
+  if (column.type === 'rollup') return row.rollups?.[column.id] ?? '';
+  return cellDisplayValue(column, row);
+}
+
+/**
+ * Unique mode across the configured sources. Empty cells do not vote; ties return null.
+ * Map insertion order makes the calculation deterministic without being used as a tie-break.
+ */
+export function comparisonMajorityValue(
+  comparisonColumn: DatabaseColumn,
+  columns: DatabaseColumn[],
+  row: DatabaseRow
+): string | null {
+  const sources = comparisonSourceColumns(comparisonColumn, columns);
+  if (sources.length < 2) return null;
+
+  const counts = new Map<string, number>();
+  for (const source of sources) {
+    const value = comparisonCellValue(source, row);
+    if (value === '') continue;
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  let winner: string | null = null;
+  let highest = 0;
+  let tied = false;
+  for (const [value, count] of counts) {
+    if (count > highest) {
+      winner = value;
+      highest = count;
+      tied = false;
+    } else if (count === highest) {
+      tied = true;
+    }
+  }
+  return tied ? null : winner;
+}

--- a/shared/databaseFormula.ts
+++ b/shared/databaseFormula.ts
@@ -222,6 +222,7 @@ export function emptyFormula(kind: FormulaKind): FormulaSpec {
  * import it without this one having to import the filter engine back.
  */
 export function comparableType(column: DatabaseColumn): DatabaseColumnType {
+  if (column.type === 'comparison') return 'text';
   if (column.type !== 'formula') return column.type;
   return formulaResultKind(column.config.formula as FormulaSpec | undefined);
 }

--- a/shared/databases.ts
+++ b/shared/databases.ts
@@ -13,6 +13,7 @@
 // Type-only (erased at compile time), so this module stays runtime-dependency-free even
 // though databaseFormula.ts imports its column types back.
 import type { FormulaColorRule, FormulaSpec } from './databaseFormula';
+import type { ImageProvider, ModelRef } from './types';
 
 // ── Column types ───────────────────────────────────────────────────────────────
 
@@ -30,7 +31,8 @@ export type DatabaseColumnType =
   | 'ai_image' // AI-generated image, stored as an attachment
   | 'relation' // Phase 3
   | 'rollup' // Rollup: aggregate a property across related rows
-  | 'formula'; // Computed from other columns by a visual recipe (see databaseFormula.ts)
+  | 'formula' // Computed from other columns by a visual recipe (see databaseFormula.ts)
+  | 'comparison'; // Most frequent exact value across two or more columns
 
 export interface ColumnTypeDef {
   id: DatabaseColumnType;
@@ -60,6 +62,7 @@ export const COLUMN_TYPES: ColumnTypeDef[] = [
   { id: 'relation', label: 'Relación', icon: 'link', hasOptions: false, available: true },
   { id: 'rollup', label: 'Rollup', icon: 'layers', hasOptions: false, available: true },
   { id: 'formula', label: 'Fórmula', icon: 'sigma', hasOptions: false, available: true },
+  { id: 'comparison', label: 'Comparación', icon: 'scale', hasOptions: false, available: true },
 ];
 
 const COLUMN_TYPE_BY_ID = new Map<DatabaseColumnType, ColumnTypeDef>(COLUMN_TYPES.map((d) => [d.id, d]));
@@ -104,6 +107,10 @@ export interface DatabaseColumnConfig {
   aiAuto?: boolean;
   /** ai columns: an attachment column whose file(s) feed the prompt (vision/OCR/summary). */
   aiSourceColumnId?: string;
+  /** ai columns: an optional per-column text/vision model; absent inherits Settings. */
+  aiModel?: ModelRef | null;
+  /** ai_image columns: an optional per-column image model; absent inherits Settings. */
+  aiImageModel?: { provider: ImageProvider; model: string } | null;
   /** relation columns: what the relation points at, and (for db_row) which database. */
   relationTargetKind?: RelationTargetKind;
   relationTargetDatabaseId?: string;
@@ -115,6 +122,8 @@ export interface DatabaseColumnConfig {
   formula?: FormulaSpec;
   formulaColors?: FormulaColorRule[];
   formulaDecimals?: number;
+  /** comparison columns: source columns whose exact visible values vote for the result. */
+  comparisonSourceColumnIds?: string[];
   [key: string]: unknown;
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5352,6 +5352,11 @@ export interface NodusApi {
   createDatabaseRow(databaseId: string): Promise<DatabaseRow>;
   deleteDatabaseRow(id: string): Promise<void>;
   setDatabaseCell(rowId: string, columnId: string, raw: string | null): Promise<DatabaseRow | null>;
+  runDatabaseComparisonCell(rowId: string, columnId: string): Promise<DatabaseRow | null>;
+  runDatabaseComparisonColumn(databaseId: string, columnId: string): Promise<{ done: number }>;
+  onDatabaseComparisonProgress(
+    cb: (payload: { vaultId: string; databaseId: string; columnId: string; done: number; total: number }) => void
+  ): () => void;
   listDatabaseAttachments(rowId: string, columnId: string): Promise<DatabaseAttachment[]>;
   getDatabaseAttachmentBlob(id: string): Promise<Uint8Array | null>;
   /**
@@ -5370,7 +5375,9 @@ export interface NodusApi {
   runDatabaseAiColumn(databaseId: string, columnId: string): Promise<{ done: number; failed: number }>;
   generateDatabaseAiImage(rowId: string, columnId: string): Promise<DatabaseAttachment>;
   generateDatabaseAiImageColumn(databaseId: string, columnId: string): Promise<{ done: number; failed: number }>;
-  onDatabaseAiProgress(cb: (payload: { columnId: string; done: number; total: number }) => void): () => void;
+  onDatabaseAiProgress(
+    cb: (payload: { vaultId: string; databaseId: string; columnId: string; done: number; total: number }) => void
+  ): () => void;
   listDatabaseRelations(rowId: string, columnId: string): Promise<DatabaseRelation[]>;
   addDatabaseRelation(
     rowId: string,

--- a/src/backgroundJobs.ts
+++ b/src/backgroundJobs.ts
@@ -11,7 +11,7 @@ import type {
   ToolkitJobProgress,
   ToolkitJobResult,
 } from '@shared/types';
-import type { DatabaseAttachment } from '@shared/databases';
+import type { DatabaseAttachment, DatabaseRow } from '@shared/databases';
 
 export type BackgroundJobStatus = 'running' | 'completed' | 'failed';
 
@@ -184,6 +184,16 @@ export interface DatabaseAiCellJobRequest {
   columnId: string;
 }
 
+export interface DatabaseColumnJobRequest {
+  databaseId: string;
+  columnId: string;
+}
+
+export interface DatabaseColumnJobProgress {
+  done: number;
+  total: number;
+}
+
 export function databaseAiTextCellJobKey(rowId: string, columnId: string): string {
   return `database:ai:text:${rowId}:${columnId}`;
 }
@@ -194,6 +204,9 @@ export function databaseAiImageCellJobKey(rowId: string, columnId: string): stri
 
 export type DatabaseAiTextCellJob = BackgroundJob<DatabaseAiCellJobRequest, never, string>;
 export type DatabaseAiImageCellJob = BackgroundJob<DatabaseAiCellJobRequest, never, DatabaseAttachment>;
+export type DatabaseComparisonCellJob = BackgroundJob<DatabaseAiCellJobRequest, never, DatabaseRow | null>;
+export type DatabaseAiColumnJob = BackgroundJob<DatabaseColumnJobRequest, DatabaseColumnJobProgress, { done: number; failed: number }>;
+export type DatabaseComparisonColumnJob = BackgroundJob<DatabaseColumnJobRequest, DatabaseColumnJobProgress, { done: number }>;
 
 export function startDatabaseAiTextCellJob(rowId: string, columnId: string): DatabaseAiTextCellJob {
   const request = { rowId, columnId };
@@ -206,6 +219,84 @@ export function startDatabaseAiImageCellJob(rowId: string, columnId: string): Da
   const request = { rowId, columnId };
   return startBackgroundJob(databaseAiImageCellJobKey(rowId, columnId), request, (current) =>
     window.nodus.generateDatabaseAiImage(current.rowId, current.columnId)
+  );
+}
+
+export function databaseComparisonCellJobKey(rowId: string, columnId: string): string {
+  return `database:comparison:cell:${rowId}:${columnId}`;
+}
+
+export function databaseComparisonColumnJobKey(databaseId: string, columnId: string): string {
+  return `database:comparison:column:${databaseId}:${columnId}`;
+}
+
+export function databaseAiTextColumnJobKey(databaseId: string, columnId: string): string {
+  return `database:ai:text:column:${databaseId}:${columnId}`;
+}
+
+export function databaseAiImageColumnJobKey(databaseId: string, columnId: string): string {
+  return `database:ai:image:column:${databaseId}:${columnId}`;
+}
+
+export function startDatabaseComparisonCellJob(rowId: string, columnId: string): DatabaseComparisonCellJob {
+  const request = { rowId, columnId };
+  return startBackgroundJob(databaseComparisonCellJobKey(rowId, columnId), request, (current) =>
+    window.nodus.runDatabaseComparisonCell(current.rowId, current.columnId)
+  );
+}
+
+export function startDatabaseComparisonColumnJob(databaseId: string, columnId: string): DatabaseComparisonColumnJob {
+  const request = { databaseId, columnId };
+  return startBackgroundJob(databaseComparisonColumnJobKey(databaseId, columnId), request, async (current, onProgress) => {
+    const unsubscribe = window.nodus.onDatabaseComparisonProgress((progress) => {
+      if (progress.databaseId === current.databaseId && progress.columnId === current.columnId) {
+        onProgress({ done: progress.done, total: progress.total });
+      }
+    });
+    try {
+      return await window.nodus.runDatabaseComparisonColumn(current.databaseId, current.columnId);
+    } finally {
+      unsubscribe();
+    }
+  });
+}
+
+function startDatabaseAiColumnJob(
+  key: string,
+  databaseId: string,
+  columnId: string,
+  run: (databaseId: string, columnId: string) => Promise<{ done: number; failed: number }>
+): DatabaseAiColumnJob {
+  const request = { databaseId, columnId };
+  return startBackgroundJob(key, request, async (current, onProgress) => {
+    const unsubscribe = window.nodus.onDatabaseAiProgress((progress) => {
+      if (progress.databaseId === current.databaseId && progress.columnId === current.columnId) {
+        onProgress({ done: progress.done, total: progress.total });
+      }
+    });
+    try {
+      return await run(current.databaseId, current.columnId);
+    } finally {
+      unsubscribe();
+    }
+  });
+}
+
+export function startDatabaseAiTextColumnJob(databaseId: string, columnId: string): DatabaseAiColumnJob {
+  return startDatabaseAiColumnJob(
+    databaseAiTextColumnJobKey(databaseId, columnId),
+    databaseId,
+    columnId,
+    (dbId, colId) => window.nodus.runDatabaseAiColumn(dbId, colId)
+  );
+}
+
+export function startDatabaseAiImageColumnJob(databaseId: string, columnId: string): DatabaseAiColumnJob {
+  return startDatabaseAiColumnJob(
+    databaseAiImageColumnJobKey(databaseId, columnId),
+    databaseId,
+    columnId,
+    (dbId, colId) => window.nodus.generateDatabaseAiImageColumn(dbId, colId)
   );
 }
 

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -6517,4 +6517,11 @@ export const DE: Record<string, string> = {
   "La IA no accede a este listado, a las notas ni a las respuestas del alumnado.": "Die KI hat keinen Zugriff auf diese Liste, Noten oder Antworten von Lernenden.",
   "Nodus no expone ninguna función de IA para calificar, perfilar o evaluar estudiantes. Los identificadores permiten minimizar nombres en usos locales y exportaciones.": "Nodus stellt keine KI-Funktion zur Benotung, Profilerstellung oder Bewertung von Lernenden bereit. Kennungen helfen, Namen bei lokaler Nutzung und in Exporten zu minimieren.",
   "La IA no recibe listas, notas ni respuestas del alumnado. Nodus no ofrece ninguna función de IA para calificar, perfilar o evaluar estudiantes; esas decisiones son siempre humanas y permanecen fuera del modelo.": "Die KI erhält keine Listen, Noten oder Antworten von Lernenden. Nodus bietet keine KI-Funktion zur Benotung, Profilerstellung oder Bewertung; diese Entscheidungen werden immer von Menschen getroffen und bleiben außerhalb des Modells.",
+  "Columnas que comparar": "Zu vergleichende Spalten",
+  "Elige al menos dos columnas": "Wählen Sie mindestens zwei Spalten",
+  "Solo cuentan coincidencias exactas; los valores vacíos se ignoran.": "Nur exakte Übereinstimmungen zählen; leere Werte werden ignoriert.",
+  "Comparar esta fila": "Diese Zeile vergleichen",
+  "Comparando…": "Vergleich läuft…",
+  "Comparar todas las filas": "Alle Zeilen vergleichen",
+  "Sin mayoría": "Keine Mehrheit",
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -6744,4 +6744,11 @@ export const EN: Record<string, string> = {
   "La IA no accede a este listado, a las notas ni a las respuestas del alumnado.": "AI has no access to this roster, grades or student answers.",
   "Nodus no expone ninguna función de IA para calificar, perfilar o evaluar estudiantes. Los identificadores permiten minimizar nombres en usos locales y exportaciones.": "Nodus exposes no AI function for grading, profiling or evaluating students. Identifiers help minimise names in local use and exports.",
   "La IA no recibe listas, notas ni respuestas del alumnado. Nodus no ofrece ninguna función de IA para calificar, perfilar o evaluar estudiantes; esas decisiones son siempre humanas y permanecen fuera del modelo.": "AI does not receive student rosters, grades or answers. Nodus offers no AI function to grade, profile or evaluate students; those decisions are always human and remain outside the model.",
+  "Columnas que comparar": "Columns to compare",
+  "Elige al menos dos columnas": "Choose at least two columns",
+  "Solo cuentan coincidencias exactas; los valores vacíos se ignoran.": "Only exact matches count; empty values are ignored.",
+  "Comparar esta fila": "Compare this row",
+  "Comparando…": "Comparing…",
+  "Comparar todas las filas": "Compare all rows",
+  "Sin mayoría": "No majority",
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -6508,4 +6508,11 @@ export const FR: Record<string, string> = {
   "La IA no accede a este listado, a las notas ni a las respuestas del alumnado.": "L’IA n’accède ni à cette liste, ni aux notes, ni aux réponses des élèves.",
   "Nodus no expone ninguna función de IA para calificar, perfilar o evaluar estudiantes. Los identificadores permiten minimizar nombres en usos locales y exportaciones.": "Nodus n’expose aucune fonction d’IA pour noter, profiler ou évaluer des élèves. Les identifiants permettent de minimiser les noms dans les usages locaux et les exportations.",
   "La IA no recibe listas, notas ni respuestas del alumnado. Nodus no ofrece ninguna función de IA para calificar, perfilar o evaluar estudiantes; esas decisiones son siempre humanas y permanecen fuera del modelo.": "L’IA ne reçoit ni listes, ni notes, ni réponses d’élèves. Nodus ne propose aucune fonction d’IA pour noter, profiler ou évaluer des élèves ; ces décisions sont toujours humaines et restent hors du modèle.",
+  "Columnas que comparar": "Colonnes à comparer",
+  "Elige al menos dos columnas": "Choisissez au moins deux colonnes",
+  "Solo cuentan coincidencias exactas; los valores vacíos se ignoran.": "Seules les correspondances exactes comptent ; les valeurs vides sont ignorées.",
+  "Comparar esta fila": "Comparer cette ligne",
+  "Comparando…": "Comparaison…",
+  "Comparar todas las filas": "Comparer toutes les lignes",
+  "Sin mayoría": "Aucune majorité",
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -5932,4 +5932,11 @@ export const IT: Record<string, string> = {
   "Vídeo de la diapositiva": "Video della diapositiva",
   // PDF Presenter (Toolkit) — macOS extras
   "AirPlay / Duplicar pantalla": "AirPlay / Duplicazione dello schermo",
+  "Columnas que comparar": "Colonne da confrontare",
+  "Elige al menos dos columnas": "Scegli almeno due colonne",
+  "Solo cuentan coincidencias exactas; los valores vacíos se ignoran.": "Contano solo le corrispondenze esatte; i valori vuoti vengono ignorati.",
+  "Comparar esta fila": "Confronta questa riga",
+  "Comparando…": "Confronto…",
+  "Comparar todas las filas": "Confronta tutte le righe",
+  "Sin mayoría": "Nessuna maggioranza",
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -6467,4 +6467,11 @@ export const PT_BR: Record<string, string> = {
   "La IA no accede a este listado, a las notas ni a las respuestas del alumnado.": "A IA não acessa esta lista, as notas nem as respostas dos alunos.",
   "Nodus no expone ninguna función de IA para calificar, perfilar o evaluar estudiantes. Los identificadores permiten minimizar nombres en usos locales y exportaciones.": "O Nodus não oferece nenhuma função de IA para dar notas, criar perfis ou avaliar estudantes. Os identificadores ajudam a minimizar nomes em usos locais e exportações.",
   "La IA no recibe listas, notas ni respuestas del alumnado. Nodus no ofrece ninguna función de IA para calificar, perfilar o evaluar estudiantes; esas decisiones son siempre humanas y permanecen fuera del modelo.": "A IA não recebe listas, notas ou respostas dos alunos. O Nodus não oferece nenhuma função de IA para dar notas, criar perfis ou avaliar estudantes; essas decisões são sempre humanas e ficam fora do modelo.",
+  "Columnas que comparar": "Colunas para comparar",
+  "Elige al menos dos columnas": "Escolha pelo menos duas colunas",
+  "Solo cuentan coincidencias exactas; los valores vacíos se ignoran.": "Somente correspondências exatas contam; valores vazios são ignorados.",
+  "Comparar esta fila": "Comparar esta linha",
+  "Comparando…": "Comparando…",
+  "Comparar todas las filas": "Comparar todas as linhas",
+  "Sin mayoría": "Sem maioria",
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -6459,4 +6459,11 @@ export const PT: Record<string, string> = {
   "La IA no accede a este listado, a las notas ni a las respuestas del alumnado.": "A IA não acede a esta lista, às notas nem às respostas dos alunos.",
   "Nodus no expone ninguna función de IA para calificar, perfilar o evaluar estudiantes. Los identificadores permiten minimizar nombres en usos locales y exportaciones.": "O Nodus não disponibiliza qualquer função de IA para classificar, criar perfis ou avaliar estudantes. Os identificadores permitem minimizar nomes em utilizações locais e exportações.",
   "La IA no recibe listas, notas ni respuestas del alumnado. Nodus no ofrece ninguna función de IA para calificar, perfilar o evaluar estudiantes; esas decisiones son siempre humanas y permanecen fuera del modelo.": "A IA não recebe listas, notas ou respostas dos alunos. O Nodus não oferece qualquer função de IA para classificar, criar perfis ou avaliar estudantes; essas decisões são sempre humanas e ficam fora do modelo.",
+  "Columnas que comparar": "Colunas a comparar",
+  "Elige al menos dos columnas": "Escolha pelo menos duas colunas",
+  "Solo cuentan coincidencias exactas; los valores vacíos se ignoran.": "Só contam correspondências exatas; os valores vazios são ignorados.",
+  "Comparar esta fila": "Comparar esta linha",
+  "Comparando…": "A comparar…",
+  "Comparar todas las filas": "Comparar todas as linhas",
+  "Sin mayoría": "Sem maioria",
 };

--- a/src/views/DatabasesView.tsx
+++ b/src/views/DatabasesView.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import type { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { AiBadge, Icon } from '../components/ui';
+import { ModelPicker } from '../components/ModelPicker';
 import { VirtualList } from '../components/VirtualList';
 import {
   ADD_COLUMN_WIDTH,
@@ -24,14 +25,25 @@ import { notifyDataChanged } from '../hooks';
 import { t, tx } from '../i18n';
 import {
   clearBackgroundJob,
+  databaseAiImageColumnJobKey,
   databaseAiImageCellJobKey,
+  databaseAiTextColumnJobKey,
   databaseAiTextCellJobKey,
+  databaseComparisonCellJobKey,
+  databaseComparisonColumnJobKey,
   getBackgroundJob,
+  startDatabaseAiImageColumnJob,
   startDatabaseAiImageCellJob,
+  startDatabaseAiTextColumnJob,
   startDatabaseAiTextCellJob,
+  startDatabaseComparisonCellJob,
+  startDatabaseComparisonColumnJob,
   subscribeBackgroundJob,
+  type DatabaseAiColumnJob,
   type DatabaseAiImageCellJob,
   type DatabaseAiTextCellJob,
+  type DatabaseComparisonCellJob,
+  type DatabaseComparisonColumnJob,
 } from '../backgroundJobs';
 import {
   attachmentKind,
@@ -45,6 +57,7 @@ import {
 } from '@shared/databases';
 import { AI_COLUMN_PRESETS } from '@shared/databaseAi';
 import { matchFilesToRows, summarizeMatches, codeTemplateToRegex } from '@shared/databaseBulk';
+import { comparisonSourceColumns, isComparisonSource } from '@shared/databaseComparison';
 import type { CsvImportPlanData } from '@shared/databaseCsv';
 import {
   applyDatabaseFilter,
@@ -85,6 +98,10 @@ import type {
   DatabaseRelation,
   DatabaseRow,
   DatabaseSelectOption,
+  AppSettings,
+  ImageProvider,
+  ImageModelInfo,
+  ModelRef,
   RelationTarget,
   RelationTargetKind,
 } from '@shared/types';
@@ -597,6 +614,7 @@ export function DatabasesView({ databaseId, onDatabasesChanged, onCreateDatabase
                     <Cell
                       key={col.id}
                       column={col}
+                      columns={columns}
                       width={widthOf(col)}
                       value={row.cells[col.id] ?? null}
                       rollup={row.rollups?.[col.id] ?? ''}
@@ -1454,6 +1472,7 @@ function RecordModal({
                     <div className="database-record-field flex-1 min-w-0 rounded-md border border-neutral-800/70 bg-neutral-900/30 min-h-[2.25rem] flex items-center hover:border-neutral-700/80 focus-within:border-neutral-600 transition-colors">
                       <RecordField
                         col={col}
+                        columns={columns}
                         row={row}
                         onChange={(raw) => void setCell(col.id, raw)}
                         onOptionsChanged={onChanged}
@@ -1474,12 +1493,14 @@ function RecordModal({
 /** One field in the record modal — reuses the table cell editors in a form layout. */
 function RecordField({
   col,
+  columns,
   row,
   onChange,
   onOptionsChanged,
   onAttachmentsChanged,
 }: {
   col: DatabaseColumn;
+  columns: DatabaseColumn[];
   row: DatabaseRow;
   onChange: (raw: string | null) => void;
   onOptionsChanged: () => void;
@@ -1508,6 +1529,8 @@ function RecordField({
   if (col.type === 'ai') return <AiCell column={col} rowId={row.id} value={value} onChange={onChange} onRan={onAttachmentsChanged} wrap />;
   if (col.type === 'relation') return <RelationCell column={col} rowId={row.id} />;
   if (col.type === 'rollup') return <RollupCell value={row.rollups?.[col.id] ?? ''} />;
+  if (col.type === 'comparison')
+    return <ComparisonCell column={col} columns={columns} rowId={row.id} value={value} onRan={onAttachmentsChanged} large />;
   if (col.type === 'formula')
     return <FormulaCell column={col} value={value} color={row.formulaColors?.[col.id]} error={row.formulaErrors?.[col.id]} large />;
   if (col.type === 'number' || col.type === 'date' || col.type === 'time')
@@ -1681,6 +1704,7 @@ function ColumnHeader({
             {column.type === 'ai_image' && <AiImageColumnConfig column={column} onChanged={onChanged} />}
             {column.type === 'relation' && <RelationColumnConfig column={column} onChanged={onChanged} />}
             {column.type === 'rollup' && <RollupColumnConfig column={column} onChanged={onChanged} />}
+            {column.type === 'comparison' && <ComparisonColumnConfig column={column} columns={columns} onChanged={onChanged} />}
             {column.type === 'formula' && (
               <FormulaColumnConfig
                 column={column}
@@ -1861,6 +1885,7 @@ function AddColumnButton({ onAdd }: { onAdd: (name: string, type: DatabaseColumn
 
 function Cell({
   column,
+  columns,
   width,
   value,
   rollup,
@@ -1874,6 +1899,7 @@ function Cell({
   onAttachmentsChanged,
 }: {
   column: DatabaseColumn;
+  columns: DatabaseColumn[];
   width: number;
   value: string | null;
   rollup?: string;
@@ -1890,6 +1916,8 @@ function Cell({
     <div style={{ width }} className="shrink-0 h-full border-r border-neutral-900 overflow-hidden">
       {column.type === 'formula' ? (
         <FormulaCell column={column} value={value} color={formulaColor} error={formulaError} wrap={wrap} />
+      ) : column.type === 'comparison' ? (
+        <ComparisonCell column={column} columns={columns} rowId={rowId} value={value} onRan={onAttachmentsChanged} wrap={wrap} />
       ) : column.type === 'checkbox' ? (
         <CheckboxCell value={value} onChange={onChange} />
       ) : column.type === 'select' ? (
@@ -1915,6 +1943,136 @@ function Cell({
       ) : (
         <LongTextCell value={value} onChange={onChange} markdown={column.type === 'text'} wrap={wrap} />
       )}
+    </div>
+  );
+}
+
+// ── Comparison columns ───────────────────────────────────────────────────────
+
+/** Read-only result with a per-cell action to recompute this row. */
+function ComparisonCell({
+  column,
+  columns,
+  rowId,
+  value,
+  onRan,
+  large = false,
+  wrap = false,
+}: {
+  column: DatabaseColumn;
+  columns: DatabaseColumn[];
+  rowId: string;
+  value: string | null;
+  onRan: () => void;
+  large?: boolean;
+  wrap?: boolean;
+}) {
+  const jobKey = databaseComparisonCellJobKey(rowId, column.id);
+  const [job, setJob] = useState<DatabaseComparisonCellJob | null>(() => getBackgroundJob(jobKey));
+  const configured = comparisonSourceColumns(column, columns).length >= 2;
+  const busy = job?.status === 'running';
+  const error = job?.status === 'failed' ? job.error : null;
+  useEffect(
+    () => subscribeBackgroundJob(jobKey, (current) => setJob(current as DatabaseComparisonCellJob | null)),
+    [jobKey]
+  );
+  useEffect(() => {
+    if (job?.status !== 'completed') return;
+    onRan();
+    clearBackgroundJob(jobKey, job.id);
+  }, [job, jobKey, onRan]);
+  const run = () => {
+    clearBackgroundJob(jobKey);
+    startDatabaseComparisonCellJob(rowId, column.id);
+  };
+  return (
+    <div className={`w-full ${large ? 'min-h-8' : 'h-full'} flex items-center gap-1 group/comparison overflow-hidden`}>
+      <span
+        className={`flex-1 min-w-0 px-2 text-sm text-neutral-300 ${wrap ? 'whitespace-pre-wrap break-words py-1' : 'truncate'}`}
+        title={value ?? t('Sin mayoría')}
+      >
+        {value || <span className="text-neutral-600">—</span>}
+      </span>
+      <button
+        className="shrink-0 mr-2 opacity-60 group-hover/comparison:opacity-100 text-indigo-400 hover:text-indigo-300 disabled:opacity-30"
+        title={error ?? (configured ? t('Comparar esta fila') : t('Elige al menos dos columnas'))}
+        onClick={run}
+        disabled={busy || !configured}
+      >
+        <Icon name={busy ? 'sync' : 'scale'} size={14} className={busy ? 'animate-spin' : ''} />
+      </button>
+    </div>
+  );
+}
+
+/** Source selector and whole-column action in the header menu. */
+function ComparisonColumnConfig({
+  column,
+  columns,
+  onChanged,
+}: {
+  column: DatabaseColumn;
+  columns: DatabaseColumn[];
+  onChanged: () => void;
+}) {
+  const candidates = columns.filter((candidate) => candidate.id !== column.id && isComparisonSource(candidate));
+  const [selected, setSelected] = useState<string[]>(() => comparisonSourceColumns(column, columns).map((candidate) => candidate.id));
+  const jobKey = databaseComparisonColumnJobKey(column.databaseId, column.id);
+  const [job, setJob] = useState<DatabaseComparisonColumnJob | null>(() => getBackgroundJob(jobKey));
+  const busy = job?.status === 'running';
+  const runProgress = busy ? job.progress : null;
+  useEffect(() => {
+    setSelected(comparisonSourceColumns(column, columns).map((candidate) => candidate.id));
+  }, [column, columns]);
+  useEffect(
+    () => subscribeBackgroundJob(jobKey, (current) => setJob(current as DatabaseComparisonColumnJob | null)),
+    [jobKey]
+  );
+  useEffect(() => {
+    if (job?.status !== 'completed') return;
+    onChanged();
+    clearBackgroundJob(jobKey, job.id);
+  }, [job, jobKey, onChanged]);
+
+  const toggle = async (id: string) => {
+    const next = selected.includes(id) ? selected.filter((sourceId) => sourceId !== id) : [...selected, id];
+    setSelected(next);
+    await window.nodus.updateDatabaseColumn(column.id, {
+      config: { ...column.config, comparisonSourceColumnIds: next },
+    });
+    onChanged();
+  };
+  const runAll = () => {
+    clearBackgroundJob(jobKey);
+    startDatabaseComparisonColumnJob(column.databaseId, column.id);
+  };
+
+  return (
+    <div className="px-2 py-1 border-t border-neutral-800 mt-1">
+      <div className="text-[10px] uppercase tracking-wide text-neutral-500 py-1">{t('Columnas que comparar')}</div>
+      <div className="max-h-32 overflow-y-auto space-y-0.5">
+        {candidates.map((candidate) => (
+          <label key={candidate.id} className="flex items-center gap-2 rounded px-1 py-1 text-xs text-neutral-300 hover:bg-neutral-800">
+            <input type="checkbox" checked={selected.includes(candidate.id)} onChange={() => void toggle(candidate.id)} />
+            <span className="truncate">{candidate.name}</span>
+          </label>
+        ))}
+      </div>
+      {selected.length < 2 && <p className="mt-1 text-[10px] text-amber-400">{t('Elige al menos dos columnas')}</p>}
+      <p className="mt-1 text-[10px] leading-snug text-neutral-500">
+        {t('Solo cuentan coincidencias exactas; los valores vacíos se ignoran.')}
+      </p>
+      <button
+        className="btn btn-ghost border border-neutral-700 w-full gap-1.5 mt-2 text-xs"
+        onClick={runAll}
+        disabled={busy || selected.length < 2}
+        title={job?.status === 'failed' ? job.error ?? undefined : undefined}
+      >
+        <Icon name={busy ? 'sync' : 'scale'} size={13} className={busy ? 'animate-spin' : ''} />
+        {busy && runProgress && runProgress.total > 0
+          ? tx('Ejecutando… {d}/{t}', { d: runProgress.done, t: runProgress.total })
+          : busy ? t('Comparando…') : t('Comparar todas las filas')}
+      </button>
     </div>
   );
 }
@@ -2228,22 +2386,31 @@ function AiColumnConfig({ column, onChanged }: { column: DatabaseColumn; onChang
   const [prompt, setPrompt] = useState(String(column.config.aiPrompt ?? ''));
   const [auto, setAuto] = useState(Boolean(column.config.aiAuto));
   const [sourceId, setSourceId] = useState(String(column.config.aiSourceColumnId ?? ''));
+  const [model, setModel] = useState<ModelRef | null>(column.config.aiModel ?? null);
+  const [settings, setSettings] = useState<AppSettings | null>(null);
   const [attachmentCols, setAttachmentCols] = useState<DatabaseColumn[]>([]);
-  const [runProgress, setRunProgress] = useState<{ done: number; total: number } | null>(null);
+  const jobKey = databaseAiTextColumnJobKey(column.databaseId, column.id);
+  const [job, setJob] = useState<DatabaseAiColumnJob | null>(() => getBackgroundJob(jobKey));
+  const running = job?.status === 'running';
+  const runProgress = running ? job.progress : null;
   useEffect(
-    () => window.nodus.onDatabaseAiProgress((p) => setRunProgress({ done: p.done, total: p.total })),
-    []
+    () => subscribeBackgroundJob(jobKey, (current) => setJob(current as DatabaseAiColumnJob | null)),
+    [jobKey]
   );
-  const runAll = async () => {
-    setRunProgress({ done: 0, total: 0 });
-    try {
-      await window.nodus.runDatabaseAiColumn(column.databaseId, column.id);
-    } finally {
-      setRunProgress(null);
-    }
+  useEffect(() => {
+    if (job?.status !== 'completed') return;
+    onChanged();
+    clearBackgroundJob(jobKey, job.id);
+  }, [job, jobKey, onChanged]);
+  const runAll = () => {
+    clearBackgroundJob(jobKey);
+    startDatabaseAiTextColumnJob(column.databaseId, column.id);
   };
   useEffect(() => {
-    void window.nodus.getDatabaseDetail(column.databaseId).then((d) => setAttachmentCols((d?.columns ?? []).filter((c) => c.type === 'attachment')));
+    void Promise.all([window.nodus.getDatabaseDetail(column.databaseId), window.nodus.getSettings()]).then(([d, nextSettings]) => {
+      setAttachmentCols((d?.columns ?? []).filter((c) => c.type === 'attachment'));
+      setSettings(nextSettings);
+    });
   }, [column.databaseId]);
   const save = async (patch: Record<string, unknown>) => {
     await window.nodus.updateDatabaseColumn(column.id, { config: { ...column.config, ...patch } });
@@ -2274,6 +2441,27 @@ function AiColumnConfig({ column, onChanged }: { column: DatabaseColumn; onChang
           </button>
         ))}
       </div>
+      {settings && (
+        <>
+          <label className="text-[10px] uppercase tracking-wide text-neutral-500 mt-2 block">{t('Modelo')}</label>
+          <ModelPicker
+            settings={settings}
+            value={model}
+            onChange={(nextModel) => {
+              setModel(nextModel);
+              void save({ aiModel: nextModel ?? undefined });
+            }}
+            compact
+            disabled={running}
+            emptyLabel={
+              (settings.chatModel ?? settings.synthesisModel)?.model
+                ? tx('Predeterminado ({model})', { model: (settings.chatModel ?? settings.synthesisModel)!.model })
+                : t('Predeterminado')
+            }
+            className="w-full mt-1"
+          />
+        </>
+      )}
       {attachmentCols.length > 0 && (
         <>
           <label className="text-[10px] uppercase tracking-wide text-neutral-500 mt-2 block">{t('Fuente (imagen/archivo)')}</label>
@@ -2307,13 +2495,14 @@ function AiColumnConfig({ column, onChanged }: { column: DatabaseColumn; onChang
       </label>
       <button
         className="btn btn-ghost border border-neutral-700 w-full gap-1.5 mt-2 text-xs"
-        onClick={() => void runAll()}
-        disabled={runProgress != null || !prompt.trim()}
+        onClick={runAll}
+        disabled={running || !prompt.trim()}
+        title={job?.status === 'failed' ? job.error ?? undefined : undefined}
       >
-        <Icon name={runProgress != null ? 'sync' : 'wand'} size={13} className={runProgress != null ? 'animate-spin' : ''} />
-        {runProgress != null && runProgress.total > 0
+        <Icon name={running ? 'sync' : 'wand'} size={13} className={running ? 'animate-spin' : ''} />
+        {running && runProgress && runProgress.total > 0
           ? tx('Ejecutando… {d}/{t}', { d: runProgress.done, t: runProgress.total })
-          : t('Ejecutar en todas las filas')}
+          : running ? t('Calculando…') : t('Ejecutar en todas las filas')}
       </button>
     </div>
   );
@@ -2419,19 +2608,50 @@ function AiImageAttachmentActions({
 
 function AiImageColumnConfig({ column, onChanged }: { column: DatabaseColumn; onChanged: () => void }) {
   const [prompt, setPrompt] = useState(String(column.config.aiPrompt ?? ''));
-  const [runProgress, setRunProgress] = useState<{ done: number; total: number } | null>(null);
-  useEffect(() => window.nodus.onDatabaseAiProgress((p) => setRunProgress({ done: p.done, total: p.total })), []);
+  const [model, setModel] = useState<{ provider: ImageProvider; model: string } | null>(column.config.aiImageModel ?? null);
+  const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [models, setModels] = useState<ImageModelInfo[]>([]);
+  const [modelsError, setModelsError] = useState<string | null>(null);
+  const jobKey = databaseAiImageColumnJobKey(column.databaseId, column.id);
+  const [job, setJob] = useState<DatabaseAiColumnJob | null>(() => getBackgroundJob(jobKey));
+  const running = job?.status === 'running';
+  const runProgress = running ? job.progress : null;
+  useEffect(
+    () => subscribeBackgroundJob(jobKey, (current) => setJob(current as DatabaseAiColumnJob | null)),
+    [jobKey]
+  );
+  useEffect(() => {
+    if (job?.status !== 'completed') return;
+    onChanged();
+    clearBackgroundJob(jobKey, job.id);
+  }, [job, jobKey, onChanged]);
+  useEffect(() => {
+    let live = true;
+    void Promise.all([window.nodus.getSettings(), window.nodus.listImageModels()])
+      .then(([nextSettings, nextModels]) => {
+        if (!live) return;
+        setSettings(nextSettings);
+        setModels(nextModels);
+        setModelsError(null);
+      })
+      .catch((reason) => {
+        if (!live) return;
+        setModelsError(reason instanceof Error ? reason.message : String(reason));
+        void window.nodus.getSettings().then((nextSettings) => {
+          if (live) setSettings(nextSettings);
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
   const save = async (patch: Record<string, unknown>) => {
     await window.nodus.updateDatabaseColumn(column.id, { config: { ...column.config, ...patch } });
     onChanged();
   };
-  const runAll = async () => {
-    setRunProgress({ done: 0, total: 0 });
-    try {
-      await window.nodus.generateDatabaseAiImageColumn(column.databaseId, column.id);
-    } finally {
-      setRunProgress(null);
-    }
+  const runAll = () => {
+    clearBackgroundJob(jobKey);
+    startDatabaseAiImageColumnJob(column.databaseId, column.id);
   };
   return (
     <div className="px-2 py-1 border-t border-neutral-800 mt-1">
@@ -2443,16 +2663,43 @@ function AiImageColumnConfig({ column, onChanged }: { column: DatabaseColumn; on
         onBlur={() => void save({ aiPrompt: prompt })}
         placeholder={t('Ej.: retrato ilustrado de esta persona en estilo acuarela')}
       />
-      <p className="text-[10px] text-neutral-500 mt-1">{t('Se usa el proveedor de imagen configurado en Ajustes → Proveedores.')}</p>
+      <label className="text-[10px] uppercase tracking-wide text-neutral-500 mt-2 block">{t('Modelo')}</label>
+      <select
+        className="input w-full text-xs mt-1"
+        value={model ? `${model.provider}::${model.model}` : ''}
+        disabled={running || !settings}
+        onChange={(event) => {
+          const selected = models.find((candidate) => `${candidate.provider}::${candidate.id}` === event.target.value);
+          const nextModel = selected ? { provider: selected.provider, model: selected.id } : null;
+          setModel(nextModel);
+          void save({ aiImageModel: nextModel ?? undefined });
+        }}
+      >
+        <option value="">
+          {settings?.imageModel
+            ? tx('Predeterminado ({model})', { model: settings.imageModel })
+            : t('Predeterminado')}
+        </option>
+        {model && !models.some((candidate) => candidate.provider === model.provider && candidate.id === model.model) && (
+          <option value={`${model.provider}::${model.model}`}>{model.provider} · {model.model}</option>
+        )}
+        {models.map((candidate) => (
+          <option key={`${candidate.provider}:${candidate.id}`} value={`${candidate.provider}::${candidate.id}`}>
+            {candidate.provider} · {candidate.name}
+          </option>
+        ))}
+      </select>
+      {modelsError && <p className="text-[10px] text-red-400 mt-1">{modelsError}</p>}
       <button
         className="btn btn-ghost border border-neutral-700 w-full gap-1.5 mt-2 text-xs"
-        onClick={() => void runAll()}
-        disabled={runProgress != null || !prompt.trim()}
+        onClick={runAll}
+        disabled={running || !prompt.trim()}
+        title={job?.status === 'failed' ? job.error ?? undefined : undefined}
       >
-        <Icon name={runProgress != null ? 'sync' : 'image'} size={13} className={runProgress != null ? 'animate-spin' : ''} />
-        {runProgress != null && runProgress.total > 0
+        <Icon name={running ? 'sync' : 'image'} size={13} className={running ? 'animate-spin' : ''} />
+        {running && runProgress && runProgress.total > 0
           ? tx('Generando… {d}/{t}', { d: runProgress.done, t: runProgress.total })
-          : t('Generar en todas las filas')}
+          : running ? t('Generando…') : t('Generar en todas las filas')}
       </button>
     </div>
   );


### PR DESCRIPTION
Closes #148

## Summary

- add a Comparison database property that returns the unique exact majority across user-selected source columns
- run Comparison, AI text, and AI image work as navigation-independent background jobs bound to the originating vault
- add per-column text/vision model selection for AI columns and provider/model selection for AI image columns
- keep existing columns backward-compatible by inheriting the global Settings model when no override is selected
- expose progress consistently through IPC and prevent duplicate cell/column jobs

## Implementation notes

- background processing uses a dedicated database connection scoped to the source vault, so switching vaults cannot redirect writes
- bulk Comparison work is batched and yields between transactions to keep navigation responsive
- ties and empty Comparison inputs produce no arbitrary winner; matching remains case-, accent-, whitespace-, and punctuation-sensitive
- model overrides are persisted in each column's existing JSON configuration

## Validation

- `npm test` — 688 tests passed
- `npm run build` — renderer, Electron main, and preload builds passed
- `npm run lint` — 0 errors (4 pre-existing warnings)
- `npm run verify:database-records` — Electron UI verification passed
- `git diff --check` — passed