### PR TITLE
Restore floating Nodi after app reactivation

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -27,6 +27,7 @@ import type { UpdateCheckResponse, UpdateProgressEvent } from '@shared/types';
 import { killChatGptSubscriptionServer } from './ai/codexSubscription';
 import { stopGitHubCopilotSubscription } from './ai/githubCopilotSubscription';
 import { installProcessSafetyNet } from './util/processSafety';
+import { restoreAppWindows } from './windowLifecycle';
 
 // Before anything else: a stray rejection from any of the fire-and-forget
 // timers below would otherwise terminate the process under Node's default.
@@ -450,13 +451,12 @@ function setupAutoUpdates(): void {
 // A second copy of this profile tried to start. It has already quit; bring the
 // window the user was actually looking for to the front.
 app.on('second-instance', () => {
-  if (!mainWindow) {
-    createWindow();
-    return;
-  }
-  if (mainWindow.isMinimized()) mainWindow.restore();
-  if (!mainWindow.isVisible()) mainWindow.show();
-  mainWindow.focus();
+  restoreAppWindows(mainWindow, createWindow, applyMascotWindow);
+  const win = mainWindow;
+  if (!win) return;
+  if (win.isMinimized()) win.restore();
+  if (!win.isVisible()) win.show();
+  win.focus();
 });
 
 app.whenReady().then(() => {
@@ -560,7 +560,7 @@ app.whenReady().then(() => {
   }
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    restoreAppWindows(mainWindow, createWindow, applyMascotWindow);
   });
 }).catch((error) => {
   // Startup opens and migrates the database before the first window exists, so

--- a/electron/windowLifecycle.ts
+++ b/electron/windowLifecycle.ts
@@ -1,0 +1,19 @@
+export type MainWindowState = {
+  isDestroyed(): boolean;
+};
+
+/**
+ * Restore the windows that belong to a running Nodus process.
+ *
+ * On macOS, closing the main window does not quit the application. The close
+ * handler also tears down Nodi's always-on-top window, so every path that later
+ * recreates the main window must re-apply the persisted mascot preference too.
+ */
+export function restoreAppWindows(
+  mainWindow: MainWindowState | null,
+  createMainWindow: () => void,
+  restoreMascotWindow: () => void,
+): void {
+  if (!mainWindow || mainWindow.isDestroyed()) createMainWindow();
+  restoreMascotWindow();
+}

--- a/scripts/test-window-lifecycle.mjs
+++ b/scripts/test-window-lifecycle.mjs
@@ -1,0 +1,71 @@
+// Regression coverage for macOS window reactivation. Closing Nodus destroys both
+// the main window and Nodi's always-on-top window while the process keeps running;
+// reopening must recreate the main window and then restore Nodi from settings.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { build } from 'esbuild';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'nodus-window-lifecycle-test-'));
+
+try {
+  const outfile = path.join(tmp, 'windowLifecycle.mjs');
+  await build({
+    entryPoints: [path.join(repoRoot, 'electron/windowLifecycle.ts')],
+    outfile,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    logLevel: 'silent',
+  });
+  const { restoreAppWindows } = await import(pathToFileURL(outfile).href);
+
+  test('recreates the main window before restoring the floating mascot', () => {
+    const calls = [];
+    restoreAppWindows(null, () => calls.push('main'), () => calls.push('mascot'));
+    assert.deepEqual(calls, ['main', 'mascot']);
+  });
+
+  test('recreates a destroyed main window before restoring the floating mascot', () => {
+    const calls = [];
+    restoreAppWindows(
+      { isDestroyed: () => true },
+      () => calls.push('main'),
+      () => calls.push('mascot'),
+    );
+    assert.deepEqual(calls, ['main', 'mascot']);
+  });
+
+  test('restores the floating mascot without duplicating a live main window', () => {
+    const calls = [];
+    restoreAppWindows(
+      { isDestroyed: () => false },
+      () => calls.push('main'),
+      () => calls.push('mascot'),
+    );
+    assert.deepEqual(calls, ['mascot']);
+  });
+
+  test('both process reactivation paths restore the persisted mascot state', async () => {
+    const main = await readFile(path.join(repoRoot, 'electron/main.ts'), 'utf8');
+    assert.match(
+      main,
+      /app\.on\('second-instance',[\s\S]*?restoreAppWindows\(mainWindow, createWindow, applyMascotWindow\)/,
+    );
+    assert.match(
+      main,
+      /app\.on\('activate',[\s\S]*?restoreAppWindows\(mainWindow, createWindow, applyMascotWindow\)/,
+    );
+    assert.doesNotMatch(
+      main,
+      /app\.on\('activate',[\s\S]*?BrowserWindow\.getAllWindows\(\)\.length === 0/,
+      'activation must key off the main window, not all windows, because Nodi is a BrowserWindow too',
+    );
+  });
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

- restore the persisted floating Nodi window whenever a running Nodus process is reactivated
- cover both macOS Dock activation and second-instance handoff
- avoid duplicating an already-live main window
- add behavioral regression tests plus integration assertions for both lifecycle hooks

## Root cause

Closing the main window destroyed Nodi's standalone always-on-top window. On macOS, the application process stayed alive, and reopening the app recreated only the main window. Because the in-app mascot is intentionally suppressed while always-on-top mode is enabled, Nodi remained invisible even though the setting still reported it as enabled.

## User impact

Users no longer need to disable and re-enable Nodi after reopening Nodus. The stored visibility preference is reconciled automatically.

## Validation

- `node --test scripts/test-window-lifecycle.mjs` — 4/4 passing
- `npm test` — 709/709 passing
- `npm run build` — production build passing
- `npm run typecheck` — passing
- targeted ESLint on the changed files — passing
- `git diff --check` — passing

Closes #167