### PR TITLE
Add Nodus Translate workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Teaching tools cover private student rosters, gradebooks, reusable rubrics and e
 
 ## Nodus Toolkit
 
-The Toolkit provides cross-vault, local-first document utilities. **Nodus Convert** converts and processes documents, PDFs, images and text. **Nodus Protect** combines PDFs and images, permanently redacts or blurs sensitive areas, adds watermarks and a legal footer, creates fully rasterised PNG/PDF/ZIP results and can issue or verify IDPS v1 traceable copies. PDF Presenter and OCR Workspace remain marked as upcoming.
+The Toolkit provides cross-vault document utilities. **Nodus Convert** converts and processes documents, PDFs, images and text. **Nodus Protect** combines PDFs and images, permanently redacts or blurs sensitive areas, adds watermarks and a legal footer, creates fully rasterised PNG/PDF/ZIP results and can issue or verify IDPS v1 traceable copies. **Nodus Translate** translates pasted text, files and Zotero attachments with a chosen AI model; it preserves DOCX/EPUB structure and includes a rasterised PDF facsimile mode that retains page geometry, backgrounds and images while replacing visible text. PDF Presenter and OCR Workspace are also available.
 
 Protect can read files selected from disk or compatible sources in the active vault and can save each result back to disk, share it through the operating system or store it in the vault’s Protected Copies library. Its document processing is entirely local: it does not send protected documents to AI providers or any external service. This statement applies specifically to Nodus Protect; other optional Nodus features can use network providers when the user configures and invokes them.
 

--- a/electron/extraction/pdfjsLoader.ts
+++ b/electron/extraction/pdfjsLoader.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 // Single place to load the pdfjs legacy build (no DOM) and open a document.
@@ -19,8 +20,14 @@ export async function loadPdfjs(): Promise<any> {
 
 export async function openPdf(filePath: string): Promise<any> {
   const pdfjs = await loadPdfjs();
+  const requireFromHere = createRequire(__filename);
+  const pdfjsRoot = path.dirname(requireFromHere.resolve('pdfjs-dist/package.json'));
   const data = new Uint8Array(fs.readFileSync(filePath));
-  const task = pdfjs.getDocument({ data, useSystemFonts: true, isEvalSupported: false, disableFontFace: true });
+  // Supplying PDF.js' bundled standard fonts is essential for raster output.
+  // Without it, PDFs using Helvetica/Times can expose a valid text layer while
+  // rendering blank glyphs in the Node canvas used by facsimile translation.
+  const standardFontDataUrl = pathToFileURL(path.join(pdfjsRoot, 'standard_fonts') + path.sep).href;
+  const task = pdfjs.getDocument({ data, useSystemFonts: true, standardFontDataUrl, isEvalSupported: false, disableFontFace: false });
   return task.promise;
 }
 

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -181,6 +181,13 @@ import {
 } from './toolkit/aiOcr';
 import type { AiOcrExportFormat, OcrOptions } from '@shared/aiOcrTypes';
 import type { ToolkitJobRequest } from '@shared/toolkitTypes';
+import type { TranslateJobRequest } from '@shared/toolkitTranslateTypes';
+import {
+  runTranslateJob,
+  suggestedTextFilename,
+  type TranslateSignal,
+} from './toolkit/translate';
+import { listTranslateHistory, removeTranslateHistory } from './toolkit/translate/history';
 import * as presenterLibrary from './toolkit/presenter/library';
 import { extractPptxNotes } from './toolkit/presenter/pptxNotes';
 import {
@@ -3609,6 +3616,48 @@ export function registerIpc(
   });
   h('toolkit:showInFolder', async (_e, filePath: string) => {
     shell.showItemInFolder(filePath);
+  });
+
+  // ── Nodus Translate ─────────────────────────────────────────────────────────
+  const translateSignals = new Map<string, TranslateSignal>();
+  h('translate:job:run', async (e, jobId: string, request: TranslateJobRequest) => {
+    const signal: TranslateSignal = { cancelled: false };
+    translateSignals.set(jobId, signal);
+    try {
+      const result = await runTranslateJob(jobId, request, {
+        signal,
+        onProgress: (progress) => e.sender.send('translate:job:event', jobId, progress),
+      });
+      if (request.openFolderOnDone && !result.cancelled && result.outputs[0]?.outputPath) {
+        shell.showItemInFolder(result.outputs[0].outputPath);
+      }
+      return result;
+    } finally {
+      translateSignals.delete(jobId);
+    }
+  });
+  h('translate:job:cancel', async (_e, jobId: string) => {
+    const signal = translateSignals.get(jobId);
+    if (signal) signal.cancelled = true;
+  });
+  h('translate:text:save', async (e, text: string, targetLanguage: string, extension: 'txt' | 'md' | 'html' = 'txt') => {
+    const win = BrowserWindow.fromWebContents(e.sender);
+    const picked = await dialog.showSaveDialog(win ?? undefined!, {
+      title: 'Guardar traducción',
+      defaultPath: suggestedTextFilename(targetLanguage, extension),
+      filters: [{ name: extension.toUpperCase(), extensions: [extension] }],
+    });
+    if (picked.canceled || !picked.filePath) return { canceled: true };
+    fs.writeFileSync(picked.filePath, text, 'utf8');
+    return { canceled: false, path: picked.filePath };
+  });
+  h('translate:history:list', async () => listTranslateHistory());
+  h('translate:history:remove', async (_e, id: string, deleteOutput = false) => {
+    const entry = listTranslateHistory().find((candidate) => candidate.id === id);
+    if (deleteOutput && entry?.outputPath && fs.existsSync(entry.outputPath)) {
+      await shell.trashItem(entry.outputPath);
+    }
+    return removeTranslateHistory(id);
   });
 
   // ── Nodus AI OCR (OCR Workspace) ────────────────────────────────────────────

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1206,6 +1206,25 @@ const api: NodusApi = {
   pickToolkitOutputDir: () => ipcRenderer.invoke('toolkit:pickOutputDir'),
   revealToolkitOutput: (filePath) => ipcRenderer.invoke('toolkit:showInFolder', filePath).then(() => undefined),
 
+  // Nodus Translate. A per-run id keeps simultaneous/late events isolated in the
+  // renderer and gives cancellation an unambiguous main-process target.
+  runTranslateJob: async (request, handlers) => {
+    const jobId = `translate-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const onEvent = (_e: unknown, id: string, progress: Parameters<typeof handlers.onProgress>[0]) => {
+      if (id === jobId) handlers.onProgress(progress);
+    };
+    ipcRenderer.on('translate:job:event', onEvent);
+    try {
+      return await ipcRenderer.invoke('translate:job:run', jobId, request);
+    } finally {
+      ipcRenderer.removeListener('translate:job:event', onEvent);
+    }
+  },
+  cancelTranslateJob: (jobId) => ipcRenderer.invoke('translate:job:cancel', jobId).then(() => undefined),
+  saveTranslatedText: (text, targetLanguage, extension) => ipcRenderer.invoke('translate:text:save', text, targetLanguage, extension),
+  listTranslateHistory: () => ipcRenderer.invoke('translate:history:list'),
+  removeTranslateHistory: (id, deleteOutput) => ipcRenderer.invoke('translate:history:remove', id, deleteOutput),
+
   // Nodus AI OCR (OCR Workspace). Progress is pushed on 'aiOcr:event' (docId + snapshot).
   createOcrDocs: (input) => ipcRenderer.invoke('aiOcr:create', input),
   listOcrDocs: () => ipcRenderer.invoke('aiOcr:list'),

--- a/electron/toolkit/translate/documents.ts
+++ b/electron/toolkit/translate/documents.ts
@@ -1,0 +1,253 @@
+// Nodus Translate — structure-preserving adapters for text, HTML, EPUB and DOCX.
+// The original archive is retained and only human-readable text payloads are changed;
+// relationships, images, styles, headers, footers, notes and embedded assets stay in
+// their original package parts.
+import AdmZip from 'adm-zip';
+import type { TranslateSegment, TranslateSegmentResult } from '@shared/toolkitTranslateTypes';
+
+export interface StructuredTranslateOptions {
+  translate: (segments: TranslateSegment[]) => Promise<TranslateSegmentResult[]>;
+  onWarning?: (message: string) => void;
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&#x([0-9a-f]+);/gi, (_m, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_m, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&');
+}
+
+function encodeXml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function stripMarkup(value: string): string {
+  return decodeXml(value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ')).trim();
+}
+
+interface SpanMatch {
+  start: number;
+  end: number;
+  source: string;
+  segment: TranslateSegment;
+}
+
+function replaceSpans(source: string, spans: SpanMatch[], values: Map<string, string>): string {
+  let cursor = 0;
+  const out: string[] = [];
+  for (const span of spans) {
+    out.push(source.slice(cursor, span.start));
+    out.push(values.get(span.segment.id) ?? span.source);
+    cursor = span.end;
+  }
+  out.push(source.slice(cursor));
+  return out.join('');
+}
+
+/** Models occasionally renumber an isolated Markdown list item because each block is
+ * translated independently. Restore syntax that describes structure rather than prose. */
+export function restoreMarkdownPrefix(source: string, translated: string): string {
+  const sourcePrefix = source.match(/^(\s*)(#{1,6}|>|\d+[.)]|[-+*])([ \t]+)/);
+  if (!sourcePrefix) return translated;
+  const translatedPrefix = translated.match(/^(\s*)(#{1,6}|>|\d+[.)]|[-+*])([ \t]+)/);
+  const prefix = `${sourcePrefix[1]}${sourcePrefix[2]}${sourcePrefix[3]}`;
+  if (translatedPrefix) return `${prefix}${translated.slice(translatedPrefix[0].length)}`;
+  return `${prefix}${translated.trimStart()}`;
+}
+
+/** Translate Markdown as paragraph-sized blocks so headings/tables never share a
+ * model response boundary in the middle of their own block. */
+export async function translateMarkdownDocument(markdown: string, options: StructuredTranslateOptions): Promise<string> {
+  const blocks = markdown.split(/(\n{2,})/);
+  const segments: TranslateSegment[] = [];
+  const indexToId = new Map<number, string>();
+  for (let i = 0; i < blocks.length; i += 2) {
+    if (!blocks[i]?.trim()) continue;
+    const id = `md-${String(i / 2 + 1).padStart(6, '0')}`;
+    segments.push({ id, text: blocks[i], kind: 'markdown' });
+    indexToId.set(i, id);
+  }
+  const sourceById = new Map(segments.map((segment) => [segment.id, segment.text]));
+  const translated = new Map((await options.translate(segments)).map((segment) => [
+    segment.id,
+    restoreMarkdownPrefix(sourceById.get(segment.id) ?? '', segment.translated),
+  ]));
+  return blocks.map((block, index) => translated.get(indexToId.get(index) ?? '') ?? block).join('');
+}
+
+export async function translatePlainDocument(text: string, options: StructuredTranslateOptions): Promise<string> {
+  const blocks = text.split(/(\n{2,})/);
+  const segments: TranslateSegment[] = [];
+  const indexToId = new Map<number, string>();
+  for (let i = 0; i < blocks.length; i += 2) {
+    if (!blocks[i]?.trim()) continue;
+    const id = `txt-${String(i / 2 + 1).padStart(6, '0')}`;
+    segments.push({ id, text: blocks[i], kind: 'plain' });
+    indexToId.set(i, id);
+  }
+  const translated = new Map((await options.translate(segments)).map((segment) => [segment.id, segment.translated]));
+  return blocks.map((block, index) => translated.get(indexToId.get(index) ?? '') ?? block).join('');
+}
+
+/** Extract leaf block elements. Inline markup remains inside a segment, so emphasis,
+ * links, ruby, superscript and other publishing markup can be moved by the translator
+ * without rebuilding the DOM. */
+function htmlSpans(html: string, prefix: string): SpanMatch[] {
+  const spans: SpanMatch[] = [];
+  const pattern = /<(title|h[1-6]|p|li|td|th|caption|figcaption|blockquote)\b[^>]*>[\s\S]*?<\/\1>/gi;
+  let match: RegExpExecArray | null;
+  let n = 0;
+  while ((match = pattern.exec(html))) {
+    if (!stripMarkup(match[0])) continue;
+    const id = `${prefix}-${String(++n).padStart(6, '0')}`;
+    spans.push({ start: match.index, end: match.index + match[0].length, source: match[0], segment: { id, text: match[0], kind: 'html' } });
+  }
+  if (!spans.length && stripMarkup(html)) {
+    spans.push({ start: 0, end: html.length, source: html, segment: { id: `${prefix}-000001`, text: html, kind: 'html' } });
+  }
+  return spans;
+}
+
+export async function translateHtmlDocument(html: string, options: StructuredTranslateOptions, prefix = 'html'): Promise<string> {
+  // Scripts/styles are replaced with stable tokens before model calls and restored after;
+  // this makes it impossible for a translation model to mutate executable content or CSS.
+  const protectedParts: string[] = [];
+  const protectedHtml = html.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, (value) => {
+    const token = `<!--NODUS_PROTECTED_${protectedParts.length}-->`;
+    protectedParts.push(value);
+    return token;
+  });
+  const spans = htmlSpans(protectedHtml, prefix);
+  const translated = new Map((await options.translate(spans.map((span) => span.segment))).map((segment) => [segment.id, segment.translated]));
+  return replaceSpans(protectedHtml, spans, translated).replace(/<!--NODUS_PROTECTED_(\d+)-->/g, (_m, index) => protectedParts[Number(index)] ?? '');
+}
+
+export async function translateEpubBytes(bytes: Uint8Array, options: StructuredTranslateOptions): Promise<Uint8Array> {
+  const zip = new AdmZip(Buffer.from(bytes));
+  const entries = zip.getEntries().filter((entry) => !entry.isDirectory && /\.(xhtml|html?|xml)$/i.test(entry.entryName));
+  let index = 0;
+  for (const entry of entries) {
+    const original = entry.getData().toString('utf8');
+    // container.xml and package manifests contain no reader prose except metadata;
+    // translating structural attributes there could invalidate the EPUB.
+    if (/META-INF\/container\.xml$/i.test(entry.entryName) || /\.opf$/i.test(entry.entryName)) continue;
+    const translated = await translateHtmlDocument(original, options, `epub-${String(++index).padStart(4, '0')}`);
+    zip.updateFile(entry.entryName, Buffer.from(translated, 'utf8'));
+  }
+  return new Uint8Array(zip.toBuffer());
+}
+
+interface WordTextNode {
+  start: number;
+  end: number;
+  open: string;
+  value: string;
+}
+
+function wordTextNodes(paragraph: string): WordTextNode[] {
+  const nodes: WordTextNode[] = [];
+  const pattern = /(<w:t\b[^>]*>)([\s\S]*?)(<\/w:t>)/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(paragraph))) {
+    nodes.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      open: match[1],
+      value: decodeXml(match[2]),
+    });
+  }
+  return nodes;
+}
+
+function paragraphPseudoXml(nodes: WordTextNode[]): string {
+  return nodes.map((node, index) => `<n id="${index}">${encodeXml(node.value)}</n>`).join('');
+}
+
+function translatedWordValues(translated: string, count: number): string[] | null {
+  const values = new Array<string | undefined>(count);
+  const pattern = /<n\s+id=["'](\d+)["']\s*>([\s\S]*?)<\/n>/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(translated))) {
+    const index = Number(match[1]);
+    if (index >= 0 && index < count && values[index] == null) values[index] = decodeXml(match[2]);
+  }
+  return values.every((value) => value != null) ? values as string[] : null;
+}
+
+function rebuildWordParagraph(paragraph: string, nodes: WordTextNode[], translated: string, onWarning?: (message: string) => void): string {
+  const values = translatedWordValues(translated, nodes.length);
+  let replacements: string[];
+  if (values) {
+    replacements = values;
+  } else {
+    // Preserve the complete translated prose even when a weak model drops inline-run
+    // tags. Styling falls back to the first run, but no words disappear silently.
+    const flattened = stripMarkup(translated);
+    replacements = nodes.map((_node, index) => index === 0 ? flattened : '');
+    onWarning?.('Un párrafo de Word no conservó todas las marcas de formato en la respuesta del modelo; se mantuvo el texto completo con el estilo del primer fragmento.');
+  }
+  let cursor = 0;
+  const out: string[] = [];
+  nodes.forEach((node, index) => {
+    out.push(paragraph.slice(cursor, node.start));
+    const value = replacements[index] ?? '';
+    const open = /\bxml:space=/.test(node.open) || /^\s|\s$/.test(value)
+      ? node.open.replace(/>$/, /\bxml:space=/.test(node.open) ? '>' : ' xml:space="preserve">')
+      : node.open;
+    out.push(`${open}${encodeXml(value)}</w:t>`);
+    cursor = node.end;
+  });
+  out.push(paragraph.slice(cursor));
+  return out.join('');
+}
+
+interface WordParagraphSpan extends SpanMatch {
+  nodes: WordTextNode[];
+}
+
+function wordParagraphSpans(xml: string, prefix: string): WordParagraphSpan[] {
+  const spans: WordParagraphSpan[] = [];
+  const pattern = /<w:p\b[^>]*>[\s\S]*?<\/w:p>/g;
+  let match: RegExpExecArray | null;
+  let index = 0;
+  while ((match = pattern.exec(xml))) {
+    const nodes = wordTextNodes(match[0]);
+    if (!nodes.some((node) => node.value.trim())) continue;
+    const id = `${prefix}-${String(++index).padStart(6, '0')}`;
+    spans.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      source: match[0],
+      nodes,
+      segment: { id, text: paragraphPseudoXml(nodes), kind: 'xml' },
+    });
+  }
+  return spans;
+}
+
+const WORD_TRANSLATABLE_PART = /^word\/(document|footnotes|endnotes|comments|header\d+|footer\d+)\.xml$/i;
+
+export async function translateDocxBytes(bytes: Uint8Array, options: StructuredTranslateOptions): Promise<Uint8Array> {
+  const zip = new AdmZip(Buffer.from(bytes));
+  const parts = zip.getEntries()
+    .filter((entry) => !entry.isDirectory && WORD_TRANSLATABLE_PART.test(entry.entryName))
+    .map((entry, partIndex) => {
+      const xml = entry.getData().toString('utf8');
+      return { entry, xml, spans: wordParagraphSpans(xml, `docx-${String(partIndex + 1).padStart(3, '0')}`) };
+    });
+  const all = parts.flatMap((part) => part.spans.map((span) => span.segment));
+  const values = new Map((await options.translate(all)).map((segment) => [segment.id, segment.translated]));
+  for (const part of parts) {
+    const replacements = new Map<string, string>();
+    for (const span of part.spans) {
+      const translated = values.get(span.segment.id) ?? span.segment.text;
+      replacements.set(span.segment.id, rebuildWordParagraph(span.source, span.nodes, translated, options.onWarning));
+    }
+    zip.updateFile(part.entry.entryName, Buffer.from(replaceSpans(part.xml, part.spans, replacements), 'utf8'));
+  }
+  return new Uint8Array(zip.toBuffer());
+}

--- a/electron/toolkit/translate/facsimile.ts
+++ b/electron/toolkit/translate/facsimile.ts
@@ -1,0 +1,537 @@
+// Nodus Translate — PDF facsimile renderer.
+//
+// Each source page is rendered once, its textual regions are translated with stable
+// block IDs, and the translated prose is fitted back into those same regions. Images,
+// rules, backgrounds, page geometry, headers and footers therefore remain visually in
+// place. The output is intentionally raster-backed: arbitrary PDF content streams and
+// subset fonts cannot be edited safely with pdf-lib alone. Pages requiring aggressive
+// fitting are reported to the UI instead of being silently presented as perfect.
+import { openPdf } from '../../extraction/pdfjsLoader';
+import type { OcrBlockLabel, OcrPageResult } from '@shared/aiOcrTypes';
+import type { TranslateSegment, TranslateSegmentResult } from '@shared/toolkitTranslateTypes';
+
+export interface FacsimileSignal { cancelled: boolean }
+
+export interface FacsimileProgress {
+  stage: 'extracting' | 'translating' | 'rendering';
+  done: number;
+  total: number;
+}
+
+export interface FacsimileOptions {
+  translate: (segments: TranslateSegment[]) => Promise<TranslateSegmentResult[]>;
+  /** Required when a page has no digital text or image-text translation is enabled. */
+  translatePageImage?: (page: { buffer: Buffer; mediaType: string; width: number; height: number; pageNumber: number }) => Promise<OcrPageResult>;
+  translateImageText?: boolean;
+  signal?: FacsimileSignal;
+  onProgress?: (progress: FacsimileProgress) => void;
+}
+
+export interface FacsimileResult {
+  data: Uint8Array;
+  pageCount: number;
+  overflowPages: number[];
+  warnings: string[];
+}
+
+interface PdfTextBlock {
+  id: string;
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fontSize: number;
+  fontFamily: string;
+  label: OcrBlockLabel;
+  /** Digital facsimile lines are kept on one visual line and horizontally fitted;
+   * paragraph wrapping is reserved for vision boxes and reflow exports. */
+  singleLine?: boolean;
+  /** Exact source-line rectangles. Erasing these instead of the paragraph's full
+   * bounding box preserves rules, arrows, images and coloured cells between lines. */
+  eraseRegions?: Array<{ x: number; y: number; width: number; height: number; fontSize: number }>;
+  /** Vision OCR translation already returned this block in the target language. */
+  alreadyTranslated?: boolean;
+}
+
+interface ExtractedPage {
+  pageNumber: number;
+  pageWidth: number;
+  pageHeight: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  canvas: any;
+  blocks: PdfTextBlock[];
+}
+
+interface RawLine extends PdfTextBlock { baseline: number }
+
+const RENDER_SCALE = 2;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function median(values: number[], fallback = 12): number {
+  if (!values.length) return fallback;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function labelFor(fontSize: number, bodySize: number, y: number, pageHeight: number): OcrBlockLabel {
+  if (y < pageHeight * 0.07) return 'HEADER';
+  if (y > pageHeight * 0.91) return 'FOOTER';
+  if (fontSize >= bodySize * 1.25) return 'TITLE';
+  if (fontSize <= bodySize * 0.78 && y > pageHeight * 0.66) return 'FOOTNOTE';
+  return 'MAIN_TEXT';
+}
+
+export function groupDigitalLines(content: any, viewport: any, pageNumber: number): RawLine[] {
+  const items = (content.items ?? []).filter((item: any) => typeof item.str === 'string' && item.str.trim());
+  const styles = content.styles ?? {};
+  const raw = items.map((item: any, index: number) => {
+    const transform = item.transform ?? [1, 0, 0, 1, 0, 0];
+    const [vx, vy] = viewport.convertToViewportPoint(transform[4], transform[5]);
+    const fontSize = Math.max(5, Math.hypot(transform[2], transform[3]) * RENDER_SCALE || Number(item.height) * RENDER_SCALE || 12);
+    const width = Math.max(fontSize * 0.25, Number(item.width || 0) * RENDER_SCALE);
+    return {
+      index,
+      text: item.str,
+      x: vx,
+      baseline: vy,
+      y: vy - fontSize,
+      width,
+      height: fontSize * 1.16,
+      fontSize,
+      fontFamily: String(styles[item.fontName]?.fontFamily || 'Arial'),
+    };
+  }).sort((a: any, b: any) => Math.abs(a.baseline - b.baseline) <= 2 ? a.x - b.x : a.baseline - b.baseline);
+
+  const lines: Array<{ items: typeof raw; baseline: number }> = [];
+  for (const item of raw) {
+    const line = lines.find((candidate) => Math.abs(candidate.baseline - item.baseline) <= Math.max(2.5, item.fontSize * 0.28));
+    if (line) {
+      line.items.push(item);
+      line.baseline = line.items.reduce((sum: number, value: { baseline: number }) => sum + value.baseline, 0) / line.items.length;
+    } else {
+      lines.push({ items: [item], baseline: item.baseline });
+    }
+  }
+  // A shared baseline does not imply a shared line: tables, diagrams and columns
+  // routinely place unrelated text at the same Y coordinate. Split a baseline band
+  // whenever the horizontal whitespace is too large to be an ordinary word gap.
+  const splitLines = lines.flatMap((line) => {
+    const ordered = line.items.sort((a: any, b: any) => a.x - b.x);
+    const clusters: typeof raw[] = [];
+    let current: typeof raw = [];
+    for (const item of ordered) {
+      const previous = current.at(-1);
+      const gap = previous ? item.x - (previous.x + previous.width) : 0;
+      // Ordinary PDF word/run gaps are small. A gap near one glyph height is much
+      // more likely to be a column or table-cell boundary and must not be merged.
+      const threshold = Math.max(10, Math.max(previous?.fontSize ?? 0, item.fontSize) * 0.72);
+      const previousIsListPrefix = Boolean(previous && /^(?:\d+[.)]|[•●▪◦])$/.test(previous.text.trim()));
+      if (previous && gap > threshold && !previousIsListPrefix) {
+        clusters.push(current);
+        current = [];
+      }
+      current.push(item);
+    }
+    if (current.length) clusters.push(current);
+    return clusters.map((items) => ({ items, baseline: items.reduce((sum: number, item: (typeof raw)[number]) => sum + item.baseline, 0) / items.length }));
+  });
+  const body = median(raw.map((item: any) => item.fontSize));
+  return splitLines.sort((a, b) => Math.abs(a.baseline - b.baseline) <= 2 ? a.items[0].x - b.items[0].x : a.baseline - b.baseline).map((line, index) => {
+    const left = Math.min(...line.items.map((item: any) => item.x));
+    const right = Math.max(...line.items.map((item: any) => item.x + item.width));
+    const top = Math.min(...line.items.map((item: any) => item.y));
+    const bottom = Math.max(...line.items.map((item: any) => item.y + item.height));
+    const fontSize = Math.max(...line.items.map((item: any) => item.fontSize));
+    const text = line.items.map((item: any, itemIndex: number) => {
+      if (!itemIndex) return item.text;
+      const previous = line.items[itemIndex - 1];
+      const gap = item.x - (previous.x + previous.width);
+      return `${gap > fontSize * 0.14 ? ' ' : ''}${item.text}`;
+    }).join('').replace(/\s+/g, ' ').trim();
+    return {
+      id: `pdf-p${String(pageNumber).padStart(4, '0')}-l${String(index + 1).padStart(4, '0')}`,
+      text, x: left, y: top, width: right - left, height: bottom - top, baseline: line.baseline,
+      fontSize, fontFamily: line.items[0]?.fontFamily || 'Arial',
+      label: labelFor(fontSize, body, top, viewport.height),
+    };
+  });
+}
+
+function overlapRatio(a: RawLine, b: RawLine): number {
+  const overlap = Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x));
+  return overlap / Math.max(1, Math.min(a.width, b.width));
+}
+
+export function groupParagraphs(lines: RawLine[], pageNumber: number): PdfTextBlock[] {
+  const groups: RawLine[][] = [];
+  for (const line of [...lines].sort((a, b) => Math.abs(a.y - b.y) <= 2 ? a.x - b.x : a.y - b.y)) {
+    let best: { group: RawLine[]; score: number } | null = null;
+    for (const group of groups) {
+      const prev = group.at(-1)!;
+      const gap = line.y - (prev.y + prev.height);
+      const sameRole = prev.label === line.label;
+      const sameScale = Math.abs(prev.fontSize - line.fontSize) <= Math.max(2, prev.fontSize * 0.22);
+      const sameColumn = overlapRatio(prev, line) >= 0.35 || Math.abs(prev.x - line.x) <= prev.fontSize * 1.5;
+      const startsNewListItem = /^(?:\d+[.)]|[•●▪◦])\s*/.test(line.text) && group.length > 0;
+      if (!sameRole || !sameScale || !sameColumn || startsNewListItem || gap < -Math.max(2, prev.fontSize * 0.18) || gap > Math.max(prev.fontSize * 0.55, 8)) continue;
+      const score = Math.abs(gap) + Math.abs(prev.x - line.x) * 0.08;
+      if (!best || score < best.score) best = { group, score };
+    }
+    if (best) best.group.push(line);
+    else groups.push([line]);
+  }
+
+  return groups.map((current, blockIndex) => {
+    const first = current[0];
+    const left = Math.min(...current.map((line) => line.x));
+    const right = Math.max(...current.map((line) => line.x + line.width));
+    const top = Math.min(...current.map((line) => line.y));
+    const bottom = Math.max(...current.map((line) => line.y + line.height));
+    const text = current.map((line, index) => {
+      const previous = current[index - 1];
+      if (index && previous.text.endsWith('-') && /^[a-záéíóúüñ]/i.test(line.text)) return line.text;
+      return `${index ? ' ' : ''}${line.text}`;
+    }).join('').replace(/-\s+(?=[a-záéíóúüñ])/gi, '');
+    return {
+      id: `pdf-p${String(pageNumber).padStart(4, '0')}-b${String(blockIndex + 1).padStart(4, '0')}`,
+      text,
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+      fontSize: median(current.map((line) => line.fontSize), first.fontSize),
+      fontFamily: first.fontFamily,
+      label: first.label,
+      eraseRegions: current.map(({ x, y, width, height, fontSize }) => ({ x, y, width, height, fontSize })),
+    };
+  }).sort((a, b) => Math.abs(a.y - b.y) <= 2 ? a.x - b.x : a.y - b.y);
+}
+
+function ocrBlocks(result: OcrPageResult, width: number, height: number, pageNumber: number): PdfTextBlock[] {
+  const usable = result.blocks.filter((block) => block.text.trim());
+  return usable.map((block, index) => {
+    const box = block.box_2d;
+    const fallbackTop = 70 + index * Math.max(35, (height - 140) / Math.max(1, usable.length));
+    const x = box ? clamp(box[1], 0, 1000) / 1000 * width : width * 0.08;
+    const y = box ? clamp(box[0], 0, 1000) / 1000 * height : fallbackTop;
+    const right = box ? clamp(box[3], 0, 1000) / 1000 * width : width * 0.92;
+    const bottom = box ? clamp(box[2], 0, 1000) / 1000 * height : Math.min(height - 40, y + 60);
+    const blockHeight = Math.max(14, bottom - y);
+    return {
+      id: `pdf-p${String(pageNumber).padStart(4, '0')}-v${String(index + 1).padStart(4, '0')}`,
+      text: block.text,
+      x,
+      y,
+      width: Math.max(24, right - x),
+      height: blockHeight,
+      fontSize: block.label === 'TITLE' ? Math.min(40, blockHeight * 0.65) : Math.min(24, Math.max(10, blockHeight * 0.35)),
+      fontFamily: 'Arial',
+      label: block.label,
+      alreadyTranslated: true,
+    };
+  });
+}
+
+async function extractPages(inputPath: string, options: FacsimileOptions): Promise<ExtractedPage[]> {
+  const { createCanvas } = await import('@napi-rs/canvas');
+  const pdf = await openPdf(inputPath);
+  const pages: ExtractedPage[] = [];
+  try {
+    for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+      if (options.signal?.cancelled) break;
+      const page = await pdf.getPage(pageNumber);
+      try {
+        const pointViewport = page.getViewport({ scale: 1 });
+        const viewport = page.getViewport({ scale: RENDER_SCALE });
+        const canvas = createCanvas(Math.ceil(viewport.width), Math.ceil(viewport.height));
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        await page.render({ canvasContext: ctx as any, viewport }).promise;
+        const content = await page.getTextContent();
+        const digitalLines = groupDigitalLines(content, viewport, pageNumber);
+        // Paragraph rectangles are useful for reflow, but too destructive for a
+        // facsimile: tables and multi-column PDFs can have overlapping paragraph
+        // bounds. Keeping exact visual lines prevents translated blocks from
+        // crossing cells, images or neighbouring columns.
+        const digitalBlocks: PdfTextBlock[] = digitalLines.map(({ baseline: _baseline, ...line }) => ({
+          ...line,
+          singleLine: true,
+          eraseRegions: [{ x: line.x, y: line.y, width: line.width, height: line.height, fontSize: line.fontSize }],
+        }));
+        const needsVision = options.translateImageText || digitalBlocks.reduce((sum, block) => sum + block.text.length, 0) < 20;
+        let blocks = digitalBlocks;
+        if (needsVision) {
+          if (!options.translatePageImage) {
+            if (!digitalBlocks.length) throw new Error(`La página ${pageNumber} necesita un modelo de visión para traducirse.`);
+          } else {
+            const buffer = canvas.toBuffer('image/jpeg', 90);
+            const result = await options.translatePageImage({ buffer, mediaType: 'image/jpeg', width: canvas.width, height: canvas.height, pageNumber });
+            blocks = ocrBlocks(result, canvas.width, canvas.height, pageNumber);
+          }
+        }
+        pages.push({
+          pageNumber,
+          pageWidth: pointViewport.width,
+          pageHeight: pointViewport.height,
+          canvasWidth: canvas.width,
+          canvasHeight: canvas.height,
+          canvas,
+          blocks,
+        });
+        options.onProgress?.({ stage: 'extracting', done: pageNumber, total: pdf.numPages });
+      } finally {
+        page.cleanup?.();
+      }
+    }
+  } finally {
+    await pdf.destroy?.();
+  }
+  return pages;
+}
+
+function channelMedian(values: number[], fallback: number): number {
+  if (!values.length) return fallback;
+  const sorted = values.sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+/** Approximate the source glyph colour before removing it. This keeps white text
+ * white on dark banners and retains coloured headings instead of forcing every
+ * translated block to black. */
+function inferTextColor(ctx: any, block: PdfTextBlock): string {
+  const canvas = ctx.canvas;
+  const margin = Math.max(4, Math.ceil(block.fontSize * 0.28));
+  const left = clamp(Math.floor(block.x - margin), 0, canvas.width - 1);
+  const top = clamp(Math.floor(block.y - margin), 0, canvas.height - 1);
+  const right = clamp(Math.ceil(block.x + block.width + margin), left + 1, canvas.width);
+  const bottom = clamp(Math.ceil(block.y + block.height + margin), top + 1, canvas.height);
+  const image = ctx.getImageData(left, top, right - left, bottom - top);
+  const { data, width, height } = image;
+  const background: number[][] = [[], [], []];
+  for (let row = 0; row < height; row += Math.max(1, Math.floor(height / 12))) {
+    for (const col of [0, Math.max(0, width - 1)]) {
+      const offset = (row * width + col) * 4;
+      for (let channel = 0; channel < 3; channel++) background[channel].push(data[offset + channel]);
+    }
+  }
+  for (let col = 0; col < width; col += Math.max(1, Math.floor(width / 20))) {
+    for (const row of [0, Math.max(0, height - 1)]) {
+      const offset = (row * width + col) * 4;
+      for (let channel = 0; channel < 3; channel++) background[channel].push(data[offset + channel]);
+    }
+  }
+  const bg = background.map((values) => channelMedian(values, 255));
+  const foreground: Array<{ rgb: [number, number, number]; distance: number }> = [];
+  for (let row = margin; row < height - margin; row += 2) {
+    for (let col = margin; col < width - margin; col += 2) {
+      const offset = (row * width + col) * 4;
+      const distance = Math.hypot(data[offset] - bg[0], data[offset + 1] - bg[1], data[offset + 2] - bg[2]);
+      if (distance < 72) continue;
+      foreground.push({ rgb: [data[offset], data[offset + 1], data[offset + 2]], distance });
+    }
+  }
+  const strongest = foreground.sort((a, b) => b.distance - a.distance).slice(0, Math.max(4, Math.ceil(foreground.length * 0.35)));
+  let rgb = foreground.length >= 4
+    ? [0, 1, 2].map((channel) => channelMedian(strongest.map((sample) => sample.rgb[channel]), bg[channel]))
+    : ((bg[0] * 0.2126 + bg[1] * 0.7152 + bg[2] * 0.0722) < 128 ? [248, 250, 252] : [17, 24, 39]);
+  const backgroundLuminance = bg[0] * 0.2126 + bg[1] * 0.7152 + bg[2] * 0.0722;
+  const foregroundLuminance = rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722;
+  if (Math.abs(backgroundLuminance - foregroundLuminance) < 70) rgb = backgroundLuminance < 128 ? [248, 250, 252] : [17, 24, 39];
+  return `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+}
+
+function eraseRegion(ctx: any, block: PdfTextBlock): void {
+  const canvas = ctx.canvas;
+  // PDF text metrics often end exactly at an antialiased glyph edge. A generous,
+  // font-relative margin prevents remnants of accents and final stems from leaking.
+  const leftMargin = Math.max(4, block.fontSize * 0.22);
+  // PDF.js widths can end before the antialiased edge of the last glyph. The
+  // asymmetric right allowance removes those characteristic stray stems while
+  // staying well inside an ordinary column gutter.
+  const rightMargin = Math.max(10, block.fontSize * 0.52);
+  const verticalMargin = Math.max(2.5, block.fontSize * 0.15);
+  const left = clamp(Math.floor(block.x - leftMargin), 0, canvas.width - 1);
+  const top = clamp(Math.floor(block.y - verticalMargin), 0, canvas.height - 1);
+  const right = clamp(Math.ceil(block.x + block.width + rightMargin), left + 1, canvas.width);
+  const bottom = clamp(Math.ceil(block.y + block.height + verticalMargin), top + 1, canvas.height);
+  const w = right - left;
+  const h = bottom - top;
+  if (w <= 0 || h <= 0) return;
+  const image = ctx.getImageData(left, top, w, h);
+  const buckets = new Map<string, { count: number; r: number; g: number; b: number }>();
+  const step = Math.max(1, Math.floor(Math.min(w, h) / 18));
+  for (let row = 0; row < h; row += step) {
+    for (let col = 0; col < w; col += step) {
+      const offset = (row * w + col) * 4;
+      const r = image.data[offset]; const g = image.data[offset + 1]; const b = image.data[offset + 2];
+      const key = `${Math.round(r / 16)},${Math.round(g / 16)},${Math.round(b / 16)}`;
+      const bucket = buckets.get(key) ?? { count: 0, r: 0, g: 0, b: 0 };
+      bucket.count += 1; bucket.r += r; bucket.g += g; bucket.b += b;
+      buckets.set(key, bucket);
+    }
+  }
+  const background = [...buckets.values()].sort((a, b) => b.count - a.count)[0] ?? { count: 1, r: 255, g: 255, b: 255 };
+  ctx.fillStyle = `rgb(${Math.round(background.r / background.count)}, ${Math.round(background.g / background.count)}, ${Math.round(background.b / background.count)})`;
+  ctx.fillRect(left, top, w, h);
+}
+
+function wordsFor(text: string): string[] {
+  const compact = text.replace(/\s+/g, ' ').trim();
+  if (/\s/.test(compact)) return compact.split(' ');
+  return [...compact];
+}
+
+function wrapText(ctx: any, text: string, width: number): string[] {
+  const words = wordsFor(text);
+  const lines: string[] = [];
+  let line = '';
+  for (const word of words) {
+    const joiner = line && /\s/.test(text) ? ' ' : '';
+    const candidate = `${line}${joiner}${word}`;
+    if (line && ctx.measureText(candidate).width > width) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = candidate;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+}
+
+function drawFitted(ctx: any, block: PdfTextBlock, text: string, color: string): { aggressive: boolean; clipped: boolean } {
+  const padding = Math.max(1.5, block.fontSize * 0.08);
+  const x = block.x + padding;
+  const y = block.y + padding;
+  const width = Math.max(8, block.width - padding * 2);
+  const height = Math.max(8, block.height - padding * 2);
+  const startSize = Math.max(7, block.fontSize * (block.label === 'TITLE' ? 0.98 : 0.9));
+  const minimum = Math.max(5.2, startSize * 0.54);
+  let size = startSize;
+  let lines: string[] = [];
+  let lineHeight = 0;
+  const weight = block.label === 'TITLE' ? '700 ' : '';
+  if (block.singleLine) {
+    const minimum = Math.max(5.2, startSize * 0.55);
+    let singleSize = startSize;
+    for (;;) {
+      ctx.font = `${weight}${singleSize}px ${block.fontFamily || 'Arial'}, Arial, sans-serif`;
+      if (ctx.measureText(text).width <= width || singleSize <= minimum) break;
+      singleSize -= 0.5;
+    }
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(block.x, block.y, block.width, block.height);
+    ctx.clip();
+    ctx.fillStyle = color;
+    ctx.textBaseline = 'top';
+    // maxWidth applies a final horizontal fit when even the minimum font is wider;
+    // this is preferable to dropping the end of a translated table or heading line.
+    ctx.fillText(text, x, y, width);
+    ctx.restore();
+    return { aggressive: singleSize < startSize * 0.72, clipped: false };
+  }
+  for (;;) {
+    ctx.font = `${weight}${size}px ${block.fontFamily || 'Arial'}, Arial, sans-serif`;
+    lineHeight = size * 1.16;
+    lines = wrapText(ctx, text, width);
+    if (lines.length * lineHeight <= height || size <= minimum) break;
+    size -= 0.5;
+  }
+  const clipped = lines.length * lineHeight > height + 0.5;
+  const maxLines = Math.max(1, Math.floor(height / lineHeight));
+  const visible = lines.slice(0, maxLines);
+  if (clipped && visible.length) {
+    let last = visible.at(-1) ?? '';
+    while (last && ctx.measureText(`${last}…`).width > width) last = last.slice(0, -1);
+    visible[visible.length - 1] = `${last}…`;
+  }
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(block.x, block.y, block.width, block.height);
+  ctx.clip();
+  ctx.fillStyle = color;
+  ctx.textBaseline = 'top';
+  visible.forEach((line, index) => ctx.fillText(line, x, y + index * lineHeight));
+  ctx.restore();
+  return { aggressive: size < startSize * 0.72, clipped };
+}
+
+export async function buildFacsimilePdf(inputPath: string, options: FacsimileOptions): Promise<FacsimileResult> {
+  const warnings: string[] = [];
+  const pages = await extractPages(inputPath, options);
+  if (options.signal?.cancelled) return { data: new Uint8Array(), pageCount: pages.length, overflowPages: [], warnings };
+  const translated = new Map<string, string>();
+  const segments = pages.flatMap((page) => page.blocks
+    .filter((block) => !block.alreadyTranslated)
+    .map((block) => ({ id: block.id, text: block.text, kind: 'plain' as const })));
+  for (const page of pages) for (const block of page.blocks) if (block.alreadyTranslated) translated.set(block.id, block.text);
+  for (const segment of await options.translate(segments)) translated.set(segment.id, segment.translated);
+  options.onProgress?.({ stage: 'translating', done: segments.length, total: segments.length });
+  const { PDFDocument } = await import('pdf-lib');
+  const output = await PDFDocument.create();
+  const overflow = new Set<number>();
+  for (const page of pages) {
+    if (options.signal?.cancelled) break;
+    const ctx = page.canvas.getContext('2d');
+    const colors = new Map(page.blocks.map((block) => [block.id, inferTextColor(ctx, block)]));
+    for (const block of page.blocks) {
+      const regions = block.eraseRegions?.length ? block.eraseRegions : [block];
+      for (const region of regions) eraseRegion(ctx, { ...block, ...region });
+    }
+    for (const block of page.blocks) {
+      const result = drawFitted(ctx, block, translated.get(block.id) ?? block.text, colors.get(block.id) ?? '#111827');
+      if (result.aggressive || result.clipped) overflow.add(page.pageNumber);
+    }
+    const jpeg = page.canvas.toBuffer('image/jpeg', 92);
+    const image = await output.embedJpg(jpeg);
+    const outPage = output.addPage([page.pageWidth, page.pageHeight]);
+    outPage.drawImage(image, { x: 0, y: 0, width: page.pageWidth, height: page.pageHeight });
+    options.onProgress?.({ stage: 'rendering', done: page.pageNumber, total: pages.length });
+  }
+  if (overflow.size) warnings.push(`Revisa las páginas ${[...overflow].join(', ')}: el texto necesitó un ajuste tipográfico intenso.`);
+  warnings.push('El facsímil conserva la apariencia mediante páginas rasterizadas: el texto deja de ser seleccionable y los enlaces o formularios pueden no seguir siendo interactivos.');
+  if (options.translateImageText) warnings.push('El modo de texto en imágenes usa análisis visual de página completa y puede modificar rótulos integrados en gráficos.');
+  return {
+    data: await output.save(),
+    pageCount: pages.length,
+    overflowPages: [...overflow],
+    warnings,
+  };
+}
+
+/** Extract a clean, role-aware Markdown representation for reflow exports. */
+export async function extractPdfMarkdown(inputPath: string, signal?: FacsimileSignal, onPage?: (done: number, total: number) => void): Promise<string> {
+  const pdf = await openPdf(inputPath);
+  const parts: string[] = [];
+  try {
+    for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+      if (signal?.cancelled) break;
+      const page = await pdf.getPage(pageNumber);
+      try {
+        const viewport = page.getViewport({ scale: RENDER_SCALE });
+        const lines = groupDigitalLines(await page.getTextContent(), viewport, pageNumber);
+        const blocks = groupParagraphs(lines, pageNumber);
+        for (const block of blocks) {
+          if (block.label === 'HEADER' || block.label === 'FOOTER') parts.push(`> ${block.text}`);
+          else if (block.label === 'TITLE') parts.push(`## ${block.text}`);
+          else if (block.label === 'FOOTNOTE') parts.push(`[^p${pageNumber}]: ${block.text}`);
+          else parts.push(block.text);
+        }
+        if (pageNumber < pdf.numPages) parts.push('---');
+        onPage?.(pageNumber, pdf.numPages);
+      } finally {
+        page.cleanup?.();
+      }
+    }
+  } finally {
+    await pdf.destroy?.();
+  }
+  return parts.join('\n\n').trim();
+}

--- a/electron/toolkit/translate/history.ts
+++ b/electron/toolkit/translate/history.ts
@@ -1,0 +1,93 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import type { ModelRef } from '@shared/types';
+import type {
+  TranslateHistoryEntry,
+  TranslateInputKind,
+  TranslateOutputFormat,
+  TranslatePdfMode,
+} from '@shared/toolkitTranslateTypes';
+
+const MAX_HISTORY_ENTRIES = 250;
+
+type StoredTranslateHistoryEntry = Omit<TranslateHistoryEntry, 'outputExists'>;
+
+export interface AddTranslateHistoryInput {
+  inputKind: TranslateInputKind;
+  sourceLabel: string;
+  sourcePath: string | null;
+  targetLanguage: string;
+  targetLanguageLabel: string;
+  model: ModelRef;
+  pdfMode: TranslatePdfMode | null;
+  outputPath: string | null;
+  format: Exclude<TranslateOutputFormat, 'same'> | null;
+  pageCount?: number;
+  overflowPages?: number[];
+  warnings?: string[];
+  translatedText?: string | null;
+}
+
+function historyFile(baseDir?: string): string {
+  const root = baseDir ?? app.getPath('userData');
+  return path.join(root, 'toolkit', 'translate', 'history.json');
+}
+
+function readStored(baseDir?: string): StoredTranslateHistoryEntry[] {
+  const file = historyFile(baseDir);
+  if (!fs.existsSync(file)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return Array.isArray(parsed) ? parsed.filter((entry) => entry && typeof entry.id === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStored(entries: StoredTranslateHistoryEntry[], baseDir?: string): void {
+  const file = historyFile(baseDir);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const temporary = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(entries.slice(0, MAX_HISTORY_ENTRIES), null, 2)}\n`, 'utf8');
+  fs.renameSync(temporary, file);
+}
+
+function hydrate(entry: StoredTranslateHistoryEntry): TranslateHistoryEntry {
+  return {
+    ...entry,
+    outputExists: Boolean(entry.outputPath && fs.existsSync(entry.outputPath)),
+  };
+}
+
+export function listTranslateHistory(baseDir?: string): TranslateHistoryEntry[] {
+  return readStored(baseDir).map(hydrate);
+}
+
+export function addTranslateHistory(input: AddTranslateHistoryInput, baseDir?: string): TranslateHistoryEntry {
+  const entry: StoredTranslateHistoryEntry = {
+    id: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+    inputKind: input.inputKind,
+    sourceLabel: input.sourceLabel,
+    sourcePath: input.sourcePath,
+    targetLanguage: input.targetLanguage,
+    targetLanguageLabel: input.targetLanguageLabel,
+    model: input.model,
+    pdfMode: input.pdfMode,
+    outputPath: input.outputPath,
+    format: input.format,
+    pageCount: input.pageCount,
+    overflowPages: input.overflowPages ?? [],
+    warnings: input.warnings ?? [],
+    translatedText: input.translatedText ?? null,
+  };
+  writeStored([entry, ...readStored(baseDir)], baseDir);
+  return hydrate(entry);
+}
+
+export function removeTranslateHistory(id: string, baseDir?: string): TranslateHistoryEntry[] {
+  writeStored(readStored(baseDir).filter((entry) => entry.id !== id), baseDir);
+  return listTranslateHistory(baseDir);
+}

--- a/electron/toolkit/translate/index.ts
+++ b/electron/toolkit/translate/index.ts
@@ -1,0 +1,388 @@
+// Nodus Translate — Electron/main-process orchestration.
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import AdmZip from 'adm-zip';
+import { app } from 'electron';
+import { completeJson, completeTextNeutral } from '../../ai/aiClient';
+import { getSettings } from '../../db/settingsRepo';
+import { htmlToPdfBytes } from '../../export/htmlToPdf';
+import * as zotero from '../../zotero/zoteroClient';
+import { markdownToHtml, escapeHtml } from '@shared/toolkitMarkdown';
+import { TRANSLATION_LANGUAGES, type ModelRef } from '@shared/types';
+import type {
+  TranslateJobProgress,
+  TranslateJobRequest,
+  TranslateJobResult,
+  TranslateOutputFormat,
+  TranslateOutputResult,
+  TranslateSegment,
+  TranslateSegmentResult,
+} from '@shared/toolkitTranslateTypes';
+import { DEFAULT_OCR_OPTIONS, type OcrPageResult } from '@shared/aiOcrTypes';
+import { ocrPageImage, type OcrModelCall } from '../aiOcr/engine';
+import { rasterizePdf } from '../aiOcr/rasterize';
+import { pageToMarkdown } from '@shared/aiOcrReconstruct';
+import { buildFacsimilePdf, extractPdfMarkdown } from './facsimile';
+import {
+  translateDocxBytes,
+  translateEpubBytes,
+  translateHtmlDocument,
+  translateMarkdownDocument,
+  translatePlainDocument,
+  type StructuredTranslateOptions,
+} from './documents';
+import { translateSegments } from './segments';
+import { addTranslateHistory } from './history';
+
+export interface TranslateSignal { cancelled: boolean }
+
+export interface RunTranslateOptions {
+  signal?: TranslateSignal;
+  onProgress?: (progress: TranslateJobProgress) => void;
+}
+
+interface TranslatedFile {
+  data: Uint8Array;
+  ext: Exclude<TranslateOutputFormat, 'same'>;
+  pageCount?: number;
+  overflowPages: number[];
+  warnings: string[];
+}
+
+const ACCEPTED_EXTENSIONS = new Set(['.txt', '.md', '.markdown', '.html', '.htm', '.docx', '.epub', '.pdf']);
+
+function resolveModel(explicit: ModelRef | null): ModelRef {
+  if (explicit?.provider && explicit.model) return explicit;
+  const settings = getSettings();
+  const fallback = settings.synthesisModel;
+  if (fallback?.provider && fallback.model) return fallback;
+  if (process.env.NODUS_E2E_TRANSLATE_FAKE === '1') return { provider: 'lmstudio', model: 'nodus-e2e-translate' };
+  throw new Error('No hay un modelo de traducción configurado. Elige un modelo antes de continuar.');
+}
+
+function fakeTranslateResponse(user: string): string {
+  // Deterministic offline translation for the E2E harness only. Sentinels and markup
+  // remain untouched so the test exercises the exact production parser and adapters.
+  return user
+    .replace(/Título Principal/g, 'Main Title')
+    .replace(/Titulo Principal/g, 'Main Title')
+    .replace(/Introducción/g, 'Introduction')
+    .replace(/Introduccion/g, 'Introduction')
+    .replace(/Este es un documento de prueba\./g, 'This is a test document.')
+    .replace(/Un párrafo con texto para traducir\./g, 'A paragraph with text to translate.')
+    .replace(/Un parrafo con texto para traducir\./g, 'A paragraph with text to translate.')
+    .replace(/Página/g, 'Page')
+    .replace(/Pagina/g, 'Page');
+}
+
+function printableHtml(body: string, title: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title><style>
+    @page { size: A4; margin: 18mm 18mm 20mm; }
+    body { margin: 0; color: #171717; font: 11.5pt/1.55 Georgia, 'Times New Roman', serif; }
+    h1,h2,h3,h4,h5,h6 { break-after: avoid; color: #111827; font-family: Arial, sans-serif; line-height: 1.2; }
+    h1 { font-size: 24pt; } h2 { font-size: 18pt; } h3 { font-size: 14pt; }
+    p, li, blockquote { orphans: 3; widows: 3; }
+    img, svg { max-width: 100%; height: auto; break-inside: avoid; }
+    table { width: 100%; border-collapse: collapse; break-inside: avoid; }
+    th, td { border: 1px solid #aaa; padding: 5px 7px; vertical-align: top; }
+    blockquote { margin-left: 0; padding-left: 12px; border-left: 3px solid #cbd5e1; color: #475569; }
+    code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+  </style></head><body>${body}</body></html>`;
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|section|h[1-6]|li|tr|blockquote)>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function epubHtml(bytes: Uint8Array): string {
+  const zip = new AdmZip(Buffer.from(bytes));
+  return zip.getEntries()
+    .filter((entry) => !entry.isDirectory && /\.(xhtml|html?)$/i.test(entry.entryName))
+    .map((entry) => entry.getData().toString('utf8').replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, ''))
+    .join('\n<hr>\n');
+}
+
+function safeStem(filePath: string): string {
+  return path.basename(filePath, path.extname(filePath)).replace(/[\\/:*?"<>|]/g, '_').trim() || 'documento';
+}
+
+function targetPath(sourcePath: string, outputDir: string, targetLanguage: string, ext: string): string {
+  const base = `${safeStem(sourcePath)} (${targetLanguage})`;
+  let candidate = path.join(outputDir, `${base}.${ext}`);
+  let index = 2;
+  while (fs.existsSync(candidate)) candidate = path.join(outputDir, `${base} (${index++}).${ext}`);
+  return candidate;
+}
+
+function writeAtomic(target: string, data: Uint8Array): void {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const temp = `${target}.tmp-${crypto.randomBytes(5).toString('hex')}`;
+  try {
+    fs.writeFileSync(temp, data);
+    fs.renameSync(temp, target);
+  } catch (error) {
+    try { fs.rmSync(temp, { force: true }); } catch { /* best effort */ }
+    throw error;
+  }
+}
+
+async function resolveInputs(request: TranslateJobRequest): Promise<string[]> {
+  if (request.inputKind === 'files') return [...new Set(request.inputPaths ?? [])];
+  if (request.inputKind !== 'zotero' || !request.zotero) return [];
+  const source = request.zotero;
+  const file = await zotero.attachmentFilePath(getSettings().zoteroUserId, source.attachmentKey);
+  if (!file) throw new Error('Zotero no devolvió una ruta local para el adjunto seleccionado. Comprueba que el archivo esté descargado.');
+  return [file];
+}
+
+function translatedExt(sourceExt: string, requested: TranslateOutputFormat, pdfMode: TranslateJobRequest['pdfMode']): Exclude<TranslateOutputFormat, 'same'> {
+  if (requested !== 'same') return requested;
+  if (sourceExt === '.markdown') return 'md';
+  if (sourceExt === '.htm') return 'html';
+  if (sourceExt === '.pdf' && pdfMode === 'reflow') return 'pdf';
+  return sourceExt.slice(1) as Exclude<TranslateOutputFormat, 'same'>;
+}
+
+async function translatedDocxConversions(bytes: Uint8Array, ext: Exclude<TranslateOutputFormat, 'same'>, title: string): Promise<Uint8Array> {
+  if (ext === 'docx') return bytes;
+  const mammoth: any = await import('mammoth');
+  if (ext === 'txt') return new TextEncoder().encode(String((await mammoth.extractRawText({ buffer: Buffer.from(bytes) })).value ?? ''));
+  const html = String((await mammoth.convertToHtml({ buffer: Buffer.from(bytes) })).value ?? '');
+  if (ext === 'html') return new TextEncoder().encode(printableHtml(html, title));
+  if (ext === 'md') return new TextEncoder().encode(stripHtml(html));
+  if (ext === 'pdf') return new Uint8Array(await htmlToPdfBytes(printableHtml(html, title)));
+  throw new Error(`No se puede exportar un DOCX traducido como .${ext}.`);
+}
+
+async function translatedEpubConversions(bytes: Uint8Array, ext: Exclude<TranslateOutputFormat, 'same'>, title: string): Promise<Uint8Array> {
+  if (ext === 'epub') return bytes;
+  const html = epubHtml(bytes);
+  if (ext === 'html') return new TextEncoder().encode(printableHtml(html, title));
+  if (ext === 'txt' || ext === 'md') return new TextEncoder().encode(stripHtml(html));
+  if (ext === 'pdf') return new Uint8Array(await htmlToPdfBytes(printableHtml(html, title)));
+  throw new Error(`No se puede exportar un EPUB traducido como .${ext}.`);
+}
+
+async function translatedTextConversions(
+  translated: string,
+  sourceKind: 'plain' | 'markdown' | 'html',
+  ext: Exclude<TranslateOutputFormat, 'same'>,
+  title: string,
+): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  if (ext === 'txt') return enc.encode(sourceKind === 'html' ? stripHtml(translated) : translated);
+  if (ext === 'md') return enc.encode(sourceKind === 'html' ? stripHtml(translated) : translated);
+  if (sourceKind === 'html' && ext === 'html') return enc.encode(translated);
+  if (sourceKind === 'html' && ext === 'pdf') return new Uint8Array(await htmlToPdfBytes(translated));
+  const body = sourceKind === 'html' ? translated : sourceKind === 'markdown' ? markdownToHtml(translated) : `<p>${escapeHtml(translated).replace(/\n{2,}/g, '</p><p>').replace(/\n/g, '<br>')}</p>`;
+  if (ext === 'html') return enc.encode(printableHtml(body, title));
+  if (ext === 'pdf') return new Uint8Array(await htmlToPdfBytes(printableHtml(body, title)));
+  throw new Error(`La conversión de texto traducido a .${ext} no está disponible.`);
+}
+
+async function translateFile(
+  inputPath: string,
+  request: TranslateJobRequest,
+  structured: StructuredTranslateOptions,
+  translate: (segments: TranslateSegment[]) => Promise<TranslateSegmentResult[]>,
+  vision: (page: { buffer: Buffer; mediaType: string; width: number; height: number; pageNumber: number }) => Promise<OcrPageResult>,
+  signal: TranslateSignal,
+  onStage: (stage: TranslateJobProgress['stage'], done?: number, total?: number) => void,
+): Promise<TranslatedFile> {
+  const sourceExt = path.extname(inputPath).toLowerCase();
+  if (!ACCEPTED_EXTENSIONS.has(sourceExt)) throw new Error(`Formato no compatible: ${sourceExt || '(sin extensión)'}.`);
+  const ext = translatedExt(sourceExt, request.outputFormat, request.pdfMode);
+  const title = safeStem(inputPath);
+  const bytes = new Uint8Array(fs.readFileSync(inputPath));
+  const warnings: string[] = [];
+  const withWarning = { ...structured, onWarning: (message: string) => { warnings.push(message); structured.onWarning?.(message); } };
+
+  if (sourceExt === '.pdf' && request.pdfMode === 'facsimile') {
+    if (ext !== 'pdf') throw new Error('El modo facsímil solo puede exportarse como PDF.');
+    const result = await buildFacsimilePdf(inputPath, {
+      translate,
+      translatePageImage: vision,
+      translateImageText: request.translateImageText,
+      signal,
+      onProgress: (progress) => onStage(progress.stage, progress.done, progress.total),
+    });
+    return { data: result.data, ext, pageCount: result.pageCount, overflowPages: result.overflowPages, warnings: [...warnings, ...result.warnings] };
+  }
+
+  onStage('extracting');
+  if (sourceExt === '.docx') {
+    const translated = await translateDocxBytes(bytes, withWarning);
+    return { data: await translatedDocxConversions(translated, ext, title), ext, overflowPages: [], warnings };
+  }
+  if (sourceExt === '.epub') {
+    const translated = await translateEpubBytes(bytes, withWarning);
+    return { data: await translatedEpubConversions(translated, ext, title), ext, overflowPages: [], warnings };
+  }
+  if (sourceExt === '.pdf') {
+    let markdown = request.translateImageText ? '' : await extractPdfMarkdown(inputPath, signal, (done, total) => onStage('extracting', done, total));
+    let alreadyTranslated = false;
+    if (!markdown.trim()) {
+      const pages = await rasterizePdf(inputPath, {}, undefined, signal);
+      const translatedPages: string[] = [];
+      for (let index = 0; index < pages.length; index++) {
+        if (signal.cancelled) break;
+        translatedPages.push(pageToMarkdown(await vision(pages[index])));
+        onStage('translating', index + 1, pages.length);
+      }
+      markdown = translatedPages.join('\n\n---\n\n');
+      alreadyTranslated = true;
+    }
+    if (!markdown.trim()) throw new Error('No se pudo obtener texto traducible del PDF. Prueba con otro modelo de visión.');
+    const translated = alreadyTranslated ? markdown : await translateMarkdownDocument(markdown, withWarning);
+    return { data: await translatedTextConversions(translated, 'markdown', ext, title), ext, overflowPages: [], warnings: [...warnings, 'El modo refluido conserva la jerarquía textual, pero puede cambiar los saltos de página del PDF original.'] };
+  }
+  const raw = Buffer.from(bytes).toString('utf8');
+  if (sourceExt === '.html' || sourceExt === '.htm') {
+    const translated = await translateHtmlDocument(raw, withWarning);
+    return { data: await translatedTextConversions(translated, 'html', ext, title), ext, overflowPages: [], warnings };
+  }
+  if (sourceExt === '.md' || sourceExt === '.markdown') {
+    const translated = await translateMarkdownDocument(raw, withWarning);
+    return { data: await translatedTextConversions(translated, 'markdown', ext, title), ext, overflowPages: [], warnings };
+  }
+  const translated = await translatePlainDocument(raw, withWarning);
+  return { data: await translatedTextConversions(translated, 'plain', ext, title), ext, overflowPages: [], warnings };
+}
+
+export async function runTranslateJob(jobId: string, request: TranslateJobRequest, options: RunTranslateOptions = {}): Promise<TranslateJobResult> {
+  const signal = options.signal ?? { cancelled: false };
+  const language = TRANSLATION_LANGUAGES.find((item) => item.code === request.targetLanguage);
+  if (!language) throw new Error(`Idioma de destino no soportado: ${request.targetLanguage}.`);
+  const model = resolveModel(request.model);
+  let currentFile: string | null = null;
+  let fileIndex = 0;
+  let fileTotal = request.inputKind === 'text' ? 1 : Math.max(1, request.inputPaths?.length ?? 1);
+  let lastPct = 0;
+  const emit = (stage: TranslateJobProgress['stage'], pct: number, message: string, done = 0, total = 0) => {
+    lastPct = Math.max(lastPct, clampProgress(pct));
+    options.onProgress?.({ jobId, stage, currentFile, fileIndex, fileTotal, unitDone: done, unitTotal: total, pct: lastPct, message, cancelled: signal.cancelled });
+  };
+  emit('resolving', 0.01, 'Preparando las fuentes…');
+
+  const modelCall = async (input: { system: string; user: string; maxTokens: number; temperature: number }): Promise<string> => {
+    if (signal.cancelled) return input.user;
+    if (process.env.NODUS_E2E_TRANSLATE_FAKE === '1') return fakeTranslateResponse(input.user);
+    return completeTextNeutral({ ...input, plainContext: true }, model);
+  };
+  const translateWithProgress = async (
+    segments: TranslateSegment[],
+    onBatchProgress: (done: number, total: number) => void,
+  ): Promise<TranslateSegmentResult[]> => {
+    if (!segments.length) return [];
+    return translateSegments(segments, {
+      targetLanguage: `${language.name} (${language.nativeName})`,
+      sourceLanguage: request.sourceLanguage,
+      glossary: request.glossary,
+      signal,
+      onProgress: onBatchProgress,
+    }, modelCall);
+  };
+  const visionCall: OcrModelCall = {
+    completeJson: (input, guard, chosen) => completeJson(input, guard, chosen),
+    completeText: (input, chosen) => completeTextNeutral(input, chosen),
+  };
+  const vision = async (page: { buffer: Buffer; mediaType: string; width: number; height: number; pageNumber: number }): Promise<OcrPageResult> => {
+    if (process.env.NODUS_E2E_TRANSLATE_FAKE === '1') return { blankPage: false, blocks: [] };
+    const outcome = await ocrPageImage(
+      { base64: page.buffer.toString('base64'), mediaType: page.mediaType },
+      { ...DEFAULT_OCR_OPTIONS, processingMode: 'translation', targetLanguage: `${language.name} (${language.nativeName})`, removeReferences: false },
+      model,
+      visionCall,
+    );
+    return outcome.result;
+  };
+  if (request.inputKind === 'text') {
+    const source = request.text?.trim() ?? '';
+    if (!source) throw new Error('Escribe o pega un texto antes de traducir.');
+    currentFile = 'Texto';
+    emit('translating', 0.1, 'Traduciendo el texto…');
+    const translateText = (segments: TranslateSegment[]) => translateWithProgress(segments, (done, total) =>
+      emit('translating', 0.22 + 0.54 * (done / Math.max(1, total)), `Traduciendo ${done} de ${total} fragmentos…`, done, total));
+    const translatedText = await translateMarkdownDocument(source, { translate: translateText });
+    if (!signal.cancelled) {
+      addTranslateHistory({
+        inputKind: 'text', sourceLabel: 'Texto pegado', sourcePath: null,
+        targetLanguage: language.code, targetLanguageLabel: language.nativeName,
+        model, pdfMode: null, outputPath: null, format: 'txt', translatedText,
+      });
+    }
+    emit('done', 1, 'Traducción completada.');
+    return { jobId, cancelled: signal.cancelled, translatedText: signal.cancelled ? null : translatedText, outputs: [], warnings: [] };
+  }
+
+  const inputs = await resolveInputs(request);
+  if (!inputs.length) throw new Error('Añade al menos un archivo para traducir.');
+  fileTotal = inputs.length;
+  const outputs: TranslateOutputResult[] = [];
+  const warnings: string[] = [];
+  for (let index = 0; index < inputs.length; index++) {
+    if (signal.cancelled) break;
+    fileIndex = index + 1;
+    currentFile = path.basename(inputs[index]);
+    const fileBase = index / inputs.length;
+    const fileWeight = 1 / inputs.length;
+    const onStage = (stage: TranslateJobProgress['stage'], done = 0, total = 0) => {
+      const stageFraction = stage === 'extracting' ? 0.12 : stage === 'translating' ? 0.55 : stage === 'rendering' ? 0.82 : 0.9;
+      const unit = total > 0 ? Math.min(1, done / total) * 0.12 : 0;
+      emit(stage, fileBase + fileWeight * Math.min(0.94, stageFraction + unit), `${currentFile}: ${stage === 'extracting' ? 'analizando' : stage === 'rendering' ? 'reconstruyendo' : 'traduciendo'}…`, done, total);
+    };
+    const translateFileSegments = (segments: TranslateSegment[]) => translateWithProgress(segments, (done, total) => onStage('translating', done, total));
+    const translated = await translateFile(inputs[index], request, { translate: translateFileSegments }, translateFileSegments, vision, signal, onStage);
+    if (signal.cancelled) break;
+    emit('writing', fileBase + fileWeight * 0.96, `${currentFile}: guardando…`);
+    const outputDir = request.outputDir || (request.inputKind === 'zotero' ? app.getPath('downloads') : path.dirname(inputs[index]));
+    const outputPath = targetPath(inputs[index], outputDir, language.nativeName, translated.ext);
+    writeAtomic(outputPath, translated.data);
+    outputs.push({ sourcePath: inputs[index], outputPath, format: translated.ext, pageCount: translated.pageCount, overflowPages: translated.overflowPages, warnings: translated.warnings });
+    addTranslateHistory({
+      inputKind: request.inputKind,
+      sourceLabel: request.inputKind === 'zotero' ? request.zotero?.title || currentFile : currentFile,
+      sourcePath: inputs[index],
+      targetLanguage: language.code,
+      targetLanguageLabel: language.nativeName,
+      model,
+      pdfMode: path.extname(inputs[index]).toLowerCase() === '.pdf' && translated.ext === 'pdf' ? request.pdfMode : null,
+      outputPath,
+      format: translated.ext,
+      pageCount: translated.pageCount,
+      overflowPages: translated.overflowPages,
+      warnings: translated.warnings,
+    });
+    warnings.push(...translated.warnings.map((warning) => `${path.basename(inputs[index])}: ${warning}`));
+  }
+  emit('done', 1, signal.cancelled ? 'Trabajo cancelado.' : 'Traducción completada.');
+  return { jobId, cancelled: signal.cancelled, translatedText: null, outputs, warnings };
+}
+
+function clampProgress(value: number): number {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+export const TRANSLATE_INPUT_EXTENSIONS = ['txt', 'md', 'markdown', 'html', 'htm', 'docx', 'epub', 'pdf'] as const;
+
+export function suggestedTextFilename(targetLanguage: string, ext = 'txt'): string {
+  const safe = targetLanguage.replace(/[\\/:*?"<>|]/g, '_').trim() || 'traduccion';
+  return `traduccion-${safe}.${ext}`;
+}
+
+export function tempTranslatePath(ext: string): string {
+  return path.join(os.tmpdir(), `nodus-translate-${crypto.randomUUID()}.${ext.replace(/^\./, '')}`);
+}

--- a/electron/toolkit/translate/segments.ts
+++ b/electron/toolkit/translate/segments.ts
@@ -1,0 +1,143 @@
+// Nodus Translate — structure-preserving segment batching.
+//
+// A document is decomposed into stable-id segments by its format adapter. The model
+// sees several segments at once for efficiency and terminology consistency, while the
+// sentinel protocol lets us prove that every source segment came back exactly once.
+// Missing/mangled segments are retried individually; the pipeline never silently drops
+// document content because a model forgot a marker.
+import type {
+  TranslateMarkupKind,
+  TranslateSegment,
+  TranslateSegmentResult,
+} from '@shared/toolkitTranslateTypes';
+
+export interface SegmentTranslationCall {
+  (input: { system: string; user: string; maxTokens: number; temperature: number }): Promise<string>;
+}
+
+export interface SegmentTranslationOptions {
+  targetLanguage: string;
+  sourceLanguage?: string | null;
+  glossary?: string;
+  maxChars?: number;
+  signal?: { cancelled: boolean };
+  onProgress?: (done: number, total: number) => void;
+}
+
+const DEFAULT_BATCH_CHARS = 7_500;
+const OPEN = '<<<NODUS_SEGMENT:';
+const CLOSE = '<<<NODUS_END:';
+
+function formatRules(kind: TranslateMarkupKind): string {
+  switch (kind) {
+    case 'markdown':
+      return 'Preserve every Markdown marker, heading level, list marker, table pipe, URL, code span and math expression. Translate only human-readable prose.';
+    case 'html':
+      return 'Preserve every HTML/XML tag, attribute, entity, URL and element order byte-for-byte where possible. Translate only visible human-readable text between tags.';
+    case 'xml':
+      return 'Preserve every <n id="…"> and </n> tag with the same id and nesting. Translate only the human-readable text inside those tags.';
+    default:
+      return 'Return faithful translated prose. Preserve numbers, citation keys, URLs, code and mathematical notation.';
+  }
+}
+
+function systemPrompt(segments: TranslateSegment[], options: SegmentTranslationOptions): string {
+  const kinds = [...new Set(segments.map((segment) => segment.kind))];
+  const source = options.sourceLanguage?.trim()
+    ? `The source language is ${options.sourceLanguage.trim()}.`
+    : 'Detect the source language independently for each segment.';
+  const glossary = options.glossary?.trim()
+    ? `\nMANDATORY GLOSSARY (source=target, one entry per line):\n${options.glossary.trim()}\n`
+    : '';
+  return `You are an expert academic and publishing translator. Translate every supplied segment into ${options.targetLanguage}.
+
+${source}
+Return ONLY the sentinel-delimited segments, in the same order, with every id exactly once.
+Never translate, remove or alter a sentinel line.
+Do not summarize, explain, add or omit content.
+Keep terminology consistent across all segments in this request.
+${kinds.map(formatRules).join('\n')}${glossary}`;
+}
+
+function encodeSegment(segment: TranslateSegment): string {
+  return `${OPEN}${segment.id}>>>\n${segment.text}\n${CLOSE}${segment.id}>>>`;
+}
+
+export function parseTranslatedSegments(output: string): Map<string, string> {
+  const parsed = new Map<string, string>();
+  const pattern = /<<<NODUS_SEGMENT:([^>\r\n]+)>>>(?:\r?\n)?([\s\S]*?)(?:\r?\n)?<<<NODUS_END:\1>>>/g;
+  for (const match of output.matchAll(pattern)) {
+    const id = match[1].trim();
+    if (id && !parsed.has(id)) parsed.set(id, match[2].trim());
+  }
+  return parsed;
+}
+
+function batchesFor(segments: TranslateSegment[], maxChars: number): TranslateSegment[][] {
+  const batches: TranslateSegment[][] = [];
+  let current: TranslateSegment[] = [];
+  let chars = 0;
+  for (const segment of segments) {
+    const cost = segment.text.length + segment.id.length * 2 + 64;
+    if (current.length && chars + cost > maxChars) {
+      batches.push(current);
+      current = [];
+      chars = 0;
+    }
+    current.push(segment);
+    chars += cost;
+  }
+  if (current.length) batches.push(current);
+  return batches;
+}
+
+async function translateBatch(
+  batch: TranslateSegment[],
+  options: SegmentTranslationOptions,
+  call: SegmentTranslationCall,
+): Promise<Map<string, string>> {
+  const output = await call({
+    system: systemPrompt(batch, options),
+    user: batch.map(encodeSegment).join('\n\n'),
+    maxTokens: Math.max(1_500, Math.min(12_000, Math.ceil(batch.reduce((n, s) => n + s.text.length, 0) / 2.2))),
+    temperature: 0.15,
+  });
+  return parseTranslatedSegments(output);
+}
+
+/** Translate every segment without accepting silent loss. A malformed batch response
+ * gets one isolated retry per missing id, producing a precise error if the chosen model
+ * cannot obey the protocol even for a single segment. */
+export async function translateSegments(
+  segments: TranslateSegment[],
+  options: SegmentTranslationOptions,
+  call: SegmentTranslationCall,
+): Promise<TranslateSegmentResult[]> {
+  const nonEmpty = segments.filter((segment) => segment.text.trim());
+  const translated = new Map<string, string>();
+  const batches = batchesFor(nonEmpty, Math.max(1_000, options.maxChars ?? DEFAULT_BATCH_CHARS));
+  options.onProgress?.(0, nonEmpty.length);
+  let done = 0;
+  for (const batch of batches) {
+    if (options.signal?.cancelled) break;
+    const parsed = await translateBatch(batch, options, call);
+    for (const segment of batch) {
+      if (options.signal?.cancelled) break;
+      let value = parsed.get(segment.id);
+      if (value == null) {
+        const retry = await translateBatch([segment], options, call);
+        value = retry.get(segment.id);
+      }
+      if (value == null) {
+        throw new Error(`El modelo no devolvió el fragmento ${segment.id}. Prueba con otro modelo o reduce el documento.`);
+      }
+      translated.set(segment.id, value);
+      done += 1;
+      options.onProgress?.(done, nonEmpty.length);
+    }
+  }
+  return segments.map((segment) => ({
+    ...segment,
+    translated: segment.text.trim() ? (translated.get(segment.id) ?? segment.text) : segment.text,
+  }));
+}

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -7,14 +7,17 @@
 // Requires a build (dist/ + dist-electron/); run via `npm run test:e2e`.
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { once } from 'node:events';
 import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, rm, readFile, readdir, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { _electron as electron } from 'playwright-core';
 import { WebSocket } from 'ws';
+import { buildTextPdf } from './toolkit-fixtures.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
@@ -36,6 +39,44 @@ if (!existsSync(path.join(repoRoot, 'dist-electron/main.js')) || !existsSync(pat
   console.log('[e2e] no build found — running npm run build first…');
   execFileSync('npm', ['run', 'build'], { cwd: repoRoot, stdio: 'inherit' });
 }
+
+const zoteroApiServer = createServer((request, response) => {
+  const pathname = new URL(request.url || '/', 'http://127.0.0.1').pathname;
+  response.setHeader('Content-Type', 'application/json');
+  response.setHeader('Last-Modified-Version', '7');
+  if (pathname.endsWith('/groups')) {
+    response.end('[]');
+    return;
+  }
+  if (pathname.endsWith('/items/top')) {
+    response.setHeader('Total-Results', '1');
+    response.end(JSON.stringify([{ key: 'ITEM1', version: 7, data: {
+      key: 'ITEM1', version: 7, itemType: 'journalArticle', title: 'Smoke Research Paper',
+      date: '2025', creators: [{ creatorType: 'author', firstName: 'Ada', lastName: 'Lovelace' }],
+      tags: [], collections: [],
+    } }]));
+    return;
+  }
+  if (pathname.endsWith('/items/ITEM1/children')) {
+    response.end(JSON.stringify([{ key: 'ATT1', version: 7, data: {
+      key: 'ATT1', version: 7, itemType: 'attachment', parentItem: 'ITEM1', title: 'Full text PDF',
+      contentType: 'application/pdf', linkMode: 'imported_file', filename: 'smoke-paper.pdf',
+    } }]));
+    return;
+  }
+  if (pathname.endsWith('/items')) {
+    response.setHeader('Total-Results', '1');
+    response.end(JSON.stringify([{ key: 'ITEM1', version: 7, data: { key: 'ITEM1', itemType: 'journalArticle', title: 'Smoke Research Paper' } }]));
+    return;
+  }
+  response.statusCode = 404;
+  response.end('{"error":"not found"}');
+});
+zoteroApiServer.listen(0, '127.0.0.1');
+await once(zoteroApiServer, 'listening');
+const zoteroAddress = zoteroApiServer.address();
+assert.ok(zoteroAddress && typeof zoteroAddress !== 'string');
+const zoteroApiBase = `http://127.0.0.1:${zoteroAddress.port}/api`;
 
 const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-e2e-'));
 const fakeWhisperPath = path.join(userData, 'fake-whisper-cli.mjs');
@@ -92,6 +133,8 @@ try {
     NODUS_E2E_UPDATE_STATUS: 'not-available',
     NODUS_E2E_DISABLE_STUDY_BACKGROUND_AI: '1',
     NODUS_E2E_FORCE_STUDY_AI_FAILURE: '1',
+    NODUS_E2E_TRANSLATE_FAKE: '1',
+    NODUS_ZOTERO_API_BASE: zoteroApiBase,
   };
   delete childEnv.ELECTRON_RUN_AS_NODE;
   const packagedExecutable = process.env.NODUS_E2E_EXECUTABLE;
@@ -110,7 +153,10 @@ try {
   const page = await app.firstWindow();
   page.setDefaultTimeout(30_000);
   const pageErrors = [];
-  page.on('pageerror', (err) => pageErrors.push(err));
+  page.on('pageerror', (err) => {
+    pageErrors.push(err);
+    process.stderr.write(`[e2e][pageerror] ${err?.stack ?? err}\n`);
+  });
   await page.waitForLoadState('domcontentloaded');
   await page.waitForFunction(() => {
     const root = document.getElementById('root');
@@ -774,7 +820,7 @@ try {
   // measured on the real rendered shell rather than trusted from the classes.
   await page.locator('[data-tour="toolkit"]').click();
   await page.getByTestId('toolkit-home').waitFor({ timeout: 30_000 });
-  const toolCards = ['toolkit-card-apps', 'toolkit-card-convert', 'toolkit-card-protect', 'toolkit-card-presenter', 'toolkit-card-aiocr'];
+  const toolCards = ['toolkit-card-apps', 'toolkit-card-convert', 'toolkit-card-protect', 'toolkit-card-translate', 'toolkit-card-presenter', 'toolkit-card-aiocr'];
   const cardBoxes = [];
   for (const testId of toolCards) {
     const box = await page.getByTestId(testId).boundingBox();
@@ -1007,6 +1053,73 @@ try {
   await page.getByTestId('aiocr-home').waitFor({ timeout: 10_000 });
   await page.getByTestId('toolkit-aiocr-back').click();
   await page.getByTestId('toolkit-home').waitFor();
+  // Nodus Translate: run a pasted-text translation through the real renderer →
+  // preload → IPC → segment protocol path. The E2E-only model is deterministic and
+  // offline, so this never needs a personal provider key.
+  const e2eTranslateModel = { provider: 'lmstudio', model: 'nodus-e2e-translate' };
+  await page.evaluate((model) => window.nodus.updateSettings({ synthesisModel: model, favorites: [model] }), e2eTranslateModel);
+  await page.getByTestId('toolkit-card-translate').click();
+  await page.getByTestId('translate-home').waitFor({ timeout: 10_000 });
+  const translatePaneLayout = await page.evaluate(() => {
+    const source = document.querySelector('[data-testid="translate-source-text"]')?.getBoundingClientRect();
+    const result = document.querySelector('[data-testid="translate-result-text"]')?.getBoundingClientRect();
+    return source && result ? { sourceWidth: source.width, resultWidth: result.width, gap: result.left - source.right } : null;
+  });
+  assert.ok(translatePaneLayout, 'both translation panes are rendered');
+  assert.ok(Math.abs(translatePaneLayout.sourceWidth - translatePaneLayout.resultWidth) <= 2, `source and result panes have equal widths (${translatePaneLayout.sourceWidth}/${translatePaneLayout.resultWidth})`);
+  assert.ok(translatePaneLayout.gap >= 20, `translation panes keep a visible gutter (${translatePaneLayout.gap}px)`);
+
+  // The Zotero tab talks to a deterministic local-API fixture through real IPC.
+  // It verifies reconnection, the library select, search-result freshness and icon spacing.
+  await page.getByTestId('translate-tab-zotero').click();
+  await page.getByTestId('translate-zotero-library').waitFor({ state: 'visible' });
+  await waitForCondition('Zotero library connected in Translate', () => page.getByTestId('translate-zotero-library').isEnabled());
+  assert.equal(await page.getByTestId('translate-zotero-library').inputValue(), 'user:0');
+  const zoteroSearchSpacing = await page.getByTestId('translate-zotero-search').evaluate((input) => {
+    const icon = input.parentElement?.querySelector('svg')?.getBoundingClientRect();
+    const field = input.getBoundingClientRect();
+    return { paddingLeft: parseFloat(getComputedStyle(input).paddingLeft), iconRight: icon ? icon.right - field.left : 0 };
+  });
+  assert.ok(zoteroSearchSpacing.paddingLeft > zoteroSearchSpacing.iconRight, `Zotero placeholder starts after its icon (${zoteroSearchSpacing.paddingLeft}px > ${zoteroSearchSpacing.iconRight}px)`);
+  await page.getByTestId('translate-zotero-search').fill('Smoke Research');
+  await page.getByTestId('translate-zotero-results').getByText('Smoke Research Paper', { exact: true }).waitFor();
+  await page.getByTestId('translate-zotero-results').getByText('Smoke Research Paper', { exact: true }).click();
+  await page.getByText('smoke-paper.pdf', { exact: true }).waitFor();
+  await page.getByTestId('translate-tab-text').click();
+  await page.getByTestId('translate-source-text').fill('# Titulo Principal\n\nEste es un documento de prueba.');
+  await page.getByTestId('translate-run').click();
+  await page.getByTestId('translate-result-text').getByText('Main Title', { exact: false }).waitFor({ timeout: 20_000 });
+  assert.match(await page.getByTestId('translate-result-text').innerText(), /This is a test document\./, 'pasted text crosses the complete translation stack');
+  await page.getByTestId('translate-tab-history').click();
+  await page.getByTestId('translate-history').getByText('Texto pegado', { exact: true }).waitFor();
+  assert.ok((await page.evaluate(() => window.nodus.listTranslateHistory())).some((entry) => entry.inputKind === 'text' && entry.translatedText?.includes('Main Title')), 'pasted translation is persisted in history');
+
+  // Facsimile mode gets its own real PDF round-trip: three source pages enter IPC,
+  // translated page rasters come out with the same geometry and no source text layer.
+  const translateDir = await mkdtemp(path.join(os.tmpdir(), 'nodus-e2e-translate-'));
+  const translateSourcePdf = await buildTextPdf(translateDir, 'translate-facsimile.pdf');
+  const facsimileResult = await page.evaluate(async ({ input, outDir, model }) => window.nodus.runTranslateJob({
+    inputKind: 'files', inputPaths: [input], targetLanguage: 'en', model,
+    outputFormat: 'pdf', pdfMode: 'facsimile', translateImageText: false,
+    outputDir: outDir, openFolderOnDone: false,
+  }, { onProgress: () => {} }), { input: translateSourcePdf, outDir: translateDir, model: e2eTranslateModel });
+  assert.equal(facsimileResult.cancelled, false);
+  assert.equal(facsimileResult.outputs.length, 1, 'facsimile job emits one translated PDF');
+  assert.equal(facsimileResult.outputs[0].pageCount, 3, 'facsimile reports the original page count');
+  const translatedFacsimilePath = facsimileResult.outputs[0].outputPath;
+  assert.ok(existsSync(translatedFacsimilePath), 'facsimile output exists');
+  const facsimilePdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const facsimileDoc = await facsimilePdfjs.getDocument({ data: new Uint8Array(await readFile(translatedFacsimilePath)), isEvalSupported: false }).promise;
+  assert.equal(facsimileDoc.numPages, 3);
+  const facsimileViewport = (await facsimileDoc.getPage(1)).getViewport({ scale: 1 });
+  assert.ok(Math.abs(facsimileViewport.width - 595) < 1 && Math.abs(facsimileViewport.height - 842) < 1, 'facsimile retains A4 page geometry');
+  assert.equal((await (await facsimileDoc.getPage(1)).getTextContent()).items.length, 0, 'source-language text is not leaked behind the facsimile');
+  const persistedFacsimile = (await page.evaluate(() => window.nodus.listTranslateHistory())).find((entry) => entry.outputPath === translatedFacsimilePath);
+  assert.ok(persistedFacsimile?.outputExists, 'facsimile output is visible in persistent history');
+  assert.equal(persistedFacsimile.pdfMode, 'facsimile');
+  await rm(translateDir, { recursive: true, force: true });
+  await page.getByTestId('toolkit-translate-back').click();
+  await page.getByTestId('toolkit-home').waitFor();
   // PDF Presenter is a working tool: it opens on its (empty) library and returns.
   assert.equal(await page.getByTestId('toolkit-card-presenter').isDisabled(), false, 'PDF Presenter opens');
   await page.getByTestId('toolkit-card-presenter').click();
@@ -1137,12 +1250,12 @@ try {
   await page.getByTestId('protect-home').waitFor();
   await page.getByTestId('toolkit-protect-back').click();
   await page.getByTestId('toolkit-home').waitFor({ timeout: 10_000 });
-  console.log('[e2e] toolkit: hub geometry, Convert regression, and full Protect redact → trace → vault → verify round-trip');
+  console.log('[e2e] toolkit: hub geometry, Convert regression, Translate text + PDF facsimile, and full Protect redact → trace → vault → verify round-trip');
   if (process.env.NODUS_E2E_TOOLKIT_ONLY === '1') {
     assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.map((error) => error.message).join(' | ')}`);
     await closeElectronApp(app); app = null;
     await rm(userData, { recursive: true, force: true });
-    console.log('[e2e] focused Toolkit + Nodus Protect smoke passed');
+    console.log('[e2e] focused Toolkit + Nodus Translate + Nodus Protect smoke passed');
     process.exit(0);
   }
 
@@ -2454,6 +2567,7 @@ try {
 } finally {
   if (app) await closeElectronApp(app);
   await rm(userData, { recursive: true, force: true });
+  await new Promise((resolve) => zoteroApiServer.close(resolve));
 }
 
 /** First .sqlite file under the profile dir (vault registry decides the layout). */

--- a/scripts/test-feedback-roadmap-ui.mjs
+++ b/scripts/test-feedback-roadmap-ui.mjs
@@ -45,6 +45,7 @@ test('roadmap follows the requested sequence and is opened from the header', asy
     'Servidor',
     'Compartir vaults y trabajo colaborativo',
     'Nodus Toolkit',
+    'Nodus Translate',
     'Nodus PDF Presenter',
     'Nodus OCR Workspace',
   ];
@@ -56,11 +57,11 @@ test('roadmap follows the requested sequence and is opened from the header', asy
   }
   assert.match(roadmapSource, /title: 'Pulido y estabilidad'.+status: 'inProgress'/);
   assert.match(roadmapSource, /title: 'Vault de docencia'.+status: 'inProgress'/);
-  for (const implemented of ['Nodus Toolkit', 'Nodus PDF Presenter', 'Nodus OCR Workspace']) {
+  for (const implemented of ['Nodus Toolkit', 'Nodus Translate', 'Nodus PDF Presenter', 'Nodus OCR Workspace']) {
     assert.match(roadmapSource, new RegExp(`title: '${implemented}'.+status: 'implemented'`), `${implemented} is marked as implemented`);
   }
   assert.match(roadmapSource, /children: \[/, 'user-suggested vaults are rendered as a nested group');
-  assert.match(roadmapSource, /Nodus Toolkit, PDF Presenter y OCR Workspace figuran como implementados/, 'current Toolkit availability is documented');
+  assert.match(roadmapSource, /Nodus Toolkit, Nodus Translate, PDF Presenter y OCR Workspace figuran como implementados/, 'current Toolkit availability is documented');
   for (const description of [
     'Handy local-first tools for file conversion and document processing, built into Nodus.',
     'Present PDFs and externally authored presentations with presenter view, mobile remote control, speaker notes, and live annotation tools.',

--- a/scripts/test-toolkit-beta-guide.mjs
+++ b/scripts/test-toolkit-beta-guide.mjs
@@ -22,10 +22,10 @@ test('the 2.4.0 update queues a one-off toolkit guide behind release notes', asy
   assert.ok(app.indexOf('<ToolkitBetaUpdateTour') < app.indexOf('<StartupUpdateModal'));
 });
 
-test('the guide covers all four tools, extraction choices, performance and subscriptions', async () => {
+test('the guide covers all five tools, extraction choices, performance and subscriptions', async () => {
   const guide = await read('src/components/ToolkitBetaGuide.tsx');
   const navigation = await read('src/navigation.ts');
-  for (const tool of ['Nodus Convert', 'Nodus Protect', 'PDF Presenter', 'OCR Workspace']) assert.ok(navigation.includes(tool));
+  for (const tool of ['Nodus Convert', 'Nodus Protect', 'Nodus Translate', 'PDF Presenter', 'OCR Workspace']) assert.ok(navigation.includes(tool));
   for (const expected of [
     'Gemma 4 E2B Q4',
     '20 ejecuciones correctas de 20',
@@ -44,7 +44,8 @@ test('the guide covers all four tools, extraction choices, performance and subsc
     assert.match(guide, new RegExp(asset.replace('.', '\\.')));
     assert.match(await read(`src/assets/brands/${asset}`), /<svg/);
   }
-  assert.match(guide, /\.\.\.\[0, 1, 2, 3\]\.map/);
+  assert.match(guide, /\.\.\.BETA_TOOLS\.map/, 'the versioned guide cannot index newer catalogue entries');
+  assert.match(guide, /BETA · \{index \+ 1\} \/ \{BETA_TOOLS\.length\}/);
   assert.match(guide, /data-testid="toolkit-beta-update-tour"/);
   assert.match(guide, /data-testid="toolkit-beta-tour-complete"/);
   assert.match(guide, /disabled=\{itemIndex > index\}/);

--- a/scripts/test-toolkit-translate.mjs
+++ b/scripts/test-toolkit-translate.mjs
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { buildDocx, buildEpub, buildScannedPdf, buildTextPdf } from './toolkit-fixtures.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const bundleDir = await mkdtemp(path.join(repoRoot, 'node_modules', '.nodus-translate-tests-'));
+const fixtureDir = await mkdtemp(path.join(os.tmpdir(), 'nodus-translate-fx-'));
+
+function bundle(file, name, external = []) {
+  const out = path.join(bundleDir, `${name}.cjs`);
+  execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
+    path.join(repoRoot, file), '--bundle', '--platform=node', '--format=cjs', '--target=es2022',
+    `--alias:@shared=${path.join(repoRoot, 'shared')}`,
+    ...external.map((value) => `--external:${value}`),
+    `--outfile=${out}`,
+  ], { cwd: repoRoot, stdio: 'inherit' });
+  return require(out);
+}
+
+const segmentsModule = bundle('electron/toolkit/translate/segments.ts', 'segments');
+const documentsModule = bundle('electron/toolkit/translate/documents.ts', 'documents', ['adm-zip']);
+const facsimileModule = bundle('electron/toolkit/translate/facsimile.ts', 'facsimile', ['pdfjs-dist', '@napi-rs/canvas', 'pdf-lib']);
+const historyModule = bundle('electron/toolkit/translate/history.ts', 'history', ['electron']);
+const markdownModule = bundle('shared/toolkitMarkdown.ts', 'markdown');
+const AdmZip = require('adm-zip');
+
+test.after(async () => {
+  await rm(bundleDir, { recursive: true, force: true });
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+function translateWords(value) {
+  return value
+    .replace(/Titulo Principal/g, 'Main Title')
+    .replace(/Texto normal/g, 'Normal text')
+    .replace(/en negrita/g, 'in bold')
+    .replace(/incluida/g, 'included')
+    .replace(/Primer elemento/g, 'First item')
+    .replace(/Segundo elemento/g, 'Second item')
+    .replace(/Celda/g, 'Cell')
+    .replace(/Capitulo Primero/g, 'First Chapter')
+    .replace(/Capitulo Segundo/g, 'Second Chapter')
+    .replace(/El comienzo de la historia narrada aqui/g, 'The beginning of the story told here')
+    .replace(/La continuacion despues del primero/g, 'The continuation after the first')
+    .replace(/Introduccion General/g, 'General Introduction')
+    .replace(/El rapido zorro marron salta sobre el perro perezoso/g, 'The quick brown fox jumps over the lazy dog')
+    .replace(/La investigacion cualitativa requiere rigor documental/g, 'Qualitative research requires documentary rigor')
+    .replace(/Los hallazgos confirman la hipotesis inicial del estudio/g, 'The findings confirm the initial study hypothesis')
+    .replace(/Encabezado de prueba/g, 'Test Header')
+    .replace(/Pie de prueba/g, 'Test Footer')
+    .replace(/Nota al pie de prueba/g, 'Test footnote');
+}
+
+const adapterTranslate = async (segments) => segments.map((segment) => ({ ...segment, translated: translateWords(segment.text) }));
+
+test('segment protocol retries a missing id and never loses content', async () => {
+  let calls = 0;
+  const input = [
+    { id: 'one', text: 'Titulo Principal', kind: 'plain' },
+    { id: 'two', text: 'Texto normal', kind: 'plain' },
+  ];
+  const output = await segmentsModule.translateSegments(input, { targetLanguage: 'English', maxChars: 10_000 }, async ({ user }) => {
+    calls += 1;
+    const translated = translateWords(user);
+    if (calls === 1) return translated.replace(/<<<NODUS_SEGMENT:two>>>[\s\S]*?<<<NODUS_END:two>>>/, '');
+    return translated;
+  });
+  assert.equal(output[0].translated, 'Main Title');
+  assert.equal(output[1].translated, 'Normal text');
+  assert.equal(calls, 2, 'one malformed batch plus one isolated retry');
+});
+
+test('HTML translation preserves scripts, URLs and inline markup', async () => {
+  const script = '<script>const titulo = "Titulo Principal";</script>';
+  const html = `<!doctype html><html><head>${script}</head><body><h1>Titulo Principal</h1><p>Texto normal con <strong>en negrita</strong>.</p><a href="https://example.com/Titulo">Texto normal</a></body></html>`;
+  const translated = await documentsModule.translateHtmlDocument(html, { translate: adapterTranslate });
+  assert.match(translated, /<h1>Main Title<\/h1>/);
+  assert.match(translated, /<strong>in bold<\/strong>/);
+  assert.ok(translated.includes(script), 'script payload remains byte-identical');
+  assert.match(translated, /href="https:\/\/example\.com\/Titulo"/, 'URL is unchanged');
+});
+
+test('Markdown translation restores list numbering changed by a model', async () => {
+  const source = '1. First item\n\n2. Second item\n\n3. Third item';
+  const translated = await documentsModule.translateMarkdownDocument(source, {
+    translate: async (segments) => segments.map((segment) => ({
+      ...segment,
+      translated: `1. ${segment.text.replace(/^\d+\.\s*/, '')} traduit`,
+    })),
+  });
+  assert.equal(translated, '1. First item traduit\n\n2. Second item traduit\n\n3. Third item traduit');
+});
+
+test('Markdown rendering preserves the start of separated ordered-list items', () => {
+  const html = markdownModule.markdownToHtml('1. First\n\n2. Second\n\n3. Third');
+  assert.match(html, /<ol><li>First<\/li><\/ol>/);
+  assert.match(html, /<ol start="2"><li>Second<\/li><\/ol>/);
+  assert.match(html, /<ol start="3"><li>Third<\/li><\/ol>/);
+});
+
+test('DOCX translation keeps styles, bold runs, media, headers, footers and footnotes', async () => {
+  const source = await buildDocx(fixtureDir, 'structured.docx');
+  const zip = new AdmZip(source);
+  zip.addFile('word/header1.xml', Buffer.from('<?xml version="1.0"?><w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>Encabezado de prueba</w:t></w:r></w:p></w:hdr>'));
+  zip.addFile('word/footer1.xml', Buffer.from('<?xml version="1.0"?><w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>Pie de prueba</w:t></w:r></w:p></w:ftr>'));
+  zip.addFile('word/footnotes.xml', Buffer.from('<?xml version="1.0"?><w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:footnote w:id="1"><w:p><w:r><w:t>Nota al pie de prueba</w:t></w:r></w:p></w:footnote></w:footnotes>'));
+  const media = Buffer.from([1, 4, 9, 16, 25, 36]);
+  zip.addFile('word/media/image1.png', media);
+  const translatedBytes = await documentsModule.translateDocxBytes(zip.toBuffer(), { translate: adapterTranslate });
+  const out = new AdmZip(Buffer.from(translatedBytes));
+  const documentXml = out.readAsText('word/document.xml');
+  assert.match(documentXml, /Main Title/);
+  assert.match(documentXml, /w:pStyle w:val="Heading1"/, 'heading style stays real');
+  assert.match(documentXml, /<w:b\b/, 'bold run remains in OOXML');
+  assert.match(documentXml, /in bold/, 'bold text was translated inside its run');
+  assert.match(out.readAsText('word/header1.xml'), /Test Header/);
+  assert.match(out.readAsText('word/footer1.xml'), /Test Footer/);
+  assert.match(out.readAsText('word/footnotes.xml'), /Test footnote/);
+  assert.deepEqual(out.readFile('word/media/image1.png'), media, 'embedded image bytes are untouched');
+});
+
+test('EPUB translation keeps package structure and binary assets', async () => {
+  const source = await buildEpub(fixtureDir, 'book.epub');
+  const zip = new AdmZip(source);
+  const cover = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  zip.addFile('OEBPS/cover.png', cover);
+  const translated = await documentsModule.translateEpubBytes(zip.toBuffer(), { translate: adapterTranslate });
+  const out = new AdmZip(Buffer.from(translated));
+  assert.match(out.readAsText('OEBPS/chap1.xhtml'), /First Chapter/);
+  assert.match(out.readAsText('OEBPS/chap2.xhtml'), /Second Chapter/);
+  assert.match(out.readAsText('OEBPS/content.opf'), /Libro de Prueba/, 'manifest metadata is not mutated unsafely');
+  assert.deepEqual(out.readFile('OEBPS/cover.png'), cover);
+  assert.equal(out.readAsText('mimetype'), 'application/epub+zip');
+});
+
+test('PDF facsimile keeps page count and page geometry while producing translated page images', async () => {
+  const source = await buildTextPdf(fixtureDir, 'facsimile-source.pdf');
+  const result = await facsimileModule.buildFacsimilePdf(source, { translate: adapterTranslate });
+  assert.equal(result.pageCount, 3);
+  assert.ok(result.data.length > 20_000, 'facsimile contains rendered page images');
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const pdf = await pdfjs.getDocument({ data: result.data, isEvalSupported: false }).promise;
+  assert.equal(pdf.numPages, 3);
+  const viewport = (await pdf.getPage(1)).getViewport({ scale: 1 });
+  assert.ok(Math.abs(viewport.width - 595) < 1 && Math.abs(viewport.height - 842) < 1, 'A4 source geometry is retained');
+  const text = (await (await pdf.getPage(1)).getTextContent()).items.map((item) => item.str || '').join('');
+  assert.equal(text, '', 'raster facsimile does not leak the original-language text layer');
+});
+
+test('facsimile layout keeps same-baseline columns in separate paragraphs', () => {
+  const viewport = {
+    height: 800,
+    convertToViewportPoint: (x, y) => [x * 2, (800 - y) * 2],
+  };
+  const item = (text, x, y, width) => ({ str: text, width, height: 10, fontName: 'F1', transform: [10, 0, 0, 10, x, y] });
+  const lines = facsimileModule.groupDigitalLines({
+    styles: { F1: { fontFamily: 'Arial' } },
+    items: [
+      item('Left first line', 30, 740, 65), item('Right first line', 260, 740, 70),
+      item('Left second line', 30, 725, 70), item('Right second line', 260, 725, 75),
+    ],
+  }, viewport, 1);
+  assert.equal(lines.length, 4, 'large horizontal whitespace splits a shared baseline');
+  const blocks = facsimileModule.groupParagraphs(lines, 1);
+  assert.equal(blocks.length, 2, 'alternating column lines reconnect to their own reading flow');
+  assert.ok(blocks.every((block) => block.eraseRegions.length === 2), 'paragraph erasure retains exact line rectangles');
+  assert.ok(blocks.some((block) => /Left first line Left second line/.test(block.text)));
+  assert.ok(blocks.some((block) => /Right first line Right second line/.test(block.text)));
+});
+
+test('PDF list prefixes stay attached to their heading run', () => {
+  const viewport = { height: 800, convertToViewportPoint: (x, y) => [x * 2, (800 - y) * 2] };
+  const lines = facsimileModule.groupDigitalLines({ styles: {}, items: [
+    { str: '1.', width: 5, height: 10, transform: [10, 0, 0, 10, 30, 740] },
+    { str: 'The Plains Indians', width: 80, height: 10, transform: [10, 0, 0, 10, 50, 740] },
+  ] }, viewport, 1);
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0].text, '1. The Plains Indians');
+});
+
+test('scanned PDF facsimile invokes page vision and places its already-translated blocks', async () => {
+  const source = await buildScannedPdf(fixtureDir, 'scanned-facsimile.pdf');
+  const pagesSeen = [];
+  const result = await facsimileModule.buildFacsimilePdf(source, {
+    translate: async (segments) => {
+      assert.equal(segments.length, 0, 'vision output is not translated a second time');
+      return [];
+    },
+    translatePageImage: async ({ pageNumber }) => {
+      pagesSeen.push(pageNumber);
+      return {
+        blankPage: false,
+        blocks: [{ text: `Translated scan page ${pageNumber}`, label: 'MAIN_TEXT', box_2d: [100, 50, 260, 900] }],
+      };
+    },
+  });
+  assert.deepEqual(pagesSeen, [1, 2]);
+  assert.equal(result.pageCount, 2);
+  assert.ok(result.data.length > 10_000);
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const pdf = await pdfjs.getDocument({ data: result.data, isEvalSupported: false }).promise;
+  assert.equal(pdf.numPages, 2);
+});
+
+test('translation history persists results, reports missing files and removes records', async () => {
+  const root = await mkdtemp(path.join(fixtureDir, 'history-'));
+  const outputPath = path.join(root, 'translated.pdf');
+  fs.writeFileSync(outputPath, 'pdf-placeholder');
+  const created = historyModule.addTranslateHistory({
+    inputKind: 'files', sourceLabel: 'source.pdf', sourcePath: path.join(root, 'source.pdf'),
+    targetLanguage: 'fr', targetLanguageLabel: 'Français',
+    model: { provider: 'lmstudio', model: 'history-test' }, pdfMode: 'facsimile',
+    outputPath, format: 'pdf', pageCount: 2, overflowPages: [2], warnings: ['review page 2'],
+  }, root);
+  assert.equal(created.outputExists, true);
+  assert.equal(historyModule.listTranslateHistory(root)[0].targetLanguage, 'fr');
+  fs.unlinkSync(outputPath);
+  assert.equal(historyModule.listTranslateHistory(root)[0].outputExists, false, 'missing output is reflected without losing its record');
+  assert.deepEqual(historyModule.removeTranslateHistory(created.id, root), []);
+});

--- a/scripts/test-toolkit-ui.mjs
+++ b/scripts/test-toolkit-ui.mjs
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 // Nodus Toolkit — the Herramientas section (hub + per-tool pages). These checks
 // cover the wiring that no e2e step can see cheaply: that the view is registered
 // in the canonical nav tables, that it stays universal across vault types, and
-// that the hub's four cards keep the structure the design requires (identical
+// that the hub's cards keep the structure the design requires (identical
 // shape, centred icons, honest state badges). The real rendering is asserted by
 // the toolkit steps in scripts/e2e-smoke.mjs.
 
@@ -60,7 +60,7 @@ test('every sidebar icon stays unique so a collapsed sidebar keeps sections apar
 
 test('the toolkit icons exist in the shared catalogue', async () => {
   const ui = await read('src/components/ui.tsx');
-  for (const icon of ['tools', 'swap', 'shield', 'scanText', 'presentation', 'chevronLeft']) {
+  for (const icon of ['tools', 'swap', 'shield', 'scanText', 'presentation', 'languages', 'chevronLeft']) {
     assert.match(ui, new RegExp(`\\n\\s{2}${icon}: '`), `${icon} is defined in ICON_PATHS`);
   }
 });
@@ -85,7 +85,7 @@ test('the toolkit shows in every vault type, including databases and study', () 
   assert.deepEqual(tools.items.map((n) => n.id), ['toolkit']);
 });
 
-test('the hub renders five tools and Protect is in development', async () => {
+test('the hub renders every built tool including Nodus Translate', async () => {
   const view = await read('src/views/ToolkitView.tsx');
   assert.ok(view.includes('data-testid="toolkit-home"'), 'the hub is addressable');
   // The cards receive their testid as a prop; ToolCard is what stamps it onto the DOM.
@@ -96,17 +96,17 @@ test('the hub renders five tools and Protect is in development', async () => {
   // set of tools from each other.
   assert.deepEqual(
     navigation.TOOLKIT_TOOLS.map((tool) => `toolkit-card-${tool.testid}`),
-    ['toolkit-card-apps', 'toolkit-card-convert', 'toolkit-card-protect', 'toolkit-card-presenter', 'toolkit-card-aiocr']
+    ['toolkit-card-apps', 'toolkit-card-convert', 'toolkit-card-protect', 'toolkit-card-translate', 'toolkit-card-presenter', 'toolkit-card-aiocr']
   );
   assert.deepEqual(
     navigation.TOOLKIT_TOOLS.map((tool) => tool.name),
-    ['Nodus Apps', 'Nodus Convert', 'Nodus Protect', 'PDF Presenter', 'OCR Workspace'],
+    ['Nodus Apps', 'Nodus Convert', 'Nodus Protect', 'Nodus Translate', 'PDF Presenter', 'OCR Workspace'],
     'brand names stay untranslated'
   );
   assert.match(view, /name=\{tool\.name\}/, 'the card shows the brand name verbatim, never through t()');
   assert.match(view, /description=\{t\(tool\.description\)\}/, 'only the description is translated');
 
-  // All five tools are built and openable; none is coming soon.
+  // Every tool is built and openable; none is coming soon.
   assert.deepEqual(
     navigation.TOOLKIT_TOOLS.filter((tool) => tool.state === 'soon').map((tool) => tool.page),
     [],
@@ -114,7 +114,7 @@ test('the hub renders five tools and Protect is in development', async () => {
   );
   assert.deepEqual(
     navigation.TOOLKIT_TOOLS.filter((tool) => tool.state === 'wip').map((tool) => tool.page),
-    ['apps', 'convert', 'protect', 'presenter', 'ocr'],
+    ['apps', 'convert', 'protect', 'translate', 'presenter', 'ocr'],
     'every tool uses the in-development badge'
   );
   assert.match(view, /const disabled = state === 'soon'/);
@@ -123,13 +123,38 @@ test('the hub renders five tools and Protect is in development', async () => {
   assert.match(view, /<ToolkitAppsView onBack=/, 'Nodus Apps renders the functional catalogue');
   assert.match(view, /<ToolkitConvertView onBack=/, 'Nodus Convert renders the functional converter');
   assert.match(view, /<ToolkitProtectView onBack=/, 'Nodus Protect renders the functional protection flow');
+  assert.match(view, /<ToolkitTranslateView onBack=/, 'Nodus Translate renders the functional translation workspace');
   assert.match(view, /<ToolkitPresenterView onBack=/, 'PDF Presenter renders the functional library');
   assert.match(view, /<ToolkitAiOcrView onBack=/, 'OCR Workspace renders the functional library');
   // Any page other than the built ones falls back to the catalogue rather than
   // rendering an empty pane.
   assert.match(view, /page === 'protect'/, 'Protect has its own routed workspace');
+  assert.match(view, /page === 'translate'/, 'Translate has its own routed workspace');
   assert.match(view, /page === 'presenter'/, 'PDF Presenter has its own routed workspace');
   assert.match(view, /page === 'ocr'/, 'OCR Workspace has its own routed workspace');
+});
+
+test('Translate exposes balanced text panes, resilient Zotero controls and persistent history', async () => {
+  const [view, preload, ipc, history, shared] = await Promise.all([
+    read('src/views/ToolkitTranslateView.tsx'),
+    read('electron/preload.ts'),
+    read('electron/ipc.ts'),
+    read('electron/toolkit/translate/history.ts'),
+    read('shared/toolkitTranslateTypes.ts'),
+  ]);
+  assert.match(view, /translate-source-text[^>]+w-full/, 'the source textarea fills its grid column');
+  assert.match(view, /grid gap-6 lg:grid-cols-2/, 'source and result use balanced columns with a visible gutter');
+  assert.match(view, /\['history', 'Historial', 'clock'\]/, 'history is a first-class fourth section');
+  assert.match(view, /input input-with-leading-icon w-full/, 'Zotero search reserves space for its icon');
+  assert.match(view, /translate-zotero-reconnect/, 'a failed Zotero connection can be retried explicitly');
+  assert.match(view, /disposed = true/, 'stale Zotero searches cannot overwrite a newer result');
+  for (const marker of ['listTranslateHistory', 'removeTranslateHistory']) {
+    assert.ok(preload.includes(marker), `preload exposes ${marker}`);
+    assert.ok(view.includes(marker), `renderer uses ${marker}`);
+  }
+  assert.match(ipc, /shell\.trashItem/, 'deleting a generated document uses the recoverable OS Trash');
+  assert.match(history, /history\.json/, 'history is persisted below userData');
+  assert.match(shared, /interface TranslateHistoryEntry/, 'history has a shared typed contract');
 });
 
 test('Protect exposes the complete local workflow and the secure preload boundary', async () => {
@@ -196,7 +221,7 @@ test('the toolkit nests one sidebar button per tool under its section', async ()
 
 test('the hub cards share one shape: equal size, centred icons, pinned badges', async () => {
   const view = await read('src/views/ToolkitView.tsx');
-  // One ToolCard component renders all five, so they cannot drift apart.
+  // One ToolCard component renders every card, so they cannot drift apart.
   assert.equal((view.match(/<ToolCard\b/g) ?? []).length, 1, 'a single ToolCard renders the whole catalogue');
   assert.match(view, /grid gap-4 sm:grid-cols-2/, 'the cards use a two-column grid when space permits');
   assert.match(view, /className=\{`flex h-full flex-col/, 'each card fills its grid cell');

--- a/scripts/verify-toolkit-translate-real-pdf.mjs
+++ b/scripts/verify-toolkit-translate-real-pdf.mjs
@@ -1,0 +1,78 @@
+// Runs both real PDF translation modes through the production preload + IPC stack.
+// Usage:
+//   NODUS_TRANSLATE_VERIFY_USERDATA=/path/to/profile \
+//   node scripts/verify-toolkit-translate-real-pdf.mjs input.pdf output-dir [language]
+import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const inputPath = path.resolve(process.argv[2] || '');
+const outputRoot = path.resolve(process.argv[3] || path.join(repoRoot, 'tmp', 'pdfs', 'example-real'));
+const targetLanguage = process.argv[4] || 'fr';
+const userData = process.env.NODUS_TRANSLATE_VERIFY_USERDATA;
+const translateImageText = process.env.NODUS_TRANSLATE_VERIFY_IMAGE_TEXT === '1';
+const pruneHistory = process.env.NODUS_TRANSLATE_VERIFY_PRUNE_HISTORY === '1';
+assert.ok(process.argv[2], 'Pass an input PDF path.');
+assert.ok(userData, 'Set NODUS_TRANSLATE_VERIFY_USERDATA to a profile with a configured model.');
+
+await Promise.all([
+  mkdir(path.join(outputRoot, 'facsimile'), { recursive: true }),
+  mkdir(path.join(outputRoot, 'reflow'), { recursive: true }),
+]);
+
+const childEnv = {
+  ...process.env,
+  NODUS_USERDATA: userData,
+  NODUS_DISABLE_AUTO_UPDATE: '1',
+  NODUS_E2E_DISABLE_STUDY_BACKGROUND_AI: '1',
+};
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+let app;
+const reports = [];
+try {
+  app = await electron.launch({ executablePath: require('electron'), args: [repoRoot, '--no-sandbox'], env: childEnv });
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(60_000);
+  await page.waitForFunction(() => typeof window.nodus?.runTranslateJob === 'function');
+  const settings = await page.evaluate(() => window.nodus.getSettings());
+  assert.ok(settings.synthesisModel?.provider && settings.synthesisModel?.model, 'The profile has no synthesis model.');
+  if (pruneHistory) {
+    await page.evaluate(async () => {
+      const entries = await window.nodus.listTranslateHistory();
+      await Promise.all(entries.map((entry) => window.nodus.removeTranslateHistory(entry.id, false)));
+    });
+  }
+
+  for (const mode of ['facsimile', 'reflow']) {
+    let lastBucket = -1;
+    const result = await page.evaluate(async ({ inputPath, outputDir, targetLanguage, model, mode, translateImageText }) => {
+      const progress = [];
+      const result = await window.nodus.runTranslateJob({
+        inputKind: 'files', inputPaths: [inputPath], sourceLanguage: 'English', targetLanguage,
+        model, outputFormat: 'pdf', pdfMode: mode, translateImageText,
+        glossary: '', outputDir, openFolderOnDone: false,
+      }, { onProgress: (event) => progress.push(event) });
+      return { result, progress };
+    }, { inputPath, outputDir: path.join(outputRoot, mode), targetLanguage, model: settings.synthesisModel, mode, translateImageText });
+    for (const event of result.progress) {
+      const bucket = Math.floor(event.pct * 10);
+      if (bucket > lastBucket) {
+        lastBucket = bucket;
+        process.stdout.write(`[real-pdf] ${mode} ${Math.round(event.pct * 100)}% ${event.message}\n`);
+      }
+    }
+    assert.equal(result.result.cancelled, false, `${mode} translation was cancelled`);
+    assert.equal(result.result.outputs.length, 1, `${mode} produces one output`);
+    reports.push({ mode, model: settings.synthesisModel, ...result.result.outputs[0] });
+  }
+  await writeFile(path.join(outputRoot, 'report.json'), `${JSON.stringify(reports, null, 2)}\n`, 'utf8');
+  process.stdout.write(`${JSON.stringify(reports, null, 2)}\n`);
+} finally {
+  if (app) await app.close().catch(() => undefined);
+}

--- a/scripts/verify-toolkit-translate.mjs
+++ b/scripts/verify-toolkit-translate.mjs
@@ -1,0 +1,164 @@
+// Reproducible visual fixtures for Nodus Translate. The output directory is
+// deliberately disposable: render the DOCX/PDF, inspect every page, then remove it.
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { createCanvas } from '@napi-rs/canvas';
+import {
+  Document, Footer, FootnoteReferenceRun, Header, HeadingLevel, ImageRun, Packer,
+  Paragraph, Table, TableCell, TableRow, TextRun, WidthType,
+} from 'docx';
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outputDir = path.join(repoRoot, 'tmp', 'translate-visual-qa');
+const bundleDir = path.join(outputDir, '.bundles');
+fs.rmSync(outputDir, { recursive: true, force: true });
+fs.mkdirSync(bundleDir, { recursive: true });
+
+const require = createRequire(import.meta.url);
+function bundle(file, name, external = []) {
+  const out = path.join(bundleDir, `${name}.cjs`);
+  execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
+    path.join(repoRoot, file), '--bundle', '--platform=node', '--format=cjs', '--target=es2022',
+    `--alias:@shared=${path.join(repoRoot, 'shared')}`,
+    ...external.map((value) => `--external:${value}`),
+    `--outfile=${out}`,
+  ], { cwd: repoRoot, stdio: 'inherit' });
+  return require(out);
+}
+
+const documents = bundle('electron/toolkit/translate/documents.ts', 'documents', ['adm-zip']);
+const facsimile = bundle('electron/toolkit/translate/facsimile.ts', 'facsimile', ['pdfjs-dist', '@napi-rs/canvas', 'pdf-lib']);
+
+const replacements = [
+  ['ENCABEZADO INSTITUCIONAL', 'INSTITUTIONAL HEADER'],
+  ['Informe de investigacion', 'Research Report'],
+  ['Contexto y objetivos', 'Context and Objectives'],
+  ['Marco metodologico', 'Methodological Framework'],
+  ['Resultados principales', 'Main Results'],
+  ['Este documento comprueba la traduccion estructural', 'This document verifies structure-preserving translation'],
+  ['manteniendo una parte en negrita', 'while keeping one part in bold'],
+  ['El analisis combina fuentes primarias y evidencia visual.', 'The analysis combines primary sources and visual evidence.'],
+  ['Las conclusiones conservan estilos, tablas e imagenes.', 'The conclusions retain styles, tables and images.'],
+  ['Indicador', 'Metric'],
+  ['Resultado', 'Result'],
+  ['Cobertura', 'Coverage'],
+  ['Alta', 'High'],
+  ['Nota al pie con procedencia archivistica.', 'Footnote with archival provenance.'],
+  ['Pie confidencial de prueba', 'Confidential test footer'],
+  ['DOCUMENTO DE PRUEBA', 'TEST DOCUMENT'],
+  ['Resumen ejecutivo', 'Executive Summary'],
+  ['La investigacion cualitativa requiere rigor documental y trazabilidad.', 'Qualitative research requires documentary rigor and traceability.'],
+  ['La imagen y la banda lateral deben permanecer exactamente en su posicion.', 'The image and side panel must remain exactly in place.'],
+  ['Nota: muestra generada para verificar el modo facsimil.', 'Note: sample generated to verify facsimile mode.'],
+  ['Pagina', 'Page'],
+];
+
+function translateWords(value) {
+  return replacements.reduce((text, [source, target]) => text.replaceAll(source, target), value);
+}
+
+const adapterTranslate = async (segments) => segments.map((segment) => ({ ...segment, translated: translateWords(segment.text) }));
+
+function buildIllustration() {
+  const canvas = createCanvas(720, 320);
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, 720, 320);
+  gradient.addColorStop(0, '#243b67');
+  gradient.addColorStop(1, '#63c7b2');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, 720, 320);
+  ctx.fillStyle = '#ffffff';
+  ctx.font = 'bold 46px sans-serif';
+  ctx.fillText('NODUS', 48, 85);
+  ctx.fillStyle = '#ffcf66';
+  ctx.fillRect(50, 130, 170, 110);
+  ctx.fillStyle = '#f4f7fb';
+  ctx.beginPath();
+  ctx.arc(360, 185, 58, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = '#e96b73';
+  ctx.fillRect(500, 115, 155, 140);
+  return canvas.toBuffer('image/png');
+}
+
+async function buildAndTranslateDocx() {
+  const illustration = buildIllustration();
+  const doc = new Document({
+    footnotes: {
+      1: { children: [new Paragraph('Nota al pie con procedencia archivistica.')] },
+    },
+    sections: [{
+      headers: { default: new Header({ children: [new Paragraph({ children: [new TextRun({ text: 'ENCABEZADO INSTITUCIONAL', bold: true, color: '335B78' })] })] }) },
+      footers: { default: new Footer({ children: [new Paragraph({ children: [new TextRun({ text: 'Pie confidencial de prueba', italics: true, color: '777777' })] })] }) },
+      children: [
+        new Paragraph({ text: 'Informe de investigacion', heading: HeadingLevel.HEADING_1 }),
+        new Paragraph({ text: 'Contexto y objetivos', heading: HeadingLevel.HEADING_2 }),
+        new Paragraph({
+          children: [
+            new TextRun('Este documento comprueba la traduccion estructural, '),
+            new TextRun({ text: 'manteniendo una parte en negrita', bold: true, color: '9B2C2C' }),
+            new TextRun('.'),
+            new FootnoteReferenceRun(1),
+          ],
+        }),
+        new Paragraph({ text: 'Marco metodologico', heading: HeadingLevel.HEADING_3 }),
+        new Paragraph('El analisis combina fuentes primarias y evidencia visual.'),
+        new Paragraph({ children: [new ImageRun({ data: illustration, transformation: { width: 500, height: 222 }, type: 'png' })] }),
+        new Paragraph({ text: 'Resultados principales', heading: HeadingLevel.HEADING_2 }),
+        new Paragraph('Las conclusiones conservan estilos, tablas e imagenes.'),
+        new Table({
+          width: { size: 7600, type: WidthType.DXA },
+          columnWidths: [3800, 3800],
+          rows: [
+            new TableRow({ children: [new TableCell({ width: { size: 3800, type: WidthType.DXA }, children: [new Paragraph({ children: [new TextRun({ text: 'Indicador', bold: true })] })] }), new TableCell({ width: { size: 3800, type: WidthType.DXA }, children: [new Paragraph({ children: [new TextRun({ text: 'Resultado', bold: true })] })] })] }),
+            new TableRow({ children: [new TableCell({ width: { size: 3800, type: WidthType.DXA }, children: [new Paragraph('Cobertura')] }), new TableCell({ width: { size: 3800, type: WidthType.DXA }, children: [new Paragraph('Alta')] })] }),
+          ],
+        }),
+      ],
+    }],
+  });
+  const source = await Packer.toBuffer(doc);
+  const sourcePath = path.join(outputDir, 'source-structured.docx');
+  const translatedPath = path.join(outputDir, 'translated-structured.docx');
+  fs.writeFileSync(sourcePath, source);
+  const translated = await documents.translateDocxBytes(source, { translate: adapterTranslate });
+  fs.writeFileSync(translatedPath, translated);
+}
+
+async function buildAndTranslatePdf() {
+  const illustration = buildIllustration();
+  const pdf = await PDFDocument.create();
+  const regular = await pdf.embedFont(StandardFonts.Helvetica);
+  const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+  const png = await pdf.embedPng(illustration);
+  for (let index = 0; index < 2; index += 1) {
+    const page = pdf.addPage([595, 842]);
+    page.drawRectangle({ x: 0, y: 808, width: 595, height: 34, color: rgb(0.11, 0.21, 0.35) });
+    page.drawText('DOCUMENTO DE PRUEBA', { x: 48, y: 820, size: 10, font: bold, color: rgb(1, 1, 1) });
+    page.drawText(index === 0 ? 'Informe de investigacion' : 'Resultados principales', { x: 48, y: 754, size: 27, font: bold, color: rgb(0.10, 0.18, 0.30) });
+    page.drawText(index === 0 ? 'Resumen ejecutivo' : 'Contexto y objetivos', { x: 48, y: 716, size: 17, font: bold, color: rgb(0.20, 0.42, 0.52) });
+    page.drawText('La investigacion cualitativa requiere rigor documental y trazabilidad.', { x: 48, y: 676, size: 11, font: regular });
+    page.drawImage(png, { x: 48, y: 376, width: 360, height: 160 });
+    page.drawRectangle({ x: 430, y: 376, width: 115, height: 160, color: rgb(0.94, 0.82, 0.45), borderColor: rgb(0.42, 0.32, 0.12), borderWidth: 1 });
+    page.drawText('42', { x: 462, y: 446, size: 38, font: bold, color: rgb(0.25, 0.19, 0.07) });
+    page.drawText('La imagen y la banda lateral deben permanecer exactamente en su posicion.', { x: 48, y: 338, size: 11, font: regular });
+    page.drawText('Nota: muestra generada para verificar el modo facsimil.', { x: 48, y: 72, size: 8, font: regular, color: rgb(0.35, 0.35, 0.35) });
+    page.drawLine({ start: { x: 48, y: 54 }, end: { x: 545, y: 54 }, color: rgb(0.75, 0.75, 0.75), thickness: 0.5 });
+    page.drawText(`Pagina ${index + 1}`, { x: 500, y: 34, size: 8, font: regular, color: rgb(0.35, 0.35, 0.35) });
+  }
+  const sourcePath = path.join(outputDir, 'source-facsimile.pdf');
+  const translatedPath = path.join(outputDir, 'translated-facsimile.pdf');
+  fs.writeFileSync(sourcePath, await pdf.save());
+  const translated = await facsimile.buildFacsimilePdf(sourcePath, { translate: adapterTranslate });
+  fs.writeFileSync(translatedPath, translated.data);
+  fs.writeFileSync(path.join(outputDir, 'facsimile-report.json'), JSON.stringify({ pageCount: translated.pageCount, overflowPages: translated.overflowPages, warnings: translated.warnings }, null, 2));
+}
+
+await buildAndTranslateDocx();
+await buildAndTranslatePdf();
+fs.rmSync(bundleDir, { recursive: true, force: true });
+console.log(outputDir);

--- a/shared/nodiDocumentation.ts
+++ b/shared/nodiDocumentation.ts
@@ -28,6 +28,7 @@ export const NODUS_ROADMAP = [
   { title: 'Servidor', detail: 'Infraestructura opcional para nuevas capacidades conectadas.', status: 'planned' },
   { title: 'Compartir vaults y trabajo colaborativo', detail: 'Compartir espacios y colaborar con control sobre los datos.', status: 'planned' },
   { title: 'Nodus Toolkit', detail: 'Herramientas prácticas y local-first para convertir archivos y procesar documentos, integradas en Nodus.', status: 'implemented' },
+  { title: 'Nodus Translate', detail: 'Traducir texto, documentos y adjuntos de Zotero con el modelo elegido, conservando la estructura de DOCX y EPUB y la apariencia de los PDF mediante un modo facsímil.', status: 'implemented' },
   { title: 'Nodus PDF Presenter', detail: 'Presentar archivos PDF y presentaciones externas con vista del presentador, control remoto desde el móvil, notas del orador y herramientas de anotación en directo.', status: 'implemented' },
   { title: 'Nodus OCR Workspace', detail: 'OCR asistido por IA para PDF escaneados e imágenes, con revisión página a página, limpieza de texto, reprocesamiento e integración directa con las bóvedas de Nodus.', status: 'implemented' },
 ] satisfies readonly RoadmapItem[];
@@ -104,10 +105,13 @@ ${ROADMAP_GUIDE}
 
 ## Herramientas (Nodus Toolkit)
 - Herramientas es una sección de la barra lateral, en su propio grupo, y también tiene un icono en la cabecera. Aparece en todos los tipos de vault.
-- Su página principal es un hub 2 × 2 con cuatro tarjetas: Nodus Convert, Nodus Protect, PDF Presenter y OCR Workspace.
+- Su página principal es un hub con cinco tarjetas: Nodus Convert, Nodus Protect, Nodus Translate, PDF Presenter y OCR Workspace.
 - Nodus Convert ya funciona: convierte y procesa archivos en local, de uno en uno o en lote, en cinco categorías —Documentos (PDF, DOCX, EPUB, Markdown, HTML, texto), utilidades PDF (unir, dividir, rotar, reordenar, extraer imágenes, metadatos, imágenes→PDF), OCR ligero (imagen o PDF escaneado a texto, y PDF buscable), Imágenes (convertir formato incluido HEIC, redimensionar, comprimir) y Texto (limpiar texto pegado de PDF, mayúsculas/minúsculas, subtítulos a texto, checksums).
 - Nodus Protect ya funciona: admite PDF e imágenes del disco o de la bóveda activa, concatena documentos, permite ocultar o desenfocar datos, recortar, rotar, enderezar, convertir a escala de grises, añadir siete patrones de marca de agua y un pie legal, y exportar copias rasterizadas como PNG, ZIP o PDF.
 - Protect puede guardar una copia en disco, compartirla o incorporarla a la biblioteca «Copias protegidas» de la bóveda. También crea y verifica marcas trazables IDPS v1 compatibles con IDprotector; la marca autentica una copia, pero no la cifra y puede perderse por JPEG, capturas, reescalado o recompresión.
+- Nodus Translate ya funciona: traduce texto pegado, archivos TXT, Markdown, HTML, DOCX, EPUB y PDF, así como adjuntos importados de Zotero. Permite elegir idioma de destino, modelo, carpeta y formato de salida, además de añadir idioma de origen y glosario opcionales.
+- En DOCX y EPUB, Translate conserva directamente estilos, jerarquía, cabeceras, pies, notas, enlaces e imágenes del archivo original. En PDF ofrece un modo de lectura redistribuida y un modo facsímil rasterizado que mantiene páginas, geometría, fondos e imágenes y sustituye visiblemente el texto en su posición; puede usar visión para escaneados y texto dentro de imágenes. Si una traducción no cabe, reduce el tamaño y avisa de las páginas afectadas.
+- La traducción requiere el proveedor de IA seleccionado y puede enviarle el texto o las páginas que deban reconocerse. El archivo original nunca se modifica: el resultado se guarda como una copia nueva.
 - PDF Presenter ya se puede abrir: importa archivos PDF o presentaciones creadas en PowerPoint, LibreOffice o Keynote a una biblioteca global de Herramientas (con carpetas, búsqueda, orden y miniaturas). Las presentaciones externas se convierten localmente a PDF, tras avisar de que las animaciones y transiciones no se conservan; las notas de los PowerPoint modernos se importan automáticamente. También permite escribir notas por diapositiva, exportarlas e importarlas juntas en TXT y añadir vídeos de YouTube por diapositiva. Al presentar abre la diapositiva a pantalla completa (en la pantalla externa si hay dos) y una vista del presentador con la diapositiva actual, la siguiente, las notas, un temporizador y el reloj; incluye herramientas de anotación en directo (linterna, dibujo, puntero y lupa), pantalla en negro, y control remoto desde el móvil escaneando un código QR protegido por PIN. El único elemento que necesita conexión son los vídeos de YouTube; el resto funciona sin internet.
 - OCR Workspace ya se puede abrir y ofrece un flujo asistido por IA para importar escaneados, revisar y corregir cada página y exportar el resultado.
 - Nodus Convert es determinista y 100 % offline (no hay IA), nunca modifica el archivo original y no sube nada a ningún servicio; la única llamada de red opcional es la descarga de idiomas de OCR de Tesseract, que el usuario decide.
@@ -117,7 +121,7 @@ ${ROADMAP_GUIDE}
 ## Estado del roadmap
 - Fuentes primarias, Testimonios, Prosopografía y Worldbuilding figuran como planificados.
 - Pulido y estabilidad y el vault de Docencia figuran en desarrollo.
-- Nodus Toolkit, PDF Presenter y OCR Workspace figuran como implementados y se pueden abrir.
+- Nodus Toolkit, Nodus Translate, PDF Presenter y OCR Workspace figuran como implementados y se pueden abrir.
 - El roadmap también contempla Servidor, compartir vaults y trabajo colaborativo, y otros vaults sugeridos por usuarios.
 
 ## Protocolo para responder sobre la interfaz

--- a/shared/toolkitMarkdown.ts
+++ b/shared/toolkitMarkdown.ts
@@ -105,12 +105,13 @@ export function markdownToHtml(markdown: string): string {
     }
 
     if (/^\s*\d+\.\s+/.test(line)) {
+      const start = Number(line.match(/^\s*(\d+)\./)?.[1] ?? '1');
       const items: string[] = [];
       while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
         items.push(`<li>${renderInline(lines[i].replace(/^\s*\d+\.\s+/, ''))}</li>`);
         i++;
       }
-      out.push(`<ol>${items.join('')}</ol>`);
+      out.push(`<ol${start === 1 ? '' : ` start="${start}"`}>${items.join('')}</ol>`);
       continue;
     }
 

--- a/shared/toolkitTranslateTypes.ts
+++ b/shared/toolkitTranslateTypes.ts
@@ -1,0 +1,116 @@
+// Nodus Translate — shared IPC and renderer contracts.
+//
+// The translation workspace is deliberately separate from Nodus Convert: AI work is
+// long-running, cancellable and source-aware (plain text, disk files or a Zotero
+// attachment). Keeping this file dependency-free lets both Electron and React use the
+// same validation-friendly shapes without exposing Node primitives to the renderer.
+import type { ModelRef } from './types';
+
+export type TranslateInputKind = 'text' | 'files' | 'zotero';
+export type TranslatePdfMode = 'reflow' | 'facsimile';
+export type TranslateOutputFormat = 'same' | 'txt' | 'md' | 'html' | 'docx' | 'epub' | 'pdf';
+export type TranslateMarkupKind = 'plain' | 'markdown' | 'html' | 'xml';
+
+export interface TranslateZoteroSource {
+  itemKey: string;
+  attachmentKey: string;
+  libraryType: 'user' | 'group';
+  libraryId: string;
+  title: string;
+}
+
+export interface TranslateJobRequest {
+  inputKind: TranslateInputKind;
+  text?: string;
+  inputPaths?: string[];
+  zotero?: TranslateZoteroSource;
+  /** Empty/undefined means automatic source-language detection by the model. */
+  sourceLanguage?: string | null;
+  /** Stable language code from TRANSLATION_LANGUAGES. */
+  targetLanguage: string;
+  model: ModelRef | null;
+  outputFormat: TranslateOutputFormat;
+  pdfMode: TranslatePdfMode;
+  /** Use page vision for scanned PDFs and text baked into images. */
+  translateImageText: boolean;
+  /** A user-maintained term list, one source=target pair per line. */
+  glossary?: string;
+  /** null writes beside each disk source; Zotero defaults to Downloads. */
+  outputDir: string | null;
+  openFolderOnDone: boolean;
+}
+
+export type TranslateJobStage =
+  | 'resolving'
+  | 'extracting'
+  | 'translating'
+  | 'rendering'
+  | 'writing'
+  | 'done';
+
+export interface TranslateJobProgress {
+  jobId: string;
+  stage: TranslateJobStage;
+  currentFile: string | null;
+  fileIndex: number;
+  fileTotal: number;
+  unitDone: number;
+  unitTotal: number;
+  /** Monotonic overall progress (0..1). */
+  pct: number;
+  message: string;
+  cancelled: boolean;
+}
+
+export interface TranslateOutputResult {
+  sourcePath: string | null;
+  outputPath: string;
+  format: Exclude<TranslateOutputFormat, 'same'>;
+  pageCount?: number;
+  /** 1-based pages whose translated text needed aggressive fitting or clipping. */
+  overflowPages: number[];
+  warnings: string[];
+}
+
+export interface TranslateJobResult {
+  jobId: string;
+  cancelled: boolean;
+  /** Only populated for a pasted-text job. */
+  translatedText: string | null;
+  outputs: TranslateOutputResult[];
+  warnings: string[];
+}
+
+/** One locally persisted result in the Translate history. Source text is never
+ * stored; pasted-text entries keep only the translated result so they can be
+ * copied again. File entries point at their generated output on disk. */
+export interface TranslateHistoryEntry {
+  id: string;
+  createdAt: string;
+  inputKind: TranslateInputKind;
+  sourceLabel: string;
+  sourcePath: string | null;
+  targetLanguage: string;
+  targetLanguageLabel: string;
+  model: ModelRef;
+  pdfMode: TranslatePdfMode | null;
+  outputPath: string | null;
+  outputExists: boolean;
+  format: Exclude<TranslateOutputFormat, 'same'> | null;
+  pageCount?: number;
+  overflowPages: number[];
+  warnings: string[];
+  translatedText: string | null;
+}
+
+/** Internal segment shape is exported so the deterministic test harness can drive
+ * the exact batching/parser code with a fake model. */
+export interface TranslateSegment {
+  id: string;
+  text: string;
+  kind: TranslateMarkupKind;
+}
+
+export interface TranslateSegmentResult extends TranslateSegment {
+  translated: string;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -41,6 +41,21 @@ export type {
   AiOcrExportResult,
 } from './aiOcrTypes';
 export type {
+  TranslateInputKind,
+  TranslatePdfMode,
+  TranslateOutputFormat,
+  TranslateMarkupKind,
+  TranslateZoteroSource,
+  TranslateJobRequest,
+  TranslateJobStage,
+  TranslateJobProgress,
+  TranslateOutputResult,
+  TranslateJobResult,
+  TranslateHistoryEntry,
+  TranslateSegment,
+  TranslateSegmentResult,
+} from './toolkitTranslateTypes';
+export type {
   ProtectInputExtension,
   ProtectSourceKind,
   ProtectSourceRef,
@@ -88,6 +103,7 @@ import type {
   ToolkitAppSessionInfo,
   ToolkitAppSessionSnapshot,
 } from './toolkitApps';
+import type { TranslateHistoryEntry, TranslateJobRequest, TranslateJobProgress, TranslateJobResult } from './toolkitTranslateTypes';
 import type { AiOcrCreateRequest, AiOcrExportFormat, AiOcrExportResult, OcrDoc, OcrDocSummary, OcrDocProgress, OcrOptions } from './aiOcrTypes';
 import type {
   Presentation,
@@ -6301,6 +6317,17 @@ export interface NodusApi {
   pickToolkitOutputDir(): Promise<string | null>;
   /** Reveal a produced file in the OS file manager. */
   revealToolkitOutput(filePath: string): Promise<void>;
+
+  // Nodus Translate — AI translation of pasted text, local files and Zotero
+  // attachments. Like Convert, the renderer re-attaches to progress after navigation.
+  runTranslateJob(
+    request: TranslateJobRequest,
+    handlers: { onProgress: (progress: TranslateJobProgress) => void },
+  ): Promise<TranslateJobResult>;
+  cancelTranslateJob(jobId: string): Promise<void>;
+  saveTranslatedText(text: string, targetLanguage: string, extension?: 'txt' | 'md' | 'html'): Promise<{ canceled: boolean; path?: string }>;
+  listTranslateHistory(): Promise<TranslateHistoryEntry[]>;
+  removeTranslateHistory(id: string, deleteOutput?: boolean): Promise<TranslateHistoryEntry[]>;
 
   // Nodus AI OCR (OCR Workspace) — a persistent, per-document OCR library backed by
   // vision models. Processing runs in main and survives navigation; progress is pushed

--- a/src/backgroundJobs.ts
+++ b/src/backgroundJobs.ts
@@ -10,6 +10,9 @@ import type {
   ToolkitJobRequest,
   ToolkitJobProgress,
   ToolkitJobResult,
+  TranslateJobRequest,
+  TranslateJobProgress,
+  TranslateJobResult,
 } from '@shared/types';
 import type { DatabaseAttachment, DatabaseRow } from '@shared/databases';
 
@@ -171,6 +174,17 @@ export type ToolkitConvertJob = BackgroundJob<ToolkitJobRequest, ToolkitJobProgr
 export function startToolkitJob(request: ToolkitJobRequest): ToolkitConvertJob {
   return startBackgroundJob(TOOLKIT_JOB_KEY, request, (currentRequest, onProgress) =>
     window.nodus.runToolkitJob(currentRequest, { onProgress }),
+  );
+}
+
+// ── Nodus Translate ──────────────────────────────────────────────────────────
+export const TRANSLATE_JOB_KEY = 'toolkit:translate';
+
+export type ToolkitTranslateJob = BackgroundJob<TranslateJobRequest, TranslateJobProgress, TranslateJobResult>;
+
+export function startTranslateJob(request: TranslateJobRequest): ToolkitTranslateJob {
+  return startBackgroundJob(TRANSLATE_JOB_KEY, request, (currentRequest, onProgress) =>
+    window.nodus.runTranslateJob(currentRequest, { onProgress }),
   );
 }
 

--- a/src/components/ToolkitBetaGuide.tsx
+++ b/src/components/ToolkitBetaGuide.tsx
@@ -9,7 +9,7 @@ import claudeLogo from '../assets/brands/claude.svg';
 import { Icon } from './ui';
 import { NodiAvatar } from './nodi/NodiAvatar';
 
-// This guide belongs to the 2.4.0 release, so its four-tool snapshot must not
+// This guide belongs to the 2.4.0 release, so its five-tool snapshot must not
 // change when newer Toolkit entries (such as Nodus Apps) are added later.
 const BETA_TOOLS = TOOLKIT_TOOLS.filter((tool) => tool.page !== 'apps');
 
@@ -25,11 +25,11 @@ const COPY = {
   es: {
     beta: 'NUEVO · BETA',
     title: 'Nuevas herramientas, mejores decisiones',
-    summary: 'Nodus Toolkit incorpora cuatro herramientas en beta y una guía práctica para elegir bien el modelo de extracción.',
+    summary: 'Nodus Toolkit incorpora cinco herramientas en beta y una guía práctica para elegir bien el modelo de extracción.',
     introTitle: 'Nodus Toolkit ya está aquí',
-    introSummary: 'Cuatro espacios de trabajo para preparar, proteger y presentar documentos sin salir de Nodus.',
-    introBody: 'Las cuatro herramientas están disponibles en beta. El procesamiento es local salvo las funciones que indiquen expresamente que usan un proveedor de IA.',
-    toolSummaries: ['Documentos, PDF, imágenes y texto', 'Copias seguras y trazables', 'PDF como presentación', 'OCR asistido para casos difíciles'],
+    introSummary: 'Cinco espacios de trabajo para preparar, proteger, traducir y presentar documentos sin salir de Nodus.',
+    introBody: 'Las cinco herramientas están disponibles en beta. El procesamiento es local salvo las funciones que indiquen expresamente que usan un proveedor de IA.',
+    toolSummaries: ['Documentos, PDF, imágenes y texto', 'Copias seguras y trazables', 'Traducción de texto y documentos', 'PDF como presentación', 'OCR asistido para casos difíciles'],
     originalFiles: 'Los archivos originales no se modifican. Nodus crea siempre una copia o un resultado nuevo.',
     extractionTitle: 'Extracción: menos razonamiento, más precisión',
     extractionSummary: 'Para extraer ideas conviene un modelo directo, disciplinado y fiable con datos estructurados.',
@@ -63,11 +63,11 @@ const COPY = {
   en: {
     beta: 'NEW · BETA',
     title: 'New tools, better model choices',
-    summary: 'Nodus Toolkit adds four beta tools and practical guidance for choosing an idea-extraction model.',
+    summary: 'Nodus Toolkit adds five beta tools and practical guidance for choosing an idea-extraction model.',
     introTitle: 'Nodus Toolkit is here',
-    introSummary: 'Four workspaces to prepare, protect and present documents without leaving Nodus.',
-    introBody: 'All four tools are available in beta. Processing is local unless a feature explicitly says it uses an AI provider.',
-    toolSummaries: ['Documents, PDFs, images and text', 'Safe, traceable copies', 'Present a PDF', 'Assisted OCR for difficult scans'],
+    introSummary: 'Five workspaces to prepare, protect, translate and present documents without leaving Nodus.',
+    introBody: 'All five tools are available in beta. Processing is local unless a feature explicitly says it uses an AI provider.',
+    toolSummaries: ['Documents, PDFs, images and text', 'Safe, traceable copies', 'Translate text and documents', 'Present a PDF', 'Assisted OCR for difficult scans'],
     originalFiles: 'Original files are never modified. Nodus always creates a copy or a new output.',
     extractionTitle: 'Extraction: less reasoning, more precision',
     extractionSummary: 'Idea extraction benefits from a direct model that reliably returns structured data.',
@@ -152,19 +152,21 @@ function toolStep(index: number, language: GuideLanguage): TourStep {
   const details = language === 'es' ? [
     <>Convierte documentos, PDF e imágenes de uno en uno o en lote. Incluye utilidades de PDF, OCR ligero, compresión, cambio de formato y operaciones de texto.</>,
     <>Oculta o desenfoca datos, añade marcas de agua y pies legales, rasteriza copias y crea o verifica marcas trazables. Todo el procesamiento del documento es local.</>,
+    <>Traduce texto pegado, documentos del disco o adjuntos de Zotero con el modelo que elijas. Conserva la estructura de DOCX y EPUB y ofrece un modo facsímil para mantener la apariencia de los PDF.</>,
     <>Convierte un PDF en una presentación con vista del público y del presentador, notas, miniaturas, puntero, dibujo y anotaciones en directo.</>,
     <>Reconstruye escaneados difíciles página a página con ayuda de un modelo visual. Permite revisar el resultado y guardarlo en Markdown o incorporarlo a una bóveda.</>,
   ] : [
     <>Convert documents, PDFs and images one at a time or in batches, with PDF utilities, light OCR, compression, format changes and text operations.</>,
     <>Redact or blur data, add watermarks and legal footers, rasterise copies, and create or verify traceable marks. Document processing remains local.</>,
+    <>Translate pasted text, documents from disk or Zotero attachments with the model you choose. DOCX and EPUB structure is retained, and facsimile mode preserves the visual appearance of PDFs.</>,
     <>Turn a PDF into a presentation with audience and presenter views, notes, thumbnails, a pointer, drawing and live annotations.</>,
     <>Reconstruct difficult scans page by page with a vision model, review the output, and save it as Markdown or add it to a vault.</>,
   ];
   return {
     icon: tool.icon,
     title: tool.name,
-    summary: language === 'es' ? 'Una de las cuatro herramientas disponibles en la beta de Nodus Toolkit.' : 'One of the four tools available in the Nodus Toolkit beta.',
-    content: <div className="toolkit-guide-tool-focus"><span><Icon name={tool.icon} size={34} /></span><p>{details[index]}</p><div><Icon name="sparkles" size={14} /> BETA · {index + 1} / 4</div></div>,
+    summary: language === 'es' ? 'Una de las cinco herramientas disponibles en la beta de Nodus Toolkit.' : 'One of the five tools available in the Nodus Toolkit beta.',
+    content: <div className="toolkit-guide-tool-focus"><span><Icon name={tool.icon} size={34} /></span><p>{details[index]}</p><div><Icon name="sparkles" size={14} /> BETA · {index + 1} / {BETA_TOOLS.length}</div></div>,
   };
 }
 
@@ -192,7 +194,7 @@ export function ToolkitBetaUpdateTour({
   const c = toolkitBetaGuideCopy(uiLanguage);
   const steps = useMemo<TourStep[]>(() => [
     { icon: 'tools', title: c.introTitle, summary: c.introSummary, content: <ToolkitOverviewPanel language={uiLanguage} /> },
-    ...[0, 1, 2, 3].map((toolIndex) => toolStep(toolIndex, uiLanguage)),
+    ...BETA_TOOLS.map((_, toolIndex) => toolStep(toolIndex, uiLanguage)),
     { icon: 'bulb', title: c.extractionTitle, summary: c.extractionSummary, content: <IdeaExtractionPanel language={uiLanguage} /> },
     { icon: 'clock', title: c.performanceTitle, summary: c.performanceSummary, content: <LocalPerformancePanel language={uiLanguage} /> },
     { icon: 'chartBar', title: c.remoteTitle, summary: c.remoteSummary, content: <RemoteModelsPanel language={uiLanguage} /> },

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -12,6 +12,8 @@ export const DE: Record<string, string> = {
   ...AI_OCR_TRANSLATIONS.de,
   ...PROTECT_TRANSLATIONS.de,
   ...TOOLKIT_APPS_TRANSLATIONS.de,
+  'Traduce texto, documentos y adjuntos de Zotero con el modelo que elijas, incluido un modo PDF facsímil.': 'Übersetze Text, Dokumente und Zotero-Anhänge mit dem Modell deiner Wahl, einschließlich eines PDF-Faksimilemodus.',
+  'Traducir texto, documentos y adjuntos de Zotero con el modelo elegido, conservando la estructura de DOCX y EPUB y la apariencia de los PDF mediante un modo facsímil.': 'Text, Dokumente und Zotero-Anhänge mit dem gewählten Modell übersetzen und dabei die DOCX- und EPUB-Struktur sowie das Erscheinungsbild von PDFs im Faksimilemodus bewahren.',
   'Mover documento a la papelera': 'Dokument in den Papierkorb verschieben',
   'Mover documentos a la papelera': 'Dokumente in den Papierkorb verschieben',
   '«{name}» dejará de aparecer. Podrás recuperarlo desde la administración de datos.': '„{name}“ wird nicht mehr angezeigt. Es kann über die Datenverwaltung wiederhergestellt werden.',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -11,6 +11,8 @@ export const EN: Record<string, string> = {
   ...AI_OCR_TRANSLATIONS.en,
   ...PROTECT_TRANSLATIONS.en,
   ...TOOLKIT_APPS_TRANSLATIONS.en,
+  'Traduce texto, documentos y adjuntos de Zotero con el modelo que elijas, incluido un modo PDF facsímil.': 'Translate text, documents and Zotero attachments with the model you choose, including a PDF facsimile mode.',
+  'Traducir texto, documentos y adjuntos de Zotero con el modelo elegido, conservando la estructura de DOCX y EPUB y la apariencia de los PDF mediante un modo facsímil.': 'Translate text, documents and Zotero attachments with the chosen model, retaining DOCX and EPUB structure and the appearance of PDFs through facsimile mode.',
   'Mover documento a la papelera': 'Move document to trash',
   'Mover documentos a la papelera': 'Move documents to trash',
   '«{name}» dejará de aparecer. Podrás recuperarlo desde la administración de datos.': '“{name}” will no longer appear. You can recover it from data management.',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -12,6 +12,8 @@ export const FR: Record<string, string> = {
   ...AI_OCR_TRANSLATIONS.fr,
   ...PROTECT_TRANSLATIONS.fr,
   ...TOOLKIT_APPS_TRANSLATIONS.fr,
+  'Traduce texto, documentos y adjuntos de Zotero con el modelo que elijas, incluido un modo PDF facsímil.': 'Traduisez du texte, des documents et des pièces jointes Zotero avec le modèle de votre choix, y compris un mode fac-similé PDF.',
+  'Traducir texto, documentos y adjuntos de Zotero con el modelo elegido, conservando la estructura de DOCX y EPUB y la apariencia de los PDF mediante un modo facsímil.': 'Traduire du texte, des documents et des pièces jointes Zotero avec le modèle choisi, tout en conservant la structure des DOCX et EPUB et l’apparence des PDF grâce au mode fac-similé.',
   'Mover documento a la papelera': 'Mettre le document à la corbeille',
   'Mover documentos a la papelera': 'Mettre les documents à la corbeille',
   '«{name}» dejará de aparecer. Podrás recuperarlo desde la administración de datos.': '« {name} » ne sera plus affiché. Vous pourrez le récupérer depuis la gestion des données.',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -6,6 +6,8 @@ import { TOOLKIT_APPS_TRANSLATIONS } from './i18n.toolkitApps';
 export const IT: Record<string, string> = {
   ...AI_OCR_TRANSLATIONS.it,
   ...TOOLKIT_APPS_TRANSLATIONS.it,
+  'Traduce texto, documentos y adjuntos de Zotero con el modelo que elijas, incluido un modo PDF facsímil.': 'Traduci testo, documenti e allegati Zotero con il modello che preferisci, inclusa una modalità facsimile PDF.',
+  'Traducir texto, documentos y adjuntos de Zotero con el modelo elegido, conservando la estructura de DOCX y EPUB y la apariencia de los PDF mediante un modo facsímil.': 'Tradurre testo, documenti e allegati Zotero con il modello scelto, mantenendo la struttura di DOCX ed EPUB e l’aspetto dei PDF tramite la modalità facsimile.',
   'Mover documento a la papelera': 'Sposta il documento nel cestino',
   'Mover documentos a la papelera': 'Sposta i documenti nel cestino',
   '«{name}» dejará de aparecer. Podrás recuperarlo desde la administración de datos.': '«{name}» non sarà più visibile. Potrai recuperarlo dalla gestione dei dati.',

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -12,6 +12,8 @@ export const PT_BR: Record<string, string> = {
   ...AI_OCR_TRANSLATIONS['pt-BR'],
   ...PROTECT_TRANSLATIONS['pt-BR'],
   ...TOOLKIT_APPS_TRANSLATIONS['pt-BR'],
+  'Traduce texto, documentos y adjuntos de Zotero con el modelo que elijas, incluido un modo PDF facsímil.': 'Traduza textos, documentos e anexos do Zotero com o modelo que você escolher, incluindo um modo fac-símile de PDF.',
+  'Traducir texto, documentos y adjuntos de Zotero con el modelo elegido, conservando la estructura de DOCX y EPUB y la apariencia de los PDF mediante un modo facsímil.': 'Traduzir textos, documentos e anexos do Zotero com o modelo escolhido, preservando a estrutura de DOCX e EPUB e a aparência dos PDFs por meio do modo fac-símile.',
   'Mover documento a la papelera': 'Mover documento para a lixeira',
   'Mover documentos a la papelera': 'Mover documentos para a lixeira',
   '«{name}» dejará de aparecer. Podrás recuperarlo desde la administración de datos.': '“{name}” deixará de aparecer. Você poderá recuperá-lo no gerenciamento de dados.',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -12,6 +12,8 @@ export const PT: Record<string, string> = {
   ...AI_OCR_TRANSLATIONS.pt,
   ...PROTECT_TRANSLATIONS.pt,
   ...TOOLKIT_APPS_TRANSLATIONS.pt,
+  'Traduce texto, documentos y adjuntos de Zotero con el modelo que elijas, incluido un modo PDF facsímil.': 'Traduza texto, documentos e anexos do Zotero com o modelo que escolher, incluindo um modo fac-símile de PDF.',
+  'Traducir texto, documentos y adjuntos de Zotero con el modelo elegido, conservando la estructura de DOCX y EPUB y la apariencia de los PDF mediante un modo facsímil.': 'Traduzir texto, documentos e anexos do Zotero com o modelo escolhido, mantendo a estrutura de DOCX e EPUB e a aparência dos PDF através do modo fac-símile.',
   'Mover documento a la papelera': 'Mover documento para o lixo',
   'Mover documentos a la papelera': 'Mover documentos para o lixo',
   '«{name}» dejará de aparecer. Podrás recuperarlo desde la administración de datos.': '«{name}» deixará de aparecer. Poderá recuperá-lo na gestão de dados.',

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -98,7 +98,7 @@ export const NAV_ITEMS: NavItem[] = [
  * never turns into a new top-level view (and never leaks into sidebarOrder, the
  * per-vault-type allow-lists or the reordering UI). The sidebar nests one button
  * per tool under the section, and 'home' is the catalogue. */
-export type ToolkitPage = 'home' | 'convert' | 'protect' | 'presenter' | 'ocr' | 'apps';
+export type ToolkitPage = 'home' | 'apps' | 'convert' | 'translate' | 'protect' | 'presenter' | 'ocr';
 
 export interface ToolkitToolDef {
   page: Exclude<ToolkitPage, 'home'>;
@@ -147,6 +147,15 @@ export const TOOLKIT_TOOLS: ToolkitToolDef[] = [
     icon: 'shield',
     state: 'wip',
     testid: 'protect',
+  },
+  {
+    page: 'translate',
+    name: 'Nodus Translate',
+    shortName: 'Translate',
+    description: 'Traduce texto, documentos y adjuntos de Zotero con el modelo que elijas, incluido un modo PDF facsímil.',
+    icon: 'languages',
+    state: 'wip',
+    testid: 'translate',
   },
   {
     page: 'presenter',

--- a/src/views/ToolkitTranslateView.tsx
+++ b/src/views/ToolkitTranslateView.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useState, type DragEvent } from 'react';
+import {
+  TRANSLATION_LANGUAGES,
+  type AppSettings,
+  type ModelRef,
+  type TranslateHistoryEntry,
+  type TranslateInputKind,
+  type TranslateJobRequest,
+  type TranslateOutputFormat,
+  type TranslatePdfMode,
+  type ZoteroAttachmentInfo,
+  type ZoteroItem,
+  type ZoteroLibrary,
+} from '@shared/types';
+import { isLocalProvider } from '@shared/providers';
+import { ModelPicker, SubscriptionQuotaNotice } from '../components/ModelPicker';
+import { Icon, Spinner } from '../components/ui';
+import { t } from '../i18n';
+import {
+  TRANSLATE_JOB_KEY,
+  clearBackgroundJob,
+  getBackgroundJob,
+  startTranslateJob,
+  subscribeBackgroundJob,
+  type ToolkitTranslateJob,
+} from '../backgroundJobs';
+
+const INPUT_EXTENSIONS = ['txt', 'md', 'markdown', 'html', 'htm', 'docx', 'epub', 'pdf'];
+type TranslateTab = TranslateInputKind | 'history';
+
+function basename(filePath: string): string {
+  const index = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  return index >= 0 ? filePath.slice(index + 1) : filePath;
+}
+
+function creatorLabel(item: ZoteroItem): string {
+  const creator = item.creators[0];
+  if (!creator) return item.year ? String(item.year) : item.itemType;
+  const name = creator.name || [creator.firstName, creator.lastName].filter(Boolean).join(' ');
+  return [name, item.year].filter(Boolean).join(' · ');
+}
+
+function progressLabel(job: ToolkitTranslateJob): string {
+  if (job.status === 'failed') return job.error || 'No se pudo completar la traducción.';
+  if (job.status === 'completed') return job.result?.cancelled ? 'Trabajo cancelado.' : 'Traducción completada.';
+  return job.progress?.message || 'Preparando la traducción…';
+}
+
+export function ToolkitTranslateView({ onBack, settings }: { onBack: () => void; settings: AppSettings | null }) {
+  const existing = getBackgroundJob<TranslateJobRequest, ToolkitTranslateJob['progress'], ToolkitTranslateJob['result']>(TRANSLATE_JOB_KEY) as ToolkitTranslateJob | null;
+  const [tab, setTab] = useState<TranslateTab>('text');
+  const [sourceText, setSourceText] = useState('');
+  const [paths, setPaths] = useState<string[]>([]);
+  const [targetLanguage, setTargetLanguage] = useState('en');
+  const [sourceLanguage, setSourceLanguage] = useState('');
+  const [model, setModel] = useState<ModelRef | null>(() => settings?.synthesisModel ?? null);
+  const [outputFormat, setOutputFormat] = useState<TranslateOutputFormat>('same');
+  const [pdfMode, setPdfMode] = useState<TranslatePdfMode>('facsimile');
+  const [translateImageText, setTranslateImageText] = useState(false);
+  const [glossary, setGlossary] = useState('');
+  const [advanced, setAdvanced] = useState(false);
+  const [outputDir, setOutputDir] = useState<string | null>(null);
+  const [openFolderOnDone, setOpenFolderOnDone] = useState(true);
+  const [job, setJob] = useState<ToolkitTranslateJob | null>(existing);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [libraries, setLibraries] = useState<ZoteroLibrary[]>([]);
+  const [library, setLibrary] = useState<ZoteroLibrary | null>(null);
+  const [zoteroQuery, setZoteroQuery] = useState('');
+  const [zoteroItems, setZoteroItems] = useState<ZoteroItem[]>([]);
+  const [zoteroBusy, setZoteroBusy] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<ZoteroItem | null>(null);
+  const [attachments, setAttachments] = useState<ZoteroAttachmentInfo[]>([]);
+  const [selectedAttachment, setSelectedAttachment] = useState<ZoteroAttachmentInfo | null>(null);
+  const [zoteroConnecting, setZoteroConnecting] = useState(false);
+  const [zoteroSearching, setZoteroSearching] = useState(false);
+  const [zoteroError, setZoteroError] = useState<string | null>(null);
+  const [zoteroConnectAttempt, setZoteroConnectAttempt] = useState(0);
+
+  const [history, setHistory] = useState<TranslateHistoryEntry[]>([]);
+  const [historyBusy, setHistoryBusy] = useState(false);
+
+  useEffect(() => subscribeBackgroundJob(TRANSLATE_JOB_KEY, (next) => setJob(next as ToolkitTranslateJob | null)), []);
+  useEffect(() => {
+    if (!model && settings?.synthesisModel) setModel(settings.synthesisModel);
+  }, [settings, model]);
+
+  useEffect(() => {
+    if (tab !== 'zotero') return;
+    let disposed = false;
+    setZoteroConnecting(true);
+    setZoteroError(null);
+    void window.nodus.zoteroPing().then(async (status) => {
+      if (!status.ok) throw new Error(status.message || 'Zotero no está disponible.');
+      const next = await window.nodus.zoteroLibraries();
+      if (disposed) return;
+      setLibraries(next);
+      setLibrary((current) => next.find((candidate) => current && candidate.type === current.type && candidate.id === current.id) ?? next[0] ?? null);
+      setZoteroError(null);
+    }).catch((error) => {
+      if (disposed) return;
+      setLibraries([]);
+      setLibrary(null);
+      setZoteroItems([]);
+      setZoteroError(error instanceof Error ? error.message : String(error));
+    }).finally(() => { if (!disposed) setZoteroConnecting(false); });
+    return () => { disposed = true; };
+  }, [tab, zoteroConnectAttempt]);
+
+  useEffect(() => {
+    if (tab !== 'zotero' || !library) return;
+    let disposed = false;
+    const timer = window.setTimeout(() => {
+      setZoteroSearching(true);
+      setZoteroError(null);
+      void window.nodus.zoteroSearchItems(library, zoteroQuery)
+        .then((next) => { if (!disposed) setZoteroItems(next); })
+        .catch((error) => { if (!disposed) setZoteroError(error instanceof Error ? error.message : String(error)); })
+        .finally(() => { if (!disposed) setZoteroSearching(false); });
+    }, 220);
+    return () => { disposed = true; window.clearTimeout(timer); };
+  }, [tab, library, zoteroQuery]);
+
+  useEffect(() => {
+    if (tab !== 'history') return;
+    let disposed = false;
+    setHistoryBusy(true);
+    void window.nodus.listTranslateHistory()
+      .then((next) => { if (!disposed) setHistory(next); })
+      .catch((error) => { if (!disposed) setNotice(error instanceof Error ? error.message : String(error)); })
+      .finally(() => { if (!disposed) setHistoryBusy(false); });
+    return () => { disposed = true; };
+  }, [tab, job?.status]);
+
+  const chooseItem = async (item: ZoteroItem) => {
+    setSelectedItem(item); setSelectedAttachment(null); setAttachments([]); setZoteroBusy(true); setZoteroError(null);
+    try {
+      const next = await window.nodus.zoteroItemAttachments(item.key, item.library);
+      const compatible = next.filter((entry) => {
+        if (!entry.available) return false;
+        const filename = entry.filename?.toLowerCase() ?? '';
+        const compatibleName = INPUT_EXTENSIONS.some((ext) => filename.endsWith(`.${ext}`));
+        const compatibleType = entry.contentType === 'application/pdf'
+          || entry.contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+          || entry.contentType === 'application/epub+zip'
+          || entry.contentType === 'text/plain'
+          || entry.contentType === 'text/html'
+          || entry.contentType === 'text/markdown';
+        return compatibleName || compatibleType;
+      });
+      setAttachments(compatible);
+      setSelectedAttachment(compatible[0] ?? null);
+      if (!compatible.length) setZoteroError('Este elemento no tiene adjuntos locales compatibles.');
+    } catch (error) {
+      setZoteroError(error instanceof Error ? error.message : String(error));
+    } finally { setZoteroBusy(false); }
+  };
+
+  const running = job?.status === 'running';
+  const hasPdf = paths.some((file) => /\.pdf$/i.test(file)) || selectedAttachment?.contentType === 'application/pdf';
+  const canRun = tab !== 'history' && Boolean(model) && !running && (
+    tab === 'text' ? Boolean(sourceText.trim()) : tab === 'files' ? paths.length > 0 : Boolean(selectedAttachment && selectedItem)
+  );
+  const target = TRANSLATION_LANGUAGES.find((language) => language.code === targetLanguage);
+  const cloud = model ? !isLocalProvider(model.provider) && model.provider !== 'nodus' : false;
+
+  const addPaths = (next: string[]) => setPaths((current) => [...new Set([...current, ...next.filter((file) => INPUT_EXTENSIONS.some((ext) => file.toLowerCase().endsWith(`.${ext}`)))])]);
+  const pickFiles = async () => addPaths(await window.nodus.pickToolkitFiles(INPUT_EXTENSIONS));
+  const drop = (event: DragEvent) => {
+    event.preventDefault();
+    addPaths([...event.dataTransfer.files].map((file) => window.nodus.getPathForDroppedFile(file)).filter(Boolean));
+  };
+
+  const removeHistoryEntry = async (entry: TranslateHistoryEntry, deleteOutput: boolean) => {
+    const question = deleteOutput
+      ? `¿Mover “${basename(entry.outputPath || entry.sourceLabel)}” a la Papelera y quitarlo del historial?`
+      : '¿Quitar esta entrada del historial? El archivo generado no se eliminará.';
+    if (!window.confirm(question)) return;
+    setHistoryBusy(true);
+    try {
+      setHistory(await window.nodus.removeTranslateHistory(entry.id, deleteOutput));
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : String(error));
+    } finally {
+      setHistoryBusy(false);
+    }
+  };
+
+  const run = () => {
+    if (!canRun) return;
+    setNotice(null);
+    clearBackgroundJob(TRANSLATE_JOB_KEY);
+    const request: TranslateJobRequest = {
+      inputKind: tab,
+      text: tab === 'text' ? sourceText : undefined,
+      inputPaths: tab === 'files' ? paths : undefined,
+      zotero: tab === 'zotero' && selectedItem && selectedAttachment ? {
+        itemKey: selectedItem.key,
+        attachmentKey: selectedAttachment.key,
+        libraryType: selectedItem.library.type,
+        libraryId: selectedItem.library.id,
+        title: selectedItem.title,
+      } : undefined,
+      sourceLanguage: sourceLanguage.trim() || null,
+      targetLanguage,
+      model,
+      outputFormat: tab === 'text' ? 'txt' : outputFormat,
+      pdfMode,
+      translateImageText,
+      glossary: glossary.trim(),
+      outputDir,
+      openFolderOnDone,
+    };
+    setJob(startTranslateJob(request));
+  };
+
+  const translatedText = job?.status === 'completed' ? job.result?.translatedText : null;
+  const outputs = job?.status === 'completed' ? job.result?.outputs ?? [] : [];
+  const progress = Math.round((job?.progress?.pct ?? (job?.status === 'completed' ? 1 : 0)) * 100);
+
+  return <div data-testid="translate-home" className="mx-auto max-w-5xl space-y-5 pb-12">
+    <header className="flex items-start gap-3">
+      <button data-testid="toolkit-translate-back" type="button" aria-label={t('Volver a Herramientas')} onClick={onBack} className="mt-1 grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-neutral-300 bg-white text-neutral-600 hover:border-amber-400 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300"><Icon name="chevronLeft" size={17} /></button>
+      <span className="grid h-12 w-12 shrink-0 place-items-center rounded-xl bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300"><Icon name="languages" size={23} /></span>
+      <div><h1 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">Nodus Translate</h1><p className="text-sm text-neutral-500">Traduce texto, documentos o adjuntos de Zotero conservando su estructura y, en PDF, la disposición de cada página.</p></div>
+    </header>
+
+    <nav className="grid grid-cols-2 gap-1 rounded-xl bg-neutral-100 p-1 sm:grid-cols-4 dark:bg-neutral-900/60" aria-label="Secciones de traducción">
+      {([['text', 'Texto', 'edit'], ['files', 'Documentos', 'file'], ['zotero', 'Zotero', 'book'], ['history', 'Historial', 'clock']] as const).map(([id, label, icon]) => <button key={id} data-testid={`translate-tab-${id}`} type="button" onClick={() => { setNotice(null); setTab(id); }} className={`flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold ${tab === id ? 'bg-white text-amber-700 shadow-sm dark:bg-neutral-800 dark:text-amber-300' : 'text-neutral-500'}`}><Icon name={icon} size={15} />{label}</button>)}
+    </nav>
+
+    {tab === 'text' && <section className="grid gap-6 lg:grid-cols-2">
+      <label className="block min-w-0"><span className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-neutral-500">Texto original</span><textarea data-testid="translate-source-text" className="input block min-h-72 w-full resize-y leading-6" value={sourceText} onChange={(event) => setSourceText(event.target.value)} placeholder="Escribe o pega aquí el texto que quieres traducir…" /></label>
+      <div className="min-w-0"><span className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-neutral-500">Traducción</span><div data-testid="translate-result-text" className="min-h-72 whitespace-pre-wrap rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm leading-6 text-neutral-800 dark:border-neutral-800 dark:bg-neutral-900/40 dark:text-neutral-200">{translatedText || <span className="text-neutral-400">El resultado aparecerá aquí.</span>}</div>{translatedText && <div className="mt-2 flex gap-2"><button className="btn btn-ghost gap-1.5" onClick={() => void navigator.clipboard.writeText(translatedText)}><Icon name="copy" size={14} />Copiar</button><button className="btn btn-ghost gap-1.5" onClick={() => void window.nodus.saveTranslatedText(translatedText, target?.nativeName || targetLanguage)}><Icon name="download" size={14} />Guardar TXT</button></div>}</div>
+    </section>}
+
+    {tab === 'files' && <section>
+      <button data-testid="translate-file-dropzone" type="button" onClick={() => void pickFiles()} onDragOver={(event) => event.preventDefault()} onDrop={drop} className="flex min-h-36 w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-neutral-300 bg-neutral-50 p-7 text-neutral-500 hover:border-amber-400 dark:border-neutral-700 dark:bg-neutral-900/30"><Icon name="upload" size={25} className="text-amber-600" /><strong className="text-sm text-neutral-700 dark:text-neutral-200">Suelta documentos o selecciónalos</strong><span className="text-xs">TXT · Markdown · HTML · DOCX · EPUB · PDF</span></button>
+      {!!paths.length && <ul className="mt-3 space-y-1.5">{paths.map((file) => <li key={file} className="flex items-center gap-2 rounded-lg border border-neutral-200 px-3 py-2 text-sm dark:border-neutral-800"><Icon name="file" size={14} /><span className="min-w-0 flex-1 truncate">{basename(file)}</span><button className="text-neutral-400 hover:text-red-400" onClick={() => setPaths((current) => current.filter((item) => item !== file))}><Icon name="x" size={14} /></button></li>)}</ul>}
+    </section>}
+
+    {tab === 'zotero' && <section className="space-y-3">
+      <div className={`flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2 text-xs ${zoteroError ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300' : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/20 dark:text-emerald-300'}`}>
+        <Icon name={zoteroError ? 'alert' : zoteroConnecting ? 'sync' : 'check'} size={14} className={zoteroConnecting ? 'animate-spin' : ''} />
+        <span className="min-w-0 flex-1">{zoteroConnecting ? 'Conectando con Zotero…' : zoteroError || `Conectado a Zotero · ${libraries.length} ${libraries.length === 1 ? 'biblioteca' : 'bibliotecas'}`}</span>
+        <button data-testid="translate-zotero-reconnect" type="button" className="btn btn-ghost !px-2 !py-1" disabled={zoteroConnecting} onClick={() => setZoteroConnectAttempt((value) => value + 1)}>Reconectar</button>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="min-w-0 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <select data-testid="translate-zotero-library" aria-label="Biblioteca de Zotero" className="input w-full sm:max-w-52" disabled={zoteroConnecting || libraries.length === 0} value={library ? `${library.type}:${library.id}` : ''} onChange={(event) => { const next = libraries.find((entry) => `${entry.type}:${entry.id}` === event.target.value) ?? null; setLibrary(next); setZoteroItems([]); setSelectedItem(null); setAttachments([]); setSelectedAttachment(null); }}><option value="" disabled>{zoteroConnecting ? 'Conectando…' : 'Selecciona biblioteca'}</option>{libraries.map((entry) => <option key={`${entry.type}:${entry.id}`} value={`${entry.type}:${entry.id}`}>{entry.name}</option>)}</select>
+            <div className="relative min-w-0 flex-1"><Icon name="search" size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" /><input data-testid="translate-zotero-search" className="input input-with-leading-icon w-full" disabled={!library || zoteroConnecting} value={zoteroQuery} onChange={(event) => setZoteroQuery(event.target.value)} placeholder="Buscar título, autor o año…" /></div>
+          </div>
+          {zoteroSearching && !zoteroItems.length ? <div className="py-10"><Spinner label="Buscando en Zotero…" /></div> : zoteroItems.length ? <ul data-testid="translate-zotero-results" className="mt-3 max-h-72 space-y-1 overflow-y-auto">{zoteroItems.map((item) => <li key={item.key}><button type="button" onClick={() => void chooseItem(item)} className={`w-full rounded-lg border px-3 py-2 text-left ${selectedItem?.key === item.key ? 'border-amber-400 bg-amber-50 dark:bg-amber-950/20' : 'border-transparent hover:bg-neutral-50 dark:hover:bg-neutral-900'}`}><span className="block truncate text-sm font-medium">{item.title}</span><span className="block truncate text-xs text-neutral-500">{creatorLabel(item)}</span></button></li>)}</ul> : library && !zoteroSearching ? <p className="py-10 text-center text-sm text-neutral-500">No hay resultados para esta búsqueda.</p> : null}
+        </div>
+        <div className="min-w-0 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800"><h2 className="text-sm font-semibold">Adjunto que se traducirá</h2>{zoteroBusy ? <div className="py-8"><Spinner label="Cargando adjuntos…" /></div> : !selectedItem ? <p className="mt-8 text-center text-sm text-neutral-500">Selecciona primero un elemento de Zotero.</p> : !attachments.length ? <p className="mt-8 text-center text-sm text-neutral-500">No hay adjuntos compatibles descargados.</p> : <div className="mt-3 space-y-2">{attachments.map((attachment) => <label key={attachment.key} className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 ${selectedAttachment?.key === attachment.key ? 'border-amber-400 bg-amber-50 dark:bg-amber-950/20' : 'border-neutral-200 dark:border-neutral-800'}`}><input type="radio" checked={selectedAttachment?.key === attachment.key} onChange={() => setSelectedAttachment(attachment)} /><Icon name="file" size={16} /><span className="min-w-0"><span className="block truncate text-sm font-medium">{attachment.title}</span><span className="block truncate text-xs text-neutral-500">{attachment.filename || attachment.contentType}</span></span></label>)}</div>}</div>
+      </div>
+    </section>}
+
+    {tab === 'history' && <section data-testid="translate-history" className="rounded-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="flex items-center gap-3 border-b border-neutral-200 px-4 py-3 dark:border-neutral-800"><div className="min-w-0 flex-1"><h2 className="text-sm font-semibold">Documentos procesados</h2><p className="text-xs text-neutral-500">Los archivos se conservan en su carpeta de salida hasta que elijas moverlos a la Papelera.</p></div><button className="btn btn-ghost gap-1.5" disabled={historyBusy} onClick={() => { setHistoryBusy(true); void window.nodus.listTranslateHistory().then(setHistory).catch((error) => setNotice(error instanceof Error ? error.message : String(error))).finally(() => setHistoryBusy(false)); }}><Icon name="sync" size={13} className={historyBusy ? 'animate-spin' : ''} />Actualizar</button></div>
+      {historyBusy && !history.length ? <div className="py-14"><Spinner label="Cargando historial…" /></div> : !history.length ? <div className="grid place-items-center gap-2 px-5 py-16 text-center text-neutral-500"><Icon name="clock" size={28} /><p className="text-sm font-medium">Todavía no hay traducciones guardadas.</p><p className="text-xs">Los próximos textos y documentos aparecerán aquí automáticamente.</p></div> : <ul className="divide-y divide-neutral-200 dark:divide-neutral-800">{history.map((entry) => <li key={entry.id} data-testid={`translate-history-entry-${entry.id}`} className="p-4"><div className="flex flex-wrap items-start gap-3"><span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300"><Icon name={entry.inputKind === 'text' ? 'edit' : entry.inputKind === 'zotero' ? 'book' : 'file'} size={15} /></span><div className="min-w-0 flex-1"><p className="truncate text-sm font-semibold">{entry.outputPath ? basename(entry.outputPath) : entry.sourceLabel}</p><p className="mt-0.5 text-xs text-neutral-500">{new Date(entry.createdAt).toLocaleString()} · {entry.targetLanguageLabel} · {entry.model.provider} · {entry.model.model}{entry.pdfMode ? ` · ${entry.pdfMode === 'facsimile' ? 'Facsímil' : 'Refluido'}` : ''}</p>{entry.outputPath && !entry.outputExists && <p className="mt-1 text-xs text-amber-600">El archivo ya no está en su ubicación original.</p>}{entry.translatedText && <p className="mt-2 line-clamp-3 whitespace-pre-wrap rounded-lg bg-neutral-50 p-2 text-xs leading-5 text-neutral-600 dark:bg-neutral-950/40 dark:text-neutral-400">{entry.translatedText}</p>}{entry.warnings.length > 0 && <p className="mt-1 text-xs text-amber-600">{entry.warnings.length} aviso{entry.warnings.length === 1 ? '' : 's'} · revisar resultado</p>}</div><div className="flex shrink-0 flex-wrap justify-end gap-1">{entry.outputPath && entry.outputExists && <button className="btn btn-ghost !px-2 !py-1 text-xs" onClick={() => void window.nodus.revealToolkitOutput(entry.outputPath!)}>Mostrar</button>}{entry.translatedText && <button className="btn btn-ghost !px-2 !py-1 text-xs" onClick={() => void navigator.clipboard.writeText(entry.translatedText!)}><Icon name="copy" size={12} />Copiar</button>}<button className="btn btn-ghost !px-2 !py-1 text-xs text-neutral-500" disabled={historyBusy} onClick={() => void removeHistoryEntry(entry, false)}>Quitar</button>{entry.outputPath && entry.outputExists && <button className="btn btn-ghost !px-2 !py-1 text-xs text-red-500" disabled={historyBusy} onClick={() => void removeHistoryEntry(entry, true)}><Icon name="trash" size={12} />Eliminar archivo</button>}</div></div></li>)}</ul>}
+    </section>}
+    {tab === 'history' && notice && <p className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300">{notice}</p>}
+
+    {tab !== 'history' && <><section className="space-y-4 rounded-xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="block text-sm"><span className="mb-1 block font-medium">Idioma de destino</span><select data-testid="translate-target-language" className="input" value={targetLanguage} onChange={(event) => setTargetLanguage(event.target.value)}>{TRANSLATION_LANGUAGES.map((language) => <option key={language.code} value={language.code}>{language.nativeName} — {language.name}</option>)}</select></label>
+        <label className="block text-sm"><span className="mb-1 block font-medium">Modelo de IA</span>{settings ? <ModelPicker settings={settings} value={model} onChange={setModel} allowEmpty={false} emptyLabel="Seleccionar modelo" /> : <Spinner label={t('Cargando…')} />}</label>
+      </div>
+      <SubscriptionQuotaNotice model={model} />
+      {cloud && model && <p className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-200"><Icon name="lock" size={13} className="mr-1 inline" />El contenido se enviará a {model.provider}. Para mantenerlo en el dispositivo, selecciona un modelo local.</p>}
+
+      {tab !== 'text' && <div className="grid gap-4 border-t border-neutral-200 pt-4 md:grid-cols-2 dark:border-neutral-800">
+        <label className="block text-sm"><span className="mb-1 block font-medium">Formato de salida</span><select className="input" value={outputFormat} onChange={(event) => { const next = event.target.value as TranslateOutputFormat; setOutputFormat(next); if (next !== 'same' && next !== 'pdf') setPdfMode('reflow'); }}><option value="same">Conservar el formato original</option><option value="pdf">PDF</option><option value="html">HTML</option><option value="md">Markdown</option><option value="txt">Texto</option></select></label>
+        <div><span className="mb-1 block text-sm font-medium">Carpeta de salida</span><div className="flex gap-2"><div className="input min-w-0 flex-1 truncate text-sm text-neutral-500">{outputDir || (tab === 'zotero' ? 'Descargas' : 'Junto al original')}</div><button className="btn btn-ghost" onClick={async () => { const picked = await window.nodus.pickToolkitOutputDir(); if (picked) setOutputDir(picked); }}>Elegir…</button></div></div>
+      </div>}
+
+      {tab !== 'text' && hasPdf && <div className="rounded-xl border border-indigo-200 bg-indigo-50/60 p-4 dark:border-indigo-900/50 dark:bg-indigo-950/15"><div className="grid gap-3 sm:grid-cols-2"><label className={`rounded-lg border p-3 ${outputFormat === 'same' || outputFormat === 'pdf' ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'} ${pdfMode === 'facsimile' ? 'border-indigo-500 bg-white dark:bg-neutral-900' : 'border-transparent'}`}><input className="mr-2" type="radio" disabled={outputFormat !== 'same' && outputFormat !== 'pdf'} checked={pdfMode === 'facsimile'} onChange={() => setPdfMode('facsimile')} /><strong className="text-sm">Facsímil</strong><span className="mt-1 block text-xs text-neutral-500">Conserva visualmente páginas, imágenes, colores y posiciones. El resultado es un PDF rasterizado y su texto no será seleccionable.</span></label><label className={`cursor-pointer rounded-lg border p-3 ${pdfMode === 'reflow' ? 'border-indigo-500 bg-white dark:bg-neutral-900' : 'border-transparent'}`}><input className="mr-2" type="radio" checked={pdfMode === 'reflow'} onChange={() => setPdfMode('reflow')} /><strong className="text-sm">Documento refluido</strong><span className="mt-1 block text-xs text-neutral-500">Prioriza lectura y jerarquía; puede cambiar los saltos de página.</span></label></div><label className="mt-3 flex items-start gap-2 text-sm"><input className="mt-0.5" type="checkbox" checked={translateImageText} onChange={(event) => setTranslateImageText(event.target.checked)} /><span>Traducir también texto integrado en imágenes <small className="block text-xs text-neutral-500">Requiere un modelo con visión y analiza cada página completa.</small></span></label></div>}
+
+      <button className="flex items-center gap-2 text-xs font-semibold text-neutral-500" onClick={() => setAdvanced((value) => !value)}><Icon name="chevronDown" size={13} className={advanced ? 'rotate-180' : ''} />Opciones avanzadas</button>
+      {advanced && <div className="grid gap-4 md:grid-cols-2"><label className="block text-sm"><span className="mb-1 block font-medium">Idioma de origen <small className="font-normal text-neutral-500">(vacío = automático)</small></span><input className="input" value={sourceLanguage} onChange={(event) => setSourceLanguage(event.target.value)} placeholder="Ej.: francés" /></label><label className="block text-sm"><span className="mb-1 block font-medium">Glosario <small className="font-normal text-neutral-500">(origen=destino)</small></span><textarea className="input min-h-20 font-mono text-xs" value={glossary} onChange={(event) => setGlossary(event.target.value)} placeholder={'machine learning=aprendizaje automático\nframework=marco'} /></label>{tab !== 'text' && <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={openFolderOnDone} onChange={(event) => setOpenFolderOnDone(event.target.checked)} />Mostrar el resultado al terminar</label>}</div>}
+    </section>
+
+    {notice && <p className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300">{notice}</p>}
+
+    <div className="flex flex-wrap items-center gap-3">
+      <button data-testid="translate-run" className="btn btn-primary min-w-40 gap-2" disabled={!canRun} onClick={run}>{running ? <><Icon name="sync" size={15} className="animate-spin" />Traduciendo…</> : <><Icon name="languages" size={15} />Traducir</>}</button>
+      {running && <button className="btn btn-ghost" onClick={() => { if (job?.progress?.jobId) void window.nodus.cancelTranslateJob(job.progress.jobId); }}>Cancelar</button>}
+      {!model && <span className="text-xs text-amber-600">Selecciona un modelo para continuar.</span>}
+    </div>
+
+    {job && <section data-testid="translate-job-status" className={`rounded-xl border p-4 ${job.status === 'failed' ? 'border-red-300 bg-red-50 dark:border-red-900/60 dark:bg-red-950/20' : 'border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/30'}`}><div className="flex items-center gap-3"><Icon name={job.status === 'failed' ? 'alert' : job.status === 'completed' ? 'check' : 'sync'} size={17} className={job.status === 'running' ? 'animate-spin text-amber-500' : ''} /><div className="min-w-0 flex-1"><p className="truncate text-sm font-medium">{progressLabel(job)}</p><div className="mt-2 h-1.5 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800"><div className="h-full rounded-full bg-gradient-to-r from-amber-500 to-teal-500 transition-all" style={{ width: `${progress}%` }} /></div></div><span className="text-xs tabular-nums text-neutral-500">{progress}%</span></div>{job.status !== 'running' && <button className="mt-3 text-xs text-neutral-500 hover:text-neutral-800" onClick={() => { clearBackgroundJob(TRANSLATE_JOB_KEY, job.id); setJob(null); }}>Cerrar estado</button>}</section>}
+
+    {!!outputs.length && <section data-testid="translate-outputs" className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900/50 dark:bg-emerald-950/15"><h2 className="text-sm font-semibold text-emerald-800 dark:text-emerald-200">Archivos traducidos</h2><ul className="mt-2 space-y-2">{outputs.map((output) => <li key={output.outputPath} className="flex flex-wrap items-center gap-2 rounded-lg bg-white px-3 py-2 dark:bg-neutral-900"><Icon name="check" size={14} className="text-emerald-500" /><span className="min-w-0 flex-1 truncate text-sm">{basename(output.outputPath)}</span>{output.overflowPages.length > 0 && <span className="rounded bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">Revisar págs. {output.overflowPages.join(', ')}</span>}<button className="btn btn-ghost !py-1" onClick={() => void window.nodus.revealToolkitOutput(output.outputPath)}>Mostrar</button></li>)}</ul>{(job?.result?.warnings.length ?? 0) > 0 && <ul className="mt-3 space-y-1 text-xs text-amber-700 dark:text-amber-300">{job?.result?.warnings.map((warning, index) => <li key={index}>• {warning}</li>)}</ul>}</section>}</>}
+  </div>;
+}

--- a/src/views/ToolkitView.tsx
+++ b/src/views/ToolkitView.tsx
@@ -12,6 +12,7 @@ import { ToolkitProtectView } from './ToolkitProtectView';
 import { ToolkitPresenterView } from './ToolkitPresenterView';
 import { ToolkitAiOcrView } from './ToolkitAiOcrView';
 import { ToolkitAppsView } from './ToolkitAppsView';
+import { ToolkitTranslateView } from './ToolkitTranslateView';
 
 interface ToolCardProps {
   testid: string;
@@ -24,7 +25,7 @@ interface ToolCardProps {
   onOpen?: () => void;
 }
 
-/** Tarjeta del hub. Las cuatro se renderizan con la MISMA estructura y altura
+/** Tarjeta del hub. Todas se renderizan con la MISMA estructura y altura
  *  (grid + h-full); el icono va en una loseta cuadrada fija para que quede
  *  perfectamente centrado, y el badge se ancla abajo con mt-auto para que el
  *  texto variable no desalinee las tarjetas entre sí. */
@@ -78,6 +79,8 @@ export function ToolkitView({
         <ToolkitConvertView onBack={() => onNavigate('home')} />
       ) : page === 'apps' ? (
         <ToolkitAppsView onBack={() => onNavigate('home')} settings={settings} />
+      ) : page === 'translate' ? (
+        <ToolkitTranslateView onBack={() => onNavigate('home')} settings={settings} />
       ) : page === 'protect' ? (
         <ToolkitProtectView onBack={() => onNavigate('home')} />
       ) : page === 'presenter' ? (
@@ -97,7 +100,7 @@ export function ToolkitView({
               </p>
             </div>
           </header>
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-4 sm:grid-cols-2 auto-rows-fr">
             {TOOLKIT_TOOLS.map((tool) => (
               <ToolCard
                 key={tool.page}


### PR DESCRIPTION
Closes #179

## Summary
- add text, document, and Zotero translation workflows with selectable target language and AI model
- preserve DOCX/EPUB structure and provide both facsimile and reflowed PDF output modes
- add persistent translation history with open, reveal, and delete actions
- fix the balanced text-editor layout and Zotero search, library selection, and attachment loading
- integrate Translate alongside the existing Toolkit tools and keep the versioned beta guide stable

## Validation
- `npm run build`
- `npm test` — 741 tests passed
- `npm run test:e2e` — Electron smoke test passed with no renderer page errors
- translated the real `example.pdf` locally in facsimile and reflowed modes

The real PDF input and generated PDF outputs were used only for local validation and are not included in this pull request.