### PR TITLE
Fix Word add-in navigation and English localization

### DIFF
--- a/electron/copilot/certs.ts
+++ b/electron/copilot/certs.ts
@@ -247,9 +247,31 @@ export async function ensureNodusCert(
  * office-addin-dev-certs setup (dev machines); otherwise generates and trusts
  * the Nodus CA. Safe to call repeatedly — it also renews a near-expiry leaf.
  */
-export async function ensureCopilotCert(): Promise<{ ok: boolean; message: string }> {
-  if (loadOfficeCert()) return { ok: true, message: 'Certificado localhost listo.' };
-  return ensureNodusCert();
+export async function ensureCopilotCert(language: unknown = 'es'): Promise<{ ok: boolean; message: string }> {
+  const result = loadOfficeCert()
+    ? { ok: true, message: 'Certificado localhost listo.' }
+    : await ensureNodusCert();
+  if (language === 'es') return result;
+  if (result.message === 'Certificado localhost listo.') {
+    return { ...result, message: 'The localhost certificate is ready.' };
+  }
+  if (result.message === 'Word de escritorio solo existe en macOS y Windows; no hay CA que confiar aquí.') {
+    return {
+      ...result,
+      message: 'Desktop Word is only available on macOS and Windows; there is no certificate authority to trust here.',
+    };
+  }
+  if (result.message === 'Certificado localhost generado y confiado para este usuario.') {
+    return { ...result, message: 'The localhost certificate was generated and trusted for this user.' };
+  }
+  const trustFailure = /^No se pudo confiar la CA local: (.+)\. Acepta el diálogo del sistema y reintenta\.$/.exec(result.message);
+  if (trustFailure) {
+    return {
+      ...result,
+      message: `The local certificate authority could not be trusted: ${trustFailure[1]}. Accept the system prompt and try again.`,
+    };
+  }
+  return { ...result, message: 'The localhost certificate could not be prepared.' };
 }
 
 /** Silently re-issue a near-expiry leaf at server start (no trust prompt needed).

--- a/electron/copilot/install.ts
+++ b/electron/copilot/install.ts
@@ -9,6 +9,10 @@ export interface CopilotInstallResult {
   manifestPath: string | null;
 }
 
+function installText(es: string, en: string): string {
+  return getSettings().uiLanguage === 'es' ? es : en;
+}
+
 function wordManifestDirectory(): string | null {
   if (process.platform === 'darwin') {
     return path.join(homedir(), 'Library', 'Containers', 'com.microsoft.Word', 'Data', 'Documents', 'wef');
@@ -55,7 +59,10 @@ export async function installCopilotAddin(appRoot: string, appVersion = '0.1.0')
     return {
       ok: false,
       manifestPath: null,
-      message: 'La instalación automática del complemento solo está preparada para Word de escritorio en macOS o Windows.',
+      message: installText(
+        'La instalación automática del complemento solo está preparada para Word de escritorio en macOS o Windows.',
+        'Automatic add-in installation is only available for desktop Word on macOS or Windows.'
+      ),
     };
   }
 
@@ -69,14 +76,19 @@ export async function installCopilotAddin(appRoot: string, appVersion = '0.1.0')
     return {
       ok: true,
       manifestPath: targetPath,
-      message:
+      message: installText(
         'Nodus Copilot instalado/actualizado para Word. Cierra Word del todo (Cmd+Q) y vuelve a abrirlo: el complemento aparece en Inicio → Complementos, y añade su pestaña “Nodus” al abrirlo por primera vez.',
+        'Nodus Copilot was installed/updated for Word. Quit Word completely (Cmd+Q) and reopen it: the add-in appears under Home → Add-ins and adds its “Nodus” tab when you open it for the first time.'
+      ),
     };
   } catch (error) {
     return {
       ok: false,
       manifestPath: null,
-      message: `No se pudo instalar el complemento: ${error instanceof Error ? error.message : String(error)}`,
+      message: installText(
+        `No se pudo instalar el complemento: ${error instanceof Error ? error.message : String(error)}`,
+        `The add-in could not be installed: ${error instanceof Error ? error.message : String(error)}`
+      ),
     };
   }
 }
@@ -102,7 +114,10 @@ export async function installLibreOfficeCopilot(appRoot: string): Promise<Copilo
     return {
       ok: false,
       manifestPath: null,
-      message: 'La instalación automática del macro de LibreOffice no está soportada en esta plataforma.',
+      message: installText(
+        'La instalación automática del macro de LibreOffice no está soportada en esta plataforma.',
+        'Automatic LibreOffice macro installation is not supported on this platform.'
+      ),
     };
   }
 
@@ -118,13 +133,19 @@ export async function installLibreOfficeCopilot(appRoot: string): Promise<Copilo
     return {
       ok: true,
       manifestPath: targetPath,
-      message: `Macro de LibreOffice instalado en: ${targetPath}. En LibreOffice Writer, ejecútalo desde Herramientas → Macros → Ejecutar macro → Mis macros → nodus_copilot → start_nodus_copilot.`,
+      message: installText(
+        `Macro de LibreOffice instalado en: ${targetPath}. En LibreOffice Writer, ejecútalo desde Herramientas → Macros → Ejecutar macro → Mis macros → nodus_copilot → start_nodus_copilot.`,
+        `LibreOffice macro installed at: ${targetPath}. In LibreOffice Writer, run it from Tools → Macros → Run Macro → My Macros → nodus_copilot → start_nodus_copilot.`
+      ),
     };
   } catch (error) {
     return {
       ok: false,
       manifestPath: null,
-      message: `No se pudo copiar el macro: ${error instanceof Error ? error.message : String(error)}`,
+      message: installText(
+        `No se pudo copiar el macro: ${error instanceof Error ? error.message : String(error)}`,
+        `The macro could not be copied: ${error instanceof Error ? error.message : String(error)}`
+      ),
     };
   }
 }

--- a/electron/copilot/server.ts
+++ b/electron/copilot/server.ts
@@ -10,6 +10,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { app, BrowserWindow, shell } from 'electron';
 import type { CopilotServerStatus } from '@shared/types';
+import { localizeRuntimeError } from '@shared/uiLanguage';
 import { getSettings, updateSettings } from '../db/settingsRepo';
 import { loadCopilotCert, loadCopilotCa, certReady, copilotStateDir, renewLeafIfNeeded } from './certs';
 import {
@@ -56,6 +57,26 @@ function addinUrl(port: number): string {
   return `https://localhost:${port}/addin/taskpane.html`;
 }
 
+function copilotLanguage(): 'es' | 'en' {
+  return getSettings().uiLanguage === 'es' ? 'es' : 'en';
+}
+
+function copilotText(es: string, en: string): string {
+  return copilotLanguage() === 'es' ? es : en;
+}
+
+function copilotError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (copilotLanguage() === 'es') return message;
+  const translated: Record<string, string> = {
+    'No se encontró la idea en Nodus.': 'The idea could not be found in Nodus.',
+    'La IA no devolvió texto insertable.': 'The AI did not return any text that could be inserted.',
+    'Selecciona (o sitúate en) un fragmento con algo más de texto para trabajarlo.':
+      'Select (or place the cursor in) a passage with a little more text to work with.',
+  };
+  return translated[message] ?? localizeRuntimeError(message, 'en');
+}
+
 /**
  * Connection info for external bridges that cannot receive the token via an
  * injected page (the LibreOffice macro). Written next to the copilot certs —
@@ -78,9 +99,12 @@ export async function writeCopilotBridgeFile(port: number, dir: string = copilot
 
 function describeError(error: unknown): string {
   if (error && typeof error === 'object' && 'code' in error && (error as { code?: string }).code === 'EADDRINUSE') {
-    return 'El puerto del copiloto ya está en uso. Elige otro puerto o cierra la app que lo usa.';
+    return copilotText(
+      'El puerto del copiloto ya está en uso. Elige otro puerto o cierra la app que lo usa.',
+      'The copilot port is already in use. Choose another port or close the app using it.'
+    );
   }
-  return error instanceof Error ? error.message : String(error);
+  return copilotError(error);
 }
 
 function ensureToken(): string {
@@ -122,7 +146,9 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   for await (const chunk of req) {
     const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     size += data.length;
-    if (size > MAX_REQUEST_BYTES) throw new Error('La solicitud supera el tamaño máximo.');
+    if (size > MAX_REQUEST_BYTES) {
+      throw new Error(copilotText('La solicitud supera el tamaño máximo.', 'The request exceeds the maximum size.'));
+    }
     chunks.push(data);
   }
   const raw = Buffer.concat(chunks).toString('utf8').trim();
@@ -170,7 +196,7 @@ async function serveAddin(req: IncomingMessage, res: ServerResponse, urlPath: st
     res.end(body);
   } catch {
     res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-    res.end('No encontrado');
+    res.end(copilotText('No encontrado', 'Not found'));
   }
 }
 
@@ -201,14 +227,16 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
   }
 
   if (!urlPath.startsWith('/api/')) {
-    sendJson(res, 404, { error: 'No encontrado' });
+    sendJson(res, 404, { error: copilotText('No encontrado', 'Not found') });
     return;
   }
 
   const token = getSettings().copilotToken;
   if (!token || !hasValidToken(req, token)) {
     res.setHeader('WWW-Authenticate', 'Bearer realm="Nodus Copilot"');
-    sendJson(res, 401, { error: 'Se requiere un bearer token válido.' });
+    sendJson(res, 401, {
+      error: copilotText('Se requiere un bearer token válido.', 'A valid bearer token is required.'),
+    });
     return;
   }
 
@@ -245,12 +273,12 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
     if (urlPath === '/api/idea' && req.method === 'POST') {
       const body = (await readJsonBody(req)) as { ideaId?: string };
       if (!body.ideaId) {
-        sendJson(res, 400, { error: 'Falta ideaId.' });
+        sendJson(res, 400, { error: copilotText('Falta ideaId.', 'Missing ideaId.') });
         return;
       }
       const idea = getCopilotIdeaDetail(body.ideaId);
       if (!idea) {
-        sendJson(res, 404, { error: 'Idea no encontrada.' });
+        sendJson(res, 404, { error: copilotText('Idea no encontrada.', 'Idea not found.') });
         return;
       }
       sendJson(res, 200, { idea });
@@ -259,7 +287,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
     if (urlPath === '/api/insert' && req.method === 'POST') {
       const body = (await readJsonBody(req)) as { ideaId?: string; paragraphText?: string; selectionText?: string };
       if (!body.ideaId) {
-        sendJson(res, 400, { error: 'Falta ideaId.' });
+        sendJson(res, 400, { error: copilotText('Falta ideaId.', 'Missing ideaId.') });
         return;
       }
       const insertion = await composeCopilotIdeaInsertion({
@@ -273,12 +301,12 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
     if (urlPath === '/api/nodus/open' && req.method === 'POST') {
       const body = (await readJsonBody(req)) as { ideaId?: string };
       if (!body.ideaId) {
-        sendJson(res, 400, { error: 'Falta ideaId.' });
+        sendJson(res, 400, { error: copilotText('Falta ideaId.', 'Missing ideaId.') });
         return;
       }
       const idea = getCopilotIdeaDetail(body.ideaId);
       if (!idea) {
-        sendJson(res, 404, { error: 'Idea no encontrada.' });
+        sendJson(res, 404, { error: copilotText('Idea no encontrada.', 'Idea not found.') });
         return;
       }
       const win = getMainWindow?.() ?? null;
@@ -286,7 +314,11 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
         if (win.isMinimized()) win.restore();
         win.show();
         win.focus();
-        win.webContents.send('copilot:openIdea', { ideaId: idea.idea.globalId, label: idea.idea.label });
+        win.webContents.send('copilot:openIdea', {
+          ideaId: idea.idea.globalId,
+          label: idea.idea.label,
+          destination: 'ideas',
+        });
       }
       sendJson(res, 200, { ok: Boolean(win) });
       return;
@@ -294,7 +326,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
     if (urlPath === '/api/zotero/select' && req.method === 'POST') {
       const body = (await readJsonBody(req)) as { zoteroKey?: string };
       if (!body.zoteroKey) {
-        sendJson(res, 400, { error: 'Falta zoteroKey.' });
+        sendJson(res, 400, { error: copilotText('Falta zoteroKey.', 'Missing zoteroKey.') });
         return;
       }
       await shell.openExternal(`zotero://select/library/items/${encodeURIComponent(body.zoteroKey)}`);
@@ -359,10 +391,10 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
       });
       return;
     }
-    sendJson(res, 404, { error: 'Ruta no encontrada.' });
+    sendJson(res, 404, { error: copilotText('Ruta no encontrada.', 'Route not found.') });
   } catch (error) {
     if (res.headersSent) return;
-    sendJson(res, 500, { error: error instanceof Error ? error.message : String(error) });
+    sendJson(res, 500, { error: copilotError(error) });
   }
 }
 
@@ -382,7 +414,10 @@ async function start(): Promise<void> {
       port: null,
       addinUrl: null,
       certReady: false,
-      error: 'Falta el certificado localhost. Genera el certificado del copiloto en Ajustes.',
+      error: copilotText(
+        'Falta el certificado localhost. Genera el certificado del copiloto en Ajustes.',
+        'The localhost certificate is missing. Generate the copilot certificate in Settings.'
+      ),
     };
     return;
   }
@@ -396,7 +431,11 @@ async function start(): Promise<void> {
       handleRequest(req, res, port).catch((error) => {
         console.warn('[copilot] request failed', error);
         try {
-          if (!res.headersSent) sendJson(res, 500, { error: 'Error interno del copiloto.' });
+          if (!res.headersSent) {
+            sendJson(res, 500, {
+              error: copilotText('Error interno del copiloto.', 'Internal copilot error.'),
+            });
+          }
         } catch {
           /* client already gone */
         }

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -1887,7 +1887,7 @@ export function registerIpc(
   h('copilot:status', async () => getCopilotStatus());
   h('copilot:regenerateToken', async () => regenerateCopilotToken());
   h('copilot:ensureCert', async () => {
-    const result = await ensureCopilotCert();
+    const result = await ensureCopilotCert(getSettings().uiLanguage);
     if (result.ok && getSettings().copilotEnabled) await restartCopilotServer();
     return result;
   });

--- a/electron/zotero-plugin/server.ts
+++ b/electron/zotero-plugin/server.ts
@@ -488,7 +488,7 @@ async function openInNodus(body: Record<string, unknown>): Promise<{ ok: boolean
   // Reuse the copilot idea-open channel for ideas (already handled by the UI);
   // other kinds focus the window and send a generic open event.
   if (kind === 'idea' && id) {
-    win.webContents.send('copilot:openIdea', { ideaId: id, label: '' });
+    win.webContents.send('copilot:openIdea', { ideaId: id, label: '', destination: 'graph' });
   } else {
     win.webContents.send('zoteroPlugin:open', { kind, id });
   }

--- a/scripts/test-copilot-addin.mjs
+++ b/scripts/test-copilot-addin.mjs
@@ -23,6 +23,8 @@ const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-copilot-addin-test-'));
 installRuntimeHooks(root);
 
 try {
+  const { updateSettings } = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
+  updateSettings({ uiLanguage: 'en' });
   const installModule = require(path.join(repoRoot, 'electron/copilot/install.ts'));
   const { renderManifest, installCopilotAddin } = installModule;
   const template = fs.readFileSync(path.join(repoRoot, 'word-addin/manifest.xml'), 'utf8');
@@ -33,6 +35,31 @@ try {
   assert.match(rendered, /<CustomTab id="Nodus\.Tab">/);
   assert.match(rendered, /<Label resid="Nodus\.Tab\.Label" \/>/);
   assert.doesNotMatch(rendered, /<OfficeTab id="TabHome">/);
+  assert.match(rendered, /<DefaultLocale>en-US<\/DefaultLocale>/);
+  assert.match(rendered, /DefaultValue="Open the pane to see how your text relates to your library\."/);
+  assert.match(rendered, /<bt:Override Locale="es-ES" Value="Abre el panel/);
+
+  // English is also the safe pre-initialization language in the task pane. The
+  // runtime switches it to Spanish when Nodus injects lang=es, but an English
+  // pane must never fall back to a Spanish string when a key is missing.
+  const taskpaneHtml = fs.readFileSync(path.join(repoRoot, 'word-addin/taskpane.html'), 'utf8');
+  const taskpaneJs = fs.readFileSync(path.join(repoRoot, 'word-addin/taskpane.js'), 'utf8');
+  assert.match(taskpaneHtml, /<html lang="en">/);
+  assert.match(taskpaneHtml, />Analyze paragraph</);
+  assert.doesNotMatch(taskpaneHtml, /Conectando|Buscar ideas|Analizar párrafo|Selección|Insertar en|Nota al pie|Pasajes/);
+  assert.match(taskpaneJs, /table\[key\] !== undefined \? table\[key\] : STR\.en\[key\]/);
+
+  // The Word bridge opens the full idea detail in Ideas, not the graph. The
+  // nonce makes a second click on the same idea retrigger the selection.
+  const appSource = fs.readFileSync(path.join(repoRoot, 'src/App.tsx'), 'utf8');
+  const ideasSource = fs.readFileSync(path.join(repoRoot, 'src/views/IdeasView.tsx'), 'utf8');
+  const serverSource = fs.readFileSync(path.join(repoRoot, 'electron/copilot/server.ts'), 'utf8');
+  assert.match(serverSource, /destination: 'ideas'/);
+  assert.match(
+    appSource,
+    /if \(target\.destination === 'ideas'\) \{\s*setIdeaTarget\(\{ ideaId: target\.ideaId, nonce: Date\.now\(\) \}\);\s*setView\('ideas'\);/s
+  );
+  assert.match(ideasSource, /if \(target\) setSelectedId\(target\.ideaId\)/);
 
   // Office's add-in cache must survive an install untouched. Deleting individual
   // files from it is documented to make ALL add-ins stop loading, and it did:
@@ -79,6 +106,7 @@ try {
     }
 
     assert.equal(result.ok, true, result.message);
+    assert.match(result.message, /installed\/updated for Word/);
     assert.equal(fs.existsSync(path.join(manifestDir, 'nodus-copilot.manifest.xml')), true);
     assert.equal(fs.existsSync(path.join(cache, 'Manifests', 'cached-nodus')), true, 'install must not touch the Office cache');
     assert.equal(

--- a/scripts/test-libreoffice-copilot.mjs
+++ b/scripts/test-libreoffice-copilot.mjs
@@ -25,9 +25,24 @@ installRuntimeHooks(root);
 
 try {
   const { updateSettings } = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
-  updateSettings({ copilotToken: 'test-token', copilotEnabled: true, copilotPort: 4320 });
+  updateSettings({ copilotToken: 'test-token', copilotEnabled: true, copilotPort: 4320, uiLanguage: 'en' });
 
   const server = require(path.join(repoRoot, 'electron/copilot/server.ts'));
+
+  // API errors shown by the pane follow the Nodus UI language.
+  {
+    const englishRes = mockResponse();
+    await server.handleRequest(mockRequest('POST', '/api/idea', authHeaders(), {}), englishRes, 4320);
+    assert.equal(englishRes.statusCode, 400);
+    assert.equal(JSON.parse(englishRes.getBody()).error, 'Missing ideaId.');
+
+    updateSettings({ uiLanguage: 'es' });
+    const spanishRes = mockResponse();
+    await server.handleRequest(mockRequest('POST', '/api/idea', authHeaders(), {}), spanishRes, 4320);
+    assert.equal(spanishRes.statusCode, 400);
+    assert.equal(JSON.parse(spanishRes.getBody()).error, 'Falta ideaId.');
+    updateSettings({ uiLanguage: 'en' });
+  }
 
   // Editor state round-trip: update-text → state.
   {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2477,6 +2477,8 @@ export interface CopilotInstallResult {
 export interface CopilotOpenIdeaTarget {
   ideaId: string;
   label: string | null;
+  /** Word opens full development in Ideas; legacy callers keep the graph destination. */
+  destination?: 'ideas' | 'graph';
 }
 
 /** One typed relation between the edited paragraph and a library entity (Word copilot). */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { setActiveVaultQueryScope } from './vaultQueryCache';
 import type {
   PendingAssistantNavigationTarget,
   PendingGraphNavigationTarget,
+  PendingIdeaNavigationTarget,
   PendingLibraryNavigationTarget,
   View,
 } from './navigation';
@@ -249,6 +250,7 @@ export function App() {
     []
   );
   const [graphTarget, setGraphTarget] = useState<PendingGraphNavigationTarget & { nonce: number } | null>(null);
+  const [ideaTarget, setIdeaTarget] = useState<PendingIdeaNavigationTarget & { nonce: number } | null>(null);
   const [libraryTarget, setLibraryTarget] = useState<PendingLibraryNavigationTarget & { nonce: number } | null>(null);
   const [assistantTarget, setAssistantTarget] = useState<PendingAssistantNavigationTarget & { nonce: number } | null>(null);
   // A note the user opened from global search; the nonce re-triggers even if the
@@ -739,6 +741,11 @@ export function App() {
   useEffect(() => {
     if (!window.nodus?.onCopilotOpenIdea) return undefined;
     return window.nodus.onCopilotOpenIdea((target) => {
+      if (target.destination === 'ideas') {
+        setIdeaTarget({ ideaId: target.ideaId, nonce: Date.now() });
+        setView('ideas');
+        return;
+      }
       navigate('graph', {
         preset: 'overview',
         nodeId: target.ideaId,
@@ -776,6 +783,7 @@ export function App() {
     setCollectionsOpen(false);
     setResearchOpen(false);
     setGraphTarget(null);
+    setIdeaTarget(null);
     setStudyGraphTarget(null);
     setStudyChatTarget(null);
     setAssistantTarget(null);
@@ -1381,7 +1389,7 @@ export function App() {
           )}
           {view === 'graph' && <GraphView settings={settings} onSettingsChange={reloadSettings} target={graphTarget} />}
           {view === 'argument' && <ArgumentMapView settings={settings} />}
-          {view === 'ideas' && <IdeasView vaultId={activeVault?.id ?? null} onOpenGraph={(target) => navigate('graph', target)} onOpenAssistant={openAssistant} />}
+          {view === 'ideas' && <IdeasView vaultId={activeVault?.id ?? null} target={ideaTarget} onOpenGraph={(target) => navigate('graph', target)} onOpenAssistant={openAssistant} />}
           {view === 'authors' && <AuthorsView vaultId={activeVault?.id ?? null} settings={settings} onOpenGraph={(target) => navigate('graph', target)} />}
           {view === 'persons' && <PersonasView initialPersonId={personsTarget} />}
           {view === 'timeline' && <TimelineView />}

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -270,9 +270,16 @@ export interface LibraryNavigationTarget {
   healthBucket?: CorpusHealthBucketId;
 }
 
+/** Navigation into Ideas that opens the complete detail panel for one idea. */
+export interface IdeaNavigationTarget {
+  nonce: number;
+  ideaId: string;
+}
+
 export type PendingGraphNavigationTarget = Omit<GraphNavigationTarget, 'nonce'>;
 export type PendingAssistantNavigationTarget = Omit<AssistantNavigationTarget, 'nonce'>;
 export type PendingLibraryNavigationTarget = Omit<LibraryNavigationTarget, 'nonce'>;
+export type PendingIdeaNavigationTarget = Omit<IdeaNavigationTarget, 'nonce'>;
 
 export const ASSISTANT_CONTEXTS: Record<'idea' | 'gap' | 'contradiction' | 'reading', ResearchContextSelection> = {
   idea: {

--- a/src/views/IdeasView.tsx
+++ b/src/views/IdeasView.tsx
@@ -15,6 +15,7 @@ import { buildIdeaNote } from '../notes';
 import { notifyDataChanged, useDataRefresh, useScanComplete } from '../hooks';
 import {
   ASSISTANT_CONTEXTS,
+  type IdeaNavigationTarget,
   type PendingAssistantNavigationTarget,
   type PendingGraphNavigationTarget,
 } from '../navigation';
@@ -30,6 +31,7 @@ const IDEAS_DETAIL_DEFAULT_WIDTH = 420;
 
 export function IdeasView({
   vaultId,
+  target,
   onOpenGraph,
   onOpenAssistant,
   dataSource = academicKnowledgeViewSource,
@@ -37,6 +39,7 @@ export function IdeasView({
   testId,
 }: {
   vaultId: string | null;
+  target?: IdeaNavigationTarget | null;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
   onOpenAssistant: (target?: PendingAssistantNavigationTarget) => void;
   dataSource?: KnowledgeViewSource;
@@ -62,6 +65,10 @@ export function IdeasView({
   const [detailWidth, setDetailWidth] = useState(() =>
     loadNumber(IDEAS_DETAIL_WIDTH_KEY, IDEAS_DETAIL_DEFAULT_WIDTH, DETAIL_MIN_WIDTH, DETAIL_MAX_WIDTH)
   );
+
+  useEffect(() => {
+    if (target) setSelectedId(target.ideaId);
+  }, [target]);
 
   const startResize = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {

--- a/word-addin/README.md
+++ b/word-addin/README.md
@@ -66,8 +66,9 @@ complemento y una pequeña API JSON **en el mismo origen HTTPS local**
   **Ideas / Pasajes** cambias a la búsqueda semántica sobre el **texto completo**:
   cada pasaje trae su cita y un botón **Insertar cita** (lo pega entre comillas con
   el autor-año).
-- Abre **Detalles** para ver fuentes y conexiones; **Abrir en Nodus** enfoca la
-  idea en el grafo; **Insertar con IA** añade una paráfrasis citada al texto.
+- Abre **Detalles** para ver fuentes y conexiones; **Abrir en Nodus** abre el
+  desarrollo completo de la idea en la sección **Ideas**; **Insertar con IA**
+  añade una paráfrasis citada al texto.
 - Con texto seleccionado, la fila **Selección** ofrece **Reescribir** (sustituye la
   selección), **Ampliar** (continúa el texto) y **Rebatir** (redacta un
   contraargumento citado a partir de las ideas que la contradicen o matizan).

--- a/word-addin/manifest.xml
+++ b/word-addin/manifest.xml
@@ -8,9 +8,11 @@
   <Id>E4352919-FFEC-4F77-8268-975BB4217FAD</Id>
   <Version>2.4.0</Version>
   <ProviderName>Nodus</ProviderName>
-  <DefaultLocale>es-ES</DefaultLocale>
+  <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Nodus Copilot" />
-  <Description DefaultValue="Muestra cómo el párrafo que escribes se relaciona con tu biblioteca de Nodus, permite explorar ideas y conexiones, y te ayuda a insertar ideas citadas." />
+  <Description DefaultValue="Shows how the paragraph you are writing relates to your Nodus library, lets you explore ideas and connections, and helps you insert cited ideas.">
+    <Override Locale="es-ES" Value="Muestra cómo el párrafo que escribes se relaciona con tu biblioteca de Nodus, permite explorar ideas y conexiones, y te ayuda a insertar ideas citadas." />
+  </Description>
   <IconUrl DefaultValue="https://localhost:4320/addin/assets/icon-32.png" />
   <HighResolutionIconUrl DefaultValue="https://localhost:4320/addin/assets/icon-80.png" />
   <SupportUrl DefaultValue="https://localhost:4320/addin/taskpane.html" />
@@ -82,8 +84,12 @@
         <bt:String id="Nodus.Taskpane.Label" DefaultValue="Nodus Copilot" />
       </bt:ShortStrings>
       <bt:LongStrings>
-        <bt:String id="GetStarted.Description" DefaultValue="Abre el panel para ver cómo tu texto se relaciona con tu biblioteca." />
-        <bt:String id="Nodus.Taskpane.Tooltip" DefaultValue="Relaciona el párrafo actual con tu biblioteca de Nodus e inserta ideas citadas." />
+        <bt:String id="GetStarted.Description" DefaultValue="Open the pane to see how your text relates to your library.">
+          <bt:Override Locale="es-ES" Value="Abre el panel para ver cómo tu texto se relaciona con tu biblioteca." />
+        </bt:String>
+        <bt:String id="Nodus.Taskpane.Tooltip" DefaultValue="Relate the current paragraph to your Nodus library and insert cited ideas.">
+          <bt:Override Locale="es-ES" Value="Relaciona el párrafo actual con tu biblioteca de Nodus e inserta ideas citadas." />
+        </bt:String>
       </bt:LongStrings>
     </Resources>
   </VersionOverrides>

--- a/word-addin/taskpane.html
+++ b/word-addin/taskpane.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -18,39 +18,39 @@
         <div class="title">Nodus Copilot</div>
         <div class="caption">Word + Nodus</div>
       </div>
-      <div id="status" class="status">Conectando…</div>
+      <div id="status" class="status">Connecting…</div>
     </header>
 
     <main>
       <section class="controls">
         <div class="search">
-          <input id="searchBox" type="search" placeholder="Buscar ideas, autores u obras" autocomplete="off" />
-          <button id="searchBtn" class="btn icon" type="button" title="Buscar">⌕</button>
+          <input id="searchBox" type="search" placeholder="Search ideas, authors or works" autocomplete="off" />
+          <button id="searchBtn" class="btn icon" type="button" title="Search">⌕</button>
         </div>
         <div class="segmented" id="searchMode" role="tablist">
           <button class="seg active" data-mode="ideas" type="button" role="tab">Ideas</button>
-          <button class="seg" data-mode="passages" type="button" role="tab">Pasajes</button>
+          <button class="seg" data-mode="passages" type="button" role="tab">Passages</button>
         </div>
         <div class="toolbar">
           <label class="auto"><input type="checkbox" id="autoToggle" checked /> Auto</label>
-          <button id="analyzeBtn" class="btn primary" type="button">Analizar párrafo</button>
+          <button id="analyzeBtn" class="btn primary" type="button">Analyze paragraph</button>
         </div>
         <div class="selection-actions" id="selectionActions">
-          <span class="sa-label">Selección</span>
-          <button class="btn small" data-compose="rewrite" type="button">Reescribir</button>
-          <button class="btn small" data-compose="expand" type="button">Ampliar</button>
-          <button class="btn small" data-compose="counter" type="button">Rebatir</button>
+          <span class="sa-label">Selection</span>
+          <button class="btn small" data-compose="rewrite" type="button">Rewrite</button>
+          <button class="btn small" data-compose="expand" type="button">Expand</button>
+          <button class="btn small" data-compose="counter" type="button">Counter</button>
         </div>
         <div class="insert-target" id="insertTarget">
-          <span class="it-label">Insertar en</span>
-          <label><input type="radio" name="insTarget" value="body" checked /> <span data-it="body">Texto</span></label>
-          <label id="footnoteOption"><input type="radio" name="insTarget" value="footnote" id="footnoteRadio" /> <span data-it="footnote">Nota al pie</span></label>
+          <span class="it-label">Insert into</span>
+          <label><input type="radio" name="insTarget" value="body" checked /> <span data-it="body">Body</span></label>
+          <label id="footnoteOption"><input type="radio" name="insTarget" value="footnote" id="footnoteRadio" /> <span data-it="footnote">Footnote</span></label>
         </div>
       </section>
 
       <div id="paragraph" class="paragraph"></div>
       <div id="results" class="results"></div>
-      <div id="empty" class="empty">Coloca el cursor en un párrafo para ver ideas relacionadas.</div>
+      <div id="empty" class="empty">Place the cursor in a paragraph to see related ideas.</div>
     </main>
 
     <script src="/addin/taskpane.js"></script>

--- a/word-addin/taskpane.js
+++ b/word-addin/taskpane.js
@@ -82,6 +82,8 @@
       searchingPassages: 'Buscando pasajes…',
       noPassages: 'Sin pasajes para esa búsqueda.',
       passagesNotIndexed: 'No hay texto completo indexado. Indexa la biblioteca en Nodus.',
+      quoteOpen: '«',
+      quoteClose: '»',
       relation: { supports: 'apoya', contradicts: 'contradice', refines: 'matiza', extends: 'amplía', related: 'relacionada' },
       kind: { idea: 'idea', note: 'nota', passage: 'pasaje', work: 'obra' },
     },
@@ -144,13 +146,16 @@
       searchingPassages: 'Searching passages…',
       noPassages: 'No passages match that search.',
       passagesNotIndexed: 'No full text indexed. Index your library in Nodus.',
+      quoteOpen: '“',
+      quoteClose: '”',
       relation: { supports: 'supports', contradicts: 'contradicts', refines: 'refines', extends: 'extends', related: 'related' },
       kind: { idea: 'idea', note: 'note', passage: 'passage', work: 'work' },
     },
   };
 
   function T(key) {
-    return STR[LANG][key] !== undefined ? STR[LANG][key] : STR.es[key];
+    var table = STR[LANG] || STR.en;
+    return table[key] !== undefined ? table[key] : STR.en[key];
   }
 
   var RELATION_LABEL = T('relation');
@@ -633,7 +638,7 @@
     btn.disabled = true;
     btn.textContent = T('inserting');
     var body = (passage.text || passage.snippet || '').trim();
-    var quote = '«' + body + '»';
+    var quote = T('quoteOpen') + body + T('quoteClose');
     if (passage.authorYear) quote += ' (' + passage.authorYear + ')';
     insertAtCursor(quote, { asFootnote: insertTarget === 'footnote' })
       .then(function () { setStatus(T('quoteInserted'), 'ok'); })


### PR DESCRIPTION
## Summary

- route **Open in Nodus** from the Word add-in to the full idea detail panel in **Ideas**
- preserve the Zotero plugin's existing graph destination by making the external navigation target explicit
- complete English localization across task-pane bootstrap copy, Office manifest metadata, API errors, and install/certificate messages
- make English the safe fallback for missing add-in translation keys while retaining Spanish overrides
- add regression coverage for navigation, localization, and server language behavior

## Root cause

The shared `copilot:openIdea` renderer handler always navigated to the graph, so the Word action could not open the Ideas detail view. Separately, several user-facing strings lived outside the task pane's translation table or fell back to Spanish at runtime.

## User impact

Word users now land directly on the selected idea's complete development, evidence, and connections. English users no longer see Spanish bootstrap, ribbon, API, installation, or certificate messages. Zotero users keep the previous graph-opening behavior.

## Validation

- `npm run typecheck`
- targeted ESLint over the changed TypeScript files
- `node scripts/test-copilot-addin.mjs`
- `node scripts/test-libreoffice-copilot.mjs`
- `node scripts/test-copilot-certs.mjs`
- `node --test scripts/test-i18n-coverage.mjs`
- `xmllint --noout word-addin/manifest.xml`
- `git diff --check`

Closes #259