### PR TITLE
Style header sync button like the rest of the rail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,14 +121,14 @@ function applyThemeClasses(theme: import('@shared/types').ThemeMode): boolean {
 }
 
 /** Header action rendered as an icon that reveals its label on hover/focus, so the
- *  top bar's action rail stays a clean row of icons. Pass `showLabel` to keep the
- *  text pinned open (e.g. the primary action, or an alert that must be noticed). */
+ *  top bar's action rail stays a clean row of icons. Every action shares the same
+ *  ghost styling so none stands out; pass `showLabel` to keep the text pinned open
+ *  (e.g. an action in progress, or an alert that must be noticed). */
 function HeaderAction({
   icon,
   label,
   onClick,
   title,
-  primary = false,
   tone = '',
   spinning = false,
   showLabel = false,
@@ -141,7 +141,6 @@ function HeaderAction({
   label: string;
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   title?: string;
-  primary?: boolean;
   tone?: string;
   spinning?: boolean;
   showLabel?: boolean;
@@ -158,7 +157,7 @@ function HeaderAction({
       disabled={disabled}
       title={title ?? label}
       aria-label={label}
-      className={`header-action group btn ${primary ? 'btn-primary' : 'btn-ghost'} h-9 min-h-9 justify-center px-2.5 py-0 leading-none ${tone}`}
+      className={`header-action group btn btn-ghost h-9 min-h-9 justify-center px-2.5 py-0 leading-none ${tone}`}
     >
       <Icon name={icon} className={`shrink-0 ${spinning ? 'animate-spin' : ''}`} />
       <span
@@ -1023,7 +1022,6 @@ export function App() {
               dataTour="sync"
               icon="refresh"
               label={syncing ? t('Actualizando…') : t('Actualizar')}
-              primary
               spinning={syncing}
               showLabel={syncing}
               disabled={syncing}


### PR DESCRIPTION
Closes #229

## What

The **Actualizar** (Zotero sync) action was the only button in the header rail rendered with `btn-primary`, which keeps it filled with the vault accent colour (blue/indigo in academic vaults) at all times. Every other icon in the rail uses the neutral `btn-ghost` style, so the sync icon stood out permanently.

## Changes

- `HeaderAction` now always renders as `btn-ghost`; the `primary` prop, which had a single call site, is removed.
- The sync button keeps its in-progress behaviour: spinner while syncing and the label pinned open.

## Scope

The button only renders in vaults that sync with Zotero (academic and primary sources) — it is hidden in genealogy, databases, study and teaching — so this covers every vault where the highlight was visible. The amber "configure an AI model" warning keeps its own tone on purpose.

## Verification

- `npx tsc --noEmit` clean.
- `npm run lint` with 0 errors (5 pre-existing warnings, none in `App.tsx`).

Not verified in a browser preview: the header belongs to the Electron renderer and needs the `window.nodus` preload, so it cannot be exercised from a standalone dev server.