### PR TITLE
Enable `disableFontFace` in the Node PDF.js loader

### DIFF
--- a/electron/extraction/pdfjsLoader.ts
+++ b/electron/extraction/pdfjsLoader.ts
@@ -27,7 +27,7 @@ export async function openPdf(filePath: string): Promise<any> {
   // Without it, PDFs using Helvetica/Times can expose a valid text layer while
   // rendering blank glyphs in the Node canvas used by facsimile translation.
   const standardFontDataUrl = pathToFileURL(path.join(pdfjsRoot, 'standard_fonts') + path.sep).href;
-  const task = pdfjs.getDocument({ data, useSystemFonts: true, standardFontDataUrl, isEvalSupported: false, disableFontFace: false });
+  const task = pdfjs.getDocument({ data, useSystemFonts: true, standardFontDataUrl, isEvalSupported: false, disableFontFace: true });
   return task.promise;
 }
 


### PR DESCRIPTION
## Summary

- set `disableFontFace: true` in the shared Node-side PDF.js loader
- keep the existing system-font and standard-font configuration intact

## Root cause

The Node/canvas PDF pipeline was explicitly enabling PDF.js font-face handling even though that path relies on browser-style font APIs. This could make extraction, OCR, conversion, or facsimile rendering produce missing or blank glyphs.

## Impact

All consumers of `openPdf()` now use PDF.js's headless-compatible font path consistently.

## Validation

- `npm run citation:check`
- `npm run lint -- --quiet`
- `npm run build`
- `node --test scripts/test-toolkit-pdf.mjs` (15/15 passed)
- `npm test` after rebuilding native Electron dependencies (844/844 passed)
- `git diff --check`
- conflict-free merge-tree check against the latest `origin/main`

Closes #245