### PR TITLE
feat(zotero): add grounded retrieval and multimodal evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Download the installer for your computer and open it. There is no server to conf
 
 The standalone Zotero plugin is available from the same release as [nodus-zotero.xpi](https://github.com/Drakonis96/nodus/releases/latest/download/nodus-zotero.xpi). In Zotero, open **Tools → Add-ons**, choose **Install Add-on From File**, and select the downloaded file.
 
+The plugin indexes the complete text of selected PDF, EPUB and HTML attachments, combines semantic and lexical retrieval across documents, and attaches exact passage/page citations to its answers. Its evidence audit flags uncited or weakly supported claims. For PDFs, **Vision** reads the rendered page—including scanned text, figures, tables, formulas and diagrams—and merges the extraction into the searchable index; **Index** applies the same OCR fallback to text-poor pages.
+
 The [latest release page](https://github.com/Drakonis96/nodus/releases/latest) always contains the newest available installers and release notes.
 
 ## Share a vault with Nodus Server

--- a/docs/zotero-plugin-evidence-multimodal-plan.md
+++ b/docs/zotero-plugin-evidence-multimodal-plan.md
@@ -1,0 +1,90 @@
+# Nodus for Zotero: evidence retrieval and multimodal reading
+
+## Outcome
+
+The plugin must answer against the complete set of selected Zotero attachments
+without silently dropping the middle of long documents. Answers must cite an
+evidence object that resolves to an exact stored passage, page, section and
+source item. PDF pages and selected regions must also be usable as visual
+context so scanned text, figures, tables, equations and diagrams can be read.
+
+## Evidence pipeline
+
+1. Read the complete attachment:
+   - PDF through `Zotero.PDFWorker.getFullText`, preserving form-feed page
+     boundaries.
+   - EPUB, HTML and plain text through Zotero's complete full-text cache.
+2. Split every logical page/section into overlapping, sentence-aligned chunks.
+   Each chunk stores an immutable evidence id, attachment/item keys, title,
+   page index/label, section, offsets and exact text.
+3. Persist indexes per attachment in the Zotero profile. Invalidate them when
+   the attachment modification time, size or text signature changes.
+4. Create embeddings in batches when the selected provider supports them.
+   Combine cosine similarity with BM25-style lexical scoring. If embeddings
+   are unavailable, lexical retrieval remains functional and the chat model
+   continues to provide explicit lexical retrieval with a visible status.
+5. Diversify results across documents and include neighbouring chunks when
+   needed. Small source sets can use complete-text mode; large source sets use
+   retrieval while retaining on-demand access to every indexed chunk.
+6. Give the model an explicit evidence catalogue and require
+   `[[e:EVIDENCE_ID]]` citations.
+
+## Citation contract and audit
+
+- Only ids in the catalogue sent for the current answer are accepted.
+- Page, idea, gap and Zotero tokens are also checked against their respective
+  allow-lists. Invalid tokens are removed before rendering.
+- Every accepted evidence citation resolves to the exact stored passage and
+  opens its Zotero source/page.
+- The client segments the answer into factual claims, measures citation
+  coverage and flags missing or weakly related support.
+- Each answer exposes an expandable evidence audit containing claims, exact
+  quotations, source titles, sections and pages.
+- The catalogue and audit travel with conversation history, so reopening a
+  conversation cannot silently bind old citations to a different document.
+
+## Multimodal pipeline
+
+1. Capture the current rendered PDF page or the rectangle associated with a
+   text/image selection and resize it to a bounded JPEG data URL.
+2. Attach one or more captures to chat requests using provider-native vision
+   message content.
+3. Offer visual extraction that returns structured OCR plus descriptions of
+   figures, tables, equations and diagrams. Store that extraction against the
+   source page and add it to the searchable evidence index.
+4. Mark pages with little or no extracted text as visual/OCR candidates. A
+   user-triggered scan walks those pages, restores the reader position and
+   updates the index incrementally.
+5. Use a page capture automatically as a fallback when the current PDF page has
+   no useful extracted text.
+6. EPUB and HTML attachments participate in complete-text indexing; visual
+   capture is PDF-specific because Zotero exposes a rendered PDF canvas.
+
+## Product controls
+
+- Context strategy: Auto, semantic retrieval or complete text.
+- Embedding model setting with provider-aware defaults.
+- Index selected/open sources, rebuild stale indexes and show progress.
+- Attach current page, index visual page and OCR text-poor pages.
+- Clear indication of active sources, indexed chunks, visual attachments and
+  whether semantic or lexical retrieval was used.
+- Cancellation and bounded document/image/batch sizes.
+
+## Verification gates
+
+- Unit tests for page splitting, section/chunk offsets, BM25, cosine/hybrid
+  ranking, source diversity, citation allow-listing, claim coverage and visual
+  feature parsing.
+- Provider tests for embeddings and multimodal request bodies.
+- Packaging tests for every new module.
+- Connected-server tests for evidence catalogues and images.
+- Syntax, lint, typecheck, build and the complete repository test suite.
+- Live Zotero 9 install/update smoke test:
+  - index a normal PDF and a multi-document selection;
+  - retrieve a passage from the middle/end and open its citation;
+  - reject a fabricated citation;
+  - attach and analyse a page containing visual content;
+  - OCR/index a text-poor page;
+  - reopen the conversation and audit its sources.
+- A low-cost real-provider run checks semantic ranking, answer coherence,
+  passage support and multimodal interpretation.

--- a/electron/zotero-plugin/server.ts
+++ b/electron/zotero-plugin/server.ts
@@ -23,8 +23,9 @@ import { getWorkByZoteroKey, getWorkByDoi, getWorkByAliasKey } from '../db/works
 import { searchCopilotIdeas, searchCopilotPassages } from '../ai/liveRelations';
 import { completeTextStream } from '../ai/aiClient';
 import { getActiveVault } from '../vaults/vaultRegistry';
+import type { VisionImagePart } from '@shared/imageAnalysis';
 
-const MAX_REQUEST_BYTES = 4 * 1024 * 1024; // documents can be large
+const MAX_REQUEST_BYTES = 20 * 1024 * 1024; // full text plus several bounded page images
 
 let httpServer: Server | null = null;
 let status: ZoteroPluginServerStatus = { running: false, port: null, url: null, error: null };
@@ -144,6 +145,7 @@ function featuredModels(): { models: ModelRef[]; default: ModelRef | null } {
 
 const CITE_INSTRUCTIONS = [
   'CITATION RULES — cite sources inline using these exact tokens (the reader turns them into clickable chips):',
+  '• Retrieved or complete Zotero evidence: [[e:PASSAGE_ID]]. Use only ids present in ZOTERO EVIDENCE and put citations immediately after supported sentences.',
   '• A page of the OPEN DOCUMENT: [[p:N]] where N is the page label/number. Only cite pages that appear in the provided document text or passages.',
   '• A Nodus idea: [[idea:GLOBAL_ID]] using an id from the "NODUS IDEAS" list below.',
   '• A Nodus research gap: [[gap:GAP_ID]] using an id from the "NODUS GAPS" list below.',
@@ -229,6 +231,7 @@ function buildPrompt(body: Record<string, unknown>, ctx: ChatContext): { system:
   const context = (body.context && typeof body.context === 'object' ? body.context : {}) as Record<string, unknown>;
   const itemTitle = typeof context.title === 'string' ? context.title : ctx.work?.title ?? '';
   const documentText = typeof context.documentText === 'string' ? context.documentText : '';
+  const evidenceText = typeof context.evidenceText === 'string' ? context.evidenceText : '';
   const selection = typeof context.selection === 'string' ? context.selection : '';
   const extraContext = typeof context.extraContext === 'string' ? context.extraContext : '';
 
@@ -237,12 +240,18 @@ function buildPrompt(body: Record<string, unknown>, ctx: ChatContext): { system:
     .filter((m) => m && (m.role === 'user' || m.role === 'assistant') && typeof m.content === 'string')
     .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
     .join('\n\n');
+  const lastUser = [...messages].reverse().find((m) => m?.role === 'user')?.content ?? '';
+  const normalizedLast = lastUser.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+  const spanishSignals = (normalizedLast.match(/\b(que|como|segun|documento|pagina|explica|describe|distingue|cita|evidencia)\b/g) ?? []).length;
+  const englishSignals = (normalizedLast.match(/\b(what|how|according|document|page|explain|describe|distinguish|cite|evidence)\b/g) ?? []).length;
+  const outputLanguage = spanishSignals >= 2 && spanishSignals > englishSignals ? 'Spanish' : 'English';
 
   const agentInstructions = typeof context.agentInstructions === 'string' ? context.agentInstructions : '';
   const system = [
     'You are Nodus, an academic research assistant embedded in Zotero. You help the user understand the open document and how it connects to their Nodus library.',
     'Be precise and concise. Ground every claim in the provided context.',
     CITE_INSTRUCTIONS,
+    `OUTPUT LANGUAGE (highest priority): answer entirely in ${outputLanguage}. Do not switch because sources or images use another language.`,
     ...(agentInstructions ? [agentInstructions] : []),
   ].join('\n\n');
 
@@ -252,6 +261,7 @@ function buildPrompt(body: Record<string, unknown>, ctx: ChatContext): { system:
   if (ctx.ideasBlock) parts.push(ctx.ideasBlock);
   if (ctx.gapsBlock) parts.push(ctx.gapsBlock);
   if (selection) parts.push(`USER SELECTION (the user highlighted this — treat it as the focus and quote/cite it):\n"""\n${selection}\n"""`);
+  if (evidenceText) parts.push(`ZOTERO EVIDENCE (authoritative passages with exact citable ids):\n${evidenceText.slice(0, 1_000_000)}`);
   // The plugin already head/tail-samples long documents to DOC_CHAR_LIMIT; keep a
   // generous ceiling here so we don't re-truncate away the sampled conclusion.
   if (documentText) parts.push(`DOCUMENT TEXT (page markers like "=== page N ===" indicate pages you may cite with [[p:N]]):\n"""\n${documentText.slice(0, 200_000)}\n"""`);
@@ -260,6 +270,22 @@ function buildPrompt(body: Record<string, unknown>, ctx: ChatContext): { system:
   parts.push('Answer the last user message.');
 
   return { system, user: parts.join('\n\n') };
+}
+
+function parseVisionImages(value: unknown): VisionImagePart[] {
+  if (!Array.isArray(value)) return [];
+  const out: VisionImagePart[] = [];
+  for (const raw of value.slice(0, 6)) {
+    if (!raw || typeof raw !== 'object') continue;
+    const item = raw as Record<string, unknown>;
+    if (typeof item.dataUrl === 'string') {
+      const match = /^data:(image\/(?:png|jpeg|webp));base64,([A-Za-z0-9+/=\s]+)$/i.exec(item.dataUrl);
+      if (match) out.push({ mediaType: match[1].toLowerCase(), base64: match[2].replace(/\s+/g, '') });
+    } else if (typeof item.mimeType === 'string' && typeof item.data === 'string' && /^image\/(?:png|jpeg|webp)$/i.test(item.mimeType)) {
+      out.push({ mediaType: item.mimeType.toLowerCase(), base64: item.data.replace(/\s+/g, '') });
+    }
+  }
+  return out;
 }
 
 // ------------------------------------------------------------- request router
@@ -365,6 +391,21 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, port: nu
 
     if (urlPath === '/api/z/chat/stream' && req.method === 'POST') {
       await handleChatStream(req, res);
+      return;
+    }
+
+    if (urlPath === '/api/z/vision' && req.method === 'POST') {
+      await handleVision(req, res);
+      return;
+    }
+
+    if (urlPath === '/api/z/rerank' && req.method === 'POST') {
+      await handleRerank(req, res);
+      return;
+    }
+
+    if (urlPath === '/api/z/citation-repair' && req.method === 'POST') {
+      await handleCitationRepair(req, res);
       return;
     }
 
@@ -539,6 +580,7 @@ async function handleChatStream(req: IncomingMessage, res: ServerResponse): Prom
   const ctx = await buildChatContext(body, lastUserText);
   const { system, user } = buildPrompt(body, ctx);
   const model = toModelRef(body.model);
+  const images = parseVisionImages(body.images);
   // Honor the plugin's reasoning/thinking selector; 'default' preserves the
   // server's historical 'off'.
   const context = (body.context && typeof body.context === 'object' ? body.context : {}) as Record<string, unknown>;
@@ -567,7 +609,7 @@ async function handleChatStream(req: IncomingMessage, res: ServerResponse): Prom
   res.on('close', () => controller.abort());
   try {
     await completeTextStream(
-      { system, user, reasoning },
+      { system, user, reasoning, images },
       (delta, kind) => {
         if (kind === 'reasoning') return;
         write({ type: 'delta', text: delta });
@@ -580,6 +622,101 @@ async function handleChatStream(req: IncomingMessage, res: ServerResponse): Prom
     write({ type: 'error', error: error instanceof Error ? error.message : String(error) });
   }
   try { res.end(); } catch { /* client gone */ }
+}
+
+async function handleVision(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await readJsonBody(req);
+  const model = toModelRef(body.model);
+  const system = typeof body.system === 'string' ? body.system.slice(0, 20_000) : 'Extract visible document content faithfully.';
+  const user = typeof body.prompt === 'string' ? body.prompt.slice(0, 30_000) : 'Describe and transcribe this document page.';
+  const images = parseVisionImages(body.images);
+  if (!images.length) {
+    sendJson(res, 400, { error: 'No valid page image supplied.' });
+    return;
+  }
+  let text = '';
+  const controller = new AbortController();
+  res.on('close', () => controller.abort());
+  try {
+    await completeTextStream(
+      { system, user, images, reasoning: 'off', plainContext: true, skipStudentPseudonyms: true },
+      (delta, kind) => { if (kind !== 'reasoning') text += delta; },
+      model,
+      controller.signal,
+    );
+    sendJson(res, 200, { text });
+  } catch (error) {
+    sendJson(res, 500, { error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+async function handleRerank(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await readJsonBody(req);
+  const model = toModelRef(body.model);
+  const query = typeof body.query === 'string' ? body.query.slice(0, 10_000) : '';
+  const candidates = Array.isArray(body.candidates) ? body.candidates.slice(0, 36) : [];
+  const rows = candidates
+    .map((raw) => {
+      const c = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
+      const id = typeof c.id === 'string' ? c.id : '';
+      const title = typeof c.title === 'string' ? c.title : '';
+      const page = typeof c.pageLabel === 'string' ? c.pageLabel : String(c.pageLabel ?? '');
+      const text = typeof c.text === 'string' ? c.text.replace(/\s+/g, ' ').slice(0, 650) : '';
+      return id ? `${id} | ${title} | page ${page} | ${text}` : '';
+    })
+    .filter(Boolean);
+  const allowed = new Set(candidates.map((raw) => raw && typeof raw === 'object' ? String((raw as Record<string, unknown>).id ?? '') : '').filter(Boolean));
+  let output = '';
+  await completeTextStream(
+    {
+      system: 'Rerank academic evidence across languages. Prefer passages that directly answer the question over related passages or bibliography entries. Return ONLY a JSON array of up to 10 exact ids, best first. Never invent ids.',
+      user: `QUESTION:\n${query}\n\nCANDIDATES:\n${rows.join('\n')}`,
+      reasoning: 'off',
+      plainContext: true,
+      skipStudentPseudonyms: true,
+      maxTokens: 1200,
+    },
+    (delta, kind) => { if (kind !== 'reasoning') output += delta; },
+    model,
+  );
+  let ids: string[] = [];
+  const start = output.indexOf('['), end = output.lastIndexOf(']');
+  if (start >= 0 && end > start) {
+    try {
+      const parsed = JSON.parse(output.slice(start, end + 1));
+      if (Array.isArray(parsed)) ids = parsed.map(String).filter((id) => allowed.has(id));
+    } catch { /* malformed model result falls back client-side */ }
+  }
+  sendJson(res, 200, { ids });
+}
+
+async function handleCitationRepair(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await readJsonBody(req);
+  const model = toModelRef(body.model);
+  const answer = typeof body.answer === 'string' ? body.answer.slice(0, 100_000) : '';
+  const evidence = Array.isArray(body.evidence) ? body.evidence.slice(0, 20) : [];
+  const catalogue = evidence.map((raw) => {
+    const e = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
+    const id = typeof e.id === 'string' ? e.id : '';
+    const title = typeof e.title === 'string' ? e.title : '';
+    const page = String(e.pageLabel ?? '');
+    const text = typeof e.text === 'string' ? e.text.slice(0, 3000) : '';
+    return id ? `[[e:${id}]] ${title} · page ${page}\n"""${text}"""` : '';
+  }).filter(Boolean).join('\n\n');
+  let text = '';
+  await completeTextStream(
+    {
+      system: 'Repair citations in the supplied academic answer. Preserve its language, meaning and structure. Add exact [[e:ID]] tokens immediately after every supported factual sentence. Never invent ids. Replace an unsupported claim only with a statement that supplied evidence is insufficient. Return only the complete repaired answer.',
+      user: `ANSWER TO REPAIR:\n${answer}\n\nEVIDENCE CATALOGUE:\n${catalogue}`,
+      reasoning: 'off',
+      plainContext: true,
+      skipStudentPseudonyms: true,
+      maxTokens: 3000,
+    },
+    (delta, kind) => { if (kind !== 'reasoning') text += delta; },
+    model,
+  );
+  sendJson(res, 200, { text: text.trim() || answer });
 }
 
 // ---------------------------------------------------------------- lifecycle

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -141,6 +141,14 @@ test('markdown: citations become chips via citeFn, body is escaped (no XSS)', ()
   assert.ok(!elementTags(container).includes('SCRIPT'), 'no live <script> element injected');
 });
 
+test('markdown: evidence citations become chips', () => {
+  const { NodusMarkdown } = loadModule('markdown.js');
+  const spans = NodusMarkdown.parseInline('Claim [[e:ev_abc|source p. 2]].');
+  const cite = spans.find((s) => s.type === 'cite');
+  assert.equal(cite.kind, 'e');
+  assert.equal(cite.id, 'ev_abc');
+});
+
 // ─────────────────────────────────────────── #2 long-document sampling
 test('util: sampleDocText keeps short docs whole', () => {
   const { NodusUtil } = loadModule('util.js');
@@ -161,6 +169,155 @@ test('util: sampleDocText keeps head AND tail of long docs', () => {
   assert.ok(r.sentChars <= 200 + 60, 'roughly within budget');
   assert.equal(r.totalChars, big.length);
   assert.ok(r.ratio > 0 && r.ratio < 1);
+});
+
+// ─────────────────────────────────────────── evidence retrieval
+test('evidence: page-aware chunking preserves exact passages and stable ids', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const text = 'INTRODUCTION\n' + 'First page evidence. '.repeat(80) + '\fRESULTS\n' + 'Second page finding. '.repeat(80);
+  const idx = E.buildIndex({ libraryID: 1, itemKey: 'PARENT', attachmentKey: 'ATT', title: 'Paper', pageLabels: ['i', '7'] }, text, { targetChars: 500, minChars: 150, overlapChars: 50 });
+  assert.equal(idx.pages.length, 2);
+  assert.ok(idx.chunks.length >= 4);
+  assert.ok(idx.chunks.some((c) => c.pageLabel === '7' && c.section === 'RESULTS'));
+  for (const chunk of idx.chunks) {
+    const page = idx.pages[chunk.pageIndex];
+    const combined = [page.text, page.visualText].filter(Boolean).join('\n\n[VISUAL/OCR]\n');
+    assert.equal(combined.slice(chunk.start, chunk.end), chunk.text);
+    assert.match(chunk.id, /^ev_/);
+  }
+  const idx2 = E.buildIndex({ libraryID: 1, itemKey: 'PARENT', attachmentKey: 'ATT', title: 'Paper', pageLabels: ['i', '7'] }, text, { targetChars: 500, minChars: 150, overlapChars: 50 });
+  assert.deepEqual([...idx.chunks.map((c) => c.id)], [...idx2.chunks.map((c) => c.id)]);
+});
+
+test('evidence: hybrid retrieval uses semantics, limits sources and produces citable catalogue', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const a = E.buildIndex({ libraryID: 1, itemKey: 'A', attachmentKey: 'AA', title: 'Alpha' }, 'Cats sleep in warm windows. '.repeat(80), { targetChars: 300, minChars: 100, overlapChars: 40 });
+  const b = E.buildIndex({ libraryID: 1, itemKey: 'B', attachmentKey: 'BB', title: 'Beta' }, 'Quantum entanglement links distant particles. '.repeat(80), { targetChars: 300, minChars: 100, overlapChars: 40 });
+  a.chunks.forEach((c) => { c.embedding = [1, 0]; });
+  b.chunks.forEach((c) => { c.embedding = [0, 1]; });
+  const result = E.hybridSearch([a, b], 'nonlocal physics', [0, 1], { topK: 5, maxPerSource: 3 });
+  assert.equal(result.method, 'hybrid');
+  assert.equal(result.hits[0].attachmentKey, 'BB');
+  assert.ok(result.hits.filter((h) => h.attachmentKey === 'BB').length <= 3);
+  const prompt = E.evidencePrompt(result.hits);
+  assert.ok(prompt.includes(`[[e:${result.hits[0].id}]]`));
+  assert.ok(prompt.includes('EXACT PASSAGE'));
+});
+
+test('evidence: full text remains citable and citation validation rejects invented ids', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const idx = E.buildIndex({ libraryID: 1, itemKey: 'A', attachmentKey: 'AA', title: 'Alpha' }, 'A supported factual sentence with enough detail. '.repeat(30), { targetChars: 300, minChars: 100, overlapChars: 40 });
+  const full = E.fullEvidencePrompt([idx], 100000);
+  assert.equal(full.hits.length, idx.chunks.length);
+  assert.ok(full.text.includes(`[[e:${idx.chunks[0].id}]]`));
+  const checked = E.validateCitations(`Supported [[e:${idx.chunks[0].id}]]. Invented [[e:nope]]. Legacy [[p:2]].`, { evidence: E.evidenceMap(full.hits) });
+  assert.equal(checked.invalid.length, 1);
+  assert.ok(!checked.text.includes('[[e:nope]]'));
+  assert.ok(checked.text.includes('[[p:2]]'), 'unspecified legacy citation kinds remain untouched');
+});
+
+test('evidence: malformed evidence brackets are normalized only for allowed ids', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const evidence = E.evidenceMap([{ id: 'first' }, { id: 'second' }]);
+  const checked = E.validateCitations('Supported [[e:first], [e:second]]. Invented [e:nope].', { evidence });
+  assert.equal(checked.text, 'Supported [[e:first]], [[e:second]]. Invented.');
+  assert.equal(checked.valid.length, 2);
+  assert.equal(checked.invalid.length, 1);
+});
+
+test('evidence: claim audit distinguishes supported, weak and uncited statements', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const evidence = [{ id: 'one', text: 'The trial enrolled 240 adult participants and reduced blood pressure significantly.' }];
+  const answer = 'The trial enrolled 240 adult participants and reduced blood pressure significantly [[e:one]].\n\nThe moon is made entirely of polished copper according to this investigation [[e:one]].\n\nA separate long factual assertion appears here without any supporting source citation.';
+  const audit = E.auditClaims(answer, evidence);
+  assert.equal(audit.covered, 1);
+  assert.equal(audit.weak, 1);
+  assert.equal(audit.missing, 1);
+});
+
+test('evidence: claim audit supports faithful English-to-Spanish citations and ignores lead-ins', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const evidence = [{
+    id: 'computer',
+    text: 'A computer is a machine that can be programmed to automatically carry out sequences of arithmetic or logical operations.',
+  }];
+  const answer = 'Aquí tienes una comparación de las fuentes:\\n'
+    + '- Un ordenador es una máquina programada para llevar a cabo automáticamente secuencias de operaciones aritméticas o lógicas [[e:computer]].';
+  const audit = E.auditClaims(answer, evidence);
+  assert.equal(audit.total, 1);
+  assert.equal(audit.covered, 1);
+  assert.equal(audit.coverage, 1);
+});
+
+test('store: conversation audits are compacted without persisting embeddings', () => {
+  const { NodusStore: S } = loadModule('store.js');
+  const conversations = [{
+    id: 'conversation',
+    messages: [{
+      role: 'assistant',
+      content: 'Supported answer.',
+      audit: {
+        total: 1, covered: 1, weak: 0, missing: 0, coverage: 1,
+        invalidCitations: [{ id: 'bad', token: '[[e:bad]]', embedding: [9, 9] }],
+        claims: [{
+          text: 'Supported answer.', citationIds: ['good'], status: 'covered', support: 0.91,
+          evidence: [{ id: 'good', embedding: [0.1, 0.2], text: 'Exact passage' }],
+        }],
+      },
+    }],
+  }];
+  const compact = S.compactConversations(conversations);
+  assert.equal(compact[0].messages[0].audit.claims[0].support, 0.91);
+  assert.equal(compact[0].messages[0].audit.claims[0].evidence, undefined);
+  assert.equal(compact[0].messages[0].audit.invalidCitations[0].embedding, undefined);
+  assert.ok(!JSON.stringify(compact).includes('embedding'));
+});
+
+test('evidence: visual extraction is merged into the correct page and re-chunked', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const idx = E.buildIndex({ libraryID: 1, itemKey: 'A', attachmentKey: 'AA', title: 'Alpha', totalPages: 2 }, 'Text page\f');
+  E.addVisualText(idx, 1, '[TABLE] Group | Mean\\nA | 42');
+  assert.ok(idx.pages[1].visualText.includes('Mean'));
+  assert.equal(idx.pages[1].needsOcr, false);
+  assert.ok(idx.chunks.some((c) => c.pageIndex === 1 && c.text.includes('[TABLE]')));
+});
+
+test('multimodal: validates images and detects figures, tables, formulas, diagrams and OCR pages', () => {
+  const { NodusMultimodal: V } = loadModule('multimodal.js');
+  const data = 'data:image/png;base64,aGVsbG8=';
+  assert.equal(V.isImageDataUrl(data), true);
+  assert.deepEqual({ ...V.dataUrlToImagePart(data) }, { mimeType: 'image/png', data: 'aGVsbG8=' });
+  const signals = V.visualSignals('Figure 2 and Table 4 show α = 0.5 in the architecture diagram');
+  assert.deepEqual({ ...signals }, { figure: true, table: true, formula: true, diagram: true });
+  assert.equal(V.needsVisualAnalysis({ needsOcr: true, text: '' }), true);
+  assert.ok(V.cleanVisualExtraction('```text\n[OCR] EMPTY\n[TABLE] A | B\n```').includes('[TABLE]'));
+});
+
+test('providers: multimodal body builders and embedding response ordering', async () => {
+  const calls = [];
+  const fakeFetch = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, json: async () => ({ data: [{ index: 1, embedding: [0, 1] }, { index: 0, embedding: [1, 0] }] }) };
+  };
+  const { NodusProviders: P } = loadModule('providers.js', { fetch: fakeFetch });
+  const image = { dataUrl: 'data:image/jpeg;base64,YQ==', label: 'page' };
+  const openai = P.withOpenAiImages([{ role: 'user', content: 'inspect' }], [image]);
+  assert.ok(Array.isArray(openai[0].content));
+  assert.equal(openai[0].content.at(-1).type, 'image_url');
+  const anthropic = P.withAnthropicImages([{ role: 'user', content: 'inspect' }], [image]);
+  assert.equal(anthropic[0].content.at(-1).type, 'image');
+  const vectors = await P.embed({ provider: 'openrouter', model: 'openai/text-embedding-3-small' }, ['a', 'b'], { key: 'secret' });
+  assert.deepEqual([...vectors[0]], [1, 0]);
+  assert.ok(calls[0].url.endsWith('/embeddings'));
+  assert.equal(JSON.parse(calls[0].init.body).input.length, 2);
+});
+
+test('providers: detects short unfinished streams without flagging complete replies', () => {
+  const { NodusProviders: P } = loadModule('providers.js');
+  assert.equal(P.isProbablyTruncated('Un ordenador es una máquina program', 'stop'), true);
+  assert.equal(P.isProbablyTruncated('Un ordenador es una máquina programable.', 'stop'), false);
+  assert.equal(P.isProbablyTruncated('A complete but long answer. '.repeat(20), 'stop'), false);
+  assert.equal(P.isProbablyTruncated('Complete.', 'length'), true);
 });
 
 // ─────────────────────────────────────────── #4 save chat as note
@@ -186,6 +343,13 @@ test('util: buildItemsSummary only fires for 2+ items', () => {
   assert.ok(s.includes('SELECTED DOCUMENTS'));
   assert.ok(s.includes('1. Paper A') && s.includes('2. Paper B'));
   assert.ok(s.includes('Smith') && s.includes('(2020)'));
+});
+
+test('util: reply language follows the last user message, not the source language', () => {
+  const { NodusUtil } = loadModule('util.js');
+  assert.equal(NodusUtil.detectLanguage('Describe la figura de la página y cita la evidencia.', 'en'), 'Spanish');
+  assert.equal(NodusUtil.detectLanguage('Describe the figure on the page and cite the evidence.', 'es'), 'English');
+  assert.equal(NodusUtil.detectLanguage('OK', 'es'), 'Spanish');
 });
 
 // ─────────────────────────────────────────── #3 agent tools

--- a/zotero-plugin/content/evidence.js
+++ b/zotero-plugin/content/evidence.js
@@ -1,0 +1,674 @@
+/* Nodus for Zotero — complete-text indexing, hybrid semantic retrieval and
+ * citation auditing. Pure helpers are deliberately kept in this chrome script
+ * so the exact production logic can be exercised by Node's vm tests.
+ *
+ * Index schema v2:
+ *   one persisted file per attachment, pages split on Zotero PDFWorker's `\f`,
+ *   sentence-aligned overlapping chunks, optional provider embeddings and
+ *   visual/OCR text merged back into its source page.
+ */
+/* eslint-disable no-undef */
+(function () {
+  "use strict";
+
+  let ZoteroRef = null;
+  try { ZoteroRef = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs").Zotero; } catch (e) {}
+
+  const INDEX_VERSION = 2;
+  const DEFAULTS = {
+    targetChars: 1400,
+    minChars: 420,
+    overlapChars: 220,
+    topK: 12,
+    candidateK: 48,
+    maxPerSource: 5,
+  };
+  const STOP = new Set((
+    "a al algo algunas algunos ante antes como con contra cual cuando de del desde donde dos el ella ellas ellos en entre era es esa ese eso esta este esto fue ha hasta hay la las le lo los más me mi muy no nos o para pero por porque que se sin sobre su sus te tiene todo un una uno y ya " +
+    "the a an and are as at be been but by can could did do does for from had has have he her here him his how i if in into is it its may more most no not of on one or our out over she so some than that their them then there these they this those to up was we were what when where which who why will with would you your"
+  ).split(/\s+/));
+
+  function clamp(n, lo, hi) { return Math.min(hi, Math.max(lo, Number(n) || 0)); }
+  function cleanText(value) {
+    return String(value == null ? "" : value)
+      .replace(/\r\n?/g, "\n")
+      .replace(/\u0000/g, "")
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n{4,}/g, "\n\n\n")
+      .normalize("NFC");
+  }
+  function fold(value) {
+    return String(value == null ? "" : value)
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase();
+  }
+  function tokenize(value) {
+    const out = [];
+    // Hyphens delimit terms: treating "open-source" as one token made an
+    // otherwise exact "open source" query score zero lexically.
+    const matches = fold(value).match(/[\p{L}\p{N}][\p{L}\p{N}_']*/gu) || [];
+    for (let token of matches) {
+      token = token.replace(/^[-']+|[-']+$/g, "");
+      if (token.length < 2 || STOP.has(token)) continue;
+      out.push(token);
+    }
+    return out;
+  }
+  function hashText(value) {
+    const s = String(value == null ? "" : value);
+    let h = 2166136261;
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return (h >>> 0).toString(36);
+  }
+  function safeId(value) {
+    return String(value || "source").replace(/[^A-Za-z0-9_-]+/g, "_").slice(0, 80);
+  }
+
+  function looksLikeHeading(line) {
+    const s = String(line || "").trim();
+    if (!s || s.length > 120 || /[.!?]["')\]]?$/.test(s)) return false;
+    if (/^(abstract|summary|resumen|introduction|introducci[oó]n|background|methods?|methodology|metodolog[ií]a|results?|resultados|discussion|discusi[oó]n|conclusions?|conclusiones|references|referencias|appendix|ap[eé]ndice|limitations?|limitaciones)$/i.test(s)) return true;
+    if (/^\d+(?:\.\d+)*[.)]?\s+\S/.test(s)) return true;
+    const letters = s.replace(/[^\p{L}]/gu, "");
+    if (letters.length >= 4 && s === s.toUpperCase()) return true;
+    const words = s.split(/\s+/);
+    const titled = words.filter((w) => /^\p{Lu}[\p{L}\p{N}'’-]*$/u.test(w)).length;
+    return words.length <= 12 && titled >= Math.max(1, Math.ceil(words.length * 0.65));
+  }
+
+  function detectHeadings(text) {
+    const s = cleanText(text);
+    const out = [];
+    let offset = 0;
+    for (const line of s.split("\n")) {
+      const trimmed = line.trim();
+      const at = offset + Math.max(0, line.indexOf(trimmed));
+      if (looksLikeHeading(trimmed)) out.push({ offset: at, title: trimmed });
+      offset += line.length + 1;
+    }
+    return out;
+  }
+
+  function sectionAt(headings, offset, fallback) {
+    let section = fallback || "";
+    for (const h of headings || []) {
+      if (h.offset > offset) break;
+      section = h.title;
+    }
+    return section;
+  }
+
+  function splitLogicalPages(text, opts) {
+    opts = opts || {};
+    const raw = cleanText(text);
+    let parts = raw.split("\f");
+    const totalPages = Math.max(parts.length, Number(opts.totalPages) || 0, 1);
+    while (parts.length < totalPages) parts.push("");
+    const labels = Array.isArray(opts.pageLabels) ? opts.pageLabels : [];
+    const pages = [];
+    let inheritedSection = opts.defaultSection || "";
+    for (let i = 0; i < parts.length; i++) {
+      const pageText = cleanText(parts[i]).trim();
+      const headings = detectHeadings(pageText);
+      if (headings.length) inheritedSection = headings[headings.length - 1].title;
+      pages.push({
+        pageIndex: i,
+        pageLabel: String(labels[i] || i + 1),
+        text: pageText,
+        visualText: "",
+        headings,
+        inheritedSection,
+        needsOcr: pageText.replace(/\s+/g, "").length < 40,
+      });
+    }
+    return pages;
+  }
+
+  function boundaryBefore(text, desired, lower) {
+    const s = String(text);
+    const probes = ["\n\n", "\n", ". ", "? ", "! ", "; ", ", ", " "];
+    for (const marker of probes) {
+      const at = s.lastIndexOf(marker, desired);
+      if (at >= lower) return at + marker.length;
+    }
+    return desired;
+  }
+  function boundaryAfter(text, desired, upper) {
+    const s = String(text);
+    const probes = ["\n\n", ". ", "? ", "! ", "\n", "; ", " "];
+    let best = -1;
+    for (const marker of probes) {
+      const at = s.indexOf(marker, desired);
+      if (at >= desired && at <= upper && (best < 0 || at < best)) best = at + marker.length;
+    }
+    return best >= 0 ? best : Math.min(upper, s.length);
+  }
+
+  function chunkPage(page, meta, opts) {
+    opts = { ...DEFAULTS, ...(opts || {}) };
+    const base = cleanText([page.text, page.visualText].filter(Boolean).join("\n\n[VISUAL/OCR]\n")).trim();
+    if (!base) return [];
+    const headings = detectHeadings(base);
+    const chunks = [];
+    let start = 0;
+    let seq = 0;
+    while (start < base.length) {
+      while (start < base.length && /\s/.test(base[start])) start++;
+      if (start >= base.length) break;
+      const desired = Math.min(base.length, start + opts.targetChars);
+      const lower = Math.min(desired, start + opts.minChars);
+      let end = desired === base.length ? base.length : boundaryBefore(base, desired, lower);
+      if (end <= start) end = boundaryAfter(base, desired, Math.min(base.length, desired + 300));
+      if (end <= start) end = Math.min(base.length, start + opts.targetChars);
+      let exactStart = start, exactEnd = end;
+      while (exactStart < exactEnd && /\s/.test(base[exactStart])) exactStart++;
+      while (exactEnd > exactStart && /\s/.test(base[exactEnd - 1])) exactEnd--;
+      const chunkText = base.slice(exactStart, exactEnd);
+      if (chunkText) {
+        const section = sectionAt(headings, exactStart, page.inheritedSection || meta.defaultSection || "");
+        const idCore = [meta.libraryID, meta.attachmentKey, page.pageIndex, seq, hashText(chunkText)].join("-");
+        chunks.push({
+          id: "ev_" + safeId(idCore),
+          libraryID: meta.libraryID,
+          itemKey: meta.itemKey,
+          attachmentKey: meta.attachmentKey,
+          title: meta.title || "",
+          contentType: meta.contentType || "",
+          pageIndex: page.pageIndex,
+          pageLabel: page.pageLabel,
+          section,
+          start: exactStart,
+          end: exactEnd,
+          chunkIndex: seq,
+          text: chunkText,
+          embedding: null,
+          embeddingModel: null,
+        });
+        seq++;
+      }
+      if (end >= base.length) break;
+      const proposed = Math.max(start + 1, end - opts.overlapChars);
+      start = boundaryBefore(base, proposed, Math.max(start + 1, proposed - 160));
+      if (start >= end) start = end;
+    }
+    return chunks;
+  }
+
+  function buildIndex(meta, fulltext, opts) {
+    meta = meta || {};
+    const pages = splitLogicalPages(fulltext, {
+      totalPages: meta.totalPages,
+      pageLabels: meta.pageLabels,
+      defaultSection: meta.defaultSection,
+    });
+    const chunks = [];
+    for (const page of pages) chunks.push(...chunkPage(page, meta, opts));
+    const now = Date.now();
+    return {
+      version: INDEX_VERSION,
+      libraryID: meta.libraryID == null ? 1 : meta.libraryID,
+      itemKey: String(meta.itemKey || ""),
+      attachmentKey: String(meta.attachmentKey || ""),
+      title: String(meta.title || ""),
+      contentType: String(meta.contentType || ""),
+      signature: String(meta.signature || hashText(fulltext)),
+      totalPages: pages.length,
+      totalChars: String(fulltext || "").length,
+      createdAt: now,
+      updatedAt: now,
+      embeddingModel: null,
+      pages,
+      chunks,
+    };
+  }
+
+  function addVisualText(index, pageIndex, visualText, opts) {
+    if (!index || !Array.isArray(index.pages)) return index;
+    const page = index.pages.find((p) => p.pageIndex === Number(pageIndex));
+    if (!page) return index;
+    const incoming = cleanText(visualText).trim();
+    if (!incoming) return index;
+    page.visualText = page.visualText ? page.visualText + "\n\n" + incoming : incoming;
+    page.needsOcr = false;
+    const unaffected = (index.chunks || []).filter((c) => c.pageIndex !== page.pageIndex);
+    const rebuilt = chunkPage(page, index, opts);
+    index.chunks = unaffected.concat(rebuilt).sort((a, b) => a.pageIndex - b.pageIndex || a.chunkIndex - b.chunkIndex);
+    index.updatedAt = Date.now();
+    index.embeddingModel = null;
+    return index;
+  }
+
+  function termFrequencies(tokens) {
+    const map = new Map();
+    for (const t of tokens) map.set(t, (map.get(t) || 0) + 1);
+    return map;
+  }
+  function bm25Scores(chunks, query, opts) {
+    const docs = Array.isArray(chunks) ? chunks : [];
+    const q = [...new Set(tokenize(query))];
+    if (!docs.length || !q.length) return docs.map(() => 0);
+    const k1 = opts && opts.k1 != null ? opts.k1 : 1.35;
+    const b = opts && opts.b != null ? opts.b : 0.72;
+    const stats = docs.map((d) => {
+      const toks = tokenize(d.text);
+      return { len: toks.length, tf: termFrequencies(toks) };
+    });
+    const avg = stats.reduce((n, s) => n + s.len, 0) / Math.max(1, stats.length);
+    const df = new Map();
+    for (const term of q) {
+      let n = 0;
+      for (const s of stats) if (s.tf.has(term)) n++;
+      df.set(term, n);
+    }
+    return stats.map((s) => {
+      let score = 0;
+      for (const term of q) {
+        const f = s.tf.get(term) || 0;
+        if (!f) continue;
+        const n = df.get(term) || 0;
+        const idf = Math.log(1 + (docs.length - n + 0.5) / (n + 0.5));
+        score += idf * ((f * (k1 + 1)) / (f + k1 * (1 - b + b * s.len / Math.max(1, avg))));
+      }
+      return score;
+    });
+  }
+
+  function cosine(a, b) {
+    if (!Array.isArray(a) || !Array.isArray(b) || !a.length || a.length !== b.length) return 0;
+    let dot = 0, aa = 0, bb = 0;
+    for (let i = 0; i < a.length; i++) {
+      const x = Number(a[i]) || 0, y = Number(b[i]) || 0;
+      dot += x * y; aa += x * x; bb += y * y;
+    }
+    return aa && bb ? dot / Math.sqrt(aa * bb) : 0;
+  }
+  function normalizeScores(values) {
+    if (!values.length) return [];
+    const lo = Math.min(...values), hi = Math.max(...values);
+    if (hi <= lo) return values.map((v) => (v > 0 ? 1 : 0));
+    return values.map((v) => (v - lo) / (hi - lo));
+  }
+
+  function flattenIndexes(indexes) {
+    const out = [];
+    for (const idx of indexes || []) {
+      for (const chunk of (idx && idx.chunks) || []) out.push({ ...chunk, indexSignature: idx.signature });
+    }
+    return out;
+  }
+
+  function hybridSearch(indexes, query, queryEmbedding, opts) {
+    opts = { ...DEFAULTS, ...(opts || {}) };
+    const chunks = flattenIndexes(indexes);
+    const sourceCount = new Set(chunks.map((c) => c.libraryID + ":" + c.attachmentKey)).size;
+    if (sourceCount <= 1) opts.maxPerSource = opts.topK;
+    const lexicalRaw = bm25Scores(chunks, query);
+    const semanticRaw = chunks.map((c) => cosine(queryEmbedding, c.embedding));
+    const lexical = normalizeScores(lexicalRaw);
+    const semantic = normalizeScores(semanticRaw);
+    const hasSemantic = Array.isArray(queryEmbedding) && queryEmbedding.length > 0 && semanticRaw.some((v) => v !== 0);
+    const ranked = chunks.map((chunk, i) => ({
+      ...chunk,
+      lexicalScore: lexicalRaw[i],
+      semanticScore: semanticRaw[i],
+      score: hasSemantic ? 0.35 * lexical[i] + 0.65 * semantic[i] : lexical[i],
+      retrieval: hasSemantic ? "hybrid" : "lexical",
+    })).sort((a, b) => b.score - a.score);
+    const selected = [];
+    const perSource = new Map();
+    for (const hit of ranked) {
+      if (selected.length >= opts.topK) break;
+      if (hit.score <= 0 && selected.length) break;
+      const source = hit.libraryID + ":" + hit.attachmentKey;
+      const n = perSource.get(source) || 0;
+      if (n >= opts.maxPerSource) continue;
+      selected.push(hit);
+      perSource.set(source, n + 1);
+    }
+    const candidates = [], candidateSeen = new Set();
+    const addCandidate = (hit) => {
+      if (!hit || candidateSeen.has(hit.id) || candidates.length >= opts.candidateK) return;
+      candidates.push(hit); candidateSeen.add(hit.id);
+    };
+    const semanticRanked = ranked.slice().sort((a, b) => b.semanticScore - a.semanticScore);
+    const lexicalRanked = ranked.slice().sort((a, b) => b.lexicalScore - a.lexicalScore);
+    const bySource = new Map();
+    for (const hit of ranked) {
+      const key = hit.libraryID + ":" + hit.attachmentKey;
+      if (!bySource.has(key)) bySource.set(key, []);
+      bySource.get(key).push(hit);
+    }
+    // Multi-question prompts often name several documents. Give the reranker
+    // representative evidence from every source: opening/abstract passages
+    // plus that source's own semantic and lexical leaders.
+    for (const sourceHits of bySource.values()) {
+      const starters = sourceHits.slice().sort((a, b) => a.pageIndex - b.pageIndex || a.chunkIndex - b.chunkIndex).slice(0, 2);
+      const sem = sourceHits.slice().sort((a, b) => b.semanticScore - a.semanticScore).slice(0, 3);
+      const lex = sourceHits.slice().sort((a, b) => b.lexicalScore - a.lexicalScore).slice(0, 2);
+      for (const hit of [...starters, ...sem, ...lex]) addCandidate(hit);
+    }
+    // Preserve independent semantic and exact-term recall. A blended top-N can
+    // otherwise exclude the best semantic hit when frequent generic terms
+    // dominate BM25; the model reranker then never gets a chance to recover it.
+    for (let i = 0; candidates.length < opts.candidateK && i < ranked.length; i++) {
+      for (const hit of [semanticRanked[i], ranked[i], lexicalRanked[i]]) {
+        if (!hit || candidateSeen.has(hit.id)) continue;
+        addCandidate(hit);
+        if (candidates.length >= opts.candidateK) break;
+      }
+    }
+    return {
+      hits: expandWithNeighbors(indexes, selected, opts),
+      candidates,
+      method: hasSemantic ? "hybrid" : "lexical",
+    };
+  }
+
+  function expandWithNeighbors(indexes, hits, opts) {
+    opts = { ...DEFAULTS, ...(opts || {}) };
+    const all = flattenIndexes(indexes);
+    const byLocation = new Map();
+    for (const chunk of all) byLocation.set([chunk.libraryID, chunk.attachmentKey, chunk.pageIndex, chunk.chunkIndex].join(":"), chunk);
+    const out = [], seen = new Set(), counts = new Map();
+    function add(hit, retrieval) {
+      if (!hit || seen.has(hit.id) || out.length >= opts.topK) return;
+      const source = hit.libraryID + ":" + hit.attachmentKey;
+      const count = counts.get(source) || 0;
+      if (count >= opts.maxPerSource) return;
+      out.push(retrieval ? { ...hit, retrieval, score: Number(hit.score || 0) * 0.85 } : hit);
+      seen.add(hit.id); counts.set(source, count + 1);
+    }
+    const seeds = (hits || []).slice(0, Math.max(1, Math.ceil(opts.topK * 0.67)));
+    for (const hit of seeds) {
+      add(hit);
+      for (const delta of [-1, 1]) {
+        const key = [hit.libraryID, hit.attachmentKey, hit.pageIndex, Number(hit.chunkIndex) + delta].join(":");
+        const neighbor = byLocation.get(key);
+        if (neighbor) add({ ...neighbor, lexicalScore: hit.lexicalScore, semanticScore: hit.semanticScore, score: hit.score }, "neighbor");
+      }
+    }
+    for (const hit of hits || []) add(hit);
+    return out;
+  }
+
+  function diversifyCandidates(candidates, orderedIds, opts) {
+    opts = { ...DEFAULTS, ...(opts || {}) };
+    const byId = new Map((candidates || []).map((c) => [c.id, c]));
+    const ordered = [];
+    for (const id of orderedIds || []) {
+      const hit = byId.get(id);
+      if (hit && !ordered.some((x) => x.id === hit.id)) ordered.push(hit);
+    }
+    for (const hit of candidates || []) if (!ordered.some((x) => x.id === hit.id)) ordered.push(hit);
+    const out = [], counts = new Map();
+    for (const hit of ordered) {
+      if (out.length >= opts.topK) break;
+      const source = hit.libraryID + ":" + hit.attachmentKey;
+      const n = counts.get(source) || 0;
+      if (n >= opts.maxPerSource) continue;
+      out.push(hit); counts.set(source, n + 1);
+    }
+    return out;
+  }
+
+  function evidenceMap(hits) {
+    const map = new Map();
+    for (const h of hits || []) map.set(h.id, h);
+    return map;
+  }
+  function evidencePrompt(hits) {
+    const lines = [
+      "EVIDENCE CATALOGUE — cite factual claims only with the exact token shown for the supporting passage.",
+      "Never invent an id or page. Put citations immediately after the supported sentence.",
+    ];
+    for (const h of hits || []) {
+      const where = [h.title || h.itemKey, h.section ? "§ " + h.section : "", h.pageLabel ? "p. " + h.pageLabel : ""].filter(Boolean).join(" · ");
+      lines.push(`- [[e:${h.id}]] ${where}\n  EXACT PASSAGE: """${String(h.text || "").trim()}"""`);
+    }
+    return lines.join("\n");
+  }
+  function fullTextPrompt(indexes, maxChars) {
+    const cap = Number(maxChars) > 0 ? Number(maxChars) : 750000;
+    const parts = [];
+    let used = 0, truncated = false;
+    for (const idx of indexes || []) {
+      parts.push(`SOURCE: ${idx.title || idx.itemKey}`);
+      for (const page of idx.pages || []) {
+        const text = [page.text, page.visualText].filter(Boolean).join("\n\n[VISUAL/OCR]\n").trim();
+        if (!text) continue;
+        const block = `\n=== ${idx.attachmentKey} · page ${page.pageLabel}${page.inheritedSection ? " · " + page.inheritedSection : ""} ===\n${text}\n`;
+        if (used + block.length > cap) { truncated = true; break; }
+        parts.push(block); used += block.length;
+      }
+      if (truncated) break;
+    }
+    return { text: parts.join("\n"), chars: used, truncated };
+  }
+  function fullEvidencePrompt(indexes, maxChars) {
+    const cap = Number(maxChars) > 0 ? Number(maxChars) : 750000;
+    const chunks = flattenIndexes(indexes);
+    const included = [];
+    let used = 0, truncated = false;
+    const parts = [
+      "COMPLETE DOCUMENT EVIDENCE — every passage below is full-text content, not a summary.",
+      "Cite factual claims with its exact [[e:...]] token. Never invent evidence ids.",
+    ];
+    for (const h of chunks) {
+      const where = [h.title || h.itemKey, h.section ? "§ " + h.section : "", h.pageLabel ? "p. " + h.pageLabel : ""].filter(Boolean).join(" · ");
+      const block = `\n[[e:${h.id}]] ${where}\n"""${String(h.text || "").trim()}"""\n`;
+      if (used + block.length > cap) { truncated = true; break; }
+      parts.push(block); included.push(h); used += block.length;
+    }
+    return { text: parts.join("\n"), hits: included, chars: used, truncated };
+  }
+
+  const CITE_RE = /\[\[(e|p|idea|zotero|gap):([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
+  function allowSet(value) {
+    if (value == null) return null;
+    if (value instanceof Map) return new Set(value.keys());
+    if (value instanceof Set) return value;
+    return new Set(Array.isArray(value) ? value : []);
+  }
+  function validateCitations(text, allowed) {
+    allowed = allowed || {};
+    const sets = {
+      e: allowSet(allowed.evidence),
+      p: allowSet(allowed.pages),
+      idea: allowSet(allowed.ideas),
+      zotero: allowSet(allowed.zotero),
+      gap: allowSet(allowed.gaps),
+    };
+    const valid = [], invalid = [];
+    // Models occasionally drop one bracket in a list such as
+    // `[[e:first], [e:second]]`. Normalize those variants only when the
+    // evidence id is in the allowlist; malformed invented ids are removed.
+    const evidenceCite = /\[{1,2}e:([A-Za-z0-9_-]+)(?:\|([^\]]+?))?\]{1,2}/g;
+    const normalized = String(text || "").replace(evidenceCite, (full, rawId, label) => {
+      const id = String(rawId || "").trim();
+      if (sets.e == null || sets.e.has(id)) {
+        valid.push({ kind: "e", id, normalized: full !== `[[e:${id}${label ? "|" + label : ""}]]` });
+        return `[[e:${id}${label ? "|" + label : ""}]]`;
+      }
+      invalid.push({ kind: "e", id, token: full });
+      return "";
+    });
+    const clean = normalized.replace(CITE_RE, (full, kind, rawId) => {
+      const id = String(rawId || "").trim();
+      if (kind === "e") return full; // already validated and normalized above
+      if (sets[kind] == null || sets[kind].has(id)) { valid.push({ kind, id }); return full; }
+      invalid.push({ kind, id, token: full });
+      return "";
+    }).replace(/[ \t]{2,}/g, " ").replace(/ +([.,;:!?])/g, "$1");
+    return { text: clean, valid, invalid };
+  }
+
+  function citationIds(text) {
+    const out = [];
+    const re = new RegExp(CITE_RE.source, "g");
+    let m;
+    while ((m = re.exec(String(text || ""))) !== null) if (m[1] === "e") out.push(String(m[2]).trim());
+    return [...new Set(out)];
+  }
+  function claimText(value) {
+    return String(value || "").replace(CITE_RE, "").replace(/[*_`>#-]/g, " ").replace(/\s+/g, " ").trim();
+  }
+  function isClaim(value) {
+    const s = claimText(value);
+    if (s.length < 35 || /[?？:]$/.test(s)) return false;
+    if (/^(note|nota|warning|advertencia|source|fuente)\s*:/i.test(s)) return false;
+    return tokenize(s).length >= 5;
+  }
+  function splitClaims(text) {
+    const claims = [];
+    const paragraphs = String(text || "").replace(/\r/g, "").split(/\n{2,}/);
+    for (const paragraph of paragraphs) {
+      if (/^\s*```/.test(paragraph)) continue;
+      const lines = paragraph.split(/\n+/).filter((line) => line.trim());
+      for (const line of lines) {
+        const lineCites = citationIds(line);
+        const sentences = line.split(/(?<=[.!?。！？])\s+(?=[\p{Lu}\p{N}])/u);
+        for (const sentence of sentences) {
+          if (!isClaim(sentence)) continue;
+          const ids = citationIds(sentence);
+          claims.push({ text: claimText(sentence), citationIds: ids.length ? ids : lineCites });
+        }
+      }
+    }
+    return claims;
+  }
+  const AUDIT_EQUIV = {
+    ordenador: "computer", ordenadores: "computer", computadora: "computer", computadoras: "computer",
+    maquina: "machine", maquinas: "machine", programada: "programmed", programado: "programmed",
+    programar: "programmed", automaticamente: "automatically", llevar: "carry", secuencia: "sequences",
+    secuencias: "sequences", operacion: "operations", operaciones: "operations", aritmetica: "arithmetic",
+    aritmeticas: "arithmetic", logica: "logical", logicas: "logical", computacion: "computation",
+    codigo: "code", abierto: "open", abierta: "open", practica: "practice", publicar: "publishing",
+    recursos: "resources", digitales: "digital", publicamente: "publicly", junto: "alongside",
+    fuente: "source", archivos: "files", permitiendo: "enabling", uso: "use", estudio: "study",
+    modificacion: "modification", redistribucion: "redistribution", funcion: "function",
+    principal: "primary", gestion: "management", bibliografica: "bibliographic", gratuito: "free",
+    administrar: "manage", datos: "data", materiales: "materials", investigacion: "research",
+    relacionados: "related",
+  };
+  function auditTokens(value) {
+    return tokenize(value).map((token) => AUDIT_EQUIV[token] || token);
+  }
+  function supportScore(claim, evidence) {
+    const a = new Set(auditTokens(claim));
+    const b = new Set(auditTokens(evidence));
+    if (!a.size || !b.size) return 0;
+    let shared = 0;
+    for (const token of a) if (b.has(token)) shared++;
+    return shared / Math.max(1, Math.min(a.size, 18));
+  }
+  function auditClaims(text, evidence) {
+    const map = evidence instanceof Map ? evidence : evidenceMap(evidence || []);
+    const claims = splitClaims(text).map((claim) => {
+      const refs = claim.citationIds.map((id) => map.get(id)).filter(Boolean);
+      if (!refs.length) return { ...claim, status: "missing", support: 0, evidence: [] };
+      const support = Math.max(...refs.map((r) => supportScore(claim.text, r.text)));
+      return { ...claim, status: support >= 0.08 ? "covered" : "weak", support, evidence: refs };
+    });
+    const covered = claims.filter((c) => c.status === "covered").length;
+    const weak = claims.filter((c) => c.status === "weak").length;
+    const missing = claims.filter((c) => c.status === "missing").length;
+    return {
+      claims,
+      total: claims.length,
+      covered,
+      weak,
+      missing,
+      coverage: claims.length ? covered / claims.length : 1,
+    };
+  }
+
+  async function attachmentSignature(att, text) {
+    let mtime = 0, size = 0;
+    try { mtime = Number(await att.attachmentModificationTime) || 0; } catch (e) {}
+    try {
+      const path = await att.getFilePathAsync();
+      if (path && typeof IOUtils !== "undefined") {
+        const stat = await IOUtils.stat(path);
+        size = Number(stat && stat.size) || 0;
+      }
+    } catch (e) {}
+    return [att.libraryID, att.key, mtime, size, String(text || "").length, hashText(String(text || "").slice(0, 4096) + String(text || "").slice(-4096))].join(":");
+  }
+
+  function readerPageLabels(att) {
+    if (!ZoteroRef || !att) return [];
+    try {
+      const readers = (ZoteroRef.Reader && ZoteroRef.Reader._readers) || [];
+      const reader = readers.find((r) => r && r.itemID === att.id);
+      const labels = reader && reader._internalReader && reader._internalReader._primaryView && reader._internalReader._primaryView._pageLabels;
+      return Array.isArray(labels) ? labels.slice() : [];
+    } catch (e) { return []; }
+  }
+
+  async function extractAttachment(att) {
+    if (!att) throw new Error("no-attachment");
+    let parent = null;
+    try { parent = att.parentItem || null; } catch (e) {}
+    const title = (() => {
+      try { return parent ? (parent.getDisplayTitle ? parent.getDisplayTitle() : parent.getField("title")) : (att.getDisplayTitle ? att.getDisplayTitle() : att.getField("title")); } catch (e) { return att.key; }
+    })();
+    let text = "", totalPages = 1;
+    const contentType = String(att.attachmentContentType || "");
+    if (contentType === "application/pdf" && ZoteroRef && ZoteroRef.PDFWorker && att.id) {
+      try {
+        const full = await ZoteroRef.PDFWorker.getFullText(att.id, null, true);
+        text = full && full.text ? String(full.text) : "";
+        totalPages = Number(full && full.totalPages) || Math.max(1, text.split("\f").length);
+      } catch (e) {
+        text = String((await att.attachmentText) || "");
+        totalPages = Math.max(1, text.split("\f").length);
+      }
+    } else {
+      try {
+        if (ZoteroRef && ZoteroRef.Fulltext && ZoteroRef.Fulltext.canIndex && ZoteroRef.Fulltext.canIndex(att)) {
+          await ZoteroRef.Fulltext.indexItems([att.id], { complete: true, ignoreErrors: true });
+        }
+      } catch (e) {}
+      text = String((await att.attachmentText) || "");
+    }
+    const signature = await attachmentSignature(att, text);
+    return {
+      libraryID: att.libraryID,
+      itemKey: parent ? parent.key : att.key,
+      attachmentKey: att.key,
+      title: title || att.key,
+      contentType,
+      totalPages,
+      pageLabels: readerPageLabels(att),
+      signature,
+      text,
+    };
+  }
+
+  async function ensureIndex(att, store, opts) {
+    opts = opts || {};
+    const extracted = await extractAttachment(att);
+    let existing = null;
+    if (!opts.force && store && store.loadEvidenceIndex) existing = await store.loadEvidenceIndex(extracted.libraryID, extracted.attachmentKey);
+    if (existing && existing.version === INDEX_VERSION && existing.signature === extracted.signature && Array.isArray(existing.chunks)) {
+      return { index: existing, rebuilt: false, extracted };
+    }
+    const index = buildIndex(extracted, extracted.text, opts);
+    if (store && store.saveEvidenceIndex) await store.saveEvidenceIndex(index);
+    return { index, rebuilt: true, extracted };
+  }
+
+  window.NodusEvidence = {
+    INDEX_VERSION, DEFAULTS,
+    cleanText, fold, tokenize, hashText, looksLikeHeading, detectHeadings,
+    splitLogicalPages, chunkPage, buildIndex, addVisualText,
+    bm25Scores, cosine, hybridSearch, expandWithNeighbors, diversifyCandidates, flattenIndexes,
+    evidenceMap, evidencePrompt, fullTextPrompt, fullEvidencePrompt,
+    validateCitations, citationIds, splitClaims, auditTokens, supportScore, auditClaims,
+    attachmentSignature, extractAttachment, ensureIndex,
+  };
+})();

--- a/zotero-plugin/content/markdown.js
+++ b/zotero-plugin/content/markdown.js
@@ -16,7 +16,7 @@
   // snake_case identifiers, file names and URLs in academic/code text and must
   // not be mangled into italics.
   const INLINE = [
-    { type: "cite", re: /\[\[(p|idea|zotero|gap):([^\]|]+?)(?:\|([^\]]+?))?\]\]/ },
+    { type: "cite", re: /\[\[(e|p|idea|zotero|gap):([^\]|]+?)(?:\|([^\]]+?))?\]\]/ },
     { type: "code", re: /`([^`]+)`/ },
     { type: "strong", re: /\*\*([\s\S]+?)\*\*/ },
     { type: "em", re: /\*(?!\s)([\s\S]+?)(?<!\s)\*/ },

--- a/zotero-plugin/content/multimodal.js
+++ b/zotero-plugin/content/multimodal.js
@@ -1,0 +1,141 @@
+/* Nodus for Zotero — visual page capture and structured OCR/figure analysis.
+ * The pure helpers are unit-tested; reader access is best-effort because Zotero
+ * does not yet expose page bitmaps through a stable public API.
+ */
+/* eslint-disable no-undef */
+(function () {
+  "use strict";
+
+  const MAX_IMAGE_DIM = 1800;
+  const MAX_IMAGES = 6;
+  const VISUAL_SYSTEM = [
+    "You are the visual extraction stage of an academic evidence system.",
+    "Inspect the supplied document page image. Transcribe meaningful text and represent non-text content faithfully.",
+    "Use only these labels, one record per line:",
+    "[OCR] visible prose or labels",
+    "[FIGURE] caption, axes, legend, salient values and relationship",
+    "[TABLE] headers and rows in compact Markdown",
+    "[FORMULA] exact formula in LaTeX, then define visible symbols",
+    "[DIAGRAM] nodes, directed connections, groups and labels",
+    "Do not infer facts that are not visible. If the page has no useful content, return [OCR] EMPTY.",
+  ].join("\n");
+
+  function isImageDataUrl(value) {
+    return /^data:image\/(?:png|jpeg|webp);base64,[A-Za-z0-9+/=\s]+$/i.test(String(value || ""));
+  }
+  function dataUrlToImagePart(value) {
+    const s = String(value || "");
+    const m = /^data:(image\/(?:png|jpeg|webp));base64,([A-Za-z0-9+/=\s]+)$/i.exec(s);
+    if (!m) throw new Error("invalid-image-data-url");
+    return { mimeType: m[1].toLowerCase(), data: m[2].replace(/\s+/g, "") };
+  }
+  function visualSignals(text) {
+    const s = String(text || "");
+    return {
+      figure: /\b(fig(?:ure)?|figura|gr[aá]fic[oa]|chart)\s*[.:]?\s*\d+/i.test(s),
+      table: /\b(table|tabla)\s*[.:]?\s*\d+/i.test(s),
+      formula: /(?:=|≤|≥|∑|∫|√|α|β|γ|λ|μ|σ|math|equation|ecuaci[oó]n)/i.test(s),
+      diagram: /\b(diagram|diagrama|flowchart|esquema|architecture|arquitectura)\b/i.test(s),
+    };
+  }
+  function needsVisualAnalysis(page) {
+    if (!page) return false;
+    if (page.needsOcr) return true;
+    const signals = visualSignals([page.text, page.visualText].filter(Boolean).join("\n"));
+    return Object.values(signals).some(Boolean);
+  }
+
+  function readerInternals(reader) {
+    try {
+      const primary = reader && reader._internalReader && reader._internalReader._primaryView;
+      const iframe = primary && primary._iframeWindow;
+      const app = iframe && iframe.PDFViewerApplication;
+      const viewer = app && app.pdfViewer;
+      return { primary, iframe, app, viewer };
+    } catch (e) { return {}; }
+  }
+  function currentPageIndex(reader) {
+    const { viewer } = readerInternals(reader);
+    if (viewer && Number.isFinite(Number(viewer.currentPageNumber))) return Math.max(0, Number(viewer.currentPageNumber) - 1);
+    try {
+      const loc = reader && reader._internalReader && reader._internalReader._state && reader._internalReader._state.location;
+      if (loc && Number.isFinite(Number(loc.pageIndex))) return Number(loc.pageIndex);
+    } catch (e) {}
+    return 0;
+  }
+  function wait(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+  async function renderedCanvas(reader, pageIndex) {
+    const { viewer } = readerInternals(reader);
+    if (!viewer) throw new Error("pdf-renderer-unavailable");
+    const original = currentPageIndex(reader);
+    if (pageIndex !== original) {
+      try { reader.navigate({ pageIndex }); } catch (e) { viewer.currentPageNumber = pageIndex + 1; }
+    }
+    let canvas = null;
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const pageView = viewer.getPageView && viewer.getPageView(pageIndex);
+      canvas = pageView && pageView.canvas;
+      if (canvas && canvas.width > 10 && canvas.height > 10) break;
+      await wait(100);
+    }
+    if (!canvas) throw new Error("page-canvas-unavailable");
+    return { canvas, original };
+  }
+  function copyCanvas(source, crop, maxDimension) {
+    const sx = crop ? Math.max(0, Math.round(crop.x || 0)) : 0;
+    const sy = crop ? Math.max(0, Math.round(crop.y || 0)) : 0;
+    const sw = crop ? Math.min(source.width - sx, Math.max(1, Math.round(crop.width || source.width))) : source.width;
+    const sh = crop ? Math.min(source.height - sy, Math.max(1, Math.round(crop.height || source.height))) : source.height;
+    const cap = Number(maxDimension) || MAX_IMAGE_DIM;
+    const scale = Math.min(1, cap / Math.max(sw, sh));
+    const out = document.createElement("canvas");
+    out.width = Math.max(1, Math.round(sw * scale));
+    out.height = Math.max(1, Math.round(sh * scale));
+    const ctx = out.getContext("2d", { alpha: false });
+    ctx.fillStyle = "#fff"; ctx.fillRect(0, 0, out.width, out.height);
+    ctx.drawImage(source, sx, sy, sw, sh, 0, 0, out.width, out.height);
+    return out;
+  }
+  async function capturePage(reader, pageIndex, opts) {
+    opts = opts || {};
+    const got = await renderedCanvas(reader, Number(pageIndex) || 0);
+    const copy = copyCanvas(got.canvas, opts.crop || null, opts.maxDimension);
+    const dataUrl = copy.toDataURL("image/jpeg", opts.quality || 0.88);
+    if (opts.restore !== false && got.original !== pageIndex) {
+      try { reader.navigate({ pageIndex: got.original }); } catch (e) {}
+    }
+    return {
+      pageIndex: Number(pageIndex) || 0,
+      dataUrl,
+      width: copy.width,
+      height: copy.height,
+      kind: opts.kind || "page",
+    };
+  }
+  function selectionCrop(selectionDraft, pageIndex, canvas) {
+    const pos = selectionDraft && selectionDraft.position;
+    if (!pos || Number(pos.pageIndex) !== Number(pageIndex) || !Array.isArray(pos.rects) || !pos.rects.length || !canvas) return null;
+    const rects = pos.rects;
+    const x1 = Math.min(...rects.map((r) => Number(r[0]) || 0));
+    const y1 = Math.min(...rects.map((r) => Number(r[1]) || 0));
+    const x2 = Math.max(...rects.map((r) => Number(r[2]) || 0));
+    const y2 = Math.max(...rects.map((r) => Number(r[3]) || 0));
+    if (!(x2 > x1 && y2 > y1)) return null;
+    const pad = 30;
+    return { x: Math.max(0, x1 - pad), y: Math.max(0, y1 - pad), width: Math.min(canvas.width, x2 - x1 + 2 * pad), height: Math.min(canvas.height, y2 - y1 + 2 * pad) };
+  }
+  function visualPrompt(pageLabel, pageText) {
+    return `Document page ${pageLabel || "?"}. Existing extraction (possibly incomplete):\n"""\n${String(pageText || "").slice(0, 12000)}\n"""\n\nExtract the visual evidence using the required labels.`;
+  }
+  function cleanVisualExtraction(value) {
+    const lines = String(value || "").replace(/```(?:markdown|text)?/gi, "").replace(/```/g, "").split(/\r?\n/);
+    return lines.map((line) => line.trimEnd()).filter((line) => line.trim() && !/^\[OCR\]\s*EMPTY\s*$/i.test(line)).join("\n").trim();
+  }
+
+  window.NodusMultimodal = {
+    MAX_IMAGE_DIM, MAX_IMAGES, VISUAL_SYSTEM,
+    isImageDataUrl, dataUrlToImagePart, visualSignals, needsVisualAnalysis,
+    readerInternals, currentPageIndex, renderedCanvas, copyCanvas, capturePage,
+    selectionCrop, visualPrompt, cleanVisualExtraction,
+  };
+})();

--- a/zotero-plugin/content/providers.js
+++ b/zotero-plugin/content/providers.js
@@ -99,6 +99,82 @@
     return { reasoning_effort: level };
   }
 
+  function imageParts(images) {
+    const out = [];
+    for (const image of images || []) {
+      if (!image) continue;
+      if (typeof image === "string" && /^data:image\//i.test(image)) out.push({ url: image, label: "" });
+      else if (image.dataUrl && /^data:image\//i.test(image.dataUrl)) out.push({ url: image.dataUrl, label: String(image.label || "") });
+      else if (image.mimeType && image.data) out.push({ url: "data:" + image.mimeType + ";base64," + image.data, label: String(image.label || "") });
+    }
+    return out.slice(0, 6);
+  }
+  function withOpenAiImages(messages, images) {
+    const normalized = (messages || []).map((m) => ({ role: m.role, content: m.content }));
+    const visuals = imageParts(images);
+    if (!visuals.length) return normalized;
+    let i = normalized.length - 1;
+    while (i >= 0 && normalized[i].role !== "user") i--;
+    if (i < 0) { normalized.push({ role: "user", content: "" }); i = normalized.length - 1; }
+    const original = normalized[i].content;
+    const content = [{ type: "text", text: typeof original === "string" ? original : JSON.stringify(original || "") }];
+    for (const visual of visuals) {
+      if (visual.label) content.push({ type: "text", text: visual.label });
+      content.push({ type: "image_url", image_url: { url: visual.url, detail: "high" } });
+    }
+    normalized[i] = { ...normalized[i], content };
+    return normalized;
+  }
+  function withAnthropicImages(messages, images) {
+    const normalized = (messages || []).map((m) => ({ role: m.role, content: m.content }));
+    const visuals = imageParts(images);
+    if (!visuals.length) return normalized;
+    let i = normalized.length - 1;
+    while (i >= 0 && normalized[i].role !== "user") i--;
+    if (i < 0) { normalized.push({ role: "user", content: "" }); i = normalized.length - 1; }
+    const original = normalized[i].content;
+    const content = [{ type: "text", text: typeof original === "string" ? original : JSON.stringify(original || "") }];
+    for (const visual of visuals) {
+      const match = /^data:(image\/(?:png|jpeg|webp));base64,(.+)$/i.exec(visual.url);
+      if (!match) continue;
+      if (visual.label) content.push({ type: "text", text: visual.label });
+      content.push({ type: "image", source: { type: "base64", media_type: match[1].toLowerCase(), data: match[2] } });
+    }
+    normalized[i] = { ...normalized[i], content };
+    return normalized;
+  }
+
+  function embeddingBase(provider, localBase) {
+    return chatBase(provider, localBase);
+  }
+  async function embed(modelRef, inputs, opts, signal) {
+    opts = opts || {};
+    const provider = modelRef && modelRef.provider;
+    const model = modelRef && modelRef.model;
+    const p = byId(provider);
+    if (!p) throw new Error("Unknown provider " + provider);
+    if (p.subscription || provider === "anthropic") throw new Error(p.label + " does not expose compatible embeddings.");
+    const values = (Array.isArray(inputs) ? inputs : [inputs]).map((v) => String(v || ""));
+    if (!values.length) return [];
+    const base = embeddingBase(provider, opts.localBase);
+    const headers = { "Content-Type": "application/json" };
+    if (opts.key) headers.Authorization = "Bearer " + opts.key;
+    if (provider === "openrouter") {
+      headers["HTTP-Referer"] = "https://github.com/Drakonis96/nodus";
+      headers["X-Title"] = "Nodus for Zotero";
+    }
+    const res = await fetch(base + "/embeddings", {
+      method: "POST", headers,
+      body: JSON.stringify({ model, input: values, encoding_format: "float" }),
+      signal,
+    });
+    if (!res.ok) throw new Error(p.label + " embeddings HTTP " + res.status + " " + (await res.text()).slice(0, 200));
+    const json = await res.json();
+    const rows = Array.isArray(json && json.data) ? json.data.slice().sort((a, b) => Number(a.index) - Number(b.index)) : [];
+    if (rows.length !== values.length || rows.some((r) => !Array.isArray(r.embedding))) throw new Error("Invalid embeddings response");
+    return rows.map((r) => r.embedding.map(Number));
+  }
+
   // Pure body builder for the Anthropic Messages API (unit-tested). `max_tokens`
   // is required by the API and was hardcoded to 4096, truncating long answers;
   // it is now configurable via opts.maxTokens. When reasoning is low/medium/high
@@ -114,6 +190,14 @@
     return body;
   }
 
+  function isProbablyTruncated(text, finishReason) {
+    const value = String(text || "").trim();
+    if (["length", "content_filter", "error"].includes(String(finishReason || "").toLowerCase())) return true;
+    if (!value || value.length > 240) return false;
+    if (/[.!?。！？…)\]}'"»”’]$/.test(value)) return false;
+    return value.length >= 20 && value.split(/\s+/).length >= 4;
+  }
+
   // messages: [{role:'user'|'assistant', content}]  system: string
   async function chatStream(modelRef, opts, onDelta, signal) {
     const provider = modelRef.provider;
@@ -124,11 +208,12 @@
     const key = (opts && opts.key) || "";
     const system = (opts && opts.system) || "";
     const messages = (opts && opts.messages) || [];
+    const images = (opts && opts.images) || [];
     const maxTokens = opts && opts.maxTokens;
     const reasoning = (opts && opts.reasoning) || "default";
 
     if (provider === "anthropic") {
-      return anthropicStream(key, model, system, messages, maxTokens, reasoning, onDelta, signal);
+      return anthropicStream(key, model, system, withAnthropicImages(messages, images), maxTokens, reasoning, onDelta, signal);
     }
     // OpenAI-compatible (incl. gemini openai-compat, local servers)
     const base = chatBase(provider, opts && opts.localBase);
@@ -136,17 +221,23 @@
     const headers = { "Content-Type": "application/json" };
     if (key) headers.Authorization = "Bearer " + key;
     if (provider === "openrouter") { headers["HTTP-Referer"] = "https://github.com/Drakonis96/nodus"; headers["X-Title"] = "Nodus for Zotero"; }
-    const body = { model, stream: true, messages: system ? [{ role: "system", content: system }, ...messages] : messages };
+    const visualMessages = withOpenAiImages(messages, images);
+    const body = { model, stream: true, messages: system ? [{ role: "system", content: system }, ...visualMessages] : visualMessages };
     // Only cap when the user configured a limit: omitting it lets the model use
     // its own (usually larger) default instead of an arbitrary ceiling.
     if (maxTokens) body.max_tokens = clampMaxTokens(maxTokens);
     Object.assign(body, reasoningBody(provider, reasoning));
     const res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body), signal });
     if (!res.ok || !res.body) throw new Error(p.label + " chat HTTP " + res.status + (res.ok ? "" : " " + (await res.text()).slice(0, 200)));
+    let finishReason = "";
     await readSSE(res.body, (json) => {
+      if (json && json.error) throw new Error(p.label + " stream error: " + String(json.error.message || json.error.code || "unknown"));
       const delta = json && json.choices && json.choices[0] && json.choices[0].delta;
       if (delta && typeof delta.content === "string") onDelta(delta.content);
+      const reason = json && json.choices && json.choices[0] && json.choices[0].finish_reason;
+      if (reason) finishReason = String(reason);
     });
+    return { finishReason };
   }
 
   async function anthropicStream(key, model, system, messages, maxTokens, reasoning, onDelta, signal) {
@@ -160,9 +251,13 @@
       signal,
     });
     if (!res.ok || !res.body) throw new Error("Anthropic chat HTTP " + res.status + " " + (res.ok ? "" : (await res.text()).slice(0, 200)));
+    let finishReason = "";
     await readSSE(res.body, (json) => {
+      if (json && json.type === "error") throw new Error("Anthropic stream error: " + String(json.error && json.error.message || "unknown"));
       if (json && json.type === "content_block_delta" && json.delta && typeof json.delta.text === "string") onDelta(json.delta.text);
+      if (json && json.type === "message_delta" && json.delta && json.delta.stop_reason) finishReason = String(json.delta.stop_reason);
     });
+    return { finishReason };
   }
 
   // Reads a text/event-stream, calling onJson for each `data: {json}` (ignores [DONE]).
@@ -170,22 +265,30 @@
     const reader = stream.getReader();
     const dec = new TextDecoder();
     let buf = "";
+    const processLine = (raw) => {
+      const line = String(raw || "").replace(/\r$/, "").trim();
+      if (!line.startsWith("data:")) return;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") return;
+      let json; try { json = JSON.parse(payload); } catch (e) { return; }
+      onJson(json);
+    };
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
       buf += dec.decode(value, { stream: true });
       let idx;
       while ((idx = buf.indexOf("\n")) >= 0) {
-        let line = buf.slice(0, idx); buf = buf.slice(idx + 1);
-        line = line.replace(/\r$/, "").trim();
-        if (!line.startsWith("data:")) continue;
-        const payload = line.slice(5).trim();
-        if (!payload || payload === "[DONE]") continue;
-        let json; try { json = JSON.parse(payload); } catch (e) { continue; }
-        onJson(json);
+        processLine(buf.slice(0, idx)); buf = buf.slice(idx + 1);
       }
     }
+    buf += dec.decode();
+    if (buf.trim()) processLine(buf);
   }
 
-  window.NodusProviders = { PROVIDERS, byId, chatBase, listModels, chatStream, buildAnthropicBody, clampMaxTokens, DEFAULT_MAX_TOKENS, reasoningBody, REASONING_LEVELS };
+  window.NodusProviders = {
+    PROVIDERS, byId, chatBase, listModels, chatStream, embed,
+    buildAnthropicBody, withOpenAiImages, withAnthropicImages, imageParts,
+    clampMaxTokens, DEFAULT_MAX_TOKENS, reasoningBody, REASONING_LEVELS, isProbablyTruncated,
+  };
 })();

--- a/zotero-plugin/content/sidebar.css
+++ b/zotero-plugin/content/sidebar.css
@@ -278,3 +278,21 @@ h4.nd-md-h, h5.nd-md-h, h6.nd-md-h { font-size: 12.5px; }
 /* Long-document truncation notice. */
 .nd-doc-note { font-size: 11px; padding: 6px 9px; border-radius: 8px; border: 1px solid rgba(245,158,11,0.4); background: rgba(245,158,11,0.12); color: #b45309; }
 @media (prefers-color-scheme: dark) { .nd-doc-note { color: #fbbf24; } }
+
+/* Evidence retrieval + claim audit. */
+.nd-evidencebar { display:flex; align-items:center; gap:6px; padding:6px 10px; border-bottom:1px solid var(--nd-border); font-size:11px; }
+.nd-evidencebar #nd-index-status { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--nd-muted); }
+.nd-index-status--busy { color:var(--nd-accent) !important; }
+.nd-index-status--ok { color:#16803c !important; }
+.nd-index-status--warn { color:#b45309 !important; }
+.nd-evidencebar button { padding:3px 7px; font-size:11px; }
+.nd-audit { margin:7px 10px 3px; border:1px solid var(--nd-border); border-radius:7px; background:rgba(124,58,237,.035); font-size:11px; }
+.nd-audit-summary { cursor:pointer; padding:7px 9px; font-weight:600; }
+.nd-audit-claim { padding:7px 9px; border-top:1px solid var(--nd-border); }
+.nd-audit-status { font-weight:600; margin-bottom:3px; }
+.nd-audit-claim--covered .nd-audit-status { color:#16803c; }
+.nd-audit-claim--weak .nd-audit-status { color:#b45309; }
+.nd-audit-claim--missing .nd-audit-status { color:#b91c1c; }
+.nd-audit-text { line-height:1.35; }
+.nd-audit-passage { display:block; width:100%; text-align:left; margin-top:5px; padding:5px 7px; border:0; border-radius:5px; background:rgba(124,58,237,.08); color:inherit; font-size:10px; cursor:pointer; }
+.nd-cite--invalid { opacity:.55; text-decoration:line-through; }

--- a/zotero-plugin/content/sidebar.html
+++ b/zotero-plugin/content/sidebar.html
@@ -44,6 +44,11 @@
         </div>
       </div>
       <div id="nd-item"></div>
+      <div id="nd-evidencebar" class="nd-evidencebar">
+        <span id="nd-index-status" data-i18n="evidence.idle">Evidence index idle</span>
+        <button id="nd-index-btn" class="nd-btn-ghost" data-i18n="evidence.index" data-i18n-title="evidence.indexTitle" title="Index selected documents">Index</button>
+        <button id="nd-visual-btn" class="nd-btn-ghost" data-i18n="evidence.vision" data-i18n-title="evidence.visionTitle" title="Analyze current page image">Vision</button>
+      </div>
       <div id="nd-selection" hidden></div>
       <div id="nd-messages"></div>
       <div id="nd-prompt-menu" class="nd-menu" hidden></div>
@@ -74,6 +79,12 @@
       <div class="nd-field">
         <label data-i18n="settings.context">Context</label>
         <label class="nd-check"><input type="checkbox" id="nd-ctx-fulltext" /> <span data-i18n="settings.useFulltext">Send document text</span></label>
+        <select id="nd-ctx-strategy">
+          <option value="auto" data-i18n="evidence.auto">Auto: full text when small, retrieval when large</option>
+          <option value="retrieval" data-i18n="evidence.retrieval">Semantic retrieval</option>
+          <option value="full" data-i18n="evidence.full">Complete text</option>
+        </select>
+        <input id="nd-embedding-model" type="text" data-i18n-ph="evidence.embedding" placeholder="Embedding model" />
         <label class="nd-check" data-nodus-only><input type="checkbox" id="nd-ctx-ideas" /> <span data-i18n="settings.useIdeas">Use Nodus ideas when available</span></label>
         <label class="nd-check" data-nodus-only><input type="checkbox" id="nd-ctx-corpus" /> <span data-i18n="settings.useCorpus">Search my Nodus library for related passages</span></label>
         <div class="nd-muted" data-nodus-only-hint hidden data-i18n="settings.standaloneNote">Nodus-only features are unavailable in Standalone mode.</div>
@@ -151,6 +162,8 @@
   <script src="chrome://nodus/content/icons.js"></script>
   <script src="chrome://nodus/content/providers.js"></script>
   <script src="chrome://nodus/content/store.js"></script>
+  <script src="chrome://nodus/content/evidence.js"></script>
+  <script src="chrome://nodus/content/multimodal.js"></script>
   <script src="chrome://nodus/content/agent.js"></script>
   <script src="chrome://nodus/content/util.js"></script>
   <script src="chrome://nodus/content/markdown.js"></script>

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -13,6 +13,8 @@ const NM = window.NodusMarkdown;
 const NU = window.NodusUtil;
 const NH = window.NodusHighlighter;
 const NI = window.NodusIcons;
+const NE = window.NodusEvidence;
+const NV = window.NodusMultimodal;
 const ico = (name, size) => (NI ? NI.svg(name, { size: size || 16 }) : "");
 
 // Full-document context cap (~50k tokens): big enough for most modern models,
@@ -33,6 +35,10 @@ const I18N = {
     "mode.hint.standalone": "Works without Nodus, using your own provider API keys. Nodus-only features are off.",
     "settings.context": "Context", "settings.useIdeas": "Use Nodus ideas when available",
     "settings.useFulltext": "Send document text", "settings.useCorpus": "Search my Nodus library for related passages",
+    "evidence.idle": "Evidence index idle", "evidence.index": "Index", "evidence.indexTitle": "Index selected documents and OCR text-poor PDF pages",
+    "evidence.vision": "Vision", "evidence.visionTitle": "Analyze and attach the current rendered PDF page",
+    "evidence.auto": "Auto: full text when small, retrieval when large", "evidence.retrieval": "Semantic retrieval", "evidence.full": "Complete text",
+    "evidence.embedding": "Embedding model",
     "settings.standaloneNote": "Nodus-only features are unavailable in Standalone mode.",
     "settings.language": "Language", "settings.connection": "Nodus connection", "settings.test": "Test connection",
     "settings.token": "token", "settings.manualHint": "Leave empty to auto-detect from Nodus.",
@@ -114,6 +120,10 @@ const I18N = {
     "mode.hint.standalone": "Funciona sin Nodus, con tus propias API keys. Las funciones exclusivas de Nodus quedan desactivadas.",
     "settings.context": "Contexto", "settings.useIdeas": "Usar ideas de Nodus cuando existan",
     "settings.useFulltext": "Enviar texto del documento", "settings.useCorpus": "Buscar pasajes relacionados en mi biblioteca Nodus",
+    "evidence.idle": "Índice de evidencia inactivo", "evidence.index": "Indexar", "evidence.indexTitle": "Indexar los documentos seleccionados y aplicar OCR a las páginas PDF sin texto",
+    "evidence.vision": "Visión", "evidence.visionTitle": "Analizar y adjuntar la página PDF renderizada actual",
+    "evidence.auto": "Auto: texto completo si es pequeño; recuperación si es grande", "evidence.retrieval": "Búsqueda semántica", "evidence.full": "Texto completo",
+    "evidence.embedding": "Modelo de embeddings",
     "settings.standaloneNote": "Las funciones exclusivas de Nodus no están disponibles en modo Autónomo.",
     "settings.language": "Idioma", "settings.connection": "Conexión con Nodus", "settings.test": "Probar conexión",
     "settings.token": "token", "settings.manualHint": "Déjalo vacío para detectarlo automáticamente desde Nodus.",
@@ -196,6 +206,7 @@ const state = {
   agentEnabled: false, agentAuto: false, selectionDraft: null,
   items: [], maxTokens: 8192, reasoning: "default", notifierID: null, pollTimer: null,
   hlColors: { high: "#ff6666", medium: "#ffd400" }, lastHighlightKeys: [],
+  indexes: [], evidence: new Map(), retrieval: null, visuals: [], contextStrategy: "auto",
 };
 
 const t = (k) => (I18N[state.lang] && I18N[state.lang][k]) || I18N.en[k] || k;
@@ -297,6 +308,8 @@ function renderModelDropdown() {
     it.addEventListener("click", () => {
       state.model = { provider: m.provider, model: m.model };
       NS.setModel(state.mode, state.model);
+      const embeddingInput = $("#nd-embedding-model");
+      if (embeddingInput) embeddingInput.value = NS.getEmbeddingModel(m.provider);
       closeModelMenu(); renderModelDropdown(); updateSendEnabled();
     });
     list.appendChild(it); shown++;
@@ -388,6 +401,311 @@ async function getDocumentText() {
   return "";
 }
 
+function setIndexStatus(text, tone) {
+  const box = $("#nd-index-status");
+  if (!box) return;
+  box.textContent = text;
+  box.className = tone ? "nd-index-status nd-index-status--" + tone : "nd-index-status";
+}
+async function selectedAttachments() {
+  const cur = getCurrentItem();
+  const out = [];
+  if (cur.attachment) out.push(cur.attachment);
+  else if (cur.item && cur.item.getBestAttachment) {
+    try { const a = await cur.item.getBestAttachment(); if (a) out.push(a); } catch (e) {}
+  }
+  if (!cur.reader) {
+    try {
+      const w = Zotero.getMainWindow();
+      const zp = (w && w.ZoteroPane) || Zotero.getActiveZoteroPane();
+      for (let item of (zp && zp.getSelectedItems ? zp.getSelectedItems() : [])) {
+        let att = null;
+        if (item.isAttachment && item.isAttachment()) att = item;
+        else if (item.getBestAttachment) { try { att = await item.getBestAttachment(); } catch (e) {} }
+        if (att && !out.some((x) => x.id === att.id)) out.push(att);
+      }
+    } catch (e) {}
+  }
+  return out;
+}
+function embeddingRef() {
+  const candidates = [];
+  if (state.model) candidates.push(state.model.provider);
+  candidates.push("openrouter", "openai", "gemini", "ollama", "lmstudio");
+  for (const provider of [...new Set(candidates)]) {
+    const p = NP.byId(provider);
+    if (!p || p.subscription || provider === "anthropic") continue;
+    if (!p.needsKey || NS.getKey(provider)) return { provider, model: NS.getEmbeddingModel(provider) };
+  }
+  return null;
+}
+async function ensureEmbeddings(indexes, signal) {
+  const ref = embeddingRef();
+  if (!ref) return { model: null, embedded: 0 };
+  let embedded = 0;
+  for (const index of indexes) {
+    const missing = (index.chunks || []).filter((c) => !Array.isArray(c.embedding) || c.embeddingModel !== ref.model);
+    for (let i = 0; i < missing.length; i += 32) {
+      const batch = missing.slice(i, i + 32);
+      setIndexStatus("Embedding " + Math.min(i + batch.length, missing.length) + "/" + missing.length + " · " + (index.title || index.attachmentKey), "busy");
+      const vectors = await NP.embed(ref, batch.map((c) => c.text), {
+        key: NS.getKey(ref.provider), localBase: NS.getLocalBase(ref.provider),
+      }, signal);
+      batch.forEach((chunk, j) => { chunk.embedding = vectors[j]; chunk.embeddingModel = ref.model; embedded++; });
+    }
+    index.embeddingModel = ref.model;
+    index.updatedAt = Date.now();
+    await NS.saveEvidenceIndex(index);
+  }
+  return { model: ref, embedded };
+}
+function parseRankedIds(value, allowed) {
+  const text = String(value || "").replace(/```(?:json)?/gi, "").replace(/```/g, "");
+  const a = text.indexOf("["), b = text.lastIndexOf("]");
+  if (a < 0 || b <= a) return [];
+  try {
+    const parsed = JSON.parse(text.slice(a, b + 1));
+    const ids = Array.isArray(parsed) ? parsed : (parsed && Array.isArray(parsed.ids) ? parsed.ids : []);
+    return ids.map(String).filter((id) => allowed.has(id));
+  } catch (e) { return []; }
+}
+async function rerankEvidence(query, result, indexes, signal) {
+  if (!result || !Array.isArray(result.candidates) || !result.candidates.length) return result && result.hits ? result.hits : [];
+  const candidates = result.candidates.slice(0, 36);
+  const allowed = new Set(candidates.map((c) => c.id));
+  const catalogue = candidates.map((c) =>
+    `${c.id} | ${c.title || c.itemKey} | page ${c.pageLabel} | ${String(c.text || "").replace(/\s+/g, " ").slice(0, 650)}`
+  ).join("\n");
+  const system = [
+    "You rerank academic evidence passages for a user question.",
+    "Understand the question across languages. Rank passages that directly answer it above merely related passages or bibliography entries.",
+    "Return ONLY a JSON array of up to 10 exact passage ids, best first. Do not invent ids.",
+  ].join("\n");
+  const prompt = `QUESTION:\n${query}\n\nCANDIDATES:\n${catalogue}`;
+  let acc = "";
+  try {
+    if (state.mode === "connected") {
+      const response = await apiJson("/api/z/rerank", {
+        method: "POST", body: JSON.stringify({ model: state.model, query, candidates }),
+        signal,
+      });
+      acc = JSON.stringify(response.ids || []);
+    } else {
+      await NP.chatStream(state.model, {
+        system,
+        key: NS.getKey(state.model.provider),
+        localBase: NS.getLocalBase(state.model.provider),
+        maxTokens: 1200,
+        reasoning: "off",
+        messages: [{ role: "user", content: prompt }],
+      }, (delta) => { acc += delta; }, signal);
+    }
+    const ids = parseRankedIds(acc, allowed);
+    const required = indexes.length > 1
+      ? indexes.map((index) => index.chunks && index.chunks[0] && index.chunks[0].id).filter((id) => id && allowed.has(id))
+      : [];
+    const fallbackIds = ids.length ? ids : (result.hits || []).map((hit) => hit.id);
+    const seeds = NE.diversifyCandidates(candidates, [...required, ...fallbackIds], { topK: 8, maxPerSource: indexes.length > 1 ? 4 : 8 });
+    return NE.expandWithNeighbors(indexes, seeds, { topK: 12, maxPerSource: indexes.length > 1 ? 5 : 12 });
+  } catch (e) {
+    try { Zotero.logError(e); } catch (x) {}
+    return result.hits;
+  }
+}
+async function repairEvidenceAnswer(answer, evidence, signal) {
+  const hits = [...(evidence instanceof Map ? evidence.values() : evidence || [])];
+  if (!hits.length || !String(answer || "").trim()) return String(answer || "");
+  const system = [
+    "You repair evidence citations in an academic answer.",
+    "Return the complete answer in the same language and preserve its meaning and structure.",
+    "For every factual claim, add one or more exact [[e:ID]] tokens from the catalogue immediately after the supported sentence.",
+    "Never invent or alter an id. If no passage supports a claim, replace only that claim with an explicit statement that the supplied evidence is insufficient.",
+    "Return only the repaired answer, with no commentary or code fence.",
+  ].join("\n");
+  const prompt = `ANSWER TO REPAIR:\n${answer}\n\n${NE.evidencePrompt(hits)}`;
+  let acc = "";
+  try {
+    if (state.mode === "connected") {
+      const response = await apiJson("/api/z/citation-repair", {
+        method: "POST", body: JSON.stringify({ model: state.model, answer, evidence: hits }),
+        signal,
+      });
+      return String(response.text || answer);
+    }
+    await NP.chatStream(state.model, {
+      system,
+      key: NS.getKey(state.model.provider),
+      localBase: NS.getLocalBase(state.model.provider),
+      maxTokens: Math.min(state.maxTokens, 3000),
+      reasoning: "off",
+      messages: [{ role: "user", content: prompt }],
+    }, (delta) => { acc += delta; }, signal);
+    return acc.trim() || answer;
+  } catch (e) {
+    try { Zotero.logError(e); } catch (x) {}
+    return answer;
+  }
+}
+function auditValidatedAnswer(value) {
+  const checked = NE.validateCitations(value, { evidence: state.evidence });
+  const audit = NE.auditClaims(checked.text, state.evidence);
+  audit.invalidCitations = checked.invalid;
+  if (checked.invalid.length) {
+    audit.claims.push({
+      text: state.lang === "es"
+        ? "Cita rechazada porque el modelo inventó o alteró el identificador de evidencia."
+        : "Citation rejected because the model invented or altered the evidence id.",
+      citationIds: checked.invalid.map((c) => c.id),
+      status: "missing", support: 0, evidence: [],
+    });
+    audit.missing += checked.invalid.length;
+    audit.total += checked.invalid.length;
+    audit.coverage = audit.total ? audit.covered / audit.total : 0;
+  }
+  return { text: checked.text, audit };
+}
+async function buildSelectedIndexes(force, signal) {
+  if (!NE) return [];
+  const attachments = await selectedAttachments();
+  if (!attachments.length) return [];
+  if (attachments.length > 1) {
+    state.item = null;
+    state.items = attachments.map((att) => {
+      let item = null;
+      try { item = att.parentItem || att; } catch (e) { item = att; }
+      const info = { key: item && item.key ? item.key : att.key };
+      try { info.title = item.getDisplayTitle ? item.getDisplayTitle() : item.getField("title"); } catch (e) { info.title = att.key; }
+      try { info.year = item.getField("date") ? String(item.getField("date")).slice(0, 4) : ""; } catch (e) {}
+      try { info.creators = item.getField("firstCreator") || ""; } catch (e) {}
+      try { info.abstract = item.getField("abstractNote") || ""; } catch (e) {}
+      return info;
+    });
+    const box = $("#nd-item");
+    if (box) {
+      box.innerHTML = "";
+      box.appendChild(el("div", "nd-item-title", tf("item.multi", { n: state.items.length })));
+      box.appendChild(el("div", "nd-muted", state.items.map((i) => i.title || i.key).join(" · ")));
+    }
+  }
+  const indexes = [];
+  for (let i = 0; i < attachments.length; i++) {
+    setIndexStatus("Indexing " + (i + 1) + "/" + attachments.length, "busy");
+    const result = await NE.ensureIndex(attachments[i], NS, { force: !!force });
+    indexes.push(result.index);
+  }
+  state.indexes = indexes;
+  setIndexStatus(indexes.length + " source" + (indexes.length === 1 ? "" : "s") + " · " + indexes.reduce((n, x) => n + x.chunks.length, 0) + " passages", "ok");
+  return indexes;
+}
+async function prepareEvidence(query, signal) {
+  state.evidence = new Map(); state.retrieval = null;
+  const ctx = NS.getContext();
+  if (!ctx.useFulltext || !NE) return { text: "", hits: [], method: "off", truncated: false };
+  await refreshItem(true);
+  const indexes = await buildSelectedIndexes(false, signal);
+  if (!indexes.length) return { text: "", hits: [], method: "empty", truncated: false };
+  const totalChars = indexes.reduce((n, x) => n + (x.totalChars || 0), 0);
+  const strategy = ctx.strategy === "auto" ? (totalChars <= 120000 && indexes.length <= 3 ? "full" : "retrieval") : ctx.strategy;
+  if (strategy === "full") {
+    const full = NE.fullEvidencePrompt(indexes, 750000);
+    state.evidence = NE.evidenceMap(full.hits);
+    state.retrieval = { method: "full", hits: full.hits, totalChars, truncated: full.truncated };
+    setIndexStatus("Complete text · " + full.hits.length + " citable passages", full.truncated ? "warn" : "ok");
+    return { ...full, method: "full" };
+  }
+  let queryEmbedding = null;
+  try {
+    const semantic = await ensureEmbeddings(indexes, signal);
+    if (semantic.model) {
+      const vectors = await NP.embed(semantic.model, [query], {
+        key: NS.getKey(semantic.model.provider), localBase: NS.getLocalBase(semantic.model.provider),
+      }, signal);
+      queryEmbedding = vectors[0];
+    }
+  } catch (e) {
+    try { Zotero.logError(e); } catch (x) {}
+    setIndexStatus("Semantic unavailable · lexical fallback", "warn");
+  }
+  const result = NE.hybridSearch(indexes, query, queryEmbedding);
+  result.hits = await rerankEvidence(query, result, indexes, signal);
+  result.method += "+rerank";
+  state.evidence = NE.evidenceMap(result.hits);
+  state.retrieval = result;
+  setIndexStatus((result.method.startsWith("hybrid") ? "Semantic + lexical + rerank" : "Lexical + rerank") + " · " + result.hits.length + " passages", "ok");
+  return { text: NE.evidencePrompt(result.hits), hits: result.hits, method: result.method, truncated: false };
+}
+async function runVisualExtraction(image, page) {
+  const prompt = NV.visualPrompt(page.pageLabel, page.text);
+  if (state.mode === "connected") {
+    const res = await apiJson("/api/z/vision", {
+      method: "POST",
+      body: JSON.stringify({ model: state.model, system: NV.VISUAL_SYSTEM, prompt, images: [image] }),
+    });
+    return NV.cleanVisualExtraction(res.text || "");
+  }
+  let acc = "";
+  await NP.chatStream(state.model, {
+    system: NV.VISUAL_SYSTEM,
+    key: NS.getKey(state.model.provider),
+    localBase: NS.getLocalBase(state.model.provider),
+    maxTokens: Math.min(state.maxTokens, 4096),
+    reasoning: "off",
+    messages: [{ role: "user", content: prompt }],
+    images: [image],
+  }, (delta) => { acc += delta; }, state.abort ? state.abort.signal : undefined);
+  return NV.cleanVisualExtraction(acc);
+}
+async function analyzeCurrentPage() {
+  if (state.busy || !NV || !NE || !currentModel()) return;
+  const cur = getCurrentItem();
+  if (!cur.reader || !cur.attachment) { showToast(state.lang === "es" ? "Abre un PDF en el lector primero." : "Open a PDF in the reader first."); return; }
+  state.busy = true; state.abort = new AbortController(); updateSendEnabled();
+  try {
+    setIndexStatus("Capturing rendered page…", "busy");
+    const ensured = await NE.ensureIndex(cur.attachment, NS);
+    const pageIndex = NV.currentPageIndex(cur.reader);
+    const image = await NV.capturePage(cur.reader, pageIndex);
+    const page = ensured.index.pages.find((p) => p.pageIndex === pageIndex);
+    if (!page) throw new Error("page-not-indexed");
+    setIndexStatus("Reading figures, tables, formulas and OCR…", "busy");
+    const visualText = await runVisualExtraction(image, page);
+    if (!visualText) throw new Error("no-visual-content");
+    NE.addVisualText(ensured.index, pageIndex, visualText);
+    await NS.saveEvidenceIndex(ensured.index);
+    state.indexes = [ensured.index];
+    state.visuals = [{ ...image, label: "Rendered document page " + page.pageLabel }];
+    setIndexStatus("Page " + page.pageLabel + " visual evidence indexed", "ok");
+    showToast(state.lang === "es" ? "Página visual indexada y adjunta a la próxima pregunta." : "Visual page indexed and attached to the next question.");
+  } catch (e) {
+    setIndexStatus("Vision failed: " + (e.message || e), "warn");
+  } finally {
+    state.busy = false; state.abort = null; updateSendEnabled();
+  }
+}
+async function analyzeMissingOcr(indexes) {
+  if (!NV || !NE) return 0;
+  const cur = getCurrentItem();
+  if (!cur.reader || !cur.attachment) return 0;
+  const index = (indexes || []).find((x) => x.attachmentKey === cur.attachment.key);
+  if (!index) return 0;
+  const pages = (index.pages || []).filter((page) => page.needsOcr);
+  let completed = 0;
+  for (let i = 0; i < pages.length; i++) {
+    if (state.abort && state.abort.signal.aborted) break;
+    const page = pages[i];
+    setIndexStatus("OCR page " + (i + 1) + "/" + pages.length + " · rendered fallback", "busy");
+    try {
+      const image = await NV.capturePage(cur.reader, page.pageIndex);
+      const visualText = await runVisualExtraction(image, page);
+      if (!visualText) continue;
+      NE.addVisualText(index, page.pageIndex, visualText);
+      await NS.saveEvidenceIndex(index);
+      completed++;
+    } catch (e) { try { Zotero.logError(e); } catch (x) {} }
+  }
+  return completed;
+}
+
 // ─────────────────────────────────────────── messages + citations
 const messagesEl = () => $("#nd-messages");
 // `index` is the message's position in state.conv.messages; when given, a small
@@ -433,8 +751,12 @@ function rerenderConversation() {
   messagesEl().innerHTML = "";
   if (!state.conv || !state.conv.messages.length) { const h = el("div", "nd-hint"); h.textContent = t("chat.hint"); messagesEl().appendChild(h); return; }
   state.conv.messages.forEach((m, i) => {
+    if (m.role === "assistant" && Array.isArray(m.evidence)) state.evidence = NE ? NE.evidenceMap(m.evidence) : new Map();
     const b = addMessage(m.role, m.content, i);
-    if (m.role === "assistant") { b.setAttribute("data-raw", m.content); renderRich(b, m.content); }
+    if (m.role === "assistant") {
+      b.setAttribute("data-raw", m.content); renderRich(b, m.content);
+      if (m.audit) renderEvidenceAudit(b, m.audit, m.evidence || []);
+    }
   });
 }
 // Reload the user message into the composer and drop it + everything after, so
@@ -468,7 +790,7 @@ function addDocNote(info) {
 }
 function renderCitations(bodyEl, text) {
   bodyEl.textContent = "";
-  const re = /\[\[(p|idea|zotero|gap):([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+  const re = /\[\[(e|p|idea|zotero|gap):([^\]|]+)(?:\|([^\]]+))?\]\]/g;
   let last = 0, m;
   while ((m = re.exec(text)) !== null) { if (m.index > last) bodyEl.appendChild(document.createTextNode(text.slice(last, m.index))); bodyEl.appendChild(makeCite(m[1], m[2].trim(), m[3])); last = re.lastIndex; }
   if (last < text.length) bodyEl.appendChild(document.createTextNode(text.slice(last)));
@@ -482,11 +804,53 @@ function renderRich(bodyEl, text) {
 }
 function makeCite(kind, id, label) {
   const chip = el("a", "nd-cite");
-  if (kind === "p") { chip.textContent = "p. " + id; chip.onclick = () => goToPage(id); }
+  if (kind === "e") {
+    const hit = state.evidence && state.evidence.get(id);
+    chip.textContent = hit ? ((hit.title || "source").slice(0, 24) + " · p. " + hit.pageLabel) : (label || "evidence");
+    if (!hit) chip.classList.add("nd-cite--invalid");
+    chip.onclick = () => hit && goToEvidence(hit);
+    chip.title = hit ? hit.text : "Evidence unavailable";
+  }
+  else if (kind === "p") { chip.textContent = "p. " + id; chip.onclick = () => goToPage(id); }
   else if (kind === "idea") { chip.textContent = "▸ " + (label || state.ideaLabels[id] || "idea"); chip.onclick = () => openInNodus("idea", id); }
   else if (kind === "gap") { chip.textContent = "◇ " + (label || "gap"); chip.onclick = () => openInNodus("gap", id); }
   else if (kind === "zotero") { chip.textContent = "↗ " + (label || "source"); chip.onclick = () => selectInZotero(id); }
   return chip;
+}
+function goToEvidence(hit) {
+  if (!hit) return;
+  const reader = activeReader();
+  const cur = getCurrentItem();
+  if (reader && cur.attachment && cur.attachment.key === hit.attachmentKey) {
+    try { reader.navigate({ pageIndex: Number(hit.pageIndex) || 0 }); return; } catch (e) {}
+  }
+  const page = encodeURIComponent(hit.pageLabel || String((Number(hit.pageIndex) || 0) + 1));
+  try { Zotero.launchURL("zotero://open-pdf/library/items/" + hit.attachmentKey + "?page=" + page); } catch (e) {}
+}
+function renderEvidenceAudit(bodyEl, audit, evidence) {
+  if (!audit) return;
+  const wrap = bodyEl.parentNode;
+  const card = el("details", "nd-audit");
+  const summary = el("summary", "nd-audit-summary");
+  const pct = Math.round((Number(audit.coverage) || 0) * 100);
+  const rejected = Array.isArray(audit.invalidCitations) ? audit.invalidCitations.length : 0;
+  summary.textContent = "Evidence audit · " + pct + "% · " + audit.covered + " supported · " + audit.weak + " weak · " + audit.missing + " uncited" + (rejected ? " · " + rejected + " rejected citation" + (rejected === 1 ? "" : "s") : "");
+  card.appendChild(summary);
+  const refs = NE ? NE.evidenceMap(evidence || []) : new Map();
+  for (const claim of audit.claims || []) {
+    const row = el("div", "nd-audit-claim nd-audit-claim--" + claim.status);
+    row.appendChild(el("div", "nd-audit-status", claim.status === "covered" ? "✓ supported" : claim.status === "weak" ? "△ weak match" : "○ missing citation"));
+    row.appendChild(el("div", "nd-audit-text", claim.text));
+    for (const id of claim.citationIds || []) {
+      const hit = refs.get(id);
+      if (!hit) continue;
+      const passage = el("button", "nd-audit-passage", (hit.title || "source") + " · p. " + hit.pageLabel + " — " + String(hit.text || "").slice(0, 240));
+      passage.onclick = () => goToEvidence(hit);
+      row.appendChild(passage);
+    }
+    card.appendChild(row);
+  }
+  wrap.appendChild(card);
 }
 function goToPage(pageLabel) {
   const n = parseInt(String(pageLabel).replace(/[^0-9]/g, ""), 10);
@@ -621,13 +985,19 @@ async function generateAssistant() {
   bodyEl.innerHTML = TYPING_HTML; // animated dots until the first token streams in
   let acc = "";
   try {
-    // Sample the open document ONCE (both modes share it) and warn if the work is
-    // too long to send whole, instead of silently truncating.
-    let docInfo = { text: "", truncated: false };
+    let docInfo = { text: "", hits: [], method: "off", truncated: false };
     if (NS.getContext().useFulltext) {
-      const raw = await getDocumentText();
-      docInfo = NU ? NU.sampleDocText(raw, DOC_CHAR_LIMIT) : { text: raw, truncated: false };
-      if (docInfo.truncated) addDocNote(docInfo);
+      const lastUser = [...state.conv.messages].reverse().find((m) => m.role === "user");
+      try {
+        docInfo = await prepareEvidence(lastUser ? lastUser.content : "", state.abort.signal);
+      } catch (e) {
+        try { Zotero.logError(e); } catch (x) {}
+        const raw = await getDocumentText();
+        const sampled = NU ? NU.sampleDocText(raw, DOC_CHAR_LIMIT) : { text: raw, truncated: false };
+        docInfo = { ...sampled, hits: [], method: "legacy" };
+        setIndexStatus("Index unavailable · plain text fallback", "warn");
+        if (docInfo.truncated) addDocNote(docInfo);
+      }
     }
     try {
       if (state.mode === "connected") acc = await sendConnected(bodyEl, state.abort.signal, docInfo);
@@ -645,11 +1015,32 @@ async function generateAssistant() {
       const parsed = NA.parseActions(acc);
       if (parsed.actions.length) { display = parsed.clean || acc; actions = parsed.actions; }
     }
+    let audit = null;
+    if (NE && state.evidence && state.evidence.size) {
+      let reviewed = auditValidatedAnswer(display);
+      if (reviewed.audit.invalidCitations.length || reviewed.audit.missing || reviewed.audit.weak) {
+        const repaired = await repairEvidenceAnswer(reviewed.text, state.evidence, state.abort.signal);
+        const second = auditValidatedAnswer(repaired);
+        second.audit.repairAttempted = true;
+        // Never let a repair make coverage worse or replace a substantive
+        // answer with a provider response that stopped midway.
+        const enoughText = repaired.trim().length >= Math.min(80, Math.max(35, reviewed.text.trim().length * 0.45));
+        if (enoughText && second.audit.coverage >= reviewed.audit.coverage && !second.audit.invalidCitations.length) reviewed = second;
+      }
+      display = reviewed.text; audit = reviewed.audit;
+    }
     if (!display) bodyEl.textContent = ""; // clear the dots if nothing came back
     bodyEl.setAttribute("data-raw", display);
     renderRich(bodyEl, display);
+    if (audit) renderEvidenceAudit(bodyEl, audit, [...state.evidence.values()]);
     if (actions) renderActionCards(bodyEl, actions);
-    const aidx = state.conv.messages.push({ role: "assistant", content: display }) - 1;
+    const storedEvidence = state.evidence ? [...state.evidence.values()].map((h) => ({
+      id: h.id, libraryID: h.libraryID, itemKey: h.itemKey, attachmentKey: h.attachmentKey,
+      title: h.title, pageIndex: h.pageIndex, pageLabel: h.pageLabel, section: h.section,
+      start: h.start, end: h.end, text: h.text, score: h.score, retrieval: h.retrieval,
+    })) : [];
+    const storedAudit = audit && NS.compactAudit ? NS.compactAudit(audit) : audit;
+    const aidx = state.conv.messages.push({ role: "assistant", content: display, evidence: storedEvidence, audit: storedAudit }) - 1;
     attachMessageActions(bodyEl.parentNode, "assistant", aidx, display);
     await persistConv();
   } catch (e) {
@@ -668,7 +1059,8 @@ async function sendConnected(bodyEl, signal, docInfo) {
     messages: state.conv.messages.map((m) => ({ role: m.role, content: m.content })),
     context: { zoteroKey: state.item ? state.item.key : "", doi: state.item ? state.item.doi : "", title: state.item ? state.item.title : "", selection: state.selection || "", useIdeas: ctx.useIdeas, useCorpus: ctx.useCorpus, agentInstructions: state.agentEnabled && NA ? NA.SYSTEM : "", extraContext, reasoning: state.reasoning },
   };
-  if (docInfo && docInfo.text) payload.context.documentText = docInfo.text;
+  if (docInfo && docInfo.text) payload.context.evidenceText = docInfo.text;
+  if (state.visuals.length) payload.images = state.visuals.slice(0, NV ? NV.MAX_IMAGES : 6);
   const res = await api("/api/z/chat/stream", { method: "POST", body: JSON.stringify(payload), signal });
   if (!res.ok || !res.body) throw new Error("HTTP " + res.status);
   let acc = ""; const reader = res.body.getReader(); const dec = new TextDecoder(); let buf = "";
@@ -684,6 +1076,7 @@ async function sendConnected(bodyEl, signal, docInfo) {
       messagesEl().scrollTop = messagesEl().scrollHeight;
     }
   }
+  state.visuals = [];
   return acc;
 }
 
@@ -693,19 +1086,32 @@ async function sendStandalone(bodyEl, signal, docInfo) {
   const itemsSummary = NU ? NU.buildItemsSummary(state.items) : "";
   if (itemsSummary) parts.push(itemsSummary);
   if (state.selection) parts.push('The user highlighted this passage (focus on it):\n"""\n' + state.selection + '\n"""');
-  if (docInfo && docInfo.text) parts.push('Document text:\n"""\n' + docInfo.text + '\n"""');
+  if (docInfo && docInfo.text) parts.push(docInfo.text);
   // Pin the reply language: some models (e.g. deepseek) otherwise drift to their
   // training language even for an English/Spanish question.
-  const lang = state.lang === "es" ? "Spanish" : "English";
-  let system = "You are a research assistant embedded in Zotero. Answer about the open document, grounded in the provided text. Be concise. Always answer in " + lang + " unless the user's last message is clearly in another language, in which case match that language.\n\n" + parts.join("\n\n");
+  const lastUser = [...state.conv.messages].reverse().find((m) => m.role === "user");
+  const lang = NU && NU.detectLanguage ? NU.detectLanguage(lastUser && lastUser.content, state.lang) : (state.lang === "es" ? "Spanish" : "English");
+  let system = "You are a research assistant embedded in Zotero. Answer about the open documents, grounded only in the supplied evidence. Cite every factual claim inline with the exact [[e:ID]] token for its supporting passage. Never invent, alter or reuse an evidence id for a claim it does not support. Put citations immediately after the sentence. If evidence is insufficient, say so. Be concise.\n\nOUTPUT LANGUAGE (highest priority): answer entirely in " + lang + ". Do not switch language because the source or an attached image uses another language.\n\n" + parts.join("\n\n");
   if (state.agentEnabled && NA) system += "\n\n" + NA.SYSTEM;
   const key = NS.getKey(state.model.provider);
   const localBase = NS.getLocalBase(state.model.provider);
   let acc = "";
-  await NP.chatStream(state.model, {
-    system, key, localBase, maxTokens: state.maxTokens, reasoning: state.reasoning,
-    messages: state.conv.messages.map((m) => ({ role: m.role, content: m.content })),
+  const messages = state.conv.messages.map((m) => ({ role: m.role, content: m.content }));
+  const images = state.visuals.slice(0, NV ? NV.MAX_IMAGES : 6);
+  let meta = await NP.chatStream(state.model, {
+    system, key, localBase, maxTokens: state.maxTokens, reasoning: state.reasoning, messages, images,
   }, (delta) => { acc += delta; bodyEl.textContent = acc; messagesEl().scrollTop = messagesEl().scrollHeight; }, signal);
+  if (NP.isProbablyTruncated && NP.isProbablyTruncated(acc, meta && meta.finishReason) && !signal.aborted) {
+    acc = "";
+    meta = await NP.chatStream(state.model, {
+      system: system + "\n\nRELIABILITY RETRY: Return the complete answer and finish every sentence.",
+      key, localBase, maxTokens: state.maxTokens, reasoning: state.reasoning, messages, images,
+    }, (delta) => { acc += delta; bodyEl.textContent = acc; messagesEl().scrollTop = messagesEl().scrollHeight; }, signal);
+  }
+  if (NP.isProbablyTruncated && NP.isProbablyTruncated(acc, meta && meta.finishReason)) {
+    throw new Error("The provider returned an incomplete response after retrying.");
+  }
+  state.visuals = [];
   return acc;
 }
 
@@ -1061,8 +1467,25 @@ function wire() {
   $("#nd-history-search").addEventListener("input", (e) => renderHistory(e.target.value));
   $("#nd-history-clear").addEventListener("click", async () => { if (await showConfirm(t("modal.delAll"))) { state.conversations = []; await NS.saveConversations([]); startNewConversation(); renderHistory(""); } });
   $("#nd-ctx-fulltext").addEventListener("change", saveContext);
+  $("#nd-ctx-strategy").addEventListener("change", saveContext);
+  $("#nd-embedding-model").addEventListener("change", (e) => {
+    NS.setEmbeddingModel(state.model ? state.model.provider : "openrouter", e.target.value);
+  });
   $("#nd-ctx-ideas").addEventListener("change", saveContext);
   $("#nd-ctx-corpus").addEventListener("change", saveContext);
+  $("#nd-index-btn").addEventListener("click", async () => {
+    if (state.busy) return;
+    state.busy = true; state.abort = new AbortController(); updateSendEnabled();
+    try {
+      await refreshItem(true);
+      const indexes = await buildSelectedIndexes(true, state.abort.signal);
+      const ocrPages = await analyzeMissingOcr(indexes);
+      await ensureEmbeddings(indexes, state.abort.signal);
+      setIndexStatus(indexes.length + " source" + (indexes.length === 1 ? "" : "s") + " fully indexed" + (ocrPages ? " · " + ocrPages + " OCR pages" : ""), "ok");
+    } catch (e) { setIndexStatus("Index failed: " + (e.message || e), "warn"); }
+    finally { state.busy = false; state.abort = null; updateSendEnabled(); }
+  });
+  $("#nd-visual-btn").addEventListener("click", () => analyzeCurrentPage());
   $("#nd-test").addEventListener("click", () => { NS.setManual($("#nd-port").value, $("#nd-token").value.trim()); connect().then(loadModelsForMode); });
   window.addEventListener("message", (e) => {
     if (!e.data || e.data.type !== "nodus-selection") return;
@@ -1085,7 +1508,15 @@ function wire() {
   // Notifier below, so this can be slow.
   state.pollTimer = setInterval(() => scheduleRefresh(false), 2000);
 }
-function saveContext() { NS.setContext({ useFulltext: $("#nd-ctx-fulltext").checked, useIdeas: $("#nd-ctx-ideas").checked, useCorpus: $("#nd-ctx-corpus").checked }); }
+function saveContext() {
+  state.contextStrategy = $("#nd-ctx-strategy").value;
+  NS.setContext({
+    useFulltext: $("#nd-ctx-fulltext").checked,
+    useIdeas: $("#nd-ctx-ideas").checked,
+    useCorpus: $("#nd-ctx-corpus").checked,
+    strategy: state.contextStrategy,
+  });
+}
 function saveHlColors() { state.hlColors = { high: $("#nd-hl-high").value || "#ff6666", medium: $("#nd-hl-medium").value || "#ffd400" }; NS.setHlColors(state.hlColors); }
 
 // Coalesced refresh so a burst of Notifier events (e.g. during sync) triggers a
@@ -1122,12 +1553,14 @@ async function boot() {
   state.reasoning = NS.getReasoning();
   state.hlColors = NS.getHlColors();
   const ctx = NS.getContext();
+  state.contextStrategy = ctx.strategy;
   wire();
   $("#nd-lang").value = state.lang;
   $("#nd-maxtokens").value = state.maxTokens;
   $("#nd-hl-high").value = state.hlColors.high; $("#nd-hl-medium").value = state.hlColors.medium;
   const m = NS.getManual(); $("#nd-port").value = m.port || ""; $("#nd-token").value = m.token || "";
   $("#nd-ctx-fulltext").checked = ctx.useFulltext; $("#nd-ctx-ideas").checked = ctx.useIdeas; $("#nd-ctx-corpus").checked = ctx.useCorpus;
+  $("#nd-ctx-strategy").value = ctx.strategy;
   state.agentEnabled = NS.getAgent(); state.agentAuto = NS.getAgentAuto();
   $("#nd-agent").checked = state.agentEnabled; $("#nd-agent-auto").checked = state.agentAuto;
   $("#nd-agent-btn").classList.toggle("nd-iconbtn--active", state.agentEnabled);
@@ -1138,6 +1571,7 @@ async function boot() {
   startNewConversation();
   await connect();
   await loadModelsForMode();
+  $("#nd-embedding-model").value = NS.getEmbeddingModel(state.model ? state.model.provider : "openrouter");
   await refreshItem(true);
 }
 boot().catch((e) => { try { Zotero.logError(e); } catch (x) {} });

--- a/zotero-plugin/content/store.js
+++ b/zotero-plugin/content/store.js
@@ -31,9 +31,25 @@
   function getHlColors() { const c = PJSON("hlColors", null); return { high: (c && c.high) || "#ff6666", medium: (c && c.medium) || "#ffd400" }; }
   function setHlColors(c) { SJSON("hlColors", { high: (c && c.high) || "#ff6666", medium: (c && c.medium) || "#ffd400" }); }
   function getContext() {
-    return { useIdeas: P("ctx.ideas", "1") !== "0", useCorpus: P("ctx.corpus", "1") !== "0", useFulltext: P("ctx.fulltext", "1") !== "0" };
+    const strategy = P("ctx.strategy", "auto");
+    return {
+      useIdeas: P("ctx.ideas", "1") !== "0",
+      useCorpus: P("ctx.corpus", "1") !== "0",
+      useFulltext: P("ctx.fulltext", "1") !== "0",
+      strategy: ["auto", "retrieval", "full"].includes(strategy) ? strategy : "auto",
+    };
   }
-  function setContext(c) { S("ctx.ideas", c.useIdeas ? "1" : "0"); S("ctx.corpus", c.useCorpus ? "1" : "0"); S("ctx.fulltext", c.useFulltext ? "1" : "0"); }
+  function setContext(c) {
+    S("ctx.ideas", c.useIdeas ? "1" : "0"); S("ctx.corpus", c.useCorpus ? "1" : "0"); S("ctx.fulltext", c.useFulltext ? "1" : "0");
+    S("ctx.strategy", ["auto", "retrieval", "full"].includes(c.strategy) ? c.strategy : "auto");
+  }
+  function defaultEmbeddingModel(provider) {
+    if (provider === "gemini") return "gemini-embedding-001";
+    if (provider === "ollama" || provider === "lmstudio") return "nomic-embed-text";
+    return provider === "openrouter" ? "openai/text-embedding-3-small" : "text-embedding-3-small";
+  }
+  function getEmbeddingModel(provider) { return P("embedding." + provider, defaultEmbeddingModel(provider)); }
+  function setEmbeddingModel(provider, model) { S("embedding." + provider, String(model || defaultEmbeddingModel(provider)).trim()); }
 
   // ---- providers ----
   function getKey(provider) { return P("key." + provider, "") || ""; }
@@ -76,20 +92,82 @@
     const dir = Services.dirsvc.get("ProfD", Components.interfaces.nsIFile).path;
     return PathUtils.join(dir, "nodus-zotero-conversations.json");
   }
+  function compactAudit(audit) {
+    if (!audit || typeof audit !== "object") return audit || null;
+    return {
+      total: Number(audit.total) || 0,
+      covered: Number(audit.covered) || 0,
+      weak: Number(audit.weak) || 0,
+      missing: Number(audit.missing) || 0,
+      coverage: Number(audit.coverage) || 0,
+      repairAttempted: !!audit.repairAttempted,
+      invalidCitations: Array.isArray(audit.invalidCitations)
+        ? audit.invalidCitations.map((citation) => ({
+          id: String(citation && citation.id || ""),
+          token: String(citation && citation.token || ""),
+        }))
+        : [],
+      claims: Array.isArray(audit.claims)
+        ? audit.claims.map((claim) => ({
+          text: String(claim && claim.text || ""),
+          citationIds: Array.isArray(claim && claim.citationIds) ? claim.citationIds.map(String) : [],
+          status: ["covered", "weak", "missing"].includes(claim && claim.status) ? claim.status : "missing",
+          support: Number(claim && claim.support) || 0,
+        }))
+        : [],
+    };
+  }
+  function compactConversations(list) {
+    if (!Array.isArray(list)) return [];
+    return list.map((conversation) => ({
+      ...conversation,
+      messages: Array.isArray(conversation && conversation.messages)
+        ? conversation.messages.map((message) => ({
+          ...message,
+          audit: message && message.audit ? compactAudit(message.audit) : null,
+        }))
+        : [],
+    }));
+  }
   async function loadConversations() {
-    try { const raw = await IOUtils.readUTF8(convPath()); const a = JSON.parse(raw); return Array.isArray(a) ? a : []; }
+    try { const raw = await IOUtils.readUTF8(convPath()); return compactConversations(JSON.parse(raw)); }
     catch (e) { return []; }
   }
   async function saveConversations(list) {
-    try { await IOUtils.writeUTF8(convPath(), JSON.stringify(list)); } catch (e) { try { Zotero.logError(e); } catch (x) {} }
+    try { await IOUtils.writeUTF8(convPath(), JSON.stringify(compactConversations(list))); } catch (e) { try { Zotero.logError(e); } catch (x) {} }
+  }
+  function indexDir() {
+    const dir = Services.dirsvc.get("ProfD", Components.interfaces.nsIFile).path;
+    return PathUtils.join(dir, "nodus-zotero-indexes");
+  }
+  function indexPath(libraryID, attachmentKey) {
+    const safe = String(libraryID) + "-" + String(attachmentKey || "").replace(/[^A-Za-z0-9_-]/g, "_");
+    return PathUtils.join(indexDir(), safe + ".json");
+  }
+  async function loadEvidenceIndex(libraryID, attachmentKey) {
+    try { return JSON.parse(await IOUtils.readUTF8(indexPath(libraryID, attachmentKey))); } catch (e) { return null; }
+  }
+  async function saveEvidenceIndex(index) {
+    try {
+      await IOUtils.makeDirectory(indexDir(), { ignoreExisting: true });
+      const target = indexPath(index.libraryID, index.attachmentKey);
+      const tmp = target + ".tmp";
+      await IOUtils.writeUTF8(tmp, JSON.stringify(index));
+      await IOUtils.move(tmp, target, { noOverwrite: false });
+      return target;
+    } catch (e) { try { Zotero.logError(e); } catch (x) {} return null; }
+  }
+  async function deleteEvidenceIndex(libraryID, attachmentKey) {
+    try { await IOUtils.remove(indexPath(libraryID, attachmentKey), { ignoreAbsent: true }); return true; } catch (e) { return false; }
   }
   function newId() { return "c_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8); }
 
   window.NodusStore = {
     getMode, setMode, getLang, setLang, getModel, setModel, getMaxTokens, setMaxTokens, getReasoning, setReasoning, getHlColors, setHlColors, getContext, setContext,
+    defaultEmbeddingModel, getEmbeddingModel, setEmbeddingModel,
     getKey, setKey, getLocalBase, setLocalBase, getPinned, setPinned, isPinned, togglePinned,
     getCustomPrompts, setCustomPrompts, addCustomPrompt, removeCustomPrompt,
     getAgent, setAgent, getAgentAuto, setAgentAuto,
-    getManual, setManual, loadConversations, saveConversations, newId,
+    getManual, setManual, loadConversations, saveConversations, compactAudit, compactConversations, loadEvidenceIndex, saveEvidenceIndex, deleteEvidenceIndex, newId,
   };
 })();

--- a/zotero-plugin/content/util.js
+++ b/zotero-plugin/content/util.js
@@ -62,5 +62,15 @@
     return "SELECTED DOCUMENTS (the user selected " + list.length + " items — you may compare, relate and reference them):\n" + lines.join("\n");
   }
 
-  window.NodusUtil = { sampleDocText, conversationToHtml, buildItemsSummary };
+  function detectLanguage(text, fallback) {
+    const s = String(text || "").normalize("NFKD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+    const count = (words) => words.reduce((n, word) => n + ((s.match(new RegExp("\\b" + word + "\\b", "g")) || []).length), 0);
+    const spanish = count(["que", "como", "segun", "documento", "pagina", "explica", "describe", "distingue", "cita", "evidencia", "vertientes", "etica"]);
+    const english = count(["what", "how", "according", "document", "page", "explain", "describe", "distinguish", "cite", "evidence"]);
+    if (spanish >= 2 && spanish > english) return "Spanish";
+    if (english >= 2 && english > spanish) return "English";
+    return fallback === "es" ? "Spanish" : "English";
+  }
+
+  window.NodusUtil = { sampleDocText, conversationToHtml, buildItemsSummary, detectLanguage };
 })();

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "0.0.16",
-  "description": "Nodus research assistant integrated into Zotero. Proof-of-concept: adds a toolbar button.",
+  "version": "0.1.0",
+  "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",
   "applications": {
     "zotero": {


### PR DESCRIPTION
## Summary

- Persist page- and section-aware full-text indexes for PDF, EPUB, and HTML attachments.
- Add hybrid BM25/embedding retrieval, reranking, neighbor expansion, per-source balancing, and a complete-text mode.
- Ground answers in an exact evidence allowlist with repair, claim-level audit, source/page chips, and Zotero page navigation.
- Add rendered-page OCR and visual understanding for scanned text, figures, tables, formulas, and diagrams, merging visual evidence back into search.
- Support standalone OpenAI-compatible providers and the linked Nodus server, English/Spanish interaction, settings, status feedback, and compact persisted audits.
- Document the implementation plan and user-facing capabilities.

## Validation

- `node --test scripts/test-zotero-plugin.mjs` — 42/42 passed.
- `npm run typecheck` — passed.
- `npm run lint` — 0 errors; 5 existing warnings.
- `npm run build` — passed.
- `node scripts/build-zotero-xpi.mjs` — generated a valid 17-file XPI.
- `node scripts/verify-zotero-install.mjs` — installed and active as v0.1.0 in Zotero 9.0.6.
- Live Zotero E2E covered three-document semantic retrieval, complete-text mode, exact citation navigation, fabricated-citation rejection, persistence/restart, and page-level visual analysis.
- Live OpenRouter streaming covered embeddings, reranking, multimodal requests, citation auditing, and coherent Spanish responses.

Closes #209