### PR TITLE
Make Nodi chat messages selectable and easy to copy

### DIFF
--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -147,6 +147,18 @@ test('Nodi chat keeps model selection inside settings and exposes deletable hist
   assert.match(globalCss, /background-repeat: no-repeat/);
 });
 
+test('Nodi chat messages are selectable and expose a per-message copy action', async () => {
+  const [component, css] = await Promise.all([
+    read('src/components/nodi/NodiCompanion.tsx'),
+    read('src/components/nodi/companion.css'),
+  ]);
+  assert.match(component, /navigator\.clipboard\.writeText\(text\)/, 'copy preserves the message Markdown source');
+  assert.match(component, /className="nodi-msg-copy"/);
+  assert.match(component, /name=\{copiedMessageIndex === i \? 'check' : 'copy'\}/, 'the action confirms a successful copy');
+  assert.match(css, /\.nodi-msg[\s\S]*?-webkit-user-select:\s*text;\s*user-select:\s*text;/, 'message text overrides the overlay selection lock');
+  assert.match(css, /\.nodi-msg-copy\s*\{[\s\S]*?user-select:\s*none;/, 'the icon itself does not interfere with text selection');
+});
+
 test('Nodi closes its eyes and centrifuges contracted limbs while thinking', async () => {
   const [component, figure, css] = await Promise.all([
     read('src/components/nodi/NodiCompanion.tsx'),

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -141,6 +141,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const [conversations, setConversations] = useState<NodiConversation[]>([]);
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
   const [chatTool, setChatTool] = useState<'none' | 'history' | 'contexts' | 'settings'>('none');
+  const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(null);
   // The source detail opened from an inline citation in an answer (idea/work/passage/…).
   const [citation, setCitation] = useState<MarkdownCitation | null>(null);
   const [settings, setSettings] = useState<AppSettings | null>(null);
@@ -687,6 +688,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     setActiveConversationId(null);
     setMessages([]);
     setInput('');
+    setCopiedMessageIndex(null);
     setChatTool('none');
     setCitation(null);
   };
@@ -697,8 +699,23 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     setMessages(conversation.messages);
     setContexts(conversation.contexts);
     setNodiModel(conversation.model ?? settings?.nodiModel ?? settings?.synthesisModel ?? null);
+    setCopiedMessageIndex(null);
     setChatTool('none');
     setCitation(null);
+  };
+
+  const copyMessage = async (content: string, index: number) => {
+    const text = content.trim();
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return;
+    }
+    setCopiedMessageIndex(index);
+    window.setTimeout(() => {
+      setCopiedMessageIndex((current) => current === index ? null : current);
+    }, 1_400);
   };
 
   const confirmDeleteConversations = async () => {
@@ -933,6 +950,15 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
               )}
               {messages.map((m, i) => (
                 <div key={i} className={`nodi-msg ${m.role}`}>
+                  <button
+                    className="nodi-msg-copy"
+                    disabled={!m.content.trim()}
+                    onClick={() => void copyMessage(m.content, i)}
+                    title={copiedMessageIndex === i ? t('Copiado') : t('Copiar en Markdown')}
+                    aria-label={copiedMessageIndex === i ? t('Copiado') : t('Copiar en Markdown')}
+                  >
+                    <Icon name={copiedMessageIndex === i ? 'check' : 'copy'} size={12} />
+                  </button>
                   {m.content
                     ? m.role === 'assistant' ? <Markdown content={m.content} onCitation={setCitation} /> : m.content
                     : streaming && i === messages.length - 1 ? <span className="nodi-typing">{t('escribiendo…')}</span> : ''}

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -335,9 +335,34 @@
 /* Chat */
 .nodi-panel.nodi-chat-panel { width: 372px; max-height: 480px; }
 .nodi-chat-msgs { display: flex; flex-direction: column; gap: 8px; padding: 8px; overflow-y: auto; }
-.nodi-msg { font-size: 13px; line-height: 1.5; padding: 7px 10px; border-radius: 12px; max-width: 86%; white-space: pre-wrap; word-break: break-word; }
+.nodi-chat-msgs,
+.nodi-msg,
+.nodi-msg .md { -webkit-user-select: text; user-select: text; }
+.nodi-msg { position: relative; font-size: 13px; line-height: 1.5; padding: 7px 32px 7px 10px; border-radius: 12px; max-width: 86%; white-space: pre-wrap; word-break: break-word; }
 .nodi-msg.user { align-self: flex-end; background: #24406b; color: #eaf1ff; border-bottom-right-radius: 4px; }
 .nodi-msg.assistant { align-self: flex-start; background: #1a2130; color: #e7ebf2; border-bottom-left-radius: 4px; white-space: normal; }
+.nodi-msg-copy {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: currentColor;
+  cursor: pointer;
+  opacity: .5;
+  transition: background .15s, opacity .15s;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.nodi-msg-copy:hover:not(:disabled),
+.nodi-msg-copy:focus-visible { background: rgba(255,255,255,.1); opacity: 1; outline: none; }
+.nodi-msg-copy:disabled { cursor: default; opacity: 0; }
 .nodi-msg .md { min-width: 0; }
 .nodi-msg .md > :first-child { margin-top: 0; }
 .nodi-msg .md > :last-child { margin-bottom: 0; }
@@ -791,6 +816,8 @@
 
 .nodi-theme-light .nodi-msg.user { background: var(--nodi-vault-accent, #6366f1); color: #ffffff; }
 .nodi-theme-light .nodi-msg.assistant { background: #f1f5f9; color: #1f2937; }
+.nodi-theme-light .nodi-msg-copy:hover:not(:disabled),
+.nodi-theme-light .nodi-msg-copy:focus-visible { background: rgba(15, 23, 42, .09); }
 .nodi-theme-light .nodi-msg .md h1,
 .nodi-theme-light .nodi-msg .md h2,
 .nodi-theme-light .nodi-msg .md h3,


### PR DESCRIPTION
Closes #154

## Summary

- allow manual text selection in embedded and floating Nodi chat messages
- add an accessible copy button to every user and assistant message
- preserve Markdown and internal citation links when copying
- show temporary success feedback and support both light and dark themes
- add regression coverage for selection and per-message copying

## Root cause

The floating Nodi host disables text selection at its root, and message bubbles did not override that behavior. Nodi also had no per-message copy control even though the research assistant already provided one.

## User impact

Users can now select any Nodi response manually or copy a complete message in one click from either Nodi surface.

## Validation

- `npm run typecheck`
- `npx eslint src/components/nodi/NodiCompanion.tsx`
- `npm test` — 692/692 tests passed