### PR TITLE
Send Zotero prompts with Enter

### DIFF
--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -349,6 +349,20 @@ test('#10: message-action buttons live-render via the real fake-DOM path', () =>
   assert.ok(src.includes('nsIClipboardHelper'), 'copy uses the clipboard helper XPCOM');
 });
 
+test('composer: Enter sends and Alt+Enter keeps the textarea newline', () => {
+  const src = readSource('zotero-plugin/content/sidebar.js');
+  assert.match(
+    src,
+    /e\.key === "Enter" && !e\.altKey\)\s*\{\s*e\.preventDefault\(\);/,
+    'plain Enter is intercepted for sending while Alt+Enter keeps its default newline',
+  );
+  assert.doesNotMatch(
+    src,
+    /e\.key === "Enter" && \(e\.metaKey \|\| e\.ctrlKey\)/,
+    'sending no longer requires Ctrl/Command',
+  );
+});
+
 // ─────────────────────────────────────────── auto-highlighter engine (pure)
 test('highlighter: parsePassages extracts {text,level} robustly', () => {
   const { NodusHighlighter: H } = loadModule('highlighter.js');

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -1034,7 +1034,7 @@ function wire() {
   $("#nd-prompt-save").addEventListener("click", savePrompt);
   $("#nd-prompt-cancel").addEventListener("click", closePromptModal);
   $("#nd-prompt-modal").addEventListener("click", (e) => { if (e.target === $("#nd-prompt-modal")) closePromptModal(); });
-  $("#nd-input").addEventListener("keydown", (e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); const v = $("#nd-input").value; $("#nd-input").value = ""; send(v); } });
+  $("#nd-input").addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.altKey) { e.preventDefault(); const v = $("#nd-input").value; $("#nd-input").value = ""; send(v); } });
   // dismiss the prompt menu on outside click
   document.addEventListener("click", (e) => { const menu = $("#nd-prompt-menu"); if (!menu || menu.hidden) return; if (!menu.contains(e.target) && !(e.target.closest && e.target.closest("#nd-prompt-btn"))) togglePromptMenu(false); });
   $("#nd-model-btn").addEventListener("click", (e) => { e.stopPropagation(); toggleModelMenu(); });


### PR DESCRIPTION
## Summary

- send the Zotero composer prompt when pressing `Enter`
- preserve multiline input with `Alt+Enter`
- add regression coverage for both keyboard behaviors

## Root cause

The composer keydown handler only sent prompts when `Ctrl` or `Command` was held, so plain `Enter` retained the textarea's newline behavior.

## User impact

Prompt submission now follows the intended shortcut while multiline prompts remain available through `Alt+Enter`.

## Validation

- `node --test scripts/test-zotero-plugin.mjs` (29 tests passed)
- `git diff origin/main...HEAD --check`

Closes #207