### PR TITLE
Collapse person dossier add buttons to an icon with a tooltip

### DIFF
--- a/scripts/test-person-dossier-layout.mjs
+++ b/scripts/test-person-dossier-layout.mjs
@@ -31,16 +31,31 @@ test('every person dossier area uses the shared section block', () => {
 });
 
 test('all dossier add actions share exactly one size contract', () => {
-  assert.match(layout, /PERSON_DOSSIER_ADD_BUTTON_CLASS[\s\S]*h-auto min-h-9 min-w-44/);
-  assert.match(layout, /whitespace-normal/);
-  assert.match(layout, /px-4 py-2 text-center/);
+  assert.match(layout, /PERSON_DOSSIER_ADD_BUTTON_CLASS[\s\S]*h-8 w-8 shrink-0/);
+  assert.match(layout, /PERSON_DOSSIER_ACTION_BUTTON_CLASS[\s\S]*h-auto min-h-9 min-w-44/);
   assert.match(dossier, /PERSON_DOSSIER_ADD_BUTTON_CLASS/);
-  assert.match(dossier, /Biografía'[\s\S]{0,240}PERSON_DOSSIER_ADD_BUTTON_CLASS/);
+  assert.match(dossier, /Biografía'[\s\S]{0,240}PERSON_DOSSIER_ACTION_BUTTON_CLASS/);
   assert.match(kinship, /PERSON_DOSSIER_ADD_BUTTON_CLASS/);
   assert.match(social, /PERSON_DOSSIER_ADD_BUTTON_CLASS/);
   assert.match(places, /PERSON_DOSSIER_ADD_BUTTON_CLASS/);
   assert.doesNotMatch(dossier, /Añadir variante'[\s\S]{0,180}h-6/);
   assert.doesNotMatch(dossier, /Añadir evento'[\s\S]{0,180}h-6/);
+});
+
+test('icon-only add buttons keep their label in the tooltip and for screen readers', () => {
+  for (const [source, label] of [
+    [kinship, 'Añadir relación'],
+    [social, 'Añadir relación'],
+    [places, 'Añadir lugar'],
+    [dossier, 'Añadir variante'],
+    [dossier, 'Añadir evento'],
+  ]) {
+    assert.match(source, new RegExp(`title=\\{t\\('Añadir'\\)\\}[\\s\\S]{0,40}aria-label=\\{t\\('${label}'\\)\\}`));
+  }
+  // The wording must not sit inside the button any more: that is what stacked vertically.
+  for (const source of [kinship, social, places, dossier]) {
+    assert.doesNotMatch(source, /<Icon name="plus"[^>]*\/>\s*\{t\('Añadir/);
+  }
 });
 
 test('portrait actions keep side padding and grow for translated labels', () => {

--- a/src/components/KinshipEditor.tsx
+++ b/src/components/KinshipEditor.tsx
@@ -150,8 +150,8 @@ export function KinshipEditor({ person, persons, onChanged, compact = false }: {
             {t('Padres, hijos, hermanos y parejas vinculados a esta persona.')}
           </p>
         </div>
-        <button className={PERSON_DOSSIER_ADD_BUTTON_CLASS} onClick={openNew}>
-          <Icon name="plus" size={11} /> {t('Añadir relación')}
+        <button className={PERSON_DOSSIER_ADD_BUTTON_CLASS} title={t('Añadir')} aria-label={t('Añadir relación')} onClick={openNew}>
+          <Icon name="plus" size={14} />
         </button>
       </div>
 

--- a/src/components/PersonDossier.tsx
+++ b/src/components/PersonDossier.tsx
@@ -22,7 +22,7 @@ import { MarkdownNotesEditor } from './MarkdownNotesEditor';
 import { RelationsSection } from './RelationsSection';
 import { PersonPlacesSection } from './PersonPlacesSection';
 import { KinshipEditor } from './KinshipEditor';
-import { PERSON_DOSSIER_ADD_BUTTON_CLASS, PERSON_DOSSIER_SECTION_CLASS } from './personDossierLayout';
+import { PERSON_DOSSIER_ACTION_BUTTON_CLASS, PERSON_DOSSIER_ADD_BUTTON_CLASS, PERSON_DOSSIER_SECTION_CLASS } from './personDossierLayout';
 import { confirm } from './feedback';
 import { useDismissableLayer } from '../hooks';
 import { t, tx } from '../i18n';
@@ -192,7 +192,7 @@ export function PersonDossier({
         <div className="mb-2 flex items-center gap-2">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">{t('Biografía')}</h3>
           <button
-            className={`${PERSON_DOSSIER_ADD_BUTTON_CLASS} ml-auto`}
+            className={`${PERSON_DOSSIER_ACTION_BUTTON_CLASS} ml-auto`}
             disabled={bioBusy}
             onClick={() => void generateBio()}
           >
@@ -566,8 +566,8 @@ function NameVariantsEditor({ person, onChanged }: { person: Person; onChanged: 
     <section className={PERSON_DOSSIER_SECTION_CLASS} data-testid="person-dossier-name-variants">
       <div className="mb-2 flex items-center gap-2">
         <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">{t('Variantes del nombre')}</h3>
-        <button className={`${PERSON_DOSSIER_ADD_BUTTON_CLASS} ml-auto`} onClick={() => { setValue(''); setModalOpen(true); }}>
-          <Icon name="plus" size={11} /> {t('Añadir variante')}
+        <button className={`${PERSON_DOSSIER_ADD_BUTTON_CLASS} ml-auto`} title={t('Añadir')} aria-label={t('Añadir variante')} onClick={() => { setValue(''); setModalOpen(true); }}>
+          <Icon name="plus" size={14} />
         </button>
       </div>
       {person.names.length > 0 ? (
@@ -639,8 +639,8 @@ function EventsEditor({
         <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
           {t('Eventos de su vida')} <span className="text-neutral-600">({events.length})</span>
         </h3>
-        <button className={`${PERSON_DOSSIER_ADD_BUTTON_CLASS} ml-auto`} onClick={() => setAdding(true)}>
-          <Icon name="plus" size={11} /> {t('Añadir evento')}
+        <button className={`${PERSON_DOSSIER_ADD_BUTTON_CLASS} ml-auto`} title={t('Añadir')} aria-label={t('Añadir evento')} onClick={() => setAdding(true)}>
+          <Icon name="plus" size={14} />
         </button>
       </div>
 

--- a/src/components/PersonPlacesSection.tsx
+++ b/src/components/PersonPlacesSection.tsx
@@ -62,9 +62,11 @@ export function PersonPlacesSection({ personId }: { personId: string }) {
         </h3>
         <button
           className={`${PERSON_DOSSIER_ADD_BUTTON_CLASS} ml-auto`}
+          title={t('Añadir')}
+          aria-label={t('Añadir lugar')}
           onClick={() => setAdding(true)}
         >
-          <Icon name="plus" size={11} /> {t('Añadir lugar')}
+          <Icon name="plus" size={14} />
         </button>
       </div>
 

--- a/src/components/RelationsSection.tsx
+++ b/src/components/RelationsSection.tsx
@@ -73,9 +73,11 @@ export function RelationsSection({
         </div>
         <button
           className={PERSON_DOSSIER_ADD_BUTTON_CLASS}
+          title={t('Añadir')}
+          aria-label={t('Añadir relación')}
           onClick={() => setAdding(true)}
         >
-          <Icon name="plus" size={11} /> {t('Añadir relación')}
+          <Icon name="plus" size={14} />
         </button>
       </div>
 

--- a/src/components/personDossierLayout.ts
+++ b/src/components/personDossierLayout.ts
@@ -1,5 +1,14 @@
 /** Shared visual contract for every section and add action in a person dossier. */
 export const PERSON_DOSSIER_SECTION_CLASS = 'rounded-md border border-neutral-800 bg-neutral-900/40 p-3';
 
+/**
+ * Add actions are icon-only squares: a translated label inside the button wrapped into a
+ * vertical stack and squeezed the section description next to it, so the wording moved to
+ * the tooltip and the button keeps a fixed, language-independent footprint.
+ */
 export const PERSON_DOSSIER_ADD_BUTTON_CLASS =
+  'btn btn-ghost h-8 w-8 shrink-0 justify-center border border-neutral-700 p-0';
+
+/** Add actions whose label carries state (busy, regenerate…) and cannot collapse to an icon. */
+export const PERSON_DOSSIER_ACTION_BUTTON_CLASS =
   'btn btn-ghost h-auto min-h-9 min-w-44 shrink-0 justify-center gap-1.5 whitespace-normal border border-neutral-700 px-4 py-2 text-center text-[11px] leading-snug';


### PR DESCRIPTION
Closes #233

## The problem

`PERSON_DOSSIER_ADD_BUTTON_CLASS` combined `min-w-44` with `whitespace-normal`: the add button claimed at least 176px of the section header and wrapped its own label. Next to it, the title and description of the section collapsed into a one-word-per-line strip, and the button ended up taller than the text it labelled — worse in every language with longer wording.

## The change

- `PERSON_DOSSIER_ADD_BUTTON_CLASS` is now an icon-only 32×32 square (`h-8 w-8 shrink-0 … p-0`). The wording moved to `title` (tooltip, translated via the existing `Añadir` key, already present in all six translation files) and to `aria-label` with the specific action, so screen readers still get "Add relation", "Add place", and so on.
- The old wide style survives as `PERSON_DOSSIER_ACTION_BUTTON_CLASS` for the biography action, whose label carries state ("Generating…" / "Regenerate") and therefore cannot collapse to an icon.
- Applied to the five `+` actions that share the class: family relations, social relations, places, name variants and life events.

## Tests

`scripts/test-person-dossier-layout.mjs` encoded the old size contract, so it was updated, and a new case asserts that each icon-only button carries both the tooltip and the `aria-label`, and that the wording never moves back inside the button.

## Verification

- `tsc --noEmit`: clean
- `eslint` on the five touched sources: clean
- `node --test scripts/test-person-dossier-layout.mjs scripts/test-i18n-coverage.mjs`: 26/26 pass
