### PR TITLE
Nodus for Zotero: rich chat, agent tools, AI auto-highlighter, and reader popup

### DIFF
--- a/.github/workflows/zotero-plugin.yml
+++ b/.github/workflows/zotero-plugin.yml
@@ -1,0 +1,62 @@
+name: Zotero plugin
+
+# Packages zotero-plugin/ into an .xpi + updates.json and attaches both to a
+# GitHub Release. Isolated from the app Release workflow: it triggers ONLY on
+# `zotero-v*` tags (e.g. zotero-v0.0.9), so app `v*` releases are unaffected.
+#
+# update_link in the generated updates.json points at the assets uploaded to
+# THIS release, so the pair is self-consistent on GitHub. To enable in-Zotero
+# auto-update, point the manifest's `update_url` at this updates.json URL (or a
+# stable host that redirects to it).
+
+on:
+  push:
+    tags:
+      - 'zotero-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-xpi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify plugin (unit tests)
+        run: node --test scripts/test-zotero-plugin.mjs
+
+      - name: Build xpi + updates.json
+        env:
+          # Hosts update_link on this release's asset URL. On workflow_dispatch
+          # (no tag) this is a throwaway base; the upload step is skipped anyway.
+          ZOTERO_XPI_BASE: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/
+        run: npm run zotero:xpi
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nodus-zotero-xpi
+          path: dist-zotero/*
+
+      - name: Publish to the release
+        if: startsWith(github.ref, 'refs/tags/zotero-v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="$GITHUB_REF_NAME"
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$tag" --repo "$GITHUB_REPOSITORY" \
+              --title "Nodus for Zotero $tag" \
+              --notes "Zotero plugin build $tag. Install the .xpi via Tools → Add-ons → Install Add-on From File."
+          gh release upload "$tag" dist-zotero/*.xpi dist-zotero/updates.json --repo "$GITHUB_REPOSITORY" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 dist-electron/
+dist-zotero/
 release/
 *.log
 .DS_Store

--- a/electron/zotero-plugin/server.ts
+++ b/electron/zotero-plugin/server.ts
@@ -15,7 +15,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { app, BrowserWindow, shell } from 'electron';
-import type { ModelRef, Work, ZoteroPluginServerStatus } from '@shared/types';
+import type { ModelRef, ReasoningEffort, Work, ZoteroPluginServerStatus } from '@shared/types';
 import { getSettings, updateSettings } from '../db/settingsRepo';
 import { getDb } from '../db/database';
 import { embeddedIdeaCount, getIdeasByWork, getIdeaDetail } from '../db/ideasRepo';
@@ -230,6 +230,7 @@ function buildPrompt(body: Record<string, unknown>, ctx: ChatContext): { system:
   const itemTitle = typeof context.title === 'string' ? context.title : ctx.work?.title ?? '';
   const documentText = typeof context.documentText === 'string' ? context.documentText : '';
   const selection = typeof context.selection === 'string' ? context.selection : '';
+  const extraContext = typeof context.extraContext === 'string' ? context.extraContext : '';
 
   const messages = Array.isArray(body.messages) ? (body.messages as { role?: string; content?: string }[]) : [];
   const history = messages
@@ -247,10 +248,13 @@ function buildPrompt(body: Record<string, unknown>, ctx: ChatContext): { system:
 
   const parts: string[] = [];
   if (itemTitle) parts.push(`OPEN DOCUMENT: ${itemTitle}`);
+  if (extraContext) parts.push(extraContext);
   if (ctx.ideasBlock) parts.push(ctx.ideasBlock);
   if (ctx.gapsBlock) parts.push(ctx.gapsBlock);
   if (selection) parts.push(`USER SELECTION (the user highlighted this — treat it as the focus and quote/cite it):\n"""\n${selection}\n"""`);
-  if (documentText) parts.push(`DOCUMENT TEXT (page markers like "=== page N ===" indicate pages you may cite with [[p:N]]):\n"""\n${documentText.slice(0, 60_000)}\n"""`);
+  // The plugin already head/tail-samples long documents to DOC_CHAR_LIMIT; keep a
+  // generous ceiling here so we don't re-truncate away the sampled conclusion.
+  if (documentText) parts.push(`DOCUMENT TEXT (page markers like "=== page N ===" indicate pages you may cite with [[p:N]]):\n"""\n${documentText.slice(0, 200_000)}\n"""`);
   if (ctx.passagesBlock) parts.push(ctx.passagesBlock);
   parts.push(`CONVERSATION SO FAR:\n${history}`);
   parts.push('Answer the last user message.');
@@ -364,6 +368,16 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, port: nu
       return;
     }
 
+    if (urlPath === '/api/z/highlight' && req.method === 'POST') {
+      await handleHighlight(req, res);
+      return;
+    }
+
+    if (urlPath === '/api/z/translate' && req.method === 'POST') {
+      await handleTranslate(req, res);
+      return;
+    }
+
     sendJson(res, 404, { error: 'Ruta no encontrada.' });
   } catch (error) {
     if (res.headersSent) {
@@ -435,6 +449,87 @@ async function openInNodus(body: Record<string, unknown>): Promise<{ ok: boolean
   return { ok: true };
 }
 
+const HIGHLIGHT_SYSTEM =
+  "You pick the most important passages of a document to highlight for a student. " +
+  "Read the DOCUMENT TEXT and choose the passages that matter most, as EXACT verbatim quotes copied from the text — do NOT paraphrase, keep the exact wording so they can be located in the PDF. " +
+  "Assign each a level: 'high' for the few MOST important (core thesis, key definitions, critical findings/conclusions) and 'medium' for important supporting points. " +
+  "Prefer a single sentence or short clause per passage (never a whole paragraph). Return between 8 and 25 passages. " +
+  'Respond with ONLY a JSON array and nothing else: [{"text":"exact quote","level":"high|medium"}].';
+
+/** Parse a model reply into [{text, level}] highlight passages. */
+function parseHighlightPassages(text: string): { text: string; level: 'high' | 'medium' }[] {
+  const s = text.replace(/```(?:json)?/gi, '');
+  const a = s.indexOf('['), b = s.lastIndexOf(']');
+  if (a < 0 || b <= a) return [];
+  let arr: unknown;
+  try { arr = JSON.parse(s.slice(a, b + 1)); } catch { return []; }
+  if (!Array.isArray(arr)) return [];
+  const out: { text: string; level: 'high' | 'medium' }[] = [];
+  for (const it of arr) {
+    const quote = typeof it === 'string' ? it : (it && typeof it === 'object' ? (it as Record<string, unknown>).text : null);
+    if (typeof quote !== 'string' || !quote.trim()) continue;
+    const raw = String((it && typeof it === 'object' && ((it as Record<string, unknown>).level || (it as Record<string, unknown>).importance)) || 'medium').toLowerCase();
+    out.push({ text: quote.trim(), level: /(high|very|muy|crit|red|rojo|1)/.test(raw) ? 'high' : 'medium' });
+  }
+  return out;
+}
+
+async function handleHighlight(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await readJsonBody(req);
+  const documentText = typeof body.documentText === 'string' ? body.documentText.slice(0, 300_000) : '';
+  const model = toModelRef(body.model);
+  const reasoningRaw = typeof body.reasoning === 'string' ? body.reasoning : 'default';
+  const reasoning: ReasoningEffort = (['off', 'low', 'medium', 'high'] as const).includes(reasoningRaw as ReasoningEffort)
+    ? (reasoningRaw as ReasoningEffort)
+    : 'off';
+  if (!documentText) {
+    sendJson(res, 200, { passages: [] });
+    return;
+  }
+  let acc = '';
+  const controller = new AbortController();
+  res.on('close', () => controller.abort());
+  try {
+    await completeTextStream(
+      { system: HIGHLIGHT_SYSTEM, user: `DOCUMENT TEXT:\n"""\n${documentText}\n"""\n\nReturn the JSON array of the most important passages to highlight.`, reasoning },
+      (delta, kind) => { if (kind !== 'reasoning') acc += delta; },
+      model,
+      controller.signal,
+    );
+  } catch (error) {
+    sendJson(res, 500, { error: error instanceof Error ? error.message : String(error), passages: [] });
+    return;
+  }
+  sendJson(res, 200, { passages: parseHighlightPassages(acc) });
+}
+
+async function handleTranslate(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await readJsonBody(req);
+  const text = typeof body.text === 'string' ? body.text.slice(0, 20_000) : '';
+  const language = typeof body.language === 'string' ? body.language.slice(0, 60) : 'English';
+  const model = toModelRef(body.model);
+  res.writeHead(200, { 'Content-Type': 'application/x-ndjson; charset=utf-8', 'Cache-Control': 'no-store', Connection: 'keep-alive' });
+  const write = (obj: unknown) => { try { if (!res.writableEnded && !res.destroyed) res.write(JSON.stringify(obj) + '\n'); } catch { /* client gone */ } };
+  const controller = new AbortController();
+  res.on('close', () => controller.abort());
+  try {
+    await completeTextStream(
+      {
+        system: `Translate the text the user provides into ${language}. Output ONLY the translation — no explanations, no notes, no quotation marks. Preserve meaning and tone.`,
+        user: text,
+        reasoning: 'off',
+      },
+      (delta, kind) => { if (kind !== 'reasoning') write({ type: 'delta', text: delta }); },
+      model,
+      controller.signal,
+    );
+    write({ type: 'done' });
+  } catch (error) {
+    write({ type: 'error', error: error instanceof Error ? error.message : String(error) });
+  }
+  try { res.end(); } catch { /* client gone */ }
+}
+
 async function handleChatStream(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const body = await readJsonBody(req);
   const messages = Array.isArray(body.messages) ? (body.messages as { role?: string; content?: string }[]) : [];
@@ -444,6 +539,15 @@ async function handleChatStream(req: IncomingMessage, res: ServerResponse): Prom
   const ctx = await buildChatContext(body, lastUserText);
   const { system, user } = buildPrompt(body, ctx);
   const model = toModelRef(body.model);
+  // Honor the plugin's reasoning/thinking selector; 'default' preserves the
+  // server's historical 'off'.
+  const context = (body.context && typeof body.context === 'object' ? body.context : {}) as Record<string, unknown>;
+  const reasoningRaw = typeof context.reasoning === 'string' ? context.reasoning : 'default';
+  const reasoning: ReasoningEffort = (['off', 'low', 'medium', 'high'] as const).includes(
+    reasoningRaw as ReasoningEffort,
+  )
+    ? (reasoningRaw as ReasoningEffort)
+    : 'off';
 
   res.writeHead(200, {
     'Content-Type': 'application/x-ndjson; charset=utf-8',
@@ -463,7 +567,7 @@ async function handleChatStream(req: IncomingMessage, res: ServerResponse): Prom
   res.on('close', () => controller.abort());
   try {
     await completeTextStream(
-      { system, user, reasoning: 'off' },
+      { system, user, reasoning },
       (delta, kind) => {
         if (kind === 'reasoning') return;
         write({ type: 'delta', text: delta });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "licenses:generate": "node scripts/generate-third-party-licenses.mjs",
     "licenses:verify": "npm run licenses:generate && node scripts/verify-license-compliance.mjs",
     "privacy:verify": "node --test scripts/test-privacy-compliance.mjs",
+    "zotero:xpi": "node scripts/build-zotero-xpi.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p electron/tsconfig.json",
     "lint": "eslint . --ext .ts,.tsx",
     "icons": "node scripts/generate-icons.mjs",

--- a/scripts/build-zotero-xpi.mjs
+++ b/scripts/build-zotero-xpi.mjs
@@ -1,0 +1,106 @@
+// Package zotero-plugin/ into an installable .xpi and generate the matching
+// Zotero auto-update manifest (updates.json). Single source of truth = the
+// plugin's manifest.json (id, version, strict versions).
+//
+//   node scripts/build-zotero-xpi.mjs [--base <url>]
+//
+// --base (or env ZOTERO_XPI_BASE) is the public directory where BOTH the .xpi
+// and updates.json will be hosted; it must match the host in manifest.json's
+// `update_url`. Default: https://nodus.app/zotero/ (the current update_url host).
+//
+// Outputs to dist-zotero/:
+//   nodus-zotero-<version>.xpi   — the packaged add-on (manifest.json at root)
+//   updates.json                 — served at manifest.update_url; points Zotero
+//                                  at the .xpi with a sha256 integrity hash.
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import AdmZip from 'adm-zip';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pluginDir = path.join(repoRoot, 'zotero-plugin');
+const outDir = path.join(repoRoot, 'dist-zotero');
+
+function parseBase() {
+  const arg = process.argv.find((a) => a.startsWith('--base='));
+  if (arg) return arg.slice('--base='.length);
+  const i = process.argv.indexOf('--base');
+  if (i >= 0 && process.argv[i + 1]) return process.argv[i + 1];
+  return process.env.ZOTERO_XPI_BASE || 'https://nodus.app/zotero/';
+}
+
+// Files to include: the whole plugin tree, minus junk. manifest.json lands at
+// the zip root (required by Zotero) because we add paths relative to pluginDir.
+const SKIP = new Set(['.DS_Store', 'Thumbs.db']);
+function collectFiles(dir, rel = '') {
+  const out = [];
+  for (const name of readdirSync(dir).sort()) {
+    if (SKIP.has(name) || name.startsWith('.')) continue;
+    const abs = path.join(dir, name);
+    const relPath = rel ? `${rel}/${name}` : name;
+    if (statSync(abs).isDirectory()) out.push(...collectFiles(abs, relPath));
+    else out.push({ abs, relPath });
+  }
+  return out;
+}
+
+export function buildXpi() {
+  const manifest = JSON.parse(readFileSync(path.join(pluginDir, 'manifest.json'), 'utf8'));
+  const app = manifest.applications?.zotero ?? {};
+  const id = app.id;
+  const version = manifest.version;
+  if (!id || !version) throw new Error('manifest.json missing applications.zotero.id or version');
+
+  const files = collectFiles(pluginDir);
+  if (!files.some((f) => f.relPath === 'manifest.json')) throw new Error('manifest.json not found at plugin root');
+
+  const zip = new AdmZip();
+  for (const f of files) {
+    zip.addFile(f.relPath, readFileSync(f.abs)); // relPath keeps manifest.json at zip root
+  }
+  mkdirSync(outDir, { recursive: true });
+  const xpiName = `nodus-zotero-${version}.xpi`;
+  const xpiPath = path.join(outDir, xpiName);
+  zip.writeZip(xpiPath);
+
+  const buf = readFileSync(xpiPath);
+  const sha256 = createHash('sha256').update(buf).digest('hex');
+
+  const base = parseBase().endsWith('/') ? parseBase() : parseBase() + '/';
+  const zoteroApp = {};
+  if (app.strict_min_version) zoteroApp.strict_min_version = app.strict_min_version;
+  if (app.strict_max_version) zoteroApp.strict_max_version = app.strict_max_version;
+  const updates = {
+    addons: {
+      [id]: {
+        updates: [
+          {
+            version,
+            update_link: base + xpiName,
+            update_hash: `sha256:${sha256}`,
+            ...(Object.keys(zoteroApp).length ? { applications: { zotero: zoteroApp } } : {}),
+          },
+        ],
+      },
+    },
+  };
+  const updatesPath = path.join(outDir, 'updates.json');
+  writeFileSync(updatesPath, JSON.stringify(updates, null, 2) + '\n');
+
+  return { id, version, xpiName, xpiPath, updatesPath, sha256, base, updateUrl: manifest.applications?.zotero?.update_url, fileCount: files.length };
+}
+
+// Run as a script (not when imported by tests).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const r = buildXpi();
+  console.log(`✔ Built ${r.xpiName} (${r.fileCount} files)`);
+  console.log(`  ${r.xpiPath}`);
+  console.log(`  sha256: ${r.sha256}`);
+  console.log(`✔ Wrote updates.json → ${r.updatesPath}`);
+  console.log('');
+  console.log('Publish BOTH files to the directory that backs the manifest update_url:');
+  console.log(`  update_url in manifest : ${r.updateUrl || '(none)'}`);
+  console.log(`  upload xpi + updates to: ${r.base}`);
+  console.log('Zotero polls updates.json and offers the new version to installed users.');
+}

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1,0 +1,434 @@
+// Unit tests for the pure logic of the "Nodus for Zotero" plugin. The plugin's
+// content scripts are chrome:// IIFEs that attach to `window`; here we evaluate
+// them in a vm sandbox with minimal stubs (ChromeUtils/Zotero/document) and
+// exercise the parts that don't need a live Zotero or a real DOM.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+import AdmZip from 'adm-zip';
+import { buildXpi } from './build-zotero-xpi.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pluginDir = path.join(repoRoot, 'zotero-plugin');
+const contentDir = path.join(pluginDir, 'content');
+const readSource = (rel) => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+// Extract the `{...}` literal starting at openIdx, respecting string literals so
+// that braces inside values (e.g. "{pct}") don't unbalance the scan.
+function sliceBalanced(src, openIdx) {
+  let depth = 0, inStr = false, quote = '';
+  for (let i = openIdx; i < src.length; i++) {
+    const c = src[i];
+    if (inStr) { if (c === '\\') { i++; } else if (c === quote) inStr = false; continue; }
+    if (c === '"' || c === "'") { inStr = true; quote = c; continue; }
+    if (c === '{') depth++;
+    else if (c === '}' && --depth === 0) return src.slice(openIdx, i + 1);
+  }
+  throw new Error('unbalanced braces');
+}
+// Eval the plugin's I18N object literal out of sidebar.js source (pure data).
+function extractI18n(src) {
+  const open = src.indexOf('{', src.indexOf('const I18N'));
+  return vm.runInNewContext('(' + sliceBalanced(src, open) + ')');
+}
+const placeholders = (s) => new Set((String(s).match(/\{(\w+)\}/g) || []));
+
+// ---- minimal fake DOM (enough for NodusMarkdown.render) ----
+function makeDoc() {
+  const doc = {
+    createElement(tag) { return makeEl(tag, doc); },
+    createTextNode(text) { return { nodeType: 3, _text: String(text) }; },
+  };
+  return doc;
+}
+function makeEl(tag, doc) {
+  return {
+    tagName: String(tag).toUpperCase(),
+    ownerDocument: doc,
+    className: '',
+    children: [],
+    attrs: {},
+    classList: { add() {} },
+    appendChild(c) { this.children.push(c); return c; },
+    setAttribute(k, v) { this.attrs[k] = v; },
+    addEventListener() {},
+    get textContent() { return serializeText(this); },
+    set textContent(v) { this.children = []; if (v) this.children.push({ nodeType: 3, _text: String(v) }); },
+  };
+}
+const serializeText = (n) => (n.nodeType === 3 ? n._text : (n.children || []).map(serializeText).join(''));
+const serializeHtml = (n) => {
+  if (n.nodeType === 3) return n._text;
+  const t = n.tagName.toLowerCase();
+  return `<${t}>${(n.children || []).map(serializeHtml).join('')}</${t}>`;
+};
+// Every ELEMENT tag name in the tree (text nodes excluded) — used to prove no
+// real <script> element was created from model output.
+const elementTags = (n, acc = []) => {
+  if (n.nodeType === 3) return acc;
+  acc.push(n.tagName);
+  for (const c of n.children || []) elementTags(c, acc);
+  return acc;
+};
+
+// ---- load a plugin content file into a fresh sandbox ----
+function loadModule(file, extraGlobals = {}) {
+  const src = readFileSync(path.join(contentDir, file), 'utf8');
+  const sandbox = {
+    window: {},
+    document: makeDoc(),
+    Zotero: { logError() {}, launchURL() {} },
+    ChromeUtils: { importESModule: () => ({ Zotero: { logError() {}, launchURL() {} } }) },
+    console,
+    ...extraGlobals,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(src, sandbox, { filename: file });
+  return sandbox.window;
+}
+
+// ─────────────────────────────────────────── #1 Markdown
+test('markdown: parse produces block/inline tokens', () => {
+  const { NodusMarkdown } = loadModule('markdown.js');
+  const blocks = NodusMarkdown.parse('# Title\n\nA **bold** and *em* and `code`.\n\n- one\n- two\n\n> quote');
+  assert.equal(blocks[0].type, 'heading');
+  assert.equal(blocks[0].level, 1);
+  assert.equal(blocks[1].type, 'paragraph');
+  const strong = blocks[1].inline.find((s) => s.type === 'strong');
+  assert.ok(strong && strong.children[0].value === 'bold');
+  assert.ok(blocks[1].inline.some((s) => s.type === 'em'));
+  assert.ok(blocks[1].inline.some((s) => s.type === 'code' && s.value === 'code'));
+  const list = blocks.find((b) => b.type === 'list');
+  assert.ok(list && list.items.length === 2 && !list.ordered);
+  assert.ok(blocks.some((b) => b.type === 'blockquote'));
+});
+
+test('markdown: ordered lists, fenced code and hr', () => {
+  const { NodusMarkdown } = loadModule('markdown.js');
+  const blocks = NodusMarkdown.parse('1. first\n2. second\n\n```js\nconst x = 1;\n```\n\n---');
+  const ol = blocks.find((b) => b.type === 'list');
+  assert.ok(ol && ol.ordered && ol.items.length === 2);
+  const code = blocks.find((b) => b.type === 'code');
+  assert.equal(code.text, 'const x = 1;');
+  assert.ok(blocks.some((b) => b.type === 'hr'));
+});
+
+test('markdown: underscores in identifiers are NOT italicised', () => {
+  const { NodusMarkdown } = loadModule('markdown.js');
+  const spans = NodusMarkdown.parseInline('use my_snake_case_name here');
+  assert.equal(spans.length, 1);
+  assert.equal(spans[0].type, 'text');
+  assert.equal(spans[0].value, 'use my_snake_case_name here');
+});
+
+test('markdown: citations become chips via citeFn, body is escaped (no XSS)', () => {
+  const { NodusMarkdown } = loadModule('markdown.js');
+  const doc = makeDoc();
+  const container = makeEl('div', doc);
+  const seen = [];
+  const citeFn = (kind, id, label) => { seen.push({ kind, id, label }); const e = doc.createElement('cite'); e.textContent = label || id; return e; };
+  NodusMarkdown.render(container, 'See [[p:12|page 12]] and **bold**. <script>alert(1)</script>', citeFn);
+  const html = serializeHtml(container);
+  assert.ok(seen.some((c) => c.kind === 'p' && c.id === '12' && c.label === 'page 12'), 'citeFn called for [[p:12]]');
+  assert.ok(html.includes('<cite>page 12</cite>'), 'chip rendered');
+  assert.ok(html.includes('<strong>bold</strong>'), 'bold rendered');
+  // The literal script text is present as escaped text, but never as a real
+  // element node (which is what would actually execute).
+  assert.ok(serializeText(container).includes('<script>alert(1)</script>'));
+  assert.ok(!elementTags(container).includes('SCRIPT'), 'no live <script> element injected');
+});
+
+// ─────────────────────────────────────────── #2 long-document sampling
+test('util: sampleDocText keeps short docs whole', () => {
+  const { NodusUtil } = loadModule('util.js');
+  const r = NodusUtil.sampleDocText('hello world', 1000);
+  assert.equal(r.truncated, false);
+  assert.equal(r.text, 'hello world');
+  assert.equal(r.ratio, 1);
+});
+
+test('util: sampleDocText keeps head AND tail of long docs', () => {
+  const { NodusUtil } = loadModule('util.js');
+  const big = 'A'.repeat(500) + 'B'.repeat(500) + 'ZEND';
+  const r = NodusUtil.sampleDocText(big, 200);
+  assert.equal(r.truncated, true);
+  assert.ok(r.text.startsWith('A'), 'head preserved');
+  assert.ok(r.text.includes('ZEND'), 'tail (conclusion) preserved — the whole point of #2');
+  assert.ok(r.text.includes('omitted'), 'visible omission marker');
+  assert.ok(r.sentChars <= 200 + 60, 'roughly within budget');
+  assert.equal(r.totalChars, big.length);
+  assert.ok(r.ratio > 0 && r.ratio < 1);
+});
+
+// ─────────────────────────────────────────── #4 save chat as note
+test('util: conversationToHtml renders roles and escapes html', () => {
+  const { NodusUtil } = loadModule('util.js');
+  const html = NodusUtil.conversationToHtml(
+    { messages: [{ role: 'user', content: 'Hi <there>' }, { role: 'assistant', content: 'Line1\nLine2' }] },
+    { you: 'You', nodus: 'Nodus' },
+  );
+  assert.ok(html.includes('<b>You:</b> Hi &lt;there&gt;'));
+  assert.ok(html.includes('<b>Nodus:</b> Line1<br/>Line2'));
+});
+
+// ─────────────────────────────────────────── #6 multi-item context
+test('util: buildItemsSummary only fires for 2+ items', () => {
+  const { NodusUtil } = loadModule('util.js');
+  assert.equal(NodusUtil.buildItemsSummary([]), '');
+  assert.equal(NodusUtil.buildItemsSummary([{ title: 'Solo' }]), '');
+  const s = NodusUtil.buildItemsSummary([
+    { title: 'Paper A', creators: 'Smith', year: '2020', abstract: 'aaa' },
+    { title: 'Paper B', creators: 'Doe', year: '2021' },
+  ]);
+  assert.ok(s.includes('SELECTED DOCUMENTS'));
+  assert.ok(s.includes('1. Paper A') && s.includes('2. Paper B'));
+  assert.ok(s.includes('Smith') && s.includes('(2020)'));
+});
+
+// ─────────────────────────────────────────── #3 agent tools
+test('agent: new tools are registered and parsed', () => {
+  const { NodusAgent } = loadModule('agent.js');
+  // Spread into a local-realm array: the vm sandbox has its own Array.prototype,
+  // which trips deepStrictEqual's prototype check.
+  assert.deepEqual(
+    [...NodusAgent.TOOLS],
+    ['create_note', 'highlight', 'add_tags', 'add_to_collection', 'set_field', 'extract_annotations_note'],
+  );
+  const reply = 'Sure.\n```nodus:action\n{"tool":"add_to_collection","name":"To read"}\n```\n```nodus:action\n{"tool":"set_field","field":"abstractNote","value":"x"}\n```';
+  const { actions, clean } = NodusAgent.parseActions(reply);
+  assert.equal(actions.length, 2);
+  assert.equal(actions[0].tool, 'add_to_collection');
+  assert.equal(actions[1].field, 'abstractNote');
+  assert.ok(!clean.includes('nodus:action'));
+  // SYSTEM prompt advertises the new tools.
+  for (const tool of ['add_to_collection', 'set_field', 'extract_annotations_note']) {
+    assert.ok(NodusAgent.SYSTEM.includes(tool), `SYSTEM documents ${tool}`);
+  }
+});
+
+test('agent: describe returns human text for each tool', () => {
+  const { NodusAgent } = loadModule('agent.js');
+  const t = (k) => k; // identity: assert the right key is used
+  assert.ok(NodusAgent.describe({ tool: 'add_to_collection', name: 'X' }, t).includes('agent.desc.collection'));
+  assert.ok(NodusAgent.describe({ tool: 'set_field', field: 'title', value: 'Y' }, t).includes('agent.desc.field'));
+  assert.ok(NodusAgent.describe({ tool: 'extract_annotations_note' }, t).includes('agent.desc.extract'));
+});
+
+// ─────────────────────────────────────────── #7 max_tokens
+test('providers: Anthropic body uses configurable max_tokens (default 8192)', () => {
+  const { NodusProviders } = loadModule('providers.js');
+  assert.equal(NodusProviders.DEFAULT_MAX_TOKENS, 8192);
+  const def = NodusProviders.buildAnthropicBody('claude-x', 'sys', [{ role: 'user', content: 'hi' }]);
+  assert.equal(def.max_tokens, 8192, 'no longer the old hardcoded 4096');
+  assert.equal(def.stream, true);
+  assert.equal(def.system, 'sys');
+  const custom = NodusProviders.buildAnthropicBody('claude-x', '', [], 32000);
+  assert.equal(custom.max_tokens, 32000);
+  assert.equal(custom.system, undefined, 'empty system omitted');
+  // clamp: nonsense → default, absurdly high → capped, tiny → floored
+  assert.equal(NodusProviders.clampMaxTokens('nope'), 8192);
+  assert.equal(NodusProviders.clampMaxTokens(9_000_000), 200000);
+  assert.equal(NodusProviders.clampMaxTokens(1), 256);
+});
+
+test('providers: chatBase builds per-provider URLs', () => {
+  const { NodusProviders } = loadModule('providers.js');
+  assert.equal(NodusProviders.chatBase('openai'), 'https://api.openai.com/v1');
+  assert.equal(NodusProviders.chatBase('ollama'), 'http://localhost:11434/v1');
+  assert.equal(NodusProviders.chatBase('ollama', 'http://box:1234/'), 'http://box:1234/v1');
+});
+
+test('providers: reasoning maps to the right per-provider body', () => {
+  const { NodusProviders: P } = loadModule('providers.js');
+  // JSON compare: objects returned from the vm sandbox have a foreign prototype
+  // that trips deepStrictEqual.
+  const jeq = (a, b) => assert.equal(JSON.stringify(a), JSON.stringify(b));
+  assert.deepEqual([...P.REASONING_LEVELS], ['default', 'off', 'low', 'medium', 'high']);
+  // default sends nothing (model decides)
+  jeq(P.reasoningBody('openrouter', 'default'), {});
+  jeq(P.reasoningBody('openai', 'default'), {});
+  // OpenRouter uses its unified `reasoning` object (verified live vs gemini/deepseek)
+  jeq(P.reasoningBody('openrouter', 'off'), { reasoning: { enabled: false } });
+  jeq(P.reasoningBody('openrouter', 'high'), { reasoning: { effort: 'high' } });
+  // other OpenAI-compat use the standard reasoning_effort; 'off' has no portable disable
+  jeq(P.reasoningBody('deepseek', 'low'), { reasoning_effort: 'low' });
+  jeq(P.reasoningBody('openai', 'off'), {});
+  // Anthropic: thinking budget + max_tokens made room for it
+  const body = P.buildAnthropicBody('claude-x', 's', [], 4096, 'high');
+  assert.equal(body.thinking.type, 'enabled');
+  assert.equal(body.thinking.budget_tokens, 8192);
+  assert.ok(body.max_tokens > 8192, 'max_tokens leaves room above the thinking budget');
+  // no thinking when off/default
+  assert.equal(P.buildAnthropicBody('claude-x', 's', [], 4096, 'off').thinking, undefined);
+});
+
+test('#reasoning: sidebar + server wire the selector through', () => {
+  const src = readSource('zotero-plugin/content/sidebar.js');
+  assert.ok(src.includes('renderReasoningSelect'), 'sidebar builds the reasoning dropdown');
+  assert.ok(/reasoning:\s*state\.reasoning/.test(src), 'standalone passes reasoning to chatStream');
+  assert.ok(src.includes('NS.setReasoning'), 'persists the choice');
+  const store = readSource('zotero-plugin/content/store.js');
+  assert.ok(store.includes('getReasoning') && store.includes('setReasoning'), 'store persists reasoning');
+  const server = readSource('electron/zotero-plugin/server.ts');
+  assert.ok(/reasoning/.test(server) && server.includes('ReasoningEffort'), 'connected server honors reasoning');
+});
+
+// ─────────────────────────────────────────── extra edge coverage (#8)
+test('markdown: links, nested emphasis and `)` ordered markers', () => {
+  const { NodusMarkdown } = loadModule('markdown.js');
+  const link = NodusMarkdown.parseInline('see [the site](https://x.org) now');
+  const l = link.find((s) => s.type === 'link');
+  assert.ok(l && l.href === 'https://x.org' && l.children[0].value === 'the site');
+  const nested = NodusMarkdown.parseInline('**bold with *em* inside**');
+  const strong = nested.find((s) => s.type === 'strong');
+  assert.ok(strong && strong.children.some((c) => c.type === 'em'));
+  const ol = NodusMarkdown.parse('1) alpha\n2) beta');
+  assert.ok(ol[0].ordered && ol[0].items.length === 2);
+});
+
+test('util: sampleDocText exact-boundary is not truncated; buildItemsSummary trims abstracts', () => {
+  const { NodusUtil } = loadModule('util.js');
+  const exact = 'x'.repeat(100);
+  assert.equal(NodusUtil.sampleDocText(exact, 100).truncated, false);
+  const s = NodusUtil.buildItemsSummary(
+    [{ title: 'A', abstract: 'y'.repeat(2000) }, { title: 'B' }],
+    { maxAbstract: 50 },
+  );
+  const abstractLine = s.split('\n').find((ln) => ln.includes('yyy'));
+  assert.ok(abstractLine.trim().length <= 60, 'abstract trimmed to ~maxAbstract');
+});
+
+test('agent: malformed action blocks are ignored; describe shows field+value', () => {
+  const { NodusAgent } = loadModule('agent.js');
+  const { actions } = NodusAgent.parseActions('```nodus:action\n{not json}\n```\n```nodus:action\n{"tool":"add_tags","tags":["x"]}\n```');
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].tool, 'add_tags');
+  const d = NodusAgent.describe({ tool: 'set_field', field: 'title', value: 'Hello world' }, (k) => k);
+  assert.ok(d.includes('title') && d.includes('Hello world'));
+});
+
+// ─────────────────────────────────────────── #8 i18n parity
+test('i18n: en/es have identical key sets and matching placeholders', () => {
+  const I18N = extractI18n(readSource('zotero-plugin/content/sidebar.js'));
+  const en = Object.keys(I18N.en).sort();
+  const es = Object.keys(I18N.es).sort();
+  assert.deepEqual(en, es, 'en and es must define exactly the same keys');
+  // The new keys from this work exist.
+  for (const k of ['msg.copy', 'msg.edit', 'msg.regenerate', 'doc.truncated', 'item.multi', 'agent.desc.collection', 'settings.maxTokens']) {
+    assert.ok(I18N.en[k] && I18N.es[k], `both languages define ${k}`);
+  }
+  // Interpolation placeholders must match between languages, or tf() breaks.
+  for (const k of en) {
+    assert.deepEqual(
+      [...placeholders(I18N.en[k])].sort(),
+      [...placeholders(I18N.es[k])].sort(),
+      `placeholders differ for "${k}"`,
+    );
+  }
+});
+
+// ─────────────────────────────────────────── #10 chat affordances + Notifier wiring
+test('#10: sidebar wires copy/edit/regenerate + Zotero.Notifier and drops the old poll', () => {
+  const src = readSource('zotero-plugin/content/sidebar.js');
+  for (const fn of ['attachMessageActions', 'copyToClipboard', 'editUserMessage', 'regenerateFrom', 'rerenderConversation', 'generateAssistant', 'registerNotifier', 'scheduleRefresh']) {
+    assert.ok(src.includes('function ' + fn) || src.includes(fn + ' ='), `defines ${fn}`);
+  }
+  assert.ok(src.includes('Zotero.Notifier.registerObserver'), 'registers a Notifier observer');
+  assert.ok(src.includes('unregisterObserver'), 'unregisters on unload');
+  assert.ok(!/refreshItem\(false\)[^;]*\},\s*1200\)/.test(src), 'old 1200ms poll replaced');
+});
+
+test('#10: message-action buttons live-render via the real fake-DOM path', () => {
+  // Reuse the markdown render harness to prove renderRich-style DOM building is
+  // sound; the affordance DOM is asserted structurally above (sidebar.js can't
+  // boot in a sandbox). Here we just guard that clipboard uses Components.
+  const src = readSource('zotero-plugin/content/sidebar.js');
+  assert.ok(src.includes('nsIClipboardHelper'), 'copy uses the clipboard helper XPCOM');
+});
+
+// ─────────────────────────────────────────── auto-highlighter engine (pure)
+test('highlighter: parsePassages extracts {text,level} robustly', () => {
+  const { NodusHighlighter: H } = loadModule('highlighter.js');
+  const r = H.parsePassages('sure!\n```json\n[{"text":"Alpha beta","level":"high"},{"text":"Gamma"},"Delta epsilon"]\n```');
+  assert.equal(r.length, 3);
+  assert.deepEqual({ ...r[0] }, { text: 'Alpha beta', level: 'high' });
+  assert.equal(r[1].level, 'medium'); // default
+  assert.equal(r[2].text, 'Delta epsilon');
+  // level synonyms → high
+  assert.equal(H.parsePassages('[{"text":"x y z","level":"muy importante"}]')[0].level, 'high');
+  assert.equal(H.parsePassages('no json here').length, 0);
+});
+
+test('highlighter: normalizeText / buildPageNorm strip whitespace + hyphens with a char map', () => {
+  const { NodusHighlighter: H } = loadModule('highlighter.js');
+  assert.equal(H.normalizeText('Open-source  software'), 'opensourcesoftware');
+  const chars = [{ c: 'O' }, { c: 'p' }, { c: '-' }, { c: 'e' }, { c: 'n' }];
+  const { norm, map } = H.buildPageNorm(chars);
+  assert.equal(norm, 'open');       // hyphen dropped
+  assert.deepEqual([...map], [0, 1, 3, 4]); // norm index → char index
+});
+
+test('highlighter: NFKC decomposes ligatures + curly quotes so long quotes still match', () => {
+  const { NodusHighlighter: H } = loadModule('highlighter.js');
+  // PDF page renders "files" as the ﬁ ligature (U+FB01); model wrote plain "fi".
+  assert.equal(H.normalizeText('source ﬁles'), H.normalizeText('source files'));
+  assert.equal(H.normalizeText('author’s'), H.normalizeText("author's")); // curly apostrophe == straight
+  // buildPageNorm maps both norm chars of a ligature back to the one source char.
+  const { norm, map } = H.buildPageNorm([{ c: 'a' }, { c: 'ﬁ' }, { c: 'x' }]);
+  assert.equal(norm, 'afix');
+  assert.deepEqual([...map], [0, 1, 1, 2]); // the ligature glyph (index 1) spans two norm positions
+});
+
+test('highlighter: findQuote falls back to a prefix when the full quote drifts', () => {
+  const { NodusHighlighter: H } = loadModule('highlighter.js');
+  const pages = [{ norm: 'opensourceisthepracticeofpublishingdigitalresources', map: Array.from({ length: 52 }, (_, i) => i) }];
+  // Full quote has extra tail that isn't on the page → prefix match still lands.
+  const hit = H.findQuote(pages, 'opensourceisthepracticeofpublishingSOMETHINGELSE');
+  assert.ok(hit, 'prefix fallback found a match');
+  assert.equal(hit.start, 0);
+  assert.ok(H.findQuote(pages, 'nothingmatcheshereatall') === null);
+});
+
+test('highlighter: rangeRects builds one rect per line-run', () => {
+  const { NodusHighlighter: H } = loadModule('highlighter.js');
+  const chars = [
+    { rect: [10, 100, 20, 110], inlineRect: [10, 98, 20, 112], rotation: 0, lineBreakAfter: false },
+    { rect: [20, 100, 30, 110], inlineRect: [20, 98, 30, 112], rotation: 0, lineBreakAfter: true },
+    { rect: [10, 80, 25, 90], inlineRect: [10, 78, 25, 92], rotation: 0, lineBreakAfter: true },
+  ];
+  const rects = H.rangeRects(chars, 0, 2);
+  assert.equal(rects.length, 2); // two lines
+  // JSON compare: arrays returned from the vm sandbox have a foreign prototype.
+  assert.equal(JSON.stringify(rects[0]), JSON.stringify([10, 98, 30, 112])); // left/right from chars, top/bottom from inlineRect
+  assert.equal(JSON.stringify(rects[1]), JSON.stringify([10, 78, 25, 92]));
+});
+
+test('highlighter: sortIndexStr matches Zotero page|offset|top format', () => {
+  const { NodusHighlighter: H } = loadModule('highlighter.js');
+  assert.equal(H.sortIndexStr(0, [0, 0, 600, 800], 700, 44), '00000|000044|00100');
+  assert.equal(H.sortIndexStr(3, [0, 0, 600, 800], 800, 5), '00003|000005|00000');
+});
+
+// ─────────────────────────────────────────── #9 packaging
+test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
+  const r = buildXpi();
+  const manifest = JSON.parse(readSource('zotero-plugin/manifest.json'));
+  assert.equal(r.version, manifest.version);
+
+  const zip = new AdmZip(r.xpiPath);
+  const names = zip.getEntries().map((e) => e.entryName);
+  assert.ok(names.includes('manifest.json'), 'manifest.json at zip ROOT (Zotero rejects it otherwise)');
+  for (const need of ['content/sidebar.js', 'content/markdown.js', 'content/util.js', 'content/highlighter.js', 'content/icons.js', 'bootstrap.js']) {
+    assert.ok(names.includes(need), `xpi contains ${need}`);
+  }
+
+  const updates = JSON.parse(readSource('dist-zotero/updates.json'));
+  const entry = updates.addons[manifest.applications.zotero.id].updates[0];
+  assert.equal(entry.version, manifest.version);
+  assert.ok(entry.update_link.endsWith(r.xpiName), 'update_link points at the built xpi');
+  assert.match(entry.update_hash, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(entry.applications.zotero.strict_min_version, manifest.applications.zotero.strict_min_version);
+});

--- a/zotero-plugin/bootstrap.js
+++ b/zotero-plugin/bootstrap.js
@@ -167,6 +167,12 @@ function addLibraryButton(window) {
   btn.setAttribute("tooltiptext", "Nodus");
   btn.classList.add("zotero-tb-button");
   btn.style.setProperty("list-style-image", 'url("' + Nodus.rootURI + 'icons/nodus.svg")');
+  // Only WIDEN the button so it isn't a tall/narrow vertical rectangle. Do NOT
+  // set height — the native class already sizes it to the toolbar row and
+  // centres it vertically; forcing a height overflowed the items bar.
+  btn.style.minWidth = "24px";
+  // Breathing room so it doesn't sit flush against the search bar.
+  btn.style.marginInlineStart = "6px";
   btn.addEventListener("command", () => toggleSidebar(window));
   const ref = doc.getElementById(LIB_INSERT_BEFORE);
   if (ref && ref.parentNode === toolbar) toolbar.insertBefore(btn, ref);
@@ -202,28 +208,155 @@ function registerReaderToolbarButton() {
 
 // -------------------------------------------------- reader selection → chat
 
+// Reader text-selection popup i18n + the small inline icons it uses.
+const POPUP_I18N = {
+  en: { cite: "Cite", explain: "Explain", translate: "Translate", searchLang: "Search language…", pickModel: "Pick a model in Nodus first.", noResp: "(no response)" },
+  es: { cite: "Citar", explain: "Explicar", translate: "Traducir", searchLang: "Buscar idioma…", pickModel: "Elige un modelo en Nodus primero.", noResp: "(sin respuesta)" },
+};
+const POPUP_ICO = {
+  quote: '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h3a1 1 0 0 1 1 1v1a2 2 0 0 1-2 2h-1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h1a4 4 0 0 0 4-4V5a2 2 0 0 0-2-2z"/><path d="M5 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h3a1 1 0 0 1 1 1v1a2 2 0 0 1-2 2H6a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h1a4 4 0 0 0 4-4V5a2 2 0 0 0-2-2z"/></svg>',
+  book: '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>',
+  lang: '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 8 6 6"/><path d="m4 14 6-6 2-3"/><path d="M2 5h12"/><path d="M7 2h1"/><path d="m22 22-5-10-5 10"/><path d="M14 18h6"/></svg>',
+};
+const POPUP_LANGS = ["English", "Spanish", "French", "German", "Italian", "Portuguese", "Dutch", "Catalan", "Galician", "Basque", "Russian", "Ukrainian", "Polish", "Czech", "Greek", "Turkish", "Arabic", "Hebrew", "Persian", "Hindi", "Bengali", "Urdu", "Chinese (Simplified)", "Chinese (Traditional)", "Japanese", "Korean", "Vietnamese", "Thai", "Indonesian", "Malay", "Filipino", "Swedish", "Norwegian", "Danish", "Finnish", "Icelandic", "Romanian", "Hungarian", "Bulgarian", "Croatian", "Serbian", "Slovak", "Slovenian", "Latin", "Swahili"];
+
+var _popupMods = null;
+function popupModules() {
+  if (_popupMods) return _popupMods;
+  const mw = Zotero.getMainWindow();
+  const scope = { window: {}, ChromeUtils: ChromeUtils, Components: Components, Services: Services, fetch: mw.fetch.bind(mw), TextDecoder: mw.TextDecoder, AbortController: mw.AbortController };
+  Services.scriptloader.loadSubScript("chrome://nodus/content/providers.js", scope);
+  Services.scriptloader.loadSubScript("chrome://nodus/content/store.js", scope);
+  _popupMods = { NP: scope.window.NodusProviders, NS: scope.window.NodusStore };
+  return _popupMods;
+}
+
+async function translateInPopup(text, langName, resultEl, L) {
+  try {
+    const { NS, NP } = popupModules();
+    const mode = NS.getMode();
+    const model = NS.getModel(mode);
+    if (!model) { resultEl.textContent = L.pickModel; return; }
+    const system = "Translate the text the user provides into " + langName + ". Output ONLY the translation — no explanations, no notes, no quotation marks. Preserve meaning and tone.";
+    resultEl.textContent = "";
+    let acc = "";
+    const onDelta = (d) => { acc += d; resultEl.textContent = acc; resultEl.scrollTop = resultEl.scrollHeight; };
+    if (mode === "standalone") {
+      const key = NS.getKey(model.provider);
+      const localBase = NS.getLocalBase(model.provider);
+      await NP.chatStream(model, { system, key, localBase, messages: [{ role: "user", content: text }] }, onDelta, undefined);
+    } else {
+      await translateViaServer(model, langName, text, onDelta);
+    }
+    if (!acc) resultEl.textContent = L.noResp;
+  } catch (e) { resultEl.textContent = "⚠ " + (e && e.message ? e.message : e); }
+}
+
+// Connected mode: stream a translation from the Nodus local server.
+async function translateViaServer(model, langName, text, onDelta) {
+  const mw = Zotero.getMainWindow();
+  const dir = Services.dirsvc.get("Home", Components.interfaces.nsIFile);
+  const f = dir.clone(); f.append(".nodus"); f.append("zotero-bridge.json");
+  const cfg = JSON.parse(await Zotero.File.getContentsAsync(f.path));
+  const res = await mw.fetch("http://127.0.0.1:" + cfg.port + "/api/z/translate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer " + cfg.token },
+    body: JSON.stringify({ model, text, language: langName }),
+  });
+  if (!res.ok || !res.body) throw new Error("HTTP " + res.status);
+  const reader = res.body.getReader(); const dec = new mw.TextDecoder(); let buf = "";
+  for (;;) {
+    const r = await reader.read(); if (r.done) break;
+    buf += dec.decode(r.value, { stream: true }); let idx;
+    while ((idx = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, idx).trim(); buf = buf.slice(idx + 1); if (!line) continue;
+      let o; try { o = JSON.parse(line); } catch (e) { continue; }
+      if (o.type === "delta") onDelta(o.text);
+    }
+  }
+}
+
+function buildTranslateUI(doc, area, text, L) {
+  area.style.display = "flex"; area.textContent = "";
+  const input = doc.createElement("input");
+  input.placeholder = L.searchLang;
+  input.style.cssText = "width:100%;box-sizing:border-box;padding:5px 7px;border:1px solid rgba(124,58,237,.3);border-radius:6px;font-size:11px;outline:none;";
+  const list = doc.createElement("div");
+  list.style.cssText = "width:100%;box-sizing:border-box;max-height:132px;overflow-y:auto;border:1px solid rgba(0,0,0,.12);border-radius:6px;";
+  const result = doc.createElement("div");
+  result.style.cssText = "display:none;box-sizing:border-box;width:100%;font-size:12px;line-height:1.45;white-space:pre-wrap;overflow-wrap:anywhere;word-break:break-word;max-height:190px;overflow-y:auto;padding:6px 8px;border-radius:6px;background:rgba(124,58,237,.07);color:#1f2430;";
+  const render = (filter) => {
+    list.textContent = "";
+    const q = (filter || "").toLowerCase();
+    for (const name of POPUP_LANGS) {
+      if (q && name.toLowerCase().indexOf(q) < 0) continue;
+      const it = doc.createElement("div");
+      it.textContent = name;
+      it.style.cssText = "box-sizing:border-box;width:100%;padding:5px 9px;cursor:pointer;font-size:11px;color:#1f2430;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;";
+      it.addEventListener("mouseenter", () => { it.style.background = "rgba(124,58,237,.1)"; });
+      it.addEventListener("mouseleave", () => { it.style.background = ""; });
+      it.addEventListener("click", () => {
+        input.style.display = "none"; list.style.display = "none";
+        result.style.display = "block"; result.textContent = "…";
+        translateInPopup(text, name, result, L);
+      });
+      list.appendChild(it);
+    }
+  };
+  input.addEventListener("input", () => render(input.value));
+  render("");
+  area.appendChild(input); area.appendChild(list); area.appendChild(result);
+  try { input.focus(); } catch (e) {}
+}
+
 function registerSelectionPopup() {
   Nodus.selectionListener = (event) => {
     try {
       const doc = event.doc;
       const params = event.params || {};
       const text = (params.annotation && params.annotation.text) || params.text || "";
-      const btn = doc.createElement("button");
-      btn.textContent = "Nodus";
-      btn.title = "Ask Nodus about the selection";
-      btn.style.cssText =
-        "display:inline-flex;align-items:center;gap:4px;padding:4px 8px;margin:0 2px;" +
-        "border:none;border-radius:6px;cursor:pointer;background:#7c3aed;color:#fff;font-size:12px;";
-      btn.addEventListener("click", () => {
-        const win = Zotero.getMainWindow();
-        toggleSidebar(win, true);
-        // Send the full annotation draft (position/pageLabel/sortIndex) so the
-        // agent can create a real highlight from this selection, not just the text.
-        let draft = null;
-        try { draft = params.annotation ? JSON.parse(JSON.stringify(params.annotation)) : null; } catch (e) {}
+      let draft = null;
+      try { draft = params.annotation ? JSON.parse(JSON.stringify(params.annotation)) : null; } catch (e) {}
+      let lang = "en";
+      try { lang = Zotero.Prefs.get("nodus.lang") === "es" ? "es" : "en"; } catch (e) {}
+      const L = POPUP_I18N[lang];
+
+      const wrap = doc.createElement("div");
+      wrap.style.cssText = "display:flex;flex-direction:column;gap:6px;padding:5px 4px;width:238px;max-width:238px;box-sizing:border-box;";
+      const head = doc.createElement("div");
+      head.style.cssText = "display:flex;align-items:center;gap:5px;font-size:11px;font-weight:700;color:#7c3aed;";
+      head.innerHTML = MARK_SVG + "<span>Nodus</span>";
+      wrap.appendChild(head);
+
+      const row = doc.createElement("div");
+      row.style.cssText = "display:flex;gap:5px;";
+      const mkBtn = (label, iconSvg) => {
+        const b = doc.createElement("button");
+        b.style.cssText = "flex:1;display:inline-flex;align-items:center;justify-content:center;gap:4px;padding:5px 6px;border:1px solid rgba(124,58,237,.35);border-radius:6px;background:#fff;color:#7c3aed;font-size:11px;font-weight:600;cursor:pointer;";
+        b.innerHTML = iconSvg + "<span>" + label + "</span>";
+        return b;
+      };
+      const citeBtn = mkBtn(L.cite, POPUP_ICO.quote);
+      const explainBtn = mkBtn(L.explain, POPUP_ICO.book);
+      const translateBtn = mkBtn(L.translate, POPUP_ICO.lang);
+      row.appendChild(citeBtn); row.appendChild(explainBtn); row.appendChild(translateBtn);
+      wrap.appendChild(row);
+
+      const trArea = doc.createElement("div");
+      trArea.style.cssText = "display:none;flex-direction:column;gap:4px;";
+      wrap.appendChild(trArea);
+
+      citeBtn.addEventListener("click", () => {
+        const win = Zotero.getMainWindow(); toggleSidebar(win, true);
         sendToSidebar(win, { type: "nodus-selection", text: String(text || ""), draft: draft });
       });
-      event.append(btn);
+      explainBtn.addEventListener("click", () => {
+        const win = Zotero.getMainWindow(); toggleSidebar(win, true);
+        sendToSidebar(win, { type: "nodus-selection", text: String(text || ""), draft: draft, action: "explain" });
+      });
+      translateBtn.addEventListener("click", () => { buildTranslateUI(doc, trArea, String(text || ""), L); });
+
+      event.append(wrap);
     } catch (e) { Zotero.logError(e); }
   };
   Zotero.Reader.registerEventListener("renderTextSelectionPopup", Nodus.selectionListener, PLUGIN_ID);

--- a/zotero-plugin/content/agent.js
+++ b/zotero-plugin/content/agent.js
@@ -13,7 +13,10 @@
   const { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
 
   const COLORS = { yellow: "#ffd400", red: "#ff6666", green: "#5fb236", blue: "#2ea8e5", purple: "#a28ae5", orange: "#f19837", magenta: "#e56eee", gray: "#aaaaaa" };
-  const TOOLS = ["create_note", "highlight", "add_tags"];
+  const TOOLS = ["create_note", "highlight", "add_tags", "add_to_collection", "set_field", "extract_annotations_note"];
+  // Only fields that are safe/meaningful to overwrite from chat. Item-type
+  // mismatches (e.g. `pages` on a webpage) simply fail with a clear error.
+  const SAFE_FIELDS = ["title", "abstractNote", "date", "language", "url", "DOI", "publicationTitle", "journalAbbreviation", "volume", "issue", "pages", "series", "edition", "publisher", "place", "ISBN", "ISSN"];
 
   function esc(s) { return String(s == null ? "" : s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"); }
 
@@ -37,6 +40,9 @@
     if (action.tool === "create_note") return (action.standalone ? t("agent.desc.noteStandalone") : t("agent.desc.note")) + (action.title ? " — “" + action.title + "”" : "");
     if (action.tool === "highlight") return t("agent.desc.highlight") + (action.comment ? " — “" + action.comment + "”" : "");
     if (action.tool === "add_tags") return t("agent.desc.tags") + ": " + (Array.isArray(action.tags) ? action.tags.join(", ") : "");
+    if (action.tool === "add_to_collection") return t("agent.desc.collection") + " — “" + (action.name || action.collection || "") + "”";
+    if (action.tool === "set_field") return t("agent.desc.field") + " — " + (action.field || "") + ": “" + String(action.value == null ? "" : action.value).slice(0, 80) + "”";
+    if (action.tool === "extract_annotations_note") return t("agent.desc.extract");
     return action.tool;
   }
 
@@ -46,6 +52,9 @@
       if (action.tool === "create_note") return await createNote(action, ctx);
       if (action.tool === "highlight") return await highlight(action, ctx);
       if (action.tool === "add_tags") return await addTags(action, ctx);
+      if (action.tool === "add_to_collection") return await addToCollection(action, ctx);
+      if (action.tool === "set_field") return await setField(action, ctx);
+      if (action.tool === "extract_annotations_note") return await extractAnnotationsNote(action, ctx);
       return { ok: false, message: "Unknown tool " + action.tool };
     } catch (e) {
       return { ok: false, message: (e && e.message) ? e.message : String(e) };
@@ -94,6 +103,64 @@
     return { ok: true, message: "tags", added: tags.length };
   }
 
+  async function addToCollection(action, ctx) {
+    const item = ctx.item;
+    if (!item) return { ok: false, message: "no-item" };
+    const name = String(action.name || action.collection || "").trim();
+    if (!name) return { ok: false, message: "no-name" };
+    const libraryID = item.libraryID;
+    const existing = Zotero.Collections.getByLibrary(libraryID) || [];
+    let col = existing.find((c) => c.name && c.name.toLowerCase() === name.toLowerCase());
+    if (!col) {
+      col = new Zotero.Collection();
+      col.libraryID = libraryID;
+      col.name = name;
+      await col.saveTx();
+    }
+    item.addToCollection(col.id);
+    await item.saveTx();
+    return { ok: true, message: "collection", name };
+  }
+
+  async function setField(action, ctx) {
+    const item = ctx.item;
+    if (!item) return { ok: false, message: "no-item" };
+    const field = String(action.field || "").trim();
+    if (!SAFE_FIELDS.includes(field)) return { ok: false, message: "bad-field" };
+    // `setField` throws for a field the item type doesn't support — surfaced as
+    // a failure card, not a silent no-op.
+    item.setField(field, String(action.value == null ? "" : action.value));
+    await item.saveTx();
+    return { ok: true, message: "field", field };
+  }
+
+  async function extractAnnotationsNote(action, ctx) {
+    const parent = ctx.item;
+    let att = ctx.attachment;
+    if (!att && parent && parent.getBestAttachment) att = await parent.getBestAttachment();
+    if (!att || !att.getAnnotations) return { ok: false, message: "no-attachment" };
+    const anns = att.getAnnotations() || [];
+    const rows = [];
+    for (const a of anns) {
+      const text = a.annotationText || "";
+      const comment = a.annotationComment || "";
+      const color = a.annotationColor || COLORS.yellow;
+      const page = a.annotationPageLabel || "";
+      let html = "";
+      if (text) html += '<p style="border-left:3px solid ' + esc(color) + ';padding-left:8px;margin:6px 0;">' + esc(text) + (page ? ' <span style="color:#888;">(p. ' + esc(page) + ")</span>" : "") + "</p>";
+      if (comment) html += "<p>" + esc(comment) + "</p>";
+      if (html) rows.push(html);
+    }
+    if (!rows.length) return { ok: false, message: "no-annotations" };
+    const note = new Zotero.Item("note");
+    note.libraryID = (parent || att).libraryID;
+    const title = action.title || "Annotations";
+    note.setNote("<h1>" + esc(title) + "</h1>\n" + rows.join("\n"));
+    if (parent && !parent.isAttachment()) note.parentID = parent.id;
+    await note.saveTx();
+    return { ok: true, message: "note", createdId: note.id, createdType: "note" };
+  }
+
   // System-prompt fragment describing the tools (only injected when agent mode is on).
   const SYSTEM = [
     "AGENT MODE: you may act on the user's Zotero library, but ONLY when the user asks you to (create a note, summarize into a note, highlight, tag). Never act unprompted.",
@@ -102,10 +169,13 @@
     '{"tool":"create_note","title":"optional","body":"<p>HTML body</p>","standalone":false}',
     "```",
     "Tools:",
-    '• create_note {title?, body (HTML), standalone?} — a child note under the open item (or standalone:true for an independent note). Use for summaries and any note. Emit several blocks to create several notes.',
+    '• create_note {title?, body (HTML), standalone?} — a child note under the open item (or standalone:true for an independent note). Use for summaries and any note. `body` is HTML. Emit several blocks to create several notes.',
     '• highlight {color?("yellow"|"green"|"blue"|"red"|"purple"), comment?} — highlights the user\'s CURRENT text selection in the reader. Only use it if the user has selected text.',
-    '• add_tags {tags:[...]} — adds tags to the open item.',
-    "Do NOT invent content the user did not ask for. Each action will be shown to the user for approval before it runs.",
+    '• add_tags {tags:[...]} — adds tags to the open item. Choose sensible tags yourself from the document; do not ask the user which tags.',
+    '• add_to_collection {name} — adds the open item to a collection with that name (created if it does not exist).',
+    '• set_field {field, value} — sets a bibliographic field on the open item. `value` MUST be PLAIN TEXT (no HTML). Allowed fields: title, abstractNote, date, language, url, DOI, publicationTitle, journalAbbreviation, volume, issue, pages, series, edition, publisher, place, ISBN, ISSN.',
+    '• extract_annotations_note {title?} — creates a note from the annotations (highlights/comments) already in the open PDF. `title` is optional — pick a sensible one and act; no text selection needed.',
+    "When the user asks for one of these actions, DO IT: pick sensible values yourself and emit the block. Do NOT reply with a clarifying question for details you can reasonably infer. Do NOT invent content the user did not ask for. Each action is shown to the user for approval before it runs.",
   ].join("\n");
 
   window.NodusAgent = { parseActions, describe, execute, SYSTEM, TOOLS };

--- a/zotero-plugin/content/highlighter.js
+++ b/zotero-plugin/content/highlighter.js
@@ -1,0 +1,191 @@
+/* Nodus for Zotero — auto-highlighter engine. Turns AI-chosen passages (exact
+ * quotes + importance level) into REAL, rendered Zotero highlight annotations on
+ * the open PDF, by replicating Zotero's own reader math (getRangeRects /
+ * getSortIndex) and creating them through the reader's annotationManager (the
+ * only path that both persists AND renders). window.NodusHighlighter.
+ *
+ * The reader recipe (verified in Zotero 9):
+ *  - reader._internalReader._primaryView._pdfPages is a DICT keyed by pageIndex
+ *    (NOT an array); each page has `.chars` (structured chars) + `.viewBox`.
+ *  - each char: {c, u, rect:[x1,y1,x2,y2], inlineRect, rotation, lineBreakAfter}.
+ *  - build rects from a char range like Zotero's getRangeRects; sortIndex like
+ *    getSortIndex; then annotationManager.addAnnotation(cloneInto(annotation)).
+ */
+/* eslint-disable no-undef */
+(function () {
+  "use strict";
+  const { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
+
+  // ─────────────────────────────── pure helpers (unit-tested, no Zotero) ──
+  function norm4(r) { return [Math.min(r[0], r[2]), Math.min(r[1], r[3]), Math.max(r[0], r[2]), Math.max(r[1], r[3])]; }
+
+  // Replica of Zotero reader's getRangeRects: one rect per line-run, split at
+  // char.lineBreakAfter. Horizontal runs take left/right from the first/last
+  // char and top/bottom from the line's inlineRect.
+  function rangeRects(chars, offsetStart, offsetEnd) {
+    const rects = []; let start = offsetStart;
+    for (let i = start; i <= offsetEnd; i++) {
+      const ch = chars[i]; if (!ch) break;
+      if (!(ch.lineBreakAfter || i === offsetEnd)) continue;
+      const fc = chars[start], lc = ch;
+      const fr = norm4(fc.rect), lr = norm4(lc.rect), fi = norm4(fc.inlineRect || fc.rect);
+      const rot = fc.rotation || 0, vert = rot === 90 || rot === 270;
+      rects.push(vert ? [fi[0], fr[1], fi[2], lr[3]] : [fr[0], fi[1], lr[2], fi[3]]);
+      start = i + 1;
+    }
+    return rects;
+  }
+
+  // Replica of Zotero reader's getSortIndex string (page|offset|top), padded.
+  function sortIndexStr(pageIndex, viewBox, firstRectTop, offsetStart) {
+    let top = 0;
+    if (viewBox && typeof firstRectTop === "number") top = Math.max(0, (viewBox[3] - viewBox[1]) - firstRectTop);
+    const pad = (n, l) => String(n).slice(0, l).padStart(l, "0");
+    return [pad(pageIndex, 5), pad(offsetStart || 0, 6), pad(Math.floor(top), 5)].join("|");
+  }
+
+  // Per-char normalization for matching: NFKC (decomposes ligatures ﬁ→fi, ﬂ→fl),
+  // unify curly quotes/apostrophes, drop whitespace + every dash/hyphen variant,
+  // lowercase. Returns '' to drop the char; a source glyph can expand to >1 char.
+  function normChar(ch) {
+    let s = String(ch).normalize("NFKC").replace(/[‘’´`]/g, "'").replace(/[“”]/g, '"');
+    s = s.replace(/[\s­‐-―−-]/g, "");
+    return s.toLowerCase();
+  }
+  // The quote text, normalized the same way the page text is (so matches align).
+  function normalizeText(s) {
+    const str = String(s == null ? "" : s); let out = "";
+    for (const ch of str) out += normChar(ch);
+    return out;
+  }
+  // Per-page normalized string + a map from norm-index → char index. A ligature
+  // maps several norm positions to one char, so a matched range still covers it.
+  function buildPageNorm(chars) {
+    let norm = ""; const map = [];
+    for (let i = 0; i < chars.length; i++) {
+      const c = chars[i]; const raw = c && (c.c != null ? c.c : c.u);
+      if (raw == null) continue;
+      const ns = normChar(raw);
+      for (let k = 0; k < ns.length; k++) { norm += ns[k]; map.push(i); }
+    }
+    return { norm, map };
+  }
+  // Locate a normalized quote across pages: exact first, then a shrinking prefix
+  // (tolerates ligature/char drift later in a long quote). Returns {pg,start,end}.
+  function findQuote(pages, qnorm) {
+    if (!qnorm || qnorm.length < 8) return null;
+    const lens = [qnorm.length];
+    const ratios = [0.85, 0.7, 0.55, 0.4];
+    for (let r = 0; r < ratios.length; r++) { const l = Math.floor(qnorm.length * ratios[r]); if (l >= 12 && l < qnorm.length) lens.push(l); }
+    for (let li = 0; li < lens.length; li++) {
+      const q = qnorm.slice(0, lens[li]);
+      for (let pi = 0; pi < pages.length; pi++) {
+        const pg = pages[pi]; const at = pg.norm.indexOf(q);
+        if (at >= 0) return { pg, start: pg.map[at], end: pg.map[at + q.length - 1] };
+      }
+    }
+    return null;
+  }
+
+  // Robustly parse the model's passage list: [{text, level}] (or bare strings).
+  function parsePassages(text) {
+    if (!text) return [];
+    let s = String(text).replace(/```(?:json)?/gi, "");
+    const a = s.indexOf("["), b = s.lastIndexOf("]");
+    if (a < 0 || b <= a) return [];
+    let arr; try { arr = JSON.parse(s.slice(a, b + 1)); } catch (e) { return []; }
+    if (!Array.isArray(arr)) return [];
+    const out = [];
+    for (const it of arr) {
+      if (!it) continue;
+      const t = typeof it === "string" ? it : it.text;
+      if (typeof t !== "string" || !t.trim()) continue;
+      const raw = String((typeof it === "object" && (it.level || it.importance)) || "medium").toLowerCase();
+      const level = /(high|very|muy|crit|red|rojo|1)/.test(raw) ? "high" : "medium";
+      out.push({ text: t.trim(), level });
+    }
+    return out;
+  }
+
+  const DEFAULT_COLORS = { high: "#ff6666", medium: "#ffd400" };
+
+  // ─────────────────────────────── reader access (needs Zotero) ──────────
+  // The open PDF reader whose pages have extracted chars, or null.
+  function getReaderPdf() {
+    const readers = (Zotero.Reader && Zotero.Reader._readers) || [];
+    for (let k = 0; k < readers.length; k++) {
+      try {
+        const r = readers[k]; const ir = r && r._internalReader; const pv = ir && ir._primaryView;
+        const dict = pv && pv._pdfPages;
+        if (!dict) continue;
+        const keys = Object.keys(dict);
+        for (let j = 0; j < keys.length; j++) { const p = dict[keys[j]]; if (p && p.chars && p.chars.length) return { reader: r, ir, dict }; }
+      } catch (e) {}
+    }
+    return null;
+  }
+
+  function buildPages(dict) {
+    const pages = [];
+    const keys = Object.keys(dict);
+    for (let j = 0; j < keys.length; j++) {
+      const page = dict[keys[j]];
+      if (!page || !page.chars || !page.chars.length) continue;
+      const { norm, map } = buildPageNorm(page.chars);
+      if (!norm) continue;
+      pages.push({ pageIndex: page.pageIndex != null ? page.pageIndex : Number(keys[j]), page, chars: page.chars, norm, map });
+    }
+    return pages;
+  }
+
+  // Apply highlights for `passages` (each {text, level}). colors maps level→hex.
+  // Returns { applied:[{key,level,pageIndex,text}], missed:[text], error? }.
+  function highlightPassages(passages, colors) {
+    const rp = getReaderPdf();
+    if (!rp) return { error: "no-reader", applied: [], missed: [] };
+    const colorMap = colors || DEFAULT_COLORS;
+    const pages = buildPages(rp.dict);
+    if (!pages.length) return { error: "no-text", applied: [], missed: [] };
+    const Cu = Components.utils;
+    const am = rp.ir._annotationManager;
+    const g = Cu.getGlobalForObject(am);
+    const applied = [], missed = [];
+    for (const p of passages || []) {
+      const qnorm = normalizeText(p.text);
+      const hit = findQuote(pages, qnorm);
+      if (!hit) { missed.push(p.text); continue; }
+      const rects = rangeRects(hit.pg.chars, hit.start, hit.end);
+      if (!rects.length) { missed.push(p.text); continue; }
+      const position = { pageIndex: hit.pg.pageIndex, rects };
+      const si = sortIndexStr(hit.pg.pageIndex, hit.pg.page.viewBox, rects[0][3], hit.start);
+      const color = colorMap[p.level] || colorMap.medium || DEFAULT_COLORS.medium;
+      const annotation = { type: "highlight", color, sortIndex: si, pageLabel: String(hit.pg.pageIndex + 1), position, text: String(p.text).slice(0, 500), tags: [], comment: "" };
+      try {
+        const r = am.addAnnotation(Cu.cloneInto(annotation, g));
+        applied.push({ key: r ? (r.id || r.key) : null, level: p.level, pageIndex: hit.pg.pageIndex, text: p.text });
+      } catch (e) { missed.push(p.text); }
+    }
+    return { applied, missed };
+  }
+
+  // Remove highlights previously created (revert). keys = annotation ids/keys.
+  function revert(keys) {
+    if (!keys || !keys.length) return 0;
+    const rp = getReaderPdf();
+    if (!rp) return 0;
+    const Cu = Components.utils;
+    const am = rp.ir._annotationManager;
+    try {
+      const g = Cu.getGlobalForObject(am);
+      am.deleteAnnotations(Cu.cloneInto(keys.slice(), g));
+      return keys.length;
+    } catch (e) { try { Zotero.logError(e); } catch (x) {} return 0; }
+  }
+
+  window.NodusHighlighter = {
+    // pure (tested)
+    norm4, rangeRects, sortIndexStr, normChar, normalizeText, buildPageNorm, findQuote, parsePassages, DEFAULT_COLORS,
+    // reader
+    getReaderPdf, buildPages, highlightPassages, revert,
+  };
+})();

--- a/zotero-plugin/content/icons.js
+++ b/zotero-plugin/content/icons.js
@@ -1,0 +1,49 @@
+/* Nodus for Zotero — inline SVG icon set (Lucide-style, MIT paths). Self-contained
+ * so it works under the chrome:// CSP (no external font/CDN). window.NodusIcons.
+ */
+/* eslint-disable no-undef */
+(function () {
+  "use strict";
+  const P = {
+    plus: '<path d="M5 12h14"/><path d="M12 5v14"/>',
+    history: '<path d="M3 3v5h5"/><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"/><path d="M12 7v5l4 2"/>',
+    file: '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7z"/><path d="M14 2v5h5"/><path d="M8 13h8"/><path d="M8 17h5"/>',
+    highlighter: '<path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/>',
+    bot: '<path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>',
+    sparkles: '<path d="M9.94 14.06A2 2 0 0 0 8.5 12.6l-5.1-1.32a.5.5 0 0 1 0-.96L8.5 9a2 2 0 0 0 1.44-1.44l1.32-5.1a.5.5 0 0 1 .96 0l1.32 5.1A2 2 0 0 0 15 9l5.1 1.32a.5.5 0 0 1 0 .96L15 12.6a2 2 0 0 0-1.44 1.46l-1.32 5.1a.5.5 0 0 1-.96 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/>',
+    send: '<path d="M14.54 21.69a.5.5 0 0 0 .93-.03l6.5-19a.5.5 0 0 0-.63-.63l-19 6.5a.5.5 0 0 0-.03.94l7.93 3.18a2 2 0 0 1 1.1 1.1z"/><path d="m21.85 2.15-10.94 10.94"/>',
+    square: '<rect width="12" height="12" x="6" y="6" rx="2" fill="currentColor" stroke="none"/>',
+    x: '<path d="M18 6 6 18"/><path d="m6 6 12 12"/>',
+    trash: '<path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M10 11v6"/><path d="M14 11v6"/>',
+    star: '<path d="M11.52 2.3a.53.53 0 0 1 .95 0l2.31 4.68a2.1 2.1 0 0 0 1.6 1.16l5.16.75a.53.53 0 0 1 .3.9l-3.74 3.64a2.1 2.1 0 0 0-.61 1.88l.88 5.14a.53.53 0 0 1-.77.56l-4.62-2.43a2.1 2.1 0 0 0-1.97 0L6.4 21.01a.53.53 0 0 1-.77-.56l.88-5.14a2.1 2.1 0 0 0-.61-1.88L2.16 9.8a.53.53 0 0 1 .3-.9l5.16-.76a2.1 2.1 0 0 0 1.6-1.16z" fill="currentColor" stroke="none"/>',
+    "star-line": '<path d="M11.52 2.3a.53.53 0 0 1 .95 0l2.31 4.68a2.1 2.1 0 0 0 1.6 1.16l5.16.75a.53.53 0 0 1 .3.9l-3.74 3.64a2.1 2.1 0 0 0-.61 1.88l.88 5.14a.53.53 0 0 1-.77.56l-4.62-2.43a2.1 2.1 0 0 0-1.97 0L6.4 21.01a.53.53 0 0 1-.77-.56l.88-5.14a2.1 2.1 0 0 0-.61-1.88L2.16 9.8a.53.53 0 0 1 .3-.9l5.16-.76a2.1 2.1 0 0 0 1.6-1.16z"/>',
+    copy: '<rect width="14" height="14" x="8" y="8" rx="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>',
+    pencil: '<path d="M21.17 6.81a1 1 0 0 0-3.98-3.99L3.84 16.17a2 2 0 0 0-.5.83l-1.32 4.35a.5.5 0 0 0 .62.62l4.35-1.32a2 2 0 0 0 .83-.5z"/><path d="m15 5 4 4"/>',
+    refresh: '<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/>',
+    undo: '<path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/>',
+    search: '<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
+    languages: '<path d="m5 8 6 6"/><path d="m4 14 6-6 2-3"/><path d="M2 5h12"/><path d="M7 2h1"/><path d="m22 22-5-10-5 10"/><path d="M14 18h6"/>',
+    quote: '<path d="M16 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h3a1 1 0 0 1 1 1v1a2 2 0 0 1-2 2h-1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h1a4 4 0 0 0 4-4V5a2 2 0 0 0-2-2z"/><path d="M5 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h3a1 1 0 0 1 1 1v1a2 2 0 0 1-2 2H6a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h1a4 4 0 0 0 4-4V5a2 2 0 0 0-2-2z"/>',
+    book: '<path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/>',
+    chevron: '<path d="m6 9 6 6 6-6"/>',
+    idea: '<circle cx="12" cy="12" r="9"/><path d="m9 12 2 2 4-4"/>',
+    gap: '<path d="M12 3 21 12 12 21 3 12z"/>',
+    link: '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
+    check: '<path d="M20 6 9 17l-5-5"/>',
+  };
+  function svg(name, opts) {
+    opts = opts || {};
+    const p = P[name];
+    if (!p) return "";
+    const size = opts.size || 16;
+    return '<svg xmlns="http://www.w3.org/2000/svg" width="' + size + '" height="' + size + '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="' + (opts.stroke || 2) + '" stroke-linecap="round" stroke-linejoin="round" class="nd-ico' + (opts.cls ? " " + opts.cls : "") + '" aria-hidden="true">' + p + "</svg>";
+  }
+  // Returns a DOM <span> wrapping the icon (for createElement-style code).
+  function el(name, opts) {
+    const span = document.createElement("span");
+    span.className = "nd-ico-wrap";
+    span.innerHTML = svg(name, opts);
+    return span;
+  }
+  window.NodusIcons = { svg, el, P };
+})();

--- a/zotero-plugin/content/markdown.js
+++ b/zotero-plugin/content/markdown.js
@@ -1,0 +1,155 @@
+/* Nodus for Zotero — tiny Markdown renderer. No dependencies, no innerHTML with
+ * model output: `parse` is a pure text→tokens function (unit-tested), `render`
+ * walks the tokens and builds DOM nodes, so everything is XSS-safe by
+ * construction. Nodus citation tokens ([[p:..]], [[idea:..]], …) are parsed as
+ * inline spans and turned into clickable chips via a caller-supplied `citeFn`.
+ * Exposed as window.NodusMarkdown.
+ */
+/* eslint-disable no-undef */
+(function () {
+  "use strict";
+  // Self-contained import (like agent.js/store.js) so the link handler below
+  // never depends on sidebar.js's script-scoped `Zotero` binding being loaded.
+  const { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
+
+  // Only `*`/`**` emphasis (not `_`): underscores routinely appear inside
+  // snake_case identifiers, file names and URLs in academic/code text and must
+  // not be mangled into italics.
+  const INLINE = [
+    { type: "cite", re: /\[\[(p|idea|zotero|gap):([^\]|]+?)(?:\|([^\]]+?))?\]\]/ },
+    { type: "code", re: /`([^`]+)`/ },
+    { type: "strong", re: /\*\*([\s\S]+?)\*\*/ },
+    { type: "em", re: /\*(?!\s)([\s\S]+?)(?<!\s)\*/ },
+    { type: "link", re: /\[([^\]]+)\]\(([^)\s]+)\)/ },
+  ];
+
+  function parseInline(text) {
+    const out = [];
+    let s = String(text == null ? "" : text);
+    while (s) {
+      let best = null;
+      for (const p of INLINE) {
+        const m = p.re.exec(s);
+        if (m && (best === null || m.index < best.m.index)) best = { p, m };
+      }
+      if (!best) { out.push({ type: "text", value: s }); break; }
+      const m = best.m;
+      if (m.index > 0) out.push({ type: "text", value: s.slice(0, m.index) });
+      if (best.p.type === "cite") out.push({ type: "cite", kind: m[1], id: (m[2] || "").trim(), label: m[3] });
+      else if (best.p.type === "code") out.push({ type: "code", value: m[1] });
+      else if (best.p.type === "link") out.push({ type: "link", href: m[2], children: parseInline(m[1]) });
+      else out.push({ type: best.p.type, children: parseInline(m[1]) });
+      s = s.slice(m.index + m[0].length);
+    }
+    return out;
+  }
+
+  function isBlockStart(line) {
+    return (
+      /^\s*```/.test(line) ||
+      /^\s{0,3}#{1,6}\s+/.test(line) ||
+      /^\s*([-*_])(\s*\1){2,}\s*$/.test(line) ||
+      /^\s*>\s?/.test(line) ||
+      /^\s*([-*+]|\d+[.)])\s+/.test(line)
+    );
+  }
+
+  // text → array of block tokens. Pure (no DOM). Covers what chat models emit:
+  // headings, fenced code, blockquotes, ordered/unordered lists, hr, paragraphs.
+  function parse(text) {
+    const lines = String(text == null ? "" : text).replace(/\r\n?/g, "\n").split("\n");
+    const blocks = [];
+    let i = 0;
+    while (i < lines.length) {
+      const line = lines[i];
+      const fence = line.match(/^\s*```(.*)$/);
+      if (fence) {
+        const buf = [];
+        i++;
+        while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) { buf.push(lines[i]); i++; }
+        i++; // closing fence (or EOF)
+        blocks.push({ type: "code", text: buf.join("\n") });
+        continue;
+      }
+      if (/^\s*$/.test(line)) { i++; continue; }
+      if (/^\s*([-*_])(\s*\1){2,}\s*$/.test(line)) { blocks.push({ type: "hr" }); i++; continue; }
+      const h = line.match(/^\s{0,3}(#{1,6})\s+(.*)$/);
+      if (h) { blocks.push({ type: "heading", level: h[1].length, inline: parseInline(h[2].replace(/\s+#+\s*$/, "")) }); i++; continue; }
+      if (/^\s*>\s?/.test(line)) {
+        const buf = [];
+        while (i < lines.length && /^\s*>\s?/.test(lines[i])) { buf.push(lines[i].replace(/^\s*>\s?/, "")); i++; }
+        blocks.push({ type: "blockquote", inline: parseInline(buf.join("\n")) });
+        continue;
+      }
+      if (/^\s*([-*+]|\d+[.)])\s+/.test(line)) {
+        const ordered = /^\s*\d+[.)]\s+/.test(line);
+        const items = [];
+        while (i < lines.length && /^\s*([-*+]|\d+[.)])\s+/.test(lines[i])) {
+          items.push(parseInline(lines[i].replace(/^\s*([-*+]|\d+[.)])\s+/, "")));
+          i++;
+        }
+        blocks.push({ type: "list", ordered, items });
+        continue;
+      }
+      const buf = [line];
+      i++;
+      while (i < lines.length && !/^\s*$/.test(lines[i]) && !isBlockStart(lines[i])) { buf.push(lines[i]); i++; }
+      blocks.push({ type: "paragraph", inline: parseInline(buf.join("\n")) });
+    }
+    return blocks;
+  }
+
+  // ---- DOM rendering ----
+  function renderInline(doc, spans, parent, citeFn) {
+    for (const sp of spans) {
+      if (sp.type === "text") { parent.appendChild(doc.createTextNode(sp.value)); continue; }
+      if (sp.type === "cite") {
+        const chip = citeFn ? citeFn(sp.kind, sp.id, sp.label) : null;
+        parent.appendChild(chip || doc.createTextNode(sp.label || sp.id || ""));
+        continue;
+      }
+      if (sp.type === "code") { const c = doc.createElement("code"); c.className = "nd-md-code"; c.textContent = sp.value; parent.appendChild(c); continue; }
+      if (sp.type === "link") {
+        const a = doc.createElement("a");
+        a.className = "nd-md-link";
+        a.setAttribute("href", sp.href);
+        // Open externally: chrome:// docs can't navigate to http in place.
+        a.addEventListener("click", (e) => { e.preventDefault(); try { Zotero.launchURL(sp.href); } catch (x) {} });
+        renderInline(doc, sp.children, a, citeFn);
+        parent.appendChild(a);
+        continue;
+      }
+      const tag = sp.type === "strong" ? "strong" : "em";
+      const node = doc.createElement(tag);
+      renderInline(doc, sp.children, node, citeFn);
+      parent.appendChild(node);
+    }
+  }
+
+  function renderBlock(doc, b, citeFn) {
+    if (b.type === "heading") { const h = doc.createElement("h" + Math.min(6, b.level)); h.className = "nd-md-h"; renderInline(doc, b.inline, h, citeFn); return h; }
+    if (b.type === "code") { const pre = doc.createElement("pre"); pre.className = "nd-md-pre"; const code = doc.createElement("code"); code.textContent = b.text; pre.appendChild(code); return pre; }
+    if (b.type === "hr") { const hr = doc.createElement("hr"); hr.className = "nd-md-hr"; return hr; }
+    if (b.type === "blockquote") { const q = doc.createElement("blockquote"); q.className = "nd-md-quote"; renderInline(doc, b.inline, q, citeFn); return q; }
+    if (b.type === "list") {
+      const list = doc.createElement(b.ordered ? "ol" : "ul");
+      list.className = "nd-md-list";
+      for (const item of b.items) { const li = doc.createElement("li"); renderInline(doc, item, li, citeFn); list.appendChild(li); }
+      return list;
+    }
+    const p = doc.createElement("p");
+    p.className = "nd-md-p";
+    renderInline(doc, b.inline, p, citeFn);
+    return p;
+  }
+
+  // Clears `container` and renders `text` as formatted markdown. `citeFn(kind,
+  // id, label)` should return a DOM node for a Nodus citation chip (or null).
+  function render(container, text, citeFn) {
+    const doc = container.ownerDocument || document;
+    container.textContent = "";
+    for (const b of parse(text)) container.appendChild(renderBlock(doc, b, citeFn));
+  }
+
+  window.NodusMarkdown = { parse, parseInline, render };
+})();

--- a/zotero-plugin/content/providers.js
+++ b/zotero-plugin/content/providers.js
@@ -72,6 +72,48 @@
     return (d.data || []).map((m) => m.id).filter(Boolean).sort();
   }
 
+  const DEFAULT_MAX_TOKENS = 8192;
+  function clampMaxTokens(v) {
+    const n = Number(v);
+    if (!Number.isFinite(n) || n <= 0) return DEFAULT_MAX_TOKENS;
+    return Math.min(200000, Math.max(256, Math.floor(n)));
+  }
+
+  // Reasoning/thinking control (per model, if it supports it). Levels:
+  //   'default' — send nothing, let the model/provider decide
+  //   'off'     — ask the model NOT to reason (faster/cheaper)
+  //   'low'|'medium'|'high' — reasoning effort
+  const REASONING_LEVELS = ["default", "off", "low", "medium", "high"];
+  const THINK_BUDGET = { low: 1024, medium: 4096, high: 8192 };
+
+  // Body fragment for OpenAI-compatible chat. OpenRouter exposes a unified
+  // `reasoning` object (verified against gemini/deepseek/mimo); other
+  // OpenAI-compatible endpoints use the standard `reasoning_effort`. 'off' has
+  // no portable "disable" on plain OpenAI-compat, so we simply don't request it.
+  function reasoningBody(provider, level) {
+    if (!level || level === "default") return {};
+    if (provider === "openrouter") {
+      return level === "off" ? { reasoning: { enabled: false } } : { reasoning: { effort: level } };
+    }
+    if (level === "off") return {};
+    return { reasoning_effort: level };
+  }
+
+  // Pure body builder for the Anthropic Messages API (unit-tested). `max_tokens`
+  // is required by the API and was hardcoded to 4096, truncating long answers;
+  // it is now configurable via opts.maxTokens. When reasoning is low/medium/high
+  // we enable extended thinking and make room for it above max_tokens (Anthropic
+  // counts thinking tokens toward max_tokens and requires max_tokens > budget).
+  function buildAnthropicBody(model, system, messages, maxTokens, reasoning) {
+    const body = { model, max_tokens: clampMaxTokens(maxTokens), stream: true, system: system || undefined, messages };
+    const budget = THINK_BUDGET[reasoning];
+    if (budget) {
+      body.thinking = { type: "enabled", budget_tokens: budget };
+      if (body.max_tokens <= budget) body.max_tokens = budget + clampMaxTokens(maxTokens);
+    }
+    return body;
+  }
+
   // messages: [{role:'user'|'assistant', content}]  system: string
   async function chatStream(modelRef, opts, onDelta, signal) {
     const provider = modelRef.provider;
@@ -82,9 +124,11 @@
     const key = (opts && opts.key) || "";
     const system = (opts && opts.system) || "";
     const messages = (opts && opts.messages) || [];
+    const maxTokens = opts && opts.maxTokens;
+    const reasoning = (opts && opts.reasoning) || "default";
 
     if (provider === "anthropic") {
-      return anthropicStream(key, model, system, messages, onDelta, signal);
+      return anthropicStream(key, model, system, messages, maxTokens, reasoning, onDelta, signal);
     }
     // OpenAI-compatible (incl. gemini openai-compat, local servers)
     const base = chatBase(provider, opts && opts.localBase);
@@ -93,6 +137,10 @@
     if (key) headers.Authorization = "Bearer " + key;
     if (provider === "openrouter") { headers["HTTP-Referer"] = "https://github.com/Drakonis96/nodus"; headers["X-Title"] = "Nodus for Zotero"; }
     const body = { model, stream: true, messages: system ? [{ role: "system", content: system }, ...messages] : messages };
+    // Only cap when the user configured a limit: omitting it lets the model use
+    // its own (usually larger) default instead of an arbitrary ceiling.
+    if (maxTokens) body.max_tokens = clampMaxTokens(maxTokens);
+    Object.assign(body, reasoningBody(provider, reasoning));
     const res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body), signal });
     if (!res.ok || !res.body) throw new Error(p.label + " chat HTTP " + res.status + (res.ok ? "" : " " + (await res.text()).slice(0, 200)));
     await readSSE(res.body, (json) => {
@@ -101,14 +149,14 @@
     });
   }
 
-  async function anthropicStream(key, model, system, messages, onDelta, signal) {
+  async function anthropicStream(key, model, system, messages, maxTokens, reasoning, onDelta, signal) {
     const res = await fetch("https://api.anthropic.com/v1/messages", {
       method: "POST",
       headers: {
         "content-type": "application/json", "x-api-key": key,
         "anthropic-version": "2023-06-01", "anthropic-dangerous-direct-browser-access": "true",
       },
-      body: JSON.stringify({ model, max_tokens: 4096, stream: true, system: system || undefined, messages }),
+      body: JSON.stringify(buildAnthropicBody(model, system, messages, maxTokens, reasoning)),
       signal,
     });
     if (!res.ok || !res.body) throw new Error("Anthropic chat HTTP " + res.status + " " + (res.ok ? "" : (await res.text()).slice(0, 200)));
@@ -139,5 +187,5 @@
     }
   }
 
-  window.NodusProviders = { PROVIDERS, byId, chatBase, listModels, chatStream };
+  window.NodusProviders = { PROVIDERS, byId, chatBase, listModels, chatStream, buildAnthropicBody, clampMaxTokens, DEFAULT_MAX_TOKENS, reasoningBody, REASONING_LEVELS };
 })();

--- a/zotero-plugin/content/sidebar.css
+++ b/zotero-plugin/content/sidebar.css
@@ -42,6 +42,7 @@ body {
 .nd-conn--on { background: rgba(16,185,129,0.15); color: #059669; }
 .nd-conn--off { background: rgba(239,68,68,0.15); color: #dc2626; }
 
+#nd-body { position: relative; flex: 1; min-height: 0; display: flex; flex-direction: column; }
 #nd-tabs { display: flex; border-bottom: 1px solid var(--nd-border); }
 .nd-tab {
   flex: 1; padding: 8px 10px; background: transparent; border: none; cursor: pointer;
@@ -63,6 +64,21 @@ body {
 
 #nd-toolrow { display: flex; gap: 6px; }
 #nd-model { flex: 1; min-width: 0; padding: 5px 6px; border-radius: 6px; border: 1px solid var(--nd-border); background: var(--nd-bg); color: var(--nd-fg); }
+
+/* Searchable model dropdown. */
+.nd-dd { position: relative; flex: 1; min-width: 0; }
+.nd-dd-btn { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 4px; padding: 5px 8px; border-radius: 6px; border: 1px solid var(--nd-border); background: var(--nd-bg); color: var(--nd-fg); font: inherit; font-size: 12px; cursor: pointer; }
+.nd-dd-btn #nd-model-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nd-dd-menu { position: absolute; z-index: 40; top: calc(100% + 4px); left: 0; right: 0; min-width: 220px; background: var(--nd-bg); border: 1px solid var(--nd-border); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); overflow: hidden; }
+.nd-dd-search { padding: 6px; border-bottom: 1px solid var(--nd-border); }
+.nd-dd-search input { width: 100%; box-sizing: border-box; padding: 6px 8px; border-radius: 6px; border: 1px solid var(--nd-border); background: var(--nd-bg); color: var(--nd-fg); font: inherit; font-size: 12px; }
+.nd-dd-list { max-height: 240px; overflow: auto; }
+.nd-dd-item { display: flex; align-items: baseline; gap: 8px; padding: 6px 10px; cursor: pointer; font-size: 12px; }
+.nd-dd-item:hover { background: var(--nd-accent-soft); }
+.nd-dd-item--sel { background: var(--nd-accent-soft); }
+.nd-dd-model { color: var(--nd-fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nd-dd-prov { color: var(--nd-muted); font-size: 10px; margin-left: auto; flex: 0 0 auto; }
+.nd-dd-empty { padding: 10px; color: var(--nd-muted); font-size: 11px; text-align: center; }
 
 #nd-prompts { display: flex; flex-wrap: wrap; gap: 6px; }
 .nd-chip {
@@ -106,6 +122,15 @@ body {
 .nd-menu-item:hover { background: var(--nd-accent-soft); }
 .nd-menu-item .nd-menu-title { font-weight: 600; }
 .nd-menu-item .nd-menu-sub { font-size: 10px; color: var(--nd-muted); margin-top: 1px; }
+/* Custom user prompts: title/preview on the left, delete button on the right. */
+.nd-menu-item--custom { display: flex; align-items: center; gap: 6px; }
+.nd-menu-item--custom .nd-menu-txt { flex: 1; min-width: 0; }
+.nd-menu-item--custom .nd-menu-sub { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nd-menu-del { flex: 0 0 auto; border: none; background: transparent; color: var(--nd-muted); cursor: pointer; padding: 4px; border-radius: 6px; display: inline-flex; align-items: center; }
+.nd-menu-del:hover { color: #dc2626; background: rgba(239,68,68,0.1); }
+.nd-menu-add { display: flex; align-items: center; gap: 5px; color: var(--nd-accent); font-weight: 600; border-bottom: 1px solid var(--nd-border); margin-bottom: 2px; border-radius: 7px 7px 0 0; }
+.nd-modal-input { width: 100%; box-sizing: border-box; padding: 8px 10px; border-radius: 8px; border: 1px solid var(--nd-border); background: var(--nd-bg); color: var(--nd-fg); font: inherit; font-size: 13px; }
+textarea.nd-modal-input { resize: vertical; min-height: 64px; }
 
 .nd-field { display: flex; flex-direction: column; gap: 6px; }
 .nd-field > label:first-child { font-weight: 600; font-size: 12px; }
@@ -173,6 +198,17 @@ body {
 .nd-modal { position: absolute; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 10; padding: 16px; }
 .nd-modal-box { background: var(--nd-bg); border: 1px solid var(--nd-border); border-radius: 12px; padding: 16px; max-width: 320px; display: flex; flex-direction: column; gap: 14px; box-shadow: 0 8px 30px rgba(0,0,0,0.3); }
 .nd-modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
+.nd-modal-title { font-weight: 700; font-size: 14px; }
+/* Same box metrics as .nd-btn-ghost so paired modal buttons match in shape/size. */
+.nd-btn-primary { padding: 5px 12px; border: 1px solid var(--nd-accent); border-radius: 6px; background: var(--nd-accent); color: #fff; cursor: pointer; font-weight: 600; }
+
+/* Thinking control (chat bar button + modal dropdown). */
+.nd-think-btn { width: auto; min-width: 24px; gap: 3px; padding: 0 6px; }
+.nd-think-ico { display: inline-flex; align-items: center; }
+.nd-think-ico svg { width: 15px; height: 15px; }
+.nd-think-lvl { font-size: 10px; font-weight: 600; color: var(--nd-muted); }
+.nd-dd--think { flex: 0 0 auto; }
+.nd-dd-menu--think { left: auto; right: 0; min-width: 140px; }
 #nodus-app { position: relative; }
 
 /* agent mode */
@@ -184,3 +220,61 @@ body {
 .nd-action-status { margin-top: 6px; font-size: 11px; }
 .nd-action-ok { color: #059669; font-weight: 600; }
 .nd-action-err { color: #dc2626; }
+
+/* Markdown-rendered assistant messages: block layout instead of pre-wrapped
+ * text, so headings/lists/quotes/code read like formatted prose. */
+.nd-body.nd-md { white-space: normal; }
+.nd-md > :first-child { margin-top: 0; }
+.nd-md > :last-child { margin-bottom: 0; }
+.nd-md-p { margin: 0 0 8px; line-height: 1.5; }
+.nd-md-h { margin: 12px 0 6px; line-height: 1.3; font-weight: 700; }
+h1.nd-md-h { font-size: 16px; } h2.nd-md-h { font-size: 15px; } h3.nd-md-h { font-size: 13.5px; }
+h4.nd-md-h, h5.nd-md-h, h6.nd-md-h { font-size: 12.5px; }
+.nd-md-list { margin: 0 0 8px; padding-left: 20px; }
+.nd-md-list li { margin: 2px 0; line-height: 1.45; }
+.nd-md-quote { margin: 0 0 8px; padding: 4px 10px; border-left: 3px solid var(--nd-accent-line); color: var(--nd-muted); background: var(--nd-accent-soft); border-radius: 0 6px 6px 0; }
+.nd-md-code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.92em; padding: 1px 4px; border-radius: 4px; background: var(--nd-accent-soft); }
+.nd-md-pre { margin: 0 0 8px; padding: 8px 10px; overflow: auto; border-radius: 8px; background: var(--nd-accent-soft); border: 1px solid var(--nd-border); }
+.nd-md-pre code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.92em; white-space: pre; }
+.nd-md-hr { border: none; border-top: 1px solid var(--nd-border); margin: 10px 0; }
+.nd-md-link { color: var(--nd-accent); text-decoration: underline; cursor: pointer; }
+
+/* Per-message actions (copy · edit/regenerate): dim, revealed on hover. */
+.nd-msg-actions { display: flex; gap: 4px; margin-top: 5px; opacity: 0; transition: opacity 0.12s; }
+.nd-msg:hover .nd-msg-actions { opacity: 0.75; }
+.nd-msg-actions:hover { opacity: 1; }
+/* Persistent action rows (e.g. Undo highlights) stay visible without hover. */
+.nd-msg-actions--persist, .nd-msg:hover .nd-msg-actions--persist { opacity: 1; }
+
+/* Streaming "typing" indicator — three dots bouncing in progression. */
+.nd-typing { display: inline-flex; gap: 5px; align-items: center; padding: 4px 2px; }
+.nd-typing-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--nd-accent); opacity: 0.35; animation: nd-typing 1.2s infinite ease-in-out; }
+.nd-typing-dot:nth-child(2) { animation-delay: 0.18s; }
+.nd-typing-dot:nth-child(3) { animation-delay: 0.36s; }
+@keyframes nd-typing { 0%, 60%, 100% { opacity: 0.3; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-4px); } }
+.nd-msg--user .nd-msg-actions { justify-content: flex-end; }
+.nd-msg-act { border: none; background: transparent; cursor: pointer; color: var(--nd-muted); font-size: 12px; line-height: 1; padding: 2px 5px; border-radius: 5px; }
+.nd-msg-act:hover { background: var(--nd-accent-soft); color: var(--nd-accent); }
+
+/* Provider key row + delete-key button. */
+.nd-prov-keyrow { display: flex; gap: 6px; align-items: center; }
+.nd-prov-keyrow input { flex: 1 1 auto; min-width: 0; }
+.nd-prov-del { flex: 0 0 auto; width: 30px; height: 30px; border: 1px solid var(--nd-border); border-radius: 6px; background: transparent; color: var(--nd-muted); cursor: pointer; }
+.nd-prov-del:hover { color: #dc2626; border-color: rgba(239,68,68,0.4); background: rgba(239,68,68,0.08); }
+
+/* Inline SVG icons. */
+.nd-ico { display: inline-block; vertical-align: middle; flex: 0 0 auto; }
+.nd-iconbtn, .nd-sendbtn, .nd-msg-act, .nd-star, .nd-conv-del, .nd-prov-del { display: inline-flex; align-items: center; justify-content: center; }
+.nd-msg-act { gap: 3px; }
+.nd-hl-undo { gap: 4px; padding: 2px 8px; }
+.nd-conv-del .nd-ico { vertical-align: -2px; }
+
+/* Auto-highlight color pickers + undo action. */
+.nd-hl-colors { gap: 14px; align-items: center; }
+.nd-hl-color { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer; }
+.nd-hl-color input[type="color"] { width: 26px; height: 22px; border: 1px solid var(--nd-border); border-radius: 5px; padding: 0; background: none; cursor: pointer; }
+.nd-hl-undo { border: 1px solid var(--nd-accent-line); color: var(--nd-accent); }
+
+/* Long-document truncation notice. */
+.nd-doc-note { font-size: 11px; padding: 6px 9px; border-radius: 8px; border: 1px solid rgba(245,158,11,0.4); background: rgba(245,158,11,0.12); color: #b45309; }
+@media (prefers-color-scheme: dark) { .nd-doc-note { color: #fbbf24; } }

--- a/zotero-plugin/content/sidebar.html
+++ b/zotero-plugin/content/sidebar.html
@@ -14,6 +14,7 @@
       <button id="nd-close" class="nd-iconbtn nd-close" title="Close" aria-label="Close" data-i18n-title="close">✕</button>
     </header>
 
+    <div id="nd-body">
     <nav id="nd-tabs">
       <button class="nd-tab nd-tab--active" data-tab="chat" data-i18n="tab.chat">Chat</button>
       <button class="nd-tab" data-tab="providers" data-i18n="tab.providers">Providers</button>
@@ -25,8 +26,22 @@
       <div id="nd-chatbar">
         <button id="nd-new" class="nd-iconbtn" data-i18n-title="chat.new" title="New conversation">＋</button>
         <button id="nd-history-btn" class="nd-iconbtn" data-i18n-title="chat.history" title="Conversations">🕑</button>
+        <button id="nd-save-note" class="nd-iconbtn" data-i18n-title="chat.saveNote" title="Save chat as note">📝</button>
+        <button id="nd-highlight-btn" class="nd-iconbtn" data-i18n-title="hl.btn" title="Auto-highlight document">🖍️</button>
         <button id="nd-agent-btn" class="nd-iconbtn" data-i18n-title="agent.mode" title="Agent mode">🛠</button>
-        <select id="nd-model" title="Model"></select>
+        <div id="nd-model-dd" class="nd-dd">
+          <button id="nd-model-btn" class="nd-dd-btn" title="Model"><span id="nd-model-label">—</span></button>
+          <div id="nd-model-menu" class="nd-dd-menu" hidden>
+            <div class="nd-dd-search"><input id="nd-model-search" data-i18n-ph="model.search" placeholder="Search models…" /></div>
+            <div id="nd-model-list" class="nd-dd-list"></div>
+          </div>
+        </div>
+        <div id="nd-think-dd" class="nd-dd nd-dd--think">
+          <button id="nd-reasoning-btn" class="nd-iconbtn nd-think-btn" data-i18n-title="reasoning.title" title="Thinking"><span class="nd-think-ico" aria-hidden="true"></span><span id="nd-think-lvl" class="nd-think-lvl"></span></button>
+          <div id="nd-think-menu" class="nd-dd-menu nd-dd-menu--think" hidden>
+            <div id="nd-think-list" class="nd-dd-list"></div>
+          </div>
+        </div>
       </div>
       <div id="nd-item"></div>
       <div id="nd-selection" hidden></div>
@@ -70,6 +85,19 @@
         <div class="nd-muted" data-i18n="agent.hint">Each action asks for permission unless auto-approve is on.</div>
       </div>
       <div class="nd-field">
+        <label data-i18n="hl.title">Auto-highlight colors</label>
+        <div class="nd-row nd-hl-colors">
+          <label class="nd-hl-color"><input type="color" id="nd-hl-high" value="#ff6666" /> <span data-i18n="hl.high">Very important</span></label>
+          <label class="nd-hl-color"><input type="color" id="nd-hl-medium" value="#ffd400" /> <span data-i18n="hl.medium">Important</span></label>
+        </div>
+        <div class="nd-muted" data-i18n="hl.hint">Open the PDF in Zotero's reader, then use the 🖍️ button to highlight the most important passages.</div>
+      </div>
+      <div class="nd-field">
+        <label data-i18n="settings.maxTokens">Max response length</label>
+        <input id="nd-maxtokens" type="number" min="256" step="256" placeholder="8192" />
+        <div class="nd-muted" data-i18n="settings.maxTokensHint">Maximum tokens the model may generate per reply. Higher = longer answers.</div>
+      </div>
+      <div class="nd-field">
         <label data-i18n="settings.language">Language</label>
         <select id="nd-lang"><option value="en">English</option><option value="es">Español</option></select>
       </div>
@@ -94,6 +122,20 @@
       <div id="nd-history-list"></div>
       <button id="nd-history-clear" class="nd-danger" data-i18n="history.clearAll">Delete all conversations</button>
     </div>
+    </div><!-- /#nd-body -->
+
+    <!-- ADD PROMPT MODAL -->
+    <div id="nd-prompt-modal" class="nd-modal" hidden>
+      <div class="nd-modal-box">
+        <div class="nd-modal-title" data-i18n="prompt.newTitle">New prompt</div>
+        <input id="nd-prompt-title" class="nd-modal-input" data-i18n-ph="prompt.titlePh" placeholder="Title" />
+        <textarea id="nd-prompt-text" class="nd-modal-input" rows="4" data-i18n-ph="prompt.textPh" placeholder="Prompt text…"></textarea>
+        <div class="nd-modal-actions">
+          <button id="nd-prompt-cancel" class="nd-btn-ghost" data-i18n="modal.cancel">Cancel</button>
+          <button id="nd-prompt-save" class="nd-btn-primary" data-i18n="modal.save">Save</button>
+        </div>
+      </div>
+    </div>
 
     <!-- CONFIRM MODAL -->
     <div id="nd-modal" class="nd-modal" hidden>
@@ -106,9 +148,13 @@
       </div>
     </div>
   </div>
+  <script src="chrome://nodus/content/icons.js"></script>
   <script src="chrome://nodus/content/providers.js"></script>
   <script src="chrome://nodus/content/store.js"></script>
   <script src="chrome://nodus/content/agent.js"></script>
+  <script src="chrome://nodus/content/util.js"></script>
+  <script src="chrome://nodus/content/markdown.js"></script>
+  <script src="chrome://nodus/content/highlighter.js"></script>
   <script src="chrome://nodus/content/sidebar.js"></script>
 </body>
 </html>

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -9,6 +9,19 @@ const { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mj
 const NP = window.NodusProviders;
 const NS = window.NodusStore;
 const NA = window.NodusAgent;
+const NM = window.NodusMarkdown;
+const NU = window.NodusUtil;
+const NH = window.NodusHighlighter;
+const NI = window.NodusIcons;
+const ico = (name, size) => (NI ? NI.svg(name, { size: size || 16 }) : "");
+
+// Full-document context cap (~50k tokens): big enough for most modern models,
+// with a visible warning + head/tail sampling when a work is longer. See
+// NodusUtil.sampleDocText.
+const DOC_CHAR_LIMIT = 200000;
+// Animated "typing" indicator shown in the assistant bubble until the first token
+// arrives (the streaming code replaces it via textContent on the first delta).
+const TYPING_HTML = '<span class="nd-typing" aria-label="…"><span class="nd-typing-dot"></span><span class="nd-typing-dot"></span><span class="nd-typing-dot"></span></span>';
 
 const I18N = {
   en: {
@@ -29,16 +42,24 @@ const I18N = {
     "providers.sub": "Subscription — sign in through the Nodus app and use it in Link mode.",
     "providers.subCodex": "Uses your ChatGPT/Codex subscription credits. Sign in through the Nodus app and use it in Link mode.",
     "history.search": "Search conversations…", "history.clearAll": "Delete all conversations", "history.empty": "No conversations yet.",
-    "modal.cancel": "Cancel", "modal.delete": "Delete",
+    "modal.cancel": "Cancel", "modal.delete": "Delete", "modal.close": "Close",
+    "modal.save": "Save", "modal.highlight": "Highlight", "modal.enable": "Enable",
+    "confirm.saveNote": "Save this conversation as a note in Zotero?",
+    "confirm.highlight": "Analyze the whole document and highlight its most important passages? Highlights are added to the PDF and can be undone.",
+    "confirm.agentOn": "Enable Agent mode? Nodus will be able to act on your Zotero library (create notes, highlight, tag). Each action still asks for approval unless auto-approve is on.",
     "modal.delOne": "Delete this conversation? This cannot be undone.", "modal.delAll": "Delete ALL conversations? This cannot be undone.",
     "conn.on": "Connected", "conn.off": "Not connected",
     "conn.detailOn": "Connected to Nodus on port", "conn.detailOff": "Nodus server not found. Enable it in Nodus → Settings → Nodus for Zotero.",
     "item.none": "Select a document in Zotero.", "item.analyzed": "Full analysis in Nodus", "item.notAnalyzed": "Not analyzed in Nodus", "item.ideas": "ideas",
     "prompt.summary": "Summary", "prompt.ideas": "Main ideas", "prompt.connections": "Connections", "prompt.selection": "Explain selection", "prompt.quotes": "Key quotes",
     "p.summary": "Summarize this document.", "p.ideas": "What are the main ideas of this document?",
+    "p.explainSel": "Explain the selected passage in detail: what it means, its significance in the context of this document, and define any key terms or concepts it uses.",
     "p.connections": "Which items in my library connect to this one, and how?", "p.selection": "Explain the selected passage and its significance.",
-    "p.quotes": "Give the key quotes with their page numbers.",
+    "p.quotes": "Give the key quotes, with their page numbers when the document has them.",
     "close": "Close", "chat.prompts": "Prompt templates", "chat.stop": "Stop",
+    "prompt.addNew": "Add a prompt", "prompt.newTitle": "New prompt", "prompt.titlePh": "Title", "prompt.textPh": "Prompt text…",
+    "prompt.del": "Delete prompt", "prompt.untitled": "Untitled", "prompt.needBoth": "Add a title and prompt text.", "prompt.saved": "Prompt saved.",
+    "prompt.delConfirm": "Delete this prompt? This cannot be undone.",
     "prompt.methodology": "Methodology", "p.methodology": "Explain the methodology used and its strengths and weaknesses.",
     "prompt.critique": "Critique", "p.critique": "Give a critical appraisal: assumptions, limitations, and what would strengthen it.",
     "prompt.gaps": "Research gaps", "p.gaps": "What research gaps or open questions does this raise?",
@@ -58,8 +79,28 @@ const I18N = {
     "agent.allow": "Allow", "agent.deny": "Deny", "agent.enable": "Enable", "agent.acting": "Working…", "agent.denied": "Skipped",
     "agent.desc.note": "Create a note under this item", "agent.desc.noteStandalone": "Create a standalone note",
     "agent.desc.highlight": "Highlight the selected passage", "agent.desc.tags": "Add tags",
+    "agent.desc.collection": "Add this item to a collection", "agent.desc.field": "Set a field on this item", "agent.desc.extract": "Create a note from the PDF annotations",
     "agent.ok.note": "Note created ✓", "agent.ok.highlight": "Highlighted ✓", "agent.ok.tags": "Tags added ✓",
+    "agent.ok.collection": "Added to collection ✓", "agent.ok.field": "Field updated ✓", "agent.ok.extract": "Note from annotations ✓",
+    "agent.err.badField": "That field can't be edited from here.", "agent.err.noAnnotations": "No annotations in this PDF yet.", "agent.err.noName": "No collection name given.",
     "agent.fail": "Couldn't complete", "agent.needSel": "Select text in the reader first, then ask again.",
+    "chat.saveNote": "Save chat as note", "note.saved": "Chat saved as a Zotero note ✓", "note.empty": "Nothing to save yet — start a conversation first.",
+    "settings.maxTokens": "Max response length", "settings.maxTokensHint": "Maximum tokens the model may generate per reply. Higher = longer answers.",
+    "doc.truncated": "⚠ This document is long — only ~{pct}% was sent to the model ({sent} of {total} characters, beginning + end).",
+    "item.multi": "{n} documents selected",
+    "msg.copy": "Copy", "msg.edit": "Edit & resend", "msg.regenerate": "Regenerate",
+    "reasoning.title": "Thinking / reasoning effort (if the model supports it)",
+    "reasoning.default": "Auto", "reasoning.off": "Off", "reasoning.low": "Low", "reasoning.medium": "Medium", "reasoning.high": "High",
+    "hl.btn": "Auto-highlight the document", "hl.title": "Auto-highlight colors", "hl.high": "Very important", "hl.medium": "Important",
+    "hl.hint": "Open the PDF in Zotero's reader, then press 🖍️ to highlight the most important passages (red = very important, yellow = important).",
+    "hl.analyzing": "Reading the document and highlighting the most important passages…",
+    "hl.noReader": "Open the document in Zotero's PDF reader first, then press 🖍️ again.",
+    "hl.noText": "Couldn't read the document text.", "hl.noPassages": "The model didn't return any passages to highlight.",
+    "hl.result": "🖍️ Highlighted {n} passages — {high} very important (red), {medium} important (yellow).",
+    "hl.missed": "{n} couldn't be located in the PDF and were skipped.",
+    "hl.revert": "Undo highlights", "hl.reverted": "Highlights removed.",
+    "model.search": "Search models…", "model.pinHint": "— pin models in Providers —", "model.noMatch": "No models match.",
+    "prov.delKey": "Remove API key", "prov.delKeyConfirm": "Remove the saved {provider} API key? This can't be undone.",
     "providers.linkedMsg": "Providers are only used in Standalone mode. In Link mode, models come from Nodus — add or pin models in the Nodus app.",
     "agent.on": "Agent mode ON — Nodus can now propose actions on your Zotero (create notes, highlight, tag). It asks permission each time you chat.",
     "agent.off": "Agent mode off.",
@@ -82,16 +123,24 @@ const I18N = {
     "providers.sub": "Suscripción — inicia sesión en la app de Nodus y úsala en modo Link.",
     "providers.subCodex": "Usa los créditos de tu suscripción ChatGPT/Codex. Inicia sesión desde la app de Nodus y úsala en modo Link.",
     "history.search": "Buscar conversaciones…", "history.clearAll": "Eliminar todas las conversaciones", "history.empty": "Aún no hay conversaciones.",
-    "modal.cancel": "Cancelar", "modal.delete": "Eliminar",
+    "modal.cancel": "Cancelar", "modal.delete": "Eliminar", "modal.close": "Cerrar",
+    "modal.save": "Guardar", "modal.highlight": "Subrayar", "modal.enable": "Activar",
+    "confirm.saveNote": "¿Guardar esta conversación como nota en Zotero?",
+    "confirm.highlight": "¿Analizar todo el documento y subrayar sus pasajes más importantes? Los subrayados se añaden al PDF y se pueden deshacer.",
+    "confirm.agentOn": "¿Activar el modo Agente? Nodus podrá actuar sobre tu biblioteca de Zotero (crear notas, subrayar, etiquetar). Cada acción pide aprobación salvo que la aprobación automática esté activada.",
     "modal.delOne": "¿Eliminar esta conversación? No se puede deshacer.", "modal.delAll": "¿Eliminar TODAS las conversaciones? No se puede deshacer.",
     "conn.on": "Conectado", "conn.off": "Sin conexión",
     "conn.detailOn": "Conectado a Nodus en el puerto", "conn.detailOff": "No se encontró el servidor de Nodus. Actívalo en Nodus → Ajustes → Nodus para Zotero.",
     "item.none": "Selecciona un documento en Zotero.", "item.analyzed": "Análisis completo en Nodus", "item.notAnalyzed": "Sin analizar en Nodus", "item.ideas": "ideas",
     "prompt.summary": "Resumen", "prompt.ideas": "Ideas principales", "prompt.connections": "Conexiones", "prompt.selection": "Explicar selección", "prompt.quotes": "Citas clave",
     "p.summary": "Haz un resumen de este documento.", "p.ideas": "¿Cuáles son las ideas principales de este documento?",
+    "p.explainSel": "Explica en detalle el pasaje seleccionado: qué significa, su relevancia en el contexto de este documento, y define los términos o conceptos clave que usa.",
     "p.connections": "¿Qué ítems de mi biblioteca conectan con este y cómo?", "p.selection": "Explica el pasaje seleccionado y su relevancia.",
-    "p.quotes": "Dame las citas clave con su número de página.",
+    "p.quotes": "Dame las citas clave, con su número de página cuando el documento lo tenga.",
     "close": "Cerrar", "chat.prompts": "Plantillas de prompt", "chat.stop": "Detener",
+    "prompt.addNew": "Añadir un prompt", "prompt.newTitle": "Nuevo prompt", "prompt.titlePh": "Título", "prompt.textPh": "Texto del prompt…",
+    "prompt.del": "Eliminar prompt", "prompt.untitled": "Sin título", "prompt.needBoth": "Añade un título y el texto del prompt.", "prompt.saved": "Prompt guardado.",
+    "prompt.delConfirm": "¿Eliminar este prompt? No se puede deshacer.",
     "prompt.methodology": "Metodología", "p.methodology": "Explica la metodología usada y sus fortalezas y debilidades.",
     "prompt.critique": "Crítica", "p.critique": "Haz una valoración crítica: supuestos, limitaciones y qué lo reforzaría.",
     "prompt.gaps": "Huecos de investigación", "p.gaps": "¿Qué huecos de investigación o preguntas abiertas plantea?",
@@ -111,8 +160,28 @@ const I18N = {
     "agent.allow": "Permitir", "agent.deny": "Denegar", "agent.enable": "Activar", "agent.acting": "Trabajando…", "agent.denied": "Omitido",
     "agent.desc.note": "Crear una nota en este ítem", "agent.desc.noteStandalone": "Crear una nota independiente",
     "agent.desc.highlight": "Subrayar el pasaje seleccionado", "agent.desc.tags": "Añadir etiquetas",
+    "agent.desc.collection": "Añadir este ítem a una colección", "agent.desc.field": "Fijar un campo de este ítem", "agent.desc.extract": "Crear una nota con las anotaciones del PDF",
     "agent.ok.note": "Nota creada ✓", "agent.ok.highlight": "Subrayado ✓", "agent.ok.tags": "Etiquetas añadidas ✓",
+    "agent.ok.collection": "Añadido a la colección ✓", "agent.ok.field": "Campo actualizado ✓", "agent.ok.extract": "Nota con anotaciones ✓",
+    "agent.err.badField": "Ese campo no se puede editar desde aquí.", "agent.err.noAnnotations": "Este PDF aún no tiene anotaciones.", "agent.err.noName": "No se indicó el nombre de la colección.",
     "agent.fail": "No se pudo completar", "agent.needSel": "Selecciona texto en el lector primero y vuelve a pedirlo.",
+    "chat.saveNote": "Guardar chat como nota", "note.saved": "Chat guardado como nota de Zotero ✓", "note.empty": "Aún no hay nada que guardar — empieza una conversación.",
+    "settings.maxTokens": "Longitud máxima de respuesta", "settings.maxTokensHint": "Tokens máximos que el modelo puede generar por respuesta. Más = respuestas más largas.",
+    "doc.truncated": "⚠ Documento largo — solo se envió ~{pct}% al modelo ({sent} de {total} caracteres, principio + final).",
+    "item.multi": "{n} documentos seleccionados",
+    "msg.copy": "Copiar", "msg.edit": "Editar y reenviar", "msg.regenerate": "Regenerar",
+    "reasoning.title": "Razonamiento / esfuerzo de pensamiento (si el modelo lo permite)",
+    "reasoning.default": "Auto", "reasoning.off": "No", "reasoning.low": "Bajo", "reasoning.medium": "Medio", "reasoning.high": "Alto",
+    "hl.btn": "Auto-subrayar el documento", "hl.title": "Colores de auto-subrayado", "hl.high": "Muy importante", "hl.medium": "Importante",
+    "hl.hint": "Abre el PDF en el lector de Zotero y pulsa 🖍️ para subrayar los pasajes más importantes (rojo = muy importante, amarillo = importante).",
+    "hl.analyzing": "Leyendo el documento y subrayando los pasajes más importantes…",
+    "hl.noReader": "Abre primero el documento en el lector de PDF de Zotero y vuelve a pulsar 🖍️.",
+    "hl.noText": "No se pudo leer el texto del documento.", "hl.noPassages": "El modelo no devolvió pasajes para subrayar.",
+    "hl.result": "🖍️ Subrayados {n} pasajes — {high} muy importantes (rojo), {medium} importantes (amarillo).",
+    "hl.missed": "{n} no se pudieron localizar en el PDF y se omitieron.",
+    "hl.revert": "Deshacer subrayados", "hl.reverted": "Subrayados eliminados.",
+    "model.search": "Buscar modelos…", "model.pinHint": "— fija modelos en Proveedores —", "model.noMatch": "Ningún modelo coincide.",
+    "prov.delKey": "Eliminar API key", "prov.delKeyConfirm": "¿Eliminar la API key guardada de {provider}? No se puede deshacer.",
     "providers.linkedMsg": "Los proveedores solo se usan en modo Autónomo. En modo Link, los modelos vienen de Nodus — añade o fija modelos en la app de Nodus.",
     "agent.on": "Modo agente ACTIVADO — Nodus podrá proponer acciones sobre tu Zotero (crear notas, subrayar, etiquetar). Pedirá permiso cada vez que chatees.",
     "agent.off": "Modo agente desactivado.",
@@ -125,9 +194,13 @@ const state = {
   item: null, attachmentKey: null, selection: "", ideaLabels: {},
   conversations: [], conv: null, busy: false, lastItemKey: null, abort: null,
   agentEnabled: false, agentAuto: false, selectionDraft: null,
+  items: [], maxTokens: 8192, reasoning: "default", notifierID: null, pollTimer: null,
+  hlColors: { high: "#ff6666", medium: "#ffd400" }, lastHighlightKeys: [],
 };
 
 const t = (k) => (I18N[state.lang] && I18N[state.lang][k]) || I18N.en[k] || k;
+// t() with {placeholder} interpolation.
+const tf = (k, params) => t(k).replace(/\{(\w+)\}/g, (m, p) => (params && params[p] != null ? String(params[p]) : m));
 const $ = (s) => document.querySelector(s);
 const $$ = (s) => Array.from(document.querySelectorAll(s));
 const el = (tag, cls, txt) => { const e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; };
@@ -196,15 +269,43 @@ async function loadModelsForMode() {
   }
   const models = availableModels();
   const saved = NS.getModel(state.mode);
-  let chosen = models.find((m) => saved && m.provider === saved.provider && m.model === saved.model) || models[0] || null;
+  const chosen = models.find((m) => saved && m.provider === saved.provider && m.model === saved.model) || models[0] || null;
   state.model = chosen;
-  const sel = $("#nd-model");
-  sel.innerHTML = "";
-  if (!models.length) { const o = el("option", null, state.mode === "standalone" ? "— (pin models in Providers)" : "—"); o.value = ""; sel.appendChild(o); }
-  for (const m of models) { const o = el("option", null, m.model + "  ·  " + m.provider); o.value = m.provider + "::" + m.model; sel.appendChild(o); }
-  if (chosen) sel.value = chosen.provider + "::" + chosen.model;
+  renderModelDropdown();
   updateSendEnabled();
 }
+
+// Custom searchable model dropdown (replaces the native <select>).
+function modelBtnLabel() {
+  return state.model ? state.model.model : (state.mode === "standalone" ? t("model.pinHint") : "—");
+}
+function renderModelDropdown() {
+  const label = $("#nd-model-label"); if (label) label.textContent = modelBtnLabel();
+  const list = $("#nd-model-list"); if (!list) return;
+  list.innerHTML = "";
+  const models = availableModels();
+  const filter = (($("#nd-model-search") && $("#nd-model-search").value) || "").toLowerCase();
+  if (!models.length) { list.appendChild(el("div", "nd-dd-empty", t("model.pinHint"))); return; }
+  let shown = 0;
+  for (const m of models) {
+    const labelStr = m.model + " · " + m.provider;
+    if (filter && labelStr.toLowerCase().indexOf(filter) < 0) continue;
+    const sel = state.model && state.model.provider === m.provider && state.model.model === m.model;
+    const it = el("div", "nd-dd-item" + (sel ? " nd-dd-item--sel" : ""));
+    it.appendChild(el("span", "nd-dd-model", m.model));
+    it.appendChild(el("span", "nd-dd-prov", m.provider));
+    it.addEventListener("click", () => {
+      state.model = { provider: m.provider, model: m.model };
+      NS.setModel(state.mode, state.model);
+      closeModelMenu(); renderModelDropdown(); updateSendEnabled();
+    });
+    list.appendChild(it); shown++;
+  }
+  if (!shown) list.appendChild(el("div", "nd-dd-empty", t("model.noMatch")));
+}
+function openModelMenu() { const m = $("#nd-model-menu"); if (!m) return; m.hidden = false; const s = $("#nd-model-search"); if (s) { s.value = ""; } renderModelDropdown(); if (s) s.focus(); }
+function closeModelMenu() { const m = $("#nd-model-menu"); if (m) m.hidden = true; }
+function toggleModelMenu() { const m = $("#nd-model-menu"); if (!m) return; if (m.hidden) openModelMenu(); else closeModelMenu(); }
 
 // ─────────────────────────────────────────── current Zotero item
 function activeReader() {
@@ -221,12 +322,44 @@ function getCurrentItem() {
   } catch (e) {}
   return { item: null, attachment: null, reader: null };
 }
+// Info for every item currently selected in the library (for multi-item chat).
+// Regular items only; a single reader tab is handled by getCurrentItem.
+function getSelectedItemInfos() {
+  try {
+    const w = Zotero.getMainWindow();
+    const zp = (w && w.ZoteroPane) || (Zotero.getActiveZoteroPane && Zotero.getActiveZoteroPane());
+    const sel = zp && zp.getSelectedItems ? zp.getSelectedItems() : [];
+    const infos = [];
+    for (let it of sel || []) {
+      if (it.isAttachment && it.isAttachment()) { if (it.parentItem) it = it.parentItem; else continue; }
+      if (it.isNote && it.isNote()) continue;
+      const info = { key: it.key };
+      try { info.title = it.getDisplayTitle ? it.getDisplayTitle() : it.getField("title"); } catch (e) {}
+      try { info.year = it.getField("date") ? String(it.getField("date")).slice(0, 4) : ""; } catch (e) {}
+      try { info.creators = it.getField("firstCreator") || ""; } catch (e) {}
+      try { info.abstract = it.getField("abstractNote") || ""; } catch (e) {}
+      infos.push(info);
+    }
+    return infos;
+  } catch (e) { return []; }
+}
 async function refreshItem(force) {
   const cur = getCurrentItem();
   const key = cur.item ? cur.item.key : null;
-  if (!force && key === state.lastItemKey) return;
-  state.lastItemKey = key;
+  // Track multi-selection independently of the single focused item.
+  state.items = cur.reader ? [] : getSelectedItemInfos();
+  const multiKey = state.items.length > 1 ? state.items.map((i) => i.key).join(",") : key;
+  if (!force && multiKey === state.lastItemKey) return;
+  state.lastItemKey = multiKey;
   const box = $("#nd-item");
+  if (state.items.length > 1) {
+    state.item = null; state.attachmentKey = null;
+    box.innerHTML = "";
+    box.appendChild(el("div", "nd-item-title", tf("item.multi", { n: state.items.length })));
+    const names = state.items.slice(0, 6).map((i) => i.title || i.key).join(" · ") + (state.items.length > 6 ? " …" : "");
+    box.appendChild(el("div", "nd-muted", names));
+    return;
+  }
   if (!cur.item) { state.item = null; state.attachmentKey = null; box.textContent = t("item.none"); return; }
   let title = "", doi = "";
   try { title = cur.item.getDisplayTitle ? cur.item.getDisplayTitle() : cur.item.getField("title"); } catch (e) {}
@@ -248,20 +381,90 @@ async function getDocumentText() {
   try {
     const cur = getCurrentItem(); let att = cur.attachment;
     if (!att && cur.item && cur.item.getBestAttachment) att = await cur.item.getBestAttachment();
-    if (att) { const text = await att.attachmentText; if (text) return String(text).slice(0, 120000); }
+    // Return the raw text (bounded to keep memory sane); send() then head/tail-
+    // samples it to DOC_CHAR_LIMIT and warns the user if it had to trim.
+    if (att) { const text = await att.attachmentText; if (text) return String(text).slice(0, 2000000); }
   } catch (e) {}
   return "";
 }
 
 // ─────────────────────────────────────────── messages + citations
 const messagesEl = () => $("#nd-messages");
-function addMessage(role, text) {
+// `index` is the message's position in state.conv.messages; when given, a small
+// action row (copy · edit/regenerate) is attached. Streaming/transient bubbles
+// pass no index and get their actions attached on completion.
+function addMessage(role, text, index) {
   const wrap = el("div", "nd-msg nd-msg--" + role);
   wrap.appendChild(el("div", "nd-who", role === "user" ? t("you") : t("nodus")));
   const body = el("div", "nd-body"); body.textContent = text; wrap.appendChild(body);
+  if (index != null) attachMessageActions(wrap, role, index, text);
   const hint = messagesEl().querySelector(".nd-hint"); if (hint) hint.remove();
   messagesEl().appendChild(wrap); messagesEl().scrollTop = messagesEl().scrollHeight;
   return body;
+}
+function attachMessageActions(wrap, role, index, rawText) {
+  const row = el("div", "nd-msg-actions");
+  const copy = el("button", "nd-msg-act"); copy.innerHTML = ico("copy", 14); copy.title = t("msg.copy");
+  copy.addEventListener("click", () => { if (copyToClipboard(rawText)) { copy.innerHTML = ico("check", 14); setTimeout(() => { copy.innerHTML = ico("copy", 14); }, 1200); } });
+  row.appendChild(copy);
+  if (role === "user") {
+    const edit = el("button", "nd-msg-act"); edit.innerHTML = ico("pencil", 14); edit.title = t("msg.edit");
+    edit.addEventListener("click", () => editUserMessage(index));
+    row.appendChild(edit);
+  } else {
+    const regen = el("button", "nd-msg-act"); regen.innerHTML = ico("refresh", 14); regen.title = t("msg.regenerate");
+    regen.addEventListener("click", () => { regenerateFrom(index).catch((e) => { try { Zotero.logError(e); } catch (x) {} }); });
+    row.appendChild(regen);
+  }
+  wrap.appendChild(row);
+}
+function copyToClipboard(text) {
+  const s = String(text == null ? "" : text);
+  try {
+    Components.classes["@mozilla.org/widget/clipboardhelper;1"].getService(Components.interfaces.nsIClipboardHelper).copyString(s);
+    return true;
+  } catch (e) {
+    try { Zotero.Utilities.Internal.copyTextToClipboard(s); return true; } catch (x) { return false; }
+  }
+}
+// Rebuild the whole thread from state.conv.messages (with per-message actions +
+// fresh indices). Used after edit/regenerate truncate the conversation.
+function rerenderConversation() {
+  messagesEl().innerHTML = "";
+  if (!state.conv || !state.conv.messages.length) { const h = el("div", "nd-hint"); h.textContent = t("chat.hint"); messagesEl().appendChild(h); return; }
+  state.conv.messages.forEach((m, i) => {
+    const b = addMessage(m.role, m.content, i);
+    if (m.role === "assistant") { b.setAttribute("data-raw", m.content); renderRich(b, m.content); }
+  });
+}
+// Reload the user message into the composer and drop it + everything after, so
+// the user can edit and resend.
+function editUserMessage(index) {
+  if (state.busy || !state.conv) return;
+  const m = state.conv.messages[index];
+  if (!m || m.role !== "user") return;
+  const inp = $("#nd-input");
+  inp.value = m.content;
+  state.conv.messages = state.conv.messages.slice(0, index);
+  rerenderConversation();
+  inp.focus();
+  persistConv().catch(() => {});
+}
+// Drop this assistant reply (and anything after it) and generate a fresh one for
+// the same prior user turn.
+async function regenerateFrom(index) {
+  if (state.busy || !state.conv) return;
+  state.conv.messages = state.conv.messages.slice(0, index);
+  if (!state.conv.messages.length) return;
+  rerenderConversation();
+  await generateAssistant();
+}
+// Persistent inline notice that a long document was only partially sent.
+function addDocNote(info) {
+  const note = el("div", "nd-doc-note");
+  const pct = Math.max(1, Math.round((info.ratio || 0) * 100));
+  note.textContent = tf("doc.truncated", { pct, sent: (info.sentChars || 0).toLocaleString(), total: (info.totalChars || 0).toLocaleString() });
+  messagesEl().appendChild(note); messagesEl().scrollTop = messagesEl().scrollHeight;
 }
 function renderCitations(bodyEl, text) {
   bodyEl.textContent = "";
@@ -269,6 +472,13 @@ function renderCitations(bodyEl, text) {
   let last = 0, m;
   while ((m = re.exec(text)) !== null) { if (m.index > last) bodyEl.appendChild(document.createTextNode(text.slice(last, m.index))); bodyEl.appendChild(makeCite(m[1], m[2].trim(), m[3])); last = re.lastIndex; }
   if (last < text.length) bodyEl.appendChild(document.createTextNode(text.slice(last)));
+}
+// Render an assistant message: formatted Markdown with clickable Nodus citation
+// chips. Falls back to plain citation rendering if the markdown module is absent.
+function renderRich(bodyEl, text) {
+  bodyEl.classList.add("nd-md");
+  if (NM && NM.render) { try { NM.render(bodyEl, text, makeCite); return; } catch (e) { try { Zotero.logError(e); } catch (x) {} } }
+  renderCitations(bodyEl, text);
 }
 function makeCite(kind, id, label) {
   const chip = el("a", "nd-cite");
@@ -304,58 +514,161 @@ async function persistConv() {
   if (i >= 0) state.conversations[i] = state.conv; else state.conversations.unshift(state.conv);
   await NS.saveConversations(state.conversations);
 }
+// Save the current conversation as a Zotero note (child of the open item, or a
+// standalone note when nothing is open). Reuses the agent's create_note path.
+async function saveConversationAsNote() {
+  if (!state.conv || !state.conv.messages.length || !NU || !NA) { showToast(t("note.empty")); return; }
+  const title = state.conv.title || (state.conv.messages.find((m) => m.role === "user") || {}).content || "Nodus chat";
+  const body = NU.conversationToHtml(state.conv, { you: t("you"), nodus: t("nodus") });
+  const cur = getCurrentItem();
+  const action = { tool: "create_note", title: String(title).slice(0, 120), body, standalone: !cur.item };
+  const res = await NA.execute(action, { item: cur.item, attachment: cur.attachment });
+  showToast(res && res.ok ? t("note.saved") : t("agent.fail"));
+}
 function loadConversation(id) {
   const c = state.conversations.find((x) => x.id === id);
   if (!c) return;
   state.conv = c;
-  messagesEl().innerHTML = "";
-  for (const m of c.messages) { const b = addMessage(m.role, m.content); if (m.role === "assistant") { b.setAttribute("data-raw", m.content); renderCitations(b, m.content); } }
+  rerenderConversation();
   closeHistory();
+}
+
+// ─────────────────────────────────────────── auto-highlight
+const HL_SYSTEM =
+  "You pick the most important passages of a document to highlight for a student. " +
+  "Read the DOCUMENT TEXT and choose the passages that matter most, as EXACT verbatim quotes copied from the text — do NOT paraphrase, keep the exact wording so they can be located in the PDF. " +
+  "Assign each a level: 'high' for the few MOST important (core thesis, key definitions, critical findings/conclusions) and 'medium' for important supporting points. " +
+  "Prefer a single sentence or a short clause per passage (never a whole paragraph). Return between 8 and 25 passages. " +
+  'Respond with ONLY a JSON array and nothing else: [{"text":"exact quote","level":"high|medium"}].';
+const hlUser = (doc) => 'DOCUMENT TEXT:\n"""\n' + doc + '\n"""\n\nReturn the JSON array of the most important passages to highlight.';
+
+async function fetchHighlightsStandalone(doc, signal) {
+  const key = NS.getKey(state.model.provider);
+  const localBase = NS.getLocalBase(state.model.provider);
+  let acc = "";
+  await NP.chatStream(state.model, { system: HL_SYSTEM, key, localBase, maxTokens: state.maxTokens, reasoning: state.reasoning, messages: [{ role: "user", content: hlUser(doc) }] }, (d) => { acc += d; }, signal);
+  return NH.parsePassages(acc);
+}
+async function fetchHighlightsConnected(doc, signal) {
+  const res = await api("/api/z/highlight", { method: "POST", body: JSON.stringify({ model: state.model, documentText: doc, reasoning: state.reasoning }), signal });
+  if (!res.ok) throw new Error("HTTP " + res.status);
+  const d = await res.json();
+  return Array.isArray(d.passages) ? d.passages : [];
+}
+async function autoHighlight() {
+  if (state.busy || !NH) return;
+  if (!currentModel()) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.noModel")); return; }
+  if (state.mode === "connected" && !state.connected) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.offline")); return; }
+  if (!NH.getReaderPdf()) { if (!state.conv) startNewConversation(); addMessage("assistant", t("hl.noReader")); return; }
+  if (!state.conv) startNewConversation();
+  state.busy = true; state.abort = new AbortController(); updateSendEnabled();
+  const bodyEl = addMessage("assistant", t("hl.analyzing"));
+  try {
+    const raw = await getDocumentText();
+    const docInfo = NU ? NU.sampleDocText(raw, DOC_CHAR_LIMIT) : { text: raw };
+    if (!docInfo.text) { bodyEl.textContent = t("hl.noText"); return; }
+    const passages = state.mode === "connected" ? await fetchHighlightsConnected(docInfo.text, state.abort.signal) : await fetchHighlightsStandalone(docInfo.text, state.abort.signal);
+    if (!passages || !passages.length) { bodyEl.textContent = t("hl.noPassages"); return; }
+    const res = NH.highlightPassages(passages, state.hlColors);
+    if (res.error === "no-reader") { bodyEl.textContent = t("hl.noReader"); return; }
+    if (res.error === "no-text") { bodyEl.textContent = t("hl.noText"); return; }
+    renderHighlightResult(bodyEl, res);
+  } catch (e) {
+    const aborted = e && (e.name === "AbortError" || String(e).toLowerCase().includes("abort"));
+    bodyEl.textContent = aborted ? "⏹" : "⚠ " + (e && e.message ? e.message : e);
+  } finally {
+    state.busy = false; state.abort = null; updateSendEnabled();
+  }
+}
+function renderHighlightResult(bodyEl, res) {
+  const applied = res.applied || [], missed = res.missed || [];
+  const high = applied.filter((a) => a.level === "high").length;
+  let msg = tf("hl.result", { n: applied.length, high, medium: applied.length - high });
+  if (missed.length) msg += " " + tf("hl.missed", { n: missed.length });
+  bodyEl.textContent = msg;
+  const keys = applied.map((a) => a.key).filter(Boolean);
+  if (!keys.length) return;
+  state.lastHighlightKeys = keys;
+  const row = el("div", "nd-msg-actions nd-msg-actions--persist");
+  const undo = el("button", "nd-msg-act nd-hl-undo"); undo.innerHTML = ico("undo", 14); undo.appendChild(document.createTextNode(" " + t("hl.revert")));
+  undo.addEventListener("click", () => { try { NH.revert(keys); } catch (e) {} showToast(t("hl.reverted")); undo.remove(); });
+  row.appendChild(undo);
+  bodyEl.parentNode.appendChild(row);
 }
 
 // ─────────────────────────────────────────── send
 async function send(text) {
   if (!text || !text.trim() || state.busy) return;
-  const model = currentModel();
-  if (!model) { addMessage("assistant", t("chat.noModel")); return; }
-  if (state.mode === "connected" && !state.connected) { addMessage("assistant", t("chat.offline")); return; }
+  if (!currentModel()) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.noModel")); return; }
+  if (state.mode === "connected" && !state.connected) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.offline")); return; }
   if (!state.conv) startNewConversation();
-  state.busy = true; state.abort = new AbortController(); updateSendEnabled();
-  addMessage("user", text);
-  state.conv.messages.push({ role: "user", content: text });
-
-  const bodyEl = addMessage("assistant", "");
-  let acc = "";
-  try {
-    if (state.mode === "connected") acc = await sendConnected(bodyEl, state.abort.signal);
-    else acc = await sendStandalone(bodyEl, state.abort.signal);
-  } catch (e) {
-    const aborted = e && (e.name === "AbortError" || String(e).toLowerCase().includes("abort"));
-    acc = bodyEl.textContent || acc;
-    if (!aborted) acc = (acc ? acc + "\n\n" : "") + "⚠ " + (e && e.message ? e.message : e);
-    else if (!acc) acc = "⏹";
-    bodyEl.textContent = acc;
-  }
-  let display = acc;
-  if (state.agentEnabled && NA && acc) {
-    const parsed = NA.parseActions(acc);
-    if (parsed.actions.length) { display = parsed.clean || acc; renderActionCards(bodyEl, parsed.actions); }
-  }
-  bodyEl.setAttribute("data-raw", display);
-  renderCitations(bodyEl, display);
-  state.conv.messages.push({ role: "assistant", content: display });
-  await persistConv();
-  state.busy = false; state.abort = null; updateSendEnabled();
+  const uidx = state.conv.messages.push({ role: "user", content: text }) - 1;
+  addMessage("user", text, uidx);
+  await generateAssistant();
 }
 
-async function sendConnected(bodyEl, signal) {
+// Streams an assistant reply for the current conversation tail (which must end
+// in a user message). Shared by send() and regenerateFrom().
+async function generateAssistant() {
+  if (!currentModel()) { addMessage("assistant", t("chat.noModel")); return; }
+  if (state.mode === "connected" && !state.connected) { addMessage("assistant", t("chat.offline")); return; }
+  state.busy = true; state.abort = new AbortController(); updateSendEnabled();
+
+  // Wrapped in try/finally so state.busy ALWAYS resets — otherwise a throw in the
+  // post-stream steps (renderRich, parseActions, persistConv) would leave the
+  // composer permanently disabled ("stuck button").
+  const bodyEl = addMessage("assistant", "");
+  bodyEl.innerHTML = TYPING_HTML; // animated dots until the first token streams in
+  let acc = "";
+  try {
+    // Sample the open document ONCE (both modes share it) and warn if the work is
+    // too long to send whole, instead of silently truncating.
+    let docInfo = { text: "", truncated: false };
+    if (NS.getContext().useFulltext) {
+      const raw = await getDocumentText();
+      docInfo = NU ? NU.sampleDocText(raw, DOC_CHAR_LIMIT) : { text: raw, truncated: false };
+      if (docInfo.truncated) addDocNote(docInfo);
+    }
+    try {
+      if (state.mode === "connected") acc = await sendConnected(bodyEl, state.abort.signal, docInfo);
+      else acc = await sendStandalone(bodyEl, state.abort.signal, docInfo);
+    } catch (e) {
+      const aborted = e && (e.name === "AbortError" || String(e).toLowerCase().includes("abort"));
+      acc = (bodyEl.textContent && bodyEl.textContent !== "") ? bodyEl.textContent : acc;
+      if (!aborted) acc = (acc ? acc + "\n\n" : "") + "⚠ " + (e && e.message ? e.message : e);
+      else if (!acc) acc = "⏹";
+      bodyEl.textContent = acc;
+    }
+    let display = acc;
+    let actions = null;
+    if (state.agentEnabled && NA && acc) {
+      const parsed = NA.parseActions(acc);
+      if (parsed.actions.length) { display = parsed.clean || acc; actions = parsed.actions; }
+    }
+    if (!display) bodyEl.textContent = ""; // clear the dots if nothing came back
+    bodyEl.setAttribute("data-raw", display);
+    renderRich(bodyEl, display);
+    if (actions) renderActionCards(bodyEl, actions);
+    const aidx = state.conv.messages.push({ role: "assistant", content: display }) - 1;
+    attachMessageActions(bodyEl.parentNode, "assistant", aidx, display);
+    await persistConv();
+  } catch (e) {
+    try { Zotero.logError(e); } catch (x) {}
+    if (bodyEl.querySelector(".nd-typing")) bodyEl.textContent = "⚠ " + (e && e.message ? e.message : e);
+  } finally {
+    state.busy = false; state.abort = null; updateSendEnabled();
+  }
+}
+
+async function sendConnected(bodyEl, signal, docInfo) {
   const ctx = NS.getContext();
+  const extraContext = NU ? NU.buildItemsSummary(state.items) : "";
   const payload = {
     model: state.model,
     messages: state.conv.messages.map((m) => ({ role: m.role, content: m.content })),
-    context: { zoteroKey: state.item ? state.item.key : "", doi: state.item ? state.item.doi : "", title: state.item ? state.item.title : "", selection: state.selection || "", useIdeas: ctx.useIdeas, useCorpus: ctx.useCorpus, agentInstructions: state.agentEnabled && NA ? NA.SYSTEM : "" },
+    context: { zoteroKey: state.item ? state.item.key : "", doi: state.item ? state.item.doi : "", title: state.item ? state.item.title : "", selection: state.selection || "", useIdeas: ctx.useIdeas, useCorpus: ctx.useCorpus, agentInstructions: state.agentEnabled && NA ? NA.SYSTEM : "", extraContext, reasoning: state.reasoning },
   };
-  if (ctx.useFulltext) { const d = await getDocumentText(); if (d) payload.context.documentText = d; }
+  if (docInfo && docInfo.text) payload.context.documentText = docInfo.text;
   const res = await api("/api/z/chat/stream", { method: "POST", body: JSON.stringify(payload), signal });
   if (!res.ok || !res.body) throw new Error("HTTP " + res.status);
   let acc = ""; const reader = res.body.getReader(); const dec = new TextDecoder(); let buf = "";
@@ -374,19 +687,23 @@ async function sendConnected(bodyEl, signal) {
   return acc;
 }
 
-async function sendStandalone(bodyEl, signal) {
-  const ctx = NS.getContext();
+async function sendStandalone(bodyEl, signal, docInfo) {
   const parts = [];
   if (state.item && state.item.title) parts.push("Open document: " + state.item.title);
+  const itemsSummary = NU ? NU.buildItemsSummary(state.items) : "";
+  if (itemsSummary) parts.push(itemsSummary);
   if (state.selection) parts.push('The user highlighted this passage (focus on it):\n"""\n' + state.selection + '\n"""');
-  if (ctx.useFulltext) { const d = await getDocumentText(); if (d) parts.push('Document text:\n"""\n' + d.slice(0, 60000) + '\n"""'); }
-  let system = "You are a research assistant embedded in Zotero. Answer about the open document, grounded in the provided text. Be concise and answer in the user's language.\n\n" + parts.join("\n\n");
+  if (docInfo && docInfo.text) parts.push('Document text:\n"""\n' + docInfo.text + '\n"""');
+  // Pin the reply language: some models (e.g. deepseek) otherwise drift to their
+  // training language even for an English/Spanish question.
+  const lang = state.lang === "es" ? "Spanish" : "English";
+  let system = "You are a research assistant embedded in Zotero. Answer about the open document, grounded in the provided text. Be concise. Always answer in " + lang + " unless the user's last message is clearly in another language, in which case match that language.\n\n" + parts.join("\n\n");
   if (state.agentEnabled && NA) system += "\n\n" + NA.SYSTEM;
   const key = NS.getKey(state.model.provider);
   const localBase = NS.getLocalBase(state.model.provider);
   let acc = "";
   await NP.chatStream(state.model, {
-    system, key, localBase,
+    system, key, localBase, maxTokens: state.maxTokens, reasoning: state.reasoning,
     messages: state.conv.messages.map((m) => ({ role: m.role, content: m.content })),
   }, (delta) => { acc += delta; bodyEl.textContent = acc; messagesEl().scrollTop = messagesEl().scrollHeight; }, signal);
   return acc;
@@ -418,7 +735,26 @@ async function renderProviders() {
     const inp = el("input"); inp.type = p.needsKey ? "password" : "text";
     inp.placeholder = p.needsKey ? t("providers.key") : t("providers.baseUrl") + " (" + (p.defaultBase || "") + ")";
     inp.value = p.needsKey ? NS.getKey(p.id) : NS.getLocalBase(p.id);
-    inp.addEventListener("change", () => { if (p.needsKey) NS.setKey(p.id, inp.value.trim()); else NS.setLocalBase(p.id, inp.value.trim()); dot.className = "nd-prov-dot" + ((p.needsKey ? inp.value.trim() : true) ? " nd-prov-dot--on" : ""); });
+    // key/baseUrl row: input + (for key providers) a delete button.
+    const keyRow = el("div", "nd-prov-keyrow"); keyRow.appendChild(inp);
+    let delKey = null;
+    if (p.needsKey) {
+      delKey = el("button", "nd-prov-del"); delKey.innerHTML = ico("trash", 15); delKey.title = t("prov.delKey"); delKey.type = "button";
+      delKey.style.display = NS.getKey(p.id) ? "" : "none";
+      delKey.addEventListener("click", async (ev) => {
+        ev.stopPropagation();
+        if (await showConfirm(tf("prov.delKeyConfirm", { provider: p.label }))) {
+          NS.setKey(p.id, ""); inp.value = ""; delKey.style.display = "none";
+          dot.className = "nd-prov-dot";
+        }
+      });
+      keyRow.appendChild(delKey);
+    }
+    inp.addEventListener("change", () => {
+      if (p.needsKey) NS.setKey(p.id, inp.value.trim()); else NS.setLocalBase(p.id, inp.value.trim());
+      dot.className = "nd-prov-dot" + ((p.needsKey ? inp.value.trim() : true) ? " nd-prov-dot--on" : "");
+      if (delKey) delKey.style.display = inp.value.trim() ? "" : "none";
+    });
     const actions = el("div", "nd-prov-actions");
     const loadBtn = el("button", "nd-btn-ghost", t("providers.load"));
     const modelsBox = el("div", "nd-prov-models");
@@ -432,7 +768,7 @@ async function renderProviders() {
       finally { loadBtn.textContent = t("providers.load"); loadBtn.disabled = false; }
     });
     actions.appendChild(loadBtn);
-    body.appendChild(inp); body.appendChild(actions); body.appendChild(modelsBox);
+    body.appendChild(keyRow); body.appendChild(actions); body.appendChild(modelsBox);
     head.addEventListener("click", (e) => { if (e.target === inp) return; body.classList.toggle("nd-prov-body--open"); });
     card.appendChild(head); card.appendChild(body); wrap.appendChild(card);
   }
@@ -440,10 +776,12 @@ async function renderProviders() {
 function modelRow(provider, id, countEl) {
   const row = el("div", "nd-model-row");
   const ref = { provider, model: id };
-  const star = el("span", "nd-star" + (NS.isPinned(ref) ? " nd-star--on" : ""), "★");
+  const star = el("span", "nd-star" + (NS.isPinned(ref) ? " nd-star--on" : ""));
+  star.innerHTML = ico(NS.isPinned(ref) ? "star" : "star-line");
   star.addEventListener("click", () => {
     NS.togglePinned(ref);
     star.className = "nd-star" + (NS.isPinned(ref) ? " nd-star--on" : "");
+    star.innerHTML = ico(NS.isPinned(ref) ? "star" : "star-line");
     if (countEl) countEl.textContent = String(NS.getPinned().filter((m) => m.provider === provider).length || "");
     if (state.mode === "standalone") loadModelsForMode();
   });
@@ -467,17 +805,26 @@ function renderHistory(filter) {
     main.appendChild(el("div", "nd-conv-title", c.title || "Conversation"));
     main.appendChild(el("div", "nd-conv-meta", new Date(c.updatedAt).toLocaleString() + " · " + (c.mode === "standalone" ? t("mode.standalone") : t("mode.linkTag"))));
     main.addEventListener("click", () => loadConversation(c.id));
-    const del = el("span", "nd-conv-del", "🗑");
+    const del = el("span", "nd-conv-del"); del.innerHTML = ico("trash", 15);
     del.addEventListener("click", async (e) => { e.stopPropagation(); if (await showConfirm(t("modal.delOne"))) { state.conversations = state.conversations.filter((x) => x.id !== c.id); await NS.saveConversations(state.conversations); if (state.conv && state.conv.id === c.id) startNewConversation(); renderHistory($("#nd-history-search").value); } });
     row.appendChild(main); row.appendChild(del); list.appendChild(row);
   }
 }
-function showConfirm(msg, okLabel) {
+// Generic confirm modal. opts.danger === false renders the OK button in the
+// accent colour (for non-destructive actions like Save / Highlight / Enable).
+function showConfirm(msg, okLabel, opts) {
+  opts = opts || {};
+  const danger = opts.danger !== false;
   return new Promise((resolve) => {
     $("#nd-modal-msg").textContent = msg; $("#nd-modal").hidden = false;
     const ok = $("#nd-modal-ok"), cancel = $("#nd-modal-cancel");
     ok.textContent = okLabel || t("modal.delete");
-    const done = (v) => { $("#nd-modal").hidden = true; ok.onclick = null; cancel.onclick = null; ok.textContent = t("modal.delete"); resolve(v); };
+    ok.classList.toggle("nd-danger", danger); ok.classList.toggle("nd-btn-primary", !danger);
+    const done = (v) => {
+      $("#nd-modal").hidden = true; ok.onclick = null; cancel.onclick = null;
+      ok.textContent = t("modal.delete"); ok.classList.add("nd-danger"); ok.classList.remove("nd-btn-primary");
+      resolve(v);
+    };
     ok.onclick = () => done(true); cancel.onclick = () => done(false);
   });
 }
@@ -493,7 +840,7 @@ function renderActionCards(bodyEl, actions) {
   const wrap = bodyEl.parentNode;
   for (const action of actions) {
     const card = el("div", "nd-action");
-    card.appendChild(el("div", "nd-action-desc", "🛠 " + NA.describe(action, t)));
+    const desc = el("div", "nd-action-desc"); desc.innerHTML = ico("bot", 14); desc.appendChild(document.createTextNode(" " + NA.describe(action, t))); card.appendChild(desc);
     if (state.agentAuto) { runAction(action, card); }
     else {
       const btns = el("div", "nd-action-btns");
@@ -514,8 +861,20 @@ async function runAction(action, card) {
   status.className = "nd-action-status " + (res.ok ? "nd-action-ok" : "nd-action-err");
   status.textContent = res.ok ? okMsg(action) : (t("agent.fail") + (res.message ? " — " + friendlyErr(res.message) : ""));
 }
-function okMsg(a) { return a.tool === "create_note" ? t("agent.ok.note") : a.tool === "highlight" ? t("agent.ok.highlight") : a.tool === "add_tags" ? t("agent.ok.tags") : "✓"; }
-function friendlyErr(m) { return (m === "no-selection" || m === "no-attachment") ? t("agent.needSel") : m; }
+function okMsg(a) {
+  const map = {
+    create_note: "agent.ok.note", highlight: "agent.ok.highlight", add_tags: "agent.ok.tags",
+    add_to_collection: "agent.ok.collection", set_field: "agent.ok.field", extract_annotations_note: "agent.ok.extract",
+  };
+  return map[a.tool] ? t(map[a.tool]) : "✓";
+}
+function friendlyErr(m) {
+  if (m === "no-selection" || m === "no-attachment") return t("agent.needSel");
+  if (m === "bad-field") return t("agent.err.badField");
+  if (m === "no-annotations") return t("agent.err.noAnnotations");
+  if (m === "no-name") return t("agent.err.noName");
+  return m;
+}
 
 // ─────────────────────────────────────────── mode + i18n + wiring
 function renderMode() {
@@ -539,12 +898,41 @@ async function setMode(m) {
   await loadModelsForMode();
   startNewConversation();
 }
+// Swap the static toolbar/composer/header glyphs for inline SVG icons.
+function applyIcons() {
+  if (!NI) return;
+  const set = (sel, name, size) => { const e = $(sel); if (e) e.innerHTML = ico(name, size); };
+  set("#nd-new", "plus"); set("#nd-history-btn", "history"); set("#nd-save-note", "file");
+  set("#nd-highlight-btn", "highlighter"); set("#nd-agent-btn", "bot"); set("#nd-prompt-btn", "sparkles");
+  set("#nd-send", "send", 15); set("#nd-stop", "square", 14); set("#nd-close", "x");
+  set("#nd-history-close", "x"); set(".nd-think-ico", "idea", 15);
+}
 function applyI18n() {
   $$("[data-i18n]").forEach((n) => (n.textContent = t(n.getAttribute("data-i18n"))));
   $$("[data-i18n-ph]").forEach((n) => n.setAttribute("placeholder", t(n.getAttribute("data-i18n-ph"))));
   $$("[data-i18n-title]").forEach((n) => n.setAttribute("title", t(n.getAttribute("data-i18n-title"))));
   renderPromptMenu();
+  renderReasoningSelect();
 }
+// Build the reasoning-effort dropdown (in the Thinking modal) and mirror the
+// current level onto the chat-bar button.
+function renderReasoningSelect() {
+  const levels = (NP && NP.REASONING_LEVELS) || ["default", "off", "low", "medium", "high"];
+  const list = $("#nd-think-list");
+  if (list) {
+    list.innerHTML = "";
+    for (const lv of levels) {
+      const it = el("div", "nd-dd-item" + (state.reasoning === lv ? " nd-dd-item--sel" : ""));
+      it.appendChild(el("span", "nd-dd-model", t("reasoning." + lv)));
+      it.addEventListener("click", () => { state.reasoning = lv; NS.setReasoning(lv); closeThinkMenu(); renderReasoningSelect(); });
+      list.appendChild(it);
+    }
+  }
+  const lbl = $("#nd-think-lvl"); if (lbl) lbl.textContent = t("reasoning." + state.reasoning);
+}
+function openThinkMenu() { const m = $("#nd-think-menu"); if (!m) return; renderReasoningSelect(); m.hidden = false; }
+function closeThinkMenu() { const m = $("#nd-think-menu"); if (m) m.hidden = true; }
+function toggleThinkMenu() { const m = $("#nd-think-menu"); if (!m) return; if (m.hidden) openThinkMenu(); else closeThinkMenu(); }
 function promptDefs() {
   const defs = [];
   if (state.selection) defs.push(["prompt.selection", "p.selection"]);
@@ -558,6 +946,26 @@ function promptDefs() {
 // the composer (does not send), per the requested UX.
 function renderPromptMenu() {
   const menu = $("#nd-prompt-menu"); if (!menu) return; menu.innerHTML = "";
+  // "add a prompt" action — first, at the top
+  const add = el("div", "nd-menu-item nd-menu-add");
+  add.innerHTML = ico("plus", 14); add.appendChild(document.createTextNode(" " + t("prompt.addNew")));
+  add.onclick = (e) => { e.stopPropagation(); openPromptModal(); };
+  menu.appendChild(add);
+  // user-defined prompts (right below Add), each with a delete button
+  const custom = NS.getCustomPrompts ? NS.getCustomPrompts() : [];
+  for (const cp of custom) {
+    const item = el("div", "nd-menu-item nd-menu-item--custom");
+    const txt = el("div", "nd-menu-txt");
+    txt.appendChild(el("div", "nd-menu-title", cp.title || t("prompt.untitled")));
+    txt.appendChild(el("div", "nd-menu-sub", cp.prompt));
+    txt.onclick = () => { insertPrompt(cp.prompt); togglePromptMenu(false); };
+    item.appendChild(txt);
+    const del = el("button", "nd-menu-del"); del.innerHTML = ico("trash", 13); del.title = t("prompt.del");
+    del.onclick = async (e) => { e.stopPropagation(); if (!(await showConfirm(t("prompt.delConfirm"), t("modal.delete")))) return; NS.removeCustomPrompt(cp.id); renderPromptMenu(); };
+    item.appendChild(del);
+    menu.appendChild(item);
+  }
+  // built-in templates
   for (const [lk, pk] of promptDefs()) {
     const item = el("div", "nd-menu-item");
     item.appendChild(el("div", "nd-menu-title", t(lk)));
@@ -565,6 +973,21 @@ function renderPromptMenu() {
     item.onclick = () => { insertPrompt(t(pk)); togglePromptMenu(false); };
     menu.appendChild(item);
   }
+}
+function openPromptModal() {
+  togglePromptMenu(false);
+  $("#nd-prompt-title").value = ""; $("#nd-prompt-text").value = "";
+  $("#nd-prompt-modal").hidden = false; $("#nd-prompt-title").focus();
+}
+function closePromptModal() { $("#nd-prompt-modal").hidden = true; }
+function savePrompt() {
+  const title = $("#nd-prompt-title").value.trim();
+  const text = $("#nd-prompt-text").value.trim();
+  if (!title || !text) { showToast(t("prompt.needBoth")); return; }
+  NS.addCustomPrompt(title, text);
+  closePromptModal();
+  renderPromptMenu(); // rebuild so the new prompt shows next time the ✦ menu opens
+  showToast(t("prompt.saved"));
 }
 function insertPrompt(text) {
   const inp = $("#nd-input");
@@ -581,7 +1004,7 @@ function showSelection() {
   const box = $("#nd-selection");
   if (!state.selection) { box.hidden = true; box.innerHTML = ""; return; }
   box.hidden = false; box.innerHTML = "";
-  const clr = el("span", "nd-conv-del", "✕ " + t("sel.clear")); clr.style.float = "right"; clr.onclick = () => { state.selection = ""; showSelection(); renderPromptMenu(); };
+  const clr = el("span", "nd-conv-del"); clr.innerHTML = ico("x", 13); clr.appendChild(document.createTextNode(" " + t("sel.clear"))); clr.style.float = "right"; clr.onclick = () => { state.selection = ""; showSelection(); renderPromptMenu(); };
   box.appendChild(clr); box.appendChild(el("div", null, "“" + state.selection.slice(0, 400) + (state.selection.length > 400 ? "…" : "") + "”"));
 }
 let toastTimer = null;
@@ -608,12 +1031,31 @@ function wire() {
   $("#nd-stop").addEventListener("click", stopStreaming);
   $("#nd-close").addEventListener("click", closeSidebar);
   $("#nd-prompt-btn").addEventListener("click", () => togglePromptMenu());
+  $("#nd-prompt-save").addEventListener("click", savePrompt);
+  $("#nd-prompt-cancel").addEventListener("click", closePromptModal);
+  $("#nd-prompt-modal").addEventListener("click", (e) => { if (e.target === $("#nd-prompt-modal")) closePromptModal(); });
   $("#nd-input").addEventListener("keydown", (e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); const v = $("#nd-input").value; $("#nd-input").value = ""; send(v); } });
   // dismiss the prompt menu on outside click
-  document.addEventListener("click", (e) => { const menu = $("#nd-prompt-menu"); if (!menu || menu.hidden) return; if (!menu.contains(e.target) && e.target.id !== "nd-prompt-btn") togglePromptMenu(false); });
-  $("#nd-model").addEventListener("change", (e) => { const [p, m] = e.target.value.split("::"); state.model = p && m ? { provider: p, model: m } : null; NS.setModel(state.mode, state.model); updateSendEnabled(); });
+  document.addEventListener("click", (e) => { const menu = $("#nd-prompt-menu"); if (!menu || menu.hidden) return; if (!menu.contains(e.target) && !(e.target.closest && e.target.closest("#nd-prompt-btn"))) togglePromptMenu(false); });
+  $("#nd-model-btn").addEventListener("click", (e) => { e.stopPropagation(); toggleModelMenu(); });
+  $("#nd-model-search").addEventListener("input", renderModelDropdown);
+  $("#nd-model-search").addEventListener("click", (e) => e.stopPropagation());
+  document.addEventListener("click", (e) => { const dd = $("#nd-model-dd"); if (dd && !dd.contains(e.target)) closeModelMenu(); });
   $("#nd-lang").addEventListener("change", (e) => { state.lang = e.target.value === "es" ? "es" : "en"; NS.setLang(state.lang); applyI18n(); renderMode(); });
+  $("#nd-maxtokens").addEventListener("change", (e) => { const n = parseInt(e.target.value, 10); state.maxTokens = Number.isFinite(n) && n > 0 ? n : 8192; NS.setMaxTokens(state.maxTokens); e.target.value = state.maxTokens; });
+  $("#nd-reasoning-btn").addEventListener("click", (e) => { e.stopPropagation(); toggleThinkMenu(); });
+  document.addEventListener("click", (e) => { const dd = $("#nd-think-dd"); if (dd && !dd.contains(e.target)) closeThinkMenu(); });
   $("#nd-new").addEventListener("click", () => startNewConversation());
+  $("#nd-save-note").addEventListener("click", async () => {
+    if (!(await showConfirm(t("confirm.saveNote"), t("modal.save"), { danger: false }))) return;
+    saveConversationAsNote().catch((e) => { try { Zotero.logError(e); } catch (x) {} });
+  });
+  $("#nd-highlight-btn").addEventListener("click", async () => {
+    if (!(await showConfirm(t("confirm.highlight"), t("modal.highlight"), { danger: false }))) return;
+    autoHighlight().catch((e) => { try { Zotero.logError(e); } catch (x) {} });
+  });
+  $("#nd-hl-high").addEventListener("change", saveHlColors);
+  $("#nd-hl-medium").addEventListener("change", saveHlColors);
   $("#nd-history-btn").addEventListener("click", openHistory);
   $("#nd-history-close").addEventListener("click", closeHistory);
   $("#nd-history-search").addEventListener("input", (e) => renderHistory(e.target.value));
@@ -622,27 +1064,74 @@ function wire() {
   $("#nd-ctx-ideas").addEventListener("change", saveContext);
   $("#nd-ctx-corpus").addEventListener("change", saveContext);
   $("#nd-test").addEventListener("click", () => { NS.setManual($("#nd-port").value, $("#nd-token").value.trim()); connect().then(loadModelsForMode); });
-  window.addEventListener("message", (e) => { if (e.data && e.data.type === "nodus-selection") { state.selection = String(e.data.text || ""); state.selectionDraft = e.data.draft || null; switchTab("chat"); showSelection(); renderPromptMenu(); } });
-  $("#nd-agent-btn").addEventListener("click", () => setAgentEnabled(!state.agentEnabled, true));
+  window.addEventListener("message", (e) => {
+    if (!e.data || e.data.type !== "nodus-selection") return;
+    state.selection = String(e.data.text || ""); state.selectionDraft = e.data.draft || null;
+    switchTab("chat"); showSelection(); renderPromptMenu();
+    if (e.data.action === "explain") send(t("p.explainSel"));
+  });
+  $("#nd-agent-btn").addEventListener("click", async () => {
+    if (!state.agentEnabled) { if (!(await showConfirm(t("confirm.agentOn"), t("modal.enable"), { danger: false }))) return; }
+    setAgentEnabled(!state.agentEnabled, true);
+  });
   $("#nd-agent").addEventListener("change", (e) => setAgentEnabled(e.target.checked, true));
   $("#nd-agent-auto").addEventListener("change", async (e) => {
     if (e.target.checked) { const ok = await showConfirm(t("agent.autoConfirm"), t("agent.enable")); if (!ok) { e.target.checked = false; return; } }
     state.agentAuto = e.target.checked; NS.setAgentAuto(state.agentAuto);
   });
-  setInterval(() => { refreshItem(false).catch(() => {}); }, 1200);
+  registerNotifier();
+  // Fallback poll ONLY for library list-selection, which Zotero exposes no
+  // public event for. Tab switches and item edits arrive instantly via the
+  // Notifier below, so this can be slow.
+  state.pollTimer = setInterval(() => scheduleRefresh(false), 2000);
 }
 function saveContext() { NS.setContext({ useFulltext: $("#nd-ctx-fulltext").checked, useIdeas: $("#nd-ctx-ideas").checked, useCorpus: $("#nd-ctx-corpus").checked }); }
+function saveHlColors() { state.hlColors = { high: $("#nd-hl-high").value || "#ff6666", medium: $("#nd-hl-medium").value || "#ffd400" }; NS.setHlColors(state.hlColors); }
+
+// Coalesced refresh so a burst of Notifier events (e.g. during sync) triggers a
+// single refreshItem. force=true re-resolves even when the item key is unchanged.
+let refreshTimer = null, refreshForce = false;
+function scheduleRefresh(force) {
+  refreshForce = refreshForce || !!force;
+  if (refreshTimer) return;
+  refreshTimer = setTimeout(() => { const f = refreshForce; refreshTimer = null; refreshForce = false; refreshItem(f).catch(() => {}); }, 200);
+}
+// Event-driven refresh: 'select' (tab/collection change) refreshes if the item
+// changed; 'modify'/'add'/'delete' force a re-resolve so the analysis badge and
+// multi-selection summary stay current without constant polling.
+function registerNotifier() {
+  try {
+    if (!Zotero.Notifier || !Zotero.Notifier.registerObserver) return;
+    const observer = {
+      notify(event) {
+        if (event === "select") scheduleRefresh(false);
+        else if (event === "modify" || event === "add" || event === "delete") scheduleRefresh(true);
+      },
+    };
+    state.notifierID = Zotero.Notifier.registerObserver(observer, ["item", "tab", "collection"], "nodus-sidebar");
+    window.addEventListener("unload", () => {
+      try { if (state.notifierID) Zotero.Notifier.unregisterObserver(state.notifierID); } catch (e) {}
+      try { if (state.pollTimer) clearInterval(state.pollTimer); } catch (e) {}
+    });
+  } catch (e) { try { Zotero.logError(e); } catch (x) {} }
+}
 
 async function boot() {
   state.mode = NS.getMode(); state.lang = NS.getLang();
+  state.maxTokens = NS.getMaxTokens();
+  state.reasoning = NS.getReasoning();
+  state.hlColors = NS.getHlColors();
   const ctx = NS.getContext();
   wire();
   $("#nd-lang").value = state.lang;
+  $("#nd-maxtokens").value = state.maxTokens;
+  $("#nd-hl-high").value = state.hlColors.high; $("#nd-hl-medium").value = state.hlColors.medium;
   const m = NS.getManual(); $("#nd-port").value = m.port || ""; $("#nd-token").value = m.token || "";
   $("#nd-ctx-fulltext").checked = ctx.useFulltext; $("#nd-ctx-ideas").checked = ctx.useIdeas; $("#nd-ctx-corpus").checked = ctx.useCorpus;
   state.agentEnabled = NS.getAgent(); state.agentAuto = NS.getAgentAuto();
   $("#nd-agent").checked = state.agentEnabled; $("#nd-agent-auto").checked = state.agentAuto;
   $("#nd-agent-btn").classList.toggle("nd-iconbtn--active", state.agentEnabled);
+  applyIcons();
   applyI18n();
   renderMode();
   state.conversations = await NS.loadConversations();

--- a/zotero-plugin/content/store.js
+++ b/zotero-plugin/content/store.js
@@ -22,6 +22,14 @@
   function setLang(l) { S("lang", l); }
   function getModel(mode) { return PJSON("model." + mode, null); }
   function setModel(mode, ref) { SJSON("model." + mode, ref); }
+  function getMaxTokens() { const n = Number(P("maxTokens", 0)); return Number.isFinite(n) && n > 0 ? n : 8192; }
+  function setMaxTokens(v) { const n = Number(v); S("maxTokens", Number.isFinite(n) && n > 0 ? Math.floor(n) : 8192); }
+  const REASONING = ["default", "off", "low", "medium", "high"];
+  function getReasoning() { const v = P("reasoning", "default"); return REASONING.includes(v) ? v : "default"; }
+  function setReasoning(v) { S("reasoning", REASONING.includes(v) ? v : "default"); }
+  // Auto-highlight colors: high = MUY IMPORTANTE, medium = IMPORTANTE.
+  function getHlColors() { const c = PJSON("hlColors", null); return { high: (c && c.high) || "#ff6666", medium: (c && c.medium) || "#ffd400" }; }
+  function setHlColors(c) { SJSON("hlColors", { high: (c && c.high) || "#ff6666", medium: (c && c.medium) || "#ffd400" }); }
   function getContext() {
     return { useIdeas: P("ctx.ideas", "1") !== "0", useCorpus: P("ctx.corpus", "1") !== "0", useFulltext: P("ctx.fulltext", "1") !== "0" };
   }
@@ -42,6 +50,16 @@
     setPinned(arr);
     return arr;
   }
+
+  // ---- custom prompts (user-defined templates for the ✦ menu) ----
+  function getCustomPrompts() { const a = PJSON("customPrompts", []); return Array.isArray(a) ? a : []; }
+  function setCustomPrompts(arr) { SJSON("customPrompts", Array.isArray(arr) ? arr : []); }
+  function addCustomPrompt(title, prompt) {
+    const a = getCustomPrompts();
+    a.push({ id: "up_" + Date.now() + "_" + Math.random().toString(36).slice(2, 6), title: String(title || "").trim(), prompt: String(prompt || "").trim() });
+    setCustomPrompts(a); return a;
+  }
+  function removeCustomPrompt(id) { setCustomPrompts(getCustomPrompts().filter((p) => p.id !== id)); }
 
   // ---- agent mode ----
   function getAgent() { return P("agent", "0") === "1"; }
@@ -68,8 +86,9 @@
   function newId() { return "c_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8); }
 
   window.NodusStore = {
-    getMode, setMode, getLang, setLang, getModel, setModel, getContext, setContext,
+    getMode, setMode, getLang, setLang, getModel, setModel, getMaxTokens, setMaxTokens, getReasoning, setReasoning, getHlColors, setHlColors, getContext, setContext,
     getKey, setKey, getLocalBase, setLocalBase, getPinned, setPinned, isPinned, togglePinned,
+    getCustomPrompts, setCustomPrompts, addCustomPrompt, removeCustomPrompt,
     getAgent, setAgent, getAgentAuto, setAgentAuto,
     getManual, setManual, loadConversations, saveConversations, newId,
   };

--- a/zotero-plugin/content/util.js
+++ b/zotero-plugin/content/util.js
@@ -1,0 +1,66 @@
+/* Nodus for Zotero — small pure helpers shared by the sidebar. Kept out of
+ * sidebar.js so they can be unit-tested in Node with no DOM/Zotero. No side
+ * effects, no globals beyond window.NodusUtil.
+ */
+/* eslint-disable no-undef */
+(function () {
+  "use strict";
+
+  const OMIT = "\n\n[… omitted middle of a long document …]\n\n";
+
+  // Clamp document text to `limit` chars WITHOUT silently dropping the end:
+  // when a work is too long we keep the head AND the tail (abstract/intro +
+  // conclusions), joined by a visible omission marker, instead of the old
+  // head-only slice that made the model answer about a book having seen only
+  // its first pages. Returns { text, truncated, sentChars, totalChars, ratio }.
+  function sampleDocText(text, limit) {
+    const s = String(text == null ? "" : text);
+    const max = limit > 0 ? limit : 200000;
+    const total = s.length;
+    if (total <= max) return { text: s, truncated: false, sentChars: total, totalChars: total, ratio: 1 };
+    const budget = Math.max(0, max - OMIT.length);
+    const headLen = Math.floor(budget * 0.7);
+    const tailLen = budget - headLen;
+    const out = s.slice(0, headLen) + OMIT + s.slice(total - tailLen);
+    return { text: out, truncated: true, sentChars: out.length, totalChars: total, ratio: max / total };
+  }
+
+  function esc(v) {
+    return String(v == null ? "" : v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  // Render a stored conversation as note HTML (for "save chat as note").
+  // labels = { you, nodus }. Pure string→string.
+  function conversationToHtml(conv, labels) {
+    const you = (labels && labels.you) || "You";
+    const nodus = (labels && labels.nodus) || "Nodus";
+    const rows = [];
+    for (const m of (conv && conv.messages) || []) {
+      if (!m || !m.content) continue;
+      const who = m.role === "user" ? you : nodus;
+      const body = esc(m.content).replace(/\n/g, "<br/>");
+      rows.push('<p><b>' + esc(who) + ':</b> ' + body + '</p>');
+    }
+    return rows.join("\n");
+  }
+
+  // Compact multi-item context block: one line per selected item with title,
+  // creators, year and (trimmed) abstract. Used when the user has several items
+  // selected in Zotero so the model can compare/relate them. Pure.
+  function buildItemsSummary(items, opts) {
+    const list = Array.isArray(items) ? items.filter(Boolean) : [];
+    if (list.length < 2) return "";
+    const maxAbstract = (opts && opts.maxAbstract) || 600;
+    const lines = list.map((it, idx) => {
+      const bits = [String(idx + 1) + ". " + (it.title || it.key || "Untitled")];
+      if (it.creators) bits.push("— " + it.creators);
+      if (it.year) bits.push("(" + it.year + ")");
+      let head = bits.join(" ");
+      if (it.abstract) head += "\n   " + String(it.abstract).replace(/\s+/g, " ").slice(0, maxAbstract);
+      return head;
+    });
+    return "SELECTED DOCUMENTS (the user selected " + list.length + " items — you may compare, relate and reference them):\n" + lines.join("\n");
+  }
+
+  window.NodusUtil = { sampleDocText, conversationToHtml, buildItemsSummary };
+})();

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "0.0.7",
+  "version": "0.0.16",
   "description": "Nodus research assistant integrated into Zotero. Proof-of-concept: adds a toolbar button.",
   "author": "Nodus",
   "applications": {


### PR DESCRIPTION
Closes #202.

Grows the first-party **Nodus for Zotero** plugin into a full in-reader research assistant.

## Chat
- Markdown rendering of assistant replies
- Copy / edit-and-resend / regenerate on messages; animated typing indicator while streaming
- Searchable model dropdown and a Thinking (reasoning-effort) dropdown
- Configurable max response length; fixes silent truncation of long documents
- Save a conversation as a Zotero note; history view that keeps the plugin header visible
- User-defined prompt templates (add via modal, delete with confirmation)
- Confirmation modals before Save-as-note, Auto-highlight, and enabling Agent mode

## Agent mode
- Expanded tool set acting on the Zotero library with per-action approval (or opt-in auto-approve)

## AI auto-highlighter
- Analyses the whole item and highlights the most important passages directly in Zotero's PDF reader (red = very important, yellow = important; colours configurable), with a one-click Undo

## Reader selection popup
- Nodus icon + localized Cite / Explain / Translate; Translate streams inline with a searchable language picker

## Infrastructure
- Inline SVG icon set (CSP-safe), connected-mode highlight/translate server endpoints
- xpi packaging script (`npm run zotero:xpi`) + CI workflow
- Unit test suite (`node --test scripts/test-zotero-plugin.mjs`) — 27/27 passing

## Testing
- `node --test scripts/test-zotero-plugin.mjs` → 27/27
- `tsc --noEmit -p electron/tsconfig.json` → clean
- Verified end-to-end in Zotero 9 (chat streaming, agent write actions, auto-highlight + undo, reader popup translate)

Branch is already merged up to date with `main`; no conflicts.