### PR TITLE
Fix selected close-mascot text contrast

### DIFF
--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -279,6 +279,16 @@ test('Nodi drags in absolute screen space and closes through an animated context
     assert.match(figureCss, new RegExp(animation));
   }
   assert.match(companionCss, /\.nodi-context-menu/);
+  assert.match(
+    companionCss,
+    /\.nodi-theme-light \.nodi-context-menu button:hover,[\s\S]*?\.nodi-theme-light \.nodi-context-menu button:focus-visible\s*\{[^}]*color:\s*#9f1239/s,
+    'the selected close-mascot action keeps readable text in the light theme',
+  );
+  assert.match(
+    companionCss,
+    /\.nodi-theme-light \.nodi-context-icon\s*\{[^}]*color:\s*#be123c/s,
+    'the close-mascot icon keeps sufficient contrast in the light theme',
+  );
   assert.match(companionCss, /\.nodi-anchor\.open-right/);
   assert.match(companionCss, /\.nodi-anchor\.open-down/);
   assert.match(companionCss, /\.nodi-figure\s*\{[^}]*z-index:\s*1/s);

--- a/scripts/verify-nodi-notes.mjs
+++ b/scripts/verify-nodi-notes.mjs
@@ -252,6 +252,22 @@ try {
   await chatPanel.locator('.nodi-panel-head button[title="Cerrar"]').click();
   log('notifications + chat share the light theme:', JSON.stringify(lightChatTheme));
 
+  // The destructive context action needs its own light-theme selection colors;
+  // inheriting the dark-theme pale pink makes the title disappear on hover.
+  await figure.click({ button: 'right' });
+  const closeMascotItem = page.getByRole('menuitem', { name: /Cerrar mascota/ });
+  await closeMascotItem.waitFor();
+  await closeMascotItem.hover();
+  const lightContextStyles = await closeMascotItem.evaluate((button) => ({
+    title: getComputedStyle(button.querySelector('b')).color,
+    icon: getComputedStyle(button.querySelector('.nodi-context-icon')).color,
+  }));
+  assert.equal(lightContextStyles.title, 'rgb(159, 18, 57)', 'selected close-mascot title must remain readable');
+  assert.equal(lightContextStyles.icon, 'rgb(190, 18, 60)', 'close-mascot icon must remain readable');
+  await page.screenshot({ path: `${shots}/notes-7-context-menu-light.png` });
+  await page.mouse.click(20, 20);
+  log('light context-menu contrast verified:', JSON.stringify(lightContextStyles));
+
   // ── Always-on-top overlay ─────────────────────────────────────────────────
   // The same persisted note must be reachable from Nodi's independent desktop
   // window, where the extra "Open Nodus" action brings the radial count to five.
@@ -290,7 +306,7 @@ try {
   await overlay.locator('[data-nodi-action="notes"]').click();
   await overlay.locator('.nodi-notes-panel').waitFor();
   assert.equal(await overlay.locator('.nodi-note-row').count(), 1, 'saved note should be shared with the overlay');
-  await overlay.screenshot({ path: `${shots}/notes-7-overlay-light.png` });
+  await overlay.screenshot({ path: `${shots}/notes-8-overlay-light.png` });
   log('always-on-top overlay verified ->', overlayMetrics.gaps.map((gap) => gap.toFixed(1)).join(', '));
 
   log('ALL CHECKS PASSED. Shots in', shots);

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -254,7 +254,9 @@
   text-align: left;
   cursor: pointer;
 }
-.nodi-context-menu button:hover { background: rgba(226, 73, 74, .13); color: #ffd8d8; }
+.nodi-context-menu button:hover,
+.nodi-context-menu button:focus-visible { background: rgba(226, 73, 74, .13); color: #ffd8d8; }
+.nodi-context-menu button:focus-visible { outline: 2px solid currentColor; outline-offset: -2px; }
 .nodi-context-icon {
   display: grid;
   width: 28px;
@@ -905,6 +907,12 @@
   color: #1f2937;
   box-shadow: 0 14px 36px rgba(15, 23, 42, .18);
 }
+.nodi-theme-light .nodi-context-menu button:hover,
+.nodi-theme-light .nodi-context-menu button:focus-visible {
+  background: rgba(226, 73, 74, .13);
+  color: #9f1239;
+}
+.nodi-theme-light .nodi-context-icon { background: #ffe4e6; color: #be123c; }
 .nodi-theme-light .nodi-context-menu small { color: #64748b; }
 
 /* Quick notes light details. They now inherit the same theme as every other Nodi panel. */


### PR DESCRIPTION
## Summary

- add dedicated readable destructive colors for the selected **Close mascot** action in Nodi's light theme
- apply the same selected styling to keyboard focus and add a visible focus outline
- strengthen the light-theme close icon contrast
- cover the state in both the static assistant test and the Electron UI verification

## Root cause

The light-theme context menu inherited the dark-theme selected foreground (`#ffd8d8`). That pale pink text was rendered over a pale pink hover background, making the action title difficult to read.

## Validation

- `node --test scripts/test-nodi-assistant.mjs` (11/11 passing)
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`
- `node scripts/verify-nodi-notes.mjs`
- verified a 6.75:1 contrast ratio for the selected label

Closes #196