### PR TITLE
Offer the tutorials as video, in-app, alongside the written guide

### DIFF
--- a/docs/tutorials.json
+++ b/docs/tutorials.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Published video tutorials, read by Nodus when a user opens a tutorial grid (see shared/tutorialVideos.ts). Adding an entry here reaches installed copies without a release. Rules the app enforces on this file: `id` is a lowercase slug, `youtubeId` must be exactly 11 YouTube-id characters, `order` sets the position, `icon` must be one of the allowed names (play, network, archive, sparkles, graduation, layers, tree, table, chartBar, microphone, image, tools, star), `vaultType` may name a vault so its tour offers the video, and `copy` carries the title/description per language (es, en, fr, tr, de, it, pt, pt-BR, zh, ja, ru, uk). A new entry with no usable copy is dropped; a built-in id may omit copy and keep the translations compiled into the app. Malformed entries are ignored one by one, and this file can never hide a tutorial the app already ships.",
+  "videos": [
+    { "id": "essentials", "youtubeId": "QqSY1_DeDRM", "order": 1, "icon": "network" },
+    { "id": "academic", "youtubeId": "Z-5CpJBVV_I", "order": 2, "icon": "archive", "vaultType": "academic" },
+    { "id": "nodi", "youtubeId": "5OTe5CtefME", "order": 3, "icon": "sparkles" }
+  ]
+}

--- a/electron/db/appPrefs.ts
+++ b/electron/db/appPrefs.ts
@@ -39,6 +39,7 @@ export const GLOBAL_PREF_KEYS = [
   'mascotOrbColorMode',
   'mascotOrbColor',
   'basicsTutorialVersion',
+  'tutorialVideosWatched',
   'recoverySetupVersion',
   'backupVaultIds',
   'backupIncludePreferences',

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -124,6 +124,7 @@ const DEFAULTS: Omit<AppSettings, 'providerKeys' | 'lockedProviderKeys'> = {
   unpaywallEmail: '',
   onboardingComplete: false,
   basicsTutorialVersion: 0,
+  tutorialVideosWatched: [],
   tourComplete: false,
   advancedTourComplete: true,
   demoMode: false,

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -347,6 +347,7 @@ import {
   inspectRecoveryFolder,
   restoreRecoverySnapshot,
 } from './recovery/recoveryManager';
+import { getTutorialCatalogue } from './tutorialCatalogue';
 import { buildSyncPackage, mergeSyncPackage } from './export/syncPackage';
 import { clearSuperseded, countSuperseded, listSuperseded, restoreSuperseded } from './db/syncSupersededRepo';
 import { clearSyncPassphrase, getSyncPassphrase, hasSyncPassphrase, setSyncPassphrase } from './secrets/secretStore';
@@ -3504,6 +3505,8 @@ export function registerIpc(
     );
     return { ok: true, message: filePath };
   });
+  // Never rejects: the built-in list is always a complete answer (see tutorialCatalogue).
+  h('tutorials:catalogue', async () => getTutorialCatalogue());
   h('recovery:status', async () => getRecoveryStatus());
   h('recovery:chooseFolder', async (_e, mode: 'create' | 'restore', language: AppLanguage = 'es') => {
     const titles: Record<AppLanguage, string> = {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -26,6 +26,7 @@ import { restorePersistedDockIcon } from './dockIcon';
 import { stopAllWhisperCpp } from './stt/whisperCpp';
 import { recoverLegacyApiKeys } from './secrets/legacySecretRecovery';
 import type { UpdateCheckResponse, UpdateProgressEvent } from '@shared/types';
+import { TUTORIAL_VIDEO_EMBED_ORIGIN } from '@shared/tutorialVideos';
 import { killChatGptSubscriptionServer } from './ai/codexSubscription';
 import { stopGitHubCopilotSubscription } from './ai/githubCopilotSubscription';
 import { installProcessSafetyNet } from './util/processSafety';
@@ -475,6 +476,18 @@ app.whenReady().then(() => {
     .replace(/\s+/g, ' ')
     .trim();
   session.defaultSession.setUserAgent(cleanUa);
+  // Same embeds, second obstacle: a packaged renderer is served from file://, so the
+  // frame request carries no http(s) referer and YouTube answers with its "error 153 —
+  // video player configuration error" card instead of the video. Only in packaged
+  // builds; from the dev server it works, which is exactly how this ships broken.
+  // Naming Nodus's own site as the embedding page is enough, and it is where these
+  // tutorials are published. Scoped to the one host Nodus ever frames.
+  session.defaultSession.webRequest.onBeforeSendHeaders(
+    { urls: [`${TUTORIAL_VIDEO_EMBED_ORIGIN}/*`] },
+    (details, callback) => {
+      callback({ requestHeaders: { ...details.requestHeaders, Referer: 'https://drakonis96.github.io/nodus/' } });
+    },
+  );
   // Nodus Toolkit OCR caches its Tesseract language traineddata here (the one
   // opt-in network call), so downloads persist across sessions in userData.
   if (!process.env.NODUS_TESSDATA_CACHE) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1174,6 +1174,7 @@ const api: NodusApi = {
   chooseBackupFolder: () => ipcRenderer.invoke('backup:chooseFolder'),
   runBackupNow: () => ipcRenderer.invoke('backup:runNow'),
   saveBackupRecoveryKit: () => ipcRenderer.invoke('backup:saveRecoveryKit'),
+  getTutorialCatalogue: () => ipcRenderer.invoke('tutorials:catalogue'),
   getRecoveryStatus: () => ipcRenderer.invoke('recovery:status'),
   chooseRecoveryFolder: (mode, language) => ipcRenderer.invoke('recovery:chooseFolder', mode, language),
   initializeRecoveryFolder: (folder, password, language) => ipcRenderer.invoke('recovery:initialize', folder, password, language),

--- a/electron/tutorialCatalogue.ts
+++ b/electron/tutorialCatalogue.ts
@@ -1,0 +1,104 @@
+import { app, net } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  mergeTutorialCatalogue,
+  parseTutorialCatalogue,
+  TUTORIAL_CATALOGUE_URL,
+  TUTORIAL_VIDEOS,
+  type TutorialVideo,
+} from '@shared/tutorialVideos';
+
+/**
+ * The published tutorial list, so a video recorded after this release still shows up.
+ *
+ * Deliberately main-process only: fetching from the renderer would mean adding a
+ * second remote host to the CSP, and the renderer never needs to talk to it. Fetched
+ * when the user opens a grid — not at startup — and the answer is cached in userData
+ * so the next launch has the list even offline.
+ *
+ * Failure is not an error state here: the built-in list is always a complete, working
+ * answer, so a timeout, a 404 or a corrupt file just means the user sees this build's
+ * three tutorials.
+ */
+
+const CACHE_FILE = 'tutorial-catalogue.json';
+const FETCH_TIMEOUT_MS = 4_000;
+/** One check per app run is plenty for a list that changes a few times a year. */
+let inFlight: Promise<TutorialVideo[]> | null = null;
+
+function cachePath(): string {
+  return path.join(app.getPath('userData'), CACHE_FILE);
+}
+
+/** Overridable so a verification run can serve a catalogue without publishing one. */
+function catalogueUrl(): string {
+  return process.env.NODUS_TUTORIAL_CATALOGUE_URL || TUTORIAL_CATALOGUE_URL;
+}
+
+function readCache(): TutorialVideo[] {
+  try {
+    const raw = JSON.parse(fs.readFileSync(cachePath(), 'utf8'));
+    return parseTutorialCatalogue(raw).videos;
+  } catch {
+    return [];
+  }
+}
+
+function writeCache(raw: unknown): void {
+  try {
+    fs.writeFileSync(cachePath(), JSON.stringify(raw), 'utf8');
+  } catch (error) {
+    console.warn('[tutorials] could not cache the catalogue:', error);
+  }
+}
+
+async function fetchCatalogue(): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    // Electron's net stack, so the app's proxy configuration applies.
+    // A cache-buster in the query rather than `cache: 'no-cache'`, which Electron's
+    // fetch typing does not accept; GitHub Pages caches aggressively otherwise.
+    const url = `${catalogueUrl()}?t=${Math.floor(Date.now() / 60_000)}`;
+    const response = await net.fetch(url, { signal: controller.signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Built-in videos plus anything published since, as the renderer should render them.
+ * Never rejects.
+ */
+export async function getTutorialCatalogue(): Promise<TutorialVideo[]> {
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const raw = await fetchCatalogue();
+      const { videos, rejected } = parseTutorialCatalogue(raw);
+      if (rejected > 0) console.warn(`[tutorials] ignored ${rejected} malformed catalogue entr${rejected === 1 ? 'y' : 'ies'}`);
+      if (videos.length === 0) throw new Error('catalogue had no usable entries');
+      writeCache(raw);
+      return mergeTutorialCatalogue(videos);
+    } catch (error) {
+      const cached = readCache();
+      if (cached.length > 0) {
+        console.log('[tutorials] using the cached catalogue:', error instanceof Error ? error.message : error);
+        return mergeTutorialCatalogue(cached);
+      }
+      console.log('[tutorials] using the built-in list:', error instanceof Error ? error.message : error);
+      return [...TUTORIAL_VIDEOS];
+    }
+  })();
+  // A failed check must not be remembered as "already done" for the whole run.
+  inFlight.catch(() => { inFlight = null; });
+  return inFlight;
+}
+
+/** Test seam: forget this run's answer. */
+export function resetTutorialCatalogueCache(): void {
+  inFlight = null;
+}

--- a/index.html
+++ b/index.html
@@ -9,10 +9,13 @@
       runtime + the Piper voice models are fetched on demand from their CDNs /
       Hugging Face (voices are then cached locally in OPFS and reused offline).
       media-src blob: lets generated and recorded clips play back from object URLs.
+      frame-src is the ONE remote frame Nodus embeds: the video tutorials, on YouTube's
+      no-cookie host (see shared/tutorialVideos.ts). Nothing loads it until the user
+      opens a tutorial, and the written guide covers the same ground offline.
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob: data: 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org; font-src 'self' data:; media-src 'self' blob: data:; connect-src 'self' https://huggingface.co https://*.huggingface.co https://*.hf.co https://*.xethub.hf.co https://cdn.jsdelivr.net https://cdnjs.cloudflare.com"
+      content="default-src 'self'; script-src 'self' blob: data: 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; worker-src 'self' blob:; child-src 'self' blob:; frame-src https://www.youtube-nocookie.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org; font-src 'self' data:; media-src 'self' blob: data:; connect-src 'self' https://huggingface.co https://*.huggingface.co https://*.hf.co https://*.xethub.hf.co https://cdn.jsdelivr.net https://cdnjs.cloudflare.com"
     />
     <title>Nodus</title>
   </head>

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -157,6 +157,10 @@ try {
     pageErrors.push(err);
     process.stderr.write(`[e2e][pageerror] ${err?.stack ?? err}\n`);
   });
+  // Kept so the tutorial walk can prove the CSP actually admits the video embed: a
+  // blocked frame never attaches, it only logs "Refused to frame …".
+  const consoleMessages = [];
+  page.on('console', (message) => { consoleMessages.push(message.text()); });
   await page.waitForLoadState('domcontentloaded');
   await page.waitForFunction(() => {
     const root = document.getElementById('root');
@@ -233,6 +237,41 @@ try {
     const settings = await window.nodus.getSettings();
     return settings.mascotStyle === 'classic' && settings.mascotStyleChosen === true;
   }));
+  // Third screen: watch the tutorials or read the deck. Walk the video path first —
+  // including the player, whose embed the CSP has to admit — then come back to the
+  // written guide, which is the offline path the rest of this walk relies on.
+  await page.getByTestId('basics-tutorial-mode').waitFor({ timeout: 30_000 });
+  await page.getByText('Comment préférez-vous apprendre ?', { exact: true }).waitFor();
+  await page.getByTestId('tutorial-mode-video').click();
+  await page.getByTestId('basics-tutorial-videos').waitFor({ timeout: 30_000 });
+  assert.equal(await page.locator('.tutorial-video-card').count(), 3, 'the video mode lists the three published tutorials');
+  assert.match(
+    await page.getByTestId('tutorial-videos-more').innerText(),
+    /D’autres tutoriels arrivent bientôt/,
+    'the promise of more tutorials is translated, not left in Spanish'
+  );
+  await page.getByTestId('tutorial-video-play-essentials').click();
+  const videoPlayer = page.getByTestId('tutorial-video-player');
+  await videoPlayer.waitFor({ timeout: 30_000 });
+  const embedSrc = (await videoPlayer.locator('iframe').getAttribute('src')) ?? '';
+  assert.match(embedSrc, /^https:\/\/www\.youtube-nocookie\.com\/embed\/QqSY1_DeDRM\?/, 'the player embeds the no-cookie host');
+  assert.match(embedSrc, /hl=fr/, 'the embed follows the language chosen for the tutorial');
+  assert.equal(await videoPlayer.locator('iframe[allowfullscreen]').count(), 1, 'the embedded player can go fullscreen');
+  await waitForCondition('vídeo marcado como visto', () => page.evaluate(async () => {
+    const settings = await window.nodus.getSettings();
+    return Array.isArray(settings.tutorialVideosWatched) && settings.tutorialVideosWatched.includes('essentials');
+  }));
+  await page.getByTestId('tutorial-video-close').click();
+  await videoPlayer.waitFor({ state: 'detached' });
+  assert.equal(
+    await page.getByTestId('tutorial-video-card-essentials').getAttribute('data-watched'),
+    'true',
+    'the card reflects the watched flag once the player closes'
+  );
+  const framingRefusals = consoleMessages.filter((text) => /Refused to frame/i.test(text));
+  assert.deepEqual(framingRefusals, [], `the CSP admits the tutorial embed: ${framingRefusals.join(' | ')}`);
+  await page.getByTestId('tutorial-mode-switch-text').click();
+
   await page.getByTestId('basics-tutorial').waitFor({ timeout: 30_000 });
   // French now has a full UI translation, so choosing it keeps the French interface
   // instead of borrowing the English one.

--- a/scripts/test-tutorial-videos.mjs
+++ b/scripts/test-tutorial-videos.mjs
@@ -1,0 +1,315 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The video tutorials are the one place Nodus embeds a remote frame, and the one place
+// the tutorial's twelve languages are served from a table that is NOT the i18n one.
+// Both facts are load-bearing, so they are pinned here.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const read = (file) => readFile(path.join(repoRoot, file), 'utf8');
+
+// shared/tutorialVideos.ts only imports types, so a plain esbuild bundle is enough.
+const outDir = await mkdtemp(path.join(os.tmpdir(), 'nodus-tutorial-videos-'));
+const bundle = path.join(outDir, 'tutorialVideos.cjs');
+execFileSync(
+  path.join(repoRoot, 'node_modules/.bin/esbuild'),
+  [path.join(repoRoot, 'shared/tutorialVideos.ts'), '--bundle', '--platform=node', '--format=cjs', '--target=es2022', `--outfile=${bundle}`],
+  { cwd: repoRoot, stdio: 'inherit' }
+);
+const catalogue = require(bundle);
+
+test.after(() => rm(outDir, { recursive: true, force: true }));
+
+// ── the catalogue ───────────────────────────────────────────────────────────────
+
+test('the three published tutorials keep their ids, order and vault mapping', () => {
+  assert.deepEqual(
+    catalogue.TUTORIAL_VIDEOS.map((video) => [video.id, video.youtubeId, video.order]),
+    [
+      ['essentials', 'QqSY1_DeDRM', 1],
+      ['academic', 'Z-5CpJBVV_I', 2],
+      ['nodi', '5OTe5CtefME', 3],
+    ]
+  );
+  // Only the academic tour can currently be replaced by a video; the other vault tours
+  // must keep their two-option opening step until their own video exists.
+  assert.equal(catalogue.tutorialVideoForVault('academic').id, 'academic');
+  for (const type of ['estudio', 'genealogy', 'databases', 'docencia', 'primary_sources']) {
+    assert.equal(catalogue.tutorialVideoForVault(type), undefined, `${type} has no video yet`);
+  }
+  assert.equal(catalogue.tutorialVideoForVault(undefined), undefined);
+});
+
+test('embeds go to the no-cookie host, in the tutorial language', () => {
+  const video = catalogue.tutorialVideo('essentials');
+  const url = new URL(catalogue.youtubeEmbedUrl(video, 'ja'));
+  assert.equal(url.origin, 'https://www.youtube-nocookie.com');
+  assert.equal(url.pathname, '/embed/QqSY1_DeDRM');
+  assert.equal(url.searchParams.get('hl'), 'ja');
+  assert.equal(url.searchParams.get('rel'), '0', 'the end screen stays on this channel');
+  assert.equal(catalogue.youtubeWatchUrl(video), 'https://www.youtube.com/watch?v=QqSY1_DeDRM');
+  assert.equal(catalogue.TUTORIAL_VIDEO_EMBED_ORIGIN, 'https://www.youtube-nocookie.com');
+});
+
+test('every language the cinematic guide offers has full video copy', async () => {
+  const tutorial = await read('src/views/BasicsTutorial.tsx');
+  // The languages are declared once, in the guide's own picker. Read them from there so
+  // adding a thirteenth language fails here instead of silently serving it English.
+  const codes = [...tutorial.matchAll(/\{ code: '([\w-]+)', label:/g)].map((match) => match[1]);
+  assert.equal(codes.length, 12, `the guide offers twelve languages, found ${codes.length}`);
+
+  const spanish = catalogue.tutorialVideoCopy('es');
+  for (const code of codes) {
+    const copy = catalogue.tutorialVideoCopy(code);
+    for (const key of ['tutorialWord', 'chooseTitle', 'chooseLede', 'gridTitle', 'gridLede', 'more', 'watched', 'markUnwatched', 'openExternal', 'hosting', 'close', 'play', 'tourVideo']) {
+      assert.ok(typeof copy[key] === 'string' && copy[key].trim().length > 0, `${code}.${key} is missing`);
+    }
+    for (const option of ['videoOption', 'textOption']) {
+      assert.ok(copy[option].title.trim().length > 0, `${code}.${option}.title is missing`);
+      assert.ok(copy[option].body.trim().length > 0, `${code}.${option}.body is missing`);
+    }
+    assert.ok(copy.videoOption.badge.trim().length > 0, `${code} does not mark the recommended option`);
+    for (const id of ['essentials', 'academic', 'nodi']) {
+      assert.ok(copy.videos[id].title.trim().length > 0, `${code}.videos.${id}.title is missing`);
+      assert.ok(copy.videos[id].body.trim().length > 0, `${code}.videos.${id}.body is missing`);
+    }
+    if (code === 'es') continue;
+    // A table that merely falls back to Spanish would satisfy every check above.
+    assert.notEqual(copy.more, spanish.more, `${code} falls back to the Spanish "more on the way"`);
+    assert.notEqual(copy.videos.essentials.title, spanish.videos.essentials.title, `${code} falls back to Spanish video titles`);
+  }
+});
+
+test('"more tutorials on the way" is promised in every language', () => {
+  for (const code of ['es', 'en', 'fr', 'tr', 'de', 'it', 'pt', 'pt-BR', 'zh', 'ja', 'ru', 'uk']) {
+    assert.ok(catalogue.tutorialVideoCopy(code).more.length > 0, `${code} says nothing about more tutorials`);
+  }
+  assert.match(catalogue.tutorialVideoCopy('en').more, /more/i);
+  assert.match(catalogue.tutorialVideoCopy('es').more, /próximamente/i);
+  // An unknown code must not crash the grid; English is the documented fallback.
+  assert.equal(catalogue.tutorialVideoCopy('xx').more, catalogue.tutorialVideoCopy('en').more);
+});
+
+// ── the surfaces ────────────────────────────────────────────────────────────────
+
+test('the CSP admits the tutorial embed and nothing wider', async () => {
+  const html = await read('index.html');
+  assert.match(html, /frame-src https:\/\/www\.youtube-nocookie\.com;/, 'frame-src names the no-cookie host');
+  // frame-src overrides child-src for frames, so youtube.com proper must stay out: the
+  // watch page is opened in the system browser, never framed.
+  assert.doesNotMatch(html, /frame-src[^;]*https:\/\/www\.youtube\.com/);
+});
+
+test('the grid never reaches Google until a video is opened', async () => {
+  const grid = await read('src/components/TutorialVideos.tsx');
+  // Posters are local: a gradient, or a WebP dropped into src/assets/tutorials/. A
+  // remote thumbnail would make the mere sight of the grid a request to Google.
+  assert.doesNotMatch(grid, /ytimg|img\.youtube|<img/);
+  assert.match(grid, /video\.poster/);
+  assert.match(grid, /import\.meta\.glob<string>\('\.\.\/assets\/tutorials\/\*/);
+  // The one request the grid does make is the catalogue, and it goes through the main
+  // process — the renderer's CSP knows nothing about that host.
+  assert.match(grid, /window\.nodus\.getTutorialCatalogue\(\)/);
+  const html = await read('index.html');
+  assert.doesNotMatch(html, /connect-src[^;]*drakonis96/);
+  // The iframe only exists inside the player, which is mounted on click.
+  assert.match(grid, /\{playing && <TutorialVideoPlayer/);
+  assert.match(grid, /allowFullScreen/, 'the player can go fullscreen');
+  assert.match(grid, /allow="autoplay; encrypted-media; fullscreen; picture-in-picture"/);
+  assert.match(grid, /void markWatched\(video\.id\)/, 'opening a video marks it watched');
+  assert.match(grid, /unmarkWatched/, 'and the user can undo that');
+  assert.match(grid, /openExternal\(youtubeWatchUrl\(video\)\)/, 'the browser stays available as a fallback');
+});
+
+test('the watched flags are app-wide, like the tutorial version they sit next to', async () => {
+  const [types, defaults, prefs] = await Promise.all([
+    read('shared/types.ts'),
+    read('electron/db/settingsRepo.ts'),
+    read('electron/db/appPrefs.ts'),
+  ]);
+  assert.match(types, /tutorialVideosWatched: string\[\]/);
+  assert.match(defaults, /tutorialVideosWatched: \[\]/);
+  assert.match(prefs, /'tutorialVideosWatched'/, 'a video watched in one vault stays watched in the others');
+});
+
+test('the cinematic guide offers video or text, and both complete it', async () => {
+  const tutorial = await read('src/views/BasicsTutorial.tsx');
+  // The choice is the third gate: it must come AFTER the two mandatory ones, so the
+  // cards and the grid are already in the chosen language.
+  const languageGate = tutorial.indexOf("if (!tutorialLanguage) return");
+  const styleGate = tutorial.indexOf('if (!styleChosen) return');
+  const modeGate = tutorial.indexOf('if (!learnMode) return');
+  assert.ok(languageGate > 0 && styleGate > languageGate && modeGate > styleGate, 'language → Nodi → learning mode');
+  assert.match(tutorial, /data-testid="basics-tutorial-mode"/);
+  assert.match(tutorial, /data-testid="tutorial-mode-video"/);
+  assert.match(tutorial, /data-testid="tutorial-mode-text"/);
+  assert.match(tutorial, /tutorial-mode-option recommended/, 'the video path is the recommended one');
+  assert.match(tutorial, /data-testid="basics-tutorial-videos"/);
+  assert.match(tutorial, /<TutorialVideoGrid language=\{activeLanguage\} variant="cinema" \/>/);
+  // Skippable from the video screen, and completable from it too.
+  assert.match(tutorial, /data-testid="tutorial-mode-switch-text"/);
+  const videoScreen = tutorial.slice(tutorial.indexOf('basics-tutorial-videos'));
+  assert.match(videoScreen.slice(0, 1400), /data-testid="basics-tutorial-complete"/);
+  assert.match(videoScreen.slice(0, 1400), /\{skipDialog\}/);
+  // The deck's arrow keys must not run while the grid or the gates are on screen.
+  assert.match(tutorial, /if \(!tutorialLanguage \|\| !styleChosen \|\| learnMode !== 'text'\) return;/);
+});
+
+test('Settings leads its tutorials section with the grid', async () => {
+  const settings = await read('src/views/Settings.tsx');
+  assert.match(settings, /<TutorialVideoGrid language=\{settings\.uiLanguage\} variant="panel" \/>/);
+  const gridAt = settings.indexOf('<TutorialVideoGrid');
+  const replayAt = settings.indexOf('basics-tutorial-replay');
+  assert.ok(gridAt > 0 && gridAt < replayAt, 'the videos come before the replay buttons');
+  const css = await read('src/components/tutorialVideos.css');
+  assert.match(css, /\.light \.tutorial-videos-panel \.tutorial-video-card/, 'the Settings grid is remapped for light mode');
+  assert.match(css, /\.light \.tutorial-video-player/);
+});
+
+test('a vault tour with a video offers three ways in', async () => {
+  const [engine, tour] = await Promise.all([read('src/views/tourEngine.tsx'), read('src/views/Tour.tsx')]);
+  assert.match(engine, /vaultType\?: VaultType/);
+  assert.match(engine, /data-testid="tour-watch-video"/);
+  assert.match(engine, /tutorialVideoCopy\(getActiveLang\(\)\)\.tourVideo/);
+  // "Sí, enséñame" stays, demoted to secondary, and "Ahora no" is untouched: three
+  // options, with the video recommended.
+  assert.match(engine, /Sí, enséñame/);
+  assert.match(engine, /Ahora no/);
+  assert.match(engine, /video \? 'btn btn-ghost border border-neutral-700' : 'btn btn-primary'/);
+  // Three buttons do not fit side by side in a 360px card: they overflowed it and each
+  // label broke into three lines. The opening step stacks them full-width instead, in
+  // every vault — the layout the rest of the videos will land on.
+  assert.match(engine, /isFirst \? 'flex flex-col gap-3' : 'flex items-center justify-between'/);
+  assert.match(engine, /isFirst \? 'flex flex-col gap-2' : 'flex gap-2'/);
+  assert.equal((engine.match(/className="btn btn-(primary|ghost) w-full"/g) ?? []).length, 2);
+  assert.match(engine, /className=\{`w-full \$\{video \?/);
+  // Escape must reach the player, not dismiss the tour behind it.
+  assert.match(engine, /if \(watchingVideo\) return;/);
+  assert.match(tour, /vaultType="academic"/);
+  // Every vault tour declares its type, so each gains the option the day its own video
+  // is published — without a release and without touching the engine.
+  for (const [file, type] of [
+    ['src/views/StudyTour.tsx', 'estudio'],
+    ['src/views/GenealogyTour.tsx', 'genealogy'],
+    ['src/views/DatabasesTour.tsx', 'databases'],
+    ['src/views/TeachingTour.tsx', 'docencia'],
+  ]) assert.match(await read(file), new RegExp(`vaultType="${type}"`), `${file} declares its vault type`);
+  assert.match(engine, /tutorialVideoForVault\(vaultType, catalogue\)/);
+});
+
+// ── the catalogue: untrusted input from the network ─────────────────────────────
+
+test('the published catalogue can add tutorials and update copy', () => {
+  const { videos, rejected } = catalogue.parseTutorialCatalogue({
+    videos: [
+      { id: 'essentials', youtubeId: 'QqSY1_DeDRM', order: 1, icon: 'network' },
+      {
+        id: 'teaching', youtubeId: 'abcdefghijk', order: 4, icon: 'graduation', vaultType: 'docencia',
+        copy: { es: { title: 'La bóveda de docencia', body: 'Cursos, horarios y clases.' }, en: { title: 'The teaching vault', body: 'Courses, timetables and classes.' } },
+      },
+    ],
+  });
+  assert.equal(rejected, 0);
+  assert.equal(videos.length, 2);
+  const merged = catalogue.mergeTutorialCatalogue(videos);
+  assert.deepEqual(merged.map((video) => video.id), ['essentials', 'academic', 'nodi', 'teaching']);
+  // A new vault video reaches that vault's tour with no code change.
+  assert.equal(catalogue.tutorialVideoForVault('docencia', merged).youtubeId, 'abcdefghijk');
+  // Its own copy is used, in the reader's language, falling back to English.
+  assert.equal(catalogue.videoCopyFor(merged[3], 'es').title, 'La bóveda de docencia');
+  assert.equal(catalogue.videoCopyFor(merged[3], 'ja').title, 'The teaching vault');
+  // Built-in videos keep the compiled translations.
+  assert.equal(catalogue.videoCopyFor(merged[0], 'ja').title, catalogue.tutorialVideoCopy('ja').videos.essentials.title);
+});
+
+test('the catalogue cannot smuggle in anything the app would render blindly', () => {
+  const { videos, rejected } = catalogue.parseTutorialCatalogue({
+    videos: [
+      { id: 'evil', youtubeId: 'https://evil.example/x', order: 1, copy: { en: { title: 'x', body: 'y' } } },
+      { id: 'Evil Slug', youtubeId: 'QqSY1_DeDRM', order: 2, copy: { en: { title: 'x', body: 'y' } } },
+      { id: 'nocopy', youtubeId: 'QqSY1_DeDRM', order: 3 },
+      { id: 'essentials', youtubeId: 'QqSY1_DeDRM', order: 4 },
+      { id: 'essentials', youtubeId: 'QqSY1_DeDRM', order: 5 },
+    ],
+  });
+  // Rejected: a non-YouTube id, a non-slug id, a new entry with no copy, and a duplicate.
+  assert.equal(rejected, 4);
+  assert.deepEqual(videos.map((video) => video.id), ['essentials']);
+
+  // A poster is never taken from the file: a remote CSS value could fetch an image and
+  // break the promise that an unopened grid makes no requests.
+  const injected = catalogue.parseTutorialCatalogue({
+    videos: [{
+      id: 'poster', youtubeId: 'QqSY1_DeDRM', order: 1, icon: '"><script>', poster: 'url(https://evil.example/pixel.png)',
+      copy: { en: { title: 'x', body: 'y' } },
+    }],
+  });
+  assert.equal(injected.videos.length, 1);
+  assert.doesNotMatch(injected.videos[0].poster, /url\(|evil/);
+  assert.equal(injected.videos[0].icon, 'play', 'an icon outside the allowlist falls back');
+
+  // Junk of every shape yields an empty list rather than an exception.
+  for (const raw of [null, undefined, 42, 'nope', {}, { videos: 'nope' }, [], [null, 7, 'x']]) {
+    assert.deepEqual(catalogue.parseTutorialCatalogue(raw).videos, []);
+  }
+});
+
+test('a broken catalogue can never hide a tutorial the app already ships', () => {
+  // Half-written file, wrong ids, empty list: the built-in three survive all of it.
+  for (const remote of [[], catalogue.parseTutorialCatalogue({ videos: [{ id: 'x' }] }).videos]) {
+    assert.deepEqual(
+      catalogue.mergeTutorialCatalogue(remote).map((video) => video.id),
+      ['essentials', 'academic', 'nodi']
+    );
+  }
+});
+
+test('the published file matches what this build ships', async () => {
+  const published = JSON.parse(await read('docs/tutorials.json'));
+  const { videos, rejected } = catalogue.parseTutorialCatalogue(published);
+  assert.equal(rejected, 0, 'every entry in docs/tutorials.json passes the app\'s own validation');
+  assert.deepEqual(
+    videos.map((video) => [video.id, video.youtubeId, video.order]),
+    catalogue.TUTORIAL_VIDEOS.map((video) => [video.id, video.youtubeId, video.order]),
+    'docs/tutorials.json and the built-in list agree'
+  );
+  assert.equal(catalogue.TUTORIAL_CATALOGUE_URL, 'https://drakonis96.github.io/nodus/tutorials.json');
+});
+
+test('the catalogue is fetched in the main process, cached, and never fatal', async () => {
+  const [main, ipc, preload] = await Promise.all([
+    read('electron/tutorialCatalogue.ts'),
+    read('electron/ipc.ts'),
+    read('electron/preload.ts'),
+  ]);
+  assert.match(ipc, /h\('tutorials:catalogue', async \(\) => getTutorialCatalogue\(\)\)/);
+  assert.match(preload, /getTutorialCatalogue: \(\) => ipcRenderer\.invoke\('tutorials:catalogue'\)/);
+  assert.match(main, /net\.fetch\(url, \{ signal: controller\.signal \}\)/, 'uses Electron\'s net stack, so the app proxy applies');
+  assert.match(main, /\$\{catalogueUrl\(\)\}\?t=/, 'and busts the GitHub Pages cache');
+  // The URL is overridable so a verification run can serve a catalogue of its own, but
+  // it must default to the published one — an unset env var cannot change production.
+  assert.match(main, /process\.env\.NODUS_TUTORIAL_CATALOGUE_URL \|\| TUTORIAL_CATALOGUE_URL/);
+  assert.match(main, /FETCH_TIMEOUT_MS = 4_000/);
+  assert.match(main, /controller\.abort\(\)/);
+  assert.match(main, /readCache\(\)/);
+  assert.match(main, /return \[\.\.\.TUTORIAL_VIDEOS\]/, 'the built-in list is the last resort');
+  // A failed check must not be remembered as done for the rest of the run.
+  assert.match(main, /inFlight\.catch\(\(\) => \{ inFlight = null; \}\)/);
+});
+
+test('a packaged renderer still gets the real player, not YouTube error 153', async () => {
+  const main = await read('electron/main.ts');
+  // file:// sends no http referer, and YouTube answers framed embeds without one with
+  // its "video player configuration error" card. Naming the Nodus site fixes it, and
+  // the rewrite must stay scoped to the single host Nodus frames.
+  assert.match(main, /onBeforeSendHeaders\(\s*\{ urls: \[`\$\{TUTORIAL_VIDEO_EMBED_ORIGIN\}\/\*`\] \}/);
+  assert.match(main, /Referer: 'https:\/\/drakonis96\.github\.io\/nodus\/'/);
+  assert.match(main, /import \{ TUTORIAL_VIDEO_EMBED_ORIGIN \} from '@shared\/tutorialVideos'/);
+});

--- a/scripts/verify-tutorial-videos.mjs
+++ b/scripts/verify-tutorial-videos.mjs
@@ -1,0 +1,231 @@
+// End-to-end verification of the video tutorials, driven through the real app.
+//
+// What only a real run can prove:
+//   1. the third gate appears after language and Nodi, in the language just chosen;
+//   2. the CSP actually admits the embed — a blocked frame never attaches, it only
+//      logs "Refused to frame …", which no static check would catch;
+//   3. opening a video records the watched flag app-wide, and the card reflects it;
+//   4. the grid also reads correctly inside Settings, in light mode;
+//   5. the academic tour opens with three ways in.
+//
+// Run with: node scripts/verify-tutorial-videos.mjs   (build first: npm run build)
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = process.env.NODUS_REPO_ROOT ?? path.resolve(import.meta.dirname, '..');
+const shots = process.env.NODUS_VERIFY_SHOTS ?? path.join(os.tmpdir(), 'nodus-tutorial-video-shots');
+const require = createRequire(import.meta.url);
+
+if (!process.argv.includes('--child')) {
+  execFileSync(require('electron'), [import.meta.filename, '--child'], {
+    cwd: repoRoot, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, stdio: 'inherit',
+  });
+  process.exit(0);
+}
+
+const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-tutorial-video-'));
+await mkdir(shots, { recursive: true });
+
+// A stand-in for the published catalogue, so the remote path is actually exercised
+// instead of only its fallback. It adds a fourth tutorial this build knows nothing
+// about — the whole point of the file being remote.
+const PUBLISHED = {
+  videos: [
+    ...JSON.parse(await readFile(path.join(repoRoot, 'docs/tutorials.json'), 'utf8')).videos,
+    {
+      id: 'worldbuilding', youtubeId: 'dQw4w9WgXcQ', order: 4, icon: 'tree', vaultType: 'worldbuilding',
+      copy: {
+        es: { title: 'La bóveda de mundos', body: 'Publicada después de esta versión de Nodus.' },
+        en: { title: 'The worldbuilding vault', body: 'Published after this Nodus build.' },
+      },
+    },
+  ],
+};
+const catalogueServer = createServer((_request, response) => {
+  response.writeHead(200, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify(PUBLISHED));
+});
+await new Promise((resolve) => catalogueServer.listen(0, '127.0.0.1', resolve));
+const cataloguePort = catalogueServer.address().port;
+
+const childEnv = {
+  ...process.env,
+  NODUS_USERDATA: userData,
+  NODUS_DISABLE_AUTO_UPDATE: '1',
+  NODUS_E2E_UPDATE_STATUS: 'not-available',
+  NODUS_TUTORIAL_CATALOGUE_URL: `http://127.0.0.1:${cataloguePort}/tutorials.json`,
+};
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+const app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
+const step = (msg) => console.log(`\n✓ ${msg}`);
+
+/** The startup update check owns the foreground on every launch into the shell. */
+async function dismissStartupUpdate(page) {
+  const modal = page.getByTestId('startup-update-modal');
+  await modal.waitFor({ timeout: 15_000 }).catch(() => {});
+  if (!(await modal.count())) return;
+  await modal.locator('.startup-update-primary').click();
+  await modal.waitFor({ state: 'detached' });
+}
+
+try {
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(30_000);
+  const console_ = [];
+  page.on('console', (message) => console_.push(message.text()));
+  // YouTube's "error 153" card is rendered INSIDE the cross-origin frame, so it cannot
+  // be read from here. Its thumbnail can: the real player pulls a poster from ytimg,
+  // the error card pulls nothing. This needs the network — it is why this lives in a
+  // verify script rather than in the offline e2e smoke.
+  const requested = [];
+  page.on('request', (request) => requested.push(request.url()));
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => !!document.getElementById('root')?.children.length, { timeout: 30_000 });
+  // A fresh profile has never seen this version's release notes, so the what's-new modal
+  // would sit over the app and swallow every later click. The sentinel is an exact
+  // match against the app version, so it has to be the real one.
+  const appVersion = require(path.join(repoRoot, 'package.json')).version;
+  await page.evaluate((version) => localStorage.setItem('nodus.lastSeenVersion', version), appVersion);
+
+  // ── 1. the three gates, in order ──────────────────────────────────────────────
+  await page.getByTestId('basics-tutorial-language').waitFor();
+  await page.getByTestId('tutorial-language-es').click();
+  await page.getByTestId('basics-tutorial-nodi-style').waitFor();
+  await page.getByTestId('nodi-style-classic').click();
+
+  const modeScreen = page.getByTestId('basics-tutorial-mode');
+  await modeScreen.waitFor();
+  await page.getByText('¿Cómo prefieres aprender?', { exact: true }).waitFor();
+  await page.getByText('Más tutoriales próximamente.', { exact: true }).waitFor();
+  await page.screenshot({ path: path.join(shots, '1-learn-mode-choice.png') });
+  step('language → Nodi → "¿Cómo prefieres aprender?", with the video path recommended');
+
+  // ── 2. the grid, and the embed the CSP has to admit ───────────────────────────
+  await page.getByTestId('tutorial-mode-video').click();
+  await page.getByTestId('basics-tutorial-videos').waitFor();
+  // The published catalogue adds a fourth tutorial this build does not contain, so the
+  // grid growing from three to four is the proof that the remote path works.
+  await page.locator('[data-testid="tutorial-video-card-worldbuilding"]').waitFor({ timeout: 15_000 });
+  assert.equal(await page.locator('.tutorial-video-card').count(), 4, 'the grid picks up a tutorial published after this build');
+  await page.getByText('La bóveda de mundos', { exact: true }).waitFor();
+  const cataloguedIds = await page.evaluate(async () => (await window.nodus.getTutorialCatalogue()).map((video) => video.id));
+  assert.deepEqual(cataloguedIds, ['essentials', 'academic', 'nodi', 'worldbuilding']);
+  assert.ok(existsSync(path.join(userData, 'tutorial-catalogue.json')), 'the answer is cached for the next offline launch');
+  // The catalogue grows over time, so the grid must keep fitting the window instead of
+  // pushing the guide sideways.
+  const layout = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+    zoom: window.devicePixelRatio,
+    gridWidth: document.querySelector('.tutorial-video-grid')?.scrollWidth ?? 0,
+    stageWidth: document.querySelector('.tutorial-videos-cinema')?.clientWidth ?? 0,
+  }));
+  assert.ok(
+    layout.scrollWidth <= layout.clientWidth,
+    `the video screen does not scroll sideways with a grown catalogue: ${JSON.stringify(layout)}`
+  );
+  await page.screenshot({ path: path.join(shots, '2-video-grid-cinema.png') });
+  step('the video mode renders the published catalogue, including a tutorial newer than the build');
+
+  await page.getByTestId('tutorial-video-play-essentials').click();
+  const player = page.getByTestId('tutorial-video-player');
+  await player.waitFor();
+  const embedSrc = await player.locator('iframe').getAttribute('src');
+  assert.match(embedSrc ?? '', /^https:\/\/www\.youtube-nocookie\.com\/embed\/QqSY1_DeDRM\?/);
+  // The frame ATTACHING is the proof: the CSP would refuse it outright otherwise.
+  await page.waitForFunction(() => {
+    const frame = document.querySelector('.tutorial-video-frame iframe');
+    return !!frame && !!frame.contentWindow;
+  });
+  const refusals = console_.filter((text) => /Refused to frame/i.test(text));
+  assert.deepEqual(refusals, [], `CSP refused the embed: ${refusals.join(' | ')}`);
+  await page.waitForTimeout(4_000); // let the embed fetch its poster and paint
+  await page.screenshot({ path: path.join(shots, '3-player.png') });
+  assert.ok(
+    requested.some((url) => /ytimg\.com/.test(url)),
+    'the embed rendered the real player (a rejected embed loads no poster) — check the Referer rewrite in main.ts'
+  );
+  step(`the in-app player loads the no-cookie embed with no CSP refusal (${embedSrc})`);
+
+  // ── 3. watched, app-wide ──────────────────────────────────────────────────────
+  const watched = await page.evaluate(async () => (await window.nodus.getSettings()).tutorialVideosWatched);
+  assert.deepEqual(watched, ['essentials'], 'opening the video records it as watched');
+  await page.getByTestId('tutorial-video-close').click();
+  await player.waitFor({ state: 'detached' });
+  assert.equal(await page.getByTestId('tutorial-video-card-essentials').getAttribute('data-watched'), 'true');
+  await page.screenshot({ path: path.join(shots, '4-grid-watched.png') });
+  step('the flag survives the player closing and the card shows it');
+
+  // Leaving through the video path still completes the guide.
+  await page.getByTestId('basics-tutorial-complete').click();
+  await page.waitForFunction(async () => (await window.nodus.getSettings()).basicsTutorialVersion > 0);
+  step('finishing from the video screen completes the essential guide');
+
+  // ── 4. the same grid in Settings, in light mode ───────────────────────────────
+  await page.evaluate(() => window.nodus.updateSettings({
+    onboardingComplete: true, recoverySetupVersion: 1, tourComplete: true, advancedTourComplete: true, theme: 'light',
+  }));
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor();
+  await dismissStartupUpdate(page);
+  await page.locator('[data-tour="nav-settings"]').click();
+  await page.getByRole('button', { name: 'Tutoriales', exact: true }).click();
+  const settingsGrid = page.getByTestId('tutorial-video-grid').first();
+  await settingsGrid.waitFor();
+  await settingsGrid.scrollIntoViewIfNeeded();
+  // Same catalogue here, so Settings also shows the tutorial published after the build.
+  assert.equal(await settingsGrid.locator('.tutorial-video-card').count(), 4, 'Settings lists the same catalogue as the guide');
+  await page.getByTestId('basics-tutorial-replay').waitFor();
+  await page.screenshot({ path: path.join(shots, '5-settings-grid-light.png') });
+  step('Settings → Tutoriales leads with the same grid, readable in light mode');
+
+  // ── 5. the academic tour opens with three ways in ─────────────────────────────
+  await page.evaluate(() => window.nodus.updateSettings({ theme: 'dark', tourComplete: false }));
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor();
+  await dismissStartupUpdate(page);
+  const tourCard = page.getByTestId('tour-card');
+  await tourCard.waitFor();
+  await tourCard.getByTestId('tour-watch-video').waitFor();
+  for (const label of ['Ahora no', 'Sí, enséñame']) {
+    assert.equal(await tourCard.getByRole('button', { name: label, exact: true }).count(), 1, `${label} is still offered`);
+  }
+  await page.screenshot({ path: path.join(shots, '6-tour-three-options.png') });
+  const tourBox = await tourCard.boundingBox();
+  for (const label of ['tour-watch-video']) {
+    const box = await tourCard.getByTestId(label).boundingBox();
+    assert.ok(
+      box.x >= tourBox.x && box.x + box.width <= tourBox.x + tourBox.width,
+      `${label} stays inside the tour card (${JSON.stringify(box)} vs ${JSON.stringify(tourBox)})`
+    );
+  }
+  step('the academic tour offers video (recommended), in-app walkthrough and "not now"');
+
+  // ── 6. a vault WITHOUT a video keeps a clean two-option card ──────────────────
+  await page.evaluate(async () => {
+    const vaults = await window.nodus.listVaults();
+    await window.nodus.setVaultType(vaults[0].id, 'estudio');
+    await window.nodus.updateSettings({ studyTourComplete: false });
+  });
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor();
+  await dismissStartupUpdate(page);
+  const studyCard = page.getByTestId('tour-card');
+  await studyCard.waitFor();
+  assert.equal(await studyCard.getByTestId('tour-watch-video').count(), 0, 'no video is offered where none is published yet');
+  await page.screenshot({ path: path.join(shots, '7-tour-without-video.png') });
+  step('a vault with no video yet still opens with "Sí, enséñame" / "Ahora no"');
+
+  console.log(`\nScreenshots: ${shots}`);
+} finally {
+  await app.close();
+  catalogueServer.close();
+}

--- a/shared/tutorialVideos.ts
+++ b/shared/tutorialVideos.ts
@@ -1,0 +1,532 @@
+import type { TutorialLanguage } from './tutorialPreferences';
+import { isVaultType, type VaultType } from './vaultTypes';
+
+/**
+ * The published video tutorials, and every string that describes them.
+ *
+ * The videos are streamed from YouTube rather than bundled: the installers already
+ * weigh 460–939 MB, and three ~15-minute captures would add hundreds of megabytes
+ * to every platform for material most users watch once. Streaming also means a new
+ * tutorial reaches installed copies without a release. The written guide remains the
+ * offline, network-silent path — which is what makes the video path defensible.
+ *
+ * The copy lives here, in the tutorial's twelve languages, instead of in the i18n
+ * tables (seven UI languages) so that a reader who picked 日本語 in the cinematic
+ * guide is not handed English cards. `AppLanguage` is a subset of
+ * `TutorialLanguage`, so Settings can look its copy up with `settings.uiLanguage`
+ * directly.
+ */
+
+export type TutorialVideoId = 'essentials' | 'academic' | 'nodi';
+
+export interface TutorialVideo {
+  /** A `TutorialVideoId` for the built-ins; any slug for entries published later. */
+  id: string;
+  youtubeId: string;
+  /** Position in the published series, rendered as "Tutorial 1", "Tutorial 2", … */
+  order: number;
+  /** Icon name from the renderer's `Icon` set. */
+  icon: string;
+  /** Poster gradient, so a card is recognisable before anything loads. */
+  poster: string;
+  /** The vault whose in-app tour this video can replace, when it covers one. */
+  vaultType?: VaultType;
+  /**
+   * Its own translations, carried by catalogue entries this build predates. Built-in
+   * videos leave this unset and take their copy from the table below instead.
+   */
+  copy?: Partial<Record<TutorialLanguage, { title: string; body: string }>>;
+}
+
+/** Frames come from the no-cookie host; keep this in step with the CSP in index.html. */
+export const TUTORIAL_VIDEO_EMBED_ORIGIN = 'https://www.youtube-nocookie.com';
+
+export const TUTORIAL_VIDEOS: readonly TutorialVideo[] = [
+  {
+    id: 'essentials',
+    youtubeId: 'QqSY1_DeDRM',
+    order: 1,
+    icon: 'network',
+    poster: 'linear-gradient(140deg, #0f766e 0%, #155e75 55%, #1e1b4b 100%)',
+  },
+  {
+    id: 'academic',
+    youtubeId: 'Z-5CpJBVV_I',
+    order: 2,
+    icon: 'archive',
+    poster: 'linear-gradient(140deg, #3730a3 0%, #1e40af 55%, #0f172a 100%)',
+    vaultType: 'academic',
+  },
+  {
+    id: 'nodi',
+    youtubeId: '5OTe5CtefME',
+    order: 3,
+    icon: 'sparkles',
+    poster: 'linear-gradient(140deg, #0369a1 0%, #4338ca 55%, #111827 100%)',
+  },
+];
+
+export function tutorialVideo(id: string, videos: readonly TutorialVideo[] = TUTORIAL_VIDEOS): TutorialVideo | undefined {
+  return videos.find((video) => video.id === id);
+}
+
+/** The video that covers a vault type, when one has been published for it. */
+export function tutorialVideoForVault(
+  type: VaultType | undefined,
+  videos: readonly TutorialVideo[] = TUTORIAL_VIDEOS,
+): TutorialVideo | undefined {
+  if (!type) return undefined;
+  return videos.find((video) => video.vaultType === type);
+}
+
+export function youtubeWatchUrl(video: TutorialVideo): string {
+  return `https://www.youtube.com/watch?v=${video.youtubeId}`;
+}
+
+/**
+ * Embed URL for the in-app player. `rel=0` keeps the end screen to this channel and
+ * `modestbranding=1` drops the watermark; the player's own controls provide pause,
+ * seeking, captions, speed and fullscreen.
+ */
+export function youtubeEmbedUrl(video: TutorialVideo, language: TutorialLanguage): string {
+  const params = new URLSearchParams({
+    rel: '0',
+    modestbranding: '1',
+    playsinline: '1',
+    autoplay: '1',
+    hl: language,
+  });
+  return `${TUTORIAL_VIDEO_EMBED_ORIGIN}/embed/${video.youtubeId}?${params.toString()}`;
+}
+
+export interface TutorialVideoCopy {
+  /** Series word, rendered next to `order`. */
+  tutorialWord: string;
+  chooseTitle: string;
+  chooseLede: string;
+  videoOption: { title: string; body: string; badge: string };
+  textOption: { title: string; body: string };
+  gridTitle: string;
+  gridLede: string;
+  /** Promise that the catalogue keeps growing. Required in every language. */
+  more: string;
+  watched: string;
+  markUnwatched: string;
+  openExternal: string;
+  hosting: string;
+  /** Says out loud that opening the list checks the Nodus site for new tutorials. */
+  catalogueNote: string;
+  close: string;
+  play: string;
+  tourVideo: string;
+  videos: Record<TutorialVideoId, { title: string; body: string }>;
+}
+
+const COPY: Record<TutorialLanguage, TutorialVideoCopy> = {
+  es: {
+    tutorialWord: 'Tutorial',
+    chooseTitle: '¿Cómo prefieres aprender?',
+    chooseLede: 'Elige cómo quieres conocer Nodus. La otra opción sigue disponible en Ajustes → Tutoriales.',
+    videoOption: { title: 'Ver los tutoriales en vídeo', body: 'Tutoriales guiados que puedes pausar y ver a pantalla completa sin salir de Nodus.', badge: 'Recomendado' },
+    textOption: { title: 'Leer la guía a tu ritmo', body: 'Capítulos con enlaces y avisos, dentro de la app y sin conexión.' },
+    gridTitle: 'Tutoriales en vídeo',
+    gridLede: 'Abre el que quieras. Se marca como visto en cuanto lo abres.',
+    more: 'Más tutoriales próximamente.',
+    watched: 'Visto',
+    markUnwatched: 'Marcar como no visto',
+    openExternal: 'Abrir en el navegador',
+    hosting: 'Los vídeos están alojados en YouTube: al abrir uno, tu conexión contacta con sus servidores. La guía en texto funciona sin conexión.',
+    catalogueNote: 'Al abrir esta lista, Nodus consulta en su web si hay tutoriales nuevos.',
+    close: 'Cerrar',
+    play: 'Ver el vídeo',
+    tourVideo: 'Ver el tutorial en vídeo',
+    videos: {
+      essentials: { title: 'Introducción y primeros pasos', body: 'Qué es Nodus, cómo se organiza en bóvedas y qué necesitas para empezar.' },
+      academic: { title: 'La bóveda académica', body: 'De tu biblioteca a un grafo de ideas, autores y relaciones.' },
+      nodi: { title: 'Nodi, tu acompañante', body: 'Cómo usar a Nodi para conversar, consultar avisos y abrir la ayuda.' },
+    },
+  },
+  en: {
+    tutorialWord: 'Tutorial',
+    chooseTitle: 'How do you prefer to learn?',
+    chooseLede: 'Choose how you want to get to know Nodus. The other option stays available under Settings → Tutorials.',
+    videoOption: { title: 'Watch the video tutorials', body: 'Guided tutorials you can pause and watch fullscreen without leaving Nodus.', badge: 'Recommended' },
+    textOption: { title: 'Read the guide at your own pace', body: 'Chapters with links and warnings, inside the app and offline.' },
+    gridTitle: 'Video tutorials',
+    gridLede: 'Open any of them. Each is marked as watched as soon as you open it.',
+    more: 'More tutorials on the way.',
+    watched: 'Watched',
+    markUnwatched: 'Mark as unwatched',
+    openExternal: 'Open in browser',
+    hosting: 'The videos are hosted on YouTube: opening one connects to its servers. The written guide works offline.',
+    catalogueNote: 'Opening this list asks the Nodus website whether new tutorials have been published.',
+    close: 'Close',
+    play: 'Watch video',
+    tourVideo: 'Watch the video tutorial',
+    videos: {
+      essentials: { title: 'Introduction and first steps', body: 'What Nodus is, how vaults organise it and what you need to begin.' },
+      academic: { title: 'The academic vault', body: 'From your library to a graph of ideas, authors and relations.' },
+      nodi: { title: 'Nodi, your companion', body: 'How to use Nodi to chat, check notifications and open help.' },
+    },
+  },
+  fr: {
+    tutorialWord: 'Tutoriel',
+    chooseTitle: 'Comment préférez-vous apprendre ?',
+    chooseLede: 'Choisissez comment découvrir Nodus. L’autre option reste disponible dans Réglages → Tutoriels.',
+    videoOption: { title: 'Voir les tutoriels en vidéo', body: 'Des tutoriels guidés que vous pouvez mettre en pause et afficher en plein écran sans quitter Nodus.', badge: 'Recommandé' },
+    textOption: { title: 'Lire le guide à votre rythme', body: 'Des chapitres avec liens et avertissements, dans l’app et hors ligne.' },
+    gridTitle: 'Tutoriels vidéo',
+    gridLede: 'Ouvrez celui que vous voulez. Il est marqué comme vu dès l’ouverture.',
+    more: 'D’autres tutoriels arrivent bientôt.',
+    watched: 'Vu',
+    markUnwatched: 'Marquer comme non vu',
+    openExternal: 'Ouvrir dans le navigateur',
+    hosting: 'Les vidéos sont hébergées sur YouTube : en ouvrir une contacte ses serveurs. Le guide écrit fonctionne hors ligne.',
+    catalogueNote: 'À l’ouverture de cette liste, Nodus demande à son site si de nouveaux tutoriels existent.',
+    close: 'Fermer',
+    play: 'Voir la vidéo',
+    tourVideo: 'Voir le tutoriel en vidéo',
+    videos: {
+      essentials: { title: 'Introduction et premiers pas', body: 'Ce qu’est Nodus, comment les coffres l’organisent et ce qu’il faut pour commencer.' },
+      academic: { title: 'Le coffre académique', body: 'De votre bibliothèque à un graphe d’idées, d’auteurs et de relations.' },
+      nodi: { title: 'Nodi, votre compagnon', body: 'Utiliser Nodi pour discuter, consulter les avis et ouvrir l’aide.' },
+    },
+  },
+  tr: {
+    tutorialWord: 'Eğitim',
+    chooseTitle: 'Nasıl öğrenmeyi tercih edersiniz?',
+    chooseLede: 'Nodus’u nasıl tanımak istediğinizi seçin. Diğer seçenek Ayarlar → Eğitimler bölümünde kalır.',
+    videoOption: { title: 'Video eğitimleri izle', body: 'Nodus’tan çıkmadan duraklatabileceğiniz ve tam ekranda izleyebileceğiniz rehberli eğitimler.', badge: 'Önerilen' },
+    textOption: { title: 'Kılavuzu kendi hızınızda okuyun', body: 'Bağlantılar ve uyarılarla bölümler; uygulama içinde ve çevrimdışı.' },
+    gridTitle: 'Video eğitimler',
+    gridLede: 'İstediğinizi açın. Açtığınız anda izlendi olarak işaretlenir.',
+    more: 'Yakında daha fazla eğitim.',
+    watched: 'İzlendi',
+    markUnwatched: 'İzlenmedi olarak işaretle',
+    openExternal: 'Tarayıcıda aç',
+    hosting: 'Videolar YouTube’da barındırılıyor: birini açtığınızda bağlantınız onun sunucularına gider. Yazılı kılavuz çevrimdışı çalışır.',
+    catalogueNote: 'Bu listeyi açtığınızda Nodus, yeni eğitim var mı diye kendi web sitesine bakar.',
+    close: 'Kapat',
+    play: 'Videoyu izle',
+    tourVideo: 'Eğitimi videoda izle',
+    videos: {
+      essentials: { title: 'Giriş ve ilk adımlar', body: 'Nodus nedir, kasalarla nasıl düzenlenir ve başlamak için ne gerekir.' },
+      academic: { title: 'Akademik kasa', body: 'Kitaplığınızdan fikir, yazar ve ilişki grafiğine.' },
+      nodi: { title: 'Nodi, yardımcınız', body: 'Sohbet etmek, bildirimlere bakmak ve yardımı açmak için Nodi’yi kullanma.' },
+    },
+  },
+  de: {
+    tutorialWord: 'Tutorial',
+    chooseTitle: 'Wie möchten Sie lernen?',
+    chooseLede: 'Wählen Sie, wie Sie Nodus kennenlernen möchten. Die andere Option bleibt unter Einstellungen → Tutorials verfügbar.',
+    videoOption: { title: 'Die Video-Tutorials ansehen', body: 'Geführte Tutorials, die Sie pausieren und im Vollbild ansehen können, ohne Nodus zu verlassen.', badge: 'Empfohlen' },
+    textOption: { title: 'Die Anleitung in Ihrem Tempo lesen', body: 'Kapitel mit Links und Hinweisen, in der App und offline.' },
+    gridTitle: 'Video-Tutorials',
+    gridLede: 'Öffnen Sie eines davon. Es wird beim Öffnen als gesehen markiert.',
+    more: 'Weitere Tutorials folgen bald.',
+    watched: 'Gesehen',
+    markUnwatched: 'Als nicht gesehen markieren',
+    openExternal: 'Im Browser öffnen',
+    hosting: 'Die Videos liegen auf YouTube: Wenn Sie eines öffnen, verbindet sich Ihr Gerät mit dessen Servern. Die schriftliche Anleitung funktioniert offline.',
+    catalogueNote: 'Beim Öffnen dieser Liste fragt Nodus auf seiner Website nach neuen Tutorials.',
+    close: 'Schließen',
+    play: 'Video ansehen',
+    tourVideo: 'Das Tutorial als Video ansehen',
+    videos: {
+      essentials: { title: 'Einführung und erste Schritte', body: 'Was Nodus ist, wie Vaults es ordnen und was Sie zum Start brauchen.' },
+      academic: { title: 'Der akademische Vault', body: 'Von Ihrer Bibliothek zu einem Graphen aus Ideen, Autoren und Beziehungen.' },
+      nodi: { title: 'Nodi, Ihre Begleitung', body: 'Wie Sie mit Nodi chatten, Hinweise sehen und die Hilfe öffnen.' },
+    },
+  },
+  it: {
+    tutorialWord: 'Tutorial',
+    chooseTitle: 'Come preferisci imparare?',
+    chooseLede: 'Scegli come conoscere Nodus. L’altra opzione resta disponibile in Impostazioni → Tutorial.',
+    videoOption: { title: 'Guarda i tutorial video', body: 'Tutorial guidati che puoi mettere in pausa e vedere a schermo intero senza uscire da Nodus.', badge: 'Consigliato' },
+    textOption: { title: 'Leggi la guida al tuo ritmo', body: 'Capitoli con link e avvisi, dentro l’app e offline.' },
+    gridTitle: 'Tutorial video',
+    gridLede: 'Apri quello che vuoi. Viene segnato come visto appena lo apri.',
+    more: 'Altri tutorial in arrivo.',
+    watched: 'Visto',
+    markUnwatched: 'Segna come non visto',
+    openExternal: 'Apri nel browser',
+    hosting: 'I video sono ospitati su YouTube: aprirne uno contatta i suoi server. La guida scritta funziona offline.',
+    catalogueNote: 'Aprendo questa lista, Nodus chiede al proprio sito se ci sono nuovi tutorial.',
+    close: 'Chiudi',
+    play: 'Guarda il video',
+    tourVideo: 'Guarda il tutorial in video',
+    videos: {
+      essentials: { title: 'Introduzione e primi passi', body: 'Che cos’è Nodus, come i vault lo organizzano e cosa serve per iniziare.' },
+      academic: { title: 'Il vault accademico', body: 'Dalla tua biblioteca a un grafo di idee, autori e relazioni.' },
+      nodi: { title: 'Nodi, il tuo compagno', body: 'Come usare Nodi per conversare, vedere gli avvisi e aprire la guida.' },
+    },
+  },
+  pt: {
+    tutorialWord: 'Tutorial',
+    chooseTitle: 'Como prefere aprender?',
+    chooseLede: 'Escolha como quer conhecer o Nodus. A outra opção continua disponível em Definições → Tutoriais.',
+    videoOption: { title: 'Ver os tutoriais em vídeo', body: 'Tutoriais guiados que pode pausar e ver em ecrã inteiro sem sair do Nodus.', badge: 'Recomendado' },
+    textOption: { title: 'Ler o guia ao seu ritmo', body: 'Capítulos com ligações e avisos, dentro da app e sem ligação.' },
+    gridTitle: 'Tutoriais em vídeo',
+    gridLede: 'Abra o que quiser. Fica marcado como visto assim que o abre.',
+    more: 'Mais tutoriais em breve.',
+    watched: 'Visto',
+    markUnwatched: 'Marcar como não visto',
+    openExternal: 'Abrir no navegador',
+    hosting: 'Os vídeos estão alojados no YouTube: ao abrir um, a sua ligação contacta os servidores dele. O guia escrito funciona sem ligação.',
+    catalogueNote: 'Ao abrir esta lista, o Nodus consulta o seu site para ver se há tutoriais novos.',
+    close: 'Fechar',
+    play: 'Ver o vídeo',
+    tourVideo: 'Ver o tutorial em vídeo',
+    videos: {
+      essentials: { title: 'Introdução e primeiros passos', body: 'O que é o Nodus, como os cofres o organizam e o que precisa para começar.' },
+      academic: { title: 'O cofre académico', body: 'Da sua biblioteca a um grafo de ideias, autores e relações.' },
+      nodi: { title: 'Nodi, o seu companheiro', body: 'Como usar o Nodi para conversar, ver avisos e abrir a ajuda.' },
+    },
+  },
+  'pt-BR': {
+    tutorialWord: 'Tutorial',
+    chooseTitle: 'Como você prefere aprender?',
+    chooseLede: 'Escolha como quer conhecer o Nodus. A outra opção continua disponível em Configurações → Tutoriais.',
+    videoOption: { title: 'Assistir aos tutoriais em vídeo', body: 'Tutoriais guiados que você pode pausar e ver em tela cheia sem sair do Nodus.', badge: 'Recomendado' },
+    textOption: { title: 'Ler o guia no seu ritmo', body: 'Capítulos com links e avisos, dentro do app e offline.' },
+    gridTitle: 'Tutoriais em vídeo',
+    gridLede: 'Abra o que quiser. Ele é marcado como visto assim que você abre.',
+    more: 'Mais tutoriais em breve.',
+    watched: 'Visto',
+    markUnwatched: 'Marcar como não visto',
+    openExternal: 'Abrir no navegador',
+    hosting: 'Os vídeos ficam no YouTube: ao abrir um, sua conexão fala com os servidores dele. O guia escrito funciona offline.',
+    catalogueNote: 'Ao abrir esta lista, o Nodus consulta o site dele para ver se há tutoriais novos.',
+    close: 'Fechar',
+    play: 'Assistir ao vídeo',
+    tourVideo: 'Assistir ao tutorial em vídeo',
+    videos: {
+      essentials: { title: 'Introdução e primeiros passos', body: 'O que é o Nodus, como os cofres organizam tudo e o que você precisa para começar.' },
+      academic: { title: 'O cofre acadêmico', body: 'Da sua biblioteca a um grafo de ideias, autores e relações.' },
+      nodi: { title: 'Nodi, seu companheiro', body: 'Como usar o Nodi para conversar, ver avisos e abrir a ajuda.' },
+    },
+  },
+  zh: {
+    tutorialWord: '教程',
+    chooseTitle: '你想怎么上手？',
+    chooseLede: '选择你想了解 Nodus 的方式。另一种方式随时可在「设置 → 教程」中使用。',
+    videoOption: { title: '观看视频教程', body: '可暂停、可全屏的引导教程，无需离开 Nodus。', badge: '推荐' },
+    textOption: { title: '按自己的节奏阅读指南', body: '带链接和提示的章节，在应用内，离线也能读。' },
+    gridTitle: '视频教程',
+    gridLede: '想看哪个就打开。打开后会自动标记为已看。',
+    more: '更多教程即将推出。',
+    watched: '已看',
+    markUnwatched: '标记为未看',
+    openExternal: '在浏览器中打开',
+    hosting: '视频托管在 YouTube：打开任一视频都会连接其服务器。文字指南可离线使用。',
+    catalogueNote: '打开这份列表时，Nodus 会向自己的网站查询是否有新教程。',
+    close: '关闭',
+    play: '观看视频',
+    tourVideo: '观看视频教程',
+    videos: {
+      essentials: { title: '介绍与第一步', body: 'Nodus 是什么、资料库如何组织，以及开始前需要准备什么。' },
+      academic: { title: '学术资料库', body: '把你的文献库变成想法、作者与关系的图谱。' },
+      nodi: { title: '认识 Nodi', body: '用 Nodi 聊天、查看提醒并打开帮助。' },
+    },
+  },
+  ja: {
+    tutorialWord: 'チュートリアル',
+    chooseTitle: 'どの方法で学びますか？',
+    chooseLede: 'Nodusを知る方法を選んでください。もう一方は「設定 → チュートリアル」からいつでも使えます。',
+    videoOption: { title: '動画チュートリアルを見る', body: '一時停止も全画面もできるガイド付き動画。Nodusを離れずに視聴できます。', badge: 'おすすめ' },
+    textOption: { title: '自分のペースでガイドを読む', body: 'リンクと注意書きのある章立て。アプリ内で、オフラインでも読めます。' },
+    gridTitle: '動画チュートリアル',
+    gridLede: '好きなものを開いてください。開いた時点で視聴済みになります。',
+    more: 'チュートリアルは今後も追加されます。',
+    watched: '視聴済み',
+    markUnwatched: '未視聴にする',
+    openExternal: 'ブラウザーで開く',
+    hosting: '動画はYouTubeにあります。開くとそのサーバーに接続します。文章のガイドはオフラインでも使えます。',
+    catalogueNote: 'このリストを開くと、Nodusは自身のサイトに新しいチュートリアルがあるか問い合わせます。',
+    close: '閉じる',
+    play: '動画を見る',
+    tourVideo: 'チュートリアルを動画で見る',
+    videos: {
+      essentials: { title: '紹介と最初の一歩', body: 'Nodusとは何か、Vaultでどう整理するか、始めるために必要なもの。' },
+      academic: { title: 'アカデミックVault', body: '蔵書から、アイデア・著者・関係のグラフへ。' },
+      nodi: { title: '相棒のNodi', body: 'Nodiで会話し、通知を確認し、ヘルプを開く方法。' },
+    },
+  },
+  ru: {
+    tutorialWord: 'Урок',
+    chooseTitle: 'Как вам удобнее учиться?',
+    chooseLede: 'Выберите, как познакомиться с Nodus. Второй вариант всегда доступен в «Настройки → Обучение».',
+    videoOption: { title: 'Смотреть видеоуроки', body: 'Уроки с пояснениями: можно ставить на паузу и открывать на весь экран, не выходя из Nodus.', badge: 'Рекомендуем' },
+    textOption: { title: 'Читать руководство в своём темпе', body: 'Главы со ссылками и предупреждениями — в приложении и офлайн.' },
+    gridTitle: 'Видеоуроки',
+    gridLede: 'Откройте любой. Он отмечается как просмотренный сразу при открытии.',
+    more: 'Скоро будут новые уроки.',
+    watched: 'Просмотрен',
+    markUnwatched: 'Отметить как непросмотренный',
+    openExternal: 'Открыть в браузере',
+    hosting: 'Видео размещены на YouTube: при открытии устройство соединяется с его серверами. Текстовое руководство работает офлайн.',
+    catalogueNote: 'При открытии этого списка Nodus запрашивает у своего сайта, появились ли новые уроки.',
+    close: 'Закрыть',
+    play: 'Смотреть видео',
+    tourVideo: 'Посмотреть урок в видео',
+    videos: {
+      essentials: { title: 'Знакомство и первые шаги', body: 'Что такое Nodus, как хранилища его организуют и что нужно для начала.' },
+      academic: { title: 'Академическое хранилище', body: 'От вашей библиотеки к графу идей, авторов и связей.' },
+      nodi: { title: 'Ноди, ваш помощник', body: 'Как общаться с Ноди, смотреть уведомления и открывать справку.' },
+    },
+  },
+  uk: {
+    tutorialWord: 'Урок',
+    chooseTitle: 'Як вам зручніше вчитися?',
+    chooseLede: 'Виберіть, як познайомитися з Nodus. Другий варіант завжди доступний у «Налаштування → Навчання».',
+    videoOption: { title: 'Дивитися відеоуроки', body: 'Уроки з поясненнями: можна ставити на паузу й відкривати на весь екран, не виходячи з Nodus.', badge: 'Рекомендуємо' },
+    textOption: { title: 'Читати посібник у своєму темпі', body: 'Розділи з посиланнями та застереженнями — у застосунку й офлайн.' },
+    gridTitle: 'Відеоуроки',
+    gridLede: 'Відкрийте будь-який. Він позначається як переглянутий одразу після відкриття.',
+    more: 'Скоро з’являться нові уроки.',
+    watched: 'Переглянуто',
+    markUnwatched: 'Позначити як непереглянутий',
+    openExternal: 'Відкрити у браузері',
+    hosting: 'Відео розміщені на YouTube: коли ви відкриваєте одне з них, ваш пристрій з’єднується з його серверами. Текстовий посібник працює офлайн.',
+    catalogueNote: 'Коли ви відкриваєте цей список, Nodus запитує на своєму сайті, чи з’явилися нові уроки.',
+    close: 'Закрити',
+    play: 'Дивитися відео',
+    tourVideo: 'Подивитися урок у відео',
+    videos: {
+      essentials: { title: 'Знайомство та перші кроки', body: 'Що таке Nodus, як сховища його впорядковують і що потрібно для початку.' },
+      academic: { title: 'Академічне сховище', body: 'Від вашої бібліотеки до графа ідей, авторів і зв’язків.' },
+      nodi: { title: 'Ноді, ваш помічник', body: 'Як спілкуватися з Ноді, дивитися повідомлення й відкривати довідку.' },
+    },
+  },
+};
+
+export function tutorialVideoCopy(language: TutorialLanguage): TutorialVideoCopy {
+  return COPY[language] ?? COPY.en;
+}
+
+/** Every language this build can serve, in the order the guide offers them. */
+export const TUTORIAL_COPY_LANGUAGES = Object.keys(COPY) as TutorialLanguage[];
+
+/** A video's title and description, wherever they come from. */
+export function videoCopyFor(video: TutorialVideo, language: TutorialLanguage): { title: string; body: string } {
+  if (video.copy) {
+    const own = video.copy[language] ?? video.copy.en ?? Object.values(video.copy)[0];
+    if (own) return own;
+  }
+  const table = tutorialVideoCopy(language).videos as Record<string, { title: string; body: string } | undefined>;
+  // The slug is a poor title, but a card with no title at all is worse — and this is
+  // only reachable for a catalogue entry that shipped without any copy.
+  return table[video.id] ?? { title: video.id, body: '' };
+}
+
+// ── the list, refreshable without shipping a release ────────────────────────────
+//
+// The three videos above are compiled in, so the grid renders instantly and offline.
+// A published catalogue can add to them: the app asks for it from the MAIN process
+// when a grid is opened (never at startup, and never from the renderer, which would
+// mean widening the CSP for a second remote host).
+//
+// Everything in that file is untrusted input from the network, so it is validated
+// rather than trusted: ids are slugs, video ids must have YouTube's exact shape (no
+// arbitrary URL can be smuggled in), and posters are NOT taken from it at all — a
+// remote CSS value in a `style` attribute could fetch a remote image and undo the
+// promise that an unopened grid makes no requests.
+
+export const TUTORIAL_CATALOGUE_URL = 'https://drakonis96.github.io/nodus/tutorials.json';
+
+const YOUTUBE_ID_SHAPE = /^[A-Za-z0-9_-]{11}$/;
+const SLUG_SHAPE = /^[a-z0-9][a-z0-9-]{0,39}$/;
+/** Icons a catalogue entry may pick; anything else falls back to the play glyph. */
+const CATALOGUE_ICONS = ['play', 'network', 'archive', 'sparkles', 'graduation', 'layers', 'tree', 'table', 'chartBar', 'microphone', 'image', 'tools', 'star'];
+/** Posters handed out, in order, to entries this build knows nothing about. */
+const CATALOGUE_POSTERS = [
+  'linear-gradient(140deg, #155e75 0%, #1e3a8a 55%, #111827 100%)',
+  'linear-gradient(140deg, #6d28d9 0%, #1e3a8a 55%, #0f172a 100%)',
+  'linear-gradient(140deg, #0f766e 0%, #3730a3 55%, #111827 100%)',
+  'linear-gradient(140deg, #9d174d 0%, #4338ca 55%, #0f172a 100%)',
+];
+
+const MAX_CATALOGUE_ENTRIES = 40;
+const MAX_TITLE = 120;
+const MAX_BODY = 320;
+
+function cleanString(value: unknown, max: number): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(/\s+/g, ' ');
+  if (!trimmed || trimmed.length > max) return null;
+  return trimmed;
+}
+
+function parseEntryCopy(value: unknown): TutorialVideo['copy'] | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const copy: NonNullable<TutorialVideo['copy']> = {};
+  for (const [language, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (!TUTORIAL_COPY_LANGUAGES.includes(language as TutorialLanguage)) continue;
+    if (!entry || typeof entry !== 'object') continue;
+    const title = cleanString((entry as Record<string, unknown>).title, MAX_TITLE);
+    const body = cleanString((entry as Record<string, unknown>).body, MAX_BODY);
+    if (!title || !body) continue;
+    copy[language as TutorialLanguage] = { title, body };
+  }
+  return Object.keys(copy).length > 0 ? copy : null;
+}
+
+function parseEntry(value: unknown, index: number): TutorialVideo | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const entry = value as Record<string, unknown>;
+  const id = typeof entry.id === 'string' && SLUG_SHAPE.test(entry.id) ? entry.id : null;
+  const youtubeId = typeof entry.youtubeId === 'string' && YOUTUBE_ID_SHAPE.test(entry.youtubeId) ? entry.youtubeId : null;
+  if (!id || !youtubeId) return null;
+  const order = typeof entry.order === 'number' && Number.isFinite(entry.order) ? entry.order : index + 1;
+  const builtIn = TUTORIAL_VIDEOS.find((video) => video.id === id);
+  const copy = parseEntryCopy(entry.copy);
+  // A brand-new entry with no usable copy would render as a bare slug: drop it.
+  if (!builtIn && !copy) return null;
+  return {
+    id,
+    youtubeId,
+    order,
+    icon: typeof entry.icon === 'string' && CATALOGUE_ICONS.includes(entry.icon) ? entry.icon : builtIn?.icon ?? 'play',
+    poster: builtIn?.poster ?? CATALOGUE_POSTERS[index % CATALOGUE_POSTERS.length],
+    ...(isVaultType(entry.vaultType) ? { vaultType: entry.vaultType } : builtIn?.vaultType ? { vaultType: builtIn.vaultType } : {}),
+    ...(copy ? { copy } : {}),
+  };
+}
+
+export interface TutorialCatalogueParse {
+  videos: TutorialVideo[];
+  /** Entries thrown away for failing validation. Logged, never silently swallowed. */
+  rejected: number;
+}
+
+export function parseTutorialCatalogue(raw: unknown): TutorialCatalogueParse {
+  const list = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === 'object' && Array.isArray((raw as { videos?: unknown }).videos)
+      ? ((raw as { videos: unknown[] }).videos)
+      : null;
+  if (!list) return { videos: [], rejected: 0 };
+  const videos: TutorialVideo[] = [];
+  let rejected = 0;
+  for (const [index, item] of list.slice(0, MAX_CATALOGUE_ENTRIES).entries()) {
+    const parsed = parseEntry(item, index);
+    if (parsed && !videos.some((video) => video.id === parsed.id)) videos.push(parsed);
+    else rejected += 1;
+  }
+  return { videos, rejected };
+}
+
+/**
+ * Built-in list plus whatever the catalogue adds, ordered by `order`.
+ *
+ * A published entry can update a built-in video's copy or its vault, but it can never
+ * make one disappear: a truncated or half-written file must not hide the tutorial a
+ * user is looking for. Retiring a video is rare enough to ride a release.
+ */
+export function mergeTutorialCatalogue(remote: readonly TutorialVideo[]): TutorialVideo[] {
+  const merged = new Map<string, TutorialVideo>();
+  for (const video of TUTORIAL_VIDEOS) merged.set(video.id, video);
+  for (const video of remote) merged.set(video.id, { ...merged.get(video.id), ...video });
+  return [...merged.values()].sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -92,6 +92,7 @@ export type {
 
 // Type-only import (erased at compile time) — keeps the no-runtime-import rule intact.
 import type { VaultType } from './vaultTypes';
+import type { TutorialVideo } from './tutorialVideos';
 import type { ToolkitJobRequest, ToolkitJobProgress, ToolkitJobResult } from './toolkitTypes';
 import type {
   ToolkitAppGenerationRequest,
@@ -1476,6 +1477,13 @@ export interface AppSettings {
   onboardingComplete: boolean;
   /** App-wide version of the introductory AI/vault tutorial already completed. */
   basicsTutorialVersion: number;
+  /**
+   * Ids of the video tutorials already opened (`TutorialVideoId` values from
+   * shared/tutorialVideos.ts, kept as plain strings so types.ts stays at the root of
+   * the import graph). App-wide, like the tutorial version above: a video watched in
+   * one vault stays watched in every other.
+   */
+  tutorialVideosWatched: string[];
   // First-run usage tour (distinct from the setup onboarding above).
   tourComplete: boolean;
   // Advanced research-workflow walkthrough. Opt-in (never auto-shown): defaults
@@ -6364,6 +6372,12 @@ export interface NodusApi {
   runBackupNow(): Promise<AutoBackupResult>;
   /** Write a plaintext recovery kit (master password + independent recovery key) to a user-chosen file. */
   saveBackupRecoveryKit(): Promise<{ ok: boolean; message: string }>;
+  /**
+   * The video tutorials to show: this build's list plus any published since, fetched
+   * and validated in the main process. Falls back to the built-in list, so it is safe
+   * to render whatever comes back.
+   */
+  getTutorialCatalogue(): Promise<TutorialVideo[]>;
   /** Inspect whether recovery onboarding is required for this installation. */
   getRecoveryStatus(): Promise<RecoveryStatus>;
   /** Pick and inspect an empty folder or an existing Nodus recovery root. */

--- a/src/components/TutorialVideos.tsx
+++ b/src/components/TutorialVideos.tsx
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { TutorialLanguage } from '@shared/tutorialPreferences';
+import {
+  TUTORIAL_VIDEOS,
+  tutorialVideoCopy,
+  videoCopyFor,
+  youtubeEmbedUrl,
+  youtubeWatchUrl,
+  type TutorialVideo,
+} from '@shared/tutorialVideos';
+import { Icon, ModalBackdrop } from './ui';
+import './tutorialVideos.css';
+
+/**
+ * Optional local poster frames: drop `<video id>.webp` into src/assets/tutorials/ and
+ * the matching card uses it instead of its gradient. Local on purpose — a remote
+ * thumbnail would make the mere sight of the grid a request to Google.
+ */
+const POSTERS: Record<string, string> = Object.fromEntries(
+  Object.entries(import.meta.glob<string>('../assets/tutorials/*.{webp,png,jpg}', { eager: true, query: '?url', import: 'default' }))
+    .map(([file, url]) => [file.replace(/^.*\/(.+)\.\w+$/, '$1'), url]),
+);
+
+function posterStyle(video: TutorialVideo): React.CSSProperties {
+  const image = POSTERS[video.id];
+  return image
+    ? { backgroundImage: `url(${image})`, backgroundSize: 'cover', backgroundPosition: 'center' }
+    : { background: video.poster };
+}
+
+/**
+ * The video tutorials, as a grid of cards plus an in-app player.
+ *
+ * Used from three places — the cinematic guide's video mode, Settings → Tutorials and
+ * the per-vault tours — so the component owns everything the hosts would otherwise
+ * duplicate: the watched flags, the player and the note about where the videos live.
+ *
+ * Nothing here touches the network until the user opens a video: the cards are drawn
+ * from a local gradient and an icon rather than a remote thumbnail, so an unopened
+ * grid makes no request at all.
+ */
+
+/** The player sits above the cinematic guide (z-190) and below its skip dialog (z-220). */
+const PLAYER_Z_INDEX = 210;
+
+async function markWatched(id: string): Promise<string[]> {
+  const settings = await window.nodus.getSettings();
+  const current = Array.isArray(settings.tutorialVideosWatched) ? settings.tutorialVideosWatched : [];
+  if (current.includes(id)) return current;
+  const next = [...current, id];
+  await window.nodus.updateSettings({ tutorialVideosWatched: next });
+  return next;
+}
+
+async function unmarkWatched(id: string): Promise<string[]> {
+  const settings = await window.nodus.getSettings();
+  const current = Array.isArray(settings.tutorialVideosWatched) ? settings.tutorialVideosWatched : [];
+  const next = current.filter((watched) => watched !== id);
+  await window.nodus.updateSettings({ tutorialVideosWatched: next });
+  return next;
+}
+
+/**
+ * The in-app player. The iframe carries YouTube's own controls, which is what gives
+ * pause, seeking, captions, playback speed and fullscreen; Escape or the close button
+ * leaves at any point. Opening it is what marks the tutorial as watched — tracking
+ * real playback progress would mean loading YouTube's iframe API script, i.e. another
+ * remote script in the CSP for a flag nobody audits.
+ */
+export function TutorialVideoPlayer({
+  video,
+  language,
+  onClose,
+}: {
+  video: TutorialVideo;
+  language: TutorialLanguage;
+  onClose: (watched: string[] | null) => void;
+}) {
+  const copy = tutorialVideoCopy(language);
+  const meta = videoCopyFor(video, language);
+  const [watched, setWatched] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void markWatched(video.id).then((next) => {
+      if (!cancelled) setWatched(next);
+    });
+    return () => { cancelled = true; };
+  }, [video.id]);
+
+  // `watched` is read through a ref-free closure on every render, so the latest value
+  // reaches the host whether the user closes before or after the write lands.
+  const close = () => onClose(watched);
+
+  return (
+    <ModalBackdrop onClose={close} zIndex={PLAYER_Z_INDEX}>
+      <div className="tutorial-video-player" data-testid="tutorial-video-player" role="dialog" aria-modal="true" aria-label={meta.title}>
+        <header className="tutorial-video-player-bar">
+          <div>
+            <span>{copy.tutorialWord} {video.order}</span>
+            <b>{meta.title}</b>
+          </div>
+          <div className="tutorial-video-player-actions">
+            <button className="btn btn-ghost" onClick={() => void window.nodus.openExternal(youtubeWatchUrl(video))}>
+              <Icon name="external" size={14} />{copy.openExternal}
+            </button>
+            <button className="btn btn-ghost" data-testid="tutorial-video-close" onClick={close}>
+              <Icon name="x" size={14} />{copy.close}
+            </button>
+          </div>
+        </header>
+        <div className="tutorial-video-frame">
+          <iframe
+            src={youtubeEmbedUrl(video, language)}
+            title={meta.title}
+            allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
+            referrerPolicy="strict-origin-when-cross-origin"
+            allowFullScreen
+          />
+        </div>
+        <p className="tutorial-video-hosting">{copy.hosting}</p>
+      </div>
+    </ModalBackdrop>
+  );
+}
+
+function TutorialVideoCard({
+  video,
+  language,
+  watched,
+  onPlay,
+  onUnwatch,
+}: {
+  video: TutorialVideo;
+  language: TutorialLanguage;
+  watched: boolean;
+  onPlay: () => void;
+  onUnwatch: () => void;
+}) {
+  const copy = tutorialVideoCopy(language);
+  const meta = videoCopyFor(video, language);
+  return (
+    <article className="tutorial-video-card" data-testid={`tutorial-video-card-${video.id}`} data-watched={watched ? 'true' : 'false'}>
+      <button
+        className="tutorial-video-poster"
+        style={posterStyle(video)}
+        onClick={onPlay}
+        aria-label={`${copy.play}: ${meta.title}`}
+        data-testid={`tutorial-video-play-${video.id}`}
+      >
+        <span className="tutorial-video-order">{copy.tutorialWord} {video.order}</span>
+        <Icon name={video.icon} size={34} className="tutorial-video-poster-icon" />
+        <span className="tutorial-video-play" aria-hidden="true"><Icon name="play" size={18} /></span>
+        {watched && <span className="tutorial-video-watched"><Icon name="check" size={12} />{copy.watched}</span>}
+      </button>
+      <div className="tutorial-video-body">
+        <h3>{meta.title}</h3>
+        <p>{meta.body}</p>
+        <div className="tutorial-video-card-actions">
+          <button className="btn btn-primary" onClick={onPlay}><Icon name="play" size={14} />{copy.play}</button>
+          <button className="btn btn-ghost" title={copy.openExternal} aria-label={copy.openExternal} onClick={() => void window.nodus.openExternal(youtubeWatchUrl(video))}>
+            <Icon name="external" size={14} />
+          </button>
+          {watched && (
+            <button className="btn btn-ghost tutorial-video-unwatch" onClick={onUnwatch}>{copy.markUnwatched}</button>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function TutorialVideoGrid({
+  language,
+  variant = 'cinema',
+  videos,
+  showHeading = true,
+}: {
+  language: TutorialLanguage;
+  /** `cinema` sits on the tutorial's dark stage; `panel` on a Settings card. */
+  variant?: 'cinema' | 'panel';
+  /** Render exactly these instead of the published catalogue. */
+  videos?: readonly TutorialVideo[];
+  showHeading?: boolean;
+}) {
+  const copy = tutorialVideoCopy(language);
+  const [watched, setWatched] = useState<string[]>([]);
+  const [playing, setPlaying] = useState<TutorialVideo | null>(null);
+  // Starts as this build's list, so the grid paints immediately and offline; the main
+  // process then answers with anything published since. `videos` overrides both when a
+  // caller wants a specific subset.
+  const [published, setPublished] = useState<readonly TutorialVideo[]>(TUTORIAL_VIDEOS);
+  const shown = videos ?? published;
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.nodus.getSettings().then((settings) => {
+      if (cancelled) return;
+      setWatched(Array.isArray(settings.tutorialVideosWatched) ? settings.tutorialVideosWatched : []);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (videos) return; // an explicit list was passed in; nothing to look up
+    let cancelled = false;
+    void window.nodus.getTutorialCatalogue().then((next) => {
+      if (cancelled || !Array.isArray(next) || next.length === 0) return;
+      setPublished(next);
+    }).catch(() => { /* the built-in list is already on screen */ });
+    return () => { cancelled = true; };
+  }, [videos]);
+
+  const closePlayer = useCallback((next: string[] | null) => {
+    setPlaying(null);
+    if (next) setWatched(next);
+  }, []);
+
+  return (
+    <div className={`tutorial-videos tutorial-videos-${variant}`} data-testid="tutorial-video-grid">
+      {showHeading && (
+        <header className="tutorial-videos-heading">
+          <h2>{copy.gridTitle}</h2>
+          <p>{copy.gridLede}</p>
+        </header>
+      )}
+      <div className="tutorial-video-grid">
+        {shown.map((video) => (
+          <TutorialVideoCard
+            key={video.id}
+            video={video}
+            language={language}
+            watched={watched.includes(video.id)}
+            onPlay={() => setPlaying(video)}
+            onUnwatch={() => void unmarkWatched(video.id).then(setWatched)}
+          />
+        ))}
+      </div>
+      <footer className="tutorial-videos-footer">
+        <p className="tutorial-videos-more" data-testid="tutorial-videos-more"><Icon name="sparkles" size={13} />{copy.more}</p>
+        <p className="tutorial-videos-hosting">{copy.hosting} {copy.catalogueNote}</p>
+      </footer>
+      {playing && <TutorialVideoPlayer video={playing} language={language} onClose={closePlayer} />}
+    </div>
+  );
+}

--- a/src/components/tutorialVideos.css
+++ b/src/components/tutorialVideos.css
@@ -1,0 +1,236 @@
+/* The video tutorials: the "how do you want to learn?" choice, the card grid and the
+   in-app player. Two hosts, two skins: `cinema` on the tutorial's dark stage and
+   `panel` inside a Settings card, which also has to survive light mode. */
+
+/* ── how do you prefer to learn? ────────────────────────────────────────────────── */
+.tutorial-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .9rem;
+  margin-top: 1.5rem;
+}
+
+.tutorial-mode-option {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .5rem;
+  padding: 1.5rem 1.1rem 1.3rem;
+  border: 1px solid rgba(255, 255, 255, .16);
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, .04);
+  color: inherit;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+.tutorial-mode-option:hover,
+.tutorial-mode-option:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(255, 255, 255, .5);
+  background: rgba(255, 255, 255, .07);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, .3);
+  outline: none;
+}
+.tutorial-mode-option.recommended {
+  border-color: rgba(45, 212, 191, .45);
+  background: rgba(13, 148, 136, .12);
+}
+.tutorial-mode-option.recommended:hover,
+.tutorial-mode-option.recommended:focus-visible {
+  border-color: rgba(94, 234, 212, .85);
+  background: rgba(13, 148, 136, .2);
+}
+.tutorial-mode-icon {
+  display: grid;
+  place-items: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  color: #5eead4;
+  background: rgba(45, 212, 191, .14);
+}
+.tutorial-mode-option b { font-size: .98rem; font-weight: 650; }
+.tutorial-mode-body { color: #a3a3a3; font-size: .8rem; line-height: 1.4; }
+.tutorial-mode-badge {
+  position: absolute;
+  top: .7rem;
+  right: .7rem;
+  border-radius: 999px;
+  padding: .18rem .5rem;
+  color: #042f2e;
+  background: #5eead4;
+  font-size: .62rem;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+/* ── the grid ───────────────────────────────────────────────────────────────────── */
+.tutorial-videos { display: flex; min-height: 0; flex-direction: column; gap: 1rem; }
+.tutorial-videos-heading h2 { color: #fff; font-size: clamp(1.3rem, 3vw, 1.9rem); font-weight: 650; }
+.tutorial-videos-heading p { margin-top: .3rem; color: #a3a3a3; font-size: .87rem; }
+
+.tutorial-video-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: .9rem;
+}
+
+.tutorial-video-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, .04);
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+.tutorial-video-card:hover { transform: translateY(-3px); border-color: rgba(255, 255, 255, .34); box-shadow: 0 16px 38px rgba(0, 0, 0, .32); }
+
+.tutorial-video-poster {
+  position: relative;
+  display: grid;
+  height: 122px;
+  place-items: center;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+.tutorial-video-poster::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(2, 6, 23, .05), rgba(2, 6, 23, .45));
+}
+.tutorial-video-poster-icon { position: relative; z-index: 1; color: rgba(255, 255, 255, .92); }
+.tutorial-video-order {
+  position: absolute;
+  top: .6rem;
+  left: .7rem;
+  z-index: 1;
+  color: rgba(255, 255, 255, .82);
+  font-size: .64rem;
+  font-weight: 800;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+.tutorial-video-play {
+  position: absolute;
+  right: .7rem;
+  bottom: .6rem;
+  z-index: 1;
+  display: grid;
+  width: 2.1rem;
+  height: 2.1rem;
+  place-items: center;
+  border-radius: 50%;
+  color: #0f172a;
+  background: rgba(255, 255, 255, .92);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, .35);
+  transition: transform 160ms ease;
+}
+.tutorial-video-poster:hover .tutorial-video-play,
+.tutorial-video-poster:focus-visible .tutorial-video-play { transform: scale(1.12); }
+.tutorial-video-watched {
+  position: absolute;
+  top: .55rem;
+  right: .6rem;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+  border-radius: 999px;
+  padding: .18rem .48rem;
+  color: #042f2e;
+  background: rgba(94, 234, 212, .95);
+  font-size: .64rem;
+  font-weight: 800;
+}
+
+.tutorial-video-body { display: flex; min-width: 0; flex: 1; flex-direction: column; gap: .35rem; padding: .85rem .95rem 1rem; }
+.tutorial-video-body h3 { color: #f5f5f4; font-size: .95rem; font-weight: 650; line-height: 1.25; }
+.tutorial-video-body p { flex: 1; color: #a3a3a3; font-size: .78rem; line-height: 1.45; }
+.tutorial-video-card-actions { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-top: .45rem; }
+.tutorial-video-card-actions .tutorial-video-unwatch { font-size: .7rem; }
+
+.tutorial-videos-footer { display: grid; gap: .3rem; }
+.tutorial-videos-more { display: flex; align-items: center; gap: .4rem; color: #5eead4; font-size: .8rem; font-weight: 600; }
+.tutorial-videos-hosting, .tutorial-video-hosting { color: #78716c; font-size: .72rem; line-height: 1.45; }
+
+/* Inside the cinematic guide the grid owns the stage and scrolls on its own. As a
+   `flex-direction: column` scroller it would SQUASH its rows instead of scrolling
+   them, so every child is pinned at its natural height. */
+.tutorial-videos-cinema {
+  position: relative;
+  z-index: 1;
+  min-height: 0;
+  flex: 1;
+  /* `safe` so a grid taller than the stage scrolls from its top instead of having its
+     first row clipped above the scroll origin. */
+  justify-content: safe center;
+  overflow-y: auto;
+  width: min(1080px, calc(100% - 64px));
+  margin: 0 auto;
+  padding: 1.5rem 0;
+}
+.tutorial-videos-cinema > * { flex: 0 0 auto; }
+
+/* The choice screen centres everything, including the promise of more tutorials. */
+.tutorial-language-card .tutorial-videos-more { justify-content: center; margin-top: 1.1rem; }
+
+/* ── the player ─────────────────────────────────────────────────────────────────── */
+.tutorial-video-player {
+  display: flex;
+  width: min(1080px, 100%);
+  max-height: 90vh;
+  flex-direction: column;
+  gap: .6rem;
+  overflow: hidden;
+  padding: .9rem 1rem 1rem;
+  border: 1px solid rgba(148, 163, 184, .25);
+  border-radius: 1.25rem;
+  color: #e7e5e4;
+  background: #090d16;
+  box-shadow: 0 40px 120px rgba(0, 0, 0, .58);
+}
+.tutorial-video-player-bar { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .5rem; }
+.tutorial-video-player-bar > div:first-child { display: grid; min-width: 0; gap: .1rem; }
+.tutorial-video-player-bar span { color: #5eead4; font-size: .64rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.tutorial-video-player-bar b { font-size: .95rem; font-weight: 650; }
+.tutorial-video-player-actions { display: flex; gap: .35rem; }
+.tutorial-video-frame {
+  position: relative;
+  overflow: hidden;
+  border-radius: .9rem;
+  background: #000;
+  aspect-ratio: 16 / 9;
+  /* The frame keeps its 16:9 ratio but must never push the dialog past the viewport. */
+  max-height: calc(90vh - 9rem);
+  margin-inline: auto;
+  width: 100%;
+}
+.tutorial-video-frame iframe { display: block; width: 100%; height: 100%; border: 0; }
+
+/* ── light mode (the Settings panel and the player) ─────────────────────────────── */
+.light .tutorial-videos-panel .tutorial-video-card { border-color: rgba(15, 23, 42, .14); background: rgba(15, 23, 42, .03); }
+.light .tutorial-videos-panel .tutorial-video-card:hover { border-color: rgba(15, 23, 42, .34); box-shadow: 0 16px 38px rgba(15, 23, 42, .14); }
+.light .tutorial-videos-panel .tutorial-video-body h3 { color: #172033; }
+.light .tutorial-videos-panel .tutorial-video-body p { color: #64748b; }
+.light .tutorial-videos-panel .tutorial-videos-heading h2 { color: #172033; }
+.light .tutorial-videos-panel .tutorial-videos-heading p { color: #64748b; }
+.light .tutorial-videos-panel .tutorial-videos-more { color: #0f766e; }
+.light .tutorial-videos-panel .tutorial-videos-hosting { color: #64748b; }
+.light .tutorial-video-player { border-color: rgba(30, 41, 59, .2); color: #172033; background: #f8fafc; box-shadow: 0 35px 100px rgba(15, 23, 42, .28); }
+.light .tutorial-video-player-bar span { color: #0f766e; }
+.light .tutorial-video-hosting { color: #64748b; }
+.light .tutorial-mode-option { border-color: rgba(15, 23, 42, .14); background: rgba(15, 23, 42, .03); }
+.light .tutorial-mode-body { color: #64748b; }
+
+@media (max-width: 720px) {
+  .tutorial-mode-grid { grid-template-columns: 1fr; }
+  .tutorial-videos-cinema { width: calc(100% - 32px); }
+  .tutorial-video-player { border-radius: 1rem; padding: .7rem .75rem .8rem; }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,6 +7,18 @@ declare global {
 
   /** App version, injected at build time from package.json (see vite.config.ts). */
   const __APP_VERSION__: string;
+
+  /**
+   * Vite's build-time file glob, declared narrowly here rather than by referencing
+   * `vite/client`, whose own `*.svg`/`*.webp` module declarations would collide with
+   * the ones in src/assets.d.ts. Used to pick up optional tutorial poster frames.
+   */
+  interface ImportMeta {
+    glob<T = unknown>(
+      pattern: string,
+      options?: { eager?: boolean; query?: string; import?: string },
+    ): Record<string, T>;
+  }
 }
 
 export {};

--- a/src/views/BasicsTutorial.tsx
+++ b/src/views/BasicsTutorial.tsx
@@ -17,6 +17,8 @@ import {
   PLATFORM_HIGHLIGHTS_TUTORIAL_VERSION,
   platformHighlightSlides,
 } from '../components/PlatformHighlightsGuide';
+import { TutorialVideoGrid } from '../components/TutorialVideos';
+import { tutorialVideoCopy } from '@shared/tutorialVideos';
 import { t } from '../i18n';
 
 export const BASICS_TUTORIAL_VERSION = PLATFORM_HIGHLIGHTS_TUTORIAL_VERSION;
@@ -348,6 +350,9 @@ export function BasicsTutorial({ language, onLanguageChosen, onNodiStyleChosen, 
   // Which Nodi guides the rest of the tutorial is the user's first real choice, so the
   // deck that follows is already staged by the companion they picked.
   const [styleChosen, setStyleChosen] = useState(false);
+  // Third and last gate: watch the tutorials or read the deck. Not persisted — either
+  // path completes the guide, and both stay reachable from Settings → Tutorials.
+  const [learnMode, setLearnMode] = useState<'video' | 'text' | null>(null);
   const activeLanguage = tutorialLanguage ?? language;
   const slides = useMemo(() => activeLanguage === 'es' ? SpanishSlides() : activeLanguage === 'en' ? EnglishSlides() : CompactSlides(activeLanguage), [activeLanguage]);
   const [index, setIndex] = useState(0);
@@ -377,7 +382,7 @@ export function BasicsTutorial({ language, onLanguageChosen, onNodiStyleChosen, 
   }, []);
 
   useEffect(() => {
-    if (!tutorialLanguage || !styleChosen) return;
+    if (!tutorialLanguage || !styleChosen || learnMode !== 'text') return;
     const onKey = (event: KeyboardEvent) => {
       if (confirmSkip) return;
       if (event.key === 'ArrowRight' || event.key === 'Enter') setIndex((value) => Math.min(slides.length - 1, value + 1));
@@ -386,7 +391,12 @@ export function BasicsTutorial({ language, onLanguageChosen, onNodiStyleChosen, 
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [confirmSkip, slides.length, styleChosen, tutorialLanguage]);
+  }, [confirmSkip, learnMode, slides.length, styleChosen, tutorialLanguage]);
+
+  const videoCopy = tutorialVideoCopy(activeLanguage);
+  // Skipping is offered from every screen that follows the two mandatory choices, so
+  // the dialog is built once and rendered by each of them.
+  const skipDialog = confirmSkip && <ConfirmModal zIndex={220} title={t('¿Saltar la guía esencial?')} message={t('Esta guía explica los espacios de trabajo, los modelos que funcionan en tu equipo, los servicios externos y las búsquedas por significado.')} cancelLabel={t('Continuar tutorial')} confirmLabel={t('Saltar de todos modos')} danger onCancel={() => setConfirmSkip(false)} onConfirm={() => void onComplete()} />;
 
   if (!tutorialLanguage) return <div className="tutorial-cinema tutorial-language-screen" data-testid="basics-tutorial-language" role="dialog" aria-modal="true" aria-labelledby="tutorial-language-title"><div className="tutorial-aurora" aria-hidden="true" /><main className="tutorial-language-card"><NodiAvatar state="waving" height={190} /><p className="tutorial-eyebrow tutorial-language-brand"><Icon name="languages" size={15} /> NODUS</p><h1 id="tutorial-language-title">Choose the language for the tutorial</h1><div className="tutorial-language-grid">{TUTORIAL_LANGUAGES.map(({ code, label, flag }) => <button key={code} data-testid={`tutorial-language-${code}`} className="tutorial-language-option" style={{ '--tutorial-flag': flag } as React.CSSProperties} onClick={() => { setTutorialLanguage(code); setIndex(0); void onLanguageChosen(code); }}>{label}</button>)}</div></main></div>;
 
@@ -403,6 +413,48 @@ export function BasicsTutorial({ language, onLanguageChosen, onNodiStyleChosen, 
         onPick={(style) => { setStyleChosen(true); setIndex(0); void onNodiStyleChosen(style); }}
       />
     </main>
+  </div>;
+
+  // Third screen: watch the tutorials or read the deck. The video path is recommended
+  // because it is the same ground covered faster; the deck stays the offline path and
+  // one click away from here.
+  if (!learnMode) return <div className="tutorial-cinema tutorial-language-screen" data-testid="basics-tutorial-mode" role="dialog" aria-modal="true" aria-labelledby="tutorial-mode-title">
+    <div className="tutorial-aurora" aria-hidden="true" />
+    <main className="tutorial-language-card">
+      <p className="tutorial-eyebrow tutorial-language-brand"><Icon name="graduation" size={15} /> NODUS</p>
+      <h1 id="tutorial-mode-title">{videoCopy.chooseTitle}</h1>
+      <p>{videoCopy.chooseLede}</p>
+      <div className="tutorial-mode-grid">
+        <button type="button" className="tutorial-mode-option recommended" data-testid="tutorial-mode-video" onClick={() => setLearnMode('video')}>
+          <span className="tutorial-mode-badge">{videoCopy.videoOption.badge}</span>
+          <span className="tutorial-mode-icon"><Icon name="play" size={22} /></span>
+          <b>{videoCopy.videoOption.title}</b>
+          <span className="tutorial-mode-body">{videoCopy.videoOption.body}</span>
+        </button>
+        <button type="button" className="tutorial-mode-option" data-testid="tutorial-mode-text" onClick={() => setLearnMode('text')}>
+          <span className="tutorial-mode-icon"><Icon name="book" size={22} /></span>
+          <b>{videoCopy.textOption.title}</b>
+          <span className="tutorial-mode-body">{videoCopy.textOption.body}</span>
+        </button>
+      </div>
+      <p className="tutorial-videos-more"><Icon name="sparkles" size={13} />{videoCopy.more}</p>
+    </main>
+    {skipDialog}
+  </div>;
+
+  // The video path: the same cinema chrome, with the catalogue as a grid.
+  if (learnMode === 'video') return <div className="tutorial-cinema" data-testid="basics-tutorial-videos" role="dialog" aria-modal="true" aria-label={videoCopy.gridTitle}>
+    <div className="tutorial-aurora" aria-hidden="true" />
+    <header className="tutorial-topbar"><span>NODUS · {ui.guide}</span><button onClick={() => setConfirmSkip(true)}>{ui.skip}</button></header>
+    <TutorialVideoGrid language={activeLanguage} variant="cinema" />
+    <footer className="tutorial-footer">
+      {/* No `ui.pace` hint here: the arrow keys belong to the deck, not to the grid. */}
+      <button className="btn btn-ghost" data-testid="tutorial-mode-switch-text" onClick={() => { setIndex(0); setLearnMode('text'); }}>
+        <Icon name="book" />{videoCopy.textOption.title}
+      </button>
+      <button className="btn btn-primary" data-testid="basics-tutorial-complete" onClick={() => void onComplete()}>{ui.finish}<Icon name="check" /></button>
+    </footer>
+    {skipDialog}
   </div>;
 
   const motionProfiles = [
@@ -428,6 +480,6 @@ export function BasicsTutorial({ language, onLanguageChosen, onNodiStyleChosen, 
       </AnimatePresence>
     </main>
     <footer className="tutorial-footer"><button className="btn btn-ghost" disabled={index === 0} onClick={() => setIndex((value) => Math.max(0, value - 1))}><Icon name="arrowLeft" />{ui.back}</button><span>{ui.pace}</span>{last ? <button data-testid="basics-tutorial-complete" className="btn btn-primary" onClick={() => void onComplete()}>{ui.finish}<Icon name="check" /></button> : <button className="btn btn-primary" onClick={() => setIndex((value) => value + 1)}>{ui.next}<Icon name="chevronRight" /></button>}</footer>
-    {confirmSkip && <ConfirmModal zIndex={220} title={t('¿Saltar la guía esencial?')} message={t('Esta guía explica los espacios de trabajo, los modelos que funcionan en tu equipo, los servicios externos y las búsquedas por significado.')} cancelLabel={t('Continuar tutorial')} confirmLabel={t('Saltar de todos modos')} danger onCancel={() => setConfirmSkip(false)} onConfirm={() => void onComplete()} />}
+    {skipDialog}
   </div>;
 }

--- a/src/views/DatabasesTour.tsx
+++ b/src/views/DatabasesTour.tsx
@@ -58,6 +58,7 @@ export function DatabasesTour({ onClose, onNavigate }: { onClose: () => void; on
     <TourOverlay
       steps={STEPS}
       label="Tutorial de bases de datos"
+      vaultType="databases"
       onClose={onClose}
       onNavigate={(v) => onNavigate(v as View)}
     />

--- a/src/views/GenealogyTour.tsx
+++ b/src/views/GenealogyTour.tsx
@@ -71,6 +71,7 @@ export function GenealogyTour({ onClose, onNavigate }: { onClose: () => void; on
     <TourOverlay
       steps={STEPS}
       label="Tutorial de genealogía"
+      vaultType="genealogy"
       onClose={onClose}
       onNavigate={(v) => onNavigate(v as View)}
     />

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -26,6 +26,7 @@ import { confirm } from '../components/feedback';
 import { Icon, PROVIDER_LABELS } from '../components/ui';
 import { ModelPicker, SubscriptionQuotaNotice, ExtractionCapabilityNotice } from '../components/ModelPicker';
 import { NodiStylePicker } from '../components/nodi/NodiStylePicker';
+import { TutorialVideoGrid } from '../components/TutorialVideos';
 import { vaultTypeLabel } from '../components/VaultSwitcher';
 import { SttSettings } from '../components/SttSettings';
 import { LocalAiModelsSettings } from '../components/LocalAiModelsSettings';
@@ -789,7 +790,11 @@ export function Settings({
 
       {visibleSettingsSection('system', 'Ayuda', 'tutorial uso avanzado') && (
           <Section title={t('Ayuda')}>
-            <div className="flex items-center justify-between gap-4">
+            {/* The videos come first: for most people they are the fastest way in. Their
+                copy comes from shared/tutorialVideos.ts rather than t() because that
+                table covers the tutorial's twelve languages, not the interface's seven. */}
+            <TutorialVideoGrid language={settings.uiLanguage} variant="panel" />
+            <div className="border-t border-neutral-800 pt-4 flex items-center justify-between gap-4">
               <div>
                 <label className="text-sm text-neutral-300">{t('Guía esencial de Nodus e IA')}</label>
                 <p className="text-xs text-neutral-500 mt-0.5">{t('Bóvedas, modelos locales, API keys, costes, embeddings y voz explicados desde cero.')}</p>

--- a/src/views/StudyTour.tsx
+++ b/src/views/StudyTour.tsx
@@ -64,5 +64,5 @@ const STEPS: TourStep[] = [
 ];
 
 export function StudyTour({ onClose, onNavigate }: { onClose: () => void; onNavigate: (view: View) => void }) {
-  return <TourOverlay steps={STEPS} label="Tutorial de estudio" onClose={onClose} onNavigate={(view) => onNavigate(view as View)} />;
+  return <TourOverlay steps={STEPS} label="Tutorial de estudio" vaultType="estudio" onClose={onClose} onNavigate={(view) => onNavigate(view as View)} />;
 }

--- a/src/views/TeachingTour.tsx
+++ b/src/views/TeachingTour.tsx
@@ -120,6 +120,7 @@ export function TeachingTour({ onClose, onNavigate }: { onClose: () => void; onN
     <TourOverlay
       steps={STEPS}
       label="Tutorial de docencia"
+      vaultType="docencia"
       accent={VAULT_TYPE_COLORS.docencia}
       onClose={onClose}
       onNavigate={(view) => onNavigate(view as View)}

--- a/src/views/Tour.tsx
+++ b/src/views/Tour.tsx
@@ -84,5 +84,12 @@ const STEPS: TourStep[] = [
 ];
 
 export function Tour({ onClose, onNavigate }: { onClose: () => void; onNavigate: (v: ViewId) => void }) {
-  return <TourOverlay steps={STEPS} onClose={onClose} onNavigate={(v) => onNavigate(v as ViewId)} />;
+  return (
+    <TourOverlay
+      steps={STEPS}
+      vaultType="academic"
+      onClose={onClose}
+      onNavigate={(v) => onNavigate(v as ViewId)}
+    />
+  );
 }

--- a/src/views/tourEngine.tsx
+++ b/src/views/tourEngine.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useLayoutEffect, useState } from 'react';
-import { t } from '../i18n';
+import type { VaultType } from '@shared/types';
+import { tutorialVideoCopy, tutorialVideoForVault, type TutorialVideo } from '@shared/tutorialVideos';
+import { TutorialVideoPlayer } from '../components/TutorialVideos';
+import { Icon } from '../components/ui';
+import { getActiveLang, t } from '../i18n';
 
 export interface TourStep {
   /** A `data-tour="…"` value to spotlight. Omit for a centered, target-less step. */
@@ -29,11 +33,21 @@ export function TourOverlay({
   steps,
   label = 'Tutorial',
   accent = DEFAULT_ACCENT,
+  vaultType,
   onClose,
   onNavigate,
 }: {
   steps: TourStep[];
   label?: string;
+  /**
+   * The vault this tour teaches. If a video covers it, the opening step offers it as the
+   * recommended third option next to the in-app walkthrough and "not now"; watching it
+   * counts as having taken the tour, which is why the player closing also closes the
+   * tour (Settings can replay either at any time). The video is looked up in the
+   * published catalogue, so a vault gains the option the day its video ships — no
+   * release required, and no change to this component.
+   */
+  vaultType?: VaultType;
   /**
    * Spotlight colour. The eyebrow and the progress dots are Tailwind `indigo-*`
    * utilities, which the per-vault `.<type>` blocks in index.css already remap; the
@@ -45,6 +59,8 @@ export function TourOverlay({
   onNavigate: (view: string) => void;
 }) {
   const [i, setI] = useState(0);
+  const [watchingVideo, setWatchingVideo] = useState(false);
+  const [video, setVideo] = useState<TutorialVideo | undefined>(() => tutorialVideoForVault(vaultType));
   const [rect, setRect] = useState<Rect | null>(null);
   // The card node lives in state rather than a ref so the first measurement happens as
   // soon as it mounts; a plain ref is still null on the pass that positions it.
@@ -58,6 +74,17 @@ export function TourOverlay({
   useEffect(() => {
     if (step.view) onNavigate(step.view);
   }, [i, step.view, onNavigate]);
+
+  // A video published after this build still reaches the opening step.
+  useEffect(() => {
+    if (!vaultType) return;
+    let cancelled = false;
+    void window.nodus.getTutorialCatalogue().then((catalogue) => {
+      if (cancelled || !Array.isArray(catalogue)) return;
+      setVideo(tutorialVideoForVault(vaultType, catalogue));
+    }).catch(() => { /* keep whatever this build knows */ });
+    return () => { cancelled = true; };
+  }, [vaultType]);
 
   /**
    * Measure the target, RETRYING until it appears.
@@ -110,6 +137,9 @@ export function TourOverlay({
   }, [card, i]);
 
   useEffect(() => {
+    // While the video plays, the keyboard belongs to the player: Escape has to leave
+    // fullscreen or close it, not dismiss the tour underneath.
+    if (watchingVideo) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
       else if (e.key === 'ArrowRight' || e.key === 'Enter') setI((n) => Math.min(steps.length - 1, n + 1));
@@ -117,7 +147,7 @@ export function TourOverlay({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [onClose, steps.length]);
+  }, [onClose, steps.length, watchingVideo]);
 
   const pad = 6;
   const spotlight: Rect | null = rect
@@ -174,7 +204,11 @@ export function TourOverlay({
         <h3 className="font-semibold text-base mb-1">{t(step.title)}</h3>
         <p className="text-neutral-300 leading-relaxed">{t(step.body)}</p>
 
-        <div className="flex items-center justify-between mt-4">
+        {/* The opening step offers up to three ways in, and the card is only 360px wide:
+            side by side they overflowed it and each label broke into three lines. They
+            are stacked full-width instead — which is also the shape every other vault
+            gets the day its own video is published. Later steps keep the compact row. */}
+        <div className={`mt-4 ${isFirst ? 'flex flex-col gap-3' : 'flex items-center justify-between'}`}>
           <div className="flex gap-1">
             {steps.map((_, n) => (
               <span
@@ -183,7 +217,7 @@ export function TourOverlay({
               />
             ))}
           </div>
-          <div className="flex gap-2">
+          <div className={isFirst ? 'flex flex-col gap-2' : 'flex gap-2'}>
             {!isFirst && (
               <button className="btn btn-ghost" onClick={() => setI((n) => Math.max(0, n - 1))}>
                 {t('Atrás')}
@@ -191,11 +225,20 @@ export function TourOverlay({
             )}
             {isFirst ? (
               <>
-                <button className="btn btn-ghost" onClick={onClose}>
-                  {t('Ahora no')}
-                </button>
-                <button className="btn btn-primary" onClick={() => setI(1)}>
+                {video && (
+                  <button className="btn btn-primary w-full" data-testid="tour-watch-video" onClick={() => setWatchingVideo(true)}>
+                    <Icon name="play" size={14} />
+                    {tutorialVideoCopy(getActiveLang()).tourVideo}
+                  </button>
+                )}
+                <button
+                  className={`w-full ${video ? 'btn btn-ghost border border-neutral-700' : 'btn btn-primary'}`}
+                  onClick={() => setI(1)}
+                >
                   {t('Sí, enséñame')}
+                </button>
+                <button className="btn btn-ghost w-full" onClick={onClose}>
+                  {t('Ahora no')}
                 </button>
               </>
             ) : isLast ? (
@@ -210,6 +253,14 @@ export function TourOverlay({
           </div>
         </div>
       </div>
+
+      {watchingVideo && video && (
+        <TutorialVideoPlayer
+          video={video}
+          language={getActiveLang()}
+          onClose={() => { setWatchingVideo(false); onClose(); }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #237.

## The flow, after this

A first run now asks three questions instead of two: language, which Nodi, and **how do you prefer to learn?** — watch the tutorials (recommended) or read the guide at your own pace. Everything after that is unchanged: the backup wizard, the vault onboarding and the tours keep their order and their gates.

The video path renders the published catalogue as a grid inside the same cinematic chrome. Each card opens an in-app player with YouTube's own controls — pause, seek, captions, speed, fullscreen — and Escape or Close leaves at any point. Opening a video marks it watched, with "mark as unwatched" to undo; the flags live in `GLOBAL_PREF_KEYS`, so a video watched in one vault stays watched in the others. The written deck stays one click away in the footer and remains the offline path.

Settings → Tutorials leads with the same grid, above the replay buttons it already had, remapped for light mode. A vault tour whose ground a video covers opens with three ways in — watch the video (recommended), walk the app, or not now — and watching counts as having taken the tour.

## Why the videos stream instead of shipping

The installers already weigh 460–939 MB. Three ~15-minute captures would add hundreds of megabytes to every platform for material most people watch once, and every new tutorial would need a release. Streaming keeps the promise cheap; the written guide keeps the offline one.

The grid itself stays quiet: posters are local gradients (a WebP dropped into `src/assets/tutorials/` overrides one), there are no remote thumbnails, and the only remote frame is the player, mounted on click. `frame-src` names exactly one host, `youtube-nocookie.com`, and the copy says out loud where the videos live.

## Two things only a packaged run could surface

**YouTube answered the embed with its "error 153" card.** A packaged renderer is served from `file://`, so the frame request carries no http referer and the embed is refused. From the dev server it works — which is precisely how this would have shipped broken. Confirmed by isolating it (same embed from an http origin plays; from `file://` it does not) and fixed by naming the Nodus site as the embedding page for that one host, in the session that already patches the User-Agent for YouTube. The same rewrite covers the PDF Presenter's YouTube overlay, which carried the same latent bug.

**Three buttons did not fit the 360px tour card** — they overflowed it and each label broke into three lines. The opening step now stacks them full-width, in every vault: academic shows three options, the others two, and both were checked on screen.

## The list is refreshable

`docs/tutorials.json` is published with the site and fetched in the **main process** when a grid opens — never at startup, and never from the renderer, which would mean widening the CSP for a second host. The answer is cached in `userData`, so the next launch has it offline, and the built-in three are always a complete fallback.

Everything in that file is untrusted input: slug ids, YouTube's exact 11-character id shape (no arbitrary URL can be smuggled in), an icon allowlist, and **no poster taken from the file at all** — a remote CSS value could fetch an image and undo the promise above. Malformed entries are dropped one by one and logged, and the merge is a union: a truncated or half-written file can never hide a tutorial the app already ships. Once this lands, adding a tutorial is one entry in that JSON.

## Verification

- `npm test` — 834/834, including 16 new checks in `scripts/test-tutorial-videos.mjs` (copy present in all twelve languages and never falling back to Spanish, catalogue validation and injection attempts, CSP shape, the layout fix, the referer rewrite).
- `npm run test:e2e` — green, with the tutorial walk extended through the new screen, the player and the watched flag.
- `npm run typecheck` and `npm run build` — clean.
- `scripts/verify-tutorial-videos.mjs` — eight phases against the real app, with screenshots: the three gates in order, the grid, the embed loading with no CSP refusal, the watched flag surviving the player closing, Settings in light mode, the academic tour's three options fitting inside the card, and a vault without a video still opening cleanly. It also serves a catalogue of its own to prove the remote path: the grid grows to a fourth tutorial this build knows nothing about.
