### PR TITLE
Keep Nodi responsive and stop its lists crushing their rows

### DIFF
--- a/electron/export/autoBackup.ts
+++ b/electron/export/autoBackup.ts
@@ -204,14 +204,17 @@ export async function runAutoBackupNow(appVersion: string): Promise<AutoBackupRe
     const hostname = os.hostname();
     const target = path.join(folder, backupFileName(hostname, new Date()));
     // Write via temp + rename so cloud clients never sync a half-written file.
+    // The archive is the whole library, so both the write and the verification
+    // re-read go through the promise API: *Sync would park the single
+    // main-process event loop for as long as the transfer takes.
     const tmp = `${target}.tmp`;
-    fs.writeFileSync(tmp, archive);
-    fs.renameSync(tmp, target);
+    await fs.promises.writeFile(tmp, archive);
+    await fs.promises.rename(tmp, target);
 
     // Prove the snapshot is recoverable BEFORE retention deletes older ones. Re-read
     // from disk rather than trusting the in-memory buffer, so a truncated or corrupted
     // write is caught here instead of on the day it is needed.
-    const verification = verifyBackupArchive(fs.readFileSync(target), password);
+    const verification = verifyBackupArchive(await fs.promises.readFile(target), password);
     if (!verification.ok) {
       fs.rmSync(target, { force: true });
       return finish({

--- a/electron/export/backupCrypto.ts
+++ b/electron/export/backupCrypto.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, createHash, randomBytes, scryptSync } from 'node:crypto';
+import { createCipheriv, createDecipheriv, createHash, randomBytes, scrypt, scryptSync } from 'node:crypto';
 
 const PASSWORD_BYTES = 24;
 const SALT_BYTES = 16;
@@ -58,6 +58,27 @@ function deriveKey(password: string, salt: Buffer): Buffer {
   });
 }
 
+/**
+ * scrypt on libuv's threadpool instead of the main thread. Same parameters and
+ * same key as {@link deriveKey}; only the scheduling differs. Used by the write
+ * path, which runs unattended every 30 minutes and must not stall the app.
+ */
+function deriveKeyAsync(password: string, salt: Buffer): Promise<Buffer> {
+  const clean = cleanPassword(password);
+  if (clean.length < MIN_BACKUP_PASSWORD_LENGTH) {
+    return Promise.reject(new Error('La contraseña de la copia de seguridad no es válida.'));
+  }
+  return new Promise((resolve, reject) => {
+    scrypt(
+      clean,
+      salt,
+      KEY_BYTES,
+      { cost: SCRYPT_N, blockSize: SCRYPT_R, parallelization: SCRYPT_P, maxmem: SCRYPT_MAXMEM },
+      (err, key) => (err ? reject(err) : resolve(key as Buffer))
+    );
+  });
+}
+
 export type KdfDescriptor = BackupCipherMetadata['kdf'];
 
 /**
@@ -114,8 +135,20 @@ export function decryptWithKey(sealed: Buffer, key: Buffer): Buffer {
 
 export function encryptBackupPayload(plaintext: Buffer, password: string): { ciphertext: Buffer; metadata: BackupCipherMetadata } {
   const salt = randomBytes(SALT_BYTES);
+  return sealPayload(plaintext, deriveKey(password, salt), salt);
+}
+
+/** {@link encryptBackupPayload} with the key derivation moved off the event loop. */
+export async function encryptBackupPayloadAsync(
+  plaintext: Buffer,
+  password: string
+): Promise<{ ciphertext: Buffer; metadata: BackupCipherMetadata }> {
+  const salt = randomBytes(SALT_BYTES);
+  return sealPayload(plaintext, await deriveKeyAsync(password, salt), salt);
+}
+
+function sealPayload(plaintext: Buffer, key: Buffer, salt: Buffer): { ciphertext: Buffer; metadata: BackupCipherMetadata } {
   const iv = randomBytes(IV_BYTES);
-  const key = deriveKey(password, salt);
   const cipher = createCipheriv('aes-256-gcm', key, iv);
   const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
   const authTag = cipher.getAuthTag();

--- a/electron/export/exportImport.ts
+++ b/electron/export/exportImport.ts
@@ -13,11 +13,12 @@ import type { VaultType } from '@shared/types';
 import { getApiKey, getAudioKey, getBackupPassword, setApiKey, setAudioKey } from '../secrets/secretStore';
 import {
   decryptBackupPayload,
-  encryptBackupPayload,
+  encryptBackupPayloadAsync,
   generateBackupPassword,
   sha256Hex,
   type BackupCipherMetadata,
 } from './backupCrypto';
+import { yieldToEventLoop, YIELD_EVERY } from '../util/async';
 
 interface ExportManifestBase {
   schemaVersion: number;
@@ -151,18 +152,21 @@ function normalizeBackupSelection(input: Partial<BackupSelection> | undefined, i
   };
 }
 
-function addFileIfPresent(files: Record<string, Buffer>, archiveName: string, sourcePath: string): void {
+// Auxiliary state is read with the promise API rather than *Sync: a library with
+// a generated-audio folder is thousands of files, and reading them synchronously
+// held the single main-process event loop for the whole sweep.
+async function addFileIfPresent(files: Record<string, Buffer>, archiveName: string, sourcePath: string): Promise<void> {
   try {
-    if (fs.statSync(sourcePath).isFile()) files[archiveName] = fs.readFileSync(sourcePath);
+    if ((await fs.promises.stat(sourcePath)).isFile()) files[archiveName] = await fs.promises.readFile(sourcePath);
   } catch {
     /* Optional auxiliary state may not have been created yet. */
   }
 }
 
-function addDirectoryIfPresent(files: Record<string, Buffer>, archivePrefix: string, sourceDir: string): void {
+async function addDirectoryIfPresent(files: Record<string, Buffer>, archivePrefix: string, sourceDir: string): Promise<void> {
   let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+    entries = await fs.promises.readdir(sourceDir, { withFileTypes: true });
   } catch {
     return;
   }
@@ -170,29 +174,29 @@ function addDirectoryIfPresent(files: Record<string, Buffer>, archivePrefix: str
     if (entry.isSymbolicLink()) continue;
     const source = path.join(sourceDir, entry.name);
     const target = `${archivePrefix}/${entry.name}`;
-    if (entry.isDirectory()) addDirectoryIfPresent(files, target, source);
-    else if (entry.isFile()) addFileIfPresent(files, target, source);
+    if (entry.isDirectory()) await addDirectoryIfPresent(files, target, source);
+    else if (entry.isFile()) await addFileIfPresent(files, target, source);
   }
 }
 
-function addAuxiliaryFiles(
+async function addAuxiliaryFiles(
   files: Record<string, Buffer>,
   vaults: ReturnType<typeof listVaults>,
   selection: BackupSelection
-): void {
+): Promise<void> {
   if (selection.includePreferences) {
     for (const name of GLOBAL_AUXILIARY_FILES) {
-      addFileIfPresent(files, `aux/global/${name}`, path.join(app.getPath('userData'), name));
+      await addFileIfPresent(files, `aux/global/${name}`, path.join(app.getPath('userData'), name));
     }
   }
   for (const vault of vaults) {
     const dir = path.dirname(vault.path);
     if (selection.includeHistories) {
-      for (const name of VAULT_HISTORY_FILES) addFileIfPresent(files, `aux/vaults/${vault.id}/${name}`, path.join(dir, name));
+      for (const name of VAULT_HISTORY_FILES) await addFileIfPresent(files, `aux/vaults/${vault.id}/${name}`, path.join(dir, name));
     }
     if (selection.includeGeneratedMedia) {
-      for (const name of VAULT_MEDIA_FILES) addFileIfPresent(files, `aux/vaults/${vault.id}/${name}`, path.join(dir, name));
-      addDirectoryIfPresent(files, `aux/vaults/${vault.id}/audio`, path.join(dir, 'audio'));
+      for (const name of VAULT_MEDIA_FILES) await addFileIfPresent(files, `aux/vaults/${vault.id}/${name}`, path.join(dir, name));
+      await addDirectoryIfPresent(files, `aux/vaults/${vault.id}/audio`, path.join(dir, 'audio'));
     }
   }
 }
@@ -250,7 +254,7 @@ export async function createBackupArchive(options: {
     vaultEntries.push({ id: vault.id, name: vault.name, type: vault.type, legacy: vault.legacy, dbFile, inventoryFile });
   }
   files['registry.json'] = Buffer.from(JSON.stringify({ activeVaultId, vaults: vaultEntries }, null, 2));
-  addAuxiliaryFiles(files, vaults, selection);
+  await addAuxiliaryFiles(files, vaults, selection);
   if (includesSecrets) {
     files['api-keys.json'] = Buffer.from(JSON.stringify(apiKeys, null, 2));
     if (Object.keys(audioKeys).length > 0) {
@@ -258,25 +262,39 @@ export async function createBackupArchive(options: {
     }
   }
 
+  // Hashing and CRC-ing every entry are both full passes over the whole library.
+  // Yield between entries so a backup — which runs unattended every 30 minutes —
+  // never holds the main-process event loop for the length of a full pass.
+  const fileDigests: Record<string, { sha256: string; bytes: number }> = {};
+  let hashed = 0;
+  for (const [name, data] of Object.entries(files)) {
+    fileDigests[name] = { sha256: sha256Hex(data), bytes: data.byteLength };
+    if (++hashed % YIELD_EVERY === 0) await yieldToEventLoop();
+  }
   const payloadManifest: PayloadManifest = {
     ...manifest,
     activeVaultId,
     vaults: vaultEntries,
     selection,
-    files: Object.fromEntries(
-      Object.entries(files).map(([name, data]) => [name, { sha256: sha256Hex(data), bytes: data.byteLength }])
-    ),
+    files: fileDigests,
   };
   files['payload-manifest.json'] = Buffer.from(JSON.stringify(payloadManifest, null, 2));
 
   const payloadZip = new AdmZip();
-  for (const [name, data] of Object.entries(files)) payloadZip.addFile(name, data);
+  let added = 0;
+  for (const [name, data] of Object.entries(files)) {
+    payloadZip.addFile(name, data);
+    if (++added % YIELD_EVERY === 0) await yieldToEventLoop();
+  }
 
   const recoveryKey = options.recoveryKey?.trim() || '';
   const payloadCredential = recoveryKey || options.password;
-  const { ciphertext, metadata } = encryptBackupPayload(payloadZip.toBuffer(), payloadCredential);
+  // toBufferPromise() deflates each entry through zlib's asynchronous API, so the
+  // compression runs on libuv's threadpool instead of blocking the event loop.
+  // On a 220 MB library that is ~3.7 s of freeze turned into ~0.3 s.
+  const { ciphertext, metadata } = await encryptBackupPayloadAsync(await payloadZip.toBufferPromise(), payloadCredential);
   const wrappedRecovery = recoveryKey
-    ? encryptBackupPayload(Buffer.from(recoveryKey, 'utf8'), options.password)
+    ? await encryptBackupPayloadAsync(Buffer.from(recoveryKey, 'utf8'), options.password)
     : null;
   const outerManifest: BackupManifest = {
     format: 'nodus.encrypted-backup',
@@ -292,7 +310,7 @@ export async function createBackupArchive(options: {
   zip.addFile('manifest.json', Buffer.from(JSON.stringify(outerManifest, null, 2)));
   zip.addFile('backup.bin', ciphertext);
   if (wrappedRecovery) zip.addFile('recovery-key.bin', wrappedRecovery.ciphertext);
-  return zip.toBuffer();
+  return zip.toBufferPromise();
 }
 
 export async function exportData(): Promise<{ path: string; password: string; recoveryKey: string } | null> {
@@ -310,7 +328,7 @@ export async function exportData(): Promise<{ path: string; password: string; re
     appVersion: app.getVersion(),
     recoveryKey,
   });
-  fs.writeFileSync(filePath, archive);
+  await fs.promises.writeFile(filePath, archive);
   return { path: filePath, password, recoveryKey };
 }
 

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -958,17 +958,24 @@ export function registerIpc(
   });
   h('nodi:viewContext:set', async (_e, context) => setNodiViewContext(context));
   h('nodi:viewContext:get', async () => getNodiViewContext());
+  // The overlay's mouse hit-test transition. Asynchronous on purpose: the flag is
+  // applied when the main process next reaches its event loop, which is exactly
+  // when a `sendSync` would have been serviced too — the synchronous form only
+  // added a stall of Nodi's own renderer while heavy work held the loop.
+  ipcMain.on('nodi:setMouseIgnore:async', (e, ignore: boolean) => {
+    const win = BrowserWindow.fromWebContents(e.sender);
+    win?.setIgnoreMouseEvents(Boolean(ignore), { forward: true });
+  });
+  h('nodi:overlayPlacement:get', async () => getMascotWindowPlacement());
+  // Retained for compatibility with older preload bundles.
   ipcMain.on('nodi:setMouseIgnoreSync', (e, ignore: boolean) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     win?.setIgnoreMouseEvents(Boolean(ignore), { forward: true });
-    // sendSync is intentional here: a forwarded mousemove must make Nodi interactive
-    // before a following physical mouse-down can pass through to the app underneath.
     e.returnValue = true;
   });
   ipcMain.on('nodi:getOverlayPlacementSync', (e) => {
     e.returnValue = getMascotWindowPlacement();
   });
-  // Retained for compatibility with older preload bundles.
   h('nodi:setMouseIgnore', async (e, ignore: boolean) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     win?.setIgnoreMouseEvents(Boolean(ignore), { forward: true });

--- a/electron/mascotWindow.ts
+++ b/electron/mascotWindow.ts
@@ -175,10 +175,17 @@ function createMascotWindow(): BrowserWindow {
     if (!tutorialVisible) win.showInactive();
   });
 
+  // positionBottomRight() above already placed the window, so the placement is
+  // known before the page loads. Carrying it in the URL lets the overlay draw
+  // its first frame in the right spot without a synchronous IPC round-trip —
+  // that call used to stall Nodi's renderer whenever the main process was busy.
+  const query = { placement: JSON.stringify(placement) };
   if (VITE_DEV_SERVER_URL) {
-    void win.loadURL(new URL('mascot.html', VITE_DEV_SERVER_URL).toString());
+    const devUrl = new URL('mascot.html', VITE_DEV_SERVER_URL);
+    devUrl.searchParams.set('placement', query.placement);
+    void win.loadURL(devUrl.toString());
   } else {
-    void win.loadFile(path.join(RENDERER_DIST, 'mascot.html'));
+    void win.loadFile(path.join(RENDERER_DIST, 'mascot.html'), { query });
   }
 
   win.on('closed', () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import type {
   NodusApi,
+  NodiOverlayPlacement,
   QueueProgress,
   UpdateProgressEvent,
   ReprocessProgress,
@@ -20,6 +21,37 @@ let activeNodiChatRequestId: string | null = null;
 let activeStudyImproveRequestId: string | null = null;
 let activeStudyAssistantRequestId: string | null = null;
 let activeStudySttRequestId: string | null = null;
+
+const DEFAULT_OVERLAY_PLACEMENT: NodiOverlayPlacement = { x: 16, y: 16, horizontal: 'left', vertical: 'up' };
+
+/**
+ * The mascot window's placement for the overlay's first frame, read from the
+ * page URL rather than fetched over IPC.
+ *
+ * mascotWindow.ts positions the native window *before* it loads mascot.html, so
+ * the value is already known at load time; carrying it in the URL keeps the
+ * first frame correct without a synchronous round-trip into a main process that
+ * may be busy with a backup or a scan.
+ */
+function readInitialOverlayPlacement(): NodiOverlayPlacement {
+  try {
+    // The preload shares the renderer's frame, so `location` is there at runtime;
+    // this tsconfig deliberately omits the DOM lib, hence the narrow cast.
+    const search = (globalThis as unknown as { location?: { search?: string } }).location?.search ?? '';
+    const raw = new URLSearchParams(search).get('placement');
+    if (!raw) return DEFAULT_OVERLAY_PLACEMENT;
+    const parsed = JSON.parse(raw) as Partial<NodiOverlayPlacement>;
+    if (typeof parsed?.x !== 'number' || typeof parsed?.y !== 'number') return DEFAULT_OVERLAY_PLACEMENT;
+    return {
+      x: parsed.x,
+      y: parsed.y,
+      horizontal: parsed.horizontal === 'right' ? 'right' : 'left',
+      vertical: parsed.vertical === 'down' ? 'down' : 'up',
+    };
+  } catch {
+    return DEFAULT_OVERLAY_PLACEMENT;
+  }
+}
 
 // Minimal, typed surface exposed to the renderer. No Node, no direct IPC names leak.
 const api: NodusApi = {
@@ -64,10 +96,20 @@ const api: NodusApi = {
   setNodiViewContext: (context) => ipcRenderer.invoke('nodi:viewContext:set', context).then(() => undefined),
   getNodiViewContext: () => ipcRenderer.invoke('nodi:viewContext:get'),
   setNodiTutorialVisible: (visible) => ipcRenderer.invoke('nodi:tutorialVisible', visible).then(() => undefined),
+  // Deliberately fire-and-forget. `sendSync` was used here to make the hit-test
+  // transition land before a following physical mouse-down, but it cannot buy
+  // that: the main process handles either message at the same point in its event
+  // loop. All the synchronous form added was a full stall of the overlay
+  // renderer — so while the main process was busy (auto backup, a scan, an
+  // import) Nodi froze mid-animation the moment the pointer crossed it.
   nodiSetMouseIgnore: async (ignore) => {
-    ipcRenderer.sendSync('nodi:setMouseIgnoreSync', ignore);
+    ipcRenderer.send('nodi:setMouseIgnore:async', ignore);
   },
-  nodiGetOverlayPlacement: () => ipcRenderer.sendSync('nodi:getOverlayPlacementSync'),
+  // The main process places the window before it loads mascot.html and passes
+  // the result in the URL, so the very first frame draws Nodi in the right spot
+  // with no IPC at all. `nodi:overlayPlacement:get` refreshes it afterwards.
+  nodiGetOverlayPlacement: () => readInitialOverlayPlacement(),
+  nodiRefreshOverlayPlacement: () => ipcRenderer.invoke('nodi:overlayPlacement:get'),
   nodiSetExpanded: (expanded) => ipcRenderer.invoke('nodi:setExpanded', expanded),
   onNodiDismiss: (cb) => {
     const listener = () => cb();

--- a/electron/serverSync/serverSyncService.ts
+++ b/electron/serverSync/serverSyncService.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
-import { gzipSync } from 'node:zlib';
+import { gzip } from 'node:zlib';
+import { promisify } from 'node:util';
 import Database from 'better-sqlite3';
 import { getDb, withVaultDatabase } from '../db/database';
 import { getActiveVault, getVault, listVaults } from '../vaults/vaultRegistry';
@@ -28,6 +29,8 @@ import { buildServerSnapshot, lightweightVaultRevision } from './serverSnapshot'
 // active one on change and refreshes the rest once per run. Connections are surfaced
 // together so Settings shows them from any vault instead of pretending the current
 // vault is "unconfigured".
+
+const gzipAsync = promisify(gzip);
 
 const CHECK_INTERVAL_MS = 30_000;
 const QUIET_PERIOD_MS = 60_000;
@@ -260,7 +263,10 @@ async function publishVault(vaultId: string): Promise<void> {
       return;
     }
     // Level 1 deliberately trades a little bandwidth for very low desktop CPU usage.
-    const compressed = gzipSync(snapshot.buffer, { level: 1 });
+    // Compressing asynchronously puts even that on libuv's threadpool: this runs on
+    // a 30 s timer, and the main process is the single thread every window's IPC
+    // goes through — including the Nodi overlay's.
+    const compressed = await gzipAsync(snapshot.buffer, { level: 1 });
     const response = await fetchWithTimeout(
       `${normalizeUrl(config.url)}/api/v1/spaces/${encodeURIComponent(config.spaceId)}/snapshot`,
       {

--- a/scripts/test-auto-backup.mjs
+++ b/scripts/test-auto-backup.mjs
@@ -5,6 +5,7 @@
 // Electron-as-Node so better-sqlite3 matches the app ABI.
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { randomFillSync } from 'node:crypto';
 import { mkdtemp, rm, writeFile, readdir, mkdir } from 'node:fs/promises';
 import Module, { createRequire } from 'node:module';
 import os from 'node:os';
@@ -206,6 +207,53 @@ try {
     crypto.decryptBackupPayload(manualZip.getEntry('backup.bin').getData(), manualRecoveryKey, manualManifest.cipher)
   );
   assert.ok(manualPayload.getEntry('api-keys.json'), 'manual export still carries keys');
+
+  // ── The archive must be built WITHOUT parking the main-process event loop ─────
+  // Automatic backups run unattended every 30 minutes on the same single thread
+  // that serves every IPC handler, so a synchronous deflate took the whole app
+  // with it — including the Nodi overlay, which pings the main process on every
+  // mouse hit-test transition and froze mid-animation for the entire pass.
+  //
+  // Metering which primitive gets used, rather than timing the call, keeps this
+  // deterministic under the parallel runner: deflateRawSync and scryptSync burn
+  // the event loop, their streaming/callback counterparts run on libuv's
+  // threadpool. The probe is a ~32 MB incompressible auxiliary file
+  // (nodi-notes.json is read from userData, which the stub points at `root`).
+  const filler = Buffer.alloc(32 * 1024 * 1024);
+  for (let offset = 0; offset < filler.length; offset += 65536) randomFillSync(filler, offset, 65536);
+  await writeFile(path.join(root, 'nodi-notes.json'), filler);
+
+  const zlib = require('node:zlib');
+  const nodeCrypto = require('node:crypto');
+  const meter = { deflateSync: 0, deflateStream: 0, scryptSync: 0, scryptAsync: 0 };
+  const original = {
+    deflateRawSync: zlib.deflateRawSync,
+    createDeflateRaw: zlib.createDeflateRaw,
+    scryptSync: nodeCrypto.scryptSync,
+    scrypt: nodeCrypto.scrypt,
+  };
+  // node:zlib exports are non-writable, so swap them through defineProperty.
+  const swap = (host, name, value) => Object.defineProperty(host, name, { value, configurable: true, writable: true });
+  swap(zlib, 'deflateRawSync', (...a) => { meter.deflateSync += 1; return original.deflateRawSync(...a); });
+  swap(zlib, 'createDeflateRaw', (...a) => { meter.deflateStream += 1; return original.createDeflateRaw(...a); });
+  swap(nodeCrypto, 'scryptSync', (...a) => { meter.scryptSync += 1; return original.scryptSync(...a); });
+  swap(nodeCrypto, 'scrypt', (...a) => { meter.scryptAsync += 1; return original.scrypt(...a); });
+  let archive;
+  try {
+    archive = await exportImport.createBackupArchive({ password: 'clave-manual-larga', appVersion: 'x' });
+  } finally {
+    for (const [name, value] of Object.entries(original)) swap(name.startsWith('scrypt') ? nodeCrypto : zlib, name, value);
+  }
+  assert.ok(archive.length > 32 * 1024 * 1024, 'the probe payload really made it into the archive');
+  assert.ok(meter.deflateStream > 0, 'the archive is deflated through zlib’s asynchronous API');
+  assert.equal(meter.deflateSync, 0, 'no entry may be deflated with deflateRawSync on the main thread');
+  assert.ok(meter.scryptAsync > 0, 'the backup key is derived on libuv’s threadpool');
+  assert.equal(meter.scryptSync, 0, 'scryptSync must not run on the main thread while writing a backup');
+  assert.equal(
+    exportImport.verifyBackupArchive(archive, 'clave-manual-larga').ok,
+    true,
+    'an archive built off the event loop is still decryptable',
+  );
 
   // ── verifyBackupArchive: the gate that must hold before retention deletes ──────
   // Retention only runs when this returns ok, so a false positive here is what would

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -191,13 +191,45 @@ test('floating Nodi dismisses every open surface on an outside click or window b
   assert.match(mascot, /width: EXPANDED_WIDTH/, 'opening controls must not resize a visible transparent NSPanel');
   assert.match(mascot, /applyClosedMousePassthrough/, 'closed transparent regions pass clicks to the app underneath');
   assert.match(component, /addEventListener\('mousemove'/, 'forwarded movement performs transparent-region hit testing');
-  assert.match(ipc, /nodi:setMouseIgnoreSync/);
-  assert.match(ipc, /e\.returnValue = true/, 'the native hit target changes before a following physical mouse-down');
-  assert.match(preload, /sendSync\('nodi:setMouseIgnoreSync'/);
+  assert.match(ipc, /ipcMain\.on\('nodi:setMouseIgnore:async'/);
+  assert.match(ipc, /nodi:setMouseIgnore:async'[\s\S]{0,220}setIgnoreMouseEvents/, 'the async channel still applies the native hit target');
+  assert.match(preload, /ipcRenderer\.send\('nodi:setMouseIgnore:async'/);
   assert.match(component, /nodiGetOverlayPlacement\(\)/, 'the first renderer frame uses the native placement rather than a provisional anchor');
-  assert.match(preload, /sendSync\('nodi:getOverlayPlacementSync'/);
+  // Nodi's own renderer must never wait on the main process: sendSync stalls this
+  // window for as long as a backup, scan or import holds the main event loop, which
+  // is exactly the freeze it was meant to prevent. The hit-test flag lands at the
+  // same point in the loop either way, and the first frame's placement now travels
+  // in the URL mascot.html is loaded with.
+  assert.doesNotMatch(preload, /sendSync\('nodi:/, 'the Nodi overlay bridge must not block on synchronous IPC');
+  assert.match(preload, /new URLSearchParams\(search\)\.get\('placement'\)/);
+  assert.match(mascot, /searchParams\.set\('placement'/, 'the dev-server overlay URL carries the placement');
+  assert.match(mascot, /loadFile\([^)]*mascot\.html'\), \{ query \}\)/, 'the packaged overlay URL carries the placement');
   assert.match(preload, /onNodiDismiss/);
   assert.match(types, /onNodiDismiss\(cb: \(\) => void\)/);
+});
+
+test('Nodi’s scrollable panels overflow instead of crushing their rows', async () => {
+  const css = await read('src/components/nodi/companion.css');
+  // A column flexbox with a definite height distributes any shortfall to its
+  // children, so rows left at the default flex-shrink:1 are compressed to fit:
+  // the list stops scrolling and every row's own `overflow: hidden` slices its
+  // text in half. That is what turned the quick-notes panel into shredded lines
+  // once the user had more notes than fit on screen.
+  const rule = (selector) => {
+    const at = css.indexOf(`${selector} {`) >= 0 ? css.indexOf(`${selector} {`) : css.indexOf(`${selector} `);
+    assert.ok(at >= 0, `${selector} is missing from companion.css`);
+    return css.slice(at, css.indexOf('}', at) + 1);
+  };
+  for (const [scroller, row] of [['.nodi-notes-list', '.nodi-note-row'], ['.nodi-chat-msgs', '.nodi-msg']]) {
+    const scrollerRule = rule(scroller);
+    assert.match(scrollerRule, /flex-direction:\s*column/, `${scroller} is a column flexbox`);
+    assert.match(scrollerRule, /overflow-y:\s*auto/, `${scroller} scrolls`);
+    assert.match(
+      rule(row),
+      /flex:\s*0\s+0\s+auto|flex-shrink:\s*0/,
+      `${row} must not shrink, or ${scroller} squashes its rows instead of scrolling`,
+    );
+  }
 });
 
 test('floating Nodi restores mouse passthrough after its radial buttons finish collapsing', async () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5331,7 +5331,10 @@ export interface NodusApi {
   nodiOpenSettings(): Promise<void>;
   onNodiNavigate(cb: (view: 'settings') => void): () => void;
   nodiSetMouseIgnore(ignore: boolean): Promise<void>;
+  /** Synchronous, but IPC-free: read from the URL the mascot window was loaded with. */
   nodiGetOverlayPlacement(): NodiOverlayPlacement;
+  /** Authoritative placement from the main process, for after a reload. */
+  nodiRefreshOverlayPlacement(): Promise<NodiOverlayPlacement>;
   nodiSetExpanded(expanded: boolean): Promise<NodiOverlayPlacement>;
   onNodiDismiss(cb: () => void): () => void;
   nodiOpenMainWindow(): Promise<void>;

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -190,6 +190,13 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
       ? window.nodus.nodiGetOverlayPlacement()
       : { x: 16, y: 16, horizontal: 'left', vertical: 'up' }
   ));
+  // The initial placement comes from the load URL, which is stale after a
+  // renderer reload (the window may have been dragged since). Reconcile with the
+  // main process once, asynchronously, so this never blocks the first frame.
+  useEffect(() => {
+    if (!isOverlay) return;
+    void window.nodus.nodiRefreshOverlayPlacement().then(setOverlayPlacement).catch(() => {});
+  }, [isOverlay]);
   const [dragging, setDragging] = useState(false);
   const [greet, setGreet] = useState(false);
   const draggingRef = useRef(false);

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -340,7 +340,10 @@
 .nodi-chat-msgs,
 .nodi-msg,
 .nodi-msg .md { -webkit-user-select: text; user-select: text; }
-.nodi-msg { position: relative; font-size: 13px; line-height: 1.5; padding: 7px 32px 7px 10px; border-radius: 12px; max-width: 86%; white-space: pre-wrap; word-break: break-word; }
+/* flex: 0 0 auto for the same reason as .nodi-note-row: without it a long
+ * conversation is compressed into the panel instead of scrolling, and the
+ * bubbles overlap each other. */
+.nodi-msg { position: relative; flex: 0 0 auto; font-size: 13px; line-height: 1.5; padding: 7px 32px 7px 10px; border-radius: 12px; max-width: 86%; white-space: pre-wrap; word-break: break-word; }
 .nodi-msg.user { align-self: flex-end; background: #24406b; color: #eaf1ff; border-bottom-right-radius: 4px; }
 .nodi-msg.assistant { align-self: flex-start; background: #1a2130; color: #e7ebf2; border-bottom-left-radius: 4px; white-space: normal; }
 .nodi-msg-copy {
@@ -623,6 +626,11 @@
   grid-template-columns: minmax(0, 1fr) 30px;
   align-items: stretch;
   gap: 3px;
+  /* The list is a column flexbox with a definite height, so a row left at the
+   * default flex-shrink:1 is squashed to fit instead of overflowing — the list
+   * never scrolls and every row's `overflow: hidden` slices its own text in
+   * half. Rows keep their natural height; the list scrolls. */
+  flex: 0 0 auto;
   overflow: hidden;
   border-radius: 9px;
   background: transparent;


### PR DESCRIPTION
Fixes #231.

Two independent defects behind the same report.

## Quick notes and chat were compressed instead of scrolling

`.nodi-notes-list` and `.nodi-chat-msgs` are column flexboxes with a definite height. Their rows were left at the default `flex-shrink: 1`, so flex distributed the shortfall to them rather than letting the list overflow: `scrollHeight === clientHeight`, the list never scrolled, and since each row also sets `overflow: hidden` the compressed rows clipped their own text through the middle of the glyphs.

Reproduced against the real stylesheet at 9 notes — rows laid out at 33px instead of 60px, title box at 3px for a 15px line — which matches the reported screenshot exactly. `flex: 0 0 auto` on `.nodi-note-row` and `.nodi-msg` restores natural heights and scrolling.

Not display corruption, and unrelated to the force quit that preceded it: it is deterministic layout that appears once there are more rows than fit.

## Nodi froze while the main process was busy

The mascot is its own renderer, so main-process work should never reach it. It froze anyway because the preload used `ipcRenderer.sendSync` for `nodiSetMouseIgnore` — fired on every mouse hit-test transition — and once more for `nodiGetOverlayPlacement`. A synchronous call parks the overlay renderer until the main process is free.

That call never bought the ordering it was written for. The main process services `send` and `sendSync` at the same point in its event loop, so `setIgnoreMouseEvents` was applied no sooner either way; the synchronous form only added the stall. The hit test is now fire-and-forget, and the first frame's placement travels in the URL `mascot.html` is loaded with, so it needs no IPC at all.

### And what was holding the loop

`createBackupArchive` runs unattended every 30 minutes and was fully synchronous. Measured on a 220 MB payload:

| Stage | Before | After |
| --- | --- | --- |
| `AdmZip.toBuffer()` | 3.65 s blocked | 0.28 s (`toBufferPromise`, async zlib on the threadpool) |
| `scryptSync` | 0.05 s | 0.00 s (async `scrypt`) |
| auxiliary reads + archive write | `readFileSync` / `writeFileSync` | `fs.promises` |
| hashing and adding entries | one uninterrupted pass | yields every `YIELD_EVERY` |

Linear in library size, so 1–2 GB meant 20–45 s of freeze per backup. `serverSyncService` now gzips asynchronously for the same reason — it runs on a 30 s timer.

The archive format is unchanged; the existing round-trip tests (create → verify → restore, multi-vault) still pass untouched.

## Verification

- 818/818 tests, `npm run typecheck` and lint green.
- `npm run test:e2e` passes; schema still v90.
- `npm run verify:nodi-overlay` passes in real Electron, including `passthrough first click + pointer jitter -> menu open` — the exact behaviour `sendSync` was justified by.
- Both new regression tests were confirmed to **fail** against the previous code before being kept.

One note on the backup test: counting event-loop turns during the build does not discriminate, because the surrounding awaits turn the loop plenty even with a synchronous deflate. It meters which primitive runs instead — `zlib.deflateRawSync` vs `createDeflateRaw`, `crypto.scryptSync` vs `scrypt` — which fails against the old code and is stable under the parallel runner.
