### PR TITLE
Add audience-aware Unit design

### DIFF
--- a/electron/ai/studyDeepResearch.ts
+++ b/electron/ai/studyDeepResearch.ts
@@ -10,9 +10,15 @@ import type {
   WritingWorkshopSection,
 } from '@shared/types';
 import type { StudySearchIndexEntry, StudySearchKind } from '@shared/studySearch';
+import {
+  normalizeStudyDeepResearchAudience,
+  type StudyDeepResearchAudience,
+} from '@shared/studyDeepResearchAudience';
 import { listStudyIdeasForSources } from '../db/studyKnowledgeRepo';
 import { completeJson, completeText } from './aiClient';
 import { retrieveStudyAssistantEntries } from './studySearch';
+
+export { normalizeStudyDeepResearchAudience };
 
 /** Hard ceiling on a teacher-authored outline; the composer offers far fewer. */
 export const MAX_UNIT_SECTIONS = 12;
@@ -201,6 +207,21 @@ export const TEACHING_UNIT_PROMPTS: Record<PromptLanguage, StudyPromptPack> = {
   },
 };
 
+/**
+ * A teaching unit can now produce either a teacher-facing plan or student-facing
+ * notes. Both prompt packs are already native in every supported output language;
+ * choosing here avoids mixing contradictory teacher and learner instructions.
+ */
+export function studyDeepResearchPromptPack(
+  language: PromptLanguage,
+  audience: StudyDeepResearchAudience,
+  unitMode: boolean,
+): StudyPromptPack {
+  return unitMode && audience === 'teacher'
+    ? TEACHING_UNIT_PROMPTS[language]
+    : STUDY_DEEP_RESEARCH_PROMPTS[language];
+}
+
 function isPlan(value: unknown): value is StudyPlan {
   return Boolean(value && typeof value === 'object' && Array.isArray((value as StudyPlan).sections));
 }
@@ -362,7 +383,14 @@ export async function generateStudyDeepResearchReport(
 ): Promise<DeepResearchReport> {
   const language = request.language ?? 'es';
   const unitMode = Boolean(request.unitMode);
-  const prompts = unitMode ? TEACHING_UNIT_PROMPTS[language] : STUDY_DEEP_RESEARCH_PROMPTS[language];
+  // Existing study reports remain student-facing, while existing teaching-unit jobs
+  // retain their historical teacher-plan behaviour.
+  const audience = normalizeStudyDeepResearchAudience(
+    request.audience,
+    unitMode ? 'teacher' : 'students',
+  );
+  const teacherPlan = unitMode && audience === 'teacher';
+  const prompts = studyDeepResearchPromptPack(language, audience, unitMode);
   onProgress?.({ phase: 'snapshot', message: unitMode ? 'Recuperando materiales, apuntes y transcripciones de clase…' : 'Recuperando apuntes, materiales y transcripciones relevantes…' });
   const retrieved = await retrieveStudyAssistantEntries(request.objective, { kinds: ['material', 'document', 'transcript'] }, [], 48);
   const sources = buildSources(retrieved);
@@ -389,15 +417,18 @@ export async function generateStudyDeepResearchReport(
     phase: 'planning',
     message: requestedOutline.length
       ? `Ajustando el esquema indicado (${count} partes) a los materiales…`
-      : unitMode
+      : teacherPlan
         ? `Diseñando la unidad en ${count} partes…`
-        : `Diseñando una explicación didáctica en ${count} secciones…`,
+        : unitMode
+          ? `Preparando apuntes para el alumnado en ${count} partes…`
+          : `Diseñando una explicación didáctica en ${count} secciones…`,
   });
   const sourcePayload = sources.map(({ id, kind, title, subtitle, location, text }) => ({ id, kind, title, subtitle, location, extract: text }));
   const plan = await completeJson<StudyPlan>({
     system: requestedOutline.length ? `${prompts.plan}\n${FIXED_OUTLINE_RULE}` : prompts.plan,
     user: JSON.stringify({
       objective: request.objective,
+      audience,
       language,
       sectionCount: count,
       ...(requestedOutline.length
@@ -442,7 +473,7 @@ export async function generateStudyDeepResearchReport(
     ).map((idea) => ({ type: idea.type, label: idea.label, statement: idea.statement }));
     onProgress?.({
       phase: 'section',
-      message: `${unitMode ? 'Redactando' : 'Explicando'}: ${section.title}`,
+      message: `${teacherPlan ? 'Redactando' : 'Explicando'}: ${section.title}`,
       sectionIndex: index + 1,
       sectionTotal: sections.length,
       sectionTitle: section.title,
@@ -451,6 +482,7 @@ export async function generateStudyDeepResearchReport(
       system: section.focus ? `${prompts.write}\n${SECTION_FOCUS_RULE}` : prompts.write,
       user: JSON.stringify({
         objective: request.objective,
+        audience,
         language,
         targetWords: Math.max(850, Math.min(1_650, Math.round((pages.max * 450) / sections.length))),
         section: {
@@ -480,11 +512,15 @@ export async function generateStudyDeepResearchReport(
 
   onProgress?.({
     phase: 'assembling',
-    message: unitMode ? 'Preparando síntesis, materiales y propuestas de evaluación…' : 'Preparando síntesis, fuentes y actividades de comprensión…',
+    message: teacherPlan
+      ? 'Preparando síntesis, materiales y propuestas de evaluación…'
+      : unitMode
+        ? 'Preparando síntesis, fuentes y actividades de autoevaluación…'
+        : 'Preparando síntesis, fuentes y actividades de comprensión…',
   });
   const final = await completeJson<StudyFinal>({
     system: prompts.finalize,
-    user: JSON.stringify({ objective: request.objective, language, provisionalTitle: plan.title, sectionTitles: sections.map((section) => section.title), sourcesUsed: [...usedSourceIds] }, null, 2),
+    user: JSON.stringify({ objective: request.objective, audience, language, provisionalTitle: plan.title, sectionTitles: sections.map((section) => section.title), sourcesUsed: [...usedSourceIds] }, null, 2),
     temperature: 0.18,
     maxTokens: 1_800,
   }, isFinal, model).catch((): StudyFinal => ({}));
@@ -511,7 +547,7 @@ export async function generateStudyDeepResearchReport(
   const usedIdeaIds = [...new Set(sections.flatMap((section) => section.ideaIds))];
   const draft: WritingWorkshopDraft = {
     generatedAt: new Date().toISOString(),
-    brief: { kind: 'deep_research', objective: request.objective, audience: request.audience, tone: 'academic', language },
+    brief: { kind: 'deep_research', objective: request.objective, audience, tone: 'academic', language },
     selection: { ideaIds: usedIdeaIds, themeIds: [], gapIds: [], contradictionIds: [], workIds: [], passageIds: [], tutorRouteIds: [] },
     title: final.title?.trim() || plan.title?.trim() || request.objective,
     abstract: final.abstract?.trim() || plan.abstract?.trim() || '',
@@ -535,8 +571,10 @@ export async function generateStudyDeepResearchReport(
   };
   onProgress?.({
     phase: 'done',
-    message: unitMode
+    message: teacherPlan
       ? `Unidad lista: ${sections.length} partes · ${usedSourceIds.size} materiales`
+      : unitMode
+        ? `Apuntes listos: ${sections.length} partes · ${usedSourceIds.size} materiales`
       : `Informe de estudio listo: ${sections.length} secciones · ${usedSourceIds.size} fuentes`,
     wordsSoFar: words,
     pagesSoFar: meta.pages,

--- a/scripts/test-unit-design.mjs
+++ b/scripts/test-unit-design.mjs
@@ -40,7 +40,15 @@ await build({
   }],
   logLevel: 'silent',
 });
-const { normalizeUnitOutline, resolveStudySections, TEACHING_UNIT_PROMPTS, MAX_UNIT_SECTIONS } =
+const {
+  normalizeStudyDeepResearchAudience,
+  normalizeUnitOutline,
+  resolveStudySections,
+  studyDeepResearchPromptPack,
+  STUDY_DEEP_RESEARCH_PROMPTS,
+  TEACHING_UNIT_PROMPTS,
+  MAX_UNIT_SECTIONS,
+} =
   await import(pathToFileURL(outfile).href);
 
 const fallbackTitle = (index) => `Parte ${index}`;
@@ -150,5 +158,27 @@ test('every supported language has a complete teaching-unit prompt pack', () => 
     // The unit is written for the teacher to teach from; a pack that slipped back into
     // the study wording would silently turn it into a report addressed to the student.
     assert.match(pack.plan, /\{"title"/, `${language} planner does not state its JSON shape`);
+  }
+});
+
+test('teaching units preserve their teacher default and accept student handouts', () => {
+  assert.equal(normalizeStudyDeepResearchAudience(undefined, 'teacher'), 'teacher');
+  assert.equal(normalizeStudyDeepResearchAudience('teacher', 'students'), 'teacher');
+  assert.equal(normalizeStudyDeepResearchAudience('students', 'teacher'), 'students');
+  assert.equal(normalizeStudyDeepResearchAudience('unknown', 'students'), 'students');
+});
+
+test('the audience selects a native teacher plan or student notes in every language', () => {
+  for (const language of Object.keys(TEACHING_UNIT_PROMPTS)) {
+    assert.equal(
+      studyDeepResearchPromptPack(language, 'teacher', true),
+      TEACHING_UNIT_PROMPTS[language],
+      `${language} teacher output uses the lesson-plan contract`,
+    );
+    assert.equal(
+      studyDeepResearchPromptPack(language, 'students', true),
+      STUDY_DEEP_RESEARCH_PROMPTS[language],
+      `${language} student output uses the learner-facing notes contract`,
+    );
   }
 });

--- a/scripts/verify-teaching-groups-ui.mjs
+++ b/scripts/verify-teaching-groups-ui.mjs
@@ -109,6 +109,23 @@ try {
   await page.reload();
   await page.waitForFunction(() => !!document.getElementById('root')?.children.length);
 
+  // ── Unit design chooses its reader before deciding the structure ────────────
+  const unitsButton = page.getByTestId('teaching-sidebar').getByRole('button', { name: 'Diseño de unidades', exact: true });
+  assert.equal(await unitsButton.count(), 1, 'the teaching sidebar exposes Unit design');
+  await unitsButton.click();
+  await page.getByRole('heading', { name: 'Diseño de unidades', exact: true }).waitFor();
+  await page.getByText('Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.', { exact: true }).waitFor();
+  await page.getByRole('button', { name: 'Nueva unidad', exact: true }).first().click();
+  const audienceSelect = page.getByTestId('deep-research-audience');
+  await audienceSelect.waitFor();
+  assert.equal(await audienceSelect.inputValue(), 'teacher', 'Unit design defaults to the teacher lesson-plan product');
+  assert.match(await page.getByTestId('deep-research-audience-help').innerText(), /objetivos, secuencia, actividades/i);
+  await audienceSelect.selectOption('students');
+  assert.equal(await audienceSelect.inputValue(), 'students', 'student handouts can be selected');
+  assert.match(await page.getByTestId('deep-research-audience-help').innerText(), /explicaciones, definiciones, ejemplos/i);
+  await page.getByRole('button', { name: 'Cancelar', exact: true }).click();
+  console.log('[ui] Unit design chooses between a teacher plan and student-ready notes');
+
   // ── The menu entry is live, not "coming soon" ───────────────────────────────
   const groupsButton = page.getByRole('button', { name: 'Grupos', exact: true }).first();
   assert.equal(await groupsButton.isDisabled(), false, 'Grupos is no longer a disabled placeholder');

--- a/shared/studyDeepResearchAudience.ts
+++ b/shared/studyDeepResearchAudience.ts
@@ -1,0 +1,15 @@
+/**
+ * The two pedagogical products offered by Deep Research.
+ *
+ * Values stay language-neutral because they are persisted with the generated draft
+ * and may be reused after the interface language changes.
+ */
+export type StudyDeepResearchAudience = 'teacher' | 'students';
+
+export function normalizeStudyDeepResearchAudience(
+  value: string | undefined,
+  fallback: StudyDeepResearchAudience = 'students',
+): StudyDeepResearchAudience {
+  if (value === 'teacher' || value === 'students') return value;
+  return fallback;
+}

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -6644,4 +6644,12 @@ export const DE: Record<string, string> = {
   'Unidad eliminada.': 'Einheit gelöscht.',
   '¿Eliminar esta unidad guardada? Esta acción no se puede deshacer.': 'Diese gespeicherte Einheit löschen? Dieser Vorgang kann nicht rückgängig gemacht werden.',
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Schreibe das Thema und Nodus verfasst die ganze Einheit aus deinen Materialien und zitiert jedes davon. Du kannst die KI die Teile vorschlagen lassen oder sie selbst festlegen: wie viele es sind, wie sie heißen und worauf sich jeder konzentrieren soll.',
+  'Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.': 'Erstelle Unterrichtseinheiten für Lehrkräfte oder Lernunterlagen für Schülerinnen und Schüler, stets auf Grundlage deiner Quellen.',
+  'Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.': 'Wähle zwischen einer Unterrichtsplanung und direkt ausgabefertigen Lernunterlagen.',
+  'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Gib das Thema der Lernunterlagen ein. Der Inhalt erklärt es anhand deiner Materialien Schritt für Schritt mit Beispielen und Selbstkontrolle.',
+  'Público objetivo y producto': 'Zielgruppe und Ergebnis',
+  'Docente · planificación de la lección': 'Lehrkraft · Unterrichtsplanung',
+  'Alumnado · apuntes para entregar': 'Lernende · ausgabefertige Unterlagen',
+  'Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.': 'Erstellt Lernziele, Ablauf, Aktivitäten, Verständnisprüfungen und Bewertung für die Lehrkraft.',
+  'Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.': 'Erstellt Erklärungen, Definitionen, Beispiele, Zusammenfassungen und Selbstkontrollen für Lernende.',
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -6871,4 +6871,12 @@ export const EN: Record<string, string> = {
   'Unidad eliminada.': 'Unit deleted.',
   '¿Eliminar esta unidad guardada? Esta acción no se puede deshacer.': 'Delete this saved unit? This action cannot be undone.',
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Write the topic and Nodus drafts the whole unit from your materials, citing each one. You can let the AI propose the parts or fix them yourself: how many there are, what they are called and what each one should concentrate on.',
+  'Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.': 'Design teacher-facing units or student handouts, always grounded in your sources.',
+  'Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.': 'Choose whether you need a plan for teaching the lesson or notes that are ready to share.',
+  'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Enter the topic for the notes. The content will explain it step by step with examples and self-assessment drawn from your materials.',
+  'Público objetivo y producto': 'Target audience and output',
+  'Docente · planificación de la lección': 'Teacher · lesson plan',
+  'Alumnado · apuntes para entregar': 'Students · ready-to-share notes',
+  'Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.': 'It will generate objectives, sequence, activities, checks for understanding, and assessment for the teacher.',
+  'Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.': 'It will generate student-facing explanations, definitions, examples, summaries, and self-assessment.',
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -6635,4 +6635,12 @@ export const FR: Record<string, string> = {
   'Unidad eliminada.': 'Unité supprimée.',
   '¿Eliminar esta unidad guardada? Esta acción no se puede deshacer.': 'Supprimer cette unité enregistrée? Cette action est irréversible.',
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Écris le sujet et Nodus rédige l’unité complète à partir de tes supports, en citant chacun d’eux. Tu peux laisser l’IA proposer les parties ou les fixer toi-même: combien il y en a, comment elles s’intitulent et sur quoi chacune doit se concentrer.',
+  'Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.': 'Conçois des unités pour l’enseignant ou des notes à distribuer aux élèves, toujours à partir de tes sources.',
+  'Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.': 'Choisis entre un plan pour donner le cours et des notes prêtes à distribuer.',
+  'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Écris le sujet des notes. Le contenu l’expliquera pas à pas avec des exemples et une autoévaluation à partir de tes supports.',
+  'Público objetivo y producto': 'Public cible et livrable',
+  'Docente · planificación de la lección': 'Enseignant · plan de cours',
+  'Alumnado · apuntes para entregar': 'Élèves · notes prêtes à distribuer',
+  'Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.': 'Cela générera des objectifs, une progression, des activités, des vérifications de compréhension et une évaluation pour l’enseignant.',
+  'Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.': 'Cela générera pour les élèves des explications, définitions, exemples, synthèses et activités d’autoévaluation.',
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -6054,4 +6054,12 @@ export const IT: Record<string, string> = {
   "Unidad eliminada.": "Unità eliminata.",
   "¿Eliminar esta unidad guardada? Esta acción no se puede deshacer.": "Eliminare questa unità salvata? Questa azione non può essere annullata.",
   "Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.": "Scrivi il tema e Nodus redige l’intera unità a partire dai tuoi materiali, citandoli uno per uno. Puoi lasciare che l’IA proponga le parti oppure fissarle tu: quante sono, come si intitolano e su che cosa deve concentrarsi ciascuna.",
+  "Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.": "Progetta unità per il docente o dispense da consegnare agli studenti, sempre a partire dalle tue fonti.",
+  "Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.": "Scegli fra un piano per svolgere la lezione e dispense pronte da consegnare.",
+  "Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.": "Scrivi l’argomento delle dispense. Il contenuto lo spiegherà passo dopo passo con esempi e autovalutazione a partire dai tuoi materiali.",
+  "Público objetivo y producto": "Destinatari e risultato",
+  "Docente · planificación de la lección": "Docente · piano della lezione",
+  "Alumnado · apuntes para entregar": "Studenti · dispense pronte da consegnare",
+  "Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.": "Genererà obiettivi, sequenza, attività, verifiche della comprensione e valutazione per il docente.",
+  "Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.": "Genererà spiegazioni, definizioni, esempi, sintesi e autovalutazione rivolti agli studenti.",
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -6594,4 +6594,12 @@ export const PT_BR: Record<string, string> = {
   'Unidad eliminada.': 'Unidade excluída.',
   '¿Eliminar esta unidad guardada? Esta acción no se puede deshacer.': 'Excluir esta unidade salva? Esta ação não pode ser desfeita.',
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Escreva o tema e o Nodus redige a unidade completa a partir dos seus materiais, citando cada um. Você pode deixar a IA propor as partes ou defini-las: quantas são, como se chamam e no que cada uma deve se concentrar.',
+  'Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.': 'Crie unidades para o docente ou material para entregar aos estudantes, sempre a partir das suas fontes.',
+  'Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.': 'Escolha entre um planejamento para ministrar a aula e material pronto para entregar.',
+  'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Escreva o tema do material. O conteúdo explicará passo a passo com exemplos e autoavaliação a partir dos seus materiais.',
+  'Público objetivo y producto': 'Público-alvo e resultado',
+  'Docente · planificación de la lección': 'Docente · planejamento da aula',
+  'Alumnado · apuntes para entregar': 'Estudantes · material pronto para entregar',
+  'Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.': 'Vai gerar objetivos, sequência, atividades, verificações de compreensão e avaliação para o docente.',
+  'Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.': 'Vai gerar explicações, definições, exemplos, sínteses e autoavaliação dirigidos aos estudantes.',
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -6586,4 +6586,12 @@ export const PT: Record<string, string> = {
   'Unidad eliminada.': 'Unidade eliminada.',
   '¿Eliminar esta unidad guardada? Esta acción no se puede deshacer.': 'Eliminar esta unidade guardada? Esta ação não pode ser anulada.',
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Escreve o tema e o Nodus redige a unidade completa a partir dos teus materiais, citando cada um. Podes deixar a IA propor as partes ou fixá-las tu: quantas são, como se intitulam e em que se deve centrar cada uma.',
+  'Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.': 'Concebe unidades para o docente ou apontamentos para entregar aos alunos, sempre a partir das tuas fontes.',
+  'Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.': 'Escolhe entre um plano para dar a aula e apontamentos prontos a entregar.',
+  'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Escreve o tema dos apontamentos. O conteúdo explica-o passo a passo com exemplos e autoavaliação a partir dos teus materiais.',
+  'Público objetivo y producto': 'Público-alvo e resultado',
+  'Docente · planificación de la lección': 'Docente · plano da aula',
+  'Alumnado · apuntes para entregar': 'Alunos · apontamentos prontos a entregar',
+  'Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.': 'Irá gerar objetivos, sequência, atividades, verificações da compreensão e avaliação para o docente.',
+  'Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.': 'Irá gerar explicações, definições, exemplos, sínteses e autoavaliação dirigidos aos alunos.',
 };

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -6401,4 +6401,12 @@ export const TR: Record<string, string> = {
   "Unidad eliminada.": "Ünite silindi.",
   "¿Eliminar esta unidad guardada? Esta acción no se puede deshacer.": "Kaydedilmiş bu ünite silinsin mi? Bu işlem geri alınamaz.",
   "Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.": "Konuyu yaz; Nodus üniteyi materyallerinden baştan sona yazar ve her birine atıf yapar. Bölümleri yapay zekâya önerttirebilir ya da kendin belirleyebilirsin: kaç tane olacağı, nasıl adlandırılacağı ve her birinin neye odaklanacağı.",
+  "Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.": "Her zaman kaynaklarına dayanarak öğretmen için üniteler veya öğrencilere verilecek ders notları hazırla.",
+  "Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.": "Dersi uygulamak için bir plan ile paylaşılmaya hazır ders notları arasında seçim yap.",
+  "Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.": "Ders notlarının konusunu yaz. İçerik, materyallerini kullanarak örnekler ve öz değerlendirmeyle adım adım açıklayacak.",
+  "Público objetivo y producto": "Hedef kitle ve çıktı",
+  "Docente · planificación de la lección": "Öğretmen · ders planı",
+  "Alumnado · apuntes para entregar": "Öğrenciler · paylaşılmaya hazır notlar",
+  "Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.": "Öğretmen için hedefler, sıralama, etkinlikler, anlama kontrolleri ve değerlendirme oluşturur.",
+  "Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.": "Öğrencilere yönelik açıklamalar, tanımlar, örnekler, özetler ve öz değerlendirme oluşturur.",
 };

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -16,6 +16,7 @@ import type {
   DecorativeImageStyle,
   ContentTranslation,
 } from '@shared/types';
+import type { StudyDeepResearchAudience } from '@shared/studyDeepResearchAudience';
 import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
 import type { PendingGraphNavigationTarget } from '../navigation';
 import { Icon, modelLabel } from '../components/ui';
@@ -166,9 +167,9 @@ const DEEP_RESEARCH_COPY: Record<DeepResearchVariant, DeepResearchCopy> = {
   },
   unit: {
     heading: 'Diseño de unidades',
-    subtitle: 'Tus unidades didácticas, escritas a partir de los materiales de clase y de las ideas extraídas de ellos.',
+    subtitle: 'Diseña unidades para el docente o apuntes para entregar al alumnado, siempre desde tus fuentes.',
     newAction: 'Nueva unidad',
-    composerSubtitle: 'La unidad se escribe con tus materiales de clase y cita cada uno de ellos.',
+    composerSubtitle: 'Elige si necesitas una planificación para impartir la lección o apuntes listos para entregar.',
     objectivePlaceholder: 'Escribe el tema de la unidad y, si quieres, para qué grupo o nivel. La unidad se desarrollará con tus materiales, citándolos.',
     missingObjective: 'Escribe el tema de la unidad antes de generarla.',
     queuedToast: 'Unidad añadida a la cola. Se generará en segundo plano.',
@@ -246,6 +247,7 @@ export function DeepResearchView({
   const [selectedModel, setSelectedModel] = useFeatureModel(settings, 'deepResearchModel');
   const [deepTarget, setDeepTarget] = useState<DeepResearchTargetLength>('adaptive');
   const [deepSectionLimit, setDeepSectionLimit] = useState<DeepResearchSectionLimit>('auto');
+  const [audience, setAudience] = useState<StudyDeepResearchAudience>(isTeaching ? 'teacher' : 'students');
   const [includeImage, setIncludeImage] = useState(false);
   const [imageStyle, setImageStyle] = useState<DecorativeImageStyle>(settings.imageStyle);
   const [focusPersonId, setFocusPersonId] = useState<string | null>(null);
@@ -344,6 +346,7 @@ export function DeepResearchView({
       language,
       targetLength: deepTarget,
       sectionLimit: deepSectionLimit,
+      ...(isStudy ? { audience } : {}),
       model: selectedModel,
       decorativeImage: { enabled: includeImage, style: imageStyle },
       ...(isGenealogy ? { focusPersonId } : {}),
@@ -382,6 +385,9 @@ export function DeepResearchView({
     setObjective(saved.brief.objective);
     if (saved.brief.language) setLanguage(saved.brief.language as PromptLanguage);
     if (saved.model) setSelectedModel(saved.model);
+    if (isTeaching && (saved.brief.audience === 'teacher' || saved.brief.audience === 'students')) {
+      setAudience(saved.brief.audience);
+    }
     setFocusPersonId(null);
     setComposerOpen(true);
   };
@@ -709,6 +715,7 @@ export function DeepResearchView({
           onStructureMode={setStructureMode}
           onUnitOutline={setUnitOutline}
           objective={objective}
+          audience={audience}
           language={language}
           model={selectedModel}
           target={deepTarget}
@@ -720,6 +727,7 @@ export function DeepResearchView({
           persons={personsList}
           focusPersonId={focusPersonId}
           onObjective={setObjective}
+          onAudience={setAudience}
           onLanguage={setLanguage}
           onModel={setSelectedModel}
           onTarget={setDeepTarget}
@@ -1096,6 +1104,7 @@ function ComposerModal({
   onStructureMode,
   onUnitOutline,
   objective,
+  audience,
   language,
   model,
   target,
@@ -1107,6 +1116,7 @@ function ComposerModal({
   persons = [],
   focusPersonId = null,
   onObjective,
+  onAudience,
   onLanguage,
   onModel,
   onTarget,
@@ -1126,6 +1136,7 @@ function ComposerModal({
   onStructureMode: (v: 'ai' | 'manual') => void;
   onUnitOutline: (v: DeepResearchOutlineSection[]) => void;
   objective: string;
+  audience: StudyDeepResearchAudience;
   language: PromptLanguage;
   model: AppSettings['deepResearchModel'];
   target: DeepResearchTargetLength;
@@ -1137,6 +1148,7 @@ function ComposerModal({
   persons?: Person[];
   focusPersonId?: string | null;
   onObjective: (v: string) => void;
+  onAudience: (v: StudyDeepResearchAudience) => void;
   onLanguage: (v: PromptLanguage) => void;
   onModel: (m: AppSettings['deepResearchModel']) => void;
   onTarget: (v: DeepResearchTargetLength) => void;
@@ -1181,8 +1193,31 @@ function ComposerModal({
             value={objective}
             autoFocus
             onChange={(e) => onObjective(e.target.value)}
-            placeholder={t(copy.objectivePlaceholder)}
+            placeholder={isTeaching && audience === 'students'
+              ? t('Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.')
+              : t(copy.objectivePlaceholder)}
           />
+          {isTeaching && (
+            <label className="block">
+              <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-neutral-500">
+                {t('Público objetivo y producto')}
+              </span>
+              <select
+                data-testid="deep-research-audience"
+                className="input w-full text-sm"
+                value={audience}
+                onChange={(event) => onAudience(event.target.value as StudyDeepResearchAudience)}
+              >
+                <option value="teacher">{t('Docente · planificación de la lección')}</option>
+                <option value="students">{t('Alumnado · apuntes para entregar')}</option>
+              </select>
+              <span className="mt-1 block text-[11px] text-neutral-500" data-testid="deep-research-audience-help">
+                {audience === 'teacher'
+                  ? t('Generará objetivos, secuencia, actividades, comprobaciones de comprensión y evaluación para el docente.')
+                  : t('Generará explicaciones, definiciones, ejemplos, síntesis y autoevaluación dirigidos al alumnado.')}
+              </span>
+            </label>
+          )}
           {isGenealogy && (
             <div>
               <select


### PR DESCRIPTION
## Summary

- add a target-audience selector to the Teaching vault's Unit design composer
- preserve **Teacher · lesson plan** as the default and add **Students · ready-to-share notes**
- route teacher and student outputs to their distinct native prompt packs in every supported output language
- carry the audience through queued generation, planning, writing, finalization, persistence, and prompt reuse
- localize the new UI copy across all supported interface languages

## Validation

- `node --test scripts/test-unit-design.mjs` — 11 passed
- `node scripts/test-i18n-coverage.mjs` — 21 passed
- targeted ESLint — passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `node scripts/verify-teaching-groups-ui.mjs` — all real Electron UI checks passed, including the teacher default and student-handout selection

Closes #261