### PR TITLE
Announce the video tutorials to installs that predate them

### DIFF
--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -320,6 +320,11 @@ try {
   await page.evaluate(async () => {
     localStorage.removeItem('nodus.lastSeenVersion');
     localStorage.removeItem('nodus.platformHighlightsSeen.2026-07');
+    // Walking the tutorial above marked the videos announcement seen, exactly as it
+    // does for a real first run. Clear it here so the announcement this existing user
+    // never got is exercised too — it must be cleared BEFORE the render, since
+    // eligibility is read once, when the modal mounts.
+    localStorage.removeItem('nodus.tutorialVideosAnnouncementSeen.2026-07');
     await window.nodus.updateSettings({ uiLanguage: 'es', promptLanguage: 'es', basicsTutorialVersion: 4 });
   });
   await page.reload();
@@ -339,6 +344,18 @@ try {
   await platformTour.waitFor({ state: 'detached' });
   assert.equal(await page.evaluate(() => localStorage.getItem('nodus.platformHighlightsSeen.2026-07')), '1', 'the summary is marked seen only after its final action');
   console.log('[e2e] release notes hand off to the translated three-part connected-workflows summary');
+
+  // …and behind that, the videos announcement: the one modal that embeds the catalogue
+  // instead of describing it, for users who completed the guide when it was text-only.
+  const videosTour = page.getByTestId('tutorial-videos-update-tour');
+  await videosTour.waitFor();
+  await videosTour.getByRole('heading', { name: 'Tutoriales en vídeo', exact: true }).waitFor();
+  assert.equal(await videosTour.locator('.tutorial-video-card').count(), 3, 'the announcement embeds the published catalogue');
+  assert.equal(await videosTour.locator('iframe').count(), 0, 'nothing is framed until a card is opened');
+  await videosTour.getByTestId('tutorial-videos-tour-complete').click();
+  await videosTour.waitFor({ state: 'detached' });
+  assert.equal(await page.evaluate(() => localStorage.getItem('nodus.tutorialVideosAnnouncementSeen.2026-07')), '1', 'the announcement is marked seen only when dismissed');
+  console.log('[e2e] the video tutorials announcement shows the catalogue in-modal, once');
 
   // Back to Spanish for the rest of the suite, which asserts on Spanish copy. The
   // reload above already consumed the once-per-session startup update check, so reset

--- a/scripts/test-startup-update-modal.mjs
+++ b/scripts/test-startup-update-modal.mjs
@@ -14,7 +14,9 @@ const [modal, app, main, styles, translations] = await Promise.all([
 ]);
 
 test('the app performs one visible update check per launch after the update guides settle', () => {
-  assert.match(app, /whatsNewSettled && platformHighlightsSettled && toolkitBetaTourSettled && !manualWhatsNewOpen && <StartupUpdateModal[\s\S]*?\/>/);
+  // Every one-time guide — release notes, the two update tours and the video tutorials
+  // announcement — must have settled before the update check takes the foreground.
+  assert.match(app, /whatsNewSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && <StartupUpdateModal[\s\S]*?\/>/);
   assert.match(app, /<WhatsNewModal[\s\S]*onSettled=\{\(\) => setWhatsNewSettled\(true\)\}/);
   // The one-time Nodi choice queues behind this modal, so a launch that never shows it
   // must still settle or that modal would wait forever.

--- a/scripts/test-tutorial-videos.mjs
+++ b/scripts/test-tutorial-videos.mjs
@@ -173,6 +173,52 @@ test('Settings leads its tutorials section with the grid', async () => {
   assert.match(css, /\.light \.tutorial-video-player/);
 });
 
+test('the videos are announced once to installs that predate them', async () => {
+  const [guide, app] = await Promise.all([
+    read('src/components/TutorialVideosGuide.tsx'),
+    read('src/App.tsx'),
+  ]);
+  // The announcement shows the videos rather than describing them: the same grid and
+  // the same in-app player, in the update tours' cinematic chrome.
+  assert.match(guide, /className="toolkit-guide-cinema tutorial-videos-guide"/);
+  assert.match(guide, /data-testid="tutorial-videos-update-tour"/);
+  assert.match(guide, /<TutorialVideoGrid language=\{uiLanguage\} variant="panel" showHeading=\{false\} \/>/);
+  // Shown once, and only to someone who finished the guide back when it was text-only.
+  assert.match(guide, /if \(previousTutorialVersion <= 0\) return false;/);
+  assert.match(guide, /localStorage\.getItem\(SEEN_KEY\) !== '1'/);
+  // Marked seen on dismissal, never merely on mount.
+  assert.match(guide, /const finish = \(\) => \{\s*\/\/[^\n]*\n\s*\/\/[^\n]*\n\s*markTutorialVideosAnnouncementSeen\(\);/);
+
+  // Completing the cinematic guide answers the same question, so it settles the
+  // announcement too — a fresh install must never be told about a choice it just made.
+  assert.match(app, /markTutorialVideosAnnouncementSeen\(\);\s*\n\s*await window\.nodus\.updateSettings\(\{ basicsTutorialVersion: BASICS_TUTORIAL_VERSION \}\)/);
+  // It queues behind the other one-time tours and ahead of the update check, so two
+  // modals never fight for the foreground.
+  const order = ['<WhatsNewModal', '<PlatformHighlightsUpdateTour', '<ToolkitBetaUpdateTour', '<TutorialVideosUpdateTour', '<StartupUpdateModal'].map((tag) => app.indexOf(tag));
+  assert.deepEqual(order, [...order].sort((a, b) => a - b), 'the videos announcement sits between the toolkit tour and the update check');
+  assert.match(app, /toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && <StartupUpdateModal/);
+});
+
+test('the announcement speaks every interface language', async () => {
+  const [guide, types] = await Promise.all([
+    read('src/components/TutorialVideosGuide.tsx'),
+    read('shared/types.ts'),
+  ]);
+  // Read the languages from the type itself, so an eighth UI language fails here.
+  const declared = types.match(/export type AppLanguage = ([^;]+);/)[1]
+    .split('|').map((code) => code.trim().replace(/'/g, ''));
+  assert.equal(declared.length, 7);
+  const table = guide.slice(guide.indexOf('const COPY: Record<AppLanguage, AnnouncementCopy>'), guide.indexOf('export function markTutorialVideosAnnouncementSeen'));
+  for (const code of declared) {
+    assert.match(table, new RegExp(`\\n  '?${code}'?: \\{`), `${code} has no announcement copy`);
+  }
+  // Seven distinct summaries: a table that quietly reused one language would pass every
+  // per-key check above.
+  const summaries = [...table.matchAll(/\n    summary: '(.+)',/g)].map((match) => match[1]);
+  assert.equal(summaries.length, 7);
+  assert.equal(new Set(summaries).size, 7, 'one of the languages falls back to another');
+});
+
 test('a vault tour with a video offers three ways in', async () => {
   const [engine, tour] = await Promise.all([read('src/views/tourEngine.tsx'), read('src/views/Tour.tsx')]);
   assert.match(engine, /vaultType\?: VaultType/);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { TeachingTour } from './views/TeachingTour';
 import { BASICS_TUTORIAL_VERSION, BasicsTutorial } from './views/BasicsTutorial';
 import { preferencesForTutorialLanguage } from '@shared/tutorialPreferences';
 import { hasPendingWhatsNew, WhatsNewModal } from './components/WhatsNewModal';
+import { markTutorialVideosAnnouncementSeen, TutorialVideosUpdateTour } from './components/TutorialVideosGuide';
 import { PlatformHighlightsUpdateTour } from './components/PlatformHighlightsGuide';
 import { ToolkitBetaUpdateTour } from './components/ToolkitBetaGuide';
 import { StartupUpdateModal } from './components/StartupUpdateModal';
@@ -188,6 +189,9 @@ export function App() {
   // The 2.4.0 toolkit/model guide queues directly behind release notes. Its own
   // versioned guard settles immediately for new installs and for users who saw it.
   const [toolkitBetaTourSettled, setToolkitBetaTourSettled] = useState(false);
+  // Users who completed the essential guide before the video tutorials existed were
+  // never asked "video or text", so the catalogue is announced to them once, here.
+  const [tutorialVideosSettled, setTutorialVideosSettled] = useState(false);
   // Set once the startup update check is done with the screen, so the one-time Nodi
   // choice can queue up behind it instead of fighting it for the foreground.
   const [updateSettled, setUpdateSettled] = useState(false);
@@ -856,6 +860,9 @@ export function App() {
           await reloadSettings();
         }}
         onComplete={async () => {
+          // The guide itself asks video or text, so whoever finishes it has already met
+          // the catalogue: the announcement for older installs must not follow them out.
+          markTutorialVideosAnnouncementSeen();
           await window.nodus.updateSettings({ basicsTutorialVersion: BASICS_TUTORIAL_VERSION });
           await reloadSettings();
         }}
@@ -1673,7 +1680,15 @@ export function App() {
         />
       )}
 
-      {whatsNewSettled && platformHighlightsSettled && toolkitBetaTourSettled && !manualWhatsNewOpen && <StartupUpdateModal onSettled={() => setUpdateSettled(true)} />}
+      {whatsNewSettled && platformHighlightsSettled && toolkitBetaTourSettled && !tutorialVideosSettled && !manualWhatsNewOpen && (
+        <TutorialVideosUpdateTour
+          uiLanguage={settings.uiLanguage}
+          previousTutorialVersion={settings.basicsTutorialVersion}
+          onSettled={() => setTutorialVideosSettled(true)}
+        />
+      )}
+
+      {whatsNewSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && <StartupUpdateModal onSettled={() => setUpdateSettled(true)} />}
 
       {/* Users who already saw the cinematic tutorial were never offered the choice of
           Nodi, so it is made here instead — once, behind the update check. New users

--- a/src/components/TutorialVideosGuide.tsx
+++ b/src/components/TutorialVideosGuide.tsx
@@ -1,0 +1,240 @@
+import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import type { AppLanguage } from '@shared/types';
+import { Icon } from './ui';
+import { NodiAvatar } from './nodi/NodiAvatar';
+import { TutorialVideoGrid } from './TutorialVideos';
+import './tutorialVideos.css';
+
+/**
+ * "The tutorials are now on video too" — the one-time announcement.
+ *
+ * The cinematic guide asks new users whether they want the videos or the written deck,
+ * so a fresh install meets the catalogue on its first run and never sees this modal.
+ * Everyone who completed the guide before the videos existed was never asked, and would
+ * otherwise only find them by wandering into Settings → Tutorials. This is that
+ * announcement, in the chrome the other update tours use — and because the point is the
+ * videos themselves, they are embedded here rather than described: the same grid, the
+ * same in-app player, one click from the modal.
+ *
+ * The privacy promise of the grid survives: nothing is requested until a card is opened
+ * (posters are local gradients), and the written guide is still named as the offline
+ * path.
+ */
+
+const SEEN_KEY = 'nodus.tutorialVideosAnnouncementSeen.2026-07';
+
+type AnnouncementCopy = {
+  badge: string;
+  title: string;
+  summary: string;
+  eyebrow: string;
+  heading: string;
+  lede: string;
+  settingsTitle: string;
+  settingsBody: string;
+  toursTitle: string;
+  toursBody: string;
+  offline: string;
+  hint: string;
+  finish: string;
+};
+
+const COPY: Record<AppLanguage, AnnouncementCopy> = {
+  es: {
+    badge: 'NUEVO · TUTORIALES EN VÍDEO',
+    title: 'Los tutoriales, ahora también en vídeo',
+    summary: 'Ya viste la guía esencial en texto. Desde ahora los mismos contenidos están disponibles en vídeo, dentro de Nodus.',
+    eyebrow: 'Míralos aquí mismo',
+    heading: 'Tutoriales en vídeo',
+    lede: 'Ábrelos sin salir de la aplicación, con pausa, subtítulos y pantalla completa. Cada uno se marca como visto en cuanto lo abres.',
+    settingsTitle: 'Siempre a mano',
+    settingsBody: 'Ajustes → Tutoriales reúne el catálogo completo y la guía escrita.',
+    toursTitle: 'También en las visitas guiadas',
+    toursBody: 'Cuando una bóveda tiene vídeo, su visita guiada lo ofrece como tercera opción.',
+    offline: 'La guía escrita no desaparece: sigue dentro de la app y funciona sin conexión.',
+    hint: 'Puedes volver a los vídeos cuando quieras desde Ajustes → Tutoriales.',
+    finish: 'Entendido',
+  },
+  en: {
+    badge: 'NEW · VIDEO TUTORIALS',
+    title: 'The tutorials are now on video too',
+    summary: 'You already went through the written guide. The same material is now available as video, inside Nodus.',
+    eyebrow: 'Watch them right here',
+    heading: 'Video tutorials',
+    lede: 'Open them without leaving the app, with pause, captions and fullscreen. Each one is marked as watched as soon as you open it.',
+    settingsTitle: 'Always within reach',
+    settingsBody: 'Settings → Tutorials holds the full catalogue and the written guide.',
+    toursTitle: 'In the guided tours too',
+    toursBody: 'When a vault has a video, its guided tour offers it as a third way in.',
+    offline: 'The written guide is not going anywhere: it stays in the app and works offline.',
+    hint: 'You can come back to the videos any time from Settings → Tutorials.',
+    finish: 'Got it',
+  },
+  fr: {
+    badge: 'NOUVEAU · TUTORIELS VIDÉO',
+    title: 'Les tutoriels existent aussi en vidéo',
+    summary: 'Vous avez déjà parcouru le guide écrit. Le même contenu est désormais disponible en vidéo, dans Nodus.',
+    eyebrow: 'Regardez-les ici même',
+    heading: 'Tutoriels vidéo',
+    lede: 'Ouvrez-les sans quitter l’application, avec pause, sous-titres et plein écran. Chacun est marqué comme vu dès son ouverture.',
+    settingsTitle: 'Toujours à portée de main',
+    settingsBody: 'Réglages → Tutoriels rassemble tout le catalogue et le guide écrit.',
+    toursTitle: 'Et dans les visites guidées',
+    toursBody: 'Quand un coffre dispose d’une vidéo, sa visite guidée la propose comme troisième option.',
+    offline: 'Le guide écrit reste en place : il vit dans l’app et fonctionne hors ligne.',
+    hint: 'Vous pouvez revenir aux vidéos à tout moment depuis Réglages → Tutoriels.',
+    finish: 'J’ai compris',
+  },
+  de: {
+    badge: 'NEU · VIDEO-TUTORIALS',
+    title: 'Die Tutorials gibt es jetzt auch als Video',
+    summary: 'Sie haben die schriftliche Anleitung bereits gesehen. Dieselben Inhalte gibt es ab sofort als Video – in Nodus.',
+    eyebrow: 'Direkt hier ansehen',
+    heading: 'Video-Tutorials',
+    lede: 'Öffnen Sie sie, ohne die App zu verlassen – mit Pause, Untertiteln und Vollbild. Jedes wird beim Öffnen als gesehen markiert.',
+    settingsTitle: 'Immer griffbereit',
+    settingsBody: 'Einstellungen → Tutorials versammelt den ganzen Katalog und die schriftliche Anleitung.',
+    toursTitle: 'Auch in den Touren',
+    toursBody: 'Hat ein Vault ein Video, bietet seine Tour es als dritten Weg an.',
+    offline: 'Die schriftliche Anleitung bleibt: Sie steckt weiter in der App und funktioniert offline.',
+    hint: 'Sie können jederzeit über Einstellungen → Tutorials zu den Videos zurückkehren.',
+    finish: 'Verstanden',
+  },
+  it: {
+    badge: 'NOVITÀ · TUTORIAL VIDEO',
+    title: 'I tutorial ora sono anche in video',
+    summary: 'Hai già seguito la guida scritta. Gli stessi contenuti sono ora disponibili in video, dentro Nodus.',
+    eyebrow: 'Guardali proprio qui',
+    heading: 'Tutorial video',
+    lede: 'Aprili senza uscire dall’app, con pausa, sottotitoli e schermo intero. Ognuno viene segnato come visto appena lo apri.',
+    settingsTitle: 'Sempre a portata di mano',
+    settingsBody: 'Impostazioni → Tutorial raccoglie l’intero catalogo e la guida scritta.',
+    toursTitle: 'Anche nei tour guidati',
+    toursBody: 'Quando un vault ha un video, il suo tour lo propone come terza opzione.',
+    offline: 'La guida scritta resta al suo posto: vive nell’app e funziona offline.',
+    hint: 'Puoi tornare ai video quando vuoi da Impostazioni → Tutorial.',
+    finish: 'Ho capito',
+  },
+  pt: {
+    badge: 'NOVO · TUTORIAIS EM VÍDEO',
+    title: 'Os tutoriais agora também estão em vídeo',
+    summary: 'Já percorreu o guia escrito. Os mesmos conteúdos estão agora disponíveis em vídeo, dentro do Nodus.',
+    eyebrow: 'Veja-os aqui mesmo',
+    heading: 'Tutoriais em vídeo',
+    lede: 'Abra-os sem sair da aplicação, com pausa, legendas e ecrã inteiro. Cada um fica marcado como visto assim que o abre.',
+    settingsTitle: 'Sempre à mão',
+    settingsBody: 'Definições → Tutoriais reúne todo o catálogo e o guia escrito.',
+    toursTitle: 'Também nas visitas guiadas',
+    toursBody: 'Quando um cofre tem vídeo, a sua visita guiada oferece-o como terceira opção.',
+    offline: 'O guia escrito não vai a lado nenhum: continua na app e funciona sem ligação.',
+    hint: 'Pode voltar aos vídeos quando quiser em Definições → Tutoriais.',
+    finish: 'Percebi',
+  },
+  'pt-BR': {
+    badge: 'NOVO · TUTORIAIS EM VÍDEO',
+    title: 'Os tutoriais agora também estão em vídeo',
+    summary: 'Você já viu o guia escrito. O mesmo conteúdo agora está disponível em vídeo, dentro do Nodus.',
+    eyebrow: 'Assista aqui mesmo',
+    heading: 'Tutoriais em vídeo',
+    lede: 'Abra sem sair do app, com pausa, legendas e tela cheia. Cada um é marcado como visto assim que você abre.',
+    settingsTitle: 'Sempre por perto',
+    settingsBody: 'Configurações → Tutoriais reúne todo o catálogo e o guia escrito.',
+    toursTitle: 'Também nos tours guiados',
+    toursBody: 'Quando um cofre tem vídeo, o tour dele oferece o vídeo como terceira opção.',
+    offline: 'O guia escrito continua: ele fica no app e funciona offline.',
+    hint: 'Você pode voltar aos vídeos quando quiser em Configurações → Tutoriais.',
+    finish: 'Entendi',
+  },
+};
+
+/**
+ * The announcement is for users who met Nodus before the videos existed, so completing
+ * the cinematic guide — which now asks video or text — settles it for good. Called from
+ * App when the guide finishes, before the settings reload that mounts the modal's host.
+ */
+export function markTutorialVideosAnnouncementSeen(): void {
+  try { localStorage.setItem(SEEN_KEY, '1'); } catch { /* storage unavailable: the modal simply appears once */ }
+}
+
+function shouldPresent(previousTutorialVersion: number): boolean {
+  // Zero means the guide has not been completed: that user is about to be asked the
+  // question this modal exists to replace.
+  if (previousTutorialVersion <= 0) return false;
+  try { return localStorage.getItem(SEEN_KEY) !== '1'; } catch { return true; }
+}
+
+export function TutorialVideosUpdateTour({
+  uiLanguage,
+  previousTutorialVersion,
+  onSettled,
+}: {
+  uiLanguage: AppLanguage;
+  previousTutorialVersion: number;
+  onSettled: () => void;
+}) {
+  const [eligible] = useState(() => shouldPresent(previousTutorialVersion));
+  const copy = COPY[uiLanguage] ?? COPY.en;
+
+  useEffect(() => { if (!eligible) onSettled(); }, [eligible, onSettled]);
+  if (!eligible) return null;
+
+  const finish = () => {
+    // Written only when the user actually dismisses the modal, so a launch that never
+    // reached the foreground does not consume the one showing.
+    markTutorialVideosAnnouncementSeen();
+    onSettled();
+  };
+
+  return <motion.div className="toolkit-guide-backdrop" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: .22 }}>
+    <motion.section
+      className="toolkit-guide-cinema tutorial-videos-guide"
+      data-testid="tutorial-videos-update-tour"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tutorial-videos-guide-title"
+      initial={{ opacity: 0, y: 28, scale: .96 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: .46, ease: [0.2, 0.8, 0.2, 1] }}
+    >
+      <header className="toolkit-guide-hero">
+        <div className="toolkit-guide-aurora" aria-hidden="true" />
+        <div className="toolkit-guide-hero-copy">
+          <div className="toolkit-guide-kicker"><Icon name="play" size={14} /> {copy.badge}</div>
+          <h2>{copy.title}</h2>
+          <p>{copy.summary}</p>
+        </div>
+        <div className="toolkit-guide-nodi"><NodiAvatar state="celebrating" height={172} /></div>
+      </header>
+
+      <div className="toolkit-guide-stage">
+        <div className="toolkit-guide-eyebrow"><Icon name="graduation" size={15} /> {copy.eyebrow}</div>
+        <h3 id="tutorial-videos-guide-title">{copy.heading}</h3>
+        <p className="toolkit-guide-summary">{copy.lede}</p>
+        <div className="toolkit-guide-content">
+          {/* The `panel` skin is the one that survives light mode, which this card follows.
+              Its own heading is dropped: the stage above already carries the title. */}
+          <TutorialVideoGrid language={uiLanguage} variant="panel" showHeading={false} />
+          <div className="tutorial-videos-guide-where">
+            <div>
+              <Icon name="settings" size={17} />
+              <div><b>{copy.settingsTitle}</b><small>{copy.settingsBody}</small></div>
+            </div>
+            <div>
+              <Icon name="compass" size={17} />
+              <div><b>{copy.toursTitle}</b><small>{copy.toursBody}</small></div>
+            </div>
+          </div>
+          <div className="toolkit-guide-notice"><Icon name="book" size={17} /><div>{copy.offline}</div></div>
+        </div>
+      </div>
+
+      <footer className="toolkit-guide-footer tutorial-videos-guide-footer">
+        <span>{copy.hint}</span>
+        <button className="primary" data-testid="tutorial-videos-tour-complete" onClick={finish}>
+          {copy.finish} <Icon name="check" size={14} />
+        </button>
+      </footer>
+    </motion.section>
+  </motion.div>;
+}

--- a/src/components/tutorialVideos.css
+++ b/src/components/tutorialVideos.css
@@ -214,6 +214,38 @@
 }
 .tutorial-video-frame iframe { display: block; width: 100%; height: 100%; border: 0; }
 
+/* ── the "now on video too" announcement ────────────────────────────────────────── */
+/* The grid sits inside the update-tour card (840px wide), so its cards are narrower
+   than in Settings; everything else is inherited from the `panel` skin, including its
+   light-mode remaps, because this card follows the theme. */
+.tutorial-videos-guide .tutorial-video-grid { grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.tutorial-videos-guide .tutorial-video-poster { height: 104px; }
+/* The tour's stage styles every h3 inside it as a 34px headline, which lands on the
+   cards' own titles too — they have the same specificity and index.css wins on order. */
+.tutorial-videos-guide .tutorial-video-body h3 { margin-top: 0; font-size: .88rem; font-weight: 650; line-height: 1.3; letter-spacing: 0; }
+
+.tutorial-videos-guide-where { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .6rem; }
+.tutorial-videos-guide-where > div {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: .6rem;
+  border: 1px solid var(--tg-border, rgba(255, 255, 255, .11));
+  border-radius: .85rem;
+  padding: .7rem .8rem;
+  background: var(--tg-card, rgba(255, 255, 255, .055));
+}
+.tutorial-videos-guide-where > div > svg { flex: 0 0 auto; margin-top: .1rem; color: #14b8a6; }
+.tutorial-videos-guide-where b { display: block; color: var(--tg-text, #f1f5f9); font-size: .78rem; font-weight: 700; }
+.tutorial-videos-guide-where small { color: var(--tg-muted, #a3acba); font-size: .72rem; line-height: 1.45; }
+
+.tutorial-videos-guide-footer span { min-width: 0; color: var(--tg-muted, #a3acba); font-size: .69rem; line-height: 1.4; }
+
+@media (max-width: 660px) {
+  .tutorial-videos-guide-where { grid-template-columns: 1fr; }
+  .tutorial-videos-guide-footer span { display: none; }
+}
+
 /* ── light mode (the Settings panel and the player) ─────────────────────────────── */
 .light .tutorial-videos-panel .tutorial-video-card { border-color: rgba(15, 23, 42, .14); background: rgba(15, 23, 42, .03); }
 .light .tutorial-videos-panel .tutorial-video-card:hover { border-color: rgba(15, 23, 42, .34); box-shadow: 0 16px 38px rgba(15, 23, 42, .14); }


### PR DESCRIPTION
Users who completed the essential guide before the video tutorials existed were never asked "video or text", so the catalogue is silent for them. This is the one-time announcement they get instead, in the same cinematic chrome as the connected-workflows summary and the Toolkit beta guide.

Because the news *is* the videos, the modal shows them rather than describing them: the published catalogue is embedded as the same grid Settings uses, and a card opens the same in-app player over the modal — pause, captions, fullscreen, marked as watched on open. Nothing is requested until a card is opened (the posters are local gradients), and the written guide is still named as the offline path.

It shows once, and only to someone whose guide predates the question it replaces: completing the guide marks the announcement seen, so a fresh install is never told about a choice it just made. It queues behind the release notes and the two update tours and ahead of the update check, so two modals never fight for the foreground. Copy is localised into all seven interface languages.

Two things the real render decided:

- The tour stage styles every `h3` inside it as a 34px headline, which landed on the cards' own titles — same specificity, `index.css` wins on order. The embedded grid needs its card titles back at card size.
- The `panel` skin, not `cinema`, is the one carrying light-mode remaps, and this card follows the theme.

## Verification

- `npm test` — 837/837 (two new checks: shown once and correctly chained; copy present and distinct in all seven languages)
- `npm run test:e2e` — the smoke test now walks the announcement on a throwaway profile: it appears for an existing user, embeds the three published tutorials, frames nothing until a card is opened, and its seen key is written only on dismissal
- `npm run lint`, typecheck and `npm run build` clean
- Rendered in the real packaged renderer in dark and light mode, and a tutorial played from inside the modal

Closes #239