### PR TITLE
Hide redundant selected emoji label

### DIFF
--- a/scripts/test-study-ui.mjs
+++ b/scripts/test-study-ui.mjs
@@ -234,7 +234,8 @@ test('study metadata uses one searchable icon and emoji catalogue', async () => 
   assert.match(picker, /data-testid="study-icon-search"/);
   assert.match(picker, /ICON_NAMES\.filter/);
   assert.match(picker, /EMOJI_SEARCH_GROUPS/);
-  assert.match(picker, /emoji \? t\('Emoji seleccionado'\)/);
+  assert.match(picker, /aria-label=\{t\('Seleccionar icono o emoji'\)\}/);
+  assert.doesNotMatch(picker, /Emoji seleccionado/);
   assert.doesNotMatch(picker, /\{emoji \|\| icon \|\| t\('Seleccionar icono o emoji'\)\}/);
   assert.match(ui, /export const ICON_NAMES/);
   assert.match(view, /className="sr-only" type="file"/);

--- a/src/components/IconEmojiPicker.tsx
+++ b/src/components/IconEmojiPicker.tsx
@@ -50,11 +50,10 @@ export function IconEmojiPicker({ icon, emoji, onChange }: {
   const chooseEmoji = (value: string) => { onChange({ icon, emoji: value }); setOpen(false); };
 
   return <>
-    <button data-testid="study-create-icon-emoji" type="button" className="input mt-1 flex w-full items-center gap-2 text-left hover:border-teal-500" onClick={() => { setQuery(''); setOpen(true); }}>
+    <button data-testid="study-create-icon-emoji" type="button" className="input mt-1 flex w-full items-center justify-between text-left hover:border-teal-500" aria-label={t('Seleccionar icono o emoji')} onClick={() => { setQuery(''); setOpen(true); }}>
       <span className="grid h-5 w-5 shrink-0 place-items-center rounded bg-indigo-950/30 text-sm text-indigo-300">
         {emoji || <Icon name={icon} size={14} />}
       </span>
-      <span className="min-w-0 flex-1 truncate">{emoji ? t('Emoji seleccionado') : icon || t('Seleccionar icono o emoji')}</span>
       <Icon name="chevronDown" size={13} className="text-neutral-500" />
     </button>
     {open && createPortal(

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -4689,7 +4689,6 @@ export const DE: Record<string, string> = {
   'Selecciona un estilo o crea uno personalizado.': 'Wählen Sie einen Stil oder erstellen Sie einen eigenen.',
   'Icono o emoji': 'Symbol oder Emoji',
   'Seleccionar icono o emoji': 'Symbol oder Emoji auswählen',
-  'Emoji seleccionado': 'Ausgewähltes Emoji',
   'Busca y elige un icono de Nodus o un emoji.': 'Suchen und wählen Sie ein Nodus-Symbol oder ein Emoji.',
   'Buscar iconos…': 'Symbole suchen…',
   'No se encontraron iconos.': 'Keine Symbole gefunden.',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -4915,7 +4915,6 @@ export const EN: Record<string, string> = {
   'Selecciona un estilo o crea uno personalizado.': 'Select a style or create a custom one.',
   'Icono o emoji': 'Icon or emoji',
   'Seleccionar icono o emoji': 'Select icon or emoji',
-  'Emoji seleccionado': 'Selected emoji',
   'Busca y elige un icono de Nodus o un emoji.': 'Search for and choose a Nodus icon or an emoji.',
   'Buscar iconos…': 'Search icons…',
   'No se encontraron iconos.': 'No icons found.',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -4683,7 +4683,6 @@ export const FR: Record<string, string> = {
   'Selecciona un estilo o crea uno personalizado.': 'Sélectionnez un style ou créez-en un personnalisé.',
   'Icono o emoji': 'Icône ou emoji',
   'Seleccionar icono o emoji': 'Sélectionner une icône ou un emoji',
-  'Emoji seleccionado': 'Emoji sélectionné',
   'Busca y elige un icono de Nodus o un emoji.': 'Recherchez et choisissez une icône Nodus ou un emoji.',
   'Buscar iconos…': 'Rechercher des icônes…',
   'No se encontraron iconos.': 'Aucune icône trouvée.',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -4190,7 +4190,6 @@ export const IT: Record<string, string> = {
   "Selecciona un estilo o crea uno personalizado.": "Seleziona uno stile o creane uno personalizzato.",
   "Icono o emoji": "Icona o emoji",
   "Seleccionar icono o emoji": "Seleziona l'icona o l'emoji",
-  "Emoji seleccionado": "Emoji selezionati",
   "Busca y elige un icono de Nodus o un emoji.": "Cerca e scegli un'icona Nodus o un emoji.",
   "Buscar iconos…": "Cerca icone...",
   "No se encontraron iconos.": "Nessuna icona trovata.",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -4652,7 +4652,6 @@ export const PT_BR: Record<string, string> = {
   'Selecciona un estilo o crea uno personalizado.': 'Selecione um estilo ou crie um personalizado.',
   'Icono o emoji': 'Ícone ou emoji',
   'Seleccionar icono o emoji': 'Selecionar ícone ou emoji',
-  'Emoji seleccionado': 'Emoji selecionado',
   'Busca y elige un icono de Nodus o un emoji.': 'Busque e escolha um ícone do Nodus ou um emoji.',
   'Buscar iconos…': 'Buscar ícones…',
   'No se encontraron iconos.': 'Nenhum ícone encontrado.',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -4645,7 +4645,6 @@ export const PT: Record<string, string> = {
   'Selecciona un estilo o crea uno personalizado.': 'Selecione um estilo ou crie um personalizado.',
   'Icono o emoji': 'Ícone ou emoji',
   'Seleccionar icono o emoji': 'Selecionar ícone ou emoji',
-  'Emoji seleccionado': 'Emoji selecionado',
   'Busca y elige un icono de Nodus o un emoji.': 'Procure e escolha um ícone do Nodus ou um emoji.',
   'Buscar iconos…': 'Procurar ícones…',
   'No se encontraron iconos.': 'Não foram encontrados ícones.',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -4557,7 +4557,6 @@ export const TR: Record<string, string> = {
   "Selecciona un estilo o crea uno personalizado.": "Bir stil seçin veya özel bir stil oluşturun.",
   "Icono o emoji": "Simge veya emoji",
   "Seleccionar icono o emoji": "Simge veya emojiyi seçin",
-  "Emoji seleccionado": "Seçilen emoji",
   "Busca y elige un icono de Nodus o un emoji.": "Bir Nodus simgesi veya emojisi bulun ve seçin.",
   "Buscar iconos…": "Simgeleri arayın…",
   "No se encontraron iconos.": "Hiçbir simge bulunamadı.",


### PR DESCRIPTION
## Summary

- show only the selected icon or emoji in the closed picker control
- retain the dropdown chevron and an accessible translated label
- remove the now-unused “Selected emoji” translations
- add a regression assertion for the shared Study and Teaching picker

## Root cause

`IconEmojiPicker` rendered a visible localized status label whenever an emoji was selected, even though the selected emoji was already displayed beside it.

## User impact

Study and Teaching vault pickers now stay visually compact and no longer show the redundant “Selected emoji” text.

## Validation

- `node --test scripts/test-study-ui.mjs` (19/19 passed)
- `npm run typecheck`
- `npx eslint src/components/IconEmojiPicker.tsx`
- `git diff --check`

The full repository test command was also run: 770 tests passed and 74 Electron-based tests failed because Electron subprocesses abort in this worktree environment; the focused Study UI suite passes.

Closes #248