### PR TITLE
perf(zotero): faster indexing via Quick/Full split, on-demand OCR, background embeddings, WebGPU

### DIFF
--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -729,7 +729,9 @@ test('local retrieval: E5 is pinned, isolated in a worker and requires no embedd
 test('agentic retrieval: both modes use a validated two-round planner', () => {
   const sidebar = readSource('zotero-plugin/content/sidebar.js');
   const server = readSource('electron/zotero-plugin/server.ts');
-  assert.match(sidebar, /for \(let round = 1; round <= 2; round\+\+\)/);
+  assert.match(sidebar, /for \(let round = 1; round <= ctx\.agenticRounds; round\+\+\)/);
+  const store = readSource('zotero-plugin/content/store.js');
+  assert.ok(store.includes('agenticRounds') && /Math\.max\(0, Math\.min\(2,/.test(store), 'agentic rounds are capped at 2, configurable via settings');
   assert.ok(sidebar.includes('/api/z/retrieval-plan'));
   assert.ok(sidebar.includes('pageRequestHits') && sidebar.includes('mergeRetrievalResults'));
   assert.ok(sidebar.includes('every named entity, requested sub-question'));

--- a/scripts/zotero-local-embedding-worker.mjs
+++ b/scripts/zotero-local-embedding-worker.mjs
@@ -32,6 +32,7 @@ env.backends.onnx.wasm.numThreads = Math.max(
 );
 
 let extractorPromise = null;
+let backendUsed = null;
 
 function createIndexedDbCache() {
   let dbPromise = null;
@@ -124,17 +125,44 @@ function progressCallback(progress) {
 
 async function extractor() {
   if (!extractorPromise) {
-    extractorPromise = pipeline('feature-extraction', MODEL_ID, {
-      revision: MODEL_REVISION,
-      dtype: MODEL_DTYPE,
-      device: 'wasm',
-      progress_callback: progressCallback,
-    }).catch((error) => {
+    extractorPromise = createExtractor().catch((error) => {
       extractorPromise = null;
       throw error;
     });
   }
   return extractorPromise;
+}
+
+// WebGPU is much faster than WASM for this model when it's actually available
+// and stable, but Zotero runs on Firefox's engine where WebGPU support in
+// ChromeWorkers varies by platform/version. Probe for navigator.gpu first and
+// fall back to WASM on any failure so indexing never hard-fails because of it.
+async function createExtractor() {
+  const canTryWebgpu = typeof navigator !== 'undefined' && !!navigator.gpu;
+  if (canTryWebgpu) {
+    try {
+      const model = await pipeline('feature-extraction', MODEL_ID, {
+        revision: MODEL_REVISION,
+        dtype: MODEL_DTYPE,
+        device: 'webgpu',
+        progress_callback: progressCallback,
+      });
+      backendUsed = 'webgpu';
+      globalThis.postMessage({ type: 'backend', backend: backendUsed });
+      return model;
+    } catch (error) {
+      // Fall through to WASM below.
+    }
+  }
+  const model = await pipeline('feature-extraction', MODEL_ID, {
+    revision: MODEL_REVISION,
+    dtype: MODEL_DTYPE,
+    device: 'wasm',
+    progress_callback: progressCallback,
+  });
+  backendUsed = 'wasm';
+  globalThis.postMessage({ type: 'backend', backend: backendUsed });
+  return model;
 }
 
 function prefix(role, value) {
@@ -175,13 +203,14 @@ globalThis.addEventListener('message', async (event) => {
           dtype: MODEL_DTYPE,
           dimensions: MODEL_DIMENSIONS,
           fingerprint: MODEL_FINGERPRINT,
+          backend: backendUsed,
         },
       });
       return;
     }
     if (message.type === 'warmup') {
       await extractor();
-      globalThis.postMessage({ type: 'result', id, result: { ready: true } });
+      globalThis.postMessage({ type: 'result', id, result: { ready: true, backend: backendUsed } });
       return;
     }
     if (message.type !== 'embed') throw new Error('unknown-local-embedding-message');

--- a/zotero-plugin/content/local-embeddings.js
+++ b/zotero-plugin/content/local-embeddings.js
@@ -18,6 +18,7 @@
 
   let worker = null;
   let seq = 0;
+  let lastBackend = null;
   const pending = new Map();
   const progressListeners = new Set();
 
@@ -31,6 +32,10 @@
         for (const listener of progressListeners) {
           try { listener(message.progress || {}); } catch (e) {}
         }
+        return;
+      }
+      if (message.type === "backend") {
+        lastBackend = String(message.backend || "") || null;
         return;
       }
       const job = pending.get(String(message.id || ""));
@@ -92,7 +97,12 @@
     return vectors && vectors[0] ? vectors[0] : [];
   }
   async function warmup(opts) {
-    return request("warmup", null, opts && opts.signal);
+    const result = await request("warmup", null, opts && opts.signal);
+    if (result && result.backend) lastBackend = result.backend;
+    return result;
+  }
+  function getBackend() {
+    return lastBackend;
   }
   function reset() {
     if (worker) { try { worker.terminate(); } catch (e) {} }
@@ -111,6 +121,7 @@
     embedQuery,
     warmup,
     onProgress,
+    getBackend,
     reset,
   };
 })();

--- a/zotero-plugin/content/sidebar.css
+++ b/zotero-plugin/content/sidebar.css
@@ -286,6 +286,8 @@ h4.nd-md-h, h5.nd-md-h, h6.nd-md-h { font-size: 12.5px; }
 .nd-index-status--ok { color:#16803c !important; }
 .nd-index-status--warn { color:#b45309 !important; }
 .nd-evidencebar button { padding:3px 7px; font-size:11px; }
+.nd-embed-progress { height:3px; background:var(--nd-border); overflow:hidden; }
+.nd-embed-progress-bar { height:100%; width:0%; background:var(--nd-accent); transition:width .25s ease; }
 .nd-audit { margin:7px 10px 3px; border:1px solid var(--nd-border); border-radius:7px; background:rgba(124,58,237,.035); font-size:11px; }
 .nd-audit-summary { cursor:pointer; padding:7px 9px; font-weight:600; }
 .nd-audit-claim { padding:7px 9px; border-top:1px solid var(--nd-border); }

--- a/zotero-plugin/content/sidebar.html
+++ b/zotero-plugin/content/sidebar.html
@@ -46,9 +46,11 @@
       <div id="nd-item"></div>
       <div id="nd-evidencebar" class="nd-evidencebar">
         <span id="nd-index-status" data-i18n="evidence.idle">Evidence index idle</span>
-        <button id="nd-index-btn" class="nd-btn-ghost" data-i18n="evidence.index" data-i18n-title="evidence.indexTitle" title="Index selected documents">Index</button>
+        <button id="nd-index-quick-btn" class="nd-btn-ghost" data-i18n="evidence.indexQuick" data-i18n-title="evidence.indexQuickTitle" title="Quick index (text only)">Quick index</button>
+        <button id="nd-index-full-btn" class="nd-btn-ghost" data-i18n="evidence.indexFull" data-i18n-title="evidence.indexFullTitle" title="Full index (OCR + embeddings)">Full index</button>
         <button id="nd-visual-btn" class="nd-btn-ghost" data-i18n="evidence.vision" data-i18n-title="evidence.visionTitle" title="Analyze current page image">Vision</button>
       </div>
+      <div id="nd-embed-progress" class="nd-embed-progress" hidden><div id="nd-embed-progress-bar" class="nd-embed-progress-bar"></div></div>
       <div id="nd-selection" hidden></div>
       <div id="nd-messages"></div>
       <div id="nd-prompt-menu" class="nd-menu" hidden></div>
@@ -85,6 +87,12 @@
           <option value="full" data-i18n="evidence.full">Complete text</option>
         </select>
         <div id="nd-local-embedding" class="nd-muted" data-i18n="evidence.localEmbedding">Local semantic model: multilingual E5 small (INT8). Runs on this device; no embedding API key required.</div>
+        <label data-i18n="settings.ocrMode">Visual OCR for text-poor pages</label>
+        <select id="nd-ctx-ocr">
+          <option value="off" data-i18n="evidence.ocrOff">Off (fastest indexing)</option>
+          <option value="ondemand" data-i18n="evidence.ocrOnDemand">On demand (only pages you ask about)</option>
+          <option value="always" data-i18n="evidence.ocrAlways">Always (full index button)</option>
+        </select>
         <label class="nd-check" data-nodus-only><input type="checkbox" id="nd-ctx-ideas" /> <span data-i18n="settings.useIdeas">Use Nodus ideas when available</span></label>
         <label class="nd-check" data-nodus-only><input type="checkbox" id="nd-ctx-corpus" /> <span data-i18n="settings.useCorpus">Search my Nodus library for related passages</span></label>
         <div class="nd-muted" data-nodus-only-hint hidden data-i18n="settings.standaloneNote">Nodus-only features are unavailable in Standalone mode.</div>

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -37,11 +37,16 @@ const I18N = {
     "settings.context": "Context", "settings.useIdeas": "Use Nodus ideas when available",
     "settings.useFulltext": "Send document text", "settings.useCorpus": "Search my Nodus library for related passages",
     "evidence.idle": "Evidence index idle", "evidence.index": "Index", "evidence.indexTitle": "Index selected documents and OCR text-poor PDF pages",
+    "evidence.indexQuick": "Quick index", "evidence.indexQuickTitle": "Extract and chunk text only (no OCR, no embeddings) — fastest",
+    "evidence.indexFull": "Full index", "evidence.indexFullTitle": "Extract text, run OCR on text-poor pages (if enabled) and compute embeddings",
     "evidence.vision": "Vision", "evidence.visionTitle": "Analyze and attach the current rendered PDF page",
     "evidence.auto": "Auto: full text when small, retrieval when large", "evidence.retrieval": "Semantic retrieval", "evidence.full": "Complete text",
     "evidence.localEmbedding": "Local semantic model: multilingual E5 small (INT8). Runs on this device; no embedding API key required.",
     "evidence.modelDownload": "Preparing the local semantic model · {pct}%",
+    "evidence.embeddingBg": "Embedding in background · {pct}%",
     "evidence.agentSearch": "Expanding evidence · round {round}",
+    "evidence.ocrOff": "Off (fastest indexing)", "evidence.ocrOnDemand": "On demand (only pages you ask about)", "evidence.ocrAlways": "Always (full index button)",
+    "settings.ocrMode": "Visual OCR for text-poor pages",
     "settings.standaloneNote": "Nodus-only features are unavailable in Standalone mode.",
     "settings.language": "Language", "settings.connection": "Nodus connection", "settings.test": "Test connection",
     "settings.token": "token", "settings.manualHint": "Leave empty to auto-detect from Nodus.",
@@ -124,11 +129,16 @@ const I18N = {
     "settings.context": "Contexto", "settings.useIdeas": "Usar ideas de Nodus cuando existan",
     "settings.useFulltext": "Enviar texto del documento", "settings.useCorpus": "Buscar pasajes relacionados en mi biblioteca Nodus",
     "evidence.idle": "Índice de evidencia inactivo", "evidence.index": "Indexar", "evidence.indexTitle": "Indexar los documentos seleccionados y aplicar OCR a las páginas PDF sin texto",
+    "evidence.indexQuick": "Indexado rápido", "evidence.indexQuickTitle": "Extraer y trocear el texto solamente (sin OCR ni embeddings) — lo más rápido",
+    "evidence.indexFull": "Indexado completo", "evidence.indexFullTitle": "Extraer texto, aplicar OCR a páginas sin texto (si está activado) y calcular embeddings",
     "evidence.vision": "Visión", "evidence.visionTitle": "Analizar y adjuntar la página PDF renderizada actual",
     "evidence.auto": "Auto: texto completo si es pequeño; recuperación si es grande", "evidence.retrieval": "Búsqueda semántica", "evidence.full": "Texto completo",
     "evidence.localEmbedding": "Modelo semántico local: multilingual E5 small (INT8). Se ejecuta en este dispositivo; no requiere API key de embeddings.",
     "evidence.modelDownload": "Preparando el modelo semántico local · {pct}%",
+    "evidence.embeddingBg": "Calculando embeddings en segundo plano · {pct}%",
     "evidence.agentSearch": "Ampliando evidencia · ronda {round}",
+    "evidence.ocrOff": "Desactivado (indexado más rápido)", "evidence.ocrOnDemand": "Bajo demanda (solo páginas por las que preguntes)", "evidence.ocrAlways": "Siempre (botón de indexado completo)",
+    "settings.ocrMode": "OCR visual para páginas sin texto",
     "settings.standaloneNote": "Las funciones exclusivas de Nodus no están disponibles en modo Autónomo.",
     "settings.language": "Idioma", "settings.connection": "Conexión con Nodus", "settings.test": "Probar conexión",
     "settings.token": "token", "settings.manualHint": "Déjalo vacío para detectarlo automáticamente desde Nodus.",
@@ -431,25 +441,37 @@ async function selectedAttachments() {
   }
   return out;
 }
-async function ensureEmbeddings(indexes, signal) {
+// opts.onProgress(done, total) reports overall chunk progress across every
+// index passed in; opts.onStatus(text) reports a human-readable line. Both
+// default to the shared setIndexStatus line so the foreground ("Full index")
+// path behaves exactly as before. embedIndexesBackground() overrides them to
+// drive the non-blocking progress bar instead.
+async function ensureEmbeddings(indexes, signal, opts) {
+  opts = opts || {};
+  const onStatus = opts.onStatus || ((text) => setIndexStatus(text, "busy"));
+  const onProgress = opts.onProgress || (() => {});
   if (!NL) throw new Error("local-embeddings-unavailable");
   const model = NL.MODEL;
   let embedded = 0;
   const stopProgress = NL.onProgress((progress) => {
     if (!progress || progress.status !== "progress") return;
     const pct = Math.max(0, Math.min(100, Math.round(Number(progress.progress) || 0)));
-    setIndexStatus(tf("evidence.modelDownload", { pct }), "busy");
+    onStatus(tf("evidence.modelDownload", { pct }));
   });
   try {
-    for (const index of indexes) {
-      const missing = (index.chunks || []).filter((c) =>
-        !Array.isArray(c.embedding)
-        || c.embedding.length !== model.dimensions
-        || c.embeddingModel !== model.fingerprint
-      );
+    const missingByIndex = indexes.map((index) => (index.chunks || []).filter((c) =>
+      !Array.isArray(c.embedding)
+      || c.embedding.length !== model.dimensions
+      || c.embeddingModel !== model.fingerprint
+    ));
+    const totalMissing = missingByIndex.reduce((n, arr) => n + arr.length, 0);
+    let doneSoFar = 0;
+    for (let idxPos = 0; idxPos < indexes.length; idxPos++) {
+      const index = indexes[idxPos];
+      const missing = missingByIndex[idxPos];
       for (let i = 0; i < missing.length; i += 24) {
         const batch = missing.slice(i, i + 24);
-      setIndexStatus("Embedding " + Math.min(i + batch.length, missing.length) + "/" + missing.length + " · " + (index.title || index.attachmentKey), "busy");
+        onStatus("Embedding " + Math.min(i + batch.length, missing.length) + "/" + missing.length + " · " + (index.title || index.attachmentKey));
         const vectors = await NL.embedPassages(batch.map((chunk) =>
           [index.title, chunk.section, chunk.text].filter(Boolean).join("\n")
         ), { signal });
@@ -458,6 +480,8 @@ async function ensureEmbeddings(indexes, signal) {
           chunk.embeddingModel = model.fingerprint;
           embedded++;
         });
+        doneSoFar += batch.length;
+        onProgress(doneSoFar, totalMissing);
       }
       index.embeddingModel = model.fingerprint;
       index.updatedAt = Date.now();
@@ -467,6 +491,31 @@ async function ensureEmbeddings(indexes, signal) {
     stopProgress();
   }
   return { model, embedded };
+}
+// Only one embedding pass runs at a time (foreground or background) so two
+// concurrent callers never race writing the same chunks/index file.
+function showEmbedProgress(pct) {
+  const wrap = $("#nd-embed-progress"), bar = $("#nd-embed-progress-bar");
+  if (!wrap || !bar) return;
+  if (pct == null) { wrap.hidden = true; bar.style.width = "0%"; return; }
+  wrap.hidden = false; bar.style.width = Math.max(0, Math.min(100, pct)) + "%";
+}
+async function ensureEmbeddingsSerialized(indexes, signal, opts) {
+  if (state.embedPromise) { try { await state.embedPromise; } catch (e) {} }
+  const job = ensureEmbeddings(indexes, signal, opts);
+  state.embedPromise = job;
+  try { return await job; } finally { if (state.embedPromise === job) state.embedPromise = null; }
+}
+// Fire-and-forget: computes embeddings without blocking the composer, driving
+// the thin progress bar under the evidence bar instead of the shared status
+// line (which stays free for whatever the user is doing meanwhile).
+function embedIndexesBackground(indexes) {
+  if (!NL || !indexes || !indexes.length) return;
+  showEmbedProgress(0);
+  ensureEmbeddingsSerialized(indexes, undefined, {
+    onStatus: () => {},
+    onProgress: (done, total) => showEmbedProgress(total ? Math.round((done / total) * 100) : 100),
+  }).catch((e) => { try { Zotero.logError(e); } catch (x) {} }).finally(() => showEmbedProgress(null));
 }
 function parseRankedIds(value, allowed) {
   const text = String(value || "").replace(/```(?:json)?/gi, "").replace(/```/g, "");
@@ -478,9 +527,19 @@ function parseRankedIds(value, allowed) {
     return ids.map(String).filter((id) => allowed.has(id));
   } catch (e) { return []; }
 }
+function diversifyExpand(candidates, seedIds, indexes) {
+  const seeds = NE.diversifyCandidates(candidates, seedIds, { topK: 8, maxPerSource: indexes.length > 1 ? 4 : 8 });
+  return NE.expandWithNeighbors(indexes, seeds, { topK: 12, maxPerSource: indexes.length > 1 ? 5 : 12 });
+}
 async function rerankEvidence(query, result, indexes, signal) {
   if (!result || !Array.isArray(result.candidates) || !result.candidates.length) return result && result.hits ? result.hits : [];
   const candidates = result.candidates.slice(0, 36);
+  // A handful of candidates rarely benefits from a whole extra LLM round-trip:
+  // the lexical/semantic blend from hybridSearch already ranks them well, so
+  // skip the network call entirely and just diversify/expand what we have.
+  if (candidates.length <= 8) {
+    return diversifyExpand(candidates, (result.hits || []).map((hit) => hit.id), indexes);
+  }
   const allowed = new Set(candidates.map((c) => c.id));
   const catalogue = candidates.map((c) =>
     `${c.id} | ${c.title || c.itemKey} | page ${c.pageLabel} | ${String(c.text || "").replace(/\s+/g, " ").slice(0, 650)}`
@@ -514,8 +573,7 @@ async function rerankEvidence(query, result, indexes, signal) {
       ? indexes.map((index) => index.chunks && index.chunks[0] && index.chunks[0].id).filter((id) => id && allowed.has(id))
       : [];
     const fallbackIds = ids.length ? ids : (result.hits || []).map((hit) => hit.id);
-    const seeds = NE.diversifyCandidates(candidates, [...required, ...fallbackIds], { topK: 8, maxPerSource: indexes.length > 1 ? 4 : 8 });
-    return NE.expandWithNeighbors(indexes, seeds, { topK: 12, maxPerSource: indexes.length > 1 ? 5 : 12 });
+    return diversifyExpand(candidates, [...required, ...fallbackIds], indexes);
   } catch (e) {
     try { Zotero.logError(e); } catch (x) {}
     return result.hits;
@@ -717,8 +775,12 @@ async function prepareEvidence(query, signal) {
   const totalTokens = indexes.reduce((n, index) =>
     n + (Number(index.estimatedTokens) || (index.chunks || []).reduce((sum, chunk) => sum + (Number(chunk.estimatedTokens) || NE.estimateTokens(chunk.text)), 0))
   , 0);
-  const tokenBudget = availableContextTokens();
-  const strategy = ctx.strategy === "auto" ? (totalTokens <= tokenBudget && indexes.length <= 3 ? "full" : "retrieval") : ctx.strategy;
+  const tokenBudget = Math.min(availableContextTokens(), ctx.fullTextThreshold);
+  // A single open document that fits the context window is exactly the
+  // "Reading Assistant" case: no retrieval/embeddings needed, just hand the
+  // whole thing to the model — always, regardless of the configured strategy.
+  const singleDocFits = indexes.length === 1 && totalTokens <= tokenBudget;
+  const strategy = singleDocFits ? "full" : (ctx.strategy === "auto" ? (totalTokens <= tokenBudget && indexes.length <= 5 ? "full" : "retrieval") : ctx.strategy);
   if (strategy === "full") {
     const full = NE.fullEvidencePrompt(indexes, { maxChars: tokenBudget * 5, maxTokens: tokenBudget });
     state.evidence = NE.evidenceMap(full.hits);
@@ -728,7 +790,7 @@ async function prepareEvidence(query, signal) {
   }
   let queryEmbedding = null;
   try {
-    await ensureEmbeddings(indexes, signal);
+    await ensureEmbeddingsSerialized(indexes, signal);
     queryEmbedding = await NL.embedQuery(query, { signal });
   } catch (e) {
     try { Zotero.logError(e); } catch (x) {}
@@ -736,9 +798,16 @@ async function prepareEvidence(query, signal) {
   }
   let result = NE.hybridSearch(indexes, query, queryEmbedding);
   result.hits = await rerankEvidence(query, result, indexes, signal);
+  if (ctx.ocr === "ondemand" && NV) {
+    const ocrCount = await ocrHitsOnDemand(result.hits, indexes, signal);
+    if (ocrCount) {
+      result = NE.hybridSearch(indexes, query, queryEmbedding);
+      result.hits = await rerankEvidence(query, result, indexes, signal);
+    }
+  }
   let rounds = 0;
   const searched = new Set([NE.fold(query)]);
-  for (let round = 1; round <= 2; round++) {
+  for (let round = 1; round <= ctx.agenticRounds; round++) {
     setIndexStatus(tf("evidence.agentSearch", { round }), "busy");
     const plan = await planEvidenceSearch(query, indexes, result.hits, round, signal);
     if (plan.sufficient) break;
@@ -824,11 +893,50 @@ async function analyzeMissingOcr(indexes) {
   if (!index) return 0;
   const pages = (index.pages || []).filter((page) => page.needsOcr);
   let completed = 0;
+  // capturePage drives the single shared PDF reader (navigate → render →
+  // restore), so captures must stay sequential. The vision LLM call per page
+  // is the slow part, so pipeline up to 3 of those concurrently.
+  const CONCURRENCY = 3;
+  let inFlight = [];
   for (let i = 0; i < pages.length; i++) {
     if (state.abort && state.abort.signal.aborted) break;
     const page = pages[i];
     setIndexStatus("OCR page " + (i + 1) + "/" + pages.length + " · rendered fallback", "busy");
+    const image = await NV.capturePage(cur.reader, page.pageIndex);
+    inFlight.push(runVisualExtraction(image, page)
+      .then((visualText) => { if (visualText) { NE.addVisualText(index, page.pageIndex, visualText); completed++; } })
+      .catch((e) => { try { Zotero.logError(e); } catch (x) {} }));
+    if (inFlight.length >= CONCURRENCY) { await Promise.all(inFlight); inFlight = []; await NS.saveEvidenceIndex(index); }
+  }
+  if (inFlight.length) { await Promise.all(inFlight); await NS.saveEvidenceIndex(index); }
+  return completed;
+}
+// Targeted OCR for ctx.ocr === "ondemand": only runs vision on the handful of
+// retrieved pages that actually need it for THIS question, instead of the
+// whole document up front (which is what the "Full index" button does).
+async function ocrHitsOnDemand(hits, indexes, signal) {
+  if (!NV || !NE) return 0;
+  const cur = getCurrentItem();
+  if (!cur.reader || !cur.attachment) return 0;
+  const index = (indexes || []).find((x) => x.attachmentKey === cur.attachment.key);
+  if (!index) return 0;
+  const pagesByIndex = new Map((index.pages || []).map((p) => [p.pageIndex, p]));
+  const seen = new Set();
+  const targets = [];
+  for (const hit of hits || []) {
+    if (hit.attachmentKey !== index.attachmentKey) continue;
+    const page = pagesByIndex.get(hit.pageIndex);
+    if (!page || !page.needsOcr || seen.has(page.pageIndex)) continue;
+    seen.add(page.pageIndex);
+    targets.push(page);
+    if (targets.length >= 4) break;
+  }
+  if (!targets.length) return 0;
+  let completed = 0;
+  for (const page of targets) {
+    if (signal && signal.aborted) break;
     try {
+      setIndexStatus("OCR p. " + page.pageLabel + " (on demand)…", "busy");
       const image = await NV.capturePage(cur.reader, page.pageIndex);
       const visualText = await runVisualExtraction(image, page);
       if (!visualText) continue;
@@ -1152,7 +1260,13 @@ async function generateAssistant() {
     let audit = null;
     if (NE && state.evidence && state.evidence.size) {
       let reviewed = auditValidatedAnswer(display);
-      if (reviewed.audit.invalidCitations.length || reviewed.audit.missing || reviewed.audit.weak) {
+      const ctx = NS.getContext();
+      const needsRepair = ctx.repair === "off" ? false
+        : ctx.repair === "always" ? (reviewed.audit.invalidCitations.length || reviewed.audit.missing || reviewed.audit.weak)
+        // "auto": only pay for a repair round-trip when citations are outright
+        // invalid or coverage is clearly weak — small nits aren't worth it.
+        : (reviewed.audit.invalidCitations.length > 0 || reviewed.audit.coverage < 0.5);
+      if (needsRepair) {
         const repaired = await repairEvidenceAnswer(reviewed.text, state.evidence, state.abort.signal);
         const second = auditValidatedAnswer(repaired);
         second.audit.repairAttempted = true;
@@ -1602,15 +1716,35 @@ function wire() {
   $("#nd-history-clear").addEventListener("click", async () => { if (await showConfirm(t("modal.delAll"))) { state.conversations = []; await NS.saveConversations([]); startNewConversation(); renderHistory(""); } });
   $("#nd-ctx-fulltext").addEventListener("change", saveContext);
   $("#nd-ctx-strategy").addEventListener("change", saveContext);
+  $("#nd-ctx-ocr").addEventListener("change", saveContext);
   $("#nd-ctx-ideas").addEventListener("change", saveContext);
   $("#nd-ctx-corpus").addEventListener("change", saveContext);
-  $("#nd-index-btn").addEventListener("click", async () => {
+  // Quick index: extraction + chunking only (no OCR, no embeddings) — fast,
+  // enough to answer with lexical/agentic retrieval right away. Embeddings then
+  // compute in the background (non-blocking) so semantic search improves
+  // without making the user wait.
+  $("#nd-index-quick-btn").addEventListener("click", async () => {
     if (state.busy) return;
     state.busy = true; state.abort = new AbortController(); updateSendEnabled();
     try {
       await refreshItem(true);
       const indexes = await buildSelectedIndexes(true, state.abort.signal);
-      const ocrPages = await analyzeMissingOcr(indexes);
+      setIndexStatus(indexes.length + " source" + (indexes.length === 1 ? "" : "s") + " · text extracted · embeddings running in background", "ok");
+      embedIndexesBackground(indexes);
+    } catch (e) { setIndexStatus("Index failed: " + (e.message || e), "warn"); }
+    finally { state.busy = false; state.abort = null; updateSendEnabled(); }
+  });
+  // Full index: extraction + chunking + (optional) OCR of text-poor pages +
+  // embeddings, all done up front. Blocking on purpose — the user explicitly
+  // asked for a complete, ready-to-query index.
+  $("#nd-index-full-btn").addEventListener("click", async () => {
+    if (state.busy) return;
+    state.busy = true; state.abort = new AbortController(); updateSendEnabled();
+    try {
+      await refreshItem(true);
+      const indexes = await buildSelectedIndexes(true, state.abort.signal);
+      const ctx = NS.getContext();
+      const ocrPages = ctx.ocr === "always" ? await analyzeMissingOcr(indexes) : 0;
       await ensureEmbeddings(indexes, state.abort.signal);
       setIndexStatus(indexes.length + " source" + (indexes.length === 1 ? "" : "s") + " fully indexed" + (ocrPages ? " · " + ocrPages + " OCR pages" : ""), "ok");
     } catch (e) { setIndexStatus("Index failed: " + (e.message || e), "warn"); }
@@ -1641,11 +1775,14 @@ function wire() {
 }
 function saveContext() {
   state.contextStrategy = $("#nd-ctx-strategy").value;
+  const prev = NS.getContext();
   NS.setContext({
+    ...prev,
     useFulltext: $("#nd-ctx-fulltext").checked,
     useIdeas: $("#nd-ctx-ideas").checked,
     useCorpus: $("#nd-ctx-corpus").checked,
     strategy: state.contextStrategy,
+    ocr: $("#nd-ctx-ocr").value,
   });
 }
 function saveHlColors() { state.hlColors = { high: $("#nd-hl-high").value || "#ff6666", medium: $("#nd-hl-medium").value || "#ffd400" }; NS.setHlColors(state.hlColors); }
@@ -1692,6 +1829,17 @@ async function boot() {
   const m = NS.getManual(); $("#nd-port").value = m.port || ""; $("#nd-token").value = m.token || "";
   $("#nd-ctx-fulltext").checked = ctx.useFulltext; $("#nd-ctx-ideas").checked = ctx.useIdeas; $("#nd-ctx-corpus").checked = ctx.useCorpus;
   $("#nd-ctx-strategy").value = ctx.strategy;
+  $("#nd-ctx-ocr").value = ctx.ocr;
+  // Pre-warm the local embedding model in the background so the first
+  // "Quick index" background embedding pass (or the first semantic query)
+  // doesn't pay the model-load cost. Non-blocking, best-effort.
+  if (NL && NL.warmup) {
+    NL.warmup().then(() => {
+      const hint = $("#nd-local-embedding");
+      const backend = NL.getBackend && NL.getBackend();
+      if (hint && backend) hint.setAttribute("data-backend", backend);
+    }).catch(() => {});
+  }
   state.agentEnabled = NS.getAgent(); state.agentAuto = NS.getAgentAuto();
   $("#nd-agent").checked = state.agentEnabled; $("#nd-agent-auto").checked = state.agentAuto;
   $("#nd-agent-btn").classList.toggle("nd-iconbtn--active", state.agentEnabled);

--- a/zotero-plugin/content/store.js
+++ b/zotero-plugin/content/store.js
@@ -32,16 +32,30 @@
   function setHlColors(c) { SJSON("hlColors", { high: (c && c.high) || "#ff6666", medium: (c && c.medium) || "#ffd400" }); }
   function getContext() {
     const strategy = P("ctx.strategy", "auto");
+    const ocr = P("ctx.ocr", "off");
+    const repair = P("ctx.repair", "auto");
+    const rounds = Number(P("ctx.agenticRounds", 1));
+    const threshold = Number(P("ctx.fullTextThreshold", 48000));
     return {
       useIdeas: P("ctx.ideas", "1") !== "0",
       useCorpus: P("ctx.corpus", "1") !== "0",
       useFulltext: P("ctx.fulltext", "1") !== "0",
       strategy: ["auto", "retrieval", "full"].includes(strategy) ? strategy : "auto",
+      ocr: ["off", "ondemand", "always"].includes(ocr) ? ocr : "off",
+      repair: ["auto", "off", "always"].includes(repair) ? repair : "auto",
+      agenticRounds: Number.isFinite(rounds) ? Math.max(0, Math.min(2, Math.floor(rounds))) : 1,
+      fullTextThreshold: Number.isFinite(threshold) && threshold > 0 ? threshold : 48000,
     };
   }
   function setContext(c) {
     S("ctx.ideas", c.useIdeas ? "1" : "0"); S("ctx.corpus", c.useCorpus ? "1" : "0"); S("ctx.fulltext", c.useFulltext ? "1" : "0");
     S("ctx.strategy", ["auto", "retrieval", "full"].includes(c.strategy) ? c.strategy : "auto");
+    S("ctx.ocr", ["off", "ondemand", "always"].includes(c.ocr) ? c.ocr : "off");
+    S("ctx.repair", ["auto", "off", "always"].includes(c.repair) ? c.repair : "auto");
+    const rounds = Number(c.agenticRounds);
+    S("ctx.agenticRounds", String(Number.isFinite(rounds) ? Math.max(0, Math.min(2, Math.floor(rounds))) : 1));
+    const threshold = Number(c.fullTextThreshold);
+    S("ctx.fullTextThreshold", String(Number.isFinite(threshold) && threshold > 0 ? threshold : 48000));
   }
   // ---- providers ----
   function getKey(provider) { return P("key." + provider, "") || ""; }


### PR DESCRIPTION
## Summary

Fixes #215 - the Zotero plugin was too slow to index documents and to respond to questions compared to competing tools.

## Changes

- **Split indexing**: the single "Index" button is now **Quick index** (text extraction + chunking only) and **Full index** (+ optional OCR + embeddings). Quick index is fast and enables lexical/agentic retrieval immediately.
- **Background embeddings**: after Quick index, embeddings are computed in the background (non-blocking) with a visible thin progress bar under the evidence bar, instead of blocking the chat composer.
- **Optional/lazy OCR**: new `ctx.ocr` setting (`off` / `ondemand` / `always`). Visual OCR of text-poor PDF pages is no longer mandatory during indexing. `ondemand` OCRs only the handful of retrieved pages relevant to the current question (via a new `ocrHitsOnDemand` helper).
- **Always-full for single fitting documents**: when exactly one document is indexed and its estimated tokens fit the context budget, retrieval/embeddings are skipped entirely and the full text is sent in context - regardless of the configured strategy.
- **Fewer LLM round-trips**:
  - `rerankEvidence` skips the LLM rerank call when there are 8 or fewer candidates.
  - Citation repair is now gated by a `ctx.repair` setting (`off` / `auto` / `always`); `auto` only repairs on invalid citations or coverage < 0.5.
  - The agentic search round count is now configurable via `ctx.agenticRounds` (default 1, capped at 2) instead of a hardcoded 2.
- **Parallel OCR**: `analyzeMissingOcr` keeps PDF page capture sequential (required by the single shared reader) but now pipelines up to 3 concurrent vision LLM calls instead of running them one at a time.
- **WebGPU embeddings with fallback**: the local embedding worker now tries `device: 'webgpu'` first (only when `navigator.gpu` is present) and falls back to `wasm` on any failure, reporting which backend is active via a new `getBackend()` accessor.

## Files changed

- `zotero-plugin/content/store.js` - new `ctx.ocr`, `ctx.repair`, `ctx.agenticRounds`, `ctx.fullTextThreshold` settings.
- `zotero-plugin/content/sidebar.html` - Quick/Full index buttons, embed progress bar, OCR mode selector.
- `zotero-plugin/content/sidebar.css` - progress bar styling.
- `zotero-plugin/content/sidebar.js` - all the logic above (button handlers, background embedding, on-demand OCR, retrieval strategy override, rerank/repair/agentic gating, parallel OCR, i18n strings).
- `zotero-plugin/content/local-embeddings.js` - tracks and exposes the active embedding backend.
- `scripts/zotero-local-embedding-worker.mjs` - WebGPU-with-WASM-fallback pipeline creation.
- `scripts/test-zotero-plugin.mjs` - updated the agentic-retrieval regression test for the configurable round count.

## Testing

- `node scripts/test-zotero-plugin.mjs` - 55/55 tests pass.
- `npm run zotero:xpi` - builds successfully.
- Installed the built xpi into a local Zotero profile (replacing the previous plugin build) and confirmed via Zotero's debug output log that the plugin bootstraps cleanly (`[Nodus] startup complete v2.6.0`) with no errors.
