### PR TITLE
Stop deleting individual files from the Office add-in cache

### DIFF
--- a/electron/copilot/install.ts
+++ b/electron/copilot/install.ts
@@ -3,42 +3,15 @@ import { homedir } from 'node:os';
 import path from 'node:path';
 import { getSettings } from '../db/settingsRepo';
 
-const COPILOT_ADDIN_ID = 'E4352919-FFEC-4F77-8268-975BB4217FAD';
-const CACHE_SCAN_MAX_BYTES = 2 * 1024 * 1024;
-
 export interface CopilotInstallResult {
   ok: boolean;
   message: string;
   manifestPath: string | null;
-  cacheEntriesRemoved?: number;
 }
 
 function wordManifestDirectory(): string | null {
   if (process.platform === 'darwin') {
     return path.join(homedir(), 'Library', 'Containers', 'com.microsoft.Word', 'Data', 'Documents', 'wef');
-  }
-  if (process.platform === 'win32') {
-    const localAppData = process.env.LOCALAPPDATA;
-    return localAppData ? path.join(localAppData, 'Microsoft', 'Office', '16.0', 'Wef') : null;
-  }
-  return null;
-}
-
-function wordCacheDirectory(): string | null {
-  if (process.platform === 'darwin') {
-    return path.join(
-      homedir(),
-      'Library',
-      'Containers',
-      'com.microsoft.Word',
-      'Data',
-      'Library',
-      'Application Support',
-      'Microsoft',
-      'Office',
-      '16.0',
-      'Wef'
-    );
   }
   if (process.platform === 'win32') {
     const localAppData = process.env.LOCALAPPDATA;
@@ -67,49 +40,15 @@ export function renderManifest(template: string, port: number, appVersion: strin
     .replace(/Copiloto Nodus/g, 'Nodus Copilot');
 }
 
-function isCopilotCacheText(text: string): boolean {
-  const lower = text.toLowerCase();
-  return (
-    lower.includes(COPILOT_ADDIN_ID.toLowerCase()) ||
-    lower.includes('nodus copilot') ||
-    lower.includes('nodus copiloto') ||
-    lower.includes('copiloto nodus')
-  );
-}
-
-export async function purgeCachedCopilotAddin(cacheDir: string | null = wordCacheDirectory()): Promise<number> {
-  if (!cacheDir) return 0;
-  let removed = 0;
-  async function visit(dir: string): Promise<void> {
-    let entries: import('node:fs').Dirent[];
-    try {
-      entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        await visit(fullPath);
-        continue;
-      }
-      if (!entry.isFile()) continue;
-      try {
-        const stat = await fs.stat(fullPath);
-        if (stat.size > CACHE_SCAN_MAX_BYTES) continue;
-        const text = await fs.readFile(fullPath, 'utf8');
-        if (!isCopilotCacheText(text)) continue;
-        await fs.unlink(fullPath);
-        removed++;
-      } catch {
-        // Cache cleanup is best-effort. A locked file should not block install.
-      }
-    }
-  }
-  await visit(cacheDir);
-  return removed;
-}
-
+/**
+ * Never delete individual files from Office's add-in cache to force a refresh.
+ * Microsoft documents that doing so "can cause all add-ins to stop loading", and
+ * it did exactly that here: a surgical purge of our own entries left Word unable
+ * to register any sideloaded add-in at all. Bumping <Version> in the manifest is
+ * the sanctioned way to make Office pick up a changed manifest; if a cache reset
+ * is ever unavoidable it must clear the whole cache directory, with Word closed.
+ * See https://learn.microsoft.com/office/dev/add-ins/testing/clear-cache
+ */
 export async function installCopilotAddin(appRoot: string, appVersion = '0.1.0'): Promise<CopilotInstallResult> {
   const targetDir = wordManifestDirectory();
   if (!targetDir) {
@@ -121,26 +60,22 @@ export async function installCopilotAddin(appRoot: string, appVersion = '0.1.0')
   }
 
   try {
-    const cacheEntriesRemoved = await purgeCachedCopilotAddin();
     const sourcePath = path.join(appRoot, 'word-addin', 'manifest.xml');
     const template = await fs.readFile(sourcePath, 'utf8');
     const manifest = renderManifest(template, getSettings().copilotPort, appVersion);
     await fs.mkdir(targetDir, { recursive: true });
     const targetPath = path.join(targetDir, 'nodus-copilot.manifest.xml');
     await fs.writeFile(targetPath, manifest, 'utf8');
-    const cacheText =
-      cacheEntriesRemoved > 0 ? ` Se limpiaron ${cacheEntriesRemoved} entrada(s) antiguas de la caché local de Word.` : '';
     return {
       ok: true,
       manifestPath: targetPath,
-      cacheEntriesRemoved,
-      message: `Nodus Copilot instalado/actualizado para Word con pestaña propia “Nodus”.${cacheText} Reinicia Word si el complemento ya estaba abierto.`,
+      message:
+        'Nodus Copilot instalado/actualizado para Word. Cierra Word del todo (Cmd+Q) y vuelve a abrirlo: el complemento aparece en Inicio → Complementos, y añade su pestaña “Nodus” al abrirlo por primera vez.',
     };
   } catch (error) {
     return {
       ok: false,
       manifestPath: null,
-      cacheEntriesRemoved: 0,
       message: `No se pudo instalar el complemento: ${error instanceof Error ? error.message : String(error)}`,
     };
   }

--- a/scripts/test-copilot-addin.mjs
+++ b/scripts/test-copilot-addin.mjs
@@ -23,7 +23,8 @@ const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-copilot-addin-test-'));
 installRuntimeHooks(root);
 
 try {
-  const { renderManifest, purgeCachedCopilotAddin } = require(path.join(repoRoot, 'electron/copilot/install.ts'));
+  const installModule = require(path.join(repoRoot, 'electron/copilot/install.ts'));
+  const { renderManifest, installCopilotAddin } = installModule;
   const template = fs.readFileSync(path.join(repoRoot, 'word-addin/manifest.xml'), 'utf8');
   const rendered = renderManifest(template, 4455, '0.7.20-beta.1');
 
@@ -33,18 +34,59 @@ try {
   assert.match(rendered, /<Label resid="Nodus\.Tab\.Label" \/>/);
   assert.doesNotMatch(rendered, /<OfficeTab id="TabHome">/);
 
-  const cache = path.join(root, 'Wef');
-  fs.mkdirSync(path.join(cache, 'Manifests'), { recursive: true });
-  fs.mkdirSync(path.join(cache, 'Other'), { recursive: true });
-  fs.writeFileSync(path.join(cache, 'Manifests', 'old-nodus'), '<Id>E4352919-FFEC-4F77-8268-975BB4217FAD</Id>');
-  fs.writeFileSync(path.join(cache, 'Other', 'old-label'), 'Nodus Copiloto');
-  fs.writeFileSync(path.join(cache, 'Other', 'keep'), 'Claude in Microsoft Office');
+  // Office's add-in cache must survive an install untouched. Deleting individual
+  // files from it is documented to make ALL add-ins stop loading, and it did:
+  // it left Word unable to register any sideloaded add-in until the whole cache
+  // was cleared. https://learn.microsoft.com/office/dev/add-ins/testing/clear-cache
+  assert.equal(
+    typeof installModule.purgeCachedCopilotAddin,
+    'undefined',
+    'the per-file Office cache purge must not come back'
+  );
 
-  const removed = await purgeCachedCopilotAddin(cache);
-  assert.equal(removed, 2);
-  assert.equal(fs.existsSync(path.join(cache, 'Manifests', 'old-nodus')), false);
-  assert.equal(fs.existsSync(path.join(cache, 'Other', 'old-label')), false);
-  assert.equal(fs.existsSync(path.join(cache, 'Other', 'keep')), true);
+  // Only macOS and Windows have a Word sideload catalog; elsewhere install bails out early.
+  if (process.platform === 'darwin' || process.platform === 'win32') {
+    const fakeHome = path.join(root, 'home');
+    const cache =
+      process.platform === 'darwin'
+        ? path.join(
+            fakeHome,
+            'Library/Containers/com.microsoft.Word/Data/Library/Application Support/Microsoft/Office/16.0/Wef'
+          )
+        : path.join(fakeHome, 'AppData/Local/Microsoft/Office/16.0/Wef');
+    const manifestDir =
+      process.platform === 'darwin'
+        ? path.join(fakeHome, 'Library/Containers/com.microsoft.Word/Data/Documents/wef')
+        : cache;
+    fs.mkdirSync(path.join(cache, 'Manifests'), { recursive: true });
+    fs.writeFileSync(path.join(cache, 'Manifests', 'cached-nodus'), '<Id>E4352919-FFEC-4F77-8268-975BB4217FAD</Id>');
+    fs.writeFileSync(path.join(cache, 'Word.RibbonCache.es-ES'), 'Nodus Copilot\nClaude in Microsoft Office');
+
+    // install.ts calls os.homedir() at call time, so patching the shared CJS
+    // module object redirects it. The ESM namespace object is read-only.
+    const osModule = require('node:os');
+    const originalHomedir = osModule.homedir;
+    const originalLocalAppData = process.env.LOCALAPPDATA;
+    osModule.homedir = () => fakeHome;
+    process.env.LOCALAPPDATA = path.join(fakeHome, 'AppData/Local');
+    let result;
+    try {
+      result = await installCopilotAddin(repoRoot, '0.7.20');
+    } finally {
+      osModule.homedir = originalHomedir;
+      if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+      else process.env.LOCALAPPDATA = originalLocalAppData;
+    }
+
+    assert.equal(result.ok, true, result.message);
+    assert.equal(fs.existsSync(path.join(manifestDir, 'nodus-copilot.manifest.xml')), true);
+    assert.equal(fs.existsSync(path.join(cache, 'Manifests', 'cached-nodus')), true, 'install must not touch the Office cache');
+    assert.equal(
+      fs.existsSync(path.join(cache, 'Word.RibbonCache.es-ES')),
+      true,
+      'install must not delete the shared ribbon cache'
+    );
+  }
   console.log('copilot add-in manifest/cache test passed');
 } finally {
   await rm(root, { recursive: true, force: true });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2460,8 +2460,6 @@ export interface CopilotInstallResult {
   ok: boolean;
   message: string;
   manifestPath: string | null;
-  /** Number of stale Nodus add-in cache entries removed from Office's Wef cache. */
-  cacheEntriesRemoved?: number;
 }
 
 /** Navigation request emitted by the local Word add-in server into the renderer. */

--- a/word-addin/README.md
+++ b/word-addin/README.md
@@ -40,10 +40,23 @@ complemento y una pequeña API JSON **en el mismo origen HTTPS local**
 2. **Activa** el toggle "Activar copiloto para Word". Verás `Activo:
    https://localhost:4320/addin/taskpane.html`.
 3. Pulsa **Instalar/actualizar en Word**. Nodus copia un manifiesto con el puerto
-   actual al catálogo local de Word, actualiza su versión para que Office no
-   reutilice una cinta antigua y limpia entradas cacheadas de Nodus en Wef.
-   Reinicia Word si el complemento ya estaba cargado. En Word verás una pestaña
-   propia **Nodus** con el botón **Nodus Copilot**.
+   actual al catálogo local de Word (`…/com.microsoft.Word/Data/Documents/wef` en
+   macOS) y actualiza su versión, que es la vía admitida para que Office recoja un
+   manifiesto cambiado. **Nodus no toca la caché de complementos de Office**:
+   borrar archivos sueltos de ella está documentado como algo que puede dejar de
+   cargar *todos* los complementos.
+4. Cierra Word del todo (`Cmd+Q`) y vuelve a abrirlo — Word solo lee ese catálogo
+   al arrancar. El complemento aparece en **Inicio → Complementos**; al abrirlo la
+   primera vez añade su pestaña propia **Nodus** con el botón **Nodus Copilot**.
+
+> **Si no aparece en la lista de complementos**: no es el manifiesto. Office para
+> Mac arrastra desde la versión 16.100 una regresión de complementos web, y hay un
+> fallo abierto ([office-js#6597](https://github.com/OfficeDev/office-js/issues/6597))
+> que afecta **solo a cuentas de trabajo/estudios**: el catálogo se queda vacío y
+> no registra ningún complemento, ni de carpeta local ni de la tienda. Se
+> reconoce en que tampoco aparecen los complementos de tienda que sí tenías. El
+> vaciado completo de caché que documenta Microsoft no lo resuelve; probar con
+> una cuenta personal sí distingue el caso.
 
 ## Uso diario
 - Abre Nodus (con el copiloto activado) y Word. En la pestaña **Nodus**, abre el


### PR DESCRIPTION
Fixes #235.

## What was wrong

`installCopilotAddin` ran `purgeCachedCopilotAddin` on every install: it walked Office's Wef cache and unlinked any file containing `nodus` or the add-in GUID, so Word would not reuse a stale ribbon.

Microsoft documents that as harmful — ["When you clear the Office cache, clear it completely. Don't delete individual manifest files. This can cause all add-ins to stop loading."](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/clear-cache) — and the purge was not surgical anyway: the scanned tree contains `AppCommands/<version>/Word.RibbonCache.<locale>`, the index shared by every installed add-in, which lists Nodus and therefore matched the filter.

## What changed

- `electron/copilot/install.ts` — the purge is gone. The installer writes the manifest and bumps its `<Version>`, which is the sanctioned way to make Office pick up a changed manifest. A comment records why the cache must never be touched file by file.
- `scripts/test-copilot-addin.mjs` — the old test asserted the purge deleted the right files. It now runs a real install against a fake home directory and asserts the Office cache, including the shared ribbon cache, survives untouched; it also asserts the purge is no longer exported.
- `shared/types.ts` — drops the now-meaningless `cacheEntriesRemoved` field.
- `word-addin/README.md` — documents the actual install flow (quit Word fully, then **Inicio → Complementos**; the custom tab appears once the add-in is opened) instead of promising an automatic ribbon tab, and adds a troubleshooting note for the unrelated Microsoft-side failure below.

## Verification

- `scripts/test-copilot-addin.mjs` and `scripts/test-copilot-certs.mjs` pass.
- The new guard was mutation-tested: re-adding a single cache deletion to the install path makes it fail with `install must not delete the shared ribbon cache`.
- `tsc --noEmit` and `eslint` clean.

## Out of scope

The machine where this surfaced also hits a separate, Microsoft-side failure: Word for Mac 16.109.3 with a work/school account registers **no** add-ins at all — not sideloaded manifests (a minimal control manifest with a fresh GUID was ignored too), not previously working store add-ins — even after the full documented cache clear. That matches [OfficeDev/office-js#6597](https://github.com/OfficeDev/office-js/issues/6597) and the reports of web add-ins breaking in Office for Mac since 16.100. This PR does not attempt to work around it; the README note lets users tell the two failures apart.