### PR TITLE
Simplify the Nodi note editor footer

### DIFF
--- a/scripts/test-nodi-notes.mjs
+++ b/scripts/test-nodi-notes.mjs
@@ -68,8 +68,11 @@ try {
   assert.match(component, /noteSaveChainRef/, 'overlapping autosaves are serialized');
   assert.match(component, /deriveNodiNoteTitle\(noteDraft\)/, 'the editor previews the shared fallback title');
   assert.match(component, /className="nodi-note-title-input"/, 'users can assign an explicit title');
-  assert.match(component, /t\('Guardado automáticamente'\)/, 'the footer communicates autosave');
+  assert.match(component, /t\('Guardado automático'\)/, 'the footer communicates autosave');
   assert.doesNotMatch(component, /className="nodi-note-save"/, 'the editor no longer requires a manual save action');
+  assert.doesNotMatch(component, /className="nodi-note-remove"/, 'delete is not available inside the editor');
+  assert.match(component, /className="nodi-note-delete"/, 'delete remains available in the notes list');
+  assert.match(css, /\.nodi-note-foot\s*\{[^}]*justify-content:\s*center/s, 'the autosave footer is horizontally centered');
   assert.match(css, /\.nodi-notes-list\s*\{[^}]*padding:\s*6px 10px/s, 'the list keeps a small lateral margin');
   assert.match(css, /\.nodi-note-row\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) 30px/s, 'each note reserves a fixed column for its delete action');
   assert.match(css, /\.nodi-note-open\s*\{[^}]*overflow:\s*hidden/s, 'note text is clipped before the delete action');

--- a/scripts/verify-nodi-notes.mjs
+++ b/scripts/verify-nodi-notes.mjs
@@ -147,7 +147,7 @@ try {
   const afterBold = await ta.inputValue();
   assert.ok(afterBold.includes('**leche**'), `bold did not wrap selection: ${afterBold}`);
   log('bold formatting applied:', JSON.stringify(afterBold));
-  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado automáticamente');
+  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado automático');
   log('note autosaved');
 
   // ── Back to list: the note shows with derived title + snippet ───────────────
@@ -164,7 +164,7 @@ try {
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Nueva nota"]').click();
   await page.locator('.nodi-note-title-input').fill('Ideas para el proyecto');
   await ta.fill('Probar el modo oscuro con un título manual');
-  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado automáticamente');
+  await page.waitForFunction(() => document.querySelector('.nodi-note-state')?.textContent === 'Guardado automático');
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Volver"]').click();
   assert.equal(await page.locator('.nodi-note-row').count(), 2, 'expected 2 notes');
 
@@ -188,7 +188,9 @@ try {
 
   // ── Delete with confirmation ────────────────────────────────────────────────
   await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Editar"]').click(); // leave preview
-  await page.locator('.nodi-note-remove').click();
+  assert.equal(await page.locator('.nodi-note-remove').count(), 0, 'delete should not be available inside the editor');
+  await page.locator('.nodi-notes-panel .nodi-panel-head button[title="Volver"]').click();
+  await page.locator('.nodi-note-row', { hasText: 'Lista de la' }).locator('.nodi-note-delete').click();
   await page.locator('.nodi-confirm-dialog').waitFor();
   await page.screenshot({ path: `${shots}/notes-4-confirm-dark.png` });
   await page.locator('.nodi-confirm-dialog button.danger').click();

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -159,14 +159,12 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const [noteTitle, setNoteTitle] = useState('');
   const [noteDraft, setNoteDraft] = useState('');
   const [noteDirty, setNoteDirty] = useState(false);
-  const [noteSaving, setNoteSaving] = useState(false);
   const [noteSearch, setNoteSearch] = useState('');
   const [notePreview, setNotePreview] = useState(false);
   const [deleteNoteTarget, setDeleteNoteTarget] = useState<NodiNote | null>(null);
   const noteEditorRef = useRef<HTMLTextAreaElement | null>(null);
   const noteSessionRef = useRef(0);
   const noteSaveChainRef = useRef<Promise<void>>(Promise.resolve());
-  const noteSavesInFlightRef = useRef(0);
   // Mirror the in-flight note so the leave-editor flush reads live values without a
   // stale closure (a lesson from the study-vault useMemo bug: closures over editor
   // state go stale between renders).
@@ -241,8 +239,6 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   useEffect(() => { if (panel === 'notes') refreshNotes(); }, [panel, refreshNotes]);
 
   const persistNote = useCallback((session: number, id: string | null, title: string, draft: string) => {
-    noteSavesInFlightRef.current += 1;
-    setNoteSaving(true);
     const task = noteSaveChainRef.current.then(async () => {
       // A second autosave may have been queued before the first one assigned its id.
       // Reuse the live id for the same editor session instead of creating duplicates.
@@ -264,9 +260,6 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
           noteRef.current = { ...current, dirty: true };
           setNoteDirty(true);
         }
-      } finally {
-        noteSavesInFlightRef.current -= 1;
-        if (noteSavesInFlightRef.current === 0) setNoteSaving(false);
       }
     });
     noteSaveChainRef.current = task.then(() => undefined, () => undefined);
@@ -1089,11 +1082,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
                   )}
                 </div>
                 <div className="nodi-note-foot">
-                  {activeNoteId && (
-                    <button className="nodi-note-remove" onClick={() => { const note = notes.find((n) => n.id === activeNoteId); if (note) setDeleteNoteTarget(note); }} title={t('Borrar nota')} aria-label={t('Borrar nota')}><Icon name="trash" size={13} /></button>
-                  )}
-                  <span className="nodi-note-state">{noteSaving ? t('Guardando…') : noteDirty ? t('Sin guardar') : activeNoteId ? t('Guardado automáticamente') : ''}</span>
-                  <span className="grow" />
+                  <span className="nodi-note-state">{t('Guardado automático')}</span>
                 </div>
               </>
             )}

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -732,22 +732,8 @@
 .nodi-note-preview .md pre code { padding: 0; background: transparent; color: #dce3ed; }
 .nodi-note-preview .md a { color: #8ec5ff; text-decoration: underline; text-underline-offset: 2px; }
 
-.nodi-note-foot { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; padding: 8px; border-top: 0.5px solid rgba(255, 255, 255, 0.08); }
-.nodi-note-remove {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border: 1px solid rgba(239, 68, 68, 0.28);
-  border-radius: 9px;
-  background: rgba(127, 29, 29, 0.22);
-  color: #f0a3a3;
-  cursor: pointer;
-}
-.nodi-note-remove:hover { background: rgba(153, 27, 27, 0.4); color: #fecaca; }
-.nodi-note-state { font-size: 10px; color: #7a8598; }
+.nodi-note-foot { display: flex; align-items: center; justify-content: center; flex: 0 0 auto; padding: 8px; border-top: 0.5px solid rgba(255, 255, 255, 0.08); }
+.nodi-note-state { font-size: 10px; color: #7a8598; text-align: center; }
 
 .nodi-notes-list,
 .nodi-note-textarea,
@@ -959,8 +945,6 @@
 .nodi-theme-light .nodi-notes-panel .nodi-note-preview .md a { color: var(--nodi-vault-accent, #6366f1); }
 .nodi-theme-light .nodi-notes-panel .nodi-note-foot { border-top-color: rgba(15, 23, 42, 0.08); }
 .nodi-theme-light .nodi-notes-panel .nodi-note-state { color: #94a3b8; }
-.nodi-theme-light .nodi-notes-panel .nodi-note-remove { border-color: rgba(239, 68, 68, 0.28); background: rgba(239, 68, 68, 0.08); color: #dc2626; }
-.nodi-theme-light .nodi-notes-panel .nodi-note-remove:hover { background: rgba(239, 68, 68, 0.16); color: #b91c1c; }
 .nodi-theme-light .nodi-notes-panel .nodi-notes-list,
 .nodi-theme-light .nodi-notes-panel .nodi-note-textarea,
 .nodi-theme-light .nodi-notes-panel .nodi-note-preview { scrollbar-color: #cbd5e1 #eef2f7; }

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -5024,7 +5024,7 @@ export const DE: Record<string, string> = {
   'en blanco': 'leer',
   'Cargando simulacro…': 'Probeprüfung wird geladen…',
   'Simulacro escrito': 'Schriftliche Probeprüfung',
-  'Guardado automáticamente': 'Automatisch gespeichert',
+  'Guardado automático': 'Automatisch gespeichert',
   'Autoguardado activo': 'Automatisches Speichern aktiv',
   'Entregar examen': 'Prüfung abgeben',
   'Marcar para revisar': 'Zur Überprüfung markieren',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -5253,7 +5253,7 @@ export const EN: Record<string, string> = {
   'en blanco': 'blank',
   'Cargando simulacro…': 'Loading mock exam…',
   'Simulacro escrito': 'Written mock exam',
-  'Guardado automáticamente': 'Saved automatically',
+  'Guardado automático': 'Saved automatically',
   'Autoguardado activo': 'Autosave active',
   'Entregar examen': 'Submit exam',
   'Marcar para revisar': 'Flag for review',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -5017,7 +5017,7 @@ export const FR: Record<string, string> = {
   'en blanco': 'vierge',
   'Cargando simulacro…': 'Chargement de l\'examen blanc…',
   'Simulacro escrito': 'Examen blanc écrit',
-  'Guardado automáticamente': 'Enregistré automatiquement',
+  'Guardado automático': 'Enregistré automatiquement',
   'Autoguardado activo': 'Enregistrement automatique actif',
   'Entregar examen': 'Rendre l\'examen',
   'Marcar para revisar': 'Marquer à revoir',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -4512,7 +4512,7 @@ export const IT: Record<string, string> = {
   "en blanco": "vuoto",
   "Cargando simulacro…": "Caricamento esame simulato…",
   "Simulacro escrito": "Esame simulato scritto",
-  "Guardado automáticamente": "Salvato automaticamente",
+  "Guardado automático": "Salvato automaticamente",
   "Autoguardado activo": "Salvataggio automatico attivo",
   "Entregar examen": "Invia esame",
   "Marcar para revisar": "Contrassegna per la revisione",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -4983,7 +4983,7 @@ export const PT_BR: Record<string, string> = {
   'en blanco': 'em branco',
   'Cargando simulacro…': 'Carregando simulado…',
   'Simulacro escrito': 'Simulado escrito',
-  'Guardado automáticamente': 'Salvo automaticamente',
+  'Guardado automático': 'Salvo automaticamente',
   'Autoguardado activo': 'Salvamento automático ativo',
   'Entregar examen': 'Entregar exame',
   'Marcar para revisar': 'Marcar para revisar',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -4976,7 +4976,7 @@ export const PT: Record<string, string> = {
   'en blanco': 'em branco',
   'Cargando simulacro…': 'A carregar o exame branco…',
   'Simulacro escrito': 'Exame branco escrito',
-  'Guardado automáticamente': 'Guardado automaticamente',
+  'Guardado automático': 'Guardado automaticamente',
   'Autoguardado activo': 'Guardado automático ativo',
   'Entregar examen': 'Entregar exame',
   'Marcar para revisar': 'Marcar para rever',


### PR DESCRIPTION
## Summary

- remove the delete action from the Nodi quick-note editor footer
- keep note deletion available from the notes list
- replace the changing save-state copy with a centered autosave label
- update the supported locale keys and note-focused verification coverage

## Why

The editor duplicated the destructive action already available in the notes list, adding unnecessary risk while writing. Its save-state label also shifted horizontally because it shared the footer with the delete button and a spacer.

The footer now communicates the autosave behavior consistently while destructive note management remains in the list.

## Validation

- `node scripts/test-nodi-notes.mjs`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`
- `node scripts/verify-nodi-notes.mjs` (dark theme, light theme, deletion from the list, and always-on-top overlay)

Closes #194