### PR TITLE
Add Spanish Kokoro voices and phonemization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
+        "@diffusionstudio/piper-wasm": "1.0.0",
         "@diffusionstudio/vits-web": "^1.0.3",
         "@github/copilot-sdk": "1.0.7",
         "@google/genai": "^2.11.0",
@@ -862,6 +863,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/@diffusionstudio/piper-wasm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@diffusionstudio/piper-wasm/-/piper-wasm-1.0.0.tgz",
+      "integrity": "sha512-4Hgh7wJ1PuGEVgVi1CpducESnyXwjFRJN4zXjYRpxgquM+Zh6Eqq8ZaiGpCKm4yXvT1Y2SPQXbv0dEckFD9NaQ==",
+      "license": "MIT"
     },
     "node_modules/@diffusionstudio/vits-web": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
+    "@diffusionstudio/piper-wasm": "1.0.0",
     "@diffusionstudio/vits-web": "^1.0.3",
     "@github/copilot-sdk": "1.0.7",
     "@google/genai": "^2.11.0",

--- a/scripts/test-kokoro-spanish.mjs
+++ b/scripts/test-kokoro-spanish.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const outDir = await mkdtemp(path.join(os.tmpdir(), 'nodus-kokoro-spanish-'));
+
+function bundle(source, output, external = []) {
+  const outfile = path.join(outDir, output);
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/esbuild'),
+    [
+      path.join(repoRoot, source),
+      '--bundle',
+      '--platform=node',
+      '--format=cjs',
+      '--target=es2022',
+      ...external.map((dependency) => `--external:${dependency}`),
+      `--outfile=${outfile}`,
+    ],
+    { cwd: repoRoot, stdio: 'inherit' }
+  );
+  return require(outfile);
+}
+
+const spanishText = bundle(
+  'src/lib/audio/kokoroSpanishText.ts',
+  'kokoroSpanishText.cjs'
+);
+const { kokoroEngine } = bundle(
+  'src/lib/audio/kokoro.ts',
+  'kokoro.cjs',
+  ['@diffusionstudio/piper-wasm', 'kokoro-js']
+);
+
+test.after(() => rm(outDir, { recursive: true, force: true }));
+
+test('Kokoro exposes every official Spanish v1.0 voice', () => {
+  assert.deepEqual(spanishText.KOKORO_SPANISH_VOICE_IDS, [
+    'ef_dora',
+    'em_alex',
+    'em_santa',
+  ]);
+
+  const voices = kokoroEngine.voices.filter((voice) => voice.language === 'es');
+  assert.deepEqual(
+    voices.map((voice) => voice.id),
+    spanishText.KOKORO_SPANISH_VOICE_IDS
+  );
+  assert.deepEqual(
+    voices.map((voice) => [voice.name, voice.gender]),
+    [
+      ['Dora', 'female'],
+      ['Alex', 'male'],
+      ['Santa', 'male'],
+    ]
+  );
+});
+
+test('only official e-prefixed embeddings take the Spanish route', () => {
+  for (const voice of spanishText.KOKORO_SPANISH_VOICE_IDS) {
+    assert.equal(spanishText.isKokoroSpanishVoice(voice), true);
+  }
+  assert.equal(spanishText.isKokoroSpanishVoice('af_heart'), false);
+  assert.equal(spanishText.isKokoroSpanishVoice('em_unknown'), false);
+});
+
+test('text preparation follows Misaki quote and parenthesis handling', () => {
+  assert.equal(
+    spanishText.prepareKokoroSpanishText('«uno» (dos) y (tres)'),
+    '“uno” «dos» y «tres»'
+  );
+});
+
+test('eSpeak ties and affricates are mapped to Kokoro symbols', () => {
+  const caretTies = 'a^ɪ a^ʊ d^z d^ʒ e^ɪ o^ʊ ə^ʊ s^s t^s t^ʃ ɔ^ɪ';
+  const combiningTies = 'a͡ɪ a͡ʊ d͡z d͡ʒ e͡ɪ o͡ʊ ə͡ʊ s͡s t͡s t͡ʃ ɔ͡ɪ';
+  const expected = 'I W ʣ ʤ A O Q S ʦ ʧ Y';
+  assert.equal(spanishText.normalizeKokoroSpanishPhonemes(caretTies), expected);
+  assert.equal(spanishText.normalizeKokoroSpanishPhonemes(combiningTies), expected);
+});
+
+test('representative Spanish eSpeak output is accepted by Kokoro', () => {
+  const espeak = 'el t͡ʃˈiko eskˈut͡ʃa d͡ʒˈas i ˈun tˈesunˈami';
+  assert.equal(
+    spanishText.normalizeKokoroSpanishPhonemes(espeak),
+    'el ʧˈiko eskˈuʧa ʤˈas i ˈun tˈesunˈami'
+  );
+  assert.equal(
+    spanishText.normalizeKokoroSpanishPhonemes('x^k-«hola»'),
+    'xk(hola)'
+  );
+});

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -4233,7 +4233,7 @@ export const DE: Record<string, string> = {
   'Guardar clave': 'Schlüssel speichern',
   'El audio se genera con tu cuenta de Hume y se factura a tu clave. El texto de la sección se envía a Hume para sintetizarlo.':
     'Das Audio wird mit Ihrem Hume-Konto generiert und Ihrem Schlüssel in Rechnung gestellt. Der Text des Abschnitts wird zur Synthese an Hume gesendet.',
-  'Modelo {label} (inglés)': 'Modell {label} (Englisch)',
+  'Modelo {label}': 'Modell {label}',
   '~{n} MB · una sola descarga para todas las voces': '~{n} MB · ein einziger Download für alle Stimmen',
   '{n}%': '{n}%',
   'Descargar modelo': 'Modell herunterladen',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -4428,7 +4428,7 @@ export const EN: Record<string, string> = {
   'Guardar clave': 'Save key',
   'El audio se genera con tu cuenta de Hume y se factura a tu clave. El texto de la sección se envía a Hume para sintetizarlo.':
     'Audio is generated with your Hume account and billed to your key. The section text is sent to Hume to synthesise it.',
-  'Modelo {label} (inglés)': '{label} model (English)',
+  'Modelo {label}': '{label} model',
   '~{n} MB · una sola descarga para todas las voces': '~{n} MB · a single download for all voices',
   '{n}%': '{n}%',
   'Descargar modelo': 'Download model',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -4227,7 +4227,7 @@ export const FR: Record<string, string> = {
   'Guardar clave': 'Enregistrer la clé',
   'El audio se genera con tu cuenta de Hume y se factura a tu clave. El texto de la sección se envía a Hume para sintetizarlo.':
     'L\'audio est généré avec votre compte Hume et facturé à votre clé. Le texte de la section est envoyé à Hume pour être synthétisé.',
-  'Modelo {label} (inglés)': 'Modèle {label} (anglais)',
+  'Modelo {label}': 'Modèle {label}',
   '~{n} MB · una sola descarga para todas las voces': '~{n} Mo · un seul téléchargement pour toutes les voix',
   '{n}%': '{n} %',
   'Descargar modelo': 'Télécharger le modèle',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -3768,7 +3768,7 @@ export const IT: Record<string, string> = {
   "Clave de API de Hume (se guarda cifrada, nunca se exporta)": "Chiave API Hume (memorizzata crittografata, mai esportata)",
   "Guardar clave": "Salva chiave",
   "El audio se genera con tu cuenta de Hume y se factura a tu clave. El texto de la sección se envía a Hume para sintetizarlo.": "L'audio viene generato con il tuo account Hume e fatturato sulla tua chiave. Il testo della sezione viene inviato a Hume per sintetizzarlo.",
-  "Modelo {label} (inglés)": "Modello {label} (inglese)",
+  "Modelo {label}": "Modello {label}",
   "~{n} MB · una sola descarga para todas las voces": "~{n} MB · un unico download per tutte le voci",
   "{n}%": "{n}%",
   "Descargar modelo": "Scarica il modello",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -4197,7 +4197,7 @@ export const PT_BR: Record<string, string> = {
   'Guardar clave': 'Salvar chave',
   'El audio se genera con tu cuenta de Hume y se factura a tu clave. El texto de la sección se envía a Hume para sintetizarlo.':
     'O áudio é gerado com sua conta da Hume e cobrado na sua chave. O texto da seção é enviado à Hume para sintetizá-lo.',
-  'Modelo {label} (inglés)': 'Modelo {label} (inglês)',
+  'Modelo {label}': 'Modelo {label}',
   '~{n} MB · una sola descarga para todas las voces': '~{n} MB · um único download para todas as vozes',
   '{n}%': '{n}%',
   'Descargar modelo': 'Baixar modelo',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -4190,7 +4190,7 @@ export const PT: Record<string, string> = {
   'Guardar clave': 'Guardar chave',
   'El audio se genera con tu cuenta de Hume y se factura a tu clave. El texto de la sección se envía a Hume para sintetizarlo.':
     'O áudio é gerado com a sua conta do Hume e é faturado à sua chave. O texto da secção é enviado ao Hume para o sintetizar.',
-  'Modelo {label} (inglés)': 'Modelo {label} (inglês)',
+  'Modelo {label}': 'Modelo {label}',
   '~{n} MB · una sola descarga para todas las voces': '~{n} MB · uma única transferência para todas as vozes',
   '{n}%': '{n}%',
   'Descargar modelo': 'Transferir modelo',

--- a/src/lib/audio/kokoro.ts
+++ b/src/lib/audio/kokoro.ts
@@ -1,17 +1,22 @@
 import type { KokoroTTS } from 'kokoro-js';
 import type { AudioEngine, AudioVoice } from './types';
+import { phonemizeKokoroSpanish } from './kokoroSpanishPhonemizer';
+import { isKokoroSpanishVoice } from './kokoroSpanishText';
 import { encodeWavPcm16 } from './wav';
 
 // Kokoro provider: one shared 82M model (StyleTTS2) powers many high-quality
-// English voices (US + UK). Runs via kokoro-js on onnxruntime-web (WASM). The
-// model is downloaded once and cached by the browser; individual voices are just
-// selectable embeddings, so there is no per-voice download.
+// English and Spanish voices. Runs via kokoro-js on onnxruntime-web (WASM). The
+// model is downloaded once and cached by the browser; individual voices are
+// small selectable embeddings, so there is no per-voice model download.
 
 const MODEL_ID = 'onnx-community/Kokoro-82M-v1.0-ONNX';
 const DTYPE = 'q8' as const; // ~86 MB, good quality/size balance for WASM
 const READY_KEY = 'nodus.audio.kokoro.ready';
 
 const VOICES: AudioVoice[] = [
+  { provider: 'kokoro', id: 'ef_dora', languageLabel: 'Español', name: 'Dora', gender: 'female', quality: 'Kokoro v1.0', language: 'es' },
+  { provider: 'kokoro', id: 'em_alex', languageLabel: 'Español', name: 'Alex', gender: 'male', quality: 'Kokoro v1.0', language: 'es' },
+  { provider: 'kokoro', id: 'em_santa', languageLabel: 'Español', name: 'Santa', gender: 'male', quality: 'Kokoro v1.0', language: 'es' },
   { provider: 'kokoro', id: 'af_heart', languageLabel: 'English (US)', name: 'Heart', gender: 'female', quality: 'A', language: 'en-us' },
   { provider: 'kokoro', id: 'af_bella', languageLabel: 'English (US)', name: 'Bella', gender: 'female', quality: 'A-', language: 'en-us' },
   { provider: 'kokoro', id: 'af_nicole', languageLabel: 'English (US)', name: 'Nicole', gender: 'female', quality: 'B-', language: 'en-us' },
@@ -63,7 +68,7 @@ async function loadModel(onProgress?: (fraction: number) => void): Promise<Kokor
 export const kokoroEngine: AudioEngine = {
   provider: 'kokoro',
   label: 'Kokoro',
-  description: 'Un solo modelo (inglés) con muchas voces de alta calidad. Se descarga una vez.',
+  description: 'Un solo modelo con voces en español e inglés de alta calidad. Se descarga una vez.',
   licenseLabel: 'Apache-2.0',
   licenseUrl: 'https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX',
   modelStyle: 'single-model',
@@ -100,10 +105,21 @@ export const kokoroEngine: AudioEngine = {
 
   async synthesize(text, voiceId) {
     const model = await loadModel();
-    // kokoro-js types `voice` as a literal union of voice ids; our curated ids are
-    // valid members but arrive as plain strings, so widen through the options type.
-    const options = { voice: voiceId, speed: 1 } as unknown as Parameters<KokoroTTS['generate']>[1];
-    const audio = await model.generate(text, options);
+    let audio;
+    if (isKokoroSpanishVoice(voiceId)) {
+      // kokoro-js 1.2.1 ships the official Spanish voice embeddings but its
+      // high-level generate() rejects them and phonemizes every non-US voice as
+      // English. Follow Kokoro/Misaki instead: eSpeak NG `es` -> Kokoro tokens ->
+      // generate_from_ids(), whose runtime accepts the published voice id.
+      const phonemes = await phonemizeKokoroSpanish(text);
+      const { input_ids } = model.tokenizer(phonemes, { truncation: true });
+      const options = { voice: voiceId, speed: 1 } as unknown as Parameters<KokoroTTS['generate_from_ids']>[1];
+      audio = await model.generate_from_ids(input_ids, options);
+    } else {
+      // kokoro-js types `voice` as a literal union; curated ids arrive as strings.
+      const options = { voice: voiceId, speed: 1 } as unknown as Parameters<KokoroTTS['generate']>[1];
+      audio = await model.generate(text, options);
+    }
     // RawAudio.toBlob() writes 32-bit float WAV, which Chromium's <audio> cannot
     // play; re-encode the raw samples as 16-bit PCM WAV instead.
     return encodeWavPcm16(audio.audio as Float32Array, audio.sampling_rate);

--- a/src/lib/audio/kokoroSpanishPhonemizer.ts
+++ b/src/lib/audio/kokoroSpanishPhonemizer.ts
@@ -1,0 +1,122 @@
+import {
+  normalizeKokoroSpanishPhonemes,
+  prepareKokoroSpanishText,
+} from './kokoroSpanishText';
+
+// These are the version-pinned browser assets published by piper-wasm. Nodus's
+// Piper provider already uses the same URLs through vits-web, so both engines
+// share the browser cache instead of packaging a second 18 MB eSpeak data file.
+const PIPER_PHONEMIZE_ASSET_BASE =
+  'https://cdn.jsdelivr.net/npm/@diffusionstudio/piper-wasm@1.0.0/build/piper_phonemize';
+
+interface PiperPhonemizeModule {
+  callMain(args: string[]): number | void;
+}
+
+interface PiperPhonemizeOutput {
+  phonemes?: unknown;
+}
+
+interface PendingOutput {
+  resolve: (phonemes: string) => void;
+  reject: (reason: Error) => void;
+  settled: boolean;
+}
+
+let modulePromise: Promise<PiperPhonemizeModule> | null = null;
+let pendingOutput: PendingOutput | null = null;
+let runQueue: Promise<void> = Promise.resolve();
+
+function consumeOutput(line: string): void {
+  const pending = pendingOutput;
+  if (!pending || pending.settled) return;
+
+  try {
+    const output = JSON.parse(line) as PiperPhonemizeOutput;
+    if (!Array.isArray(output.phonemes) || !output.phonemes.every((item) => typeof item === 'string')) {
+      throw new Error('eSpeak NG devolvió una respuesta sin fonemas');
+    }
+    pending.settled = true;
+    pending.resolve(output.phonemes.join(''));
+  } catch (error) {
+    pending.settled = true;
+    pending.reject(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+function consumeError(line: string): void {
+  const pending = pendingOutput;
+  if (!pending || pending.settled) return;
+  pending.settled = true;
+  pending.reject(new Error(`Error del fonetizador español de eSpeak NG: ${line}`));
+}
+
+async function loadPhonemizer(): Promise<PiperPhonemizeModule> {
+  if (!modulePromise) {
+    modulePromise = import('@diffusionstudio/piper-wasm')
+      .then(({ default: createPiperPhonemize }) =>
+        createPiperPhonemize({
+          print: consumeOutput,
+          printErr: consumeError,
+          locateFile: (file: string) => {
+            if (file.endsWith('.wasm')) return `${PIPER_PHONEMIZE_ASSET_BASE}.wasm`;
+            if (file.endsWith('.data')) return `${PIPER_PHONEMIZE_ASSET_BASE}.data`;
+            return file;
+          },
+        })
+      )
+      .catch((error) => {
+        // A transient download/init failure must not poison every later attempt.
+        modulePromise = null;
+        throw error;
+      });
+  }
+  return modulePromise;
+}
+
+async function runPhonemizer(text: string): Promise<string> {
+  const module = await loadPhonemizer();
+  const input = JSON.stringify([{ text: prepareKokoroSpanishText(text.trim()) }]);
+
+  try {
+    const ipa = await new Promise<string>((resolve, reject) => {
+      const output: PendingOutput = { resolve, reject, settled: false };
+      pendingOutput = output;
+      try {
+        module.callMain([
+          '-l',
+          'es',
+          '--input',
+          input,
+          '--espeak_data',
+          '/espeak-ng-data',
+        ]);
+        if (!output.settled) {
+          output.settled = true;
+          reject(new Error('eSpeak NG terminó sin devolver fonemas'));
+        }
+      } catch (error) {
+        if (!output.settled) {
+          output.settled = true;
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+    });
+    return normalizeKokoroSpanishPhonemes(ipa);
+  } finally {
+    pendingOutput = null;
+  }
+}
+
+/**
+ * Phonemize Spanish with eSpeak NG and adapt its IPA to Kokoro's tokenizer.
+ * Calls are serialized because the Emscripten module owns process-global stdout.
+ */
+export function phonemizeKokoroSpanish(text: string): Promise<string> {
+  const result = runQueue.then(() => runPhonemizer(text));
+  runQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}

--- a/src/lib/audio/kokoroSpanishText.ts
+++ b/src/lib/audio/kokoroSpanishText.ts
@@ -1,0 +1,62 @@
+// Kokoro's official Spanish pipeline uses Misaki's EspeakG2P with language
+// code "es". Keep the small compatibility layer separate from the WASM runtime
+// so its text transformations can be tested without loading eSpeak NG.
+
+export const KOKORO_SPANISH_VOICE_IDS = ['ef_dora', 'em_alex', 'em_santa'] as const;
+
+export type KokoroSpanishVoiceId = (typeof KOKORO_SPANISH_VOICE_IDS)[number];
+
+const SPANISH_VOICE_IDS = new Set<string>(KOKORO_SPANISH_VOICE_IDS);
+
+/** True for the three Spanish embeddings published with Kokoro v1.0. */
+export function isKokoroSpanishVoice(voiceId: string): voiceId is KokoroSpanishVoiceId {
+  return SPANISH_VOICE_IDS.has(voiceId);
+}
+
+/**
+ * Preserve parentheses through eSpeak in the same way as Misaki's EspeakG2P.
+ * Existing guillemets become curly quotes; parentheses temporarily become
+ * guillemets and are restored after phonemization.
+ */
+export function prepareKokoroSpanishText(text: string): string {
+  return text
+    .replaceAll('«', '“')
+    .replaceAll('»', '”')
+    .replaceAll('(', '«')
+    .replaceAll(')', '»');
+}
+
+// Exact eSpeak-to-Kokoro substitutions from Misaki's EspeakG2P. The official
+// Python backend asks phonemizer for caret ties; piper-phonemize emits the same
+// IPA with U+0361 combining ties, so accept both representations.
+const ESPEAK_TO_KOKORO: ReadonlyArray<readonly [string, string]> = [
+  ['a^ɪ', 'I'],
+  ['a^ʊ', 'W'],
+  ['d^z', 'ʣ'],
+  ['d^ʒ', 'ʤ'],
+  ['e^ɪ', 'A'],
+  ['o^ʊ', 'O'],
+  ['ə^ʊ', 'Q'],
+  ['s^s', 'S'],
+  ['t^s', 'ʦ'],
+  ['t^ʃ', 'ʧ'],
+  ['ɔ^ɪ', 'Y'],
+];
+
+/** Convert eSpeak NG IPA into the symbol inventory expected by Kokoro v1.0. */
+export function normalizeKokoroSpanishPhonemes(phonemes: string): string {
+  let normalized = phonemes;
+  for (const [source, replacement] of ESPEAK_TO_KOKORO) {
+    normalized = normalized
+      .replaceAll(source, replacement)
+      .replaceAll(source.replace('^', '͡'), replacement);
+  }
+
+  return normalized
+    .replaceAll('^', '')
+    .replaceAll('͡', '')
+    .replaceAll('-', '')
+    .replaceAll('«', '(')
+    .replaceAll('»', ')')
+    .trim();
+}

--- a/src/types/piper-wasm.d.ts
+++ b/src/types/piper-wasm.d.ts
@@ -1,0 +1,15 @@
+declare module '@diffusionstudio/piper-wasm' {
+  interface PiperPhonemizeOptions {
+    print?: (line: string) => void;
+    printErr?: (line: string) => void;
+    locateFile?: (file: string) => string;
+  }
+
+  interface PiperPhonemizeModule {
+    callMain(args: string[]): number | void;
+  }
+
+  export default function createPiperPhonemize(
+    options?: PiperPhonemizeOptions
+  ): Promise<PiperPhonemizeModule>;
+}

--- a/src/views/AudioGenerationSettings.tsx
+++ b/src/views/AudioGenerationSettings.tsx
@@ -296,7 +296,7 @@ export function AudioGenerationSettings({
             <div className="flex min-w-0 flex-1 items-start gap-3">
               <SettingsModelDot selected={modelReady} />
               <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{tx('Modelo {label} (inglés)', { label: engine.label })}</div>
+                <div className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{tx('Modelo {label}', { label: engine.label })}</div>
                 <div className="text-[10px] text-neutral-500">{tx('~{n} MB · una sola descarga para todas las voces', { n: engine.modelSizeMb ?? 0 })}</div>
                 {progress[MODEL_KEY] != null && (
                   <div className="mt-1.5 h-1 w-full overflow-hidden rounded bg-neutral-200 dark:bg-neutral-800">


### PR DESCRIPTION
## Summary

- expose Kokoro's official Spanish voices: Dora, Alex, and Santa
- add an eSpeak NG Spanish phonemizer compatible with Kokoro/Misaki symbols
- route Spanish phonemes through Kokoro's tokenizer and `generate_from_ids`
- keep the existing English generation path unchanged
- update the audio settings copy and all translations
- add regression coverage for the voice catalog and phoneme normalization

## Root cause

Kokoro v1.0 publishes Spanish voice embeddings, but the installed `kokoro-js` high-level API does not expose those voice IDs and phonemizes unsupported languages as English. Nodus therefore could not select or correctly synthesize the published Spanish voices.

## Validation

- `npm test` — 696 tests passed
- `npm run build`
- `npm run licenses:verify`
- ESLint on the changed audio and settings modules
- real worker synthesis produced valid, non-silent PCM WAV audio with Dora
- consecutive worker synthesis completed successfully with Alex and Santa

Closes #152