### PR TITLE
Improve reader translation and professional PDF exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+tmp/
 dist/
 dist-electron/
 release/

--- a/electron/export/immersionExport.ts
+++ b/electron/export/immersionExport.ts
@@ -1,0 +1,342 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { app, dialog } from 'electron';
+import type { DecorativeImageSource, ImmersionCitation, ImmersionSession } from '@shared/types';
+import { escapeHtml } from '@shared/toolkitMarkdown';
+import { zoteroSelectUrl } from '@shared/pageLocation';
+import { getDecorativeImage, getDecorativeImageData } from '../db/decorativeImagesRepo';
+import {
+  PROFESSIONAL_REPORT_THEMES,
+  anchoredMarkdown,
+  professionalReportPdf,
+  reportLink,
+  type ProfessionalReportInput,
+  type ProfessionalReportSection,
+} from './professionalReportPdf';
+
+interface ImmersionReportLabels {
+  kind: string;
+  contents: string;
+  generated: string;
+  objective: string;
+  overview: string;
+  overviewEyebrow: string;
+  vocabulary: string;
+  vocabularyEyebrow: string;
+  station: string;
+  stationEyebrow: string;
+  guidingQuestion: string;
+  guidedReading: string;
+  positions: string;
+  takeaways: string;
+  whyItMatters: string;
+  commentary: string;
+  contrasts: string;
+  contrastsEyebrow: string;
+  frontiers: string;
+  frontiersEyebrow: string;
+  feynman: string;
+  feynmanEyebrow: string;
+  sources: string;
+  sourcesEyebrow: string;
+  zotero: string;
+  minutes: string;
+  stations: string;
+  works: string;
+  imageAi: string;
+  imageCustom: string;
+  saveTitle: string;
+}
+
+const LABELS: Record<ImmersionSession['language'], ImmersionReportLabels> = {
+  es: {
+    kind: 'Dossier profesional · Inmersión',
+    contents: 'Contenido',
+    generated: 'Generado',
+    objective: 'Tema',
+    overview: 'Panorama',
+    overviewEyebrow: 'Mapa de orientación',
+    vocabulary: 'Vocabulario esencial',
+    vocabularyEyebrow: 'Conceptos clave',
+    station: 'Estación',
+    stationEyebrow: 'Itinerario de aprendizaje',
+    guidingQuestion: 'Pregunta guía',
+    guidedReading: 'Lectura guiada',
+    positions: 'Posiciones',
+    takeaways: 'Para retener',
+    whyItMatters: 'Por qué importa',
+    commentary: 'Comentario',
+    contrasts: 'Matriz de contrastes',
+    contrastsEyebrow: 'Perspectivas comparadas',
+    frontiers: 'Fronteras del corpus',
+    frontiersEyebrow: 'Límites y oportunidades',
+    feynman: 'Cierre Feynman',
+    feynmanEyebrow: 'Síntesis personal',
+    sources: 'Fuentes y enlaces',
+    sourcesEyebrow: 'Trazabilidad',
+    zotero: 'Abrir en Zotero',
+    minutes: 'minutos',
+    stations: 'estaciones',
+    works: 'obras',
+    imageAi: 'Imagen de portada generada por IA en Nodus.',
+    imageCustom: 'Imagen de portada aportada por el usuario.',
+    saveTitle: 'Exportar inmersión como PDF',
+  },
+  en: {
+    kind: 'Professional dossier · Immersion',
+    contents: 'Contents',
+    generated: 'Generated',
+    objective: 'Topic',
+    overview: 'Overview',
+    overviewEyebrow: 'Orientation map',
+    vocabulary: 'Essential vocabulary',
+    vocabularyEyebrow: 'Key concepts',
+    station: 'Station',
+    stationEyebrow: 'Learning route',
+    guidingQuestion: 'Guiding question',
+    guidedReading: 'Guided reading',
+    positions: 'Positions',
+    takeaways: 'Key takeaways',
+    whyItMatters: 'Why it matters',
+    commentary: 'Commentary',
+    contrasts: 'Contrast matrix',
+    contrastsEyebrow: 'Compared perspectives',
+    frontiers: 'Corpus frontiers',
+    frontiersEyebrow: 'Limits and opportunities',
+    feynman: 'Feynman close',
+    feynmanEyebrow: 'Personal synthesis',
+    sources: 'Sources and links',
+    sourcesEyebrow: 'Traceability',
+    zotero: 'Open in Zotero',
+    minutes: 'minutes',
+    stations: 'stations',
+    works: 'works',
+    imageAi: 'Cover image generated with AI in Nodus.',
+    imageCustom: 'Cover image provided by the user.',
+    saveTitle: 'Export immersion as PDF',
+  },
+};
+
+function slug(value: string): string {
+  const clean = value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 72);
+  return clean || 'inmersion';
+}
+
+function localizedDate(iso: string, language: ImmersionSession['language']): string {
+  try {
+    return new Intl.DateTimeFormat(language === 'en' ? 'en-GB' : 'es-ES', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function imageCredit(source: DecorativeImageSource | null, labels: ImmersionReportLabels): string | null {
+  if (source === 'ai') return labels.imageAi;
+  if (source === 'custom') return labels.imageCustom;
+  return null;
+}
+
+function reportImage(session: ImmersionSession, labels: ImmersionReportLabels): { dataUrl: string | null; credit: string | null } {
+  const meta = getDecorativeImage('immersion', session.id);
+  const data = getDecorativeImageData('immersion', session.id);
+  if (!meta || meta.status !== 'ready' || !data) return { dataUrl: null, credit: null };
+  return {
+    dataUrl: `data:${data.mimeType};base64,${data.bytes.toString('base64')}`,
+    credit: imageCredit(meta.source, labels),
+  };
+}
+
+function citationLabel(citation: ImmersionCitation): string {
+  return [
+    citation.workTitle,
+    citation.authors.slice(0, 3).join(', '),
+    citation.year ? String(citation.year) : '',
+    citation.pageLabel ? `p. ${citation.pageLabel}` : '',
+  ].filter(Boolean).join(' · ');
+}
+
+function citationHtml(citation: ImmersionCitation, labels: ImmersionReportLabels): string {
+  const source = reportLink(`nodus://passage/${encodeURIComponent(citation.passageId)}`, citationLabel(citation));
+  const zotero = citation.zoteroKey
+    ? ` · ${reportLink(zoteroSelectUrl(citation.zoteroKey), labels.zotero)}`
+    : '';
+  return `<article class="source-card">
+    <blockquote>“${escapeHtml(citation.text.trim())}”</blockquote>
+    <footer>${source}${zotero}</footer>
+    ${citation.whyItMatters ? `<p class="commentary"><strong>${escapeHtml(labels.whyItMatters)}.</strong> ${escapeHtml(citation.whyItMatters)}</p>` : ''}
+    ${citation.commentary ? `<p class="commentary"><strong>${escapeHtml(labels.commentary)}.</strong> ${escapeHtml(citation.commentary)}</p>` : ''}
+  </article>`;
+}
+
+function stationHtml(session: ImmersionSession, index: number, labels: ImmersionReportLabels): { html: string; headings: ReturnType<typeof anchoredMarkdown>['headings'] } {
+  const station = session.plan.stations[index];
+  const synthesis = anchoredMarkdown(station.synthesis, `station-${index + 1}`);
+  const readings = station.citations.length
+    ? `<h3>${escapeHtml(labels.guidedReading)}</h3>${station.citations.map((citation) => citationHtml(citation, labels)).join('')}`
+    : '';
+  const positions = station.positions.length
+    ? `<h3>${escapeHtml(labels.positions)}</h3><div class="evidence-grid">${station.positions.map((position) =>
+        `<article class="evidence-card"><span>${escapeHtml(labels.positions)}</span><h3>${escapeHtml(position.name)}</h3><div>${escapeHtml(position.position)}</div></article>`
+      ).join('')}</div>`
+    : '';
+  const takeaways = station.takeaways.length
+    ? `<aside class="takeaway-list"><h3>${escapeHtml(labels.takeaways)}</h3><ul>${station.takeaways.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul></aside>`
+    : '';
+  return {
+    html: `<div class="question-box"><small>${escapeHtml(labels.guidingQuestion)}</small><p>${escapeHtml(station.question)}</p></div>
+      ${station.context ? `<div class="prose"><p>${escapeHtml(station.context)}</p></div>` : ''}
+      <div class="prose">${synthesis.html}</div>
+      ${readings}${positions}${takeaways}`,
+    headings: synthesis.headings,
+  };
+}
+
+function contrastHtml(session: ImmersionSession): string {
+  const { authors, rows } = session.plan.contrasts;
+  if (!authors.length || !rows.length) return '';
+  return `<table><thead><tr><th></th>${authors.map((author) => `<th>${escapeHtml(author)}</th>`).join('')}</tr></thead>
+    <tbody>${rows.map((row) => `<tr><th>${escapeHtml(row.question)}</th>${row.cells.map((cell) => `<td>${escapeHtml(cell.stance || '—')}</td>`).join('')}</tr>`).join('')}</tbody></table>`;
+}
+
+function frontiersHtml(session: ImmersionSession): string {
+  return `<div class="evidence-grid">${session.plan.frontiers.map((frontier) =>
+    `<article class="evidence-card"><span>${escapeHtml(frontier.kind.replace('_', ' '))}</span><h3>${escapeHtml(frontier.statement)}</h3>${frontier.detail ? `<div>${escapeHtml(frontier.detail)}</div>` : ''}${frontier.workTitle ? `<div class="muted" style="margin-top:2mm">${escapeHtml(frontier.workTitle)}</div>` : ''}</article>`
+  ).join('')}</div>`;
+}
+
+function sourcesHtml(session: ImmersionSession, labels: ImmersionReportLabels): string {
+  const seen = new Set<string>();
+  const sources = session.plan.stations.flatMap((station) => station.citations).filter((citation) => {
+    const key = citation.passageId || `${citation.workId}:${citation.pageLabel ?? ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  return `<ol class="reference-list">${sources.map((citation) => {
+    const passage = reportLink(`nodus://passage/${encodeURIComponent(citation.passageId)}`, citationLabel(citation));
+    const zotero = citation.zoteroKey ? ` · ${reportLink(zoteroSelectUrl(citation.zoteroKey), labels.zotero)}` : '';
+    return `<li>${passage}${zotero}</li>`;
+  }).join('')}</ol>`;
+}
+
+/** Structured report model shared by the save-dialog exporter and PDF visual tests. */
+export function buildImmersionPdfInput(session: ImmersionSession, imageOverride?: { dataUrl: string | null; credit: string | null }): ProfessionalReportInput {
+  const labels = LABELS[session.language];
+  const image = imageOverride ?? reportImage(session, labels);
+  const overview = anchoredMarkdown(session.plan.overview, 'overview');
+  const sections: ProfessionalReportSection[] = [
+    {
+      id: 'overview',
+      number: '01',
+      title: labels.overview,
+      eyebrow: labels.overviewEyebrow,
+      html: `<div class="prose">${overview.html}</div>`,
+      tocChildren: overview.headings,
+    },
+  ];
+  if (session.plan.keyTerms.length) {
+    sections.push({
+      id: 'vocabulary',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.vocabulary,
+      eyebrow: labels.vocabularyEyebrow,
+      html: `<div class="term-grid">${session.plan.keyTerms.map((term) =>
+        `<article class="term-card"><h3>${escapeHtml(term.term)}</h3><p>${escapeHtml(term.definition)}</p></article>`
+      ).join('')}</div>`,
+    });
+  }
+  session.plan.stations.forEach((station, index) => {
+    const content = stationHtml(session, index, labels);
+    sections.push({
+      id: `station-${index + 1}`,
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: `${labels.station} ${index + 1} · ${station.title}`,
+      eyebrow: labels.stationEyebrow,
+      lead: station.question,
+      html: content.html,
+      tocChildren: content.headings,
+      pageBreakBefore: true,
+    });
+  });
+  if (session.plan.contrasts.authors.length && session.plan.contrasts.rows.length) {
+    sections.push({
+      id: 'contrasts',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.contrasts,
+      eyebrow: labels.contrastsEyebrow,
+      html: contrastHtml(session),
+      pageBreakBefore: true,
+    });
+  }
+  if (session.plan.frontiers.length) {
+    sections.push({
+      id: 'frontiers',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.frontiers,
+      eyebrow: labels.frontiersEyebrow,
+      html: frontiersHtml(session),
+    });
+  }
+  if (session.plan.exam.feynman) {
+    sections.push({
+      id: 'feynman-close',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.feynman,
+      eyebrow: labels.feynmanEyebrow,
+      html: `<div class="abstract-box prose"><p>${escapeHtml(session.plan.exam.feynman)}</p></div>`,
+    });
+  }
+  const sourceCount = new Set(session.plan.stations.flatMap((station) => station.citations.map((citation) => citation.passageId))).size;
+  if (sourceCount) {
+    sections.push({
+      id: 'sources',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.sources,
+      eyebrow: labels.sourcesEyebrow,
+      html: sourcesHtml(session, labels),
+      pageBreakBefore: true,
+    });
+  }
+  return {
+    title: session.plan.title,
+    subtitle: session.topic,
+    kindLabel: labels.kind,
+    language: session.language,
+    generatedLabel: labels.generated,
+    generatedAt: localizedDate(session.plan.generatedAt || session.createdAt, session.language),
+    objectiveLabel: labels.objective,
+    objective: session.topic,
+    imageDataUrl: image.dataUrl,
+    imageCredit: image.credit,
+    contentsLabel: labels.contents,
+    metrics: [
+      { value: String(session.minutes), label: labels.minutes },
+      { value: String(session.plan.stats.stations), label: labels.stations },
+      { value: String(session.plan.stats.works), label: labels.works },
+    ],
+    sections,
+    theme: PROFESSIONAL_REPORT_THEMES.immersion,
+  };
+}
+
+export async function exportImmersionSessionPdf(session: ImmersionSession): Promise<{ path: string } | null> {
+  const labels = LABELS[session.language];
+  const { canceled, filePath } = await dialog.showSaveDialog({
+    title: labels.saveTitle,
+    defaultPath: path.join(app.getPath('documents'), `${slug(session.plan.title)}.pdf`),
+    filters: [{ name: 'PDF', extensions: ['pdf'] }],
+  });
+  if (canceled || !filePath) return null;
+  fs.writeFileSync(filePath, await professionalReportPdf(buildImmersionPdfInput(session)));
+  return { path: filePath };
+}

--- a/electron/export/professionalReportPdf.ts
+++ b/electron/export/professionalReportPdf.ts
@@ -1,0 +1,503 @@
+import { PDFDocument, StandardFonts, rgb, type PDFPage } from 'pdf-lib';
+import { escapeHtml, markdownToHtml } from '@shared/toolkitMarkdown';
+import { htmlToPdfBytes } from './htmlToPdf';
+
+export interface ProfessionalReportTheme {
+  accent: string;
+  accentDark: string;
+  accentSoft: string;
+  accentRgb: [number, number, number];
+}
+
+export interface ProfessionalReportMetric {
+  value: string;
+  label: string;
+}
+
+export interface ProfessionalReportTocItem {
+  id: string;
+  title: string;
+  children?: ProfessionalReportTocItem[];
+}
+
+export interface ProfessionalReportSection {
+  id: string;
+  number: string;
+  title: string;
+  eyebrow?: string;
+  lead?: string;
+  html: string;
+  tocChildren?: ProfessionalReportTocItem[];
+  pageBreakBefore?: boolean;
+  className?: string;
+}
+
+export interface ProfessionalReportInput {
+  title: string;
+  subtitle?: string;
+  kindLabel: string;
+  language: string;
+  generatedLabel: string;
+  generatedAt: string;
+  objectiveLabel?: string;
+  objective?: string;
+  imageDataUrl?: string | null;
+  imageCredit?: string | null;
+  metrics?: ProfessionalReportMetric[];
+  contentsLabel: string;
+  sections: ProfessionalReportSection[];
+  theme: ProfessionalReportTheme;
+}
+
+export interface AnchoredMarkdown {
+  html: string;
+  headings: ProfessionalReportTocItem[];
+}
+
+const DEEP_THEME: ProfessionalReportTheme = {
+  accent: '#4f46e5',
+  accentDark: '#312e81',
+  accentSoft: '#eef2ff',
+  accentRgb: [79 / 255, 70 / 255, 229 / 255],
+};
+
+const IMMERSION_THEME: ProfessionalReportTheme = {
+  accent: '#0f766e',
+  accentDark: '#134e4a',
+  accentSoft: '#ecfdf5',
+  accentRgb: [15 / 255, 118 / 255, 110 / 255],
+};
+
+export const PROFESSIONAL_REPORT_THEMES = {
+  deepResearch: DEEP_THEME,
+  immersion: IMMERSION_THEME,
+} as const;
+
+function slug(value: string, fallback: string): string {
+  const clean = value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 70);
+  return clean || fallback;
+}
+
+function plainInline(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[*_`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Render the app's Markdown subset and attach stable destinations to its headings. */
+export function anchoredMarkdown(markdown: string, prefix: string): AnchoredMarkdown {
+  const headings: ProfessionalReportTocItem[] = [];
+  const ids: string[] = [];
+  const seen = new Map<string, number>();
+  for (const line of markdown.replace(/\r\n?/g, '\n').split('\n')) {
+    const match = /^(#{1,6})\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const base = `${prefix}-${slug(plainInline(match[2]), 'section')}`;
+    const count = (seen.get(base) ?? 0) + 1;
+    seen.set(base, count);
+    const id = count === 1 ? base : `${base}-${count}`;
+    ids.push(id);
+    if (match[1].length <= 3) headings.push({ id, title: plainInline(match[2]) });
+  }
+  let index = 0;
+  const html = markdownToHtml(markdown).replace(/<h([1-6])>/g, (_match, level: string) => {
+    const id = ids[index++] ?? `${prefix}-section-${index}`;
+    return `<h${level} id="${escapeHtml(id)}">`;
+  });
+  return { html, headings };
+}
+
+export function reportLink(href: string, label: string, className = ''): string {
+  const safeHref = /^(?:https?:\/\/|nodus:\/\/|zotero:\/\/|#)/.test(href) ? href : '#';
+  return `<a${className ? ` class="${escapeHtml(className)}"` : ''} href="${escapeHtml(safeHref)}">${escapeHtml(label)}</a>`;
+}
+
+export function reportList(items: string[], ordered = false, className = ''): string {
+  if (!items.length) return '';
+  const tag = ordered ? 'ol' : 'ul';
+  return `<${tag}${className ? ` class="${escapeHtml(className)}"` : ''}>${items
+    .map((item) => `<li>${item}</li>`)
+    .join('')}</${tag}>`;
+}
+
+function imageIsSafe(dataUrl: string | null | undefined): dataUrl is string {
+  return !!dataUrl && /^data:image\/(?:png|jpe?g|webp);base64,[a-z0-9+/=\s]+$/i.test(dataUrl);
+}
+
+function tocHtml(items: ProfessionalReportTocItem[]): string {
+  return `<ol class="toc-list">${items.map((item, index) => {
+    const children = item.children?.length
+      ? `<ol class="toc-children">${item.children.map((child) =>
+          `<li><a href="#${escapeHtml(child.id)}"><span>${escapeHtml(child.title)}</span><i></i></a></li>`
+        ).join('')}</ol>`
+      : '';
+    return `<li>
+      <a href="#${escapeHtml(item.id)}"><b>${String(index + 1).padStart(2, '0')}</b><span>${escapeHtml(item.title)}</span><i></i></a>
+      ${children}
+    </li>`;
+  }).join('')}</ol>`;
+}
+
+function sectionHtml(section: ProfessionalReportSection): string {
+  return `<section id="${escapeHtml(section.id)}" class="report-section ${section.pageBreakBefore ? 'page-break' : ''} ${escapeHtml(section.className ?? '')}">
+    <header class="section-heading">
+      <span>${escapeHtml(section.number)}</span>
+      <div>
+        ${section.eyebrow ? `<p>${escapeHtml(section.eyebrow)}</p>` : ''}
+        <h2>${escapeHtml(section.title)}</h2>
+        ${section.lead ? `<div class="section-lead">${escapeHtml(section.lead)}</div>` : ''}
+      </div>
+    </header>
+    <div class="section-body">${section.html}</div>
+  </section>`;
+}
+
+export function renderProfessionalReportHtml(input: ProfessionalReportInput): string {
+  const image = imageIsSafe(input.imageDataUrl)
+    ? `<figure class="cover-image"><img src="${input.imageDataUrl}" alt="" />${input.imageCredit ? `<figcaption>${escapeHtml(input.imageCredit)}</figcaption>` : ''}</figure>`
+    : `<div class="cover-motif" aria-hidden="true"><span></span><span></span><span></span><span></span></div>`;
+  const metrics = input.metrics?.length
+    ? `<div class="cover-metrics">${input.metrics.map((metric) =>
+        `<div><strong>${escapeHtml(metric.value)}</strong><span>${escapeHtml(metric.label)}</span></div>`
+      ).join('')}</div>`
+    : '';
+  const tocItems = input.sections.map((section) => ({
+    id: section.id,
+    title: section.title,
+    children: section.tocChildren,
+  }));
+
+  return `<!doctype html>
+<html lang="${escapeHtml(input.language)}">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(input.title)}</title>
+  <style>
+    @page { size: A4; margin: 20mm 20mm 20mm; }
+    * { box-sizing: border-box; }
+    :root {
+      --accent: ${input.theme.accent};
+      --accent-dark: ${input.theme.accentDark};
+      --accent-soft: ${input.theme.accentSoft};
+      --ink: #182033;
+      --muted: #667085;
+      --line: #d9deea;
+      --paper-soft: #f7f8fb;
+    }
+    html { color: var(--ink); background: #fff; font-family: Georgia, "Times New Roman", serif; }
+    body { margin: 0; font-size: 10.7pt; line-height: 1.62; }
+    a { color: var(--accent-dark); text-decoration-color: color-mix(in srgb, var(--accent) 45%, transparent); text-underline-offset: 2px; overflow-wrap: anywhere; }
+    p { margin: 0 0 3.8mm; }
+    strong { color: #111827; }
+    .cover {
+      min-height: 245mm;
+      display: flex;
+      flex-direction: column;
+      break-after: page;
+      position: relative;
+      overflow: hidden;
+    }
+    .cover-kicker {
+      margin-top: 7mm;
+      color: var(--accent);
+      font: 700 8.3pt/1.2 Arial, sans-serif;
+      letter-spacing: .19em;
+      text-transform: uppercase;
+    }
+    .cover-rule { width: 19mm; height: 1.4mm; margin: 5mm 0 8mm; border-radius: 99px; background: var(--accent); }
+    .cover h1 {
+      max-width: 165mm;
+      margin: 0;
+      color: var(--ink);
+      font: 700 30pt/1.07 Arial, sans-serif;
+      letter-spacing: -.035em;
+    }
+    .cover-subtitle { max-width: 150mm; margin: 5mm 0 0; color: var(--muted); font-size: 13pt; line-height: 1.48; }
+    .cover-image { margin: 10mm 0 0; }
+    .cover-image img {
+      display: block;
+      width: 100%;
+      height: 91mm;
+      object-fit: cover;
+      border: .25mm solid #d9deea;
+      border-radius: 4mm;
+      box-shadow: 0 4mm 12mm rgba(22, 31, 55, .13);
+    }
+    .cover-image figcaption { margin-top: 2mm; color: var(--muted); font: italic 7.7pt/1.35 Georgia, serif; text-align: right; }
+    .cover-motif {
+      position: relative;
+      height: 74mm;
+      margin-top: 11mm;
+      overflow: hidden;
+      border: .25mm solid color-mix(in srgb, var(--accent) 25%, white);
+      border-radius: 4mm;
+      background:
+        radial-gradient(circle at 22% 24%, color-mix(in srgb, var(--accent) 16%, white) 0 1.5mm, transparent 1.6mm),
+        radial-gradient(circle at 72% 68%, color-mix(in srgb, var(--accent) 14%, white) 0 1.2mm, transparent 1.3mm),
+        linear-gradient(145deg, var(--accent-soft), #fff 56%, color-mix(in srgb, var(--accent) 8%, white));
+    }
+    .cover-motif span { position: absolute; height: .35mm; transform-origin: left; background: color-mix(in srgb, var(--accent) 35%, white); }
+    .cover-motif span:nth-child(1) { width: 76mm; left: 20mm; top: 19mm; transform: rotate(12deg); }
+    .cover-motif span:nth-child(2) { width: 97mm; left: 62mm; top: 36mm; transform: rotate(-17deg); }
+    .cover-motif span:nth-child(3) { width: 68mm; left: 27mm; top: 51mm; transform: rotate(-9deg); }
+    .cover-motif span:nth-child(4) { width: 58mm; left: 94mm; top: 17mm; transform: rotate(27deg); }
+    .cover-meta {
+      margin-top: auto;
+      padding-top: 8mm;
+      border-top: .25mm solid var(--line);
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 8mm;
+      align-items: end;
+    }
+    .cover-meta dl { margin: 0; display: grid; grid-template-columns: auto 1fr; column-gap: 3mm; row-gap: 1.2mm; }
+    .cover-meta dt { color: var(--muted); font: 700 7.4pt/1.35 Arial, sans-serif; letter-spacing: .08em; text-transform: uppercase; }
+    .cover-meta dd { margin: 0; max-width: 110mm; font-size: 9pt; }
+    .cover-metrics { display: flex; gap: 2mm; }
+    .cover-metrics div { min-width: 22mm; padding: 2.5mm 3mm; border-radius: 2.3mm; background: var(--accent-soft); text-align: center; }
+    .cover-metrics strong { display: block; color: var(--accent-dark); font: 700 14pt/1 Arial, sans-serif; }
+    .cover-metrics span { display: block; margin-top: 1.2mm; color: var(--muted); font: 700 6.4pt/1.2 Arial, sans-serif; letter-spacing: .06em; text-transform: uppercase; }
+    .contents { break-after: page; padding-top: 5mm; }
+    .contents-kicker { color: var(--accent); font: 700 8pt/1.2 Arial, sans-serif; letter-spacing: .16em; text-transform: uppercase; }
+    .contents h2 { margin: 2mm 0 10mm; font: 700 25pt/1.1 Arial, sans-serif; color: var(--ink); letter-spacing: -.025em; }
+    .toc-list, .toc-children { margin: 0; padding: 0; list-style: none; }
+    .toc-list > li { padding: 3.1mm 0; border-bottom: .25mm solid var(--line); }
+    .toc-list a { display: flex; align-items: baseline; gap: 3mm; color: var(--ink); font: 600 10.3pt/1.35 Arial, sans-serif; text-decoration: none; }
+    .toc-list a b { color: var(--accent); font-size: 8pt; letter-spacing: .08em; }
+    .toc-list a i { flex: 1; border-bottom: .25mm dotted #c5cad5; }
+    .toc-children { margin: 2mm 0 0 12mm; }
+    .toc-children li { margin: 1.2mm 0; }
+    .toc-children a { color: var(--muted); font-size: 8.6pt; font-weight: 500; }
+    .report-section { padding-top: 5mm; }
+    .report-section + .report-section { margin-top: 10mm; }
+    .report-section.page-break { break-before: page; }
+    .section-heading {
+      display: grid;
+      grid-template-columns: 13mm 1fr;
+      gap: 4mm;
+      align-items: start;
+      margin: 0 0 7mm;
+      break-after: avoid;
+    }
+    .section-heading > span {
+      display: grid;
+      width: 11mm;
+      height: 11mm;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--accent-soft);
+      color: var(--accent-dark);
+      font: 700 8pt/1 Arial, sans-serif;
+    }
+    .section-heading p { margin: 0 0 1.3mm; color: var(--accent); font: 700 7pt/1.2 Arial, sans-serif; letter-spacing: .13em; text-transform: uppercase; }
+    .section-heading h2 { margin: 0; color: var(--accent-dark); font: 700 20pt/1.15 Arial, sans-serif; letter-spacing: -.02em; }
+    .section-lead { max-width: 145mm; margin-top: 2mm; color: var(--muted); font-size: 9.5pt; line-height: 1.48; }
+    .section-body { margin-left: 17mm; }
+    .prose { color: #262d3d; }
+    .prose p { text-align: justify; text-indent: 1.35em; hyphens: auto; orphans: 3; widows: 3; }
+    .prose h1, .prose h2, .prose h3, .prose h4 {
+      margin: 8mm 0 3mm;
+      color: var(--accent-dark);
+      font-family: Arial, sans-serif;
+      line-height: 1.22;
+      break-after: avoid;
+    }
+    .prose h1 { padding-bottom: 2mm; border-bottom: .35mm solid color-mix(in srgb, var(--accent) 27%, white); font-size: 18pt; }
+    .prose h2 { font-size: 15pt; }
+    .prose h3 { font-size: 12pt; color: var(--accent); }
+    .prose h4 { font-size: 10.5pt; }
+    .prose h1:first-child, .prose h2:first-child, .prose h3:first-child { margin-top: 0; }
+    .prose h1 + p, .prose h2 + p, .prose h3 + p, .prose li p { text-indent: 0; }
+    .prose ul, .prose ol { margin: 0 0 4mm 5mm; padding-left: 5mm; }
+    .prose li { margin: 1.2mm 0; padding-left: 1.5mm; text-align: justify; }
+    .prose li::marker { color: var(--accent); font-weight: 700; }
+    blockquote {
+      margin: 5mm 0;
+      padding: 4mm 5mm;
+      border-left: 1.2mm solid var(--accent);
+      border-radius: 0 2.5mm 2.5mm 0;
+      background: var(--accent-soft);
+      color: #344054;
+      font-size: 9.8pt;
+      line-height: 1.58;
+      break-inside: avoid;
+    }
+    table { width: 100%; margin: 5mm 0; border-collapse: collapse; table-layout: fixed; font: 7.8pt/1.38 Arial, sans-serif; }
+    th { padding: 2.6mm; border: .25mm solid color-mix(in srgb, var(--accent) 23%, #d9deea); background: var(--accent-soft); color: var(--accent-dark); text-align: left; }
+    td { padding: 2.6mm; border: .25mm solid var(--line); vertical-align: top; overflow-wrap: anywhere; }
+    tr { break-inside: avoid; }
+    code { padding: .25mm 1mm; border-radius: 1mm; background: #f1f3f7; font: 8.7pt Consolas, monospace; }
+    pre { max-width: 100%; padding: 4mm; overflow-wrap: anywhere; white-space: pre-wrap; border-radius: 2mm; background: #161b2b; color: #f8fafc; }
+    .abstract-box, .question-box {
+      padding: 6mm;
+      border: .25mm solid color-mix(in srgb, var(--accent) 24%, #d9deea);
+      border-radius: 3mm;
+      background: linear-gradient(145deg, var(--accent-soft), #fff);
+    }
+    .abstract-box p, .question-box p { text-indent: 0; margin: 0; font-size: 11pt; line-height: 1.7; }
+    .question-box { margin-bottom: 5mm; }
+    .question-box small { display: block; margin-bottom: 1.5mm; color: var(--accent); font: 700 7pt/1.2 Arial, sans-serif; letter-spacing: .11em; text-transform: uppercase; }
+    .outline-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: start;
+      gap: 3.5mm;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      counter-reset: outline;
+    }
+    .outline-list > li { position: relative; padding: 4mm 4mm 4mm 14mm; border: .25mm solid var(--line); border-radius: 2.5mm; break-inside: avoid; counter-increment: outline; }
+    .outline-list > li::before { content: counter(outline, decimal-leading-zero); position: absolute; left: 4mm; top: 4.2mm; color: var(--accent); font: 700 8pt Arial, sans-serif; }
+    .outline-list h3 { margin: 0; color: var(--ink); font: 700 10.5pt/1.3 Arial, sans-serif; }
+    .outline-list p { margin: 1.2mm 0 0; color: var(--muted); font-size: 8.8pt; text-indent: 0; text-align: left; }
+    .claim-list { margin: 2mm 0 0; padding-left: 4mm; font-size: 8.3pt; }
+    .claim-list li { margin: .7mm 0; }
+    .source-pills { display: flex; flex-wrap: wrap; gap: 1.2mm; margin-top: 2mm; }
+    .source-pills span { padding: .8mm 1.8mm; border-radius: 99px; background: var(--paper-soft); color: var(--muted); font: 6.8pt/1.2 Arial, sans-serif; }
+    .evidence-grid { display: grid; gap: 3mm; }
+    .evidence-card { padding: 4mm; border: .25mm solid var(--line); border-left: 1mm solid var(--accent); border-radius: 2mm; break-inside: avoid; }
+    .evidence-card > span { color: var(--accent); font: 700 6.8pt/1.2 Arial, sans-serif; letter-spacing: .1em; text-transform: uppercase; }
+    .evidence-card h3 { margin: 1.3mm 0 2.5mm; color: var(--ink); font: 700 10pt/1.35 Arial, sans-serif; }
+    .evidence-card dl { display: grid; grid-template-columns: 21mm 1fr; gap: 1mm 3mm; margin: 0; font-size: 8.3pt; }
+    .evidence-card dt { color: var(--muted); font: 700 6.8pt/1.35 Arial, sans-serif; letter-spacing: .06em; text-transform: uppercase; }
+    .evidence-card dd { margin: 0; }
+    .term-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 3mm; }
+    .term-card { padding: 3.5mm; border: .25mm solid var(--line); border-radius: 2mm; break-inside: avoid; }
+    .term-card h3 { margin: 0 0 1mm; color: var(--accent-dark); font: 700 9.5pt/1.3 Arial, sans-serif; }
+    .term-card p { margin: 0; color: #475467; font-size: 8.5pt; line-height: 1.45; text-indent: 0; text-align: left; }
+    .section-body > h3 {
+      margin: 6mm 0 2.5mm;
+      color: var(--accent-dark);
+      font: 700 11pt/1.3 Arial, sans-serif;
+      break-after: avoid;
+    }
+    .source-card { margin: 4mm 0; padding: 4mm; border: .25mm solid var(--line); border-radius: 2.5mm; break-inside: avoid; }
+    .source-card blockquote { margin: 0 0 2.5mm; padding: 0 0 0 4mm; border-radius: 0; background: transparent; font-style: italic; }
+    .source-card footer { color: var(--muted); font: 7.8pt/1.4 Arial, sans-serif; }
+    .source-card .commentary { margin: 2.5mm 0 0; padding-top: 2.5mm; border-top: .25mm solid var(--line); font-size: 8.8pt; text-indent: 0; }
+    .takeaway-list { margin-top: 3mm; padding: 4mm 5mm; border-radius: 2.5mm; background: var(--accent-soft); }
+    .takeaway-list h3 { margin: 0 0 2mm; color: var(--accent-dark); font: 700 9pt Arial, sans-serif; }
+    .takeaway-list ul { margin-bottom: 0; }
+    .reference-list { padding-left: 5mm; }
+    .reference-list li { margin: 2mm 0; padding-left: 1mm; font-size: 8.7pt; }
+    .muted { color: var(--muted); }
+    .no-indent, .no-indent p { text-indent: 0 !important; }
+    @media print {
+      a { color: var(--accent-dark); }
+      .report-section, .source-card, .evidence-card, .term-card { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="cover">
+      <div class="cover-kicker">${escapeHtml(input.kindLabel)}</div>
+      <div class="cover-rule"></div>
+      <h1>${escapeHtml(input.title)}</h1>
+      ${input.subtitle ? `<p class="cover-subtitle">${escapeHtml(input.subtitle)}</p>` : ''}
+      ${image}
+      <div class="cover-meta">
+        <dl>
+          <dt>${escapeHtml(input.generatedLabel)}</dt><dd>${escapeHtml(input.generatedAt)}</dd>
+          ${input.objectiveLabel && input.objective ? `<dt>${escapeHtml(input.objectiveLabel)}</dt><dd>${escapeHtml(input.objective)}</dd>` : ''}
+        </dl>
+        ${metrics}
+      </div>
+    </section>
+    <nav class="contents" aria-label="${escapeHtml(input.contentsLabel)}">
+      <div class="contents-kicker">NODUS</div>
+      <h2>${escapeHtml(input.contentsLabel)}</h2>
+      ${tocHtml(tocItems)}
+    </nav>
+    ${input.sections.map(sectionHtml).join('\n')}
+  </main>
+</body>
+</html>`;
+}
+
+function pdfSafe(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[–—]/g, '-')
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[^\x20-\x7e]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function fitText(value: string, font: Awaited<ReturnType<PDFDocument['embedFont']>>, size: number, maxWidth: number): string {
+  const text = pdfSafe(value);
+  if (font.widthOfTextAtSize(text, size) <= maxWidth) return text;
+  let clipped = text;
+  while (clipped.length > 1 && font.widthOfTextAtSize(`${clipped}...`, size) > maxWidth) clipped = clipped.slice(0, -1);
+  return `${clipped.trim()}...`;
+}
+
+function drawNodusMark(page: PDFPage, centerX: number, y: number, accent: ReturnType<typeof rgb>): void {
+  const left = centerX - 6.7;
+  const right = centerX + 6.7;
+  const bottom = y - 4.8;
+  const top = y + 4.8;
+  const line = { thickness: 1.55, color: accent, opacity: 0.95 };
+  page.drawLine({ start: { x: left, y: bottom }, end: { x: left, y: top }, ...line });
+  page.drawLine({ start: { x: left, y: top }, end: { x: right, y: bottom }, ...line });
+  page.drawLine({ start: { x: right, y: bottom }, end: { x: right, y: top }, ...line });
+  for (const [x, cy] of [[left, bottom], [left, top], [right, bottom], [right, top]] as const) {
+    page.drawCircle({ x, y: cy, size: 1.7, color: accent });
+  }
+}
+
+async function stampProfessionalPdf(bytes: Buffer, input: ProfessionalReportInput): Promise<Buffer> {
+  const doc = await PDFDocument.load(bytes);
+  const regular = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const accent = rgb(...input.theme.accentRgb);
+  const gray = rgb(0.46, 0.49, 0.56);
+  const line = rgb(0.84, 0.86, 0.9);
+  const pages = doc.getPages();
+
+  doc.setTitle(input.title);
+  doc.setAuthor('Nodus');
+  doc.setCreator('Nodus');
+  doc.setProducer('Nodus Professional PDF');
+  doc.setSubject(input.kindLabel);
+  doc.setCreationDate(new Date());
+
+  pages.forEach((page, index) => {
+    const { width, height } = page.getSize();
+    const margin = 56.7;
+    const centerX = width / 2;
+    const headerY = height - 25;
+    page.drawLine({ start: { x: margin, y: height - 39 }, end: { x: centerX - 16, y: height - 39 }, thickness: 0.45, color: line });
+    page.drawLine({ start: { x: centerX + 16, y: height - 39 }, end: { x: width - margin, y: height - 39 }, thickness: 0.45, color: line });
+    drawNodusMark(page, centerX, headerY, accent);
+
+    page.drawLine({ start: { x: margin, y: 39 }, end: { x: width - margin, y: 39 }, thickness: 0.45, color: line });
+    const kind = fitText(input.kindLabel.toUpperCase(), bold, 6.5, 145);
+    page.drawText(kind, { x: margin, y: 22, size: 6.5, font: bold, color: gray });
+    const brand = 'NODUS';
+    const brandWidth = bold.widthOfTextAtSize(brand, 6.5);
+    page.drawText(brand, { x: width - margin - brandWidth, y: 22, size: 6.5, font: bold, color: accent });
+    const pageLabel = `${index + 1} / ${pages.length}`;
+    const pageWidth = regular.widthOfTextAtSize(pageLabel, 7.5);
+    page.drawText(pageLabel, { x: centerX - pageWidth / 2, y: 21.5, size: 7.5, font: regular, color: gray });
+  });
+
+  return Buffer.from(await doc.save());
+}
+
+export async function professionalReportPdf(input: ProfessionalReportInput): Promise<Buffer> {
+  const printed = await htmlToPdfBytes(renderProfessionalReportHtml(input));
+  return stampProfessionalPdf(printed, input);
+}

--- a/electron/export/writingWorkshopExport.ts
+++ b/electron/export/writingWorkshopExport.ts
@@ -2,12 +2,142 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { app, dialog } from 'electron';
 import type {
+  DecorativeImageSource,
+  PromptLanguage,
   WritingWorkshopDraft,
   WritingWorkshopExportFormat,
   WritingWorkshopExportRequest,
   WritingWorkshopMatrixRow,
 } from '@shared/types';
 import { markdownToPdf } from './markdownRender';
+import { getDecorativeImage, getDecorativeImageData } from '../db/decorativeImagesRepo';
+import {
+  PROFESSIONAL_REPORT_THEMES,
+  anchoredMarkdown,
+  professionalReportPdf,
+  reportLink,
+  type ProfessionalReportInput,
+  type ProfessionalReportSection,
+} from './professionalReportPdf';
+
+interface DeepReportLabels {
+  kind: string;
+  contents: string;
+  generated: string;
+  objective: string;
+  summary: string;
+  summaryEyebrow: string;
+  outline: string;
+  outlineEyebrow: string;
+  report: string;
+  reportEyebrow: string;
+  recommendations: string;
+  recommendationsEyebrow: string;
+  traceability: string;
+  traceabilityEyebrow: string;
+  sections: string;
+  sources: string;
+  words: string;
+  imageAi: string;
+  imageCustom: string;
+  claims: string;
+  source: string;
+  evidence: string;
+  notes: string;
+}
+
+const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
+  es: {
+    kind: 'Informe profesional · Deep Research',
+    contents: 'Contenido',
+    generated: 'Generado',
+    objective: 'Objetivo',
+    summary: 'Resumen ejecutivo',
+    summaryEyebrow: 'Síntesis',
+    outline: 'Esquema de investigación',
+    outlineEyebrow: 'Arquitectura del informe',
+    report: 'Informe',
+    reportEyebrow: 'Desarrollo',
+    recommendations: 'Siguientes pasos',
+    recommendationsEyebrow: 'Recomendaciones',
+    traceability: 'Matriz de trazabilidad',
+    traceabilityEyebrow: 'Evidencia y enlaces',
+    sections: 'secciones',
+    sources: 'fuentes',
+    words: 'palabras',
+    imageAi: 'Imagen de portada generada por IA en Nodus.',
+    imageCustom: 'Imagen de portada aportada por el usuario.',
+    claims: 'Afirmaciones clave',
+    source: 'Fuente',
+    evidence: 'Evidencia',
+    notes: 'Notas',
+  },
+  en: {
+    kind: 'Professional report · Deep Research',
+    contents: 'Contents',
+    generated: 'Generated',
+    objective: 'Objective',
+    summary: 'Executive summary',
+    summaryEyebrow: 'Synthesis',
+    outline: 'Research outline',
+    outlineEyebrow: 'Report architecture',
+    report: 'Report',
+    reportEyebrow: 'Analysis',
+    recommendations: 'Next steps',
+    recommendationsEyebrow: 'Recommendations',
+    traceability: 'Evidence matrix',
+    traceabilityEyebrow: 'Evidence and links',
+    sections: 'sections',
+    sources: 'sources',
+    words: 'words',
+    imageAi: 'Cover image generated with AI in Nodus.',
+    imageCustom: 'Cover image provided by the user.',
+    claims: 'Key claims',
+    source: 'Source',
+    evidence: 'Evidence',
+    notes: 'Notes',
+  },
+  fr: {
+    kind: 'Rapport professionnel · Deep Research', contents: 'Sommaire', generated: 'Généré', objective: 'Objectif',
+    summary: 'Résumé exécutif', summaryEyebrow: 'Synthèse', outline: 'Plan de recherche', outlineEyebrow: 'Architecture du rapport',
+    report: 'Rapport', reportEyebrow: 'Analyse', recommendations: 'Prochaines étapes', recommendationsEyebrow: 'Recommandations',
+    traceability: 'Matrice de traçabilité', traceabilityEyebrow: 'Preuves et liens', sections: 'sections', sources: 'sources', words: 'mots',
+    imageAi: 'Image de couverture générée par IA dans Nodus.', imageCustom: 'Image de couverture fournie par l’utilisateur.',
+    claims: 'Affirmations clés', source: 'Source', evidence: 'Preuve', notes: 'Notes',
+  },
+  tr: {
+    kind: 'Profesyonel rapor · Deep Research', contents: 'İçindekiler', generated: 'Oluşturulma', objective: 'Amaç',
+    summary: 'Yönetici özeti', summaryEyebrow: 'Sentez', outline: 'Araştırma planı', outlineEyebrow: 'Rapor mimarisi',
+    report: 'Rapor', reportEyebrow: 'Analiz', recommendations: 'Sonraki adımlar', recommendationsEyebrow: 'Öneriler',
+    traceability: 'İzlenebilirlik matrisi', traceabilityEyebrow: 'Kanıt ve bağlantılar', sections: 'bölüm', sources: 'kaynak', words: 'kelime',
+    imageAi: 'Kapak görseli Nodus’ta yapay zekâ ile oluşturuldu.', imageCustom: 'Kapak görseli kullanıcı tarafından sağlandı.',
+    claims: 'Temel iddialar', source: 'Kaynak', evidence: 'Kanıt', notes: 'Notlar',
+  },
+  de: {
+    kind: 'Professioneller Bericht · Deep Research', contents: 'Inhalt', generated: 'Erstellt', objective: 'Ziel',
+    summary: 'Zusammenfassung', summaryEyebrow: 'Synthese', outline: 'Forschungsstruktur', outlineEyebrow: 'Berichtsarchitektur',
+    report: 'Bericht', reportEyebrow: 'Analyse', recommendations: 'Nächste Schritte', recommendationsEyebrow: 'Empfehlungen',
+    traceability: 'Nachweismatrix', traceabilityEyebrow: 'Evidenz und Links', sections: 'Abschnitte', sources: 'Quellen', words: 'Wörter',
+    imageAi: 'Titelbild mit KI in Nodus generiert.', imageCustom: 'Titelbild vom Benutzer bereitgestellt.',
+    claims: 'Kernaussagen', source: 'Quelle', evidence: 'Evidenz', notes: 'Notizen',
+  },
+  pt: {
+    kind: 'Relatório profissional · Deep Research', contents: 'Conteúdo', generated: 'Gerado', objective: 'Objetivo',
+    summary: 'Resumo executivo', summaryEyebrow: 'Síntese', outline: 'Esquema de investigação', outlineEyebrow: 'Arquitetura do relatório',
+    report: 'Relatório', reportEyebrow: 'Análise', recommendations: 'Próximos passos', recommendationsEyebrow: 'Recomendações',
+    traceability: 'Matriz de rastreabilidade', traceabilityEyebrow: 'Evidência e ligações', sections: 'secções', sources: 'fontes', words: 'palavras',
+    imageAi: 'Imagem de capa gerada por IA no Nodus.', imageCustom: 'Imagem de capa fornecida pelo utilizador.',
+    claims: 'Afirmações-chave', source: 'Fonte', evidence: 'Evidência', notes: 'Notas',
+  },
+  'pt-BR': {
+    kind: 'Relatório profissional · Deep Research', contents: 'Conteúdo', generated: 'Gerado', objective: 'Objetivo',
+    summary: 'Resumo executivo', summaryEyebrow: 'Síntese', outline: 'Estrutura da pesquisa', outlineEyebrow: 'Arquitetura do relatório',
+    report: 'Relatório', reportEyebrow: 'Análise', recommendations: 'Próximos passos', recommendationsEyebrow: 'Recomendações',
+    traceability: 'Matriz de rastreabilidade', traceabilityEyebrow: 'Evidências e links', sections: 'seções', sources: 'fontes', words: 'palavras',
+    imageAi: 'Imagem de capa gerada por IA no Nodus.', imageCustom: 'Imagem de capa fornecida pelo usuário.',
+    claims: 'Afirmações-chave', source: 'Fonte', evidence: 'Evidência', notes: 'Notas',
+  },
+};
 
 export async function exportWritingWorkshopDraft(
   request: WritingWorkshopExportRequest
@@ -36,11 +166,170 @@ export async function exportWritingWorkshopDraft(
   const format: WritingWorkshopExportFormat = path.extname(filePath).toLowerCase() === '.pdf' ? 'pdf' : 'markdown';
   const markdown = renderDraftMarkdown(draft);
   if (format === 'pdf') {
-    fs.writeFileSync(filePath, await markdownToPdf(markdown, draft.title || 'Informe'));
+    const bytes = draft.brief.kind === 'deep_research'
+      ? await professionalReportPdf(buildDeepResearchPdfInput(draft, request.entityId))
+      : await markdownToPdf(markdown, draft.title || 'Informe');
+    fs.writeFileSync(filePath, bytes);
   } else {
     fs.writeFileSync(filePath, markdown, 'utf8');
   }
   return { path: filePath };
+}
+
+function reportImage(entityId: string | undefined, labels: DeepReportLabels): { dataUrl: string | null; credit: string | null } {
+  if (!entityId) return { dataUrl: null, credit: null };
+  const meta = getDecorativeImage('deep_research', entityId);
+  const data = getDecorativeImageData('deep_research', entityId);
+  if (!meta || meta.status !== 'ready' || !data) return { dataUrl: null, credit: null };
+  return {
+    dataUrl: `data:${data.mimeType};base64,${data.bytes.toString('base64')}`,
+    credit: imageCredit(meta.source, labels),
+  };
+}
+
+function imageCredit(source: DecorativeImageSource | null, labels: DeepReportLabels): string | null {
+  if (source === 'ai') return labels.imageAi;
+  if (source === 'custom') return labels.imageCustom;
+  return null;
+}
+
+function localizedDate(iso: string, language: PromptLanguage): string {
+  try {
+    return new Intl.DateTimeFormat(language, { day: '2-digit', month: 'long', year: 'numeric' }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function stripLeadingAbstract(markdown: string, abstract: string): string {
+  const lines = markdown.replace(/\r\n?/g, '\n').split('\n');
+  const first = lines.findIndex((line) => line.trim().length > 0);
+  if (first < 0 || !/^#{1,3}\s+/.test(lines[first])) return markdown;
+  let next = first + 1;
+  while (next < lines.length && !/^#{1,3}\s+/.test(lines[next])) next++;
+  const block = lines.slice(first + 1, next).join(' ').replace(/\s+/g, ' ').trim();
+  const expected = abstract.replace(/\s+/g, ' ').trim();
+  if (!expected || !block || !block.includes(expected.slice(0, Math.min(80, expected.length)))) return markdown;
+  return lines.slice(next).join('\n').trim();
+}
+
+function outlineHtml(draft: WritingWorkshopDraft, labels: DeepReportLabels): string {
+  return `<ol class="outline-list">${draft.outline.map((section) => {
+    const claims = section.keyClaims.length
+      ? `<div class="muted" style="margin-top:2mm;font:700 6.8pt Arial,sans-serif;text-transform:uppercase;letter-spacing:.07em">${labels.claims}</div><ul class="claim-list">${section.keyClaims.map((claim) => `<li>${escapeCellHtml(claim)}</li>`).join('')}</ul>`
+      : '';
+    const sources = section.sources.length
+      ? `<div class="source-pills">${section.sources.map((source) => `<span>${escapeCellHtml(source)}</span>`).join('')}</div>`
+      : '';
+    return `<li><h3>${escapeCellHtml(section.title)}</h3>${section.purpose ? `<p>${escapeCellHtml(section.purpose)}</p>` : ''}${claims}${sources}</li>`;
+  }).join('')}</ol>`;
+}
+
+function matrixHtml(rows: WritingWorkshopMatrixRow[], labels: DeepReportLabels): string {
+  if (!rows.length) return '';
+  return `<div class="evidence-grid">${rows.map((row) => {
+    const source = row.citation
+      ? reportLink(row.citation, row.sourceLabel || labels.source)
+      : escapeCellHtml(row.sourceLabel || labels.source);
+    return `<article class="evidence-card">
+      <span>${escapeCellHtml(row.role)}</span>
+      <h3>${escapeCellHtml(row.claim)}</h3>
+      <dl>
+        <dt>${escapeCellHtml(labels.source)}</dt><dd>${source}</dd>
+        <dt>${escapeCellHtml(labels.evidence)}</dt><dd>${escapeCellHtml(row.evidence)}</dd>
+        ${row.notes ? `<dt>${escapeCellHtml(labels.notes)}</dt><dd>${escapeCellHtml(row.notes)}</dd>` : ''}
+      </dl>
+    </article>`;
+  }).join('')}</div>`;
+}
+
+function escapeCellHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Pure document model used by the Electron exporter and its visual regression fixture. */
+export function buildDeepResearchPdfInput(
+  draft: WritingWorkshopDraft,
+  entityId?: string,
+  imageOverride?: { dataUrl: string | null; credit: string | null }
+): ProfessionalReportInput {
+  const language = draft.brief.language ?? 'es';
+  const labels = DEEP_LABELS[language];
+  const image = imageOverride ?? reportImage(entityId, labels);
+  const body = stripLeadingAbstract(draft.draftMarkdown, draft.abstract);
+  const report = anchoredMarkdown(body, 'report');
+  const abstract = anchoredMarkdown(draft.abstract || draft.brief.objective, 'summary');
+  const sections: ProfessionalReportSection[] = [
+    {
+      id: 'executive-summary',
+      number: '01',
+      title: labels.summary,
+      eyebrow: labels.summaryEyebrow,
+      html: `<div class="abstract-box prose">${abstract.html}</div>`,
+    },
+  ];
+  if (draft.outline.length) {
+    sections.push({
+      id: 'research-outline',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.outline,
+      eyebrow: labels.outlineEyebrow,
+      html: outlineHtml(draft, labels),
+    });
+  }
+  sections.push({
+    id: 'research-report',
+    number: String(sections.length + 1).padStart(2, '0'),
+    title: labels.report,
+    eyebrow: labels.reportEyebrow,
+    html: `<div class="prose">${report.html}</div>`,
+    tocChildren: report.headings,
+    pageBreakBefore: true,
+  });
+  if (draft.nextSteps.length) {
+    sections.push({
+      id: 'next-steps',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.recommendations,
+      eyebrow: labels.recommendationsEyebrow,
+      html: `<div class="prose no-indent"><ol>${draft.nextSteps.map((item) => `<li>${escapeCellHtml(item)}</li>`).join('')}</ol></div>`,
+    });
+  }
+  if (draft.matrix.length) {
+    sections.push({
+      id: 'traceability',
+      number: String(sections.length + 1).padStart(2, '0'),
+      title: labels.traceability,
+      eyebrow: labels.traceabilityEyebrow,
+      html: matrixHtml(draft.matrix, labels),
+      pageBreakBefore: true,
+    });
+  }
+  const words = draft.draftMarkdown.split(/\s+/).filter(Boolean).length;
+  return {
+    title: draft.title || labels.report,
+    subtitle: draft.brief.objective,
+    kindLabel: labels.kind,
+    language,
+    generatedLabel: labels.generated,
+    generatedAt: localizedDate(draft.generatedAt, language),
+    objectiveLabel: labels.objective,
+    objective: draft.brief.objective,
+    imageDataUrl: image.dataUrl,
+    imageCredit: image.credit,
+    contentsLabel: labels.contents,
+    metrics: [
+      { value: String(draft.outline.length), label: labels.sections },
+      { value: String(draft.stats.selectedWorks || draft.bibliography.length), label: labels.sources },
+      { value: words.toLocaleString(language), label: labels.words },
+    ],
+    sections,
+    theme: PROFESSIONAL_REPORT_THEMES.deepResearch,
+  };
 }
 
 function renderDraftMarkdown(draft: WritingWorkshopDraft): string {

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -493,6 +493,7 @@ import * as workSummaries from './db/workSummariesRepo';
 import * as projects from './db/projectsRepo';
 import { closeDb, getDb, withVaultDatabase } from './db/database';
 import { exportWritingWorkshopDraft } from './export/writingWorkshopExport';
+import { exportImmersionSessionPdf } from './export/immersionExport';
 import { generateProjectSuggestions } from './ai/projectInsertion';
 import { exportProject, exportProjectChapter } from './export/projectExport';
 import {
@@ -3074,6 +3075,11 @@ export function registerIpc(
     immersionRepo.setImmersionProgress(id, progress)
   );
   h('immersion:answer', async (_e, request: ImmersionAnswerRequest) => evaluateImmersionAnswer(request));
+  h('immersion:exportPdf', async (_e, id: string) => {
+    const session = immersionRepo.getImmersionSession(id);
+    if (!session) throw new Error('La inmersión ya no existe.');
+    return exportImmersionSessionPdf(session);
+  });
   h('immersion:delete', async (_e, id: string) => {
     invalidateDecorativeImageGeneration('immersion', id);
     translationsRepo.deleteEntityTranslations('immersion', id);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -899,6 +899,7 @@ const api: NodusApi = {
   restartImmersionSession: (id) => ipcRenderer.invoke('immersion:restart', id),
   setImmersionProgress: (id, progress) => ipcRenderer.invoke('immersion:progress:set', id, progress).then(() => undefined),
   answerImmersionQuestion: (request) => ipcRenderer.invoke('immersion:answer', request),
+  exportImmersionSessionPdf: (id) => ipcRenderer.invoke('immersion:exportPdf', id),
   deleteImmersionSession: (id) => ipcRenderer.invoke('immersion:delete', id).then(() => undefined),
 
   listManagedThemes: () => ipcRenderer.invoke('themes:listManaged'),

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dist:linux": "npm run build && electron-builder --linux",
     "verify:exam-generation": "node scripts/verify-exam-generation.mjs",
     "verify:exam-pdf": "node scripts/verify-exam-pdf.mjs",
+    "verify:professional-pdf": "node scripts/verify-professional-report-pdf.mjs",
     "verify:rubric-generation": "node scripts/verify-rubric-generation.mjs",
     "capture:docs": "npm run build && electron-rebuild -f -w better-sqlite3 && node scripts/capture-doc-screenshots.mjs"
   },

--- a/scripts/verify-professional-report-pdf.mjs
+++ b/scripts/verify-professional-report-pdf.mjs
@@ -1,0 +1,224 @@
+// Visual and structural verification for the professional Deep Research and
+// Immersion PDFs. Runs through the real Electron printToPDF engine and writes
+// stable fixtures under tmp/pdfs for Poppler rendering/inspection.
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+if (!process.argv.includes('--electron-professional-pdf')) {
+  execFileSync(
+    path.join(root, 'node_modules/.bin/electron'),
+    [path.join(root, 'scripts/verify-professional-report-pdf.mjs'), '--electron-professional-pdf'],
+    { cwd: root, env: { ...process.env }, stdio: 'inherit' }
+  );
+  process.exit(0);
+}
+
+console.log('Professional PDF verification started.');
+
+{
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) return path.join(root, `${request.replace('@shared/', 'shared/')}.ts`);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  require.extensions['.ts'] = function (module, filename) {
+    const output = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}
+
+const { app, BrowserWindow } = require('electron');
+const { createCanvas } = require('@napi-rs/canvas');
+const { buildDeepResearchPdfInput } = require(path.join(root, 'electron/export/writingWorkshopExport.ts'));
+const { buildImmersionPdfInput } = require(path.join(root, 'electron/export/immersionExport.ts'));
+const { professionalReportPdf } = require(path.join(root, 'electron/export/professionalReportPdf.ts'));
+
+function coverDataUrl() {
+  const canvas = createCanvas(1400, 760);
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, 1400, 760);
+  gradient.addColorStop(0, '#18263b');
+  gradient.addColorStop(0.55, '#315b67');
+  gradient.addColorStop(1, '#d2ab70');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, 1400, 760);
+  ctx.globalAlpha = 0.3;
+  for (let i = 0; i < 22; i++) {
+    const x = 80 + ((i * 223) % 1240);
+    const y = 75 + ((i * 137) % 610);
+    ctx.beginPath();
+    ctx.arc(x, y, 7 + (i % 4) * 3, 0, Math.PI * 2);
+    ctx.fillStyle = i % 3 === 0 ? '#f8e4ad' : '#a9e3d8';
+    ctx.fill();
+    if (i > 0) {
+      const prevX = 80 + (((i - 1) * 223) % 1240);
+      const prevY = 75 + (((i - 1) * 137) % 610);
+      ctx.strokeStyle = '#e8eef5';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(prevX, prevY);
+      ctx.lineTo(x, y);
+      ctx.stroke();
+    }
+  }
+  ctx.globalAlpha = 0.72;
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '700 54px Arial';
+  ctx.fillText('ARCHIVO · MEMORIA · EVIDENCIA', 88, 680);
+  return `data:image/jpeg;base64,${canvas.toBuffer('image/jpeg', 92).toString('base64')}`;
+}
+
+const abstract = 'Este informe examina cómo la memoria cultural se conserva, se transforma y se disputa cuando los testimonios, los archivos y las instituciones compiten por definir un relato compartido.';
+const paragraph = 'La evidencia disponible sugiere que la memoria no funciona como un depósito estable, sino como una práctica social sometida a selección, mediación y reinterpretación. El análisis compara fuentes de distinta naturaleza y distingue con claridad entre los hechos documentados, las inferencias plausibles y las preguntas que siguen abiertas.';
+const deepDraft = {
+  generatedAt: '2026-07-23T10:00:00.000Z',
+  brief: {
+    kind: 'deep_research',
+    objective: 'Analizar la relación entre archivo, memoria colectiva y transmisión cultural a partir del corpus académico.',
+    audience: 'Investigadores y estudiantes de posgrado',
+    tone: 'academic',
+    language: 'es',
+  },
+  selection: { ideaIds: ['i1', 'i2'], themeIds: [], gapIds: [], contradictionIds: [], workIds: ['w1', 'w2'], passageIds: ['p1'], tutorRouteIds: [] },
+  title: 'Memoria, evidencia y transmisión cultural',
+  abstract,
+  outline: [
+    { id: 's1', title: 'El archivo como tecnología de selección', purpose: 'Delimitar qué conserva el archivo y qué queda fuera.', keyClaims: ['Toda colección responde a criterios institucionales.', 'La ausencia documental también constituye evidencia.'], sources: ['Assmann (2011)', 'Ricoeur (2000)'] },
+    { id: 's2', title: 'Memoria colectiva y mediación', purpose: 'Explicar el papel de los marcos sociales.', keyClaims: ['La memoria se actualiza desde el presente.', 'Los soportes condicionan la transmisión.'], sources: ['Halbwachs (1950)'] },
+    { id: 's3', title: 'Conflictos de interpretación', purpose: 'Comparar lecturas incompatibles sin borrar la incertidumbre.', keyClaims: ['La discrepancia debe permanecer visible.'], sources: ['Pasaje archivístico A', 'Pasaje archivístico B'] },
+    { id: 's4', title: 'Implicaciones metodológicas', purpose: 'Proponer un protocolo de lectura trazable.', keyClaims: ['Separar dato, inferencia y valoración.'], sources: ['Matriz del corpus'] },
+  ],
+  draftMarkdown: `## Resumen\n\n${abstract}\n\n## 1. El archivo como tecnología de selección\n\n${paragraph} [Consultar la idea original](nodus://idea/i1).\n\n${paragraph}\n\n### 1.1 Presencias y ausencias\n\n${paragraph}\n\n> La ausencia de una voz en el archivo no demuestra su inexistencia; obliga a reconstruir las condiciones de conservación.\n\n${paragraph}\n\n## 2. Memoria colectiva y mediación\n\n${paragraph} [Abrir el pasaje citado](nodus://passage/p1).\n\n${paragraph}\n\n### 2.1 Soportes de transmisión\n\n${paragraph}\n\n- Testimonios orales y memorias personales.\n- Documentos institucionales y registros administrativos.\n- Reinterpretaciones públicas, educativas y familiares.\n\n${paragraph}\n\n## 3. Conflictos de interpretación\n\n${paragraph}\n\n${paragraph}\n\n### 3.1 Criterios de comparación\n\n${paragraph}\n\n${paragraph}\n\n## 4. Implicaciones metodológicas\n\n${paragraph}\n\n${paragraph}\n\n## Limitaciones\n\n- El corpus no representa por igual a todos los actores.\n- Algunas relaciones siguen siendo inferencias pendientes de contraste.\n\n## Referencias\n\n- Assmann, A. (2011). *Cultural Memory and Western Civilization*.\n- Halbwachs, M. (1950). *La mémoire collective*.\n- Ricoeur, P. (2000). *La mémoire, l’histoire, l’oubli*.`,
+  matrix: [
+    { claim: 'El archivo institucional selecciona y jerarquiza la evidencia.', role: 'context', sourceLabel: 'Idea: política del archivo', citation: 'nodus://idea/i1', evidence: 'Tres obras del corpus convergen en esta formulación.', notes: 'Contexto teórico.' },
+    { claim: 'Los marcos sociales orientan el recuerdo individual.', role: 'support', sourceLabel: 'Pasaje de Halbwachs', citation: 'nodus://passage/p1', evidence: 'Cita literal localizada en la página 42.', notes: 'Evidencia primaria del argumento.' },
+    { claim: 'La ausencia documental puede ser analíticamente significativa.', role: 'gap', sourceLabel: 'Hueco del corpus', citation: 'nodus://gap/g1', evidence: 'Cobertura desigual entre instituciones y testimonios.', notes: 'Debe tratarse como límite, no como conclusión.' },
+  ],
+  bibliography: ['Assmann (2011)', 'Halbwachs (1950)', 'Ricoeur (2000)'],
+  nextSteps: ['Contrastar los pasajes clave con sus documentos originales.', 'Ampliar la búsqueda a testimonios no institucionales.', 'Registrar por separado hechos, inferencias y desacuerdos.'],
+  limitations: ['Cobertura documental desigual.'],
+  stats: { selectedIdeas: 2, selectedThemes: 1, selectedGaps: 1, selectedContradictions: 0, selectedWorks: 3, selectedPassages: 1, selectedTutorRoutes: 0, contextChars: 12000, truncated: false },
+};
+
+const citation = (id, title, text) => ({
+  passageId: id,
+  workId: `work-${id}`,
+  workTitle: title,
+  authors: ['María Ortega', 'Luis Ferrer'],
+  year: 2021,
+  zoteroKey: `ZOTERO${id.toUpperCase()}`,
+  pageLabel: '42',
+  text,
+  whyItMatters: 'Permite separar la descripción documental de la interpretación posterior.',
+  commentary: 'Conviene leer el fragmento atendiendo a quién produce el registro y para qué audiencia.',
+});
+
+const stations = [1, 2, 3].map((index) => ({
+  id: `station-${index}`,
+  title: ['Cómo leer un archivo', 'Memoria y marcos sociales', 'Comparar relatos en conflicto'][index - 1],
+  question: ['¿Qué decisiones hacen visible o invisible una evidencia?', '¿Cómo transforma el presente aquello que una comunidad recuerda?', '¿Cómo comparar versiones incompatibles sin forzar una síntesis?'][index - 1],
+  minutes: 20,
+  context: paragraph,
+  synthesis: `### Núcleo de la estación\n\n${paragraph}\n\n${paragraph} [Explorar la evidencia](nodus://passage/p${index}).\n\n### Método de lectura\n\n${paragraph}`,
+  citations: [citation(`p${index}`, `Fuente documental ${index}`, 'El documento conserva una huella situada: registra una acción y, al mismo tiempo, el marco institucional desde el que esa acción fue descrita.')],
+  positions: [
+    { authorId: null, name: 'Perspectiva institucional', position: 'Subraya la continuidad y la autoridad del registro.', ideaIds: [] },
+    { authorId: null, name: 'Perspectiva crítica', position: 'Examina los silencios, sesgos y exclusiones del archivo.', ideaIds: [] },
+  ],
+  takeaways: ['Toda fuente tiene condiciones de producción.', 'La discrepancia es información, no ruido.', 'Una conclusión debe conservar su enlace con la evidencia.'],
+  ideaIds: [],
+  quiz: [],
+}));
+
+const immersionSession = {
+  id: 'immersion-professional-fixture',
+  topic: 'Archivo, memoria y transmisión cultural',
+  language: 'es',
+  minutes: 60,
+  model: null,
+  plan: {
+    topic: 'Archivo, memoria y transmisión cultural',
+    title: 'Leer la memoria: una inmersión en archivos y relatos',
+    language: 'es',
+    minutes: 60,
+    generatedAt: '2026-07-23T10:00:00.000Z',
+    model: null,
+    overview: `## Punto de partida\n\n${paragraph}\n\n${paragraph}\n\n## Ruta de aprendizaje\n\nLa inmersión avanza desde la lectura crítica del archivo hasta la comparación explícita de relatos y evidencias.`,
+    keyTerms: [
+      { term: 'Archivo', definition: 'Sistema de selección, descripción y conservación de documentos.' },
+      { term: 'Memoria colectiva', definition: 'Reconstrucción social del pasado desde marcos compartidos.' },
+      { term: 'Trazabilidad', definition: 'Capacidad de volver desde una afirmación hasta su evidencia.' },
+      { term: 'Silencio documental', definition: 'Ausencia significativa producida por prácticas de registro o conservación.' },
+    ],
+    stations,
+    contrasts: {
+      authors: ['Institucional', 'Crítica', 'Pragmática'],
+      rows: [
+        { stationId: 'station-1', question: '¿Qué representa el archivo?', cells: [{ author: 'Institucional', authorId: null, stance: 'Continuidad documental.', ideaIds: [] }, { author: 'Crítica', authorId: null, stance: 'Selección atravesada por poder.', ideaIds: [] }, { author: 'Pragmática', authorId: null, stance: 'Infraestructura para verificar afirmaciones.', ideaIds: [] }] },
+        { stationId: 'station-2', question: '¿Cómo cambia la memoria?', cells: [{ author: 'Institucional', authorId: null, stance: 'Mediante nuevas incorporaciones.', ideaIds: [] }, { author: 'Crítica', authorId: null, stance: 'Por disputas sobre visibilidad.', ideaIds: [] }, { author: 'Pragmática', authorId: null, stance: 'Al revisar hipótesis con nueva evidencia.', ideaIds: [] }] },
+      ],
+    },
+    frontiers: [
+      { kind: 'thin_coverage', statement: 'Cobertura desigual de voces no institucionales', detail: 'El corpus conserva más documentación administrativa que testimonios personales.', workTitle: 'Colección principal' },
+      { kind: 'gap', statement: 'Falta una comparación longitudinal', detail: 'Sería necesario observar cómo cambia el mismo relato en varias generaciones.', workTitle: null },
+    ],
+    exam: { questions: [], feynman: 'Explica con tus propias palabras por qué un archivo no es un espejo neutral del pasado y describe un procedimiento concreto para enlazar cada interpretación con su evidencia.' },
+    graph: { nodes: [], edges: [] },
+    ideaIndex: [],
+    stats: { stations: 3, ideas: 12, works: 3, authors: 6, citations: 3, quizQuestions: 0 },
+    stoppedReason: null,
+  },
+  progress: { currentStep: 0, furthestStep: 0, completedSteps: [], answers: [], startedAt: null, finishedAt: null },
+  image: null,
+  createdAt: '2026-07-23T10:00:00.000Z',
+  updatedAt: '2026-07-23T10:00:00.000Z',
+};
+
+const keepAlive = setInterval(() => undefined, 1_000);
+app.whenReady().then(async () => {
+  const keeper = new BrowserWindow({ show: false });
+  try {
+    const output = path.join(root, 'tmp/pdfs');
+    fs.mkdirSync(output, { recursive: true });
+    const image = { dataUrl: coverDataUrl(), credit: 'Imagen de portada generada por IA en Nodus.' };
+    const deepInput = buildDeepResearchPdfInput(deepDraft, undefined, image);
+    const immersionInput = buildImmersionPdfInput(immersionSession, image);
+    const deepBytes = await professionalReportPdf(deepInput);
+    const immersionBytes = await professionalReportPdf(immersionInput);
+    const deepPath = path.join(output, 'deep-research-professional-sample.pdf');
+    const immersionPath = path.join(output, 'immersion-professional-sample.pdf');
+    fs.writeFileSync(deepPath, deepBytes);
+    fs.writeFileSync(immersionPath, immersionBytes);
+    for (const [label, file, bytes] of [['Deep Research', deepPath, deepBytes], ['Immersion', immersionPath, immersionBytes]]) {
+      if (bytes.subarray(0, 5).toString('latin1') !== '%PDF-') throw new Error(`${label} did not produce a PDF`);
+      console.log(`${label}: ${file} (${Math.round(bytes.length / 1024)} KB)`);
+    }
+    keeper.destroy();
+    clearInterval(keepAlive);
+    app.exit(0);
+  } catch (error) {
+    console.error(error);
+    keeper.destroy();
+    clearInterval(keepAlive);
+    app.exit(1);
+  }
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4407,6 +4407,8 @@ export interface WritingWorkshopExportRequest {
   draft: WritingWorkshopDraft;
   /** Output format. Defaults to `'markdown'` when omitted. */
   format?: WritingWorkshopExportFormat;
+  /** Saved Deep Research id, used only to include its ready decorative image in PDF exports. */
+  entityId?: string;
 }
 
 /** A locally saved workshop draft, including the exact prompt and selected evidence. */
@@ -6101,6 +6103,7 @@ export interface NodusApi {
   restartImmersionSession(id: string): Promise<ImmersionSession | null>;
   setImmersionProgress(id: string, progress: ImmersionProgress): Promise<void>;
   answerImmersionQuestion(request: ImmersionAnswerRequest): Promise<ImmersionAnswerResult>;
+  exportImmersionSessionPdf(id: string): Promise<{ path: string } | null>;
   deleteImmersionSession(id: string): Promise<void>;
   // main-theme management ("temas principales")
   listManagedThemes(): Promise<ManagedTheme[]>;

--- a/src/components/TranslationModal.tsx
+++ b/src/components/TranslationModal.tsx
@@ -6,14 +6,60 @@ import {
   type ModelRef,
   type TranslationEntityKind,
 } from '@shared/types';
-import { Icon } from './ui';
+import { Icon, ModalBackdrop } from './ui';
 import { confirm } from './feedback';
 import { t, tx } from '../i18n';
 
-/** Inline translation manager. Jobs are persisted by the main process before the
- * first AI call, so this list survives navigation away from the reader. Selecting
- * a ready translation asks the parent reader to render it in its normal layout. */
-export function TranslationPanel({
+/**
+ * Translation manager presented next to the action that opens it instead of at
+ * the end of a potentially very long document. Jobs are persisted by the main
+ * process before the first AI call, so closing the dialog never interrupts them.
+ */
+export function TranslationModal({
+  onClose,
+  ...panelProps
+}: {
+  entityKind: TranslationEntityKind;
+  entityId: string;
+  sourceTitle: string;
+  sourceMarkdown: string;
+  model: ModelRef | null;
+  activeTranslationId: string | null;
+  onApply: (translation: ContentTranslation | null) => void;
+  onClose: () => void;
+}) {
+  return (
+    <ModalBackdrop onClose={onClose}>
+      <section
+        className="card-modal flex max-h-[86vh] w-full max-w-2xl flex-col overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="translation-modal-title"
+        data-testid="translation-modal"
+      >
+        <header className="flex items-center gap-2 border-b border-neutral-200 px-5 py-3 dark:border-neutral-800">
+          <Icon name="languages" className="text-indigo-500 dark:text-indigo-300" />
+          <h2 id="translation-modal-title" className="text-sm font-semibold">{t('Traducciones')}</h2>
+          <div className="flex-1" />
+          <button className="btn btn-ghost !p-2" onClick={onClose} aria-label={t('Cerrar')} title={t('Cerrar')}>
+            <Icon name="x" size={15} />
+          </button>
+        </header>
+        <div className="min-h-0 overflow-y-auto p-5">
+          <TranslationPanel
+            {...panelProps}
+            onApply={(translation) => {
+              panelProps.onApply(translation);
+              onClose();
+            }}
+          />
+        </div>
+      </section>
+    </ModalBackdrop>
+  );
+}
+
+function TranslationPanel({
   entityKind,
   entityId,
   sourceTitle,
@@ -74,14 +120,14 @@ export function TranslationPanel({
   };
 
   const remove = async (summary: ContentTranslationSummary) => {
-    const ok = await confirm({ title: t('Eliminar traducción'), message: tx('¿Eliminar la traducción a {lang}? Esta acción no se puede deshacer.', { lang: summary.languageLabel }), confirmLabel: t('Eliminar'), danger: true });
+    const ok = await confirm({ title: t('Eliminar traducción'), message: tx('¿Eliminar la traducción a {lang}? Esta acción no se puede deshacer.', { lang: summary.languageLabel }), confirmLabel: t('Eliminar'), danger: true, zIndex: 140 });
     if (!ok) return;
     await window.nodus.deleteContentTranslation(summary.id);
     if (activeTranslationId === summary.id) onApply(null);
     await refresh();
   };
 
-  return <section className="mt-8 rounded-xl border border-neutral-200 bg-neutral-50/70 p-4 dark:border-neutral-800 dark:bg-neutral-900/30" data-testid="translation-panel">
+  return <section className="rounded-xl border border-neutral-200 bg-neutral-50/70 p-4 dark:border-neutral-800 dark:bg-neutral-900/30" data-testid="translation-panel">
     <div className="flex flex-wrap items-end gap-2">
       <div className="min-w-48 flex-1"><label className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-neutral-500">{t('Idioma')}</label><select className="input w-full text-sm" value={language} onChange={(event) => setLanguage(event.target.value)}>{TRANSLATION_LANGUAGES.map((item) => <option key={item.code} value={item.code}>{item.nativeName} — {item.name}</option>)}</select></div>
       <button className="btn btn-primary gap-1.5" disabled={starting.includes(language) || list.some((item) => item.language === language && item.status === 'generating')} onClick={() => generate(language)}><Icon name={starting.includes(language) ? 'sync' : 'languages'} className={starting.includes(language) ? 'animate-spin' : ''} size={15} />{starting.includes(language) ? t('Traduciendo…') : t('Generar traducción')}</button>

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -22,7 +22,7 @@ import { ModelPicker } from '../components/ModelPicker';
 import { confirm } from '../components/feedback';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
 import { SaveToNotesModal } from '../components/SaveToNotesModal';
-import { TranslationPanel } from '../components/TranslationModal';
+import { TranslationModal } from '../components/TranslationModal';
 import { Markdown } from '../components/Markdown';
 import { DraftActionBar, DraftResultMain, SupportMatrix } from './writingShared';
 import { DecorativeImageCard } from '../components/DecorativeImageCard';
@@ -121,7 +121,7 @@ export function DeepResearchView({
   const [showMatrix, setShowMatrix] = useState(false);
   const [citation, setCitation] = useState<CitationTarget>(null);
   const [savingToNotes, setSavingToNotes] = useState(false);
-  const [showTranslations, setShowTranslations] = useState(true);
+  const [translationOpen, setTranslationOpen] = useState(false);
   const [appliedTranslation, setAppliedTranslation] = useState<ContentTranslation | null>(null);
   const [exporting, setExporting] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
@@ -203,14 +203,14 @@ export function DeepResearchView({
     setShowMatrix(false);
     setError(null);
     setMessage(null);
-    setShowTranslations(true);
+    setTranslationOpen(false);
     setAppliedTranslation(null);
   };
 
   const backToGallery = () => {
     setMode('gallery');
     setOpenDraft(null);
-    setShowTranslations(false);
+    setTranslationOpen(false);
     setAppliedTranslation(null);
     void refreshSavedDrafts();
   };
@@ -280,7 +280,7 @@ export function DeepResearchView({
     setError(null);
     setMessage(null);
     try {
-      const result = await window.nodus.exportWritingWorkshopDraft({ draft: openDraft.draft, format });
+      const result = await window.nodus.exportWritingWorkshopDraft({ draft: openDraft.draft, format, entityId: openDraft.id });
       if (result) setMessage(`${t('Exportado')}: ${result.path}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -330,13 +330,11 @@ export function DeepResearchView({
           message={message}
           error={error}
           appliedTranslation={appliedTranslation}
-          showTranslations={showTranslations}
           onToggleMatrix={() => setShowMatrix((v) => !v)}
           onBack={backToGallery}
           onCopy={() => void copyDraft()}
           onSaveToNotes={() => setSavingToNotes(true)}
-          onTranslate={() => setShowTranslations((value) => !value)}
-          onApplyTranslation={setAppliedTranslation}
+          onTranslate={() => setTranslationOpen(true)}
           onExport={(format) => void exportDraft(format)}
           onCitation={setCitation}
           onImageChange={onImageChange}
@@ -344,6 +342,18 @@ export function DeepResearchView({
           onOpenStudyMaterial={onOpenStudyMaterial}
           onOpenStudyRecording={onOpenStudyRecording}
         />
+        {translationOpen && (
+          <TranslationModal
+            entityKind="deep_research"
+            entityId={openDraft.id}
+            sourceTitle={openDraft.draft.title}
+            sourceMarkdown={`# ${openDraft.draft.title}\n\n${openDraft.draft.abstract ? `${openDraft.draft.abstract}\n\n` : ''}${openDraft.draft.draftMarkdown}`}
+            model={openDraft.model}
+            activeTranslationId={appliedTranslation?.id ?? null}
+            onApply={setAppliedTranslation}
+            onClose={() => setTranslationOpen(false)}
+          />
+        )}
         {citation && (
           <SourceCitationModal
             target={citation}
@@ -801,13 +811,11 @@ function ReaderView({
   message,
   error,
   appliedTranslation,
-  showTranslations,
   onToggleMatrix,
   onBack,
   onCopy,
   onSaveToNotes,
   onTranslate,
-  onApplyTranslation,
   onExport,
   onCitation,
   onImageChange,
@@ -822,13 +830,11 @@ function ReaderView({
   message: string | null;
   error: string | null;
   appliedTranslation: ContentTranslation | null;
-  showTranslations: boolean;
   onToggleMatrix: () => void;
   onBack: () => void;
   onCopy: () => void;
   onSaveToNotes: () => void;
   onTranslate: () => void;
-  onApplyTranslation: (translation: ContentTranslation | null) => void;
   onExport: (format: 'markdown' | 'pdf') => void;
   onCitation: (target: CitationTarget) => void;
   onImageChange: (image: DecorativeImage) => void;
@@ -901,7 +907,6 @@ function ReaderView({
               onStudyMaterial={onOpenStudyMaterial}
               onStudyRecording={onOpenStudyRecording}
             />}
-            {showTranslations && <TranslationPanel entityKind="deep_research" entityId={saved.id} sourceTitle={saved.draft.title} sourceMarkdown={`# ${saved.draft.title}\n\n${saved.draft.abstract ? `${saved.draft.abstract}\n\n` : ''}${saved.draft.draftMarkdown}`} model={saved.model} activeTranslationId={appliedTranslation?.id ?? null} onApply={onApplyTranslation} />}
           </div>
         </main>
         {showMatrix && (

--- a/src/views/ImmersionView.tsx
+++ b/src/views/ImmersionView.tsx
@@ -35,8 +35,8 @@ import { ModelPicker } from '../components/ModelPicker';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
 import { SaveToNotesModal } from '../components/SaveToNotesModal';
-import { TranslationPanel } from '../components/TranslationModal';
-import { confirm } from '../components/feedback';
+import { TranslationModal } from '../components/TranslationModal';
+import { confirm, toast } from '../components/feedback';
 import { SigmaGraph } from './graph/SigmaGraph';
 import { GraphErrorBoundary } from './graph/GraphErrorBoundary';
 import { GRAPH_NODE_TYPES, EDGE_TYPE_COLORS, type GraphFilters } from './graph/model';
@@ -1223,8 +1223,9 @@ function ImmersionPlayer({
   onSaveToNotes: () => void;
 }) {
   const steps = useMemo(() => playerSteps(session), [session]);
-  const [showTranslations, setShowTranslations] = useState(true);
+  const [translationOpen, setTranslationOpen] = useState(false);
   const [appliedTranslation, setAppliedTranslation] = useState<ContentTranslation | null>(null);
+  const [exportingPdf, setExportingPdf] = useState(false);
   // Honest total study time from the actual route, not the requested budget:
   // a deep route can hold far more stations than a single afternoon.
   const totalMinutes = useMemo(() => steps.reduce((acc, s) => acc + stepMeta(s, session).minutes, 0), [steps, session]);
@@ -1232,6 +1233,18 @@ function ImmersionPlayer({
   const current = Math.min(progress.currentStep, steps.length - 1);
   const [direction, setDirection] = useState(1);
   const mainRef = useRef<HTMLDivElement | null>(null);
+
+  const exportPdf = async () => {
+    setExportingPdf(true);
+    try {
+      const result = await window.nodus.exportImmersionSessionPdf(session.id);
+      if (result) toast(tx('Exportado a {path}', { path: result.path }));
+    } catch (cause) {
+      toast(cause instanceof Error ? cause.message : String(cause), { tone: 'error' });
+    } finally {
+      setExportingPdf(false);
+    }
+  };
 
   const persist = useCallback(
     (next: ImmersionProgress) => {
@@ -1392,7 +1405,11 @@ function ImmersionPlayer({
           </div>
         </div>
         <div className="flex-1" />
-        <button className={`btn btn-ghost gap-1.5 text-xs border ${showTranslations ? 'border-indigo-600 text-indigo-300' : 'border-neutral-700'}`} onClick={() => setShowTranslations((value) => !value)}>
+        <button className="btn btn-ghost gap-1.5 border border-neutral-700 text-xs" disabled={exportingPdf} onClick={() => void exportPdf()}>
+          <Icon name={exportingPdf ? 'sync' : 'download'} size={13} className={exportingPdf ? 'animate-spin' : ''} />
+          {exportingPdf ? t('Exportando…') : `${t('Exportar')} PDF`}
+        </button>
+        <button className="btn btn-ghost gap-1.5 border border-neutral-700 text-xs" onClick={() => setTranslationOpen(true)}>
           <Icon name="languages" size={13} /> {t('Traducir')}
         </button>
         <button className="btn btn-ghost gap-1.5 text-xs border border-neutral-700" onClick={onSaveToNotes}>
@@ -1484,7 +1501,6 @@ function ImmersionPlayer({
                 {step.kind === 'exam' && (
                   <ExamStep session={session} onAnswered={onAnswered} onFinish={finish} onSaveToNotes={onSaveToNotes} onExit={onExit} />
                 )}</>}
-                {showTranslations && <TranslationPanel entityKind="immersion" entityId={session.id} sourceTitle={session.plan.title} sourceMarkdown={sessionMarkdown(session)} model={session.model} activeTranslationId={appliedTranslation?.id ?? null} onApply={setAppliedTranslation} />}
               </div>
               <ContextRail step={step} session={session} onCitation={onCitation} />
             </motion.div>
@@ -1511,6 +1527,18 @@ function ImmersionPlayer({
         )}
       </footer>
       <FindInPage targetRef={mainRef} />
+      {translationOpen && (
+        <TranslationModal
+          entityKind="immersion"
+          entityId={session.id}
+          sourceTitle={session.plan.title}
+          sourceMarkdown={sessionMarkdown(session)}
+          model={session.model}
+          activeTranslationId={appliedTranslation?.id ?? null}
+          onApply={setAppliedTranslation}
+          onClose={() => setTranslationOpen(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #200.

## What changed

- Replaced the inline translation panels in Immersion and Deep Research with a focused modal opened from the reader toolbar.
- Added a dedicated PDF export action to Immersion.
- Replaced the basic Deep Research PDF output with a shared professional A4 report renderer.
- Added linked tables of contents, internal Nodus links, Zotero links, structured evidence sections, justified and indented body text, styled headings, centered Nodus header marks, and `page / total` footers.
- Included the saved user-provided or AI-generated decorative image when available, with a source-aware caption and a branded fallback motif.
- Added a real Electron PDF verification fixture for visual and structural checks.

## Root cause

Translation controls were mounted directly after the reader content, so activating them placed the UI at the bottom of long documents. PDF generation was also split across incomplete paths: Deep Research printed plain Markdown and Immersion had no dedicated exporter.

## User impact

Translation now stays in context and both readers produce consistent, presentation-ready reports with working traceability links and reliable pagination.

## Validation

- `npm run verify:professional-pdf`
  - rendered and visually inspected all pages of representative Deep Research and Immersion reports
  - verified internal destinations, Nodus links, Zotero links, and exact `page / total` labels
- `npm run typecheck`
- ESLint on all changed TypeScript and TSX files (0 errors; 2 pre-existing warnings in `shared/types.ts`)
- `npm test` — 752 passed, 0 failed
- `npm run build`