### PR TITLE
feat(zotero): self-updating plugin via Zotero AddonManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Zotero plugin self-updates.** The Nodus for Zotero add-on now keeps itself
+  current: it registers with Zotero's own add-on updater and installs each new
+  plugin release automatically from the latest GitHub Release (downloaded and
+  sha256-verified by Zotero, applied on the next restart). This is on by default
+  and can be turned off under Settings → Updates; turning it off asks for
+  confirmation first. Plugin bumped to 2.7.0.
+
 ## 2.6.2 — 2026-07-23
 
 ### Changed

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -795,6 +795,37 @@ test('#reasoning: sidebar + server wire the selector through', () => {
   assert.ok(/reasoning/.test(server) && server.includes('ReasoningEffort'), 'connected server honors reasoning');
 });
 
+test('self-update: default-on preference, AddonManager wiring and a guarded disable toggle', () => {
+  // Store defaults ON and round-trips the preference.
+  const { NodusStore: S } = loadModule('store.js');
+  assert.equal(S.getAutoUpdate(), true, 'auto-update defaults to enabled');
+  assert.equal(typeof S.setAutoUpdate, 'function', 'store exposes setAutoUpdate');
+
+  // updater.js drives Zotero's own AddonManager (per-add-on background updates +
+  // an immediate check), rather than reinventing download/verify.
+  const updater = readSource('zotero-plugin/content/updater.js');
+  assert.ok(updater.includes('AddonManager.sys.mjs'), 'imports the AddonManager');
+  assert.ok(updater.includes('applyBackgroundUpdates'), 'sets per-add-on auto-update');
+  assert.ok(updater.includes('AUTOUPDATE_ENABLE') && updater.includes('AUTOUPDATE_DISABLE'), 'enables/disables explicitly');
+  assert.ok(updater.includes('findUpdates'), 'can check for an update immediately');
+  assert.ok(updater.includes('window.NodusUpdater'), 'exposes NodusUpdater');
+
+  // bootstrap applies the preference at startup, defaulting to enabled.
+  const bootstrap = readSource('zotero-plugin/bootstrap.js');
+  assert.ok(bootstrap.includes('configureAutoUpdate'), 'startup configures auto-update');
+  assert.ok(/nodus\.autoUpdate/.test(bootstrap), 'reads the auto-update preference');
+  assert.ok(/updater\.js/.test(bootstrap), 'startup loads the shared updater module');
+
+  // sidebar exposes the toggle, confirms before turning it OFF, and reverts on cancel.
+  const sidebar = readSource('zotero-plugin/content/sidebar.js');
+  const html = readSource('zotero-plugin/content/sidebar.html');
+  assert.ok(html.includes('id="nd-autoupdate"'), 'settings expose the toggle');
+  assert.ok(html.includes('chrome://nodus/content/updater.js'), 'sidebar loads the updater');
+  assert.ok(sidebar.includes('NS.setAutoUpdate'), 'persists the choice');
+  assert.ok(/showConfirm\(t\("update\.disableConfirm"\)/.test(sidebar), 'disabling asks for confirmation');
+  assert.ok(/e\.target\.checked = true;\s*return;/.test(sidebar), 'cancelling reverts the toggle to on');
+});
+
 test('local retrieval: E5 is pinned, isolated in a worker and requires no embedding setting or API', () => {
   const worker = readSource('scripts/zotero-local-embedding-worker.mjs');
   const bridge = readSource('zotero-plugin/content/local-embeddings.js');
@@ -1000,6 +1031,7 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   assert.ok(names.includes('manifest.json'), 'manifest.json at zip ROOT (Zotero rejects it otherwise)');
   for (const need of [
     'content/sidebar.js',
+    'content/updater.js',
     'content/local-embeddings.js',
     'content/runtime/local-embedding-worker.js',
     'content/runtime/ort-wasm-simd-threaded.jsep.mjs',
@@ -1015,7 +1047,7 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '2.6.0');
+  assert.equal(manifest.version, '2.7.0');
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/zotero-plugin/bootstrap.js
+++ b/zotero-plugin/bootstrap.js
@@ -50,7 +50,24 @@ async function startup({ id, version, rootURI, resourceURI }) {
   registerReaderToolbarButton();
   registerSelectionPopup();
   eachMainWindow((w) => { injectSidebar(w); addLibraryButton(w); });
+  configureAutoUpdate();
   log("startup complete v" + version);
+}
+
+// Self-update: on by default. Reads the user's preference (Settings toggle) and
+// tells Zotero's AddonManager whether to keep this add-on current, checking for
+// a new release immediately when enabled. Shares content/updater.js with the
+// sidebar so both apply the same behaviour.
+function autoUpdateEnabled() {
+  try { return Zotero.Prefs.get("nodus.autoUpdate") !== "0"; } catch (e) { return true; }
+}
+function configureAutoUpdate() {
+  try {
+    const scope = { window: {}, ChromeUtils: ChromeUtils };
+    Services.scriptloader.loadSubScript("chrome://nodus/content/updater.js", scope);
+    const NU = scope.window.NodusUpdater;
+    if (NU && NU.configure) NU.configure(autoUpdateEnabled());
+  } catch (e) { log("auto-update config failed: " + (e && e.message ? e.message : e)); }
 }
 
 function onMainWindowLoad({ window }) {

--- a/zotero-plugin/content/sidebar.html
+++ b/zotero-plugin/content/sidebar.html
@@ -120,6 +120,11 @@
         <label data-i18n="settings.language">Language</label>
         <select id="nd-lang"><option value="en">English</option><option value="es">Español</option></select>
       </div>
+      <div class="nd-field">
+        <label data-i18n="update.title">Updates</label>
+        <label class="nd-check"><input type="checkbox" id="nd-autoupdate" /> <span data-i18n="update.autoDesc">Keep the plugin up to date automatically</span></label>
+        <div class="nd-muted" data-i18n="update.hint">Nodus installs each new plugin release automatically when Zotero checks for add-on updates. Updates are downloaded from GitHub and verified before installing.</div>
+      </div>
       <div class="nd-field" data-nodus-only>
         <label data-i18n="settings.connection">Nodus connection</label>
         <div id="nd-conn-detail" class="nd-muted"></div>
@@ -170,6 +175,7 @@
   <script src="chrome://nodus/content/icons.js"></script>
   <script src="chrome://nodus/content/providers.js"></script>
   <script src="chrome://nodus/content/store.js"></script>
+  <script src="chrome://nodus/content/updater.js"></script>
   <script src="chrome://nodus/content/local-embeddings.js"></script>
   <script src="chrome://nodus/content/evidence.js"></script>
   <script src="chrome://nodus/content/multimodal.js"></script>

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -16,6 +16,7 @@ const NI = window.NodusIcons;
 const NE = window.NodusEvidence;
 const NV = window.NodusMultimodal;
 const NL = window.NodusLocalEmbeddings;
+const NUP = window.NodusUpdater;
 const ico = (name, size) => (NI ? NI.svg(name, { size: size || 16 }) : "");
 
 // Full-document context cap (~50k tokens): big enough for most modern models,
@@ -118,6 +119,11 @@ const I18N = {
     "providers.linkedMsg": "Providers are only used in Standalone mode. In Link mode, models come from Nodus — add or pin models in the Nodus app.",
     "agent.on": "Agent mode ON — Nodus can now propose actions on your Zotero (create notes, highlight, tag). It asks permission each time you chat.",
     "agent.off": "Agent mode off.",
+    "update.title": "Updates", "update.autoDesc": "Keep the plugin up to date automatically",
+    "update.hint": "Nodus installs each new plugin release automatically when Zotero checks for add-on updates. Updates are downloaded from GitHub and verified before installing.",
+    "update.disable": "Turn off",
+    "update.disableConfirm": "Turn off automatic updates? You'll then have to update the Nodus plugin manually to get new features and fixes.",
+    "update.on": "Automatic updates on.", "update.off": "Automatic updates off.",
   },
   es: {
     "tab.chat": "Chat", "tab.providers": "Proveedores", "tab.settings": "Ajustes",
@@ -210,6 +216,11 @@ const I18N = {
     "providers.linkedMsg": "Los proveedores solo se usan en modo Autónomo. En modo Link, los modelos vienen de Nodus — añade o fija modelos en la app de Nodus.",
     "agent.on": "Modo agente ACTIVADO — Nodus podrá proponer acciones sobre tu Zotero (crear notas, subrayar, etiquetar). Pedirá permiso cada vez que chatees.",
     "agent.off": "Modo agente desactivado.",
+    "update.title": "Actualizaciones", "update.autoDesc": "Mantener el plugin actualizado automáticamente",
+    "update.hint": "Nodus instala cada nueva versión del plugin automáticamente cuando Zotero busca actualizaciones de complementos. Las actualizaciones se descargan de GitHub y se verifican antes de instalarse.",
+    "update.disable": "Desactivar",
+    "update.disableConfirm": "¿Desactivar las actualizaciones automáticas? Tendrás que actualizar el plugin de Nodus manualmente para recibir nuevas funciones y correcciones.",
+    "update.on": "Actualizaciones automáticas activadas.", "update.off": "Actualizaciones automáticas desactivadas.",
   },
 };
 
@@ -218,7 +229,7 @@ const state = {
   modelsConnected: [], model: null,
   item: null, attachmentKey: null, selection: "", ideaLabels: {},
   conversations: [], conv: null, busy: false, lastItemKey: null, abort: null,
-  agentEnabled: false, agentAuto: false, selectionDraft: null,
+  agentEnabled: false, agentAuto: false, autoUpdate: true, selectionDraft: null,
   items: [], maxTokens: 8192, reasoning: "default", notifierID: null, pollTimer: null,
   hlColors: { high: "#ff6666", medium: "#ffd400" }, lastHighlightKeys: [],
   indexes: [], evidence: new Map(), retrieval: null, visuals: [], contextStrategy: "auto",
@@ -1876,6 +1887,15 @@ function wire() {
     if (e.target.checked) { const ok = await showConfirm(t("agent.autoConfirm"), t("agent.enable")); if (!ok) { e.target.checked = false; return; } }
     state.agentAuto = e.target.checked; NS.setAgentAuto(state.agentAuto);
   });
+  // Self-update toggle. Turning it OFF is the guarded action: confirm first, and
+  // revert the checkbox if the user cancels. Enabling also triggers an immediate
+  // update check via Zotero's AddonManager.
+  $("#nd-autoupdate").addEventListener("change", async (e) => {
+    if (!e.target.checked) { const ok = await showConfirm(t("update.disableConfirm"), t("update.disable")); if (!ok) { e.target.checked = true; return; } }
+    state.autoUpdate = e.target.checked; NS.setAutoUpdate(state.autoUpdate);
+    if (NUP && NUP.configure) NUP.configure(state.autoUpdate);
+    showToast(t(state.autoUpdate ? "update.on" : "update.off"));
+  });
   registerNotifier();
   // Fallback poll ONLY for library list-selection, which Zotero exposes no
   // public event for. Tab switches and item edits arrive instantly via the
@@ -1949,6 +1969,8 @@ async function boot() {
       if (hint && backend) hint.setAttribute("data-backend", backend);
     }).catch(() => {});
   }
+  state.autoUpdate = NS.getAutoUpdate();
+  $("#nd-autoupdate").checked = state.autoUpdate;
   state.agentEnabled = NS.getAgent(); state.agentAuto = NS.getAgentAuto();
   $("#nd-agent").checked = state.agentEnabled; $("#nd-agent-auto").checked = state.agentAuto;
   $("#nd-agent-btn").classList.toggle("nd-iconbtn--active", state.agentEnabled);

--- a/zotero-plugin/content/store.js
+++ b/zotero-plugin/content/store.js
@@ -83,6 +83,10 @@
   }
   function removeCustomPrompt(id) { setCustomPrompts(getCustomPrompts().filter((p) => p.id !== id)); }
 
+  // ---- self-update (default ON; the plugin keeps itself current via Zotero) ----
+  function getAutoUpdate() { return P("autoUpdate", "1") !== "0"; }
+  function setAutoUpdate(v) { S("autoUpdate", v ? "1" : "0"); }
+
   // ---- agent mode ----
   function getAgent() { return P("agent", "0") === "1"; }
   function setAgent(v) { S("agent", v ? "1" : "0"); }
@@ -343,6 +347,7 @@
     getMode, setMode, getLang, setLang, getModel, setModel, getMaxTokens, setMaxTokens, getReasoning, setReasoning, getHlColors, setHlColors, getContext, setContext,
     getKey, setKey, getLocalBase, setLocalBase, getPinned, setPinned, isPinned, togglePinned,
     getCustomPrompts, setCustomPrompts, addCustomPrompt, removeCustomPrompt,
+    getAutoUpdate, setAutoUpdate,
     getAgent, setAgent, getAgentAuto, setAgentAuto,
     getManual, setManual, loadConversations, saveConversations, compactAudit, compactConversations,
     EVIDENCE_CACHE_VERSION, gzipText, gunzipText, detachEmbeddings, attachEmbeddings,

--- a/zotero-plugin/content/updater.js
+++ b/zotero-plugin/content/updater.js
@@ -1,0 +1,71 @@
+/* Nodus for Zotero — self-update.
+ *
+ * Drives Zotero's own AddonManager so the plugin keeps itself current with each
+ * Nodus release. The update source is the manifest's
+ * applications.zotero.update_url (updates.json on the latest GitHub Release),
+ * which Zotero fetches, integrity-checks (sha256) and stages like any other
+ * add-on update. We only decide WHETHER background updates apply to this add-on
+ * (applyBackgroundUpdates) and, when enabled, ask Zotero to look right now
+ * instead of waiting for its daily poll. window.NodusUpdater.
+ *
+ * Loaded both in the sidebar (chrome://nodus/content/updater.js) and by
+ * bootstrap.js at startup, so it must depend on nothing but ChromeUtils.
+ */
+/* eslint-disable no-undef */
+(function () {
+  "use strict";
+  const PLUGIN_ID = "nodus-zotero@nodus.app";
+
+  function log(m) {
+    try {
+      const { Zotero } = ChromeUtils.importESModule("chrome://zotero/content/zotero.mjs");
+      Zotero.debug("[Nodus] updater: " + m);
+    } catch (e) {}
+  }
+  function addonManager() {
+    return ChromeUtils.importESModule("resource://gre/modules/AddonManager.sys.mjs").AddonManager;
+  }
+
+  // Point Zotero's background updater at this add-on, or turn it off. ENABLE
+  // forces auto-install for Nodus regardless of the global add-on preference;
+  // DISABLE leaves the add-on installed but frozen at its current version.
+  async function apply(enabled) {
+    try {
+      const AM = addonManager();
+      const addon = await AM.getAddonByID(PLUGIN_ID);
+      if (!addon) { log("add-on not found; skipped"); return false; }
+      addon.applyBackgroundUpdates = enabled ? AM.AUTOUPDATE_ENABLE : AM.AUTOUPDATE_DISABLE;
+      log("applyBackgroundUpdates = " + (enabled ? "ENABLE" : "DISABLE"));
+      return true;
+    } catch (e) { log("apply failed: " + (e && e.message ? e.message : e)); return false; }
+  }
+
+  // Ask Zotero to look for a newer version right now and stage it silently if
+  // one is published (applied on the next restart, like any add-on update).
+  // Safe to call repeatedly; a no-op when already current.
+  async function checkNow() {
+    try {
+      const AM = addonManager();
+      const addon = await AM.getAddonByID(PLUGIN_ID);
+      if (!addon) return;
+      addon.findUpdates(
+        {
+          onUpdateAvailable(addonArg, install) {
+            try { install.install(); log("staging update " + (install.version || "")); }
+            catch (e) { log("install failed: " + (e && e.message ? e.message : e)); }
+          },
+          onNoUpdateAvailable() { log("up to date"); },
+        },
+        AM.UPDATE_WHEN_PERIODIC_UPDATE,
+      );
+    } catch (e) { log("checkNow failed: " + (e && e.message ? e.message : e)); }
+  }
+
+  // Apply the preference and, when enabled, immediately look for an update.
+  async function configure(enabled) {
+    const ok = await apply(enabled);
+    if (ok && enabled) checkNow();
+  }
+
+  window.NodusUpdater = { apply, checkNow, configure };
+})();

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",
   "icons": {


### PR DESCRIPTION
Closes #224.

## What

The **Nodus for Zotero** add-on now keeps itself current with each release. On startup it registers with Zotero's own background updater (`applyBackgroundUpdates`) and immediately checks the manifest `update_url` (`updates.json` on the latest GitHub Release), which Zotero downloads, sha256-verifies and stages like any add-on update (applied on the next restart).

- **Enabled by default.**
- A **Settings → Updates** toggle lets the user turn it off; **disabling asks for confirmation first** and reverts the toggle if the user cancels.
- The update logic lives in `content/updater.js`, shared by `bootstrap.js` (startup) and the sidebar (toggle), and drives Zotero's `AddonManager` rather than reimplementing download/verify.

## Why this path

Zotero's native add-on updater is the standard, least-invasive mechanism: it works with the Nodus desktop app closed, respects integrity verification, and never closes Zotero behind the user's back. The plugin only decides *whether* background updates apply to it and triggers an immediate check when enabled.

## Changes

| File | Change |
| --- | --- |
| `zotero-plugin/content/updater.js` *(new)* | `NodusUpdater`: `apply` / `checkNow` / `configure` over `AddonManager`. |
| `zotero-plugin/bootstrap.js` | `startup()` applies the preference and checks for updates. |
| `zotero-plugin/content/store.js` | `getAutoUpdate` / `setAutoUpdate` (default ON). |
| `zotero-plugin/content/sidebar.html` + `sidebar.js` | Settings toggle, EN/ES i18n, guarded disable (confirm modal), init in `boot()`. |
| `zotero-plugin/manifest.json` | Plugin version **2.6.0 → 2.7.0** so current users are offered the self-updating build. |
| `scripts/test-zotero-plugin.mjs` | Updated expected version, new wiring test, `updater.js` added to the packaged-XPI assertion. |
| `CHANGELOG.md` | Entry under *Unreleased*. |

## Verification

- `node --test scripts/test-zotero-plugin.mjs` — **62/62 pass** (incl. EN/ES i18n parity and a new self-update wiring test).
- `npm run lint` — 0 errors (only pre-existing `catch`-variable warnings).
- `npm run zotero:xpi` — packages `content/updater.js` and generates `updates.json` with `version: 2.7.0` and a sha256 `update_hash`.

## Note on versioning

The plugin version bump is required for the update mechanism to actually offer the new build to users currently on 2.6.0. Going forward, bump `zotero-plugin/manifest.json` only when the plugin itself changes, to avoid empty "update available" prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzqNRBDQi9V51E7WPz6w5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzqNRBDQi9V51E7WPz6w5W)_