### PR TITLE
Fix audio narration lifecycle bugs and local Whisper cancellation

### DIFF
--- a/electron/audio/speakable.ts
+++ b/electron/audio/speakable.ts
@@ -124,7 +124,11 @@ const SEGMENT_SPLIT_CHARS = 2600;
 export function splitForNarration(text: string, limit = SEGMENT_SPLIT_CHARS): string[] {
   const clean = text.trim();
   if (clean.length <= limit) return clean ? [clean] : [];
-  const sentences = clean.match(/[^.!?]+[.!?]+(?:["')\]]+)?|\S+$/g) ?? [clean];
+  // Match whole sentences (text up to a terminator), plus a final alternative for
+  // a trailing clause with no terminator. That last alternative is a *run* of
+  // non-terminator chars — not `\S+$`, which only kept the last word and silently
+  // dropped the rest of an unpunctuated tail (a source of cut-off narration).
+  const sentences = clean.match(/[^.!?]+[.!?]+(?:["')\]]+)?|[^.!?]+$/g) ?? [clean];
   const chunks: string[] = [];
   let current = '';
   for (const s of sentences) {
@@ -161,6 +165,10 @@ export function deepResearchSegments(draft: DeepResearchDraftLike): AudioSegment
   for (const section of splitMarkdownSections(draft.draftMarkdown ?? '')) {
     const body = markdownToSpeech(section.body);
     if (!body) continue;
+    // The assembled report embeds the abstract as its own heading section (see
+    // assembleMarkdown), and it is already narrated as the intro segment above.
+    // Skip that duplicate so the summary is not synthesised — and heard — twice.
+    if (abstract && body === abstract) continue;
     const parts = splitForNarration([section.heading ? `${section.heading}.` : '', body].filter(Boolean).join('\n\n'));
     parts.forEach((part, i) => {
       segments.push({

--- a/scripts/test-background-jobs.mjs
+++ b/scripts/test-background-jobs.mjs
@@ -53,6 +53,16 @@ try {
   });
   const aiProgressListeners = new Set();
   const comparisonProgressListeners = new Set();
+  const audioSegments = [
+    { index: 0, label: 'Resumen', text: 'Uno.' },
+    { index: 1, label: 'Contexto', text: 'Dos.' },
+    { index: 2, label: 'Análisis', text: 'Tres.' },
+  ];
+  const savedAudioClips = [];
+  let audioCleared = 0;
+  let synthCalls = 0;
+  let releaseSynth;
+  let synthGate = new Promise((resolve) => { releaseSynth = resolve; });
   const fakeSession = { id: 'imm-1', topic: 'Tema recuperable' };
   const fakeReport = {
     draft: { title: 'Informe recuperable', brief: { kind: 'deep_research' } },
@@ -115,6 +125,12 @@ try {
         for (const listener of comparisonProgressListeners) listener({ databaseId, columnId, done: 4, total: 8 });
         await Promise.resolve();
         return { done: 8 };
+      },
+      getAudioSegments: async () => audioSegments,
+      clearAudioClips: async () => { audioCleared += 1; savedAudioClips.length = 0; },
+      saveAudioClip: async (kind, id, input) => {
+        savedAudioClips.push({ kind, id, index: input.segmentIndex });
+        return { id: `clip-${input.segmentIndex}` };
       },
     },
   };
@@ -244,6 +260,58 @@ try {
   await waitFor(() => jobs.getBackgroundJob(comparisonKey)?.status === 'completed', 'comparison column completion');
   assert.deepEqual(jobs.getBackgroundJob(comparisonKey).progress, { done: 4, total: 8 });
   assert.equal(comparisonColumnCalls, 1);
+
+  // ── Audio narration survives leaving the view (the progress bar reappears) ──
+  // The synthesis loop runs in the store, not the panel. Leaving only unsubscribes;
+  // it must not stop the loop, and a remounted panel picks progress up mid-run.
+  const fakeSynth = async () => {
+    synthCalls += 1;
+    await synthGate;
+    return new Uint8Array([82, 73, 70, 70]);
+  };
+  const audioRequest = {
+    entityKind: 'deep_research',
+    entityId: 'report-1',
+    provider: 'kokoro',
+    voiceId: 'ef_dora',
+    language: 'es',
+    segmentRequest: { mode: 'full' },
+    labels: { preparing: 'Preparando…', noText: 'No hay texto narrable en este contenido.' },
+  };
+  const audioKey = jobs.audioGenerationJobKey('deep_research', 'report-1');
+  let audioBeforeUnmount = null;
+  const unsubscribeAudio = jobs.subscribeBackgroundJob(audioKey, (job) => { audioBeforeUnmount = job; });
+  const audioJob = jobs.startAudioGeneration(audioRequest, fakeSynth);
+  const duplicateAudio = jobs.startAudioGeneration(audioRequest, fakeSynth);
+  assert.equal(duplicateAudio.id, audioJob.id, 'a second "Generar audio" click reuses the running job');
+  await waitFor(() => jobs.getBackgroundJob(audioKey)?.progress?.label === 'Resumen', 'audio progress before unmount');
+  assert.equal(jobs.getBackgroundJob(audioKey).progress.total, 3, 'progress reports the segment total');
+  assert.equal(audioCleared, 1, 'existing clips are cleared once at the start');
+  unsubscribeAudio();
+  assert.equal(audioBeforeUnmount?.status, 'running', 'the mounted panel saw the running state');
+  releaseSynth();
+  await waitFor(() => jobs.getBackgroundJob(audioKey)?.status === 'completed', 'audio completion after unmount');
+  assert.equal(synthCalls, 3, 'every segment is synthesised even though the view was left');
+  assert.equal(savedAudioClips.length, 3, 'every clip is saved');
+  assert.deepEqual(jobs.getBackgroundJob(audioKey).result, { count: 3, cancelled: false });
+  let recoveredAudio = null;
+  const unsubscribeRecoveredAudio = jobs.subscribeBackgroundJob(audioKey, (job) => { recoveredAudio = job; });
+  assert.equal(recoveredAudio.status, 'completed', 'a remounted panel receives the retained job (bar reappears)');
+  unsubscribeRecoveredAudio();
+  jobs.clearBackgroundJob(audioKey, jobs.getBackgroundJob(audioKey).id);
+
+  // ── Cancelling mid-run stops the loop and reports it ────────────────────────
+  synthGate = new Promise((resolve) => { releaseSynth = resolve; });
+  const cancelKey = jobs.audioGenerationJobKey('immersion', 'imm-cancel');
+  const synthCallsBefore = synthCalls;
+  jobs.startAudioGeneration({ ...audioRequest, entityKind: 'immersion', entityId: 'imm-cancel' }, fakeSynth);
+  await waitFor(() => synthCalls === synthCallsBefore + 1, 'first segment synthesis started');
+  jobs.cancelAudioGeneration('immersion', 'imm-cancel');
+  releaseSynth();
+  await waitFor(() => jobs.getBackgroundJob(cancelKey)?.status === 'completed', 'cancelled audio settles');
+  const cancelledResult = jobs.getBackgroundJob(cancelKey).result;
+  assert.equal(cancelledResult.cancelled, true, 'cancellation is reported');
+  assert.ok(cancelledResult.count < 3, 'cancelling stops before every segment is synthesised');
 
   console.log('background generation jobs test passed');
 } finally {

--- a/scripts/test-kokoro-chunk.mjs
+++ b/scripts/test-kokoro-chunk.mjs
@@ -1,0 +1,93 @@
+// Unit tests for the Kokoro narration chunker. kokoro-js truncates input past
+// ~509 tokens, cutting audio off mid-word; src/lib/audio/kokoroChunk.ts splits a
+// segment into sentence-aligned pieces first and joins the PCM back. The module
+// is pure (no kokoro-js runtime), so we bundle just it and exercise the real
+// functions — locking the guarantee that no word is ever dropped or split.
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'nodus-kokoro-chunk-test-'));
+try {
+  const outfile = path.join(tmp, 'kokoroChunk.mjs');
+  await build({
+    entryPoints: [path.join(repoRoot, 'src/lib/audio/kokoroChunk.ts')],
+    outfile,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    logLevel: 'silent',
+  });
+  const { splitSentences, chunkForKokoro, concatAudio } = await import(pathToFileURL(outfile).href);
+
+  const LIMIT = 360;
+
+  // ── splitSentences keeps a trailing, unterminated clause whole ──────────────
+  {
+    assert.deepEqual(
+      splitSentences('Uno. Dos! cola sin punto con varias palabras'),
+      ['Uno.', 'Dos!', 'cola sin punto con varias palabras'],
+    );
+    assert.deepEqual(splitSentences('   '), []);
+  }
+
+  // ── Short text is a single chunk; blank text yields none ────────────────────
+  {
+    assert.deepEqual(chunkForKokoro('Frase corta.'), ['Frase corta.']);
+    assert.deepEqual(chunkForKokoro('   '), []);
+  }
+
+  // ── Long prose chunks under the budget without losing or splitting a word ───
+  {
+    const sentence = 'Esta es una frase de prueba con bastantes palabras para el troceado. ';
+    const long = sentence.repeat(60); // ~4000 chars, well past the token ceiling
+    const chunks = chunkForKokoro(long);
+    assert.ok(chunks.length > 1, 'splits into several pieces');
+    assert.ok(chunks.every((c) => c.length <= LIMIT), 'each chunk stays within budget');
+    assert.deepEqual(
+      chunks.join(' ').split(/\s+/),
+      long.trim().split(/\s+/),
+      'every word is preserved, in order, none cut',
+    );
+  }
+
+  // ── A single sentence longer than the budget wraps on word boundaries ───────
+  {
+    const words = Array.from({ length: 200 }, (_, i) => `palabra${i}`).join(' ');
+    const chunks = chunkForKokoro(words);
+    assert.ok(chunks.every((c) => c.length <= LIMIT));
+    assert.deepEqual(chunks.join(' ').split(/\s+/), words.split(/\s+/));
+  }
+
+  // ── A lone word longer than the budget is hard-sliced, never truncated ──────
+  {
+    const oneWord = 'a'.repeat(1000);
+    const chunks = chunkForKokoro(oneWord);
+    assert.ok(chunks.every((c) => c.length <= LIMIT));
+    assert.equal(chunks.join(''), oneWord, 'hard-sliced word fully preserved');
+  }
+
+  // ── concatAudio joins buffers with a silent gap and preserves the samples ───
+  {
+    const a = Float32Array.from([0.1, 0.2]);
+    const b = Float32Array.from([0.3]);
+    const merged = concatAudio([a, b], 1000, 10); // 10 ms @ 1000 Hz → 10-sample gap
+    assert.equal(merged.length, 2 + 10 + 1);
+    assert.equal(merged[0], a[0]);
+    assert.equal(merged[1], a[1]);
+    assert.equal(merged[merged.length - 1], b[0]);
+    assert.equal(merged[2], 0, 'gap is silence');
+
+    assert.equal(concatAudio([a], 1000).length, 2, 'single part returned as-is');
+    assert.equal(concatAudio([], 1000).length, 0, 'no parts → empty');
+    assert.equal(concatAudio([new Float32Array(0), b], 1000).length, 1, 'empty parts skipped (no phantom gap)');
+  }
+
+  console.log('test-kokoro-chunk: all assertions passed');
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/scripts/test-speakable.mjs
+++ b/scripts/test-speakable.mjs
@@ -92,6 +92,32 @@ try {
     assert.deepEqual(segs.map((s) => s.index), [0, 1, 2], 'indices are contiguous');
   }
 
+  // ── Deep Research: the abstract is never narrated twice ─────────────────────
+  // assembleMarkdown() embeds the abstract as a "## Resumen" section inside
+  // draftMarkdown; it is also the intro segment. It must be spoken exactly once.
+  {
+    const abstract = 'Este resumen sintetiza el análisis del turismo como propaganda.';
+    const draft = {
+      title: 'Informe',
+      abstract,
+      draftMarkdown: `## Resumen\n\n${abstract}\n\n## Contexto\n\nCuerpo del contexto.`,
+    };
+    const segs = deepResearchSegments(draft);
+    const withAbstract = segs.filter((s) => s.text.includes('Este resumen sintetiza'));
+    assert.equal(withAbstract.length, 1, 'abstract narrated exactly once');
+    assert.deepEqual(segs.map((s) => s.label), ['Resumen', 'Contexto'], 'no duplicate Resumen section');
+    assert.deepEqual(segs.map((s) => s.index), [0, 1], 'indices contiguous after skipping the duplicate');
+  }
+
+  // ── An unpunctuated tail is not dropped when splitting a long block ──────────
+  {
+    const head = 'Frase completa de relleno con suficientes palabras. '.repeat(60); // > 2600 chars
+    const tail = 'cola final sin punto con varias palabras que no deben perderse';
+    const parts = splitForNarration(head + tail);
+    assert.ok(parts.length > 1, 'long text splits into multiple chunks');
+    assert.ok(parts.join(' ').includes(tail), 'the whole unpunctuated tail survives (not just its last word)');
+  }
+
   // ── Immersion: panorama + one segment per station, takeaways included ────────
   {
     const plan = {

--- a/src/backgroundJobs.ts
+++ b/src/backgroundJobs.ts
@@ -1,4 +1,7 @@
 import type {
+  AudioEntityKind,
+  AudioProvider,
+  AudioSegmentRequest,
   DeepResearchProgress,
   DeepResearchReport,
   DeepResearchRequest,
@@ -463,4 +466,90 @@ function drainDeepQueue(): void {
     notifyDeepQueue();
     drainDeepQueue();
   }
+}
+
+// ── Audio narration generation ───────────────────────────────────────────────
+//
+// Synthesising a whole report or immersion runs one segment at a time in the
+// renderer (Piper/Kokoro in a worker; Hume over IPC). The loop lives here, at
+// module scope, so it keeps running while the user navigates away from the panel
+// that started it — and the progress bar reappears, mid-run, when they return.
+// The panel used to own the loop, so leaving the view unmounted it, cancelled the
+// synthesis, and discarded the progress.
+
+export interface AudioGenerationRequest {
+  entityKind: AudioEntityKind;
+  entityId: string;
+  provider: AudioProvider;
+  voiceId: string;
+  language: string;
+  segmentRequest: AudioSegmentRequest;
+  /** Localised strings the module-scope loop cannot resolve through i18n itself. */
+  labels: { preparing: string; noText: string };
+}
+
+export interface AudioGenerationProgress {
+  done: number;
+  total: number;
+  label: string;
+}
+
+export interface AudioGenerationResult {
+  count: number;
+  cancelled: boolean;
+}
+
+export type AudioGenerationJob = BackgroundJob<AudioGenerationRequest, AudioGenerationProgress, AudioGenerationResult>;
+
+export function audioGenerationJobKey(kind: AudioEntityKind, id: string): string {
+  return `audio:generate:${kind}:${id}`;
+}
+
+// Keys whose in-flight generation the user has asked to cancel. Checked between
+// segments; cleared when the loop observes it (so a later run starts clean).
+const audioCancellations = new Set<string>();
+
+export function cancelAudioGeneration(kind: AudioEntityKind, id: string): void {
+  audioCancellations.add(audioGenerationJobKey(kind, id));
+}
+
+/** The synthesis backend, injected by the caller so this module stays free of the
+ *  heavy WASM/onnx audio engines (and can be bundled and unit-tested on its own). */
+export type SegmentSynthesizer = (provider: AudioProvider, voiceId: string, text: string) => Promise<Uint8Array>;
+
+export function startAudioGeneration(request: AudioGenerationRequest, synthesize: SegmentSynthesizer): AudioGenerationJob {
+  const key = audioGenerationJobKey(request.entityKind, request.entityId);
+  const existing = getBackgroundJob<AudioGenerationRequest, AudioGenerationProgress, AudioGenerationResult>(key);
+  if (existing?.status === 'running') return existing;
+  audioCancellations.delete(key);
+
+  return startBackgroundJob<AudioGenerationRequest, AudioGenerationProgress, AudioGenerationResult>(key, request, async (req, onProgress) => {
+    const segments = await window.nodus.getAudioSegments(req.entityKind, req.entityId, req.segmentRequest);
+    if (!segments.length) throw new Error(req.labels.noText);
+
+    await window.nodus.clearAudioClips(req.entityKind, req.entityId);
+    onProgress({ done: 0, total: segments.length, label: req.labels.preparing });
+
+    let done = 0;
+    let cancelled = false;
+    for (const segment of segments) {
+      if (audioCancellations.has(key)) { cancelled = true; break; }
+      onProgress({ done, total: segments.length, label: segment.label });
+      const bytes = await synthesize(req.provider, req.voiceId, segment.text);
+      if (audioCancellations.has(key)) { cancelled = true; break; }
+      await window.nodus.saveAudioClip(req.entityKind, req.entityId, {
+        segmentIndex: segment.index,
+        segmentLabel: segment.label,
+        provider: req.provider,
+        voice: req.voiceId,
+        language: req.language,
+        bytes,
+      });
+      done += 1;
+      onProgress({ done, total: segments.length, label: segment.label });
+    }
+
+    audioCancellations.delete(key);
+    return { count: done, cancelled };
+  });
 }

--- a/src/components/AudioPanel.tsx
+++ b/src/components/AudioPanel.tsx
@@ -11,6 +11,16 @@ import type {
 } from '@shared/types';
 import { findVoice, getEngine } from '../lib/audio';
 import { synthesizeSegment } from '../lib/audio/synth';
+import {
+  audioGenerationJobKey,
+  cancelAudioGeneration,
+  clearBackgroundJob,
+  startAudioGeneration,
+  subscribeBackgroundJob,
+  type AudioGenerationProgress,
+  type AudioGenerationRequest,
+  type AudioGenerationResult,
+} from '../backgroundJobs';
 import { useAudioPlayer, type PlayerTrack } from './AudioPlayer';
 import { t, tx } from '../i18n';
 
@@ -60,8 +70,6 @@ export function AudioPanel({
   const [playlist, setPlaylist] = useState<StudyAudioPlaylistItem[]>([]);
   const [dictionaryDraft, setDictionaryDraft] = useState({ written: '', spoken: '' });
   const [showStudyTools, setShowStudyTools] = useState(false);
-  const cancelRef = useRef(false);
-  const clipsDoneRef = useRef(0);
   const mounted = useRef(true);
 
   const generating = run != null;
@@ -115,8 +123,31 @@ export function AudioPanel({
     void checkVoice();
     return () => {
       mounted.current = false;
-      cancelRef.current = true;
     };
+    // eslint-disable-next-line
+  }, [entityKind, entityId]);
+
+  // The synthesis loop runs in the module-scope job store, so it survives leaving
+  // this view. Subscribe to its progress: on remount the bar picks up mid-run, and
+  // clips are reflected as they are saved. Leaving simply unsubscribes — it never
+  // cancels the work.
+  useEffect(() => {
+    const key = audioGenerationJobKey(entityKind, entityId);
+    return subscribeBackgroundJob<AudioGenerationRequest, AudioGenerationProgress, AudioGenerationResult>(key, (job) => {
+      if (!mounted.current) return;
+      if (job?.status === 'running') {
+        setRun(job.progress ?? { done: 0, total: 0, label: t('Preparando…') });
+        if (job.progress) void refreshClips();
+        return;
+      }
+      setRun(null);
+      if (!job) return;
+      if (job.status === 'failed' && job.error) setError(job.error);
+      void refreshClips();
+      void refreshStudyMeta();
+      // Drop the finished snapshot so a later remount does not resurrect it.
+      clearBackgroundJob(key, job.id);
+    });
     // eslint-disable-next-line
   }, [entityKind, entityId]);
 
@@ -142,53 +173,23 @@ export function AudioPanel({
     // Local voices carry static metadata; cloud (Hume) voices are dynamic, so the
     // language is best-effort and defaults to empty.
     const language = findVoice(chosen.provider, chosen.voiceId)?.language ?? '';
-    let segments;
-    try {
-      segments = await window.nodus.getAudioSegments(entityKind, entityId, segmentRequest);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      return;
-    }
-    if (!segments.length) {
-      setError(t('No hay texto narrable en este contenido.'));
-      return;
-    }
-
-    cancelRef.current = false;
     player.stop();
-    await window.nodus.clearAudioClips(entityKind, entityId);
-    setClips([]);
-    setRun({ done: 0, total: segments.length, label: t('Preparando…') });
-
-    try {
-      for (const segment of segments) {
-        if (cancelRef.current) break;
-        setRun({ done: clipsDoneRef.current, total: segments.length, label: segment.label });
-        const bytes = await synthesizeSegment(chosen.provider, chosen.voiceId, segment.text);
-        if (cancelRef.current) break;
-        const clip = await window.nodus.saveAudioClip(entityKind, entityId, {
-          segmentIndex: segment.index,
-          segmentLabel: segment.label,
-          provider: chosen.provider,
-          voice: chosen.voiceId,
-          language,
-          bytes,
-        });
-        clipsDoneRef.current += 1;
-        if (mounted.current) setClips((prev) => [...prev, clip]);
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      clipsDoneRef.current = 0;
-      if (mounted.current) setRun(null);
-      await refreshClips();
-      await refreshStudyMeta();
-    }
+    // Hand the loop to the module-scope job store; the subscription above drives
+    // the progress bar and clip list. Segment fetching, clip clearing and errors
+    // (including "no narratable text") are reported through the job.
+    startAudioGeneration({
+      entityKind,
+      entityId,
+      provider: chosen.provider,
+      voiceId: chosen.voiceId,
+      language,
+      segmentRequest,
+      labels: { preparing: t('Preparando…'), noText: t('No hay texto narrable en este contenido.') },
+    }, synthesizeSegment);
   };
 
   const cancel = () => {
-    cancelRef.current = true;
+    cancelAudioGeneration(entityKind, entityId);
   };
 
   const playFrom = (clip: AudioClip) => {

--- a/src/lib/audio/kokoro.ts
+++ b/src/lib/audio/kokoro.ts
@@ -2,6 +2,7 @@ import type { KokoroTTS } from 'kokoro-js';
 import type { AudioEngine, AudioVoice } from './types';
 import { phonemizeKokoroSpanish } from './kokoroSpanishPhonemizer';
 import { isKokoroSpanishVoice } from './kokoroSpanishText';
+import { chunkForKokoro, concatAudio } from './kokoroChunk';
 import { encodeWavPcm16 } from './wav';
 
 // Kokoro provider: one shared 82M model (StyleTTS2) powers many high-quality
@@ -105,23 +106,36 @@ export const kokoroEngine: AudioEngine = {
 
   async synthesize(text, voiceId) {
     const model = await loadModel();
-    let audio;
-    if (isKokoroSpanishVoice(voiceId)) {
-      // kokoro-js 1.2.1 ships the official Spanish voice embeddings but its
-      // high-level generate() rejects them and phonemizes every non-US voice as
-      // English. Follow Kokoro/Misaki instead: eSpeak NG `es` -> Kokoro tokens ->
-      // generate_from_ids(), whose runtime accepts the published voice id.
-      const phonemes = await phonemizeKokoroSpanish(text);
-      const { input_ids } = model.tokenizer(phonemes, { truncation: true });
-      const options = { voice: voiceId, speed: 1 } as unknown as Parameters<KokoroTTS['generate_from_ids']>[1];
-      audio = await model.generate_from_ids(input_ids, options);
-    } else {
-      // kokoro-js types `voice` as a literal union; curated ids arrive as strings.
-      const options = { voice: voiceId, speed: 1 } as unknown as Parameters<KokoroTTS['generate']>[1];
-      audio = await model.generate(text, options);
+    const spanish = isKokoroSpanishVoice(voiceId);
+    // Split into sentence-sized pieces first: the tokenizer truncates past ~509
+    // tokens, so a whole segment (up to ~2600 chars) would otherwise be cut off
+    // mid-word. Each piece is synthesised separately and the audio is joined back.
+    const pieces = chunkForKokoro(text);
+    if (pieces.length === 0) return encodeWavPcm16(new Float32Array(0), 24000);
+
+    const parts: Float32Array[] = [];
+    let sampleRate = 24000;
+    for (const piece of pieces) {
+      let audio;
+      if (spanish) {
+        // kokoro-js 1.2.1 ships the official Spanish voice embeddings but its
+        // high-level generate() rejects them and phonemizes every non-US voice as
+        // English. Follow Kokoro/Misaki instead: eSpeak NG `es` -> Kokoro tokens ->
+        // generate_from_ids(), whose runtime accepts the published voice id.
+        const phonemes = await phonemizeKokoroSpanish(piece);
+        const { input_ids } = model.tokenizer(phonemes, { truncation: true });
+        const options = { voice: voiceId, speed: 1 } as unknown as Parameters<KokoroTTS['generate_from_ids']>[1];
+        audio = await model.generate_from_ids(input_ids, options);
+      } else {
+        // kokoro-js types `voice` as a literal union; curated ids arrive as strings.
+        const options = { voice: voiceId, speed: 1 } as unknown as Parameters<KokoroTTS['generate']>[1];
+        audio = await model.generate(piece, options);
+      }
+      parts.push(audio.audio as Float32Array);
+      sampleRate = audio.sampling_rate;
     }
     // RawAudio.toBlob() writes 32-bit float WAV, which Chromium's <audio> cannot
-    // play; re-encode the raw samples as 16-bit PCM WAV instead.
-    return encodeWavPcm16(audio.audio as Float32Array, audio.sampling_rate);
+    // play; re-encode the joined raw samples as 16-bit PCM WAV instead.
+    return encodeWavPcm16(concatAudio(parts, sampleRate), sampleRate);
   },
 };

--- a/src/lib/audio/kokoroChunk.ts
+++ b/src/lib/audio/kokoroChunk.ts
@@ -1,0 +1,89 @@
+// Kokoro's tokenizer caps input at ~512 tokens and `generate()` /
+// `generate_from_ids()` clamp the token dimension to 509 — anything longer is
+// SILENTLY truncated, cutting narration off mid-sentence, even mid-word. A single
+// Deep Research segment can be ~2600 characters, far past that ceiling, so we
+// split it into short, sentence-aligned pieces before synthesis and concatenate
+// the audio back together. Kept free of the kokoro-js runtime so the pure text /
+// PCM helpers can be unit-tested without loading the WASM model.
+
+// Conservative character budget per synthesis call. Kokoro phoneme tokens track
+// characters closely (≈1 token per phoneme symbol), so ~360 source characters
+// stays comfortably under the 509-token ceiling with margin for phoneme
+// expansion — no truncation, while keeping the number of pieces (and seams) low.
+const MAX_CHUNK_CHARS = 360;
+
+/**
+ * Sentence-aware splitter that never drops text. Returns whole sentences (text up
+ * to and including a terminator) plus, for a trailing clause with no terminator,
+ * the entire remaining run — never just its last word.
+ */
+export function splitSentences(text: string): string[] {
+  const matches = text.match(/[^.!?…]+[.!?…]+(?:["'”’)\]]+)?|[^.!?…]+$/g);
+  const sentences = (matches ?? [text]).map((s) => s.trim()).filter(Boolean);
+  return sentences.length ? sentences : [];
+}
+
+/** Break an over-long single sentence on word boundaries so no piece exceeds the
+ *  budget. A lone word longer than the budget (rare) is hard-sliced as a last
+ *  resort — far better than the model truncating an unbounded tail. */
+function hardWrap(sentence: string, limit: number): string[] {
+  if (sentence.length <= limit) return [sentence];
+  const out: string[] = [];
+  let line = '';
+  for (const word of sentence.split(/\s+/)) {
+    if (!word) continue;
+    if (word.length > limit) {
+      if (line) { out.push(line); line = ''; }
+      for (let i = 0; i < word.length; i += limit) out.push(word.slice(i, i + limit));
+      continue;
+    }
+    if (line && line.length + 1 + word.length > limit) { out.push(line); line = ''; }
+    line = line ? `${line} ${word}` : word;
+  }
+  if (line) out.push(line);
+  return out;
+}
+
+/**
+ * Split narration text into synthesis-sized pieces, aligned to sentence
+ * boundaries and each within the token budget. Whitespace is normalised so
+ * paragraph breaks do not inflate the character count.
+ */
+export function chunkForKokoro(text: string, limit = MAX_CHUNK_CHARS): string[] {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (!clean) return [];
+  if (clean.length <= limit) return [clean];
+
+  const chunks: string[] = [];
+  let current = '';
+  for (const sentence of splitSentences(clean)) {
+    for (const piece of hardWrap(sentence, limit)) {
+      if (current && current.length + 1 + piece.length > limit) {
+        chunks.push(current);
+        current = '';
+      }
+      current = current ? `${current} ${piece}` : piece;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+/**
+ * Concatenate the mono PCM of several synthesis calls into one buffer, inserting
+ * a short silence between pieces so consecutive sentences do not butt together.
+ */
+export function concatAudio(parts: Float32Array[], sampleRate: number, gapMs = 60): Float32Array {
+  const usable = parts.filter((part) => part.length > 0);
+  if (usable.length === 0) return new Float32Array(0);
+  if (usable.length === 1) return usable[0];
+  const gap = Math.max(0, Math.round((gapMs / 1000) * sampleRate));
+  const total = usable.reduce((n, part) => n + part.length, 0) + gap * (usable.length - 1);
+  const out = new Float32Array(total);
+  let offset = 0;
+  usable.forEach((part, index) => {
+    out.set(part, offset);
+    offset += part.length + (index < usable.length - 1 ? gap : 0);
+  });
+  return out;
+}

--- a/src/views/StudyRecordingsView.tsx
+++ b/src/views/StudyRecordingsView.tsx
@@ -226,7 +226,11 @@ export function StudyRecordingsView({ onOpenDocument, initialRecordingId, initia
     if (recorderRef.current && recorderRef.current.state !== 'inactive') recorderRef.current.stop();
     streamRef.current?.getTracks().forEach((track) => track.stop());
     void contextRef.current?.close();
-    cancelLocalWhisper();
+    // Deliberately NOT cancelling local Whisper here: leaving the view must not
+    // kill an in-flight transcription. The worker keeps going and saveStudyTranscript
+    // persists the result (and resets the recording status) from its own promise
+    // chain, matching how the cloud / whisper_cpp providers already survive
+    // navigation. The explicit Cancel button still stops it on purpose.
   }, []);
 
   const subjects = useMemo(() => workspace?.subjects.filter((subject) => !courseId || subject.courseId === courseId) ?? [], [workspace, courseId]);


### PR DESCRIPTION
Closes #219

## What

Fixes four bugs in the local audio narration (TTS) and speech-to-text (STT) features. The first and last are the same class: a long-running process that lives in the renderer was tied to the view lifecycle and got cancelled when the user navigated away.

## Changes

### 1. Audio progress bar disappears on navigation (and generation was cancelled)
The synthesis loop and its progress state lived inside `AudioPanel`, and the unmount cleanup set a cancel flag — so leaving the view cancelled the whole generation, not just the bar. Moved the loop into the module-scope `backgroundJobs.ts` store (`startAudioGeneration` / `cancelAudioGeneration` / `audioGenerationJobKey`), same pattern as Deep Research / immersion / database jobs. `AudioPanel` now subscribes by entity key: leaving only unsubscribes, and the bar reappears mid-run on return. The synthesizer is injected into the store so it stays free of the WASM/onnx audio engines.

### 2. Deep Research summary narrated twice
`assembleMarkdown` embeds the abstract as a `## Resumen` section inside `draftMarkdown`, and `deepResearchSegments` also narrates it as the intro segment. The body section that duplicates the abstract is now skipped (language-agnostic text comparison), so the summary is synthesized once. The visual report is untouched.

### 3. Kokoro cuts sentences/words in half
kokoro-js truncates input past ~509 tokens; a segment up to ~2600 chars was silently cut mid-word. New pure, tested `src/lib/audio/kokoroChunk.ts` splits text into sentence-aligned pieces under the token budget and concatenates the PCM. Also fixed a `\S+$` in `splitForNarration` that dropped an unpunctuated trailing clause. Piper was unaffected.

### 4. Local Whisper transcription killed on unmount
`StudyRecordingsView` called `cancelLocalWhisper()` (which terminates the worker) in its unmount cleanup, killing an in-flight local ONNX transcription and mislabeling the recording as "error". Removed only that call; the worker keeps going and `saveStudyTranscript` persists the result and resets the recording status from the main process — matching how the cloud and `whisper_cpp` providers already survive navigation. The explicit Cancel button still stops it.

## Tests

- New `scripts/test-kokoro-chunk.mjs`: sentence splitting never drops text, chunks stay under budget, no word split, PCM concatenation.
- `scripts/test-speakable.mjs`: abstract is narrated exactly once; unpunctuated tail survives the split.
- `scripts/test-background-jobs.mjs`: audio generation survives leaving the view (loop keeps running, progress restored on remount) and cancellation stops it.

## Verification

`npm run typecheck`, `npm run lint`, `npm run build`, and `npm test` (810/810) all pass.
