### PR TITLE
Release 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.6.3 — 2026-07-24
 
 ### Added
 
@@ -10,6 +10,38 @@
   sha256-verified by Zotero, applied on the next restart). This is on by default
   and can be turned off under Settings → Updates; turning it off asks for
   confirmation first. Plugin bumped to 2.7.0.
+
+### Changed
+
+- **Nodus Server publishes every connected vault.** A server pairing is stored
+  per vault, but the desktop only published the active one, so a shared vault
+  silently went stale after switching away. Every connected vault is now tracked
+  and published in the background regardless of which is open, Settings lists all
+  connections with their status, and each can be synced or disconnected
+  individually.
+- **Refined Deep Research PDF report design.** The exported report now uses the
+  stylized Nodus brand mark in the header, a clean title-page cover, a centered
+  executive summary, automatic section numbering (01–04) and a compact
+  table-based traceability matrix; the standalone research outline section was
+  removed.
+
+### Fixed
+
+- **Page-aware answers for long Zotero PDFs.** A document map now injects
+  authoritative structural facts (total pages, current reader page, first/last
+  labels and honest truncation coverage) ahead of the evidence, so page and
+  length questions are answered from the map instead of guessed. Positional
+  retrieval fetches "current/last/first page" and "page N" deterministically,
+  embedding is bounded and non-blocking (only BM25 candidates plus the current
+  page embed up front, the rest continues in the background), and full-text mode
+  marks truncation honestly while always including the requested pages.
+- **Audio narration lifecycle and local Whisper cancellation.** Audio synthesis
+  now lives in the global background-jobs store, so generation survives leaving
+  the view and the panel restores its progress on return. A Deep Research report
+  no longer narrates its abstract twice, Kokoro input is chunked on sentence
+  boundaries so long segments are no longer truncated mid-word, and the local
+  Whisper worker is no longer terminated on view unmount so an in-flight
+  transcription finishes and persists in the background.
 
 ## 2.6.2 — 2026-07-23
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "2.6.2"
-date-released: "2026-07-23"
+version: "2.6.3"
+date-released: "2026-07-24"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,9 +25,9 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '2.6.2');
-  assert.equal(currentRelease?.date, '2026-07-23');
-  assert.equal(currentRelease?.highlights.length, 2);
+  assert.equal(currentRelease?.version, '2.6.3');
+  assert.equal(currentRelease?.date, '2026-07-24');
+  assert.equal(currentRelease?.highlights.length, 5);
   assert.ok(currentRelease?.highlights.every((highlight) => highlight.it.length > 0));
   const whatsNew = fs.readFileSync(path.join(root, 'src/components/WhatsNewModal.tsx'), 'utf8');
   assert.match(whatsNew, /function ZoteroReleaseIcon/);

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -20,8 +20,17 @@ export const RELEASE_2_6_2_IT: string[] = [
   "La ricerca semantica è più efficiente: le chiamate extra al modello vengono evitate quando ci sono pochi risultati, la riparazione delle citazioni è configurabile e i round di ricerca agentica sono regolabili (1 per impostazione predefinita). L'OCR viene elaborato in parallelo e gli embedding locali usano WebGPU quando disponibile, con fallback a Wasm.",
 ];
 
+export const RELEASE_2_6_3_IT: string[] = [
+  "Il componente aggiuntivo Nodus per Zotero si mantiene aggiornato da solo: si registra nel gestore di aggiornamenti di Zotero e installa ogni nuova versione automaticamente dall'ultima pubblicazione su GitHub, verificata da Zotero e applicata al riavvio. È attivo per impostazione predefinita e può essere disattivato nelle Impostazioni, che chiedono prima conferma.",
+  "L'assistente di Nodus per Zotero risponde con precisione sui PDF lunghi: una mappa del documento gli fornisce dati reali sulle pagine —totale, pagina corrente, prima e ultima— così da non inventarli, e le domande su «pagina corrente», «ultima pagina» o «pagina N» recuperano quelle pagine esatte. Inoltre la prima risposta non attende più l'indicizzazione dell'intero documento: si calcolano solo gli embedding indispensabili e il resto prosegue in background.",
+  "Nodus Server mantiene pubblicati in background tutti i depositi collegati, non solo quello aperto: cambiando deposito gli altri continuano a sincronizzarsi e a essere serviti, senza diventare obsoleti. Le Impostazioni mostrano ora tutte le tue connessioni con il relativo stato e puoi sincronizzare o disconnettere ciascuna separatamente.",
+  "La generazione audio è più affidabile: la narrazione prosegue anche se esci dalla vista e recupera il suo avanzamento al ritorno, il riassunto di un report di Deep Research non viene più letto due volte e i segmenti lunghi non si interrompono più a metà parola. Anche la trascrizione con Whisper locale ora termina in background invece di essere annullata quando cambi schermata.",
+  "I report PDF di Deep Research adottano un design più curato: copertina pulita con il marchio Nodus, riassunto esecutivo centrato, numerazione automatica delle sezioni e una matrice di tracciabilità compatta in forma di tabella.",
+];
+
 /** Italian history, indexed by release and highlight order. */
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "2.6.3": RELEASE_2_6_3_IT,
   "2.6.2": RELEASE_2_6_2_IT,
   "2.6.1": RELEASE_2_6_IT,
   "2.6.0": RELEASE_2_6_IT,

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -173,7 +173,60 @@ const RELEASE_2_6_2_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+const RELEASE_2_6_3_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'plugin',
+    es: 'El complemento Nodus para Zotero se mantiene actualizado por sí solo: se registra en el actualizador de complementos del propio Zotero e instala cada nueva versión automáticamente desde la última publicación de GitHub, verificada por Zotero y aplicada al reiniciar. Viene activado y puedes desactivarlo en Ajustes, que primero te pide confirmación.',
+    en: 'The Nodus for Zotero add-on now keeps itself up to date: it registers with Zotero’s own add-on updater and installs each new release automatically from the latest GitHub Release, verified by Zotero and applied on restart. It is on by default and can be turned off in Settings, which asks for confirmation first.',
+    fr: 'L’extension Nodus pour Zotero se maintient à jour toute seule : elle s’enregistre auprès du gestionnaire de mises à jour de Zotero et installe chaque nouvelle version automatiquement depuis la dernière publication GitHub, vérifiée par Zotero et appliquée au redémarrage. Activée par défaut, elle peut être désactivée dans les Paramètres, qui demandent d’abord confirmation.',
+    de: 'Das Add-on Nodus für Zotero hält sich jetzt selbst aktuell: Es registriert sich beim Add-on-Updater von Zotero und installiert jede neue Version automatisch aus dem neuesten GitHub-Release, von Zotero geprüft und beim Neustart angewendet. Standardmäßig aktiviert, lässt es sich in den Einstellungen abschalten, die zuvor um Bestätigung bitten.',
+    pt: 'O complemento Nodus para o Zotero mantém-se atualizado sozinho: regista-se no atualizador de complementos do próprio Zotero e instala cada nova versão automaticamente a partir da última publicação do GitHub, verificada pelo Zotero e aplicada ao reiniciar. Vem ativado e pode ser desativado nas Definições, que pedem confirmação primeiro.',
+    'pt-BR': 'O complemento Nodus para o Zotero se mantém atualizado sozinho: ele se registra no atualizador de complementos do próprio Zotero e instala cada nova versão automaticamente a partir da última publicação do GitHub, verificada pelo Zotero e aplicada ao reiniciar. Vem ativado e pode ser desativado nas Configurações, que pedem confirmação primeiro.',
+  },
+  {
+    scope: 'plugin',
+    es: 'El asistente de Nodus para Zotero responde con precisión sobre PDF largos: un mapa del documento le aporta datos reales de páginas —total, página actual, primera y última— para no inventarlos, y las preguntas por «página actual», «última página» o «página N» recuperan esas páginas exactas. Además, la primera respuesta ya no espera a indexar todo el documento: se calculan solo los embeddings imprescindibles y el resto continúa en segundo plano.',
+    en: 'The Nodus for Zotero assistant answers accurately about long PDFs: a document map gives it real page facts —total, current, first and last— so it no longer guesses them, and questions about the “current page”, “last page” or “page N” fetch those exact pages. The first answer also no longer waits for the whole document to be indexed: only the essential embeddings are computed and the rest continues in the background.',
+    fr: 'L’assistant Nodus pour Zotero répond avec précision sur les PDF longs : une carte du document lui fournit des données de pages réelles —total, page actuelle, première et dernière— pour ne pas les inventer, et les questions sur la « page actuelle », la « dernière page » ou la « page N » récupèrent ces pages exactes. La première réponse n’attend plus l’indexation de tout le document : seuls les embeddings indispensables sont calculés et le reste se poursuit en arrière-plan.',
+    de: 'Der Nodus-Assistent für Zotero beantwortet Fragen zu langen PDFs präzise: Eine Dokumentkarte liefert ihm echte Seitendaten – Gesamtzahl, aktuelle, erste und letzte Seite –, sodass er sie nicht mehr errät, und Fragen nach „aktueller Seite“, „letzter Seite“ oder „Seite N“ rufen genau diese Seiten ab. Die erste Antwort wartet außerdem nicht mehr auf die Indexierung des gesamten Dokuments: Nur die nötigen Embeddings werden berechnet, der Rest läuft im Hintergrund weiter.',
+    pt: 'O assistente do Nodus para o Zotero responde com precisão sobre PDF longos: um mapa do documento dá-lhe dados reais de páginas —total, página atual, primeira e última— para não os inventar, e as perguntas por «página atual», «última página» ou «página N» recuperam essas páginas exatas. A primeira resposta já não espera pela indexação de todo o documento: calculam-se apenas os embeddings indispensáveis e o resto continua em segundo plano.',
+    'pt-BR': 'O assistente do Nodus para o Zotero responde com precisão sobre PDFs longos: um mapa do documento dá a ele dados reais de páginas —total, página atual, primeira e última— para não inventá-los, e as perguntas por “página atual”, “última página” ou “página N” recuperam essas páginas exatas. A primeira resposta também não espera mais pela indexação de todo o documento: apenas os embeddings essenciais são calculados e o restante continua em segundo plano.',
+  },
+  {
+    scope: 'mcp',
+    es: 'Nodus Server mantiene publicadas en segundo plano todas las bóvedas conectadas, no solo la que tengas abierta: al cambiar de bóveda las demás siguen sincronizándose y sirviéndose, sin quedarse obsoletas. Ajustes muestra ahora todas tus conexiones con su estado y puedes sincronizar o desconectar cada una por separado.',
+    en: 'Nodus Server now keeps every connected vault published in the background, not just the one you have open: switching vaults no longer leaves the others stale, since they keep syncing and serving. Settings now lists all your connections with their status, and you can sync or disconnect each one individually.',
+    fr: 'Nodus Server garde désormais publiés en arrière-plan tous les espaces connectés, pas seulement celui qui est ouvert : changer d’espace ne laisse plus les autres obsolètes, car ils continuent à se synchroniser et à être servis. Les Paramètres affichent maintenant toutes vos connexions avec leur statut, et vous pouvez synchroniser ou déconnecter chacune séparément.',
+    de: 'Nodus Server hält jetzt alle verbundenen Arbeitsbereiche im Hintergrund veröffentlicht, nicht nur den geöffneten: Ein Wechsel des Arbeitsbereichs lässt die anderen nicht mehr veralten, da sie weiter synchronisiert und bereitgestellt werden. Die Einstellungen listen nun alle Verbindungen mit ihrem Status auf, und du kannst jede einzeln synchronisieren oder trennen.',
+    pt: 'O Nodus Server mantém publicados em segundo plano todos os espaços ligados, não apenas o que tem aberto: ao mudar de espaço os restantes continuam a sincronizar e a ser servidos, sem ficarem desatualizados. As Definições mostram agora todas as suas ligações com o respetivo estado e pode sincronizar ou desligar cada uma separadamente.',
+    'pt-BR': 'O Nodus Server agora mantém publicados em segundo plano todos os espaços conectados, não só o que você tem aberto: ao trocar de espaço os demais continuam sincronizando e sendo servidos, sem ficarem desatualizados. As Configurações agora mostram todas as suas conexões com o respectivo status, e você pode sincronizar ou desconectar cada uma separadamente.',
+  },
+  {
+    scope: 'general',
+    es: 'La generación de audio es más fiable: la narración continúa aunque salgas de la vista y recupera su progreso al volver, el resumen de un informe de Deep Research ya no se lee dos veces y los fragmentos largos dejan de cortarse a mitad de palabra. La transcripción con Whisper local también termina en segundo plano en lugar de cancelarse al cambiar de pantalla.',
+    en: 'Audio generation is more reliable: narration keeps going even if you leave the view and restores its progress when you return, a Deep Research report summary is no longer read twice, and long segments no longer cut off mid-word. Local Whisper transcription now also finishes in the background instead of being cancelled when you switch screens.',
+    fr: 'La génération audio est plus fiable : la narration se poursuit même si vous quittez la vue et retrouve sa progression au retour, le résumé d’un rapport Deep Research n’est plus lu deux fois et les longs segments ne se coupent plus au milieu d’un mot. La transcription avec Whisper local se termine désormais en arrière-plan au lieu d’être annulée lorsque vous changez d’écran.',
+    de: 'Die Audioerzeugung ist zuverlässiger: Die Erzählung läuft weiter, auch wenn du die Ansicht verlässt, und stellt beim Zurückkehren ihren Fortschritt wieder her; die Zusammenfassung eines Deep-Research-Berichts wird nicht mehr doppelt vorgelesen und lange Abschnitte brechen nicht mehr mitten im Wort ab. Auch die lokale Whisper-Transkription wird jetzt im Hintergrund fertiggestellt, statt beim Bildschirmwechsel abgebrochen zu werden.',
+    pt: 'A geração de áudio é mais fiável: a narração continua mesmo que saia da vista e recupera o seu progresso ao voltar, o resumo de um relatório de Deep Research já não é lido duas vezes e os fragmentos longos deixam de ser cortados a meio de uma palavra. A transcrição com Whisper local também termina em segundo plano em vez de ser cancelada ao mudar de ecrã.',
+    'pt-BR': 'A geração de áudio é mais confiável: a narração continua mesmo que você saia da tela e recupera seu progresso ao voltar, o resumo de um relatório de Deep Research não é mais lido duas vezes e os trechos longos deixam de ser cortados no meio de uma palavra. A transcrição com Whisper local também termina em segundo plano em vez de ser cancelada ao trocar de tela.',
+  },
+  {
+    scope: 'general',
+    es: 'Los informes PDF de Deep Research estrenan un diseño más cuidado: portada limpia con la marca de Nodus, resumen ejecutivo centrado, numeración automática de secciones y una matriz de trazabilidad compacta en forma de tabla.',
+    en: 'Deep Research PDF reports get a more polished design: a clean cover page with the Nodus brand mark, a centred executive summary, automatic section numbering and a compact, table-based traceability matrix.',
+    fr: 'Les rapports PDF de Deep Research adoptent un design plus soigné : page de couverture épurée avec la marque Nodus, résumé exécutif centré, numérotation automatique des sections et une matrice de traçabilité compacte sous forme de tableau.',
+    de: 'Die PDF-Berichte von Deep Research erhalten ein feineres Design: eine aufgeräumte Titelseite mit der Nodus-Bildmarke, eine zentrierte Zusammenfassung, automatische Abschnittsnummerierung und eine kompakte, tabellenbasierte Nachverfolgbarkeitsmatrix.',
+    pt: 'Os relatórios PDF do Deep Research estreiam um design mais cuidado: capa limpa com a marca do Nodus, resumo executivo centrado, numeração automática de secções e uma matriz de rastreabilidade compacta em forma de tabela.',
+    'pt-BR': 'Os relatórios PDF do Deep Research estreiam um design mais caprichado: capa limpa com a marca do Nodus, resumo executivo centralizado, numeração automática de seções e uma matriz de rastreabilidade compacta em forma de tabela.',
+  },
+];
+
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '2.6.3',
+    date: '2026-07-24',
+    highlights: RELEASE_2_6_3_HIGHLIGHTS,
+  },
   {
     version: '2.6.2',
     date: '2026-07-23',


### PR DESCRIPTION
Prepares the **2.6.3** release. Merging this into `main` lets the `v2.6.3` tag be pushed to trigger the release workflow (installers + Zotero `.xpi`).

## What's in this release

Version bump to `2.6.3` plus What's New / CHANGELOG entries for every user-facing PR merged after 2.6.2:

- **Self-updating Zotero plugin** (#225) — the add-on registers with Zotero's own updater and installs each new release automatically; on by default, toggleable in Settings.
- **Page-aware answers for long PDFs** (#223) — a document map supplies real page facts (total/current/first/last) so the assistant stops guessing; positional retrieval fetches exact pages; embedding is bounded and non-blocking so the first answer no longer waits on the whole document.
- **Nodus Server publishes every connected vault** (#218) — all connected vaults keep syncing and serving in the background, not just the active one; Settings lists every connection with status and per-vault sync/disconnect.
- **Audio narration & local Whisper lifecycle fixes** (#221) — narration survives leaving the view and restores progress, no duplicated Deep Research intro, long segments no longer truncated mid-word, and local Whisper transcription finishes in the background.
- **Refined Deep Research PDF report design** (#227) — clean brand-mark cover, centered executive summary, automatic section numbering and a compact table-based traceability matrix.

## Changes

| File | Change |
|------|--------|
| `package.json` | `2.6.2` → `2.6.3` |
| `CITATION.cff` | version `2.6.3`, date `2026-07-24` |
| `shared/releaseNotes.ts`, `shared/releaseNotes.it.ts` | 5 new highlights across all 7 UI languages |
| `scripts/test-release-notes.mjs` | current-release asserts updated to 2.6.3 / 5 highlights |
| `CHANGELOG.md` | new `2.6.3` section |

## Verification

- `npm run citation:check` ✅ synchronized for 2.6.3
- `node scripts/test-release-notes.mjs` ✅ passed
- `node scripts/test-whats-new-support.mjs` ✅ passed
- `npm run typecheck` ✅ passed

## Next step

After merge, push tag `v2.6.3` on `main` to trigger the Release workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMtB2CjLEmzkERrCVdeWJJ)_