### PR TITLE
Publish releases only after asset verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,9 @@ jobs:
       HAS_MACOS_SIGNING: ${{ secrets.MACOS_CERTIFICATE != '' }}
     strategy:
       fail-fast: false
-      # electron-builder creates the GitHub Release as part of publishing. Running
-      # both OS jobs at once can race on release creation for the same tag.
+      # electron-builder creates a shared draft GitHub Release. Running the OS jobs
+      # at once can race on creation for the same tag; the verification job below
+      # promotes the draft only after every installer and updater manifest exists.
       max-parallel: 1
       matrix:
         include:
@@ -131,9 +132,9 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
-      - name: Verify stable installer assets
+      - name: Verify stable release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -142,10 +143,18 @@ jobs:
             Nodus-mac-arm64.dmg \
             Nodus-win-x64.exe \
             Nodus-linux-amd64.deb \
-            Nodus-linux-x86_64.AppImage
+            Nodus-linux-x86_64.AppImage \
+            latest-mac.yml \
+            latest.yml \
+            latest-linux.yml
           do
             if ! grep -Fxq "$asset" <<< "$assets"; then
               echo "::error::Missing release asset: $asset"
               exit 1
             fi
           done
+
+      - name: Publish completed release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false --latest

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
         "provider": "github",
         "owner": "drakonis96",
         "repo": "nodus",
-        "releaseType": "release"
+        "releaseType": "draft"
       }
     ],
     "beforePack": "build/beforePack.cjs",


### PR DESCRIPTION
## What changed

- Create electron-builder GitHub releases as drafts.
- Verify the macOS, Windows, and Linux installers plus all three updater manifests.
- Publish and mark the release as latest only after the complete asset set is present.

## Why

A release became public as soon as the first macOS artifact was uploaded, while `latest-mac.yml` was still missing. Clients checking during that window received a transient 404. Keeping the release as a draft makes the publication atomic from the updater's perspective.

## Validation

- Parsed `package.json` and confirmed `releaseType` is `draft`.
- Parsed `.github/workflows/release.yml` successfully.
- Ran Git whitespace validation on the committed diff.