### PR TITLE
Fix light-theme contrast in the ChatGPT MCP connection UI

### DIFF
--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -451,6 +451,73 @@ try {
   await page.getByRole('button', { name: /Anthropic/ }).click();
   await page.getByText(/Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude\.ai/).waitFor();
   console.log('[e2e] provider UI exposes subscriptions, usage limits and real light/dark surfaces');
+
+  // ── ChatGPT MCP connector: every semantic surface must work in both themes ──
+  await page.getByRole('button', { name: 'Integraciones', exact: true }).click();
+  const mcpSettingsCard = page.getByTestId('mcp-settings-card');
+  await mcpSettingsCard.waitFor();
+  await mcpSettingsCard.getByRole('button', { name: /Conectar con ChatGPT|Administrar conexión/ }).click();
+  await page.getByTestId('mcp-privacy-notice').waitFor();
+  const mcpThemeStyles = await page.evaluate(() => {
+    const root = document.documentElement;
+    const settingsCard = document.querySelector('[data-testid="mcp-settings-card"]');
+    const notice = document.querySelector('[data-testid="mcp-privacy-notice"]');
+    const status = document.querySelector('[data-testid="mcp-tunnel-status"]');
+    const tabs = document.querySelector('[data-testid="mcp-client-tabs"]');
+    const step = document.querySelector('[data-testid="mcp-setup-step"]');
+    const settingsHeading = settingsCard?.querySelector('h3');
+    const statusHeading = status?.querySelector('h3');
+    if (!settingsCard || !notice || !status || !tabs || !step || !settingsHeading || !statusHeading) {
+      throw new Error('MCP theme surfaces are missing');
+    }
+    const original = { light: root.classList.contains('light'), dark: root.classList.contains('dark') };
+    const read = () => ({
+      settingsBackground: getComputedStyle(settingsCard).backgroundColor,
+      settingsText: getComputedStyle(settingsHeading).color,
+      noticeBackground: getComputedStyle(notice).backgroundColor,
+      noticeText: getComputedStyle(notice).color,
+      noticeBorder: getComputedStyle(notice).borderTopColor,
+      statusBackground: getComputedStyle(status).backgroundColor,
+      statusText: getComputedStyle(statusHeading).color,
+      tabsBackground: getComputedStyle(tabs).backgroundColor,
+      stepBorder: getComputedStyle(step).borderTopColor,
+    });
+    root.classList.add('light');
+    root.classList.remove('dark');
+    const light = read();
+    root.classList.remove('light');
+    root.classList.add('dark');
+    const dark = read();
+    root.classList.toggle('light', original.light);
+    root.classList.toggle('dark', original.dark);
+    return { light, dark };
+  });
+  const rgbChannels = (color) => (color.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number);
+  const relativeLuminance = (color) => {
+    const channels = rgbChannels(color).map((channel) => {
+      const value = channel / 255;
+      return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  };
+  const contrastRatio = (foreground, background) => {
+    const a = relativeLuminance(foreground);
+    const b = relativeLuminance(background);
+    return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+  };
+  assert.ok(contrastRatio(mcpThemeStyles.light.noticeText, mcpThemeStyles.light.noticeBackground) >= 4.5, 'MCP privacy notice meets WCAG AA contrast in light mode');
+  assert.ok(contrastRatio(mcpThemeStyles.dark.noticeText, mcpThemeStyles.dark.noticeBackground) >= 4.5, 'MCP privacy notice meets WCAG AA contrast in dark mode');
+  assert.ok(contrastRatio(mcpThemeStyles.light.statusText, mcpThemeStyles.light.statusBackground) >= 4.5, 'MCP status heading is readable in light mode');
+  assert.ok(contrastRatio(mcpThemeStyles.dark.statusText, mcpThemeStyles.dark.statusBackground) >= 4.5, 'MCP status heading is readable in dark mode');
+  assert.ok(contrastRatio(mcpThemeStyles.light.settingsText, mcpThemeStyles.light.settingsBackground) >= 4.5, 'MCP Settings heading is readable in light mode');
+  assert.notEqual(mcpThemeStyles.light.noticeBackground, mcpThemeStyles.dark.noticeBackground, 'MCP privacy notice follows the active theme');
+  assert.notEqual(mcpThemeStyles.light.noticeBorder, mcpThemeStyles.dark.noticeBorder, 'MCP privacy border follows the active theme');
+  assert.notEqual(mcpThemeStyles.light.statusBackground, mcpThemeStyles.dark.statusBackground, 'MCP status panel follows the active theme');
+  assert.notEqual(mcpThemeStyles.light.tabsBackground, mcpThemeStyles.dark.tabsBackground, 'MCP client tabs follow the active theme');
+  assert.notEqual(mcpThemeStyles.light.stepBorder, mcpThemeStyles.dark.stepBorder, 'MCP setup steps follow the active theme');
+  await page.getByRole('dialog', { name: 'Conectar Nodus' }).getByRole('button', { name: 'Cerrar', exact: true }).last().click();
+  console.log('[e2e] ChatGPT MCP connector has readable light/dark surfaces');
+
   await page.getByRole('button', { name: 'Modelos IA', exact: true }).click();
   await page.getByText('Generación de imágenes', { exact: true }).waitFor({ timeout: 30_000 });
   assert.equal(await page.getByText('gemini-3.1-flash-lite-image', { exact: false }).count() > 0, true, 'image settings render selected verified model');

--- a/scripts/test-mcp-theme.mjs
+++ b/scripts/test-mcp-theme.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const modal = await readFile(new URL('../src/components/McpConnectionModal.tsx', import.meta.url), 'utf8');
+const settings = await readFile(new URL('../src/views/Settings.tsx', import.meta.url), 'utf8');
+
+const settingsStart = settings.indexOf('data-testid="mcp-settings-card"');
+const settingsEnd = settings.indexOf('</Section>', settingsStart);
+const mcpSettings = settings.slice(settingsStart, settingsEnd);
+
+const darkOnlyPatterns = [
+  /(?<![:\w-])border-neutral-(?:700|800|900)\b/g,
+  /(?<![:\w-])bg-neutral-(?:800|900|950)(?:\/\d+)?\b/g,
+  /(?<![:\w-])text-neutral-(?:100|200|300|400)\b/g,
+  /(?<![:\w-])border-(?:amber|emerald|indigo|red)-(?:700|800|900)(?:\/\d+)?\b/g,
+  /(?<![:\w-])bg-(?:amber|emerald|indigo|red)-(?:900|950)(?:\/\d+)?\b/g,
+  /(?<![:\w-])text-(?:amber|emerald|indigo|red)-(?:200|300|400)(?:\/\d+)?\b/g,
+];
+
+function assertNoDarkOnlyPalette(source, label) {
+  const matches = darkOnlyPatterns.flatMap((pattern) => [...source.matchAll(pattern)].map((match) => match[0]));
+  assert.deepEqual(matches, [], `${label} contains dark-theme-only color tokens: ${matches.join(', ')}`);
+}
+
+test('the ChatGPT MCP privacy notice has readable palettes in both themes', () => {
+  const notice = modal.match(/data-testid="mcp-privacy-notice"[\s\S]*?<\/div>/)?.[0] ?? '';
+  assert.match(notice, /border-amber-200/);
+  assert.match(notice, /bg-amber-50/);
+  assert.match(notice, /text-amber-800/);
+  assert.match(notice, /dark:border-amber-800\/60/);
+  assert.match(notice, /dark:bg-amber-950\/20/);
+  assert.match(notice, /dark:text-amber-200/);
+});
+
+test('the complete MCP connection modal avoids dark-only semantic palettes', () => {
+  assertNoDarkOnlyPalette(modal, 'McpConnectionModal');
+  for (const token of [
+    'border-neutral-200',
+    'dark:border-neutral-800',
+    'bg-neutral-50',
+    'dark:bg-neutral-950',
+    'text-neutral-600',
+    'dark:text-neutral-400',
+    'border-emerald-200',
+    'dark:border-emerald-800/70',
+    'border-red-200',
+    'dark:border-red-900/70',
+    'border-indigo-200',
+    'dark:border-indigo-900/70',
+  ]) assert.ok(modal.includes(token), `McpConnectionModal is missing ${token}`);
+});
+
+test('the MCP Settings card and server status support light and dark themes', () => {
+  assert.ok(settingsStart >= 0 && settingsEnd > settingsStart, 'MCP Settings section not found');
+  assertNoDarkOnlyPalette(mcpSettings, 'MCP Settings section');
+  for (const token of [
+    'border-indigo-200',
+    'bg-indigo-50',
+    'dark:border-indigo-900/70',
+    'dark:bg-indigo-950/20',
+    'text-neutral-900',
+    'dark:text-neutral-100',
+    'border-neutral-200',
+    'bg-neutral-50',
+    'dark:border-neutral-800',
+    'dark:bg-neutral-950/50',
+  ]) assert.ok(mcpSettings.includes(token), `MCP Settings section is missing ${token}`);
+});

--- a/src/components/McpConnectionModal.tsx
+++ b/src/components/McpConnectionModal.tsx
@@ -140,37 +140,37 @@ export function McpConnectionModal({
         <div className="flex items-start justify-between gap-4">
           <div>
             <h2 className="font-semibold">{t('Conectar Nodus')}</h2>
-            <p className="mt-1 text-sm text-neutral-400">{t('Usa tus contenidos de Nodus desde tu asistente preferido.')}</p>
+            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">{t('Usa tus contenidos de Nodus desde tu asistente preferido.')}</p>
           </div>
           <button className="btn btn-ghost" aria-label={t('Cerrar')} onClick={onClose}><Icon name="x" /></button>
         </div>
 
-        <div className="mt-5 flex gap-1 rounded-xl border border-neutral-800 bg-neutral-950/40 p-1">
+        <div data-testid="mcp-client-tabs" className="mt-5 flex gap-1 rounded-xl border border-neutral-200 bg-neutral-100 p-1 dark:border-neutral-800 dark:bg-neutral-950/40">
           {([
             ['chatgpt', 'ChatGPT'],
             ['claude', 'Claude Desktop'],
             ['generic', t('Otro cliente')],
           ] as const).map(([id, label]) => (
-            <button key={id} className={`flex-1 rounded-lg px-3 py-2 text-sm ${tab === id ? 'bg-neutral-800 font-medium text-white' : 'text-neutral-400 hover:text-neutral-200'}`} onClick={() => setTab(id)}>{label}</button>
+            <button key={id} className={`flex-1 rounded-lg px-3 py-2 text-sm ${tab === id ? 'bg-white font-medium text-neutral-900 shadow-sm dark:bg-neutral-800 dark:text-white' : 'text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200'}`} onClick={() => setTab(id)}>{label}</button>
           ))}
         </div>
 
         {tab === 'chatgpt' && (
           <div className="mt-5 space-y-4">
-            <div className={`rounded-xl border p-4 ${isConnected ? 'border-emerald-800/70 bg-emerald-950/20' : tunnel.phase === 'error' ? 'border-red-900/70 bg-red-950/20' : 'border-indigo-900/70 bg-indigo-950/20'}`}>
+            <div data-testid="mcp-tunnel-status" className={`rounded-xl border p-4 ${isConnected ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-800/70 dark:bg-emerald-950/20' : tunnel.phase === 'error' ? 'border-red-200 bg-red-50 dark:border-red-900/70 dark:bg-red-950/20' : 'border-indigo-200 bg-indigo-50 dark:border-indigo-900/70 dark:bg-indigo-950/20'}`}>
               <div className="flex items-start gap-3">
-                <span className={`mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-full ${isConnected ? 'bg-emerald-500/15 text-emerald-300' : 'bg-indigo-500/15 text-indigo-300'}`}><Icon name={isConnected ? 'check' : 'lock'} /></span>
+                <span className={`mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-full ${isConnected ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' : tunnel.phase === 'error' ? 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300' : 'bg-indigo-100 text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-300'}`}><Icon name={isConnected ? 'check' : 'lock'} /></span>
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center justify-between gap-2">
-                    <h3 className="font-medium text-neutral-100">{isConnected ? t('Conectado a ChatGPT') : t('Túnel seguro de OpenAI')}</h3>
-                    <span className={`text-xs ${isConnected ? 'text-emerald-400' : tunnel.phase === 'error' ? 'text-red-400' : 'text-indigo-300'}`}>{phaseLabel(tunnel)}</span>
+                    <h3 className="font-medium text-neutral-900 dark:text-neutral-100">{isConnected ? t('Conectado a ChatGPT') : t('Túnel seguro de OpenAI')}</h3>
+                    <span className={`text-xs ${isConnected ? 'text-emerald-700 dark:text-emerald-400' : tunnel.phase === 'error' ? 'text-red-700 dark:text-red-400' : 'text-indigo-700 dark:text-indigo-300'}`}>{phaseLabel(tunnel)}</span>
                   </div>
-                  <p className="mt-1 text-sm text-neutral-400">{t('Conecta ChatGPT sin publicar tu servidor ni abrir puertos. Nodus usa el túnel seguro oficial de OpenAI.')}</p>
+                  <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">{t('Conecta ChatGPT sin publicar tu servidor ni abrir puertos. Nodus usa el túnel seguro oficial de OpenAI.')}</p>
                   {tunnel.clientVersion && <p className="mt-1 text-[11px] text-neutral-500">tunnel-client {tunnel.clientVersion}</p>}
                 </div>
               </div>
               {tunnel.installProgress != null && tunnel.phase === 'installing' && (
-                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-neutral-800"><div className="h-full rounded-full bg-indigo-500 transition-[width]" style={{ width: `${Math.round(tunnel.installProgress * 100)}%` }} /></div>
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800"><div className="h-full rounded-full bg-indigo-500 transition-[width]" style={{ width: `${Math.round(tunnel.installProgress * 100)}%` }} /></div>
               )}
             </div>
 
@@ -181,28 +181,28 @@ export function McpConnectionModal({
                   <button className="btn btn-primary mt-3" onClick={() => void window.nodus.openExternal(CHATGPT_PLUGINS_URL)}><Icon name="external" />{t('Abrir configuración de ChatGPT')}</button>
                 </Step>
                 <div className="flex flex-wrap gap-2">
-                  {tunnel.uiUrl && <button className="btn btn-ghost border border-neutral-700" onClick={() => void window.nodus.openExternal(tunnel.uiUrl!)}><Icon name="settings" />{t('Abrir diagnóstico')}</button>}
-                  <button className="btn btn-ghost border border-neutral-700" disabled={busy} onClick={() => void disconnect()}><Icon name="stop" />{t('Desconectar')}</button>
+                  {tunnel.uiUrl && <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void window.nodus.openExternal(tunnel.uiUrl!)}><Icon name="settings" />{t('Abrir diagnóstico')}</button>}
+                  <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" disabled={busy} onClick={() => void disconnect()}><Icon name="stop" />{t('Desconectar')}</button>
                 </div>
               </div>
             ) : (
               <div className="space-y-3">
                 <Step number="1" title={t('Crea un túnel en OpenAI')}>
                   <p>{t('Abre la página de túneles, pulsa Create y copia el identificador que empieza por tunnel_.')}</p>
-                  <button className="btn btn-ghost mt-3 border border-neutral-700" onClick={() => void window.nodus.openExternal(OPENAI_TUNNELS_URL)}><Icon name="external" />{t('Abrir túneles de OpenAI')}</button>
-                  <label className="mt-3 block text-xs font-medium text-neutral-400">{t('ID del túnel')}
-                    <input className={`input mt-1 w-full font-mono text-xs ${tunnelId && !tunnelIdValid ? 'border-red-800' : ''}`} spellCheck={false} placeholder="tunnel_0123456789abcdef0123456789abcdef" value={tunnelId} onChange={(event) => setTunnelId(event.target.value.trim())} />
+                  <button className="btn btn-ghost mt-3 border border-neutral-300 dark:border-neutral-700" onClick={() => void window.nodus.openExternal(OPENAI_TUNNELS_URL)}><Icon name="external" />{t('Abrir túneles de OpenAI')}</button>
+                  <label className="mt-3 block text-xs font-medium text-neutral-600 dark:text-neutral-400">{t('ID del túnel')}
+                    <input className={`input mt-1 w-full font-mono text-xs ${tunnelId && !tunnelIdValid ? 'border-red-400 dark:border-red-800' : ''}`} spellCheck={false} placeholder="tunnel_0123456789abcdef0123456789abcdef" value={tunnelId} onChange={(event) => setTunnelId(event.target.value.trim())} />
                   </label>
-                  {tunnelId && !tunnelIdValid && <p className="mt-1 text-xs text-red-400">{t('El ID debe empezar por tunnel_ y contener los 32 caracteres que muestra OpenAI.')}</p>}
+                  {tunnelId && !tunnelIdValid && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{t('El ID debe empezar por tunnel_ y contener los 32 caracteres que muestra OpenAI.')}</p>}
                 </Step>
 
                 <Step number="2" title={t('Crea una clave de ejecución')}>
                   <p>{t('La clave necesita permisos Tunnels Read + Use. Nodus la guarda en el almacén protegido de este dispositivo y nunca vuelve a mostrarla.')}</p>
-                  <button className="btn btn-ghost mt-3 border border-neutral-700" onClick={() => void window.nodus.openExternal(OPENAI_RUNTIME_KEYS_URL)}><Icon name="external" />{t('Crear clave de ejecución')}</button>
-                  <label className="mt-3 block text-xs font-medium text-neutral-400">{t('Clave de ejecución')}
+                  <button className="btn btn-ghost mt-3 border border-neutral-300 dark:border-neutral-700" onClick={() => void window.nodus.openExternal(OPENAI_RUNTIME_KEYS_URL)}><Icon name="external" />{t('Crear clave de ejecución')}</button>
+                  <label className="mt-3 block text-xs font-medium text-neutral-600 dark:text-neutral-400">{t('Clave de ejecución')}
                     <div className="mt-1 flex gap-2">
                       <input className="input min-w-0 flex-1 font-mono text-xs" type={showApiKey ? 'text' : 'password'} autoComplete="off" spellCheck={false} placeholder={tunnel.hasApiKey ? t('Ya hay una clave guardada; déjalo vacío para conservarla.') : t('Pega aquí la clave nueva')} value={apiKey} onChange={(event) => setApiKey(event.target.value)} />
-                      <button className="btn btn-ghost border border-neutral-700" type="button" onClick={() => setShowApiKey((value) => !value)}><Icon name={showApiKey ? 'eyeOff' : 'eye'} />{showApiKey ? t('Ocultar') : t('Mostrar')}</button>
+                      <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" type="button" onClick={() => setShowApiKey((value) => !value)}><Icon name={showApiKey ? 'eyeOff' : 'eye'} />{showApiKey ? t('Ocultar') : t('Mostrar')}</button>
                     </div>
                   </label>
                 </Step>
@@ -217,34 +217,34 @@ export function McpConnectionModal({
             )}
 
             {(tunnel.errorCode || actionError) && (
-              <div className="rounded-xl border border-red-900/70 bg-red-950/20 p-3 text-sm text-red-200">
+              <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900/70 dark:bg-red-950/20 dark:text-red-200">
                 <p>{actionError || tunnelErrorLabel(tunnel.errorCode)}</p>
-                {tunnel.errorDetail && <details className="mt-2 text-xs text-red-300/70"><summary className="cursor-pointer">{t('Ver detalle técnico')}</summary><pre className="mt-2 max-h-36 overflow-auto whitespace-pre-wrap break-words rounded bg-black/20 p-2">{tunnel.errorDetail}</pre></details>}
+                {tunnel.errorDetail && <details className="mt-2 text-xs text-red-700 dark:text-red-300/70"><summary className="cursor-pointer">{t('Ver detalle técnico')}</summary><pre className="mt-2 max-h-36 overflow-auto whitespace-pre-wrap break-words rounded bg-red-100/70 p-2 text-red-900 dark:bg-black/20 dark:text-red-100">{tunnel.errorDetail}</pre></details>}
               </div>
             )}
 
-            <div className="rounded-xl border border-amber-900/50 bg-amber-950/15 p-3 text-xs leading-5 text-amber-200/80">
+            <div data-testid="mcp-privacy-notice" className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs leading-5 text-amber-800 dark:border-amber-800/60 dark:bg-amber-950/20 dark:text-amber-200">
               <Icon name="shield" size={13} className="mr-1" />
               {t('Cuando uses Nodus desde ChatGPT, OpenAI recibirá las consultas y los resultados que ChatGPT solicite. Las bóvedas permanecen en este equipo y el servidor local no se publica en Internet.')}
             </div>
 
             {tunnel.configured && !isConnected && (
-              <div className="flex justify-end"><button className="text-xs text-red-400 hover:text-red-300" disabled={busy} onClick={() => void forget()}>{t('Borrar conexión guardada')}</button></div>
+              <div className="flex justify-end"><button className="text-xs text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300" disabled={busy} onClick={() => void forget()}>{t('Borrar conexión guardada')}</button></div>
             )}
           </div>
         )}
 
         {tab === 'claude' && (
           <div className="mt-5 space-y-3">
-            <p className="text-sm text-neutral-400">{t('Claude Desktop puede conectar directamente con el servidor local de Nodus mediante este puente stdio:')}</p>
-            <pre className="overflow-x-auto rounded-lg border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-300">{claudeConfig}</pre>
+            <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('Claude Desktop puede conectar directamente con el servidor local de Nodus mediante este puente stdio:')}</p>
+            <pre className="overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-3 text-xs text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">{claudeConfig}</pre>
             <p className="text-xs text-neutral-500">{t('Copia esta configuración en Claude Desktop y reinicia la aplicación.')}</p>
           </div>
         )}
 
         {tab === 'generic' && (
           <div className="mt-5 space-y-3">
-            <p className="text-sm text-neutral-400">{t('Usa Streamable HTTP con la URL local y la cabecera bearer siguientes.')}</p>
+            <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('Usa Streamable HTTP con la URL local y la cabecera bearer siguientes.')}</p>
             <ConnectionValue label={t('URL del servidor')} value={url} copied={copied === 'url'} onCopy={() => void onCopy('url', url)} />
             <ConnectionValue label={t('Bearer token')} value={token || t('Activa el servidor para generar un token.')} copied={copied === 'token'} onCopy={() => void onCopy('token', token)} />
           </div>
@@ -258,10 +258,10 @@ export function McpConnectionModal({
 
 function Step({ number, title, children }: { number: string; title: string; children: React.ReactNode }) {
   return (
-    <section className="rounded-xl border border-neutral-800 p-4">
+    <section data-testid="mcp-setup-step" className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
       <div className="flex items-start gap-3">
-        <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-indigo-500/15 text-xs font-semibold text-indigo-300">{number}</span>
-        <div className="min-w-0 flex-1 text-sm text-neutral-400"><h3 className="font-medium text-neutral-100">{title}</h3><div className="mt-1">{children}</div></div>
+        <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-indigo-100 text-xs font-semibold text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-300">{number}</span>
+        <div className="min-w-0 flex-1 text-sm text-neutral-600 dark:text-neutral-400"><h3 className="font-medium text-neutral-900 dark:text-neutral-100">{title}</h3><div className="mt-1">{children}</div></div>
       </div>
     </section>
   );
@@ -271,8 +271,8 @@ function ConnectionValue({ label, value, copied, onCopy }: { label: string; valu
   return (
     <div>
       <div className="mb-1 text-xs font-medium uppercase tracking-wide text-neutral-500">{label}</div>
-      <div className="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-950/60 p-2">
-        <code className="min-w-0 flex-1 break-all text-xs text-neutral-200">{value}</code>
+      <div className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-800 dark:bg-neutral-950/60">
+        <code className="min-w-0 flex-1 break-all text-xs text-neutral-800 dark:text-neutral-200">{value}</code>
         <button className="btn btn-ghost shrink-0" disabled={!value} onClick={onCopy}><Icon name={copied ? 'check' : 'copy'} />{copied ? t('Copiado') : t('Copiar')}</button>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1635,6 +1635,7 @@ body {
 .genealogy.dark .dark\:border-indigo-800 { border-color: #854d0e; }
 .genealogy.dark .dark\:border-indigo-800\/60 { border-color: rgba(133, 77, 14, 0.6); }
 .genealogy.dark .dark\:border-indigo-800\/70 { border-color: rgba(133, 77, 14, 0.7); }
+.genealogy.dark .dark\:border-indigo-900\/70 { border-color: rgba(120, 53, 15, 0.7); }
 .genealogy.dark .dark\:hover\:text-indigo-300:hover { color: #fcd34d; }
 .genealogy.dark .dark\:text-indigo-100 { color: #fef3c7; }
 .genealogy.dark .dark\:text-indigo-200 { color: #fde68a; }
@@ -1659,6 +1660,7 @@ body {
 .estudio.dark .dark\:border-indigo-800 { border-color: #115e59; }
 .estudio.dark .dark\:border-indigo-800\/60 { border-color: rgba(17, 94, 89, 0.6); }
 .estudio.dark .dark\:border-indigo-800\/70 { border-color: rgba(17, 94, 89, 0.7); }
+.estudio.dark .dark\:border-indigo-900\/70 { border-color: rgba(19, 78, 74, 0.7); }
 .estudio.dark .dark\:hover\:text-indigo-300:hover { color: #5eead4; }
 .estudio.dark .dark\:text-indigo-100 { color: #ccfbf1; }
 .estudio.dark .dark\:text-indigo-200 { color: #99f6e4; }
@@ -1683,6 +1685,7 @@ body {
 .docencia.dark .dark\:border-indigo-800 { border-color: #9a3412; }
 .docencia.dark .dark\:border-indigo-800\/60 { border-color: rgba(154, 52, 18, 0.6); }
 .docencia.dark .dark\:border-indigo-800\/70 { border-color: rgba(154, 52, 18, 0.7); }
+.docencia.dark .dark\:border-indigo-900\/70 { border-color: rgba(124, 45, 18, 0.7); }
 .docencia.dark .dark\:hover\:border-teal-800:hover { border-color: #9a3412; }
 .docencia.dark .dark\:hover\:text-indigo-300:hover { color: #fdba74; }
 .docencia.dark .dark\:ring-teal-900 { --tw-ring-color: #7c2d12; }
@@ -1709,6 +1712,7 @@ body {
 .databases.dark .dark\:border-indigo-800 { border-color: #6b011e; }
 .databases.dark .dark\:border-indigo-800\/60 { border-color: rgba(107, 1, 30, 0.6); }
 .databases.dark .dark\:border-indigo-800\/70 { border-color: rgba(107, 1, 30, 0.7); }
+.databases.dark .dark\:border-indigo-900\/70 { border-color: rgba(77, 1, 22, 0.7); }
 .databases.dark .dark\:hover\:text-indigo-300:hover { color: #f27a97; }
 .databases.dark .dark\:text-indigo-100 { color: #ffe4ec; }
 .databases.dark .dark\:text-indigo-200 { color: #f9b4c4; }

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -990,15 +990,15 @@ export function Settings({
 
       {visibleSettingsSection('integrations', 'Servidor MCP', 'mcp servidor puerto token cliente conexion chatgpt openai tunnel tunel') && (
           <Section title={t('Servidor MCP')}>
-            <div className="rounded-xl border border-indigo-900/70 bg-indigo-950/20 p-4">
+            <div data-testid="mcp-settings-card" className="rounded-xl border border-indigo-200 bg-indigo-50 p-4 dark:border-indigo-900/70 dark:bg-indigo-950/20">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-start gap-3">
-                  <span className={`mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-full ${mcpTunnelStatus?.phase === 'connected' ? 'bg-emerald-500/15 text-emerald-300' : 'bg-indigo-500/15 text-indigo-300'}`}>
+                  <span className={`mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-full ${mcpTunnelStatus?.phase === 'connected' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' : 'bg-indigo-100 text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-300'}`}>
                     <Icon name={mcpTunnelStatus?.phase === 'connected' ? 'check' : 'globe'} />
                   </span>
                   <div>
-                    <h3 className="text-sm font-medium text-neutral-100">ChatGPT</h3>
-                    <p className="mt-0.5 text-xs text-neutral-400">
+                    <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">ChatGPT</h3>
+                    <p className="mt-0.5 text-xs text-neutral-600 dark:text-neutral-400">
                       {mcpTunnelStatus?.phase === 'connected'
                         ? t('Conectado mediante el túnel seguro de OpenAI.')
                         : t('Configúralo con un asistente guiado, sin abrir puertos ni publicar tu biblioteca.')}
@@ -1012,10 +1012,10 @@ export function Settings({
             </div>
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-2">
-                <label className="text-sm text-neutral-300">{t('Activar servidor MCP')}</label>
+                <label className="text-sm text-neutral-700 dark:text-neutral-300">{t('Activar servidor MCP')}</label>
                 <button
                   type="button"
-                  className="text-neutral-500 hover:text-neutral-200"
+                  className="text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200"
                   aria-label={t('Ayuda para conectar un cliente MCP')}
                   title={t('Ayuda para conectar un cliente MCP')}
                   onClick={() => setMcpHelpOpen(true)}
@@ -1039,20 +1039,20 @@ export function Settings({
                 }}
               />
             </Row>
-            <div className="rounded-lg border border-neutral-800 bg-neutral-950/50 px-3 py-2 text-xs">
+            <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/50">
               {mcpStatus.running ? (
-                <span className="text-emerald-400">{t('Activo')}: {mcpStatus.url}</span>
+                <span className="text-emerald-700 dark:text-emerald-400">{t('Activo')}: {mcpStatus.url}</span>
               ) : mcpStatus.error ? (
-                <span className="text-red-400">{t('Error del servidor MCP')}: {mcpStatus.error}</span>
+                <span className="text-red-700 dark:text-red-400">{t('Error del servidor MCP')}: {mcpStatus.error}</span>
               ) : (
                 <span className="text-neutral-500">{t('Apagado')}</span>
               )}
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <button className="btn btn-ghost border border-neutral-700" onClick={() => void setMcpHelpOpen(true)}>
+              <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void setMcpHelpOpen(true)}>
                 <Icon name="link" /> {t('Ver datos de conexión')}
               </button>
-              <button className="btn btn-ghost border border-neutral-700" onClick={() => void regenerateMcpToken()}>
+              <button className="btn btn-ghost border border-neutral-300 dark:border-neutral-700" onClick={() => void regenerateMcpToken()}>
                 <Icon name="refresh" /> {t('Regenerar token')}
               </button>
             </div>


### PR DESCRIPTION
Closes #150

## Summary
- add explicit light and dark palettes across the ChatGPT MCP settings card and connection modal
- make the privacy notice and every semantic status, setup, error, tab, and connection surface readable in both themes
- preserve vault-specific accent remapping for the new dark border utility
- add focused theme regression coverage and real Electron contrast checks

## Validation
- `npm test` (691 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 4 pre-existing warnings)
- `npm run build`
- `npm run test:e2e`
- `git diff --check`