### PR TITLE
Polish AI model settings and share pinned models

### DIFF
--- a/electron/db/appPrefs.ts
+++ b/electron/db/appPrefs.ts
@@ -7,10 +7,11 @@ import type { AppSettings } from '@shared/types';
 // families live here, both persisted in a single JSON in userData so that creating
 // or switching vaults never resets them:
 //
-//  • GLOBAL_PREF_KEYS   — theme/interface preferences and the recovery policy. Always
-//                         present, so the first vault read seeds them unconditionally.
-//  • SHARED_MODEL_KEYS  — the AI model configuration (favorites, every workload
-//                         selector, local-provider base URLs and the image model).
+//  • GLOBAL_PREF_KEYS   — theme/interface preferences, model favorites and the
+//                         recovery policy. Always present, so the first vault read
+//                         seeds them unconditionally.
+//  • SHARED_MODEL_KEYS  — the AI model configuration (every workload selector,
+//                         local-provider base URLs and the image model).
 //                         API keys are already shared across vaults, so the models
 //                         chosen for them should travel too. These are seeded only
 //                         from a vault that has actually configured them (see
@@ -29,6 +30,7 @@ export const GLOBAL_PREF_KEYS = [
   'highContrast',
   'reduceMotion',
   'readingFocusMode',
+  'favorites',
   'mascotEnabled',
   'mascotAlwaysOnTop',
   'mascotVaultCostumes',
@@ -55,7 +57,6 @@ export const GLOBAL_PREF_KEYS = [
 export type GlobalPrefKey = (typeof GLOBAL_PREF_KEYS)[number];
 
 export const SHARED_MODEL_KEYS = [
-  'favorites',
   'codexReasoningEfforts',
   'localProviders',
   'providerFreeTier',

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -232,9 +232,9 @@ export function getSettings(): AppSettings {
     merged.defaultModel = null;
     writeRaw('app', JSON.stringify(merged));
   }
-  // App-wide preferences (theme, language) are shared across every vault: overlay the
-  // global store, seeding it once from this vault's value so existing users keep their
-  // current theme/language when the first new vault is created.
+  // App-wide preferences (theme, language and favorite models) are shared across every
+  // vault: overlay the global store, seeding it once from this vault's value so existing
+  // users keep their preferences when the first new vault is created.
   const globalPrefs = recoverV23SharedModelPrefs() as ReturnType<typeof readGlobalPrefs>;
   const seed: Record<string, unknown> = {};
   for (const key of GLOBAL_PREF_KEYS) {
@@ -306,14 +306,14 @@ export function updateSettings(patch: Partial<AppSettings>): AppSettings {
     patch = { ...patch, studyAiPrivacyMode: patch.studyAiLocalOnly ? 'local' : 'hybrid' };
   }
   const current = getSettings();
-  // Shared keys (theme/language + the AI model configuration) go to the global store;
+  // Shared keys (theme/language/favorites + the AI model configuration) go to the global store;
   // everything else stays per-vault. Model keys are also kept in the per-vault blob as a
   // fallback, so switching vaults never loses a value.
   const { global, local } = splitGlobalPatch(patch);
   if (Object.keys(global).length) writeGlobalPrefs(global);
   // providerKeys is derived from the secret store, never persisted.
   const { providerKeys: _ignore, lockedProviderKeys: _ignoreLocked, ...rest } = { ...current, ...local };
-  // Never persist the theme/language keys into the per-vault blob (they'd shadow the
+  // Never persist the app-wide keys into the per-vault blob (they'd shadow the
   // shared store and drift), so keep them exclusively in the global prefs file.
   for (const key of GLOBAL_PREF_KEYS) delete (rest as Record<string, unknown>)[key];
   writeRaw('app', JSON.stringify(rest));

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -521,9 +521,15 @@ try {
   await page.getByRole('button', { name: 'Modelos IA', exact: true }).click();
   await page.getByText('Generación de imágenes', { exact: true }).waitFor({ timeout: 30_000 });
   assert.equal(await page.getByText('gemini-3.1-flash-lite-image', { exact: false }).count() > 0, true, 'image settings render selected verified model');
-  const advancedPickerHeights = await page.locator('[data-testid="common-model-overrides"] select').evaluateAll((selects) => selects.map((select) => select.getBoundingClientRect().height));
-  assert.ok(advancedPickerHeights.length >= 5, 'advanced model settings render a common selector for every task, including Nodi');
+  const advancedPickerBoxes = await page.locator('[data-testid="common-model-overrides"] select').evaluateAll((selects) => selects.map((select) => {
+    const box = select.getBoundingClientRect();
+    return { width: box.width, height: box.height };
+  }));
+  assert.ok(advancedPickerBoxes.length >= 5, 'advanced model settings render a common selector for every task, including Nodi');
+  const advancedPickerHeights = advancedPickerBoxes.map((box) => box.height);
+  const advancedPickerWidths = advancedPickerBoxes.map((box) => box.width);
   assert.ok(Math.max(...advancedPickerHeights) - Math.min(...advancedPickerHeights) <= 1, 'the Nodi model selector has the same height as adjacent advanced selectors');
+  assert.ok(Math.max(...advancedPickerWidths) - Math.min(...advancedPickerWidths) <= 1, 'all common advanced model selectors have the same width');
   console.log('[e2e] image provider settings rendered');
   await page.getByRole('button', { name: 'Acerca de Nodus', exact: true }).click();
   await page.getByTestId('about-privacy').waitFor();

--- a/scripts/test-model-prefs-recovery.mjs
+++ b/scripts/test-model-prefs-recovery.mjs
@@ -63,6 +63,7 @@ const granularKeys = [
   'gradingModel', 'flashcardModel',
 ];
 
+const primary = registry.getActiveVault();
 let db = database.getDb();
 const broken = {
   embeddingProvider: 'openai',
@@ -131,6 +132,19 @@ const secondarySettings = settingsRepo.getSettings();
 assert.equal(secondarySettings.embeddingProvider, 'openai', 'each vault recovers against its own independent index');
 assert.equal(secondarySettings.embeddingModel, 'text-embedding-3-small');
 assert.deepEqual(secondarySettings.codexReasoningEfforts, { 'gpt-test': 'xhigh' }, 'Codex reasoning preferences are shared across vaults');
+
+const favoritesPinnedInSecondary = [gemini, integrated];
+settingsRepo.updateSettings({ favorites: favoritesPinnedInSecondary });
+database.closeDb();
+registry.setActiveVault(primary.id);
+db = database.getDb();
+assert.deepEqual(settingsRepo.getSettings().favorites, favoritesPinnedInSecondary, 'models pinned in one vault appear in every other vault');
+
+settingsRepo.updateSettings({ favorites: [integrated] });
+database.closeDb();
+registry.setActiveVault(secondary.id);
+db = database.getDb();
+assert.deepEqual(settingsRepo.getSettings().favorites, [integrated], 'unpinning a shared model updates every vault too');
 
 database.closeDb();
 console.log('2.3 model preference recovery tests passed');

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1266,8 +1266,9 @@ export interface AppSettings {
   // Connection settings for local providers (Ollama, LM Studio). The base URL is
   // user-editable; an optional access token, when set, is stored like an API key.
   localProviders: Record<LocalProvider, LocalProviderConfig>;
-  // Favorite models the user pinned. Workload and feature selectors below are
-  // deliberately independent: changing one must never retarget another flow.
+  // Favorite models the user pinned. This list is app-wide and shared across vaults.
+  // Workload and feature selectors below remain deliberately independent: changing
+  // one must never retarget another flow.
   favorites: ModelRef[];
   /** @deprecated Legacy global selector, retained only for one-time migration. */
   defaultModel: ModelRef | null;

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -152,6 +152,7 @@ export const DE: Record<string, string> = {
   'Abrir origen en Zotero': 'Quelle in Zotero öffnen',
   'Solo puede haber un modo de configuración activo. Cambiar de modo modifica qué selección de modelos utiliza Nodus, no solo la vista de este formulario.':
     'Es kann jeweils nur ein Konfigurationsmodus aktiv sein. Ein Moduswechsel ändert, welche Modellauswahl Nodus verwendet, nicht nur die Ansicht dieses Formulars.',
+  'Selección de modelos': 'Modellauswahl',
   'Configuración básica': 'Basiskonfiguration',
   'Configuración avanzada': 'Erweiterte Konfiguration',
   '¿Cambiar a la configuración básica?': 'Zur Basiskonfiguration wechseln?',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -144,6 +144,7 @@ export const EN: Record<string, string> = {
   'Se abre en Zotero': 'Opens in Zotero',
   'Abrir origen en Zotero': 'Open source in Zotero',
   'Solo puede haber un modo de configuración activo. Cambiar de modo modifica qué selección de modelos utiliza Nodus, no solo la vista de este formulario.': 'Only one configuration mode can be active. Changing modes modifies which model selections Nodus uses; it does not merely change this form\'s appearance.',
+  'Selección de modelos': 'Model selection',
   'Configuración básica': 'Basic configuration',
   'Configuración avanzada': 'Advanced configuration',
   '¿Cambiar a la configuración básica?': 'Switch to basic configuration?',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -152,6 +152,7 @@ export const FR: Record<string, string> = {
   'Abrir origen en Zotero': 'Ouvrir la source dans Zotero',
   'Solo puede haber un modo de configuración activo. Cambiar de modo modifica qué selección de modelos utiliza Nodus, no solo la vista de este formulario.':
     'Un seul mode de configuration peut être actif. Changer de mode modifie la sélection de modèles utilisée par Nodus, pas seulement l\'affichage de ce formulaire.',
+  'Selección de modelos': 'Sélection des modèles',
   'Configuración básica': 'Configuration de base',
   'Configuración avanzada': 'Configuration avancée',
   '¿Cambiar a la configuración básica?': 'Passer à la configuration de base ?',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -129,6 +129,7 @@ export const IT: Record<string, string> = {
   "Se abre en Zotero": "Apre a Zotero",
   "Abrir origen en Zotero": "Open source a Zotero",
   "Solo puede haber un modo de configuración activo. Cambiar de modo modifica qué selección de modelos utiliza Nodus, no solo la vista de este formulario.": "Può essere attiva solo una modalità di configurazione. Il cambiamento delle modalità modifica le selezioni del modello utilizzate da Nodus; non cambia semplicemente l'aspetto di questa forma.",
+  "Selección de modelos": "Selezione dei modelli",
   "Configuración básica": "Configurazione di base",
   "Configuración avanzada": "Configurazione avanzata",
   "¿Cambiar a la configuración básica?": "Passare alla configurazione di base?",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -152,6 +152,7 @@ export const PT_BR: Record<string, string> = {
   'Abrir origen en Zotero': 'Abrir origem no Zotero',
   'Solo puede haber un modo de configuración activo. Cambiar de modo modifica qué selección de modelos utiliza Nodus, no solo la vista de este formulario.':
     'Só pode haver um modo de configuração ativo. Mudar de modo altera qual seleção de modelos o Nodus utiliza, não apenas a aparência deste formulário.',
+  'Selección de modelos': 'Seleção de modelos',
   'Configuración básica': 'Configuração básica',
   'Configuración avanzada': 'Configuração avançada',
   '¿Cambiar a la configuración básica?': 'Mudar para a configuração básica?',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -152,6 +152,7 @@ export const PT: Record<string, string> = {
   'Abrir origen en Zotero': 'Abrir origem no Zotero',
   'Solo puede haber un modo de configuración activo. Cambiar de modo modifica qué selección de modelos utiliza Nodus, no solo la vista de este formulario.':
     'Só pode haver um modo de configuração ativo. Mudar de modo altera a seleção de modelos que o Nodus utiliza, não apenas o aspeto deste formulário.',
+  'Selección de modelos': 'Seleção de modelos',
   'Configuración básica': 'Configuração básica',
   'Configuración avanzada': 'Configuração avançada',
   '¿Cambiar a la configuración básica?': 'Mudar para a configuração básica?',

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1464,7 +1464,7 @@ export function Settings({
       )}
 
       {visibleSettingsSection('models', 'Modelos de IA', 'basico avanzado modelo general extraccion sintesis tutor resumen fusion embeddings transcripcion voz imagen') && (<>
-          <Section title={t('Modelos de IA')}>
+          <Section title={t('Selección de modelos')}>
             <p className="mb-2 text-xs leading-5 text-neutral-600 dark:text-neutral-400">
               {t('Solo puede haber un modo de configuración activo. Cambiar de modo modifica qué selección de modelos utiliza Nodus, no solo la vista de este formulario.')}
             </p>
@@ -1499,11 +1499,6 @@ export function Settings({
                 onEmbeddingChange={(provider, model) => setPendingEmbeddingChange({ provider, model })}
               />
             </Row>
-            <LocalAiModelsSettings
-              settings={settings}
-              patch={patch}
-            />
-            <SttSettings settings={settings} patch={patch} />
             {activeVault?.type === 'estudio' && <Row
               label={t('Procesamiento de materiales nuevos con IA')}
               hint={t('Controla si Nodus crea automáticamente conceptos, citas y relaciones para el mapa de Ideas y el grafo de estudio.')}
@@ -1524,17 +1519,17 @@ export function Settings({
                 <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-neutral-500">{t('Ajustes avanzados comunes')}</h3>
                 {/* The four selectors below drive the scan pipeline: one run covers a
                     whole corpus, so a subscription plan's quota is the real limit. */}
-                <Row label={t('Extracción de temas, ideas y evidencias')}><ModelPicker allowEmpty={false} settings={settings} value={settings.extractionModel} onChange={(extractionModel) => void patch({ extractionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
+                <Row label={t('Extracción de temas, ideas y evidencias')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.extractionModel} onChange={(extractionModel) => void patch({ extractionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
                 <ExtractionCapabilityNotice model={settings.extractionModel} />
                 <SubscriptionQuotaNotice model={settings.extractionModel} />
-                <Row label={t('Visión y OCR de imágenes')}><ModelPicker allowEmpty={false} settings={settings} value={settings.visionModel} onChange={(visionModel) => void patch({ visionModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <Row label={t('Visión y OCR de imágenes')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.visionModel} onChange={(visionModel) => void patch({ visionModel })} emptyLabel="Seleccionar modelo" /></Row>
                 <SubscriptionQuotaNotice model={settings.visionModel} />
-                <Row label={t('Resúmenes de obras')}><ModelPicker allowEmpty={false} settings={settings} value={settings.summaryModel} onChange={(summaryModel) => void patch({ summaryModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <Row label={t('Resúmenes de obras')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.summaryModel} onChange={(summaryModel) => void patch({ summaryModel })} emptyLabel="Seleccionar modelo" /></Row>
                 <SubscriptionQuotaNotice model={settings.summaryModel} />
-                <Row label={t('Fusión y deduplicación')}><ModelPicker allowEmpty={false} settings={settings} value={settings.fusionModel} onChange={(fusionModel) => void patch({ fusionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
+                <Row label={t('Fusión y deduplicación')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.fusionModel} onChange={(fusionModel) => void patch({ fusionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
                 <ExtractionCapabilityNotice model={settings.fusionModel} />
                 <SubscriptionQuotaNotice model={settings.fusionModel} />
-                <Row label={t('Asistente Nodi')}><ModelPicker allowEmpty={false} settings={settings} value={settings.nodiModel} onChange={(nodiModel) => void patch({ nodiModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <Row label={t('Asistente Nodi')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.nodiModel} onChange={(nodiModel) => void patch({ nodiModel })} emptyLabel="Seleccionar modelo" /></Row>
               </div>
               <VaultModelOverrides settings={settings} vaultType={activeVault?.type ?? 'academic'} vaultName={activeVault?.name ?? t('Vault actual')} patch={patch} />
             </>}
@@ -1587,7 +1582,7 @@ export function Settings({
               label={t('IA y datos del alumnado')}
               hint={t('La IA de Nodus no recibe listados, notas ni respuestas del alumnado y no puede calificar, perfilar ni evaluar estudiantes. Solo puede generar o estructurar contenido docente que no contenga datos del alumnado.')}
             >
-              <span data-testid="settings-no-ai-student-evaluation" className="inline-flex items-center gap-1.5 rounded-full border border-emerald-800/60 bg-emerald-950/30 px-2.5 py-1 text-xs font-medium text-emerald-300">
+              <span data-testid="settings-no-ai-student-evaluation" className="inline-flex items-center gap-1.5 rounded-full border border-emerald-300 bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-800/60 dark:bg-emerald-950/30 dark:text-emerald-300">
                 <Icon name="shield" size={12} /> {t('Bloqueado por diseño')}
               </span>
             </Row>
@@ -1626,6 +1621,11 @@ export function Settings({
               />
             </Row>
           </Section>
+          <LocalAiModelsSettings
+            settings={settings}
+            patch={patch}
+          />
+          <SttSettings settings={settings} patch={patch} />
           <ImageGenerationSettings settings={settings} onChange={onChange} />
           <AudioGenerationSettings settings={settings} onChange={onChange} />
       </>)}


### PR DESCRIPTION
Closes #163

## Summary

- group all model-selection controls in a dedicated **Model selection** section immediately after the embedding selector
- move local-model and transcription panels after that section
- add theme-aware light and dark styles to the student-data safety badge
- give all common advanced-model dropdowns the same width
- store pinned model favorites exclusively as an app-wide preference shared across vaults
- preserve historical favorites through the existing cross-vault recovery path

## Root cause

The layout placed intrinsically sized native selects beside controls whose option labels were longer, so otherwise identical dropdowns rendered at different widths. The safety badge also used dark-theme colors unconditionally. Favorites were mirrored as shared model settings but still retained per-vault fallbacks; treating them as an app-wide preference makes the shared behavior authoritative for both pin and unpin operations.

## User impact

Users see a clearer model-settings hierarchy, consistent controls in both themes, and one favorite-model list across every vault.

## Validation

- `npm run build`
- `npm run typecheck`
- `node --test scripts/test-model-independence.mjs`
- `node --test scripts/test-model-prefs-recovery.mjs`
- `node --test scripts/test-i18n-coverage.mjs`
- `git diff --check`