### PR TITLE
Refine Deep Research PDF report design

### DIFF
--- a/electron/export/professionalReportPdf.ts
+++ b/electron/export/professionalReportPdf.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, StandardFonts, rgb, type PDFPage } from 'pdf-lib';
+import { PDFDocument, StandardFonts, LineCapStyle, rgb, type PDFPage } from 'pdf-lib';
 import { escapeHtml, markdownToHtml } from '@shared/toolkitMarkdown';
 import { htmlToPdfBytes } from './htmlToPdf';
 
@@ -301,6 +301,15 @@ export function renderProfessionalReportHtml(input: ProfessionalReportInput): st
     .section-heading h2 { margin: 0; color: var(--accent-dark); font: 700 20pt/1.15 Arial, sans-serif; letter-spacing: -.02em; }
     .section-lead { max-width: 145mm; margin-top: 2mm; color: var(--muted); font-size: 9.5pt; line-height: 1.48; }
     .section-body { margin-left: 17mm; }
+    .report-section.exec-summary .section-heading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 2.5mm;
+    }
+    .report-section.exec-summary .section-body { margin-left: 0; }
+    .report-section.exec-summary .abstract-box { max-width: 150mm; margin: 0 auto; }
     .prose { color: #262d3d; }
     .prose p { text-align: justify; text-indent: 1.35em; hyphens: auto; orphans: 3; widows: 3; }
     .prose h1, .prose h2, .prose h3, .prose h4 {
@@ -370,6 +379,31 @@ export function renderProfessionalReportHtml(input: ProfessionalReportInput): st
     .evidence-card dl { display: grid; grid-template-columns: 21mm 1fr; gap: 1mm 3mm; margin: 0; font-size: 8.3pt; }
     .evidence-card dt { color: var(--muted); font: 700 6.8pt/1.35 Arial, sans-serif; letter-spacing: .06em; text-transform: uppercase; }
     .evidence-card dd { margin: 0; }
+    .evidence-table { width: 100%; margin: 0; border-collapse: collapse; table-layout: fixed; font: 8pt/1.42 Arial, sans-serif; }
+    .evidence-table th {
+      padding: 2.2mm 2.4mm;
+      border-bottom: .35mm solid color-mix(in srgb, var(--accent) 30%, #d9deea);
+      background: var(--accent-soft);
+      color: var(--accent-dark);
+      text-align: left;
+      font: 700 6.6pt/1.25 Arial, sans-serif;
+      letter-spacing: .07em;
+      text-transform: uppercase;
+    }
+    .evidence-table td { padding: 2.3mm 2.4mm; border-bottom: .25mm solid var(--line); vertical-align: top; overflow-wrap: anywhere; }
+    .evidence-table tr { break-inside: avoid; }
+    .evidence-table .claim { color: var(--ink); font-weight: 700; }
+    .evidence-table .role-tag {
+      display: inline-block;
+      padding: .5mm 1.7mm;
+      border-radius: 99px;
+      background: var(--accent-soft);
+      color: var(--accent-dark);
+      font: 700 5.7pt/1.3 Arial, sans-serif;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+      overflow-wrap: break-word;
+    }
     .term-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 3mm; }
     .term-card { padding: 3.5mm; border: .25mm solid var(--line); border-radius: 2mm; break-inside: avoid; }
     .term-card h3 { margin: 0 0 1mm; color: var(--accent-dark); font: 700 9.5pt/1.3 Arial, sans-serif; }
@@ -444,17 +478,22 @@ function fitText(value: string, font: Awaited<ReturnType<PDFDocument['embedFont'
   return `${clipped.trim()}...`;
 }
 
+// The Nodus brand mark: the same stylized "N" as the app icon — bold strokes
+// with round caps and prominent nodes at each vertex, drawn taller than wide
+// (28×32 in the source SVG) so it reads as the logo rather than a bare letter.
 function drawNodusMark(page: PDFPage, centerX: number, y: number, accent: ReturnType<typeof rgb>): void {
-  const left = centerX - 6.7;
-  const right = centerX + 6.7;
-  const bottom = y - 4.8;
-  const top = y + 4.8;
-  const line = { thickness: 1.55, color: accent, opacity: 0.95 };
-  page.drawLine({ start: { x: left, y: bottom }, end: { x: left, y: top }, ...line });
-  page.drawLine({ start: { x: left, y: top }, end: { x: right, y: bottom }, ...line });
-  page.drawLine({ start: { x: right, y: bottom }, end: { x: right, y: top }, ...line });
+  const halfW = 4.9;
+  const halfH = 5.8;
+  const left = centerX - halfW;
+  const right = centerX + halfW;
+  const bottom = y - halfH;
+  const top = y + halfH;
+  const stroke = { thickness: 2.4, color: accent, lineCap: LineCapStyle.Round };
+  page.drawLine({ start: { x: left, y: bottom }, end: { x: left, y: top }, ...stroke });
+  page.drawLine({ start: { x: left, y: top }, end: { x: right, y: bottom }, ...stroke });
+  page.drawLine({ start: { x: right, y: bottom }, end: { x: right, y: top }, ...stroke });
   for (const [x, cy] of [[left, bottom], [left, top], [right, bottom], [right, top]] as const) {
-    page.drawCircle({ x, y: cy, size: 1.7, color: accent });
+    page.drawCircle({ x, y: cy, size: 2.5, color: accent });
   }
 }
 
@@ -479,6 +518,8 @@ async function stampProfessionalPdf(bytes: Buffer, input: ProfessionalReportInpu
     const margin = 56.7;
     const centerX = width / 2;
     const headerY = height - 25;
+    // The cover is a clean title page: no header/footer rules framing the image.
+    if (index === 0) return;
     page.drawLine({ start: { x: margin, y: height - 39 }, end: { x: centerX - 16, y: height - 39 }, thickness: 0.45, color: line });
     page.drawLine({ start: { x: centerX + 16, y: height - 39 }, end: { x: width - margin, y: height - 39 }, thickness: 0.45, color: line });
     drawNodusMark(page, centerX, headerY, accent);

--- a/electron/export/writingWorkshopExport.ts
+++ b/electron/export/writingWorkshopExport.ts
@@ -41,6 +41,8 @@ interface DeepReportLabels {
   imageAi: string;
   imageCustom: string;
   claims: string;
+  role: string;
+  claim: string;
   source: string;
   evidence: string;
   notes: string;
@@ -68,6 +70,8 @@ const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
     imageAi: 'Imagen de portada generada por IA en Nodus.',
     imageCustom: 'Imagen de portada aportada por el usuario.',
     claims: 'Afirmaciones clave',
+    role: 'Rol',
+    claim: 'Afirmación',
     source: 'Fuente',
     evidence: 'Evidencia',
     notes: 'Notas',
@@ -93,6 +97,8 @@ const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
     imageAi: 'Cover image generated with AI in Nodus.',
     imageCustom: 'Cover image provided by the user.',
     claims: 'Key claims',
+    role: 'Role',
+    claim: 'Claim',
     source: 'Source',
     evidence: 'Evidence',
     notes: 'Notes',
@@ -103,7 +109,7 @@ const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
     report: 'Rapport', reportEyebrow: 'Analyse', recommendations: 'Prochaines étapes', recommendationsEyebrow: 'Recommandations',
     traceability: 'Matrice de traçabilité', traceabilityEyebrow: 'Preuves et liens', sections: 'sections', sources: 'sources', words: 'mots',
     imageAi: 'Image de couverture générée par IA dans Nodus.', imageCustom: 'Image de couverture fournie par l’utilisateur.',
-    claims: 'Affirmations clés', source: 'Source', evidence: 'Preuve', notes: 'Notes',
+    claims: 'Affirmations clés', role: 'Rôle', claim: 'Affirmation', source: 'Source', evidence: 'Preuve', notes: 'Notes',
   },
   tr: {
     kind: 'Profesyonel rapor · Deep Research', contents: 'İçindekiler', generated: 'Oluşturulma', objective: 'Amaç',
@@ -111,7 +117,7 @@ const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
     report: 'Rapor', reportEyebrow: 'Analiz', recommendations: 'Sonraki adımlar', recommendationsEyebrow: 'Öneriler',
     traceability: 'İzlenebilirlik matrisi', traceabilityEyebrow: 'Kanıt ve bağlantılar', sections: 'bölüm', sources: 'kaynak', words: 'kelime',
     imageAi: 'Kapak görseli Nodus’ta yapay zekâ ile oluşturuldu.', imageCustom: 'Kapak görseli kullanıcı tarafından sağlandı.',
-    claims: 'Temel iddialar', source: 'Kaynak', evidence: 'Kanıt', notes: 'Notlar',
+    claims: 'Temel iddialar', role: 'Rol', claim: 'İddia', source: 'Kaynak', evidence: 'Kanıt', notes: 'Notlar',
   },
   de: {
     kind: 'Professioneller Bericht · Deep Research', contents: 'Inhalt', generated: 'Erstellt', objective: 'Ziel',
@@ -119,7 +125,7 @@ const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
     report: 'Bericht', reportEyebrow: 'Analyse', recommendations: 'Nächste Schritte', recommendationsEyebrow: 'Empfehlungen',
     traceability: 'Nachweismatrix', traceabilityEyebrow: 'Evidenz und Links', sections: 'Abschnitte', sources: 'Quellen', words: 'Wörter',
     imageAi: 'Titelbild mit KI in Nodus generiert.', imageCustom: 'Titelbild vom Benutzer bereitgestellt.',
-    claims: 'Kernaussagen', source: 'Quelle', evidence: 'Evidenz', notes: 'Notizen',
+    claims: 'Kernaussagen', role: 'Rolle', claim: 'Aussage', source: 'Quelle', evidence: 'Evidenz', notes: 'Notizen',
   },
   pt: {
     kind: 'Relatório profissional · Deep Research', contents: 'Conteúdo', generated: 'Gerado', objective: 'Objetivo',
@@ -127,7 +133,7 @@ const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
     report: 'Relatório', reportEyebrow: 'Análise', recommendations: 'Próximos passos', recommendationsEyebrow: 'Recomendações',
     traceability: 'Matriz de rastreabilidade', traceabilityEyebrow: 'Evidência e ligações', sections: 'secções', sources: 'fontes', words: 'palavras',
     imageAi: 'Imagem de capa gerada por IA no Nodus.', imageCustom: 'Imagem de capa fornecida pelo utilizador.',
-    claims: 'Afirmações-chave', source: 'Fonte', evidence: 'Evidência', notes: 'Notas',
+    claims: 'Afirmações-chave', role: 'Papel', claim: 'Afirmação', source: 'Fonte', evidence: 'Evidência', notes: 'Notas',
   },
   'pt-BR': {
     kind: 'Relatório profissional · Deep Research', contents: 'Conteúdo', generated: 'Gerado', objective: 'Objetivo',
@@ -135,7 +141,7 @@ const DEEP_LABELS: Record<PromptLanguage, DeepReportLabels> = {
     report: 'Relatório', reportEyebrow: 'Análise', recommendations: 'Próximos passos', recommendationsEyebrow: 'Recomendações',
     traceability: 'Matriz de rastreabilidade', traceabilityEyebrow: 'Evidências e links', sections: 'seções', sources: 'fontes', words: 'palavras',
     imageAi: 'Imagem de capa gerada por IA no Nodus.', imageCustom: 'Imagem de capa fornecida pelo usuário.',
-    claims: 'Afirmações-chave', source: 'Fonte', evidence: 'Evidência', notes: 'Notas',
+    claims: 'Afirmações-chave', role: 'Papel', claim: 'Afirmação', source: 'Fonte', evidence: 'Evidência', notes: 'Notas',
   },
 };
 
@@ -213,34 +219,29 @@ function stripLeadingAbstract(markdown: string, abstract: string): string {
   return lines.slice(next).join('\n').trim();
 }
 
-function outlineHtml(draft: WritingWorkshopDraft, labels: DeepReportLabels): string {
-  return `<ol class="outline-list">${draft.outline.map((section) => {
-    const claims = section.keyClaims.length
-      ? `<div class="muted" style="margin-top:2mm;font:700 6.8pt Arial,sans-serif;text-transform:uppercase;letter-spacing:.07em">${labels.claims}</div><ul class="claim-list">${section.keyClaims.map((claim) => `<li>${escapeCellHtml(claim)}</li>`).join('')}</ul>`
-      : '';
-    const sources = section.sources.length
-      ? `<div class="source-pills">${section.sources.map((source) => `<span>${escapeCellHtml(source)}</span>`).join('')}</div>`
-      : '';
-    return `<li><h3>${escapeCellHtml(section.title)}</h3>${section.purpose ? `<p>${escapeCellHtml(section.purpose)}</p>` : ''}${claims}${sources}</li>`;
-  }).join('')}</ol>`;
-}
-
 function matrixHtml(rows: WritingWorkshopMatrixRow[], labels: DeepReportLabels): string {
   if (!rows.length) return '';
-  return `<div class="evidence-grid">${rows.map((row) => {
+  const head = `<colgroup><col style="width:20mm" /><col /><col style="width:26mm" /><col /><col style="width:26mm" /></colgroup>
+    <thead><tr>
+      <th>${escapeCellHtml(labels.role)}</th>
+      <th>${escapeCellHtml(labels.claim)}</th>
+      <th>${escapeCellHtml(labels.source)}</th>
+      <th>${escapeCellHtml(labels.evidence)}</th>
+      <th>${escapeCellHtml(labels.notes)}</th>
+    </tr></thead>`;
+  const body = rows.map((row) => {
     const source = row.citation
       ? reportLink(row.citation, row.sourceLabel || labels.source)
       : escapeCellHtml(row.sourceLabel || labels.source);
-    return `<article class="evidence-card">
-      <span>${escapeCellHtml(row.role)}</span>
-      <h3>${escapeCellHtml(row.claim)}</h3>
-      <dl>
-        <dt>${escapeCellHtml(labels.source)}</dt><dd>${source}</dd>
-        <dt>${escapeCellHtml(labels.evidence)}</dt><dd>${escapeCellHtml(row.evidence)}</dd>
-        ${row.notes ? `<dt>${escapeCellHtml(labels.notes)}</dt><dd>${escapeCellHtml(row.notes)}</dd>` : ''}
-      </dl>
-    </article>`;
-  }).join('')}</div>`;
+    return `<tr>
+      <td><span class="role-tag">${escapeCellHtml(row.role)}</span></td>
+      <td class="claim">${escapeCellHtml(row.claim)}</td>
+      <td>${source}</td>
+      <td>${escapeCellHtml(row.evidence)}</td>
+      <td>${row.notes ? escapeCellHtml(row.notes) : '—'}</td>
+    </tr>`;
+  }).join('');
+  return `<table class="evidence-table">${head}<tbody>${body}</tbody></table>`;
 }
 
 function escapeCellHtml(value: string): string {
@@ -270,17 +271,9 @@ export function buildDeepResearchPdfInput(
       title: labels.summary,
       eyebrow: labels.summaryEyebrow,
       html: `<div class="abstract-box prose">${abstract.html}</div>`,
+      className: 'exec-summary',
     },
   ];
-  if (draft.outline.length) {
-    sections.push({
-      id: 'research-outline',
-      number: String(sections.length + 1).padStart(2, '0'),
-      title: labels.outline,
-      eyebrow: labels.outlineEyebrow,
-      html: outlineHtml(draft, labels),
-    });
-  }
   sections.push({
     id: 'research-report',
     number: String(sections.length + 1).padStart(2, '0'),


### PR DESCRIPTION
Closes #226.

Reworks the Deep Research PDF export design.

### Changes
1. **Logo** — Header now renders the stylized Nodus brand mark (bold strokes, rounded caps, prominent vertex nodes) matching the app icon, replacing the thin plain "N". Adapts to each report's accent colour (indigo for Deep Research, teal for Immersion).
2. **Cover** — Now a clean title page: the grey header/footer rules no longer frame the cover image.
3. **Executive summary** — The block (badge, eyebrow, title and box) is centered horizontally.
4. **Research outline** — Section removed from the report.
5. **Traceability matrix** — Redesigned from stacked full-height cards into a compact table (Role · Claim · Source · Evidence · Notes), with new localized `role`/`claim` headers across all 7 languages.
6. **Section numbering** — Follows automatically: `01` Executive summary → `02` Report → `03` Next steps → `04` Traceability matrix (verified in the TOC and section badges).

### Notes
- All changes are confined to the shared PDF exporter. The Immersion report (which shares this code) was verified to render intact — `.evidence-card` / `.evidence-grid` styles it relies on are preserved.

### Verification
- Rendered the real PDF via the Electron `printToPDF` engine (`scripts/verify-professional-report-pdf.mjs`) and inspected cover, summary, TOC and matrix pages for both Deep Research and Immersion.
- `npm run lint` — pass (0 errors).
- `npm run build` (includes typecheck) — pass.