### PR TITLE
Fix OAuth callback CSP compatibility for remote MCP clients

### DIFF
--- a/scripts/test-nodus-server.mjs
+++ b/scripts/test-nodus-server.mjs
@@ -69,10 +69,19 @@ async function oauthLogin(origin, client, cookie) {
   });
   const consentResponse = await fetch(`${origin}/oauth/authorize?${params}`, { headers: { cookie } });
   assert.equal(consentResponse.status, 200);
+  const callbackOrigin = new URL(client.redirect_uris[0]).origin;
+  assert.ok(
+    (consentResponse.headers.get('content-security-policy') || '').includes(`form-action 'self' ${callbackOrigin};`),
+    'the consent CSP must allow only the validated OAuth callback origin after its same-origin POST',
+  );
   const consent = await consentResponse.text();
   const csrf = hidden(consent, 'csrf');
   const authorization = await postForm(`${origin}/oauth/authorize`, { ...Object.fromEntries(params), csrf }, { headers: { cookie } });
   assert.equal(authorization.status, 303);
+  assert.ok(
+    (authorization.headers.get('content-security-policy') || '').includes(`form-action 'self' ${callbackOrigin};`),
+    'the authorization redirect must retain the callback-compatible CSP',
+  );
   const callback = new URL(authorization.headers.get('location'));
   assert.equal(callback.searchParams.get('state'), state);
   const code = callback.searchParams.get('code');
@@ -239,6 +248,19 @@ test('Nodus Server pairs a desktop publisher and protects read-only MCP with OAu
     });
     assert.equal(registered.status, 201);
     const client = await registered.json();
+
+    for (const redirectUri of [
+      'http://client.example/callback',
+      'https://user:password@client.example/callback',
+      'https://client.example/callback#fragment',
+    ]) {
+      const rejectedRegistration = await fetch(`${origin}/oauth/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ client_name: 'Untrusted callback test', redirect_uris: [redirectUri] }),
+      });
+      assert.equal(rejectedRegistration.status, 400, `unsafe OAuth redirect must be rejected: ${redirectUri}`);
+    }
 
     const readerLogin = await postForm(`${origin}/login`, {
       email: 'student@example.test',

--- a/server/lib/http.mjs
+++ b/server/lib/http.mjs
@@ -44,8 +44,12 @@ export async function jsonBody(req, limit) {
   }
 }
 
+export function contentSecurityPolicy(formActionSources = ["'self'"]) {
+  return `default-src 'none'; style-src 'unsafe-inline'; form-action ${formActionSources.join(' ')}; frame-ancestors 'none'; base-uri 'none'`;
+}
+
 const SECURITY_HEADERS = {
-  'content-security-policy': "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'",
+  'content-security-policy': contentSecurityPolicy(),
   'permissions-policy': 'camera=(), microphone=(), geolocation=(), payment=()',
   'referrer-policy': 'no-referrer',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -5,7 +5,7 @@ import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
 import { Store, digest, token } from './lib/store.mjs';
-import { body, cookies, escapeHtml, form, html, json, jsonBody, redirect } from './lib/http.mjs';
+import { body, contentSecurityPolicy, cookies, escapeHtml, form, html, json, jsonBody, redirect } from './lib/http.mjs';
 
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = process.env.NODUS_DATA_DIR || path.join(ROOT, 'data');
@@ -97,6 +97,15 @@ function validRedirectUri(value) {
   } catch {
     return false;
   }
+}
+
+function oauthRedirectHeaders(redirectUri) {
+  // The consent form posts only to this server. Browsers also apply form-action
+  // to every redirect in that navigation, so the validated OAuth callback
+  // origin must be present or ChatGPT/Claude cannot receive the code. Keeping
+  // the source to the exact registered origin preserves the restrictive CSP.
+  const callbackOrigin = new URL(redirectUri).origin;
+  return { 'content-security-policy': contentSecurityPolicy(["'self'", callbackOrigin]) };
 }
 
 function membership(userId, spaceId) {
@@ -345,7 +354,7 @@ async function route(req, res) {
     const requestedInput = (url.searchParams.get('scope') || 'profile spaces.read materials.read').split(/\s+/).filter((scope) => SCOPES.has(scope));
     const requested = requestedInput.length > 0 ? requestedInput : ['materials.read'];
     const hidden = [...url.searchParams].map(([key, value]) => `<input type="hidden" name="${escapeHtml(key)}" value="${escapeHtml(value)}">`).join('');
-    return html(res, 200, page('Autorizar', `<h1>Conectar ${escapeHtml(client.client_name)}</h1><div class="card"><p>La aplicación podrá:</p><ul>${requested.map((scope) => `<li>${escapeHtml(scope)}</li>`).join('')}</ul><p class="muted">Solo tendrá acceso a los espacios asignados a ${escapeHtml(current.user.email)}.</p><form method="post" action="/oauth/authorize">${hidden}<input type="hidden" name="csrf" value="${current.session.csrf}"><button>Autorizar</button></form></div>`));
+    return html(res, 200, page('Autorizar', `<h1>Conectar ${escapeHtml(client.client_name)}</h1><div class="card"><p>La aplicación podrá:</p><ul>${requested.map((scope) => `<li>${escapeHtml(scope)}</li>`).join('')}</ul><p class="muted">Solo tendrá acceso a los espacios asignados a ${escapeHtml(current.user.email)}.</p><form method="post" action="/oauth/authorize">${hidden}<input type="hidden" name="csrf" value="${current.session.csrf}"><button>Autorizar</button></form></div>`), oauthRedirectHeaders(redirectUri));
   }
 
   if (url.pathname === '/oauth/authorize' && req.method === 'POST') {
@@ -360,7 +369,7 @@ async function route(req, res) {
     store.state.oauthCodes.push({ hash: digest(raw), userId: current.user.id, clientId: client.client_id, redirectUri: values.redirect_uri, codeChallenge: values.code_challenge, scopes, resource: mcpResource(), expiresAt: new Date(Date.now() + 5 * 60_000).toISOString() });
     store.save();
     const target = new URL(values.redirect_uri); target.searchParams.set('code', raw); if (values.state) target.searchParams.set('state', values.state);
-    return redirect(res, target.toString());
+    return redirect(res, target.toString(), oauthRedirectHeaders(values.redirect_uri));
   }
 
   if (url.pathname === '/oauth/token' && req.method === 'POST') {


### PR DESCRIPTION
Closes #186

## What changed

- Extract the server Content Security Policy into a reusable helper.
- Allow the exact origin of the already validated OAuth redirect URI during consent and the authorization redirect.
- Keep same-origin form submission support and the existing restrictive CSP directives.
- Add regression coverage for the callback-compatible CSP.
- Add negative tests for external HTTP callbacks, credential-bearing URLs, and callback URLs with fragments.

## Root cause

Browsers apply CSP `form-action` to the complete form navigation, including redirects. The previous `form-action 'self'` policy allowed the consent POST but blocked the final registered callback used by remote MCP clients before they could receive the authorization code.

## User impact

ChatGPT and Claude can now complete Nodus OAuth authorization automatically without weakening the callback policy to arbitrary destinations.

## Security

The CSP includes only the exact origin derived from a redirect URI that has already passed Nodus validation and exact client-registration matching. Existing CSRF, PKCE, scope, membership, token, and read-only MCP protections remain unchanged. The published patch was checked for personal data, email addresses, passwords, API keys, private keys, and provider tokens; no real credentials or personal data are included.

## Validation

- `npm test` — 747 passed, 0 failed
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Live OAuth and MCP verification with temporary synthetic data in ChatGPT and Claude
- Negative external tests for anonymous access, forged bearer tokens, unsafe redirects, and unauthorized private-space access