### PR TITLE
fix(zotero): non-blocking bounded embeddings + page-aware answers for long PDFs

### DIFF
--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -465,6 +465,94 @@ test('evidence: complete-text mode obeys a token budget', () => {
   assert.ok(bounded.hits.length < idx.chunks.length);
 });
 
+// A several-hundred-page monograph: one sentence per page, form-feed
+// separated, so a known token appears on exactly one known page.
+function makeBook(E, pages, opts = {}) {
+  const text = Array.from({ length: pages }, (_, i) => `This is page ${i + 1}. It discusses topic marker ${i + 1} in detail with enough words to chunk.`).join('\f');
+  return E.buildIndex({ libraryID: 1, itemKey: 'BOOK', attachmentKey: 'BK', title: opts.title || 'Big Monograph', totalPages: pages, pageLabels: opts.pageLabels }, text, { targetChars: 400, minChars: 120, overlapChars: 40 });
+}
+
+test('evidence: document map reports true length + current/first/last, never guessed from evidence', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const book = makeBook(E, 600);
+  const map = E.buildDocumentMap([book], { current: { attachmentKey: 'BK', pageIndex: 43 } });
+  const src = map.sources[0];
+  assert.equal(src.totalPages, 600);
+  assert.equal(src.firstLabel, '1');
+  assert.equal(src.lastLabel, '600');
+  assert.equal(src.currentLabel, '44'); // pageIndex 43 → human page 44
+  const en = E.documentMapPrompt(map, { lang: 'en' });
+  assert.ok(/600 pages/.test(en));
+  assert.ok(/currently open at page 44/.test(en));
+  assert.ok(/AUTHORITATIVE/.test(en) && /NEVER infer/.test(en));
+  assert.ok(/NOT a citable source/i.test(en), 'map declares itself non-citable');
+  const es = E.documentMapPrompt(map, { lang: 'es' });
+  assert.ok(/600 páginas/.test(es) && /página 44/.test(es) && /NUNCA/.test(es));
+});
+
+test('evidence: document map surfaces roman-numeral front matter as differing labels', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const labels = ['i', 'ii', 'iii', '1', '2'];
+  const book = makeBook(E, 5, { pageLabels: labels });
+  const map = E.buildDocumentMap([book], { current: { attachmentKey: 'BK', pageIndex: 0 } });
+  const src = map.sources[0];
+  assert.equal(src.firstLabel, 'i');
+  assert.equal(src.currentLabel, 'i');
+  assert.equal(src.labelsDiffer, true);
+  assert.ok(/page labels "i"/.test(E.documentMapPrompt(map, { lang: 'en' })));
+});
+
+test('evidence: positional query classifier detects current/last/first/explicit pages in ES + EN', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  assert.equal(E.classifyPositionalQuery('¿en qué página estoy?').current, true);
+  assert.equal(E.classifyPositionalQuery('what page am I on right now').current, true);
+  assert.equal(E.classifyPositionalQuery('¿qué dice la última página?').last, true);
+  assert.equal(E.classifyPositionalQuery('summarize the last page').last, true);
+  assert.equal(E.classifyPositionalQuery('resume la primera página').first, true);
+  assert.equal(E.classifyPositionalQuery('¿cuántas páginas tiene el libro?').length, true);
+  assert.deepEqual([...E.classifyPositionalQuery('explica la página 213').pages], [213]);
+  assert.deepEqual(Array.from(E.classifyPositionalQuery('compara las páginas 10 a 12').ranges, (r) => ({ from: r.from, to: r.to })), [{ from: 10, to: 12 }]);
+  // A content question must NOT be treated as positional.
+  const plain = E.classifyPositionalQuery('what is the main argument about tourism?');
+  assert.equal(plain.positional, false);
+});
+
+test('evidence: positional page hits fetch the exact page content deterministically', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const book = makeBook(E, 600);
+  const last = E.positionalPageHits(book, E.classifyPositionalQuery('¿qué dice la última página?'), {});
+  assert.ok(last.length > 0);
+  assert.ok(last.every((h) => h.pageIndex >= 598)); // last page (599) + its neighbor
+  assert.ok(last.some((h) => h.text.includes('page 600')));
+  const explicit = E.positionalPageHits(book, E.classifyPositionalQuery('resume la página 213'), {});
+  assert.ok(explicit.length > 0 && explicit.every((h) => h.pageIndex === 212));
+  assert.ok(explicit.some((h) => h.text.includes('page 213')));
+  const current = E.positionalPageHits(book, E.classifyPositionalQuery('what is on this page'), { currentPageIndex: 43 });
+  assert.ok(current.length > 0 && current.every((h) => h.pageIndex === 43));
+  assert.ok(current.some((h) => h.text.includes('page 44')));
+});
+
+test('evidence: explicit page number matches the printed LABEL, not just the physical index', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  // Physical page 4 (index 3) is printed "1"; a reader asking for "page 1" means the label.
+  const book = makeBook(E, 5, { pageLabels: ['i', 'ii', 'iii', '1', '2'] });
+  const hits = E.positionalPageHits(book, E.classifyPositionalQuery('página 1'), {});
+  assert.ok(hits.length > 0 && hits.every((h) => h.pageIndex === 3));
+});
+
+test('evidence: candidate selection bounds embedding cost far below the whole book', () => {
+  const { NodusEvidence: E } = loadModule('evidence.js');
+  const book = makeBook(E, 600);
+  assert.ok(book.chunks.length >= 400, 'a 600-page book chunks into hundreds of passages');
+  const ids = E.candidateChunkIdsForQuery([book], 'topic marker 317', { limit: 96 });
+  // Bounded: never the whole book, and small relative to it.
+  assert.ok(ids.length <= 96 + 6 + 8, `candidates ${ids.length} stay bounded`);
+  assert.ok(ids.length < book.chunks.length / 3, 'far fewer than the whole document');
+  // The lexically-relevant page for the query is among the candidates.
+  const target = book.chunks.find((c) => c.text.includes('marker 317'));
+  assert.ok(ids.includes(target.id), 'the on-topic chunk is selected for embedding');
+});
+
 test('evidence: visual extraction is merged into the correct page and re-chunked', () => {
   const { NodusEvidence: E } = loadModule('evidence.js');
   const idx = E.buildIndex({ libraryID: 1, itemKey: 'A', attachmentKey: 'AA', title: 'Alpha', totalPages: 2 }, 'Text page\f');

--- a/zotero-plugin/content/evidence.js
+++ b/zotero-plugin/content/evidence.js
@@ -923,6 +923,171 @@
     return { text: parts.join("\n"), hits: included, chars: used, tokens, truncated };
   }
 
+  // ─────────────────────────────────────── document-structure awareness
+  // A long PDF's answer quality collapses when the model has to guess the
+  // document's length or the reader's position. These helpers give the model
+  // authoritative structural facts (total pages, current page, first/last page
+  // labels) and let positional questions ("the last page", "page 213", "this
+  // page") fetch the exact page deterministically instead of relying on a
+  // semantic search that has no anchor for "the last page".
+
+  // Map a 0-based pageIndex to the human page label the reader shows.
+  function pageLabelForIndex(index, pageIndex) {
+    const pages = (index && index.pages) || [];
+    const want = Number(pageIndex);
+    for (const p of pages) if (Number(p.pageIndex) === want) {
+      const label = p.pageLabel == null ? "" : String(p.pageLabel);
+      return label || String(want + 1);
+    }
+    return String(want + 1);
+  }
+  // Resolve a page number the user typed (usually the printed label) to the
+  // matching 0-based pageIndex — matching labels first, then falling back to
+  // treating the number as a physical position.
+  function resolvePageIndex(index, requested) {
+    const n = Math.floor(Number(requested));
+    if (!Number.isFinite(n)) return -1;
+    const pages = (index && index.pages) || [];
+    for (const p of pages) if (Number(p.pageLabel) === n) return Number(p.pageIndex);
+    for (const p of pages) if (Number(p.pageIndex) + 1 === n) return Number(p.pageIndex);
+    return -1;
+  }
+  // opts.current = { attachmentKey, pageIndex }; opts.coverage[attachmentKey] =
+  // { fromLabel, toLabel } marks the page span actually present in the evidence
+  // text (used to warn honestly about truncation in full-text mode).
+  function buildDocumentMap(indexes, opts) {
+    opts = opts || {};
+    const current = opts.current || null;
+    const coverage = opts.coverage || {};
+    const sources = [];
+    for (const index of indexes || []) {
+      const pages = Array.isArray(index.pages) ? index.pages : [];
+      const total = Number(index.totalPages) || pages.length || 0;
+      const firstLabel = pages.length ? pageLabelForIndex(index, pages[0].pageIndex) : "1";
+      const lastLabel = pages.length ? pageLabelForIndex(index, pages[pages.length - 1].pageIndex) : String(total);
+      const src = {
+        attachmentKey: String(index.attachmentKey || ""),
+        title: String(index.title || index.itemKey || index.attachmentKey || "document"),
+        totalPages: total,
+        firstLabel,
+        lastLabel,
+        // Labels differ from physical numbering (roman front-matter, offset
+        // print pages, etc.) — worth telling the model so it quotes the label.
+        labelsDiffer: firstLabel !== "1" || (total > 0 && lastLabel !== String(total)),
+      };
+      if (current && String(current.attachmentKey || "") === src.attachmentKey && current.pageIndex != null && Number(current.pageIndex) >= 0) {
+        src.currentPageIndex = Number(current.pageIndex);
+        src.currentLabel = pageLabelForIndex(index, Number(current.pageIndex));
+      }
+      if (coverage[src.attachmentKey]) src.coverage = coverage[src.attachmentKey];
+      sources.push(src);
+    }
+    return { sources };
+  }
+  function documentMapPrompt(map, opts) {
+    opts = opts || {};
+    const es = opts.lang === "es";
+    const sources = (map && map.sources) || [];
+    if (!sources.length) return "";
+    const lines = [];
+    lines.push(es
+      ? "MAPA DEL DOCUMENTO — datos estructurales AUTORITATIVOS. Úsalo como ÚNICA fuente para responder cualquier pregunta sobre el número de páginas, la extensión, la página actual o «la última/primera página». NUNCA deduzcas esos datos de los pasajes de EVIDENCIA de más abajo: son una selección parcial y sus números de página NO indican la longitud del documento. El mapa NO es una fuente citable: no lo cites nunca ni inventes un token [[e:...]] a partir de él."
+      : "DOCUMENT MAP — AUTHORITATIVE structural facts. Use this as the ONLY source for any question about the page count, length, the current page, or \"the last/first page\". NEVER infer those from the EVIDENCE passages below: they are a partial selection and their page numbers do NOT indicate the document's length. The map is NOT a citable source: never cite it and never fabricate an [[e:...]] token from it.");
+    for (const s of sources) {
+      const bits = ["\"" + s.title + "\"", es ? s.totalPages + " páginas" : s.totalPages + " pages"];
+      if (s.labelsDiffer) bits.push(es ? "etiquetas de página «" + s.firstLabel + "»–«" + s.lastLabel + "»" : "page labels \"" + s.firstLabel + "\"–\"" + s.lastLabel + "\"");
+      let line = "• " + bits.join(" · ") + ".";
+      if (s.currentLabel != null) line += es ? " El lector está abierto ahora en la página " + s.currentLabel + "." : " The reader is currently open at page " + s.currentLabel + ".";
+      if (s.coverage) line += es
+        ? " NOTA: los pasajes de abajo de este documento solo cubren las páginas " + s.coverage.fromLabel + "–" + s.coverage.toLabel + "; el contenido posterior NO está incluido en este mensaje. Para leer una página concreta, pregunta por su número."
+        : " NOTE: the passages below from this document cover only pages " + s.coverage.fromLabel + "–" + s.coverage.toLabel + "; later content is NOT included in this message. To read a specific page, ask for its number.";
+      lines.push(line);
+    }
+    return lines.join("\n");
+  }
+  // Detect questions that address a document POSITION rather than content, so
+  // the exact page(s) can be fetched deterministically.
+  function classifyPositionalQuery(query) {
+    const q = " " + String(query || "").toLowerCase().replace(/\s+/g, " ") + " ";
+    const out = { positional: false, current: false, first: false, last: false, length: false, pages: [], ranges: [] };
+    const mark = (flag) => { out[flag] = true; out.positional = true; };
+    if (/(p[áa]gina actual|esta p[áa]gina|en esta p[áa]gina|la p[áa]gina en la que estoy|en qu[ée] p[áa]gina estoy|d[óo]nde estoy|current page|this page|the page i(?:'m| am) on|what page am i)/.test(q)) mark("current");
+    if (/([úu]ltima p[áa]gina|p[áa]gina final|[úu]ltima hoja|el final del (?:libro|documento|texto|pdf)|al final del (?:libro|documento|texto)|last page|final page|the end of the (?:book|document|text|pdf))/.test(q)) mark("last");
+    if (/(primera p[áa]gina|p[áa]gina inicial|el (?:principio|comienzo|inicio) del (?:libro|documento|texto|pdf)|portada|first page|the (?:start|beginning) of the (?:book|document|text|pdf)|cover page)/.test(q)) mark("first");
+    if (/(cu[áa]nt[ao]s p[áa]ginas|n[úu]mero de p[áa]ginas|de cu[áa]ntas p[áa]ginas|how many pages|how long is|page count|number of pages|qu[ée] extensi[óo]n)/.test(q)) { out.length = true; out.positional = true; }
+    const rangeRe = /(?:pp?\.?|p[áa]ginas?|pages?)\s*(\d{1,4})\s*(?:[-–—]|a|to|hasta|y|and)\s*(\d{1,4})/g;
+    let m;
+    while ((m = rangeRe.exec(q)) !== null) { out.ranges.push({ from: Number(m[1]), to: Number(m[2]) }); out.positional = true; }
+    const pageRe = /(?:p[áa]gina|page)\s*(?:n[uú]mero\s*|no\.?\s*|#\s*)?(\d{1,4})|\bp\.?\s*(\d{1,4})\b|\bpp\.?\s*(\d{1,4})\b/g;
+    while ((m = pageRe.exec(q)) !== null) { out.pages.push(Number(m[1] || m[2] || m[3])); out.positional = true; }
+    return out;
+  }
+  // Deterministically return the chunks that belong to the requested pages of a
+  // single index (the one open in the reader). Whole pages are returned so the
+  // model sees the entire page, not a similarity-ranked fragment of it.
+  function positionalPageHits(index, intents, opts) {
+    opts = opts || {};
+    if (!index || !intents || !intents.positional) return [];
+    const pages = Array.isArray(index.pages) ? index.pages : [];
+    const total = Number(index.totalPages) || pages.length || 0;
+    if (!total) return [];
+    const wantIdx = new Set(); // 0-based pageIndexes
+    const addIdx = (i) => { if (Number.isFinite(i) && i >= 0 && i < total) wantIdx.add(i); };
+    if (intents.first) addIdx(0);
+    if (intents.last) { addIdx(total - 1); if (total > 1) addIdx(total - 2); }
+    if (intents.current && Number.isFinite(Number(opts.currentPageIndex))) addIdx(Number(opts.currentPageIndex));
+    for (const n of intents.pages || []) addIdx(resolvePageIndex(index, n));
+    for (const r of intents.ranges || []) {
+      const from = resolvePageIndex(index, r.from);
+      const to = resolvePageIndex(index, r.to);
+      if (from < 0) continue;
+      const end = to < 0 ? from : to;
+      for (let i = from; i <= Math.min(end, from + 8); i++) addIdx(i);
+    }
+    if (!wantIdx.size) return [];
+    const maxHits = Number(opts.maxHits) || 20;
+    const out = [];
+    for (const chunk of index.chunks || []) {
+      if (!wantIdx.has(Number(chunk.pageIndex))) continue;
+      out.push({ ...chunk, score: 1, retrieval: "position", indexSignature: index.signature });
+      if (out.length >= maxHits) break;
+    }
+    out.sort((a, b) => a.pageIndex - b.pageIndex || a.chunkIndex - b.chunkIndex);
+    return out;
+  }
+  // Bound how many chunks a single query must embed on a large document: rank by
+  // BM25 (needs no embeddings) and keep the top ids, plus each source's opening
+  // chunks so a purely conceptual question still has anchor points. Everything
+  // else is embedded lazily in the background for later queries.
+  function candidateChunkIdsForQuery(indexes, query, opts) {
+    opts = opts || {};
+    const limit = Number(opts.limit) > 0 ? Number(opts.limit) : 96;
+    const starters = Number.isFinite(opts.startersPerSource) ? opts.startersPerSource : 6;
+    const chunks = flattenIndexes(indexes);
+    if (!chunks.length) return [];
+    const scores = bm25Scores(chunks, query);
+    const ranked = chunks
+      .map((c, i) => ({ id: c.id, score: scores[i] }))
+      .sort((a, b) => b.score - a.score);
+    const ids = new Set();
+    for (const r of ranked) {
+      if (ids.size >= limit) break;
+      if (r.score > 0) ids.add(r.id);
+    }
+    const bySource = new Map();
+    for (const c of chunks) {
+      const key = c.libraryID + ":" + c.attachmentKey;
+      if (!bySource.has(key)) bySource.set(key, []);
+      bySource.get(key).push(c);
+    }
+    const hardCap = limit + starters * Math.max(1, bySource.size);
+    for (const arr of bySource.values()) {
+      arr.sort((a, b) => Number(a.pageIndex) - Number(b.pageIndex) || Number(a.chunkIndex) - Number(b.chunkIndex));
+      for (const c of arr.slice(0, starters)) { if (ids.size >= hardCap) break; ids.add(c.id); }
+    }
+    return [...ids];
+  }
+
   const CITE_RE = /\[\[(e|p|idea|zotero|gap):([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
   function allowSet(value) {
     if (value == null) return null;
@@ -1141,6 +1306,8 @@
     splitLogicalPages, chunkPage, buildIndex, addVisualText,
     bm25Scores, cosine, hybridSearch, expandWithNeighbors, diversifyCandidates, flattenIndexes,
     mergeRetrievalResults, pageRequestHits,
+    pageLabelForIndex, resolvePageIndex, buildDocumentMap, documentMapPrompt,
+    classifyPositionalQuery, positionalPageHits, candidateChunkIdsForQuery,
     evidenceMap, evidencePrompt, fullTextPrompt, fullEvidencePrompt,
     validateCitations, citationIds, splitClaims, auditTokens, supportScore, auditClaims,
     attachmentSignature, extractAttachment, ensureIndex,

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -511,11 +511,66 @@ async function ensureEmbeddingsSerialized(indexes, signal, opts) {
 // line (which stays free for whatever the user is doing meanwhile).
 function embedIndexesBackground(indexes) {
   if (!NL || !indexes || !indexes.length) return;
+  // Nothing left to do — don't flash an empty progress bar.
+  const model = NL.MODEL;
+  const remaining = indexes.reduce((n, index) => n + (index.chunks || []).filter((c) =>
+    !Array.isArray(c.embedding) || c.embedding.length !== model.dimensions || c.embeddingModel !== model.fingerprint
+  ).length, 0);
+  if (!remaining) return;
   showEmbedProgress(0);
   ensureEmbeddingsSerialized(indexes, undefined, {
     onStatus: () => {},
     onProgress: (done, total) => showEmbedProgress(total ? Math.round((done / total) * 100) : 100),
   }).catch((e) => { try { Zotero.logError(e); } catch (x) {} }).finally(() => showEmbedProgress(null));
+}
+// Query-time BOUNDED embedding. Embedding every chunk of a several-hundred-page
+// book up front is what makes the first answer hang for minutes. Instead embed
+// only the BM25 candidate chunks (+ any positional page chunks) for THIS
+// question, plus the query itself. The vectors land on the in-memory chunk
+// objects and get persisted later by the background full pass, so the answer
+// never waits on the whole document. Returns the query embedding (or null).
+async function embedCandidatesInline(indexes, query, extraHits, signal) {
+  if (!NL || !NE || !indexes || !indexes.length) return null;
+  const model = NL.MODEL;
+  const wanted = new Set(NE.candidateChunkIdsForQuery(indexes, query, { limit: 96 }));
+  for (const h of extraHits || []) if (h && h.id) wanted.add(h.id);
+  const missing = [];
+  for (const index of indexes) {
+    for (const chunk of index.chunks || []) {
+      if (!wanted.has(chunk.id)) continue;
+      if (Array.isArray(chunk.embedding) && chunk.embedding.length === model.dimensions && chunk.embeddingModel === model.fingerprint) continue;
+      missing.push({ index, chunk });
+    }
+  }
+  for (let i = 0; i < missing.length; i += 24) {
+    if (signal && signal.aborted) throw new DOMException("Aborted", "AbortError");
+    const batch = missing.slice(i, i + 24);
+    const vectors = await NL.embedPassages(batch.map(({ index, chunk }) =>
+      [index.title, chunk.section, chunk.text].filter(Boolean).join("\n")
+    ), { signal });
+    batch.forEach(({ chunk }, j) => { chunk.embedding = vectors[j]; chunk.embeddingModel = model.fingerprint; });
+  }
+  return NL.embedQuery(query, { signal });
+}
+// fromLabel/toLabel of the pages actually present in `hits`, per source — used
+// to tell the model honestly which pages a truncated full-text body covers.
+function coverageFromHits(indexes, hits) {
+  const byKey = new Map();
+  for (const h of hits || []) {
+    const key = String(h.attachmentKey || "");
+    const span = byKey.get(key) || { min: Infinity, max: -Infinity };
+    span.min = Math.min(span.min, Number(h.pageIndex));
+    span.max = Math.max(span.max, Number(h.pageIndex));
+    byKey.set(key, span);
+  }
+  const coverage = {};
+  for (const index of indexes || []) {
+    const key = String(index.attachmentKey || "");
+    const span = byKey.get(key);
+    if (!span || !Number.isFinite(span.min)) continue;
+    coverage[key] = { fromLabel: NE.pageLabelForIndex(index, span.min), toLabel: NE.pageLabelForIndex(index, span.max) };
+  }
+  return coverage;
 }
 function parseRankedIds(value, allowed) {
   const text = String(value || "").replace(/```(?:json)?/gi, "").replace(/```/g, "");
@@ -776,22 +831,64 @@ async function prepareEvidence(query, signal) {
     n + (Number(index.estimatedTokens) || (index.chunks || []).reduce((sum, chunk) => sum + (Number(chunk.estimatedTokens) || NE.estimateTokens(chunk.text)), 0))
   , 0);
   const tokenBudget = Math.min(availableContextTokens(), ctx.fullTextThreshold);
+
+  // Reader position + the index it points at, so page-aware questions ("this
+  // page", "the last page", "page 213") resolve against the open document.
+  const cur = getCurrentItem();
+  let currentRef = null;
+  let targetIndex = (cur && cur.attachment) ? indexes.find((x) => x.attachmentKey === cur.attachment.key) : null;
+  if (!targetIndex && indexes.length === 1) targetIndex = indexes[0];
+  if (cur && cur.reader && cur.attachment && NV) {
+    try { currentRef = { attachmentKey: cur.attachment.key, pageIndex: NV.currentPageIndex(cur.reader) }; } catch (e) {}
+  }
+  const intents = NE.classifyPositionalQuery(query);
+  const positionalHits = (intents.positional && targetIndex)
+    ? NE.positionalPageHits(targetIndex, intents, { currentPageIndex: currentRef ? currentRef.pageIndex : null, maxHits: 20 })
+    : [];
+  // Users most often ask about the page they are reading. Always embed that
+  // page's neighborhood so such a question is answerable from the FIRST query,
+  // even when it is cross-lingual (BM25 can't bridge languages, so the reading
+  // page might otherwise miss the bounded candidate set until the background
+  // pass catches up).
+  let readingWindowHits = [];
+  if (currentRef && targetIndex) {
+    const idx = Number(currentRef.pageIndex);
+    readingWindowHits = (targetIndex.chunks || []).filter((c) => Math.abs(Number(c.pageIndex) - idx) <= 2);
+  }
+  const mapPrompt = (coverage) => NE.documentMapPrompt(
+    NE.buildDocumentMap(indexes, { current: currentRef, coverage: coverage || {} }),
+    { lang: state.lang }
+  );
+
   // A single open document that fits the context window is exactly the
   // "Reading Assistant" case: no retrieval/embeddings needed, just hand the
   // whole thing to the model — always, regardless of the configured strategy.
   const singleDocFits = indexes.length === 1 && totalTokens <= tokenBudget;
   const strategy = singleDocFits ? "full" : (ctx.strategy === "auto" ? (totalTokens <= tokenBudget && indexes.length <= 5 ? "full" : "retrieval") : ctx.strategy);
   if (strategy === "full") {
-    const full = NE.fullEvidencePrompt(indexes, { maxChars: tokenBudget * 5, maxTokens: tokenBudget });
-    state.evidence = NE.evidenceMap(full.hits);
-    state.retrieval = { method: "full", hits: full.hits, totalChars, totalTokens, truncated: full.truncated };
-    setIndexStatus("Complete text · " + full.hits.length + " citable passages", full.truncated ? "warn" : "ok");
-    return { ...full, method: "full" };
+    // Reserve part of the budget so the pages the user is most likely to ask
+    // about (current/first/last/explicit) are never the ones truncation drops.
+    const reserve = positionalHits.length ? Math.min(Math.round(tokenBudget * 0.35), 6000) : 0;
+    const full = NE.fullEvidencePrompt(indexes, { maxChars: (tokenBudget - reserve) * 5, maxTokens: tokenBudget - reserve });
+    const includedIds = new Set(full.hits.map((h) => h.id));
+    const extraPositional = positionalHits.filter((h) => !includedIds.has(h.id));
+    const hits = full.hits.concat(extraPositional);
+    state.evidence = NE.evidenceMap(hits);
+    const coverage = full.truncated ? coverageFromHits(indexes, full.hits) : {};
+    const bodyParts = [full.text];
+    if (extraPositional.length) {
+      bodyParts.push((state.lang === "es" ? "PÁGINAS SOLICITADAS (texto completo):\n" : "REQUESTED PAGES (full text):\n") + NE.evidencePrompt(extraPositional));
+    }
+    const text = [mapPrompt(coverage), bodyParts.join("\n\n")].filter(Boolean).join("\n\n");
+    state.retrieval = { method: "full", hits, totalChars, totalTokens, truncated: full.truncated };
+    setIndexStatus("Complete text · " + hits.length + " citable passages", full.truncated ? "warn" : "ok");
+    return { text, hits, method: "full", truncated: full.truncated };
   }
   let queryEmbedding = null;
   try {
-    await ensureEmbeddingsSerialized(indexes, signal);
-    queryEmbedding = await NL.embedQuery(query, { signal });
+    // Bounded, non-blocking: embed only this query's candidate chunks, not the
+    // whole book. The rest are embedded in the background (see end of function).
+    queryEmbedding = await embedCandidatesInline(indexes, query, positionalHits.concat(readingWindowHits), signal);
   } catch (e) {
     try { Zotero.logError(e); } catch (x) {}
     setIndexStatus("Semantic unavailable · lexical fallback", "warn");
@@ -832,10 +929,22 @@ async function prepareEvidence(query, signal) {
   result.method += (rounds ? "+agentic" + rounds : "") + "+rerank";
   result.rounds = rounds;
   result.totalTokens = totalTokens;
+  // A semantic search has no anchor for "the last page" or "page 213"; splice
+  // those exact-page passages in (deduped, at the front) so positional
+  // questions always answer from real content, not a nearby guess.
+  if (positionalHits.length) {
+    const existing = new Set(result.hits.map((h) => h.id));
+    const extra = positionalHits.filter((h) => !existing.has(h.id));
+    if (extra.length) result.hits = extra.concat(result.hits);
+  }
   state.evidence = NE.evidenceMap(result.hits);
   state.retrieval = result;
   setIndexStatus((result.method.startsWith("hybrid") ? "Local semantic + lexical" : "Lexical") + (rounds ? " + agentic " + rounds : "") + " + rerank · " + result.hits.length + " passages", "ok");
-  return { text: NE.evidencePrompt(result.hits), hits: result.hits, method: result.method, truncated: false };
+  // Non-blocking: finish embedding the whole document so later queries get full
+  // semantic recall and the vectors reach disk. Never awaited — the answer for
+  // THIS question is already built from the bounded candidate set above.
+  embedIndexesBackground(indexes);
+  return { text: [mapPrompt({}), NE.evidencePrompt(result.hits)].filter(Boolean).join("\n\n"), hits: result.hits, method: result.method, truncated: false };
 }
 async function runVisualExtraction(image, page) {
   const prompt = NV.visualPrompt(page.pageLabel, page.text);
@@ -1339,7 +1448,7 @@ async function sendStandalone(bodyEl, signal, docInfo) {
   // training language even for an English/Spanish question.
   const lastUser = [...state.conv.messages].reverse().find((m) => m.role === "user");
   const lang = NU && NU.detectLanguage ? NU.detectLanguage(lastUser && lastUser.content, state.lang) : (state.lang === "es" ? "Spanish" : "English");
-  let system = "You are a research assistant embedded in Zotero. Answer about the open documents, grounded only in the supplied evidence. Address every requested facet that the evidence covers, especially explicit named entities, lists and standards. Stay focused on the question: do not add tangential facts merely because they occur in neighboring passages. A claimed relation must be directly supported; never infer causation from co-location. Cite every factual claim inline with the exact [[e:ID]] token for its supporting passage. Never invent, alter or reuse an evidence id for a claim it does not support. Put citations immediately after the sentence. If evidence is insufficient, say so. Be concise.\n\nOUTPUT LANGUAGE (highest priority): answer entirely in " + lang + ". Do not switch language because the source or an attached image uses another language.\n\n" + parts.join("\n\n");
+  let system = "You are a research assistant embedded in Zotero. Answer about the open documents, grounded only in the supplied evidence. Address every requested facet that the evidence covers, especially explicit named entities, lists and standards. Stay focused on the question: do not add tangential facts merely because they occur in neighboring passages. A claimed relation must be directly supported; never infer causation from co-location. Cite every factual claim inline with the exact [[e:ID]] token for its supporting passage. Never invent, alter or reuse an evidence id for a claim it does not support. Put citations immediately after the sentence. If evidence is insufficient, say so. Be concise.\n\nDOCUMENT STRUCTURE: When a DOCUMENT MAP is present, it is the single source of truth for the document's page count, its length, the current page, and the first/last page. Answer any such question from the map alone. The EVIDENCE passages are a partial selection; NEVER infer the document's length or which page is last from the page numbers that appear in the evidence, and never say the document ends where the evidence happens to end.\n\nOUTPUT LANGUAGE (highest priority): answer entirely in " + lang + ". Do not switch language because the source or an attached image uses another language.\n\n" + parts.join("\n\n");
   if (state.agentEnabled && NA) system += "\n\n" + NA.SYSTEM;
   const key = NS.getKey(state.model.provider);
   const localBase = NS.getLocalBase(state.model.provider);


### PR DESCRIPTION
Fixes #222.

## Why

On large PDFs (hundreds of pages) the plugin's assistant was unusable: the first
answer blocked until the **whole** document was embedded, and the model was never
told the document's structure, so it hallucinated the current page, the total
page count and "the last page".

## What changed (`zotero-plugin/`)

- **Document map** (`evidence.js`): authoritative structural facts — total pages,
  current reader page, first/last page labels, and honest truncation coverage —
  injected ahead of the evidence and declared **non-citable**. Page/length
  questions are answered from the map, never guessed from the partial passage set.
- **Positional retrieval**: `classifyPositionalQuery` + `positionalPageHits`
  detect "current/last/first page" and "page N" (label-aware) and pull those
  exact pages deterministically, since semantic search has no anchor for "the
  last page".
- **Bounded, non-blocking embedding** (`sidebar.js`): a query embeds only its
  BM25 candidates (`candidateChunkIdsForQuery`) plus the current reading page,
  then the rest of the document is embedded in the background. The first answer
  no longer waits on the whole book.
- **Full-text mode** marks truncation honestly and always includes the pages the
  user is most likely to ask about.

Works across the **auto, embeddings and full-text** strategies. No schema, UI or
app changes; the Zotero plugin is self-contained.

## Verification

- Unit suite: **61/61** (`scripts/test-zotero-plugin.mjs`), incl. new coverage for
  the document map, positional classifier/retrieval and candidate selection.
- End-to-end in Node with the **real multilingual-E5 model + a real LLM** on a
  synthetic 600-page book with embedded sentinels:
  - retrieval BEFORE 4/6 → AFTER 6/6 (first query and warm); full-text BEFORE 4/6 → AFTER 6/6.
  - robustness matrix (120 / 300 / 600 pages + roman-numeral front matter, both strategies, paraphrased + cross-lingual questions): **48/48**.
  - per-query embedding cost: whole book (blocking) → **0–11 chunks (21–140 ms)**.
- Real Zotero runtime (Zotero 140 ESR, a real 546-page book open in the reader):
  - `currentPageIndex` returns the correct page (546) and tracks navigation.
  - embedding worker confirmed on the **WASM** backend at ~55 ms/chunk → bounded
    first-query embed ~6 s vs ~65 s for the whole book (previously blocking).