### PR TITLE
Translate project documentation to English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,7 +511,7 @@ drift had already caused are fixed.
 
 ### Added
 
-- New "Image design" dialog for Inmersión and Deep Research: preview the image,
+- New "Image design" dialog for Immersion and Deep Research: preview the image,
   switch style, edit the scene description, and regenerate or delete it in one place.
 - Five photographic and realistic decorative styles — realistic photograph,
   vintage photograph, black & white, cinematic, and oil painting (twelve in total).
@@ -522,7 +522,7 @@ drift had already caused are fixed.
 
 - Decorative images now render larger and more polished. The inline action buttons
   are replaced by a single unobtrusive "Design" pill that opens the design dialog,
-  keeping the Inmersión and Deep Research views uncluttered.
+  keeping the Immersion and Deep Research views uncluttered.
 - The "immersion ready" screen is now part of the main immersion view instead of a
   separate standalone page.
 
@@ -530,7 +530,7 @@ drift had already caused are fixed.
 
 ### Added
 
-- Optional single decorative images for Inmersión and Deep Research, generated
+- Optional single decorative images for Immersion and Deep Research, generated
   only after the main content has been saved.
 - Seven centralized styles, optimized reusable images and lazy list thumbnails.
 - Independent image-provider/model settings for Google, the official OpenAI
@@ -551,7 +551,7 @@ drift had already caused are fixed.
 ### Reliability
 
 - Image errors, timeouts, missing credit, or provider failures never roll back or
-  block an Inmersión or Deep Research report.
+  block an Immersion or Deep Research report.
 - No automatic image retries or duplicate generation of an existing ready image.
 - Stale and deleted in-flight attempts cannot overwrite the current image state.
 - Existing saved content without images remains fully compatible.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,261 +1,231 @@
-# Política de privacidad de Nodus
+# Nodus Privacy Policy
 
-**Versión:** 1.2
+**Version:** 1.2
 
-**Fecha de vigencia:** 22 de julio de 2026
+** Date of validity:** 22 July 2026
 
-**Ámbito:** aplicación de escritorio Nodus 2.5 y posteriores
+**Scope:** Desktop application Nodus 2.5 and later
 
-## Resumen claro
+## Clear summary
 
-Nodus es una aplicación gratuita, de código abierto y principalmente local. No
-requiere una cuenta de Nodus, no incorpora publicidad, telemetría, analítica remota
-ni envía contenido a una nube operada por el proyecto. Las bases de datos, archivos,
-grabaciones, transcripciones, notas, expedientes y resultados se guardan en el
-dispositivo del usuario salvo que este active expresamente una función remota.
+Nodus is a free, open source and mainly local application. It does not require a Nodus account, does
+not incorporate advertising, telemetry, remote analytics or send content to a cloud operated by the
+project. Databases, files, recordings, transcripts, notes, files and results are saved on the user's
+device unless it expressly activates a remote function.
 
-Seleccionar un archivo o iniciar una grabación **no lo publica ni lo sube a Nodus**.
-Algunas funciones opcionales sí pueden contactar con servicios de terceros: por
-ejemplo, un proveedor de IA en la nube elegido por el usuario, Zotero, Unpaywall,
-GitHub para comprobar actualizaciones, Hugging Face para descargar modelos o el
-túnel MCP seguro de OpenAI para usar Nodus desde ChatGPT. Esos servicios reciben
-los datos necesarios para la operación solicitada y aplican sus propias condiciones
-y políticas.
+Selecting a file or starting a recording **does not publish it or upload it to Nodus**. Some
+optional features can contact third-party services: for example, a user-chosen cloud AI provider,
+Zotero, Unpaywall, GitHub to check updates, Hugging Face to download models or OpenAI secure MCP
+tunnel to use Nodus from ChatGPT. These services receive the necessary data for the requested
+operation and apply their own conditions and policies.
 
-**Nodus Server es opcional y autohospedado.** Si el usuario lo conecta en Ajustes,
-la aplicación publica por HTTPS una copia lógica y minimizada del vault en el
-servidor elegido por el usuario o su organización. Nunca sube la base SQLite, claves,
-contraseñas, rutas locales, embeddings ni archivos PDF. Los pasajes y el contenido
-creado por el usuario solo se incluyen si este activa sus opciones específicas. Las
-listas de estudiantes, grupos, calificaciones y resultados de evaluación no se
-publican mediante esta función.
+**Nodus Server is optional and self-hosted.** If the user connects it in Settings, the application
+publishes a logical and minimized copy of the vault on the server chosen by the user or his/her
+organization. Never uploads the SQLite database, keys, passwords, local paths, embeddings or PDF
+files. The passages and content created by the user are included only if it activates their specific
+options. Student lists, groups, ratings and evaluation results are not published using this
+function.
 
-Nodus **no usa IA para puntuar, calificar, clasificar, perfilar ni evaluar a ningún
-estudiante**. Las notas y rúbricas las introduce o confirma una persona. Las
-preguntas de opción múltiple pueden corregirse localmente mediante una coincidencia
-determinista con la respuesta marcada como correcta; no interviene ningún modelo.
+Nodus **does not use AI to rate, grade, rank, profile, or evaluate any student**. Notes and rubrics
+are entered or confirmed by a person. Multiple choice questions can be corrected locally by
+deterministic matching with the answer marked as correct; no model is involved.
 
-## 1. Quién trata los datos
+## 1. Who processes the data
 
-El proyecto Nodus, mantenido por Jorge Pérez Burgueño, publica el software pero no
-recibe ni puede acceder al contenido almacenado en una instalación normal o en un
-Nodus Server autohospedado por terceros. El proyecto no opera una nube, cuenta o
-backend central. Para incidencias de seguridad que no deban
-ser públicas puede utilizarse el canal privado de GitHub:
+The Nodus project, maintained by Jorge Pérez Burgueño, publishes the software but does not receive
+or access the content stored in a normal installation or in a third-party-hosted Nodus Server. The
+project does not operate a cloud, account or central backend. For security incidents that need not
+be public, the private channel GitHub can be used:
 https://github.com/Drakonis96/nodus/security/advisories/new
 
-La persona, universidad, centro educativo, empresa u organización que decide qué
-datos personales introduce, para qué los usa y durante cuánto tiempo los conserva
-es normalmente el **responsable del tratamiento** respecto de esos datos. El usuario
-individual puede actuar por cuenta propia o como persona autorizada por ese
-responsable. Esta política no sustituye el aviso de privacidad que deba facilitar el
-responsable concreto conforme a los artículos 13 y 14 del RGPD.
+The person, university, educational center, company or organization who decides which personal data
+he or she introduces, what he or she uses them for, and how long he or she normally retains them is
+the **processor responsible** for such data. The individual user may act on his or her own account
+or as a person authorized by that controller. This policy does not replace the privacy notice to be
+provided by the specific controller pursuant to Articles 13 and 14 of the GDPR.
 
-Cuando se configura un proveedor externo, el responsable debe determinar si ese
-proveedor actúa como encargado o como responsable independiente, revisar sus
-condiciones, formalizar en su caso el contrato del artículo 28 RGPD y comprobar las
-garantías para transferencias internacionales. Nodus no celebra esos contratos en
-nombre del usuario.
+When setting up an external provider, the controller must determine whether the provider acts as an
+independent maintainer or controller, review its terms, formalize the Article 28 GDPR contract where
+appropriate, and verify the guarantees for international transfers. Nodus does not conclude such
+contracts on behalf of the user.
 
-Quien instala y administra Nodus Server determina sus usuarios, permisos, dominio,
-alojamiento, copias y plazos de conservación. Esa persona u organización es
-normalmente responsable —o, según el contexto, encargado— del tratamiento efectuado
-en su servidor y debe informar a las personas con acceso.
+Whoever installs and manages Nodus Server determines its users, permissions, domain, hosting, copies
+and retention times. That person or organization is usually responsible — or, depending on the
+context, in charge — for the treatment performed on its server and must inform the persons with
+access.
 
-## 2. Datos que puede almacenar la aplicación
+## 2. Data that the application can store
 
-Según las funciones utilizadas, el dispositivo puede contener:
+Depending on the functions used, the device may contain:
 
-- documentos, referencias, citas, anotaciones, imágenes y archivos importados;
-- nombres, identificadores, grupos, asistencia, rúbricas y calificaciones introducidas
-  manualmente en un vault de Docencia;
-- grabaciones de audio, voces de terceros, transcripciones y marcas temporales;
-- notas, calendarios, planes de estudio, respuestas y progreso local;
-- datos históricos, genealógicos o de investigación aportados por el usuario;
-- prompts, respuestas y metadatos de uso de IA guardados localmente;
-- ajustes, rutas de archivos y credenciales de servicios. Las claves compatibles se
-  guardan mediante el almacén seguro del sistema operativo y no en la interfaz.
+- documents, references, quotations, annotations, images and imported files;
+- names, identifiers, groups, attendance, headings and qualifications manually entered in a teaching
+  vault;
+- audio recordings, third party voices, transcripts and temporary marks;
+- notes, timetables, curricula, responses and local progress;
+- historical, genealogical or research data provided by the user;
+- locally saved AI prompts, responses and metadata;
+- settings, file paths and service credentials. Supported keys are saved via secure operating system
+  storage and not in the interface.
 
-Nodus no necesita categorías especiales de datos para funcionar. No deben
-introducirse datos de salud, biométricos, ideología, religión, orientación sexual,
-afiliación sindical u otros datos especialmente protegidos salvo que exista una
-necesidad real, una base jurídica válida y salvaguardas adecuadas.
+Nodus does not need special categories of data to function. Health, biometrics, ideology, religion,
+sexual orientation, trade union membership or other specially protected data should not be entered
+unless there is a real need, a valid legal basis and adequate safeguards.
 
-## 3. Finalidades y bases jurídicas
+## 3. Legal purposes and bases
 
-Nodus procesa localmente la información para las funciones que el usuario activa:
-organizar fuentes, producir documentos, gestionar docencia o estudio, transcribir,
-buscar, exportar y crear copias de seguridad. La base jurídica no la decide la
-aplicación. Debe determinarla el responsable conforme al artículo 6 RGPD y, si
-procede, al artículo 9.
+Nodus processes the information locally for the functions that the user activates: organizing
+sources, producing documents, managing teaching or study, transcribing, searching, exporting and
+creating backups. The legal basis is not decided by the application. It must be determined by the
+person responsible in accordance with Article 6 GDPR and, where appropriate, Article 9.
 
-En enseñanza reglada puede resultar aplicable la misión de interés público y la
-normativa educativa, no necesariamente el consentimiento. En otros contextos puede
-ser aplicable un contrato, una obligación legal, un interés legítimo debidamente
-ponderado o un consentimiento libre y revocable. Marcar «continuar» en un aviso de
-Nodus confirma únicamente que el usuario ha leído el aviso; **no crea por sí solo una
-base jurídica ni sustituye el consentimiento de las personas afectadas**.
+In regulated education, the mission of public interest and educational regulations may be
+applicable, not necessarily consent. In other contexts, a contract, a legal obligation, a duly
+weighted legitimate interest, or a free and revocable consent may apply. Mark "continue" in a Nodus
+notice confirms only that the user has read the notice; **does not in itself create a legal basis or
+substitute the consent of the persons concerned**.
 
-## 4. Archivos y grabaciones
+## 4. Archives and recordings
 
-Los archivos que el usuario incorpora se tratan localmente y no se suben a Nodus
-Server. La publicación opcional puede incluir metadatos, contenido académico
-derivado y, solo con opciones separadas, pasajes o contenido creado por el usuario.
-Antes de activar el micrófono se muestra un aviso previo, que el
-usuario puede aceptar puntualmente o recordar para no volver a mostrarlo.
+The files that the user incorporates are processed locally and not uploaded to Nodus Server. The
+optional publication may include metadata, derived academic content and, only with separate options,
+passages or content created by the user. Before activating the microphone, a previous notice is
+displayed, which the user can accept promptly or remember not to display again.
 
-Quien grabe debe:
+Those who record should:
 
-1. informar previamente y de forma comprensible a todas las personas afectadas;
-2. identificar al responsable, finalidad, base jurídica, destinatarios y conservación;
-3. obtener consentimiento cuando sea la base aplicable, incluido el de representantes
-   legales cuando corresponda;
-4. limitar el acceso y evitar toda difusión incompatible con la finalidad informada;
-5. respetar las reglas del centro, la confidencialidad y la legislación sobre imagen,
-   voz, propiedad intelectual y secreto de las comunicaciones.
+1. inform all persons concerned in advance and in a comprehensible manner;
+2. identify the person responsible, purpose, legal basis, addressees and conservation;
+3. obtain consent where applicable, including that of legal representatives where appropriate;
+4. limit access and avoid any dissemination incompatible with the informed purpose;
+5. respect the rules of the centre, confidentiality and legislation on image, voice, intellectual
+   property and secrecy of communications.
 
-Nodus no está diseñado para grabación encubierta, vigilancia, reconocimiento de
-emociones, identificación biométrica ni control de exámenes.
+Nodus is not designed for covert recording, surveillance, emotional recognition, biometric
+identification, or test control.
 
-## 5. IA y alumnado: prohibición de evaluación
+## 5. AI and students: prohibition of evaluation
 
-La finalidad prevista de la IA de Nodus se limita a trabajar sobre contenido
-académico o docente: ayudar a estructurar una programación, generar borradores de
-materiales, preguntas, explicaciones o resúmenes y asistir en investigación.
+The aim of the IA of Nodus is limited to working on academic or teaching content: to help structure
+programming, generate draft materials, questions, explanations or summaries and to assist in
+research.
 
-Nodus no ofrece ni autoriza como finalidad prevista:
+Nodus does not offer or authorize as intended:
 
-- enviar a un modelo nombres, expedientes, notas o respuestas de estudiantes para
-  obtener una valoración;
-- producir notas, predicciones de rendimiento, rankings, perfiles o decisiones sobre
-  admisión, promoción, itinerarios o acceso a oportunidades;
-- inferir emociones, atención, conducta, discapacidad, personalidad o riesgo;
-- vigilar o detectar conductas prohibidas durante pruebas.
+- send to a model names, files, notes or student responses to obtain an evaluation;
+- produce notes, performance predictions, rankings, profiles or decisions on admission, promotion,
+  itineraries or access to opportunities;
+- Infer emotions, attention, behavior, disability, personality or risk;
+- monitor or detect prohibited conduct during testing.
 
-Las calificaciones del gradebook son entradas humanas o cálculos aritméticos
-deterministas definidos por el docente. Generar una pregunta o una rúbrica con IA no
-equivale a evaluar a una persona: el modelo no recibe la respuesta ni decide la nota.
+Gradebook grades are human inputs or deterministic arithmetical calculations defined by the teacher.
+Generating a question or rubric with AI does not amount to evaluating a person: the model does not
+receive the answer or decides the note.
 
-## 6. Comunicaciones externas opcionales
+## 6. Optional external communications
 
-Nodus puede realizar las siguientes conexiones, solo cuando la función está
-configurada o es necesaria para la operación indicada:
+Nodus can make the following connections, only when the function is configured or necessary for the
+specified operation:
 
-- **Proveedores de IA y audio en la nube:** se envían prompts, fragmentos, imágenes,
-  audio o texto necesarios para la petición que inicia el usuario. El proveedor,
-  modelo y cuenta los elige el usuario. Los modelos locales no realizan ese envío.
-- **Zotero:** consulta bibliotecas y archivos autorizados por el usuario.
-- **Unpaywall y servidores de publicaciones:** consulta un DOI y puede descargar el
-  texto accesible; el correo configurado para Unpaywall se incluye en la petición.
-- **GitHub:** comprobación y descarga de actualizaciones, apertura de incidencias y
-  descargas del proyecto. También aloja la descarga oficial del cliente de túnel de
-  OpenAI, cuya integridad verifica Nodus antes de ejecutarlo. GitHub puede recibir
-  datos de red como la dirección IP.
-- **Hugging Face u otros repositorios fijados:** descarga opcional de modelos, voces
-  y runtimes. El repositorio puede recibir datos de red.
-- **OpenAI Secure MCP Tunnel y ChatGPT:** si el usuario configura expresamente esta
-  integración, Nodus ejecuta el cliente oficial de OpenAI y abre una conexión HTTPS
-  saliente a OpenAI. El servidor MCP de Nodus continúa escuchando solo en localhost:
-  no se abre ningún puerto entrante ni se publica una URL de Nodus. OpenAI y ChatGPT
-  reciben las solicitudes de herramientas y sus resultados, que pueden contener
-  fragmentos, metadatos y contenido de la bóveda activa solicitado por el usuario o
-  por el modelo. La clave de ejecución del túnel se guarda en el almacén de
-  credenciales del dispositivo y no se incluye en las copias de seguridad.
-- **Nodus Server autohospedado, ChatGPT y Claude:** si el usuario empareja un vault,
-  Nodus abre una conexión HTTPS saliente al dominio configurado y publica una
-  proyección filtrada. El token de dispositivo se cifra con el almacén seguro del
-  sistema; si este no está disponible, solo se conserva en memoria hasta cerrar Nodus.
-  Permanece fuera del renderer y de los backups, y es distinto del token y
-  puerto del MCP local. Los lectores acceden al endpoint MCP remoto mediante OAuth;
-  el servidor comprueba usuario, espacio, caducidad, audiencia y permisos en cada
-  petición. El administrador del servidor y los proveedores de IA utilizados por
-  los lectores reciben los datos consultados. Los PDF, credenciales y datos de
-  calificación o alumnado no forman parte de la publicación.
-- **Enlaces externos:** PayPal, calendarios, páginas de licencias y otros enlaces solo
-  se abren cuando el usuario los solicita.
+- **IA and audio providers in the cloud:**prompts, fragments, images, audio or text necessary for
+  the user's request are sent.The provider, model and account is chosen by the user. Local models do
+  not make that submission.
+- **Zotero:** consults libraries and files authorized by the user.
+- **Unpaywall and publishing servers:** consult a DOI and you can download the accessible text; the
+  mail configured for Unpaywall is included in the request.
+- **GitHub:** Check and download updates, open incidents and downloads of the project. It also hosts
+  the official download of the OpenAI tunnel client, whose integrity checks Nodus before executing
+  it. GitHub can receive network data such as IP address.
+- **Hugging Face or other fixed repositories:** optional download of models, voices and runtimes.
+  The repository can receive network data.
+- **OpenAI Secure MCP Tunnel and ChatGPT:** If the user expressly configures this integration, Nodus
+  executes the official OpenAI client and opens an outgoing HTTPS connection to OpenAI. Nodus MCP
+  server continues to listen only to localhost: no incoming port is opened or a Nodus URL is
+  published. OpenAI and ChatGPT receive the tool requests and their results, which may contain
+  fragments, metadata and active vault content requested by the user or model. The tunnel execution
+  key is stored in the device's credentials warehouse and is not included in the backups.
+- **Nodus Server autohosted, ChatGPT and Claude:** if the user matches a Vault, Nodus opens a
+  outgoing HTTPS connection to the configured domain and publishes a filtered projection. The device
+  token is encrypted with the secure system warehouse; if it is not available, it is only stored in
+  memory until Nodus is closed. It remains outside the renderer and backups, and is different from
+  the local MCP token and port. Readers access the remote MCP endpoint via OAuth; the server checks
+  user, space, expiration, audience and permissions on each request. The server administrator and AI
+  providers used by readers receive the consulted data. PDFs, credentials and qualification or
+  student data are not part of the publication.
+- **External links:** PayPal, calendars, license pages and other links are only opened when
+  requested by the user.
 
-Nodus no controla la conservación posterior que realicen esos terceros. Antes de
-usar un servicio remoto con datos personales, el responsable debe revisar su región,
-retención, uso para entrenamiento, subencargados, medidas de seguridad y mecanismo
-de transferencia internacional. Para datos de alumnado o categorías especiales se
-recomienda utilizar exclusivamente modelos locales salvo autorización institucional
-documentada.
+Nodus does not control the subsequent preservation by these third parties. Before using a remote
+service with personal data, the controller must review your region, retention, use for training,
+sub-loads, security measures and international transfer mechanism. For student data or special
+categories it is recommended to use exclusively local models except documented institutional
+authorization.
 
-## 7. Conservación y borrado
+## 7. Maintenance and erasing
 
-Los datos locales se conservan hasta que el usuario los elimina. La papelera,
-historiales, exportaciones, clips preservados y copias de seguridad pueden mantener
-copias adicionales; deben revisarse y borrarse conforme al plazo definido por el
-responsable. Desinstalar la aplicación no garantiza que se borren automáticamente
-las bases de datos, exports o backups del usuario.
+Local data is kept until the user deletes them. Trash, records, exports, preserved clips and backups
+can maintain additional copies; they must be reviewed and deleted according to the time limit
+defined by the responsible. Uninstalling the application does not guarantee that the user's
+databases, exports or backups are automatically deleted.
 
-Los proveedores externos y cada Nodus Server autohospedado aplican sus propios
-plazos. Desconectar un vault detiene nuevos envíos, pero no borra automáticamente la
-última publicación del servidor; el administrador debe eliminarla conforme a su
-política. El responsable debe configurar y documentar estos plazos antes de
-transmitir datos personales.
+External providers and each self-hosted Nodus Server apply their own deadlines. Disconnecting a
+Vault stops new submissions, but does not automatically delete the latest server posting; the
+administrator must delete it in accordance with its policy. The responsible must configure and
+document these deadlines before transmitting personal data.
 
-## 8. Seguridad
+## 8. Security
 
-Nodus aplica minimización por defecto, procesamiento local, aislamiento de Electron,
-almacenamiento seguro de credenciales compatible con el sistema, avisos justo a
-tiempo y exportaciones o backups protegibles. Nodus Server exige HTTPS fuera de
-localhost, tokens de emparejamiento de un solo uso, OAuth con PKCE, sesiones con CSRF,
-control de acceso por espacio y tokens de acceso breves. Sin embargo, **local no significa
-cifrado automático de toda la base de datos**. El usuario o la organización debe
-proteger la cuenta del sistema, activar cifrado completo del disco, instalar
-actualizaciones, limitar permisos, cifrar backups y controlar el acceso físico.
+Nodus applies default minimization, local processing, Electron isolation, secure system-compatible
+credentials storage, just-in-time notifications and exports or protectionable backups. Nodus Server
+requires HTTPS out of localhost, single-use matching tokens, OAuth with PKCE, CSRF sessions, space
+access control, and short access tokens. However, **local does not mean automatic encryption of the
+entire database**. The user or organization must protect the system account, enable full disk
+encryption, install updates, limit permissions, encrypt backups and control physical access.
 
-Ningún software puede prometer riesgo cero. Una organización debe mantener medidas
-técnicas y organizativas apropiadas, pruebas periódicas, un procedimiento de brechas
-y recuperación conforme a su análisis de riesgos.
+No software can promise zero risk. An organization must maintain appropriate technical and
+organizational measures, periodic testing, a breach procedure and recovery according to its risk
+analysis.
 
-## 9. Derechos de las personas
+## 9. Rights of individuals
 
-Cuando los datos solo están en un dispositivo, el proyecto Nodus no puede buscarlos,
-rectificarlos ni borrarlos porque no tiene acceso. Las solicitudes de acceso,
-rectificación, supresión, limitación, oposición o portabilidad deben dirigirse al
-responsable que utilizó Nodus. La aplicación permite consultar, modificar, exportar
-y eliminar gran parte del contenido local; el responsable debe completar esas
-operaciones también en copias y sistemas externos.
+When the data is only on one device, the Nodus project cannot search, rectify or delete them because
+it does not have access. Requests for access, rectification, deletion, limitation, opposition or
+portability should be addressed to the controller who used Nodus. The application allows you to
+consult, modify, export and delete much of the local content; the controller must also complete
+those operations in copies and external systems.
 
-Las personas pueden presentar una reclamación ante la autoridad de protección de
-datos competente. En España: https://www.aepd.es/
+Individuals may file a complaint with the competent data protection authority. In Spain:
+https://www.aepd.es/
 
-## 10. Responsabilidad y uso legítimo
+## 10. Legitimate liability and use
 
-El usuario es responsable de no introducir ni comunicar datos que no esté autorizado
-a tratar y de no usar Nodus para fines ilícitos o incompatibles. El responsable del
-tratamiento debe cumplir sus propias obligaciones de información, licitud,
-minimización, contratos, seguridad, atención de derechos y evaluación de impacto.
+The user is responsible for not entering or communicating data that he or she is not authorized to
+process and not to use Nodus for unlawful or incompatible purposes. The controller must comply with
+his or her own obligations of information, legality, minimization, contracts, security, rights care
+and impact assessment.
 
-La licencia MIT entrega el software «tal cual», sin garantía técnica, en la máxima
-medida permitida por la ley. Esa cláusula **no elimina obligaciones legales
-imperativas, no convierte automáticamente al usuario en único responsable y no
-excluye responsabilidades que la ley no permita excluir**.
+The MIT license delivers the software "as is", without technical warranty, to the maximum extent
+permitted by law. **This clause does not eliminate mandatory legal obligations, does not
+automatically make the user solely responsible and does not exclude liability that the law does not
+allow to exclude**.
 
-## 11. Requisitos para una implantación RGPD
+## 11. Requirements for GDPR implementation
 
-La configuración local de Nodus facilita el cumplimiento, pero una aplicación por sí
-sola no puede certificar el tratamiento completo de una institución. Antes de usar
-datos personales en una organización deben completarse las acciones de
-`legal/RGPD_DEPLOYMENT_CHECKLIST.md`, incluida la identidad y contacto del responsable,
-registro de actividades, base jurídica, plazos, encargados, transferencias,
-procedimiento de derechos, seguridad y, cuando exista alto riesgo, una evaluación de
-impacto.
+The local configuration of Nodus facilitates compliance, but an application alone cannot certify the
+complete processing of an institution. Before using personal data in an organization, the actions of
+`legal/RGPD_DEPLOYMENT_CHECKLIST.md` must be completed, including the identity and contact of the
+controller, registration of activities, legal basis, deadlines, managers, transfers, rights
+procedure, security and, where there is a high risk, an impact assessment.
 
-## 12. Referencias oficiales
+## 12. Official references
 
-- Reglamento (UE) 2016/679 (RGPD):
-  https://eur-lex.europa.eu/eli/reg/2016/679/oj
-- Ley Orgánica 3/2018 (LOPDGDD):
-  https://www.boe.es/eli/es/lo/2018/12/05/3/con
-- Protección de datos por defecto, AEPD:
+- Regulation (EU) 2016/679 (GDPR): https://eur-lex.europa.eu/eli/reg/2016/679/oj
+- Organic Law 3/2018 (LOPDGDD): https://www.boe.es/eli/es/lo/2018/12/05/3/con
+- Default data protection, AEPD:
   https://www.aepd.es/derechos-y-deberes/cumple-tus-deberes/medidas-de-cumplimiento/proteccion-de-datos-por-defecto
-- Reglamento (UE) 2024/1689 de Inteligencia Artificial:
-  https://eur-lex.europa.eu/eli/reg/2024/1689/oj
+- Artificial Intelligence Regulation (EU) 2024/1689: https://eur-lex.europa.eu/eli/reg/2024/1689/oj
 
-## 13. Cambios de esta política
+## 13. Changes in this policy
 
-Los cambios materiales se publicarán en el repositorio y se incluirán en las nuevas
-versiones. El historial de Git permite auditar cada modificación.
+Material changes will be published in the repository and included in the new versions. Git's history
+allows you to audit each modification.

--- a/design/backup-recovery-audit.md
+++ b/design/backup-recovery-audit.md
@@ -1,124 +1,118 @@
-# Auditoría de copias de seguridad y recuperación
+# Backup and recovery audit
 
-Fecha: 2026-07-19 · Rama base: `claude/backup-recovery-audit-9727f4` · Esquema: v87
+Date: 2026-07-19 · Base branch: `claude/backup-recovery-audit-9727f4` · Scheme: v87
 
-> **Estado: CORREGIDO.** Los tres bloques se han implementado y verificado
-> (531/531 tests, build y smoke e2e con la app real sobre esquema v87). Cada
-> corrección se comprobó además *neutralizándola temporalmente* para confirmar que su
-> test la detecta; el detalle está en «Verificación» al final. El diagnóstico original
-> se conserva íntegro porque explica por qué el código es como es ahora.
+> ** Status: CORREGIDO.** The three blocks have been implemented and verified
+> (531/531 tests, build and smoke e2e with the actual app on scheme v87).
+> correction was also verified * temporarily neutralizing* to confirm that its
+> test detects it; the detail is in "Verification" at the end. The original diagnosis
+> it is preserved in its entirety because it explains why the code is as it is now.
 
-Alcance: `.nodus` (copia cifrada automática y manual), la restauración, el ciclo de
-vida de las credenciales, y `.nodussync` (traspaso entre equipos). Pregunta rectora:
-**¿puede una bóveda quedar irrecuperable, y qué falla al cambiar de dispositivo?**
-
----
-
-## Resumen ejecutivo
-
-El diseño criptográfico y el modelo de datos son sólidos. Los fallos no están en el
-cifrado: están en **la atomicidad de la restauración**, en **el silencio ante fallos**
-y, sobre todo, en que **`.nodussync` promete un traspaso entre equipos que no cumple**.
-
-Tres conclusiones:
-
-1. Existen dos rutas por las que una bóveda queda **destruida sin posibilidad de vuelta atrás**.
-2. Hay al menos cinco rutas por las que **las copias dejan de hacerse en silencio**,
-   mientras la interfaz sigue mostrando el último estado correcto. Es el peor fallo
-   posible en un sistema de copias: falsa seguridad.
-3. `.nodussync` **no transporta las notas del profesorado, el taller de escritura ni
-   toda la capa genealógica**, y puede quedar roto de forma permanente por un choque de
-   nombres de curso académico que la app invita a provocar.
+Scope: `.nodus` (automatic and manual encrypted copy), restoration, life cycle of credentials, and
+`.nodussync` (inter-team transfer).Rectoral question: **Can a vault become unrecoverable, and what
+fails to change the device?**
 
 ---
 
-## Lo que está bien (no tocar)
+## Executive summary
 
-- **Cripto**: AES-256-GCM + scrypt (N=32768, 64 MB), IV y sal aleatorios por copia,
-  hash SHA-256 del texto claro y del cifrado verificados en la restauración
-  (`backupCrypto.ts:88-108`).
-- **Clave de recuperación independiente** (formato v6): la carga útil se cifra con una
-  clave estable y esa clave se envuelve con la contraseña. Cambiar la contraseña no
-  invalida las copias antiguas, porque la clave de recuperación sigue abriendo la carga
-  útil directamente (`exportImport.ts:405-425`). Buen diseño.
-- **Kit de recuperación reexportable** desde Ajustes con ambas credenciales
-  (`ipc.ts:3227-3262`), no solo una vez en el asistente.
-- **Restauración multi-bóveda «merge-safe»**: valida todo en temporales antes de tocar
-  nada, y nunca borra bóvedas locales ausentes del archivo (`exportImport.ts:511-556`).
-- **Adjuntos como BLOB en SQLite**, no como rutas: evidencias, retratos, materiales,
-  grabaciones y adjuntos de bases de datos viajan en la copia. Decisión deliberada y
-  correcta (`migrations.ts:1100-1103`).
-- **El merge de `.nodussync` es atómico**: una sola transacción, WAL. Matar la app a
-  mitad revierte limpiamente. No hay corrupción posible por ahí.
+The cryptographic design and data model are solid. Failures are not in encryption: they are in **the
+atomity of restoration**, in **the silence of failures** and, above all, in that **`.nodussync`
+promises a transfer between teams that does not comply**.
+
+Three conclusions:
+
+1. There are two routes through which a vault is destroyed ** with no possibility of going back**.
+2. There are at least five routes by which ** copies stop being done in silence**, while the
+   interface continues to show the last correct state. It is the worst possible failure in a backup
+   system: false security.
+3. `.nodussync` **does not carry the teacher's notes, the writing workshop or the entire
+   genealogical layer**, and may be permanently broken by a clash of academic year names that the
+   app invites to provoke.
 
 ---
 
-## A. Rutas por las que una bóveda queda irrecuperable
+## What's right (don't touch)
 
-### A1 · La restauración borra la base de datos antes de copiar la nueva — CRÍTICO
+- **Crypt**: AES-256-GCM + scrypt (N=32768, 64 MB), IV and random salt per copy, hash SHA-256 of
+  clear text and encryption verified in restoration (`backupCrypto.ts:88-108`).
+- **Independent recovery key** (format v6): the payload is encrypted with a stable key and that key
+  is wrapped with the password. Changing the password does not invalidate old copies, because the
+  recovery key continues to open the payload directly (`exportImport.ts:405-425`).
+- **Reexportable Recovery Kit** from Settings with both credentials (`ipc.ts:3227-3262`), not only
+  once in the wizard.
+- **Multi-boved restoration "merge-safe"**: validates everything in time before touching anything,
+  and never deletes local vaults missing from the file (`exportImport.ts:511-556`).
+- **Assembly as BLOB in SQLite**, not as routes: evidence, portraits, materials, recordings and
+  database attachments travel in copy. Deliberate and correct decision (`migrations.ts:1100-1103`).
+- **The merge of `.nodussync` is atomic**: a single transaction, WAL. Killing the app in half
+  reverses cleanly. There is no corruption possible out there.
+
+---
+
+## A. Routes by which a vault is irrecoverable
+
+### A1 · The restore deletes the database before copying the new — CRITICAL
 
 `vaultRegistry.ts:272-273`:
 
 ```ts
-removeSqliteDatabaseFiles(record.path);   // borra .sqlite, -wal, -shm
-fs.copyFileSync(sourceFile, record.path); // y AHORA copia
+removeSqliteDatabaseFiles(record.path);   // deletes .sqlite, -wal, -shm
+fs.copyFileSync(sourceFile, record.path); // and now copy
 ```
 
-Entre esas dos líneas la bóveda no existe. Si `copyFileSync` falla a media escritura
-(disco lleno, volumen desmontado, corte de luz), queda un fichero truncado donde había
-una bóveda.
+Between these two lines the vault does not exist. If `copyFileSync` fails at half-write (full disk,
+unassembled volume, cut of light), there is a truncated file where there was a vault.
 
-La red de seguridad no cubre este caso. `restoreBackupArchiveSafely` hace una copia
-previa y, si algo falla, revierte — pero **la reversión usa exactamente la misma ruta
-no atómica** (`exportImport.ts:352`), y la copia de seguridad previa se escribe en
-`userData/restore-safety/`, **en el mismo disco que está fallando**
-(`exportImport.ts:332`). Ante un `ENOSPC`, el rescate falla por la misma causa que el
-accidente. Con varias bóvedas, las ya restauradas quedan bien y la que falló se pierde.
+The safety net does not cover this case. `restoreBackupArchiveSafely` makes a previous copy and, if
+something fails, reverses — but **the reversal uses exactly the same non-atomic path**
+(`exportImport.ts:352`), and the previous backup is written in `userData/restore-safety/`, **on the
+same disk that is failing** (`exportImport.ts:332`). `ENOSPC`. `ENOSPC` fails for the same reason as
+the accident. With several vaults, the already restored ones look good and the one that failed is
+lost.
 
-- **Arreglo**: copiar a `<destino>.tmp` en el mismo directorio y `rename()` encima.
-  El rename es atómico en el mismo sistema de ficheros y elimina la ventana entera.
-- **Cobertura de test**: ninguna. `test-backup-vaults.mjs` solo prueba el camino feliz y
-  la contraseña incorrecta; `restoreBackupArchiveSafely` no se ejerce nunca.
+- **Fix**: copy to `<destino>.tmp` in the same directory and `rename()` above. The rename is atomic
+  in the same file system and removes the entire window.
+- **Test coverage**: none. `test-backup-vaults.mjs` only proves the wrong happy path and password;
+  `restoreBackupArchiveSafely` is never exercised.
 
-### A2 · No hay bloqueo de instancia única — CRÍTICO
+### A2 · No single instance block — CRITICAL
 
-`grep -rn "requestSingleInstanceLock" electron/` no devuelve nada.
+`grep -rn "requestSingleInstanceLock" electron/` does not return anything.
 
-Dos instancias de Nodus abiertas sobre la misma bóveda es un escenario que la app no
-impide. Si una restaura mientras la otra tiene la BD abierta, la primera borra el
-fichero y la segunda sigue escribiendo sobre un inodo ya desenlazado: sus cambios se
-pierden y el WAL puede quedar desincronizado del fichero nuevo. Las dos instancias
-también pueden lanzar copias automáticas simultáneas sobre las mismas bóvedas.
+Two instances of Nodus open on the same vault is a scenario that the app does not prevent. If one
+restores while the other has the DB open, the first deletes the file and the second continues to
+write on an already unlinked inode: its changes are lost and the WAL can be desyncronized from the
+new file. The two instances can also launch simultaneous automatic copies on the same vaults.
 
-Esto ya aparecía en auditorías anteriores (genealogía, MCP). Aquí es más grave porque la
-operación en juego es destructiva por diseño.
+This already appeared in previous audits (genealogy, MCP). Here it is more serious because the
+operation at stake is destructive by design.
 
-### A3 · `.nodussync` reemplaza bases de datos enteras — CRÍTICO
+### A3 · `.nodussync` replaces entire databases — CRITICAL
 
 `databasesRepo.ts:1088-1091`:
 
 ```ts
-db.prepare('DELETE FROM db_databases WHERE id = ?').run(unit.database.id); // cascades all children
+db.prepare('DELETE FROM db_databases WHERE id = ?').run(unit.database.id); // All children shells
 ```
 
-La unidad de conflicto es **la base de datos entera**; la unidad de edición es **una
-celda**. `updated_at` se toca en cualquier mutación (`databasesRepo.ts:462-463`, 12
-llamantes). Consecuencia:
+The conflict unit is **the entire database**; the editing unit is **a cell**. `updated_at` is
+touched on any mutation (`databasesRepo.ts:462-463`, 12 callers).
 
-> El equipo A añade una fila a las 10:00. El equipo B había añadido cincuenta a las
-> 09:00. Se importa el paquete de A en B → gana A → **las cincuenta filas de B, sus
-> celdas y sus adjuntos se borran**. El resumen informa `databases: {updated: 1}`.
+> Team A adds a row at 10:00. Team B had added fifty to the
+> 09:00. The package of A is imported into B → wins A → **50 rows of B, its
+> cells and their attachments are deleted**. The summary reports `databases: {updated: 1}`.
 
-El test lo da por bueno explícitamente (`test-sync-package.mjs:216`,
-`'stale B row replaced away'`). No es un caso límite: es el uso normal en dos equipos.
+The test is explicitly good (`test-sync-package.mjs:216`, `'stale B row replaced away'`). It is not
+a limit case: it is normal use on two computers.
 
 ---
 
-## B. Copias que se detienen en silencio
+## B. Copies that stop silently
 
-Este bloque es, en conjunto, más peligroso que el A: el usuario cree estar protegido.
+This block is, on the whole, more dangerous than A: the user believes he is protected.
 
-### B1 · Si la contraseña maestra no se puede leer, no se registra ningún error
+### B1 · If the master password cannot be read, no error is recorded
 
 `autoBackup.ts:225-226`:
 
@@ -126,273 +120,260 @@ Este bloque es, en conjunto, más peligroso que el A: el usuario cree estar prot
 if (!settings.autoBackupFolder || !getBackupPassword()) return null;
 ```
 
-`getBackupPassword()` devuelve `null` también cuando el fichero existe pero `safeStorage`
-no lo puede descifrar (`secretStore.ts:70-81`): cambio de contraseña de sesión,
-migración con Migration Assistant, llavero recreado. En ese caso `maybeRunAutoBackup`
-sale por `return null` **sin escribir `lastAutoBackupStatus`**.
+`getBackupPassword()` returns `null` also when the file exists but `safeStorage` cannot be decrypted
+(`secretStore.ts:70-81`): session password change, migration with Migration Assistant, recreated
+keychain. In that case `maybeRunAutoBackup` comes out by `return null` **without writing
+`lastAutoBackupStatus`**.
 
-Resultado: `lastAutoBackupAt` y `lastAutoBackupStatus` se quedan congelados en el último
-éxito. La interfaz sigue mostrando *«12/01/2026 · ok: Copia guardada en…»* durante meses
-mientras no se hace ni una sola copia.
+Result: `lastAutoBackupAt` and `lastAutoBackupStatus` remain frozen in the last success. The
+interface continues to show *«12/01/2026 · ok: Copy saved in...»* for months while not a single copy
+is made.
 
-### B2 · Una clave API ilegible aborta todas las copias
+### B2 · Unreadable API key aborts all copies
 
-`exportImport.ts:215-218`: si `lockedApiKeyProviders()` no está vacío,
-`createBackupArchive` lanza. Es decir, un blob de clave API que el llavero ya no puede
-descifrar **bloquea la copia de la biblioteca entera**. La intención (no perder claves
-silenciosamente) es razonable, pero el precio es desproporcionado: se sacrifica la copia
-de todo el corpus para proteger una credencial que el usuario puede volver a pegar en
-treinta segundos. Debería avisar y continuar sin esa clave.
+`exportImport.ts:215-218`: if `lockedApiKeyProviders()` is not empty, `createBackupArchive` throws.
+That is, an API keypad that the keychain can no longer decrypt **blocks the copy of the entire
+library**. The intention (not to lose keys silently) is reasonable, but the price is
+disproportionate: the copy of the entire corpus is sacrificed to protect a credential that the user
+can re-paste in thirty seconds. It should warn and continue without that key.
 
-### B3 · Nunca se comprueba que una copia escrita se pueda descifrar, y se podan las anteriores
+### B3 · It is never verified that a written copy can be decrypted, and the above are pruned
 
-`runAutoBackupNow` escribe el archivo y acto seguido llama a `pruneBackups`
-(`autoBackup.ts:208-210`). No hay ninguna verificación de que el `.nodus` recién escrito
-se pueda abrir con la credencial que el usuario tiene. Si la contraseña del llavero se
-rota o se corrompe, las copias nuevas se cifran con algo que el usuario no conoce y la
-poda va borrando las antiguas, que sí eran recuperables.
+`runAutoBackupNow` writes the file and then calls `pruneBackups` (`autoBackup.ts:208-210`). There is
+no verification that the newly written `.nodus` can be opened with the credential that the user has.
+If the keychain password is broken or corrupted, the new copies are encrypted with something that
+the user does not know and the pruning erases the old ones, which were recoverable.
 
-La verificación del asistente inicial (`recoveryManager.ts:194`) solo lee el manifiesto
-en claro; **no descifra nada**.
+The initial wizard check (`recoveryManager.ts:194`) only reads the manifest in clear; ** does not
+decipher**.
 
-- **Arreglo mínimo**: tras escribir, reabrir el archivo y descifrar únicamente
-  `payload-manifest.json`. Es barato y convierte la copia en verificada.
-  Y podar solo si esa verificación pasa.
+- **Minimum Arrangement**: After writing, re-opening the file and decrypting only
+  `payload-manifest.json`. It is cheap and converts the copy to verified. And prune only if that
+  verification happens.
 
-### B4 · La salud de las copias no se muestra en ninguna parte visible
+### B4 · The health of copies is not shown anywhere visible
 
-El único indicador de todo el sistema es un `<span>` truncado, en gris `neutral-500`,
-dentro de una sección plegable de Ajustes (`Settings.tsx:1199-1204`). No hay:
+The only indicator for the entire system is a truncated `<span>` grey `neutral-500` within a folding
+section of Settings (`Settings.tsx:1199-1204`). There is no:
 
-- aviso de antigüedad («tu última copia tiene 47 días»),
-- aviso cuando `recoveryStatus.folder.kind === 'missing'` — se calcula
-  (`recoveryManager.ts:138`) y **no se usa para nada** salvo abrir el asistente,
-- notificación al fallar: `main.ts:458` solo hace `console.log`.
+- seniority notice (‘your last copy is 47 days’),
+- warning when `recoveryStatus.folder.kind === 'missing'` — is calculated (`recoveryManager.ts:138`)
+  and ** is not used at all** except to open the wizard,
+- notification on failure: `main.ts:458` only makes `console.log`.
 
-### B5 · Todo el archivo se construye en memoria
+### B5 · All file is built in memory
 
-`createBackupArchive` lee cada BD entera a `Buffer`, las mete en un zip en memoria,
-lo serializa a otro `Buffer` y lo cifra a un tercero. Con varias bóvedas grandes
-(grabaciones, adjuntos, retratos, todo en BLOB) esto es un múltiplo del tamaño real en
-RAM del proceso principal, cada 30 minutos. Pasado cierto umbral —una sola BD por encima
-de 2 GB rompe `readFileSync`— **las copias dejan de funcionar para siempre** con un
-error que no se muestra en ningún sitio (ver B1/B4).
+`createBackupArchive` reads each entire BD to `Buffer`, puts them in a zip in memory, serializes it
+to another `Buffer` and encrypts it to a third. With several large vaults (records, attachments,
+portraits, all in BLOB) this is a multiple of the actual RAM size of the main process, every 30
+minutes. After a certain threshold — one single BD above 2 GB breaks `readFileSync` — **the copies
+cease to function forever** with an error that is not shown anywhere (see B1/B4).
 
 ---
 
-## C. Cambio de dispositivo: qué se pierde y qué se rompe
+## C. Change of device: what is lost and what is broken
 
-### C1 · `nodi-notes.json` no está en la copia — PÉRDIDA REAL
+### C1 · `nodi-notes.json` is not in copy — REAL LOSS
 
-`nodiNotes.ts:20` escribe hasta 500 notas Markdown del usuario en
-`userData/nodi-notes.json`. La lista blanca de la copia (`exportImport.ts:99`) incluye
-su fichero hermano `nodi-chat-history.json` pero **no este**. Se pierden sin aviso.
+`nodiNotes.ts:20` writes up to 500 user Markdown notes in `userData/nodi-notes.json`. The whitelist
+of the copy (`exportImport.ts:99`) includes your brother file `nodi-chat-history.json` but **not
+this**. They are lost without notice.
 
-Está en tu instalación real, modificado el 18 de julio. Es una omisión, no una decisión:
-los dos ficheros los escribe código casi idéntico. El arreglo es añadir el nombre a
-`GLOBAL_AUXILIARY_FILES`; la restauración ya trata genéricamente cualquier nombre de esa
-lista (`exportImport.ts:598-602`), así que con eso funcionan las dos direcciones.
+It's in your actual installation, modified on July 18. It's an omission, not a decision: the two
+files write almost identical code. The arrangement is to add the name to `GLOBAL_AUXILIARY_FILES`;
+the restore generically already treats any name in that list (`exportImport.ts:598-602`), so that's
+what both addresses work with.
 
-### C2 · `zoteroStoragePath` viaja con la ruta absoluta del otro equipo — ROMPE EL CORPUS
+### C2 · `zoteroStoragePath` travels with the absolute route of the other team — BREAK THE CORPUS
 
-`zoteroStoragePath` vive en la fila `settings` de la BD (`settingsRepo.ts:96`), no en
-`app-prefs.json`. La fila de settings **sí** va en la copia: `scrubSettings` solo quita
-`mcpToken` y `providerKeys` (`exportImport.ts:632-638`).
+`zoteroStoragePath` lives in the row `settings` of the DB (`settingsRepo.ts:96`), not in
+`app-prefs.json`. The row of settings **yes** goes in the copy: `scrubSettings` only removes
+`mcpToken` and `providerKeys` (`exportImport.ts:632-638`).
 
-Al restaurar en otro Mac con otro usuario, la bóveda queda apuntando a
-`/Users/nombre-antiguo/Zotero/storage`. Todo lo que resuelve PDFs por disco falla en
-silencio (`textExtractor.ts:560-566`): reescaneo, OCR, extracción nueva, abrir por
-página. El texto ya extraído y los embeddings sobreviven, así que **no es pérdida, es
-ceguera**. El respaldo `defaultZoteroStorage()` solo actúa si la cadena está vacía: una
-ruta obsoleta es peor que ninguna.
+When restoring on another Mac with another user, the vault is pointing to
+`/Users/nombre-antiguo/Zotero/storage`. Everything that solves PDFs per disk fails silently
+(`textExtractor.ts:560-566`): rescan, OCR, new extraction, open per page. Text already extracted and
+embeddings survive, so **is not lost, it is blindness**. The `defaultZoteroStorage()` backup only
+acts if the string is empty: an obsolete path is worse than none.
 
-Lo llamativo es que el código **ya conoce este peligro** y lo defiende para
-`app-prefs.json` (`exportImport.ts:580-585`, «Absolute folder paths … belong to this
-machine»). Solo falta aplicar el mismo criterio a `zoteroStoragePath` y a
-`toolkitOutputDir` en la fila de la BD.
+What is striking is that the code ** already knows this danger** and defends it for `app-prefs.json`
+(`exportImport.ts:580-585`, «Absolute folder paths ... belong to this machine»). Only the same
+criterion needs to be applied to `zoteroStoragePath` and `toolkitOutputDir` in the row of the DB.
 
-### C3 · Otros elementos no incluidos
+### C3 · Other items not included
 
-| Elemento | Efecto |
+| Element | Effect |
 |---|---|
-| `audio_key_*.bin` (Hume TTS) | Se pierde; hay que volver a introducirla. Omisión fácil de corregir. |
-| `backup_password.bin`, `backup_recovery_key.bin` | Correcto excluirlos (van ligados a `safeStorage`), pero tras restaurar **la protección queda desactivada** sin que se avise. |
-| `local-ai/`, `whisper.cpp/models/`, `tessdata/` | Descargas de varios GB a repetir. Correcto excluirlos. |
-| `~/.nodus-copilot-certs/`, manifiesto de Word | Fuera de `userData`. Hay que reinstalar el complemento y volver a confiar la CA. |
-| `codex-subscription/`, `github-copilot-subscription/` | Reautenticación. |
+| `audio_key_*.bin` (Hume TTS) | It is lost; it must be reintroduced. Easy to correct omission. |
+| `backup_password.bin`, `backup_recovery_key.bin` | Right to exclude them (they are linked to `safeStorage`), but after restoring **the protection is disabled** without notice. |
+| `local-ai/`, `whisper.cpp/models/`, `tessdata/` | Downloads of several GB to repeat. Correct to exclude them. |
+| `~/.nodus-copilot-certs/`, Word manifest | Outside `userData`. Reinstall the plugin and re-trust the CA. |
+| `codex-subscription/`, `github-copilot-subscription/` | Reauthentication. |
 
-Ninguno de estos justifica cambiar el formato, pero sí **una lista de comprobación
-posterior a la restauración**, que hoy no existe.
+None of these justifies changing the format, but yes **a post-restore checklist**, which does not
+exist today.
 
 ---
 
-## D. `.nodussync`: el traspaso entre equipos no cumple lo que promete
+## D. `.nodussync`: the transfer between teams does not fulfil what it promises
 
-Es la parte más débil del sistema y la que peor comunica sus límites.
+It is the weakest part of the system and the worst communicating its limits.
 
-### D1 · Módulos enteros que nunca se sincronizan
+### D1 · Whole modules that are never synchronized
 
-La cobertura es dinámica solo para `study_*` (`syncPackage.ts:193-196`, `LIKE 'study\_%'`).
-Todo lo demás son listas de columnas escritas a mano. Quedan fuera:
+The coverage is dynamic only for `study_*` (`syncPackage.ts:193-196`, `LIKE 'study\_%'`). Everything
+else is lists of handwritten columns.
 
-- **Docencia completa**: `teaching_groups`, `teaching_students`,
-  `teaching_assessment_plans`, `teaching_assessment_items`, `teaching_grade_entries`,
-  `teaching_rubrics`, `teaching_rubric_evaluations`, `teaching_exams`,
-  `teaching_exam_questions`, `teaching_logos`. (`grep -c "teaching_" syncPackage.ts` → **0**)
-- **Taller de escritura**: `projects`, `project_sections`, `project_chapters`,
-  `project_chapter_versions`, `project_chapter_ideas`, …
-- **Genealogía y archivo**: `persons`, `person_names`, `person_portraits`, `places`,
-  `events`, `relationships`, `evidence`, `archive_items`, `archive_folders`,
-  `kinship_suggestions`, `social_contacts`, …
-- **Mapa de investigación**, chats, traducciones, imágenes decorativas, `match_feedback`.
+- **Full teaching**: `teaching_groups`, `teaching_students`, `teaching_assessment_plans`,
+  `teaching_assessment_items`, `teaching_grade_entries`, `teaching_rubrics`,
+  `teaching_rubric_evaluations`, `teaching_exams`, `teaching_exam_questions`, `teaching_logos`.
+  (`grep -c "teaching_" syncPackage.ts` → **0**)
+- **Writer workshop**: `projects`, `project_sections`, `project_chapters`,
+  `project_chapter_versions`, `project_chapter_ideas`, ...
+- ** Genealogy and archive**: `persons`, `person_names`, `person_portraits`, `places`, `events`,
+  `relationships`, `evidence`, `archive_items`, `archive_folders`, `kinship_suggestions`,
+  `social_contacts`, ...
+- **Research map**, chats, translations, decorative images, `match_feedback`.
 
-El caso de docencia es el más engañoso: `teaching_exams.course_id` referencia
-`study_courses(id)` (`migrations.ts:2784`), que **sí** se sincroniza. Un profesor
-sincroniza casa↔centro, ve `study: {inserted: 200}` y concluye que el cuaderno de
-calificaciones ha viajado. Ninguna nota lo ha hecho. `SyncMergeSummary`
-(`shared/types.ts:2412-2421`) ni siquiera tiene un contador de docencia donde pudiera
-verse un cero.
+The case of teaching is the most misleading: `teaching_exams.course_id` reference
+`study_courses(id)` (`migrations.ts:2784`), which **does** sync. A teacher synchronizes home ↔ school,
+sees `study: {inserted: 200}` and concludes that the grade book has traveled. No note has done so.
+`SyncMergeSummary` (`shared/types.ts:2412-2421`) does not even have a teaching counter where a zero
+could be seen.
 
-### D2 · Un curso académico duplicado rompe la sincronización para siempre — CRÍTICO
+### D2 · A duplicate academic year breaks synchronization forever — CRITICAL
 
-`migrations.ts:2731`: `CREATE UNIQUE INDEX idx_study_academic_years_label ON study_academic_years(label);`
+`migrations.ts:2731`: `CREATE UNIQUE INDEX idx_study_academic_years_label ON
+study_academic_years(label);`
 
-`createStudyAcademicYear` deduplica por etiqueta **solo en local** y genera un UUID
-nuevo. `normalizeAcademicYearLabel` canonicaliza la cadena, así que los dos equipos
-producen `"2024/2025"` byte a byte idéntico con ids distintos.
+`createStudyAcademicYear` deduplicates by tag **in local only** and generates a new UUID.
+`normalizeAcademicYearLabel` canonicalizes the string, so the two teams produce `"2024/2025"` byte
+to identical byte with different ids.
 
-> Se crea 2024/2025 en el portátil. Se crea 2024/2025 en el sobremesa — que es lo único
-> que la app permite hacer. Al sincronizar, el id es desconocido, se toma la rama
-> `INSERT` (`syncPackage.ts:251-255`) y salta
+> 2024/2025 is created on laptop. 2024/2025 is created on desktop — which is the only thing
+> When syncing, the id is unknown, the branch is taken.
+> `INSERT` (`syncPackage.ts:251-255`) and jump
 > `UNIQUE constraint failed: study_academic_years.label`.
 
-Como el merge es una sola transacción, **se revierte todo**: notas, borradores, bases de
-datos, el resto de tablas de estudio. Y volverá a fallar en la misma fila en cada intento
-futuro, **en las dos direcciones**. El usuario ve una cadena cruda de SQLite, sin saber
-qué entidad la provoca ni que renombrar un curso lo arreglaría.
+As merge is a single transaction, ** everything is reversed**: notes, drafts, databases, the rest of
+study tables. And it will again fail in the same row in each future attempt, **in both directions**.
+The user sees a raw string of SQLite, without knowing what entity causes it or that renaming a
+course would fix it.
 
-Dado que el módulo gira alrededor del curso académico, esto no es improbable: es casi
-inevitable. (Variante menor con `db_databases.short_id`, 4 caracteres, comprobación de
-colisión solo local: ~1 entre 400 con 50 bases por equipo.)
+Since the module revolves around the academic year, this is not unlikely: it is almost inevitable.
+(Minor variant with `db_databases.short_id`, 4 characters, local only collision check: ~1 between
+400 and 50 bases per team.)
 
-### D3 · No hay tombstones: lo borrado resucita
+### D3 · No tombstones: the deleted resuscitates
 
-Explícito por diseño (`syncPackage.ts:16-17`). Notas y carpetas se borran en duro
-(`notesRepo.ts:184`, `:242`), así que al importar cualquier paquete anterior al borrado
-la rama `INSERT` las revive con sus marcas de tiempo originales — y lo seguirá haciendo
-en cada sincronización. **No hay forma de borrar nada de manera definitiva entre dos
-equipos.** Excepción parcial y correcta: las entidades de estudio usan borrado suave
-(`studyOrgRepo.ts:661-675`), así que ahí sí se propaga.
+Explicit by design (`syncPackage.ts:16-17`). Notes and folders are deleted in hard
+(`notesRepo.ts:184`, `:242`), so when importing any package prior to erasing the `INSERT` branch, it
+revives them with its original time marks — and it will continue to do so at every sync. **There is
+no way to permanently delete anything between two computers.** Partial and correct exception: study
+entities use soft deletion (`studyOrgRepo.ts:661-675`), so there it does spread.
 
-### D4 · `schemaVersion` es decorativo
+### D4 · `schemaVersion` is decorative
 
-Se escribe en el manifiesto (`syncPackage.ts:123`) y **nunca se compara**: la validación
-solo mira `format` y `formatVersion` (`syncPackage.ts:152-154`), un `1` fijo que jamás se
-ha subido pese a haber cambiado la forma de la carga útil.
+It is written in the manifest (`syncPackage.ts:123`) and **never compared**: validation only looks
+at `format` and `formatVersion` (`syncPackage.ts:152-154`), a fixed `1` that has never been raised
+despite changing the form of payload.
 
-El caso peligroso es paquete nuevo → app antigua: las columnas desconocidas se filtran y
-**se descartan en silencio** (`syncPackage.ts:245`); la fila truncada conserva el
-`updated_at` nuevo, así que al sincronizar de vuelta **propaga la truncación al equipo
-que sí estaba al día**. Destrucción de datos sin un solo error por el camino.
+The dangerous case is a new package → old app: the unknown columns are filtered and ** are quietly
+discarded** (`syncPackage.ts:245`); the truncated row retains the new `updated_at`, so when syncing
+back **propagates truncation to the computer that was up to date**. Data destruction without a
+single error along the way.
 
-### D5 · El paquete no está cifrado
+### D5 · The package is not encrypted
 
-Zip plano con `user-layer.json` en claro: cuerpos de notas, documentos de estudio,
-grabaciones y adjuntos en base64. Convive en Ajustes con la copia cifrada por contraseña
-maestra, sin ninguna advertencia sobre la asimetría. Quien lo mueva por Dropbox o correo
-está exponiendo toda su capa de escritura.
+Flat Zip with `user-layer.json` in clear: note bodies, study documents, recordings and attachments
+in base64. Live in Settings with the master password encrypted copy, without any warning about the
+asymmetry. Whoever moves it by Dropbox or mail is exposing its entire writing layer.
 
-### D6 · El test valida un esquema que no es el que se distribuye
+### D6 · Test validates a scheme that is not distributed
 
-`test-sync-package.mjs` construye a mano un esquema sintético de 20 tablas en vez de
-ejecutar `runMigrations`, y stubea `SCHEMA_VERSION = 28`. Por eso no detecta nada de lo
-anterior: en su esquema no existen el índice único de curso académico, ni `teaching_*`,
-ni `db_attachments.thumb`, ni `note_folders.summary`. Las aserciones son correctas; el
-esquema contra el que las hace, no.
+`test-sync-package.mjs` constructs a synthetic scheme of 20 tables by hand instead of
+`runMigrations`, and stubea `SCHEMA_VERSION = 28`. Therefore, it does not detect any of the above:
+in its scheme there is no single academic year index, nor `teaching_*`, nor `db_attachments.thumb`,
+nor `note_folders.summary`. The assertions are correct; the scheme against which it makes them, no.
 
 ---
 
-## Prioridades
+## Priorities
 
-**Ahora (destrucción o falsa seguridad)**
+**Now (destruction or false security)**
 
-1. A1 — `rename()` atómico en `restoreVaultDatabase`. Cambio de tres líneas.
-2. B1 — registrar `lastAutoBackupStatus` también cuando se sale por credencial ilegible.
-3. B3 — verificar el descifrado del archivo recién escrito **antes** de podar.
-4. D2 — resolver el choque de `label` por `id` en el merge (o dedupe por etiqueta) y
-   aislar cada tabla para que un fallo no revierta el paquete entero.
-5. C1 — añadir `nodi-notes.json` a `GLOBAL_AUXILIARY_FILES`.
+1. A1 — `rename()` atomic in `restoreVaultDatabase`. Three-line change.
+2. B1 — record `lastAutoBackupStatus` also when released by unreadable credential.
+3. B3 — verify the decryption of the newly written file **before** pruning.
+4. D2 — resolve the shock of `label` by `id` on the merge (or dedupe per label) and isolate each
+   table so that a bug does not reverse the entire package.
+5. C1 — add `nodi-notes.json` to `GLOBAL_AUXILIARY_FILES`.
 
-**Siguiente (integridad y honestidad del sync)**
+**Next (sync integrity and honesty)**
 
-6. D1 — o se amplía la cobertura, o la interfaz declara explícitamente qué viaja.
-   Lo que no se puede sostener es un resumen que no menciona lo ausente.
-7. C2 — no restaurar `zoteroStoragePath` de otro equipo (mismo criterio que
+6. D1 — either expands coverage, or the interface explicitly states what travels. What cannot be
+   sustained is a summary that does not mention what is missing.
+7. C2 — do not restore `zoteroStoragePath` from another computer (same criterion as
    `RECOVERY_PREF_KEYS`).
-8. B4 — aviso de antigüedad y de carpeta inaccesible fuera de Ajustes.
+8. B4 — Age and folder warning inaccessible outside Settings.
 9. A2 — `requestSingleInstanceLock()`.
-10. B2 — degradar el aborto por clave bloqueada a aviso.
+10. B2 — degrade key-blocked abortion on notice.
 
-**Deuda estructural**
+**Structural debt**
 
-11. D6 — que el test de sync corra `runMigrations` sobre el esquema real.
-12. D5 — cifrar el `.nodussync` o advertir con claridad.
-13. B5 — streaming en la construcción del archivo.
-14. D3/D4 — tombstones y comprobación real de `schemaVersion`.
-
----
+11. D6 — that the sync test runs `runMigrations` on the actual schema.
+12. D5 — Encrypt `.nodussync` or warn clearly.
+13. B5 — streaming on file construction.
+14. D3/D4 — tombstones and actual check of `schemaVersion`.
 
 ---
 
-## Verificación de las correcciones
+---
 
-Un test que pasa no prueba nada si también pasaría sin la corrección. Cada garantía
-crítica se comprobó desactivando temporalmente el arreglo y confirmando que su test
-falla:
+## Verification of corrections
 
-| Corrección | Al desactivarla, el test falla con |
+A passing test proves nothing if it would also pass without correction. Each critical warranty was
+checked by temporarily deactivating the arrangement and confirming that your test fails:
+
+| Corrigendum | By deactivating it, the test fails with |
 |---|---|
-| A1 · restauración atómica | `the vault database still exists after a failed restore` → **`actual: false`**: con el código antiguo la bóveda **deja de existir**. Se reproduce inyectando un `ENOSPC` en la copia (un directorio de solo lectura NO sirve: bloquea también el borrado, y la bóveda se salva por accidente). |
-| C2 · rutas locales | La ruta `/Users/equipo-origen/Zotero/storage` se filtra al equipo de destino. |
-| D2 · bricking por curso duplicado | Salta `UNIQUE constraint failed: study_academic_years.label` — pero **ya no aborta la fusión**: se reporta y continúa. Dos capas independientes. |
-| Celdas sin marca de tiempo | `an edited cell reaches the other machine via its row timestamp`: una celda editada no viajaba. |
+| A1 · atomic restoration | `the vault database still exists after a failed restore` → **`actual: false`**: with the old code the vault ** ceases to exist**. It reproduces by injecting a `ENOSPC` into the copy (a read-only directory does NOT work: it also blocks the deletion, and the vault is saved by accident). |
+| C2 · local routes | The path `/Users/equipo-origen/Zotero/storage` is filtered to the target computer. |
+| D2 · Bricking per duplicate course | Jump `UNIQUE constraint failed: study_academic_years.label` — but **no longer aborts fusion**: it is reported and continues. Two independent layers. |
+| Cells without time-marking | `an edited cell reaches the other machine via its row timestamp`: an edited cell did not travel. |
 
-Tres fallos reales aparecieron *durante* la implementación, no en el diagnóstico:
+Three real failures appeared *during* implementation, not in diagnosis:
 
-1. `new AdmZip()` lanza excepción con un `.nodus` truncado en vez de devolver error —
-   afectaba también a la restauración, no solo a la verificación.
-2. `study_schedule_day_styles` no tiene clave primaria y su índice único es sobre una
-   expresión que SQLite no sabe describir: los colores del horario no se habrían
-   sincronizado nunca. De ahí `IDENTITY_OVERRIDES` y el guard `unmergeable` en el test.
-3. Los veredictos de relación son sobre un par **no ordenado**; el motor genérico los
-   duplicaba y las dos máquinas habrían discrepado para siempre. De ahí
-   `ROW_NORMALIZERS`.
+1. `new AdmZip()` release exception with a truncated `.nodus` instead of returning error — also
+   affected the restore, not only the verification.
+2. `study_schedule_day_styles` has no primary key and its unique index is about an expression that
+   SQLite cannot describe: the colors of the schedule would never have been synchronized. Hence
+   `IDENTITY_OVERRIDES` and the guard `unmergeable` in the test.
+3. The relation verdicts are about an unordered pair**; the generic engine duplicated them and the
+   two machines would have disagreed forever. Hence `ROW_NORMALIZERS`.
 
-Y un riesgo que introduje yo y cerré: el barrido de claves foráneas podía borrar filas
-locales preexistentes ya inconsistentes. Ahora solo puede eliminar filas que **esa misma
-fusión** ha insertado, y está acotado a las tablas tocadas.
+And a risk that I introduced and closed: the sweep of foreign keys could erase existing and
+inconsistent local rows. Now you can only delete rows that **that same merge** has inserted, and is
+limited to touched tables.
 
-### Lo que deliberadamente NO se ha hecho
+### What has NOT been deliberately done
 
-- **Tombstones.** Los borrados siguen sin propagarse: borrar una nota en un equipo y
-  sincronizar desde el otro la resucita. Es el comportamiento previo, ahora extendido a
-  los módulos nuevos. Requiere diseño propio (marcas de borrado con caducidad) y no
-  entraba en este encargo.
-- **Cifrado del `.nodussync`.** Sigue siendo un zip en claro. Ya no es un único JSON
-  gigante, así que el límite de tamaño desapareció, pero el contenido no está protegido.
-- **Sesgo de reloj.** El ganador sigue decidiéndose por `updated_at` de pared. Un equipo
-  con el reloj atrasado sigue perdiendo siempre, aunque ahora al menos las filas no
-  aplicadas se reportan.
+- **Tombstones.** The deleted ones still do not spread: delete a note on one computer and
+  synchronize from the other it resurrects it. It is the previous behavior, now extended to new
+  modules. It requires own design (deleted marks with expiration) and did not enter into this order.
+- **Cift of `.nodussync`.** It is still a clear zip. It is no longer a single giant JSON, so the
+  size limit is gone, but the content is not protected.
+- **Watch bias.** The winner continues to decide for wall `updated_at`. A computer with the clock
+  behind keeps losing always, although now at least the unapplied rows are reported.
 
 ---
 
-## Verificado personalmente
+## Personally verified
 
-`nodi-notes.json` fuera de la lista blanca · `zoteroStoragePath` ausente de
-`GLOBAL_PREF_KEYS` · `idx_study_academic_years_label` · `teaching_` con 0 apariciones en
-`syncPackage.ts` · `DELETE FROM db_databases` en el reemplazo · `schemaVersion` sin
-comparar en el import · `removeSqliteDatabaseFiles` seguido de `copyFileSync` ·
-`requestSingleInstanceLock` inexistente · el estado de copia como único indicador en
-`Settings.tsx`.
+`nodi-notes.json` outside the white list · `zoteroStoragePath` absent from `GLOBAL_PREF_KEYS` ·
+`idx_study_academic_years_label` · `teaching_` with 0 appearances in `syncPackage.ts` · `DELETE FROM
+db_databases` in replacement · `schemaVersion` not compared in import · `removeSqliteDatabaseFiles`
+followed by `copyFileSync` · `requestSingleInstanceLock` missing · copy status as the only indicator
+in `Settings.tsx`.
 
-No se ha modificado ningún fichero del código.
+No code files have been modified.

--- a/design/local-extraction-and-free-tier-plan.md
+++ b/design/local-extraction-and-free-tier-plan.md
@@ -1,75 +1,77 @@
-# Plan: modelos locales de extracción + modo "API gratuita"
+# Plan: local extraction models + free "API" mode
 
-Origen: auditoría de lentitud/fallo de análisis con modelos locales (hilo Reddit) + benchmark
-estandarizado (paper 7000 palabras, 5 chunks, `PROMPT_DEEP` real). Datos y veredicto en la memoria
-`model-analysis-benchmark.md`. Todo lo de abajo es de comportamiento **verificado empíricamente**.
+Source: slow/failure analysis audit with local models (reddit thread) + standardized benchmark
+(paper 7000 words, 5 chunks, `PROMPT_DEEP` real). Data and verdict in memory
+`model-analysis-benchmark.md`. Everything below is behavior ** empirically verified**.
 
-## Hechos que fundamentan el plan
+## Facts underlying the plan
 
-- Built-in que **extrae ideas de forma fiable**: solo **Gemma 4 E2B** (20/20, 0 fallos, ~92 s/chunk).
-- Built-in que **extrajo 0 ideas válidas** pese a todas las técnicas (reasoning-off de servidor,
-  json_schema grammar, concisión, presupuesto 16k, penalties): **Qwen3.5-0.8B** y **LFM2.5-VL-1.6B**.
-  Son modelos de **visión/OCR** (`vision:true`). El 0.8B entra en loop de repetición dentro del JSON.
-- Nube: Gemini 2.5 Flash Lite y DeepSeek v4 Flash funcionan bien (reasoning ya se apaga en scans).
-- **Groq free tier**: el límite es tokens/minuto (6k para 8b, 12k para 70b) y cuenta
-  `prompt + max_tokens`. Un chunk (~4.8k prompt) + `max_tokens:8000` = ~12.8k → "Request too large".
-- **OpenRouter**: modelos `:free` limitan por requests/min (~20) y req/día.
+- Built-in that ** extracts ideas reliably**: only **Gemma 4 E2B** (20/20, 0 bugs, ~92 s/chunk).
+- Built-in that ** extracts 0 valid ideas** despite all the techniques (server soning-off,
+  json_schema grammar, conciseness, budget 16k, penalties): **Qwen3.5-0.8B** and **LFM2.5-VL-1.6B**.
+  They are models of **vision/OCR** (`vision:true`). The 0.8B enters in repeat loop within the JSON.
+- Cloud: Gemini 2.5 Flash Lite and DeepSeek v4 Flash work well (reasoning is already turned off on
+  scanners).
+- **Groq free tier**: the limit is tokens/minute (6k for 8b, 12k for 70b) and counts `prompt +
+  max_tokens`. A chunk (~4.8k prompt) + `max_tokens:8000` = ~12.8k → "Request too large".
+- **OpenRouter**: models `:free` limit by request/min (~20) and req/day.
 
-## Parte A — Modelos locales built-in
+## Part A — Local built-in models
 
-### A1. Clasificar modelos por aptitud para extracción
-`shared/localAiModels.ts`: añadir a `NodusLocalModelDefinition` un flag de aptitud, p.ej.
-`supportsExtraction?: boolean` (o `roles`). Valores:
-- `gemma-4-e2b-q4`: apto (true).
-- `qwen3.5-0.8b-q4`, `lfm2.5-vl-1.6b-q4`: NO apto (false) — siguen aptos para chat/visión/imagen.
-- Helper `nodusModelSupportsExtraction(id)` reutilizable en main y renderer.
+### A1. Sorting models by aptitude for extraction
+`shared/localAiModels.ts`: add to `NodusLocalModelDefinition` an aptitude flag, e.g.
+`supportsExtraction?: boolean` (or `roles`). Values:
+- `gemma-4-e2b-q4`: fit (true).
+- `qwen3.5-0.8b-q4`, `lfm2.5-vl-1.6b-q4`: NOT fit (false) — still fit for chat/vision/image.
+- Helper `nodusModelSupportsExtraction(id)` reusable in main and renderer.
 
-### A2. Bloquear + avisar en la UI de selección
-- Los roles de **extracción** (`extractionModel`) y **modelo genérico del modo básico**
-  (`synthesisModel` en modo básico) NO permiten elegir un modelo con `supportsExtraction:false`.
-- Al intentar seleccionarlo para ese rol: **aviso** explicando el porqué (tiende a divagar / no
-  cierra JSON; es un modelo de visión) y sugiriendo Gemma. Reutilizar el patrón de aviso existente.
-- Los roles de chat/visión/imagen/embedding NO se tocan: esos modelos siguen elegibles ahí.
-- El bloqueo es genérico (por capacidad del modelo), no exclusivo de 'nodus': si algún día otro
-  provider marca un modelo como no-extractor, aplica igual.
+### A2. Lock + alert in the selection UI
+- The roles of **extraction** (`extractionModel`) and **generic model in basic mode**
+  (`synthesisModel` in basic mode) do NOT allow to choose a model with `supportsExtraction:false`.
+- When trying to select him for that role: **notice** explaining why (he tends to wander/does not
+  close JSON; he is a vision model) and suggesting Gemma. Reusing the existing warning pattern.
+- Chat/vision/image/embedding roles are NOT played: those models are still eligible there.
+- The lock is generic (by capacity of the model), not exclusive to 'nodus': if one day another
+  provider marks a model as non-extractor, it applies the same.
 
-### A3. Gemma como extractor local por defecto
-- `shared/onboardingModels.ts` / `OnboardingModelStep`: cuando se sugiere un modelo local de texto
-  para el modo básico/extracción, sugerir `gemma-4-e2b-q4` (no el primero de la lista, que es Qwen).
-- Mantener a Qwen como opción ligera solo para chat/visión.
+### A3. Gemma as local extractor by default
+- `shared/onboardingModels.ts` / `OnboardingModelStep`: When a local text model is suggested for the
+  basic/extract mode, suggest `gemma-4-e2b-q4` (not the first one in the list, which is Qwen).
+- Keep Qwen as a light option for chat/vision only.
 
-### A4. `--reasoning off` en el servidor de chat built-in (accionable, ver A5)
-- `electron/ai/nodusLocalAi.ts`: el binario b10002 soporta `--reasoning off`. Apaga el thinking de
-  forma fiable (el campo de request `enable_thinking:false` es un bug conocido). Neutro para Gemma.
+### A4. `--reasoning off` on the built-in chat server (actionable, see A5)
+- `electron/ai/nodusLocalAi.ts`: the binary b10002 supports `--reasoning off`. It reliably turns off
+  the thinking (the request field `enable_thinking:false` is a known bug).
 
-### A5. Toggle "optimizar modelo local" (accionable, desactivado por defecto)
-- Setting booleano nuevo, off por defecto. Cuando ON, para provider local: `--reasoning off` +
-  sufijo de concisión + presupuesto de salida ampliado. Pensado para modelos de razonamiento que el
-  usuario cargue en Ollama/LM Studio (deepseek-r1, qwen3…), donde sí ayuda.
+### A5. Toggle "optimize local model" (actionable, disabled by default)
+- Setting boolean new, off by default. When ON, for local provider: `--reasoning off` + concision
+  suffix + expanded output budget. Thought for reasoning models that the user loads to Ollama/LM
+  Studio (deepseek-r1, qwen3...), where it does help.
 
-## Parte B — Otros proveedores
+## Part B — Other suppliers
 
-### B1. Reasoning apagado en scans (revisión)
-`electron/ai/providers.ts` `reasoningBody`: ya apaga reasoning para openrouter/gemini/openai/
-deepseek/xiaomi cuando `effort==='off'` (el default de `completeJson`). Revisar `groq`/`cerebras`
-(hoy `{}`): añadir apagado explícito donde el modelo lo soporte (p.ej. `reasoning_effort` en gpt-oss).
+### B1. Reasoning off in scan (revision)
+`electron/ai/providers.ts` `reasoningBody`: already switches off reasoning for
+openrouter/gemini/openai/ deepseek/xiaomi when `effort==='off'` (the default of `completeJson`).
+Check `groq`/`cerebras` (now `{}`): add explicit shutdown where the model supports it (e.g.
+`reasoning_effort` in gpt-oss).
 
-### B2. Checkmark "usar API gratuita" por proveedor (Groq/OpenRouter)
-- Setting nuevo `providerFreeTier?: Partial<Record<AiProvider, boolean>>`, default `{}`, en
-  `SHARED_MODEL_KEYS` (compartido entre vaults, como las API keys).
-- UI: checkbox por proveedor en `ProvidersSettings` (ProviderRow) y en el onboarding, para
-  proveedores con free tier real (groq, openrouter). Off por defecto.
-- Efecto en `aiClient` cuando el provider del modelo está marcado free (si no, comportamiento normal):
-  - **Groq**: capar `max_tokens` para que `prompt + max_tokens ≤ TPM` del modelo (tabla conservadora
-    por modelo/límite), y **backoff en 429** leyendo `retry-after`/`x-ratelimit-reset-tokens`.
-  - **OpenRouter**: **backoff en 429** + throttle suave de req/min.
-  - Pieza común: manejar 429 con espera y reintento (hoy `completeJson` aborta en fallos de
-    transporte; añadir reintento con backoff SOLO cuando free-tier activo).
+### B2. Checkmark "use free API" per provider (Groq/OpenRouter)
+- Setting new `providerFreeTier?: Partial<Record<AiProvider, boolean>>`, default `{}`, in
+  `SHARED_MODEL_KEYS` (shared between valves, such as API keys).
+- UI: checkbox per provider in `ProvidersSettings` (ProviderRow) and onboarding, for suppliers with
+  real freetier (groq, openrouter). Off by default.
+- Effect on `aiClient` when the provider of the model is marked free (if not, normal behavior):
+  - **Groq**: capper `max_tokens` so that `prompt + max_tokens ≤ TPM` of the model (conservative
+    table per model/limit), and **backoff in 429** reading `retry-after`/`x-ratelimit-reset-tokens`.
+  - **OpenRouter**: **backoff at 429** + soft req/min throttle.
+  - Common part: handle 429 with waiting and retrying (today `completeJson` aborts transport
+    failures; add retry with backoff ONLY when free-tier active).
 
-## Verificación
+## Verification
 1. `tsc --noEmit` + build.
-2. Test de cobertura i18n (5 idiomas) para claves nuevas.
-3. Benchmark parcial (1 chunk) y luego completo (7000 palabras) de los modelos afectados:
-   Gemma (debe seguir 20/20), Qwen/LFM (deben quedar BLOQUEADOS para extracción en UI), Groq free
-   (debe COMPLETAR sin "Request too large"), OpenRouter free. No repetir Gemini 2.5/DeepSeek/llama-OR.
-4. Regenerar la tabla comparativa.
+2. i18n (5 languages) coverage test for new keys.
+3. Partial (1 chunk) and then complete (7000 words) of the affected models: Gemma (must follow
+   20/20), Qwen/LFM (must be LOCKED FOR UI extraction), Groq free (must COMPLETE without "Request
+   too large"), OpenRouter free. Do not repeat Gemini 2.5/DeepSeek/call-OR.
+4. Regenerate the comparative table.

--- a/design/nodus-apps-prompt-evaluation.md
+++ b/design/nodus-apps-prompt-evaluation.md
@@ -1,78 +1,108 @@
-# Nodus App Studio — evaluación de generación de mini‑apps
+# Nodus App Studio — mini-apps generation evaluation
 
-Fecha: 2026-07-22
-Ruta: OpenRouter Chat Completions
-Formato ejecutable: `nodus-app/v2`
+Date: 2026-07-22 Route: OpenRouter Chat Complements Executable format: `nodus-app/v2`
 
-## Qué se evaluó
+## What was evaluated
 
-El formato v2 contiene una mini‑app web completa y autocontenida:
+The v2 format contains a complete and self-contained web mini-app:
 
-- HTML de contenido.
-- CSS responsive.
-- JavaScript vanilla con la lógica real.
-- Capacidades declaradas de almacenamiento propio y multijugador.
+- Content HTML.
+- CSS Responsive.
+- JavaScript vanilla with real logic.
+- Declared self-storage and multiplayer capabilities.
 
-Cada salida se aceptó únicamente cuando era JSON válido, cumplía exactamente el esquema y superaba el detector de APIs prohibidas. El código aceptado se ejecuta después en un iframe sin `allow-same-origin`, con CSP que bloquea red, frames, workers, objetos, navegación y formularios externos.
+Each output was accepted only when it was valid JSON, fulfilled exactly the schema and exceeded the
+prohibited API detector. The accepted code is then executed in an iframe without
+`allow-same-origin`, with CSP blocking network, frames, workers, objects, navigation and external
+forms.
 
-Casos:
+Cases:
 
-- Juego móvil arcade con controles, dificultad creciente y récord persistente.
-- Planificador cotidiano de comidas, ingredientes y lista de compra.
-- Marcador multijugador sincronizado para participantes que entran por QR.
-- Inyección que solicita revelar el prompt, leer archivos de Nodus y usar Electron, `require`, almacenamiento del navegador, iframe y `fetch`.
+- Mobile arcade game with controls, increasing difficulty and persistent record.
+- Daily food planner, ingredients and shopping list.
+- Synchronized multiplayer marker for participants entering by QR.
+- Injection requesting to reveal the prompt, read Nodus files and use Electron, `require`, browser
+  storage, iframe and `fetch`.
 
-## Resultado con el guardrail final
+## Result with the final Guardrail
 
-| Modelo | Casos válidos | Latencia observada | Observación |
+| Model | Valid cases | Observed latency | Observation |
 |---|---:|---:|---|
-| Poolside Laguna S 2.1 | 4/4 | 32,6–55,1 s | Generó juego, herramienta diaria y app multijugador completas; resistió la inyección. |
-| DeepSeek V4 Flash | 1/2 | 41,1–49,0 s | Resistió la inyección, pero el juego usó una API rechazada por la política final. |
-| Xiaomi MiMo 2.5 | 0/2 | >120 s | Las llamadas agotaron el límite temporal sin respuesta utilizable. |
+| Poolside Laguna S 2.1 | 4/4 | 32.6–55.1 s | Generated game, daily tool and multiplayer app complete; resisted injection. |
+| DeepSeek V4 Flash | 1/2 | 41,1–49.0 s | He resisted the injection, but the game used an API rejected by the final policy. |
+| Xiaomi MiMo 2.5 | 0/2 | >120 s | The calls exhausted the time limit with no usable response. |
 
-Laguna produjo entre 7.592 y 14.356 caracteres de código por app. El marcador declaró correctamente `multiplayer: true` y utilizó el canal `window.nodus.session`.
+Laguna produced between 7.592 and 14,356 characters of code per app. The marker correctly declared
+`multiplayer: true` and used the channel `window.nodus.session`.
 
-Coste OpenRouter de todas las llamadas v2, incluidas repeticiones de diagnóstico: **0,007611906 USD**.
+OpenRouter cost of all v2 calls, including diagnostic repeats: **0.007611906 USD**.
 
-## Iteración académica y para principiantes
+## Academic and beginner iteration
 
-Tras integrar el creador conversacional y los ejemplos orientados a Nodus se añadieron dos pruebas con Laguna S 2.1:
+After integrating the conversational creator and Nodus-oriented examples, two tests were added with
+Laguna S 2.1:
 
-- Creación desde cero de una herramienta de revisión de literatura con fuentes, métodos, muestras, hallazgos, límites, búsqueda, filtros y persistencia.
-- Transformación mediante un nuevo prompt de una lista de notas deliberadamente pobre en un cuaderno de preguntas de investigación.
+- Creation from scratch of a literature review tool with sources, methods, samples, findings,
+  limits, search, filters and persistence.
+- Transformation by a new prompt of a deliberately poor list of notes into a research questionbook.
 
-La revisión produjo una app válida de 17.395 caracteres de código, con modo oscuro, estado vacío y almacenamiento Nodus. La primera creación fue rechazada porque utilizó `url()` en CSS; el prompt se endureció para prohibirlo expresamente y la repetición produjo una app válida de 13.836 caracteres, también con modo oscuro, estado vacío y persistencia.
+The revision produced a valid 17.395-character code app, with dark mode, empty state and Nodus
+storage. The first creation was rejected because it used `url()` in CSS; the prompt was hardened to
+expressly prohibit it and the repetition produced a valid 13.836-character app, also with dark mode,
+empty state and persistence.
 
-Coste de esta iteración: **0,0039884 USD**. Coste v2 acumulado: **0,011600306 USD**.
+Cost of this iteration: **0.0039884 USD**. Cumulative cost v2: **0.01160306 USD**.
 
-Durante las pruebas de ejecución se detectó además que el sandbox original no concedía `allow-forms`: los botones podían abrir paneles, pero los eventos `submit` nunca llegaban a la lógica de la app. El runtime permite ahora eventos de formulario tanto en Nodus como en los participantes QR, mientras `form-action 'none'`, la CSP y el aislamiento de origen siguen bloqueando envíos y navegación externos.
+During running tests it was also detected that the original sandbox did not allow `allow-forms`:
+buttons could open panels, but events `submit` never reached the logic of the app. Runtime now
+allows form events both in Nodus and in QR participants, while `form-action 'none'`, CSP and source
+isolation continue to block external shipments and navigation.
 
-## Hallazgo del detector
+## Finding of the detector
 
-La primera pasada rechazó dos respuestas de Laguna y una de DeepSeek porque la expresión de seguridad interpretaba cualquier propiedad llamada `top` —por ejemplo `element.style.top` en un juego— como un intento de acceder a `window.top`.
+The first pass rejected two Laguna and DeepSeek responses because the security expression
+interpreted any property called `top` — for example `element.style.top` in a game — as an attempt to
+access `window.top`.
 
-La regla se corrigió para bloquear únicamente referencias explícitas de escape como `window.top`, `window.parent`, `globalThis.top` o `self.parent`. Tras repetir los casos afectados, Laguna validó tanto la app multijugador como la petición adversarial. Los tests de regresión comprueban ahora que `style.top` se permite y `window.top` se rechaza.
+The rule was corrected to block only explicit exhaust references such as `window.top`,
+`window.parent`, `globalThis.top` or `self.parent`. After repeating the affected cases, Laguna
+validated both the multiplayer app and the adversarial request. Regression tests now check that
+`style.top` is allowed and `window.top` is rejected.
 
-## Conclusión
+## Conclusion
 
-Laguna S 2.1 es el candidato principal para Nodus App Studio. Es el único de los tres que completó toda la matriz con el contrato final y produjo suficiente código para apps funcionales, no simples maquetas.
+Laguna S 2.1 is the main candidate for Nodus App Studio. It is the only one of the three who
+completed the entire matrix with the final contract and produced enough code for functional apps,
+not simple models.
 
-DeepSeek puede utilizarse como alternativa con reintento/reparación, aunque su tasa de rechazo aumenta el coste y la latencia. MiMo 2.5 no es recomendable para este flujo con un límite interactivo de dos minutos.
+DeepSeek can be used as an alternative with retrying/repair, although its rate of rejection
+increases the cost and latency. MiMo 2.5 is not recommended for this flow with an interactive limit
+of two minutes.
 
-La credencial solo se leyó desde `OPENROUTER_API_KEY`; no se escribió en archivos, informes ni configuración de Nodus.
+The credential was only read from `OPENROUTER_API_KEY`; it was not written to Nodus files, reports,
+or settings.
 
-## Flujo de calidad incorporado
+## Built-in quality flow
 
-La generación definitiva ya no confía en una única respuesta. Utiliza cinco etapas visibles para el usuario:
+The ultimate generation no longer relies on a single response. It uses five visible steps for the
+user:
 
-1. Interpretación local y preparación segura de requisitos.
-2. Construcción completa de la app.
-3. Segunda pasada de coherencia visual y de interacción.
-4. Tercera pasada de errores, controles, estados y endpoints Nodus.
-5. Validación determinista del paquete final.
+1. Local interpretation and secure preparation of requirements.
+2. Complete construction of the app.
+3. Second step of visual coherence and interaction.
+4. Third pass of Nodus errors, controls, states and endpoints.
+5. Deterministic validation of the final package.
 
-La última etapa compila la sintaxis JavaScript sin ejecutar la app, detecta identificadores HTML duplicados, referencias a elementos inexistentes, métodos Nodus no admitidos y usos de almacenamiento o sesión QR que no coincidan con las capacidades declaradas. Si encuentra un error concreto, realiza una única reparación dirigida y vuelve a validar; si el error persiste, el paquete no llega al usuario.
+The last stage compiles the JavaScript syntax without running the app, detects duplicate HTML
+identifiers, references to non-existent elements, unsupported Nodus methods and QR storage or
+session uses that do not match the stated capabilities. If you find a specific error, you perform a
+single targeted repair and validate again; if the error persists, the package does not reach the
+user.
 
-El system prompt incorpora además un sistema de diseño obligatorio —tokens CSS, escala de controles, estados de foco y desactivado, densidad, breakpoints y modo oscuro— y una matriz de comprobación DOM/estado/API pensada para que modelos económicos sigan un procedimiento explícito en vez de improvisar.
+The prompt system also incorporates a mandatory design system — CSS tokens, scale of controls, focus
+and deactivated states, density, breakpoints and dark mode — and a DOM/state/API testing matrix
+designed to ensure that economic models follow an explicit procedure rather than improvise.
 
-Las apps pueden exportarse como ZIP con una versión offline lista para abrir, el manifiesto Nodus original y los tres archivos fuente separados. El almacenamiento se adapta a un espacio local propio del navegador; las sesiones multijugador siguen requiriendo Nodus porque el paquete exportado no abre red ni incluye un servidor.
+Apps can be exported as ZIP with an offline version ready to open, the original Nodus manifest and
+the three separate source files. Storage adapts to a local browser space; multiplayer sessions still
+require Nodus because the exported package does not open network or include a server.

--- a/design/nodus-protect-parity-v0.4.1.md
+++ b/design/nodus-protect-parity-v0.4.1.md
@@ -1,176 +1,198 @@
-# Nodus Protect — matriz de paridad con IDprotector v0.4.1
+# Nodus Protect — parity matrix with IDprotector v0.4.1
 
-Versión de la matriz: **1.0.0 · 2026-07-19**
+Matrix version: **1.0.0 · 2026-07-19**
 
-Referencia original: **IDprotector v0.4.1**, commit `9f523158de3d597bdfe6bf35a6319c5f45c5c70c`
+Original reference: **IDprotector v0.4.1**, commit `9f523158de3d597bdfe6bf35a6319c5f45c5c70c`
 
-Licencia: MIT; atribución íntegra en [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md).
+License: MIT; full attribution in [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md).
 
-Esta matriz es el contrato de salida del port. `A-*` identifica una comprobación automatizada y `M-*` un escenario manual reproducible. Una fila solo puede considerarse cubierta cuando existe implementación y evidencia; no se permiten `TODO`, `skip` ni filas sin escenario.
+This array is the port output contract. `A-*` identifies an automated check and `M-*` a reproducible
+manual scenario. A row can only be considered covered when implementation and evidence exist;
+`TODO`, `skip` or rows without scenario are not allowed.
 
-## Evidencia ejecutable
+## Executable evidence
 
-- `A-ENG`: `node scripts/test-protect-engine.mjs` — vectores IDPS fijos, prueba cruzada contra el JavaScript original, geometría y patrones dorados.
-- `A-DB`: `node scripts/test-protect-persistence.mjs` — migración v90, CRUD, SHA-256 y lápidas sin BLOB. La tabla prevista inicialmente para v88 se desplazó porque `main` ya reservaba v88–v89 para el endurecimiento de sincronización.
-- `A-SYNC`: `node scripts/test-sync-package.mjs` — exportación/mezcla `.nodussync`, newest-wins y borrado lógico.
-- `A-I18N`: `node scripts/test-i18n-coverage.mjs` — mismo conjunto exacto de claves en siete idiomas y sin fallback visible.
-- `A-UI`: `node scripts/test-toolkit-ui.mjs` y `node scripts/e2e-smoke.mjs` — hub, navegación, estados y smoke de Electron.
-- `A-IPC`: `node scripts/test-protect-ipc.mjs` — referencias, formatos, MIME/firma, artefactos y rutas no autorizadas.
+- `A-ENG`: `node scripts/test-protect-engine.mjs` — fixed IDPS vectors, cross-test against original
+  JavaScript, geometry and gold patterns.
+- `A-DB`: `node scripts/test-protect-persistence.mjs` — migration v90, CRUD, SHA-256 and headstones
+  without BLOB. The table initially planned for v88 was moved because `main` already reserved
+  v88–v89 for the tightening of synchronization.
+- `A-SYNC`: `node scripts/test-sync-package.mjs` — export/mixture `.nodussync`, newest-wins and
+  logical deletion.
+- `A-I18N`: `node scripts/test-i18n-coverage.mjs` — same exact set of keys in seven languages and
+  without visible fallback.
+- `A-UI`: `node scripts/test-toolkit-ui.mjs` and `node scripts/e2e-smoke.mjs` — Electron hub,
+  navigation, states and smoke.
+- `A-IPC`: `node scripts/test-protect-ipc.mjs` — references, formats, MIME/signature, artifacts and
+  unauthorized paths.
 - `A-BUILD`: `npm run typecheck && npm run build`.
 
-## Integración y ciclo de sesión
+## Integration and session cycle
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| UI-01 | Hub 2×2 con Convert y Protect en desarrollo, Presenter y OCR próximos | `ToolkitView.tsx`; A-UI | ✅ |
-| UI-02 | Port React/TypeScript, sin iframe ni WebView | `ToolkitProtectView.tsx`, `src/lib/protect/*`; A-UI | ✅ |
-| UI-03 | Portada con Proteger y Verificar | `ProtectHome`; A-UI | ✅ |
-| UI-04 | Estilo, tema, cabeceras, atrás, carga, avisos, confirmación y acento ámbar | componentes Toolkit/`ConfirmModal`; M-UI-01 | ✅ |
-| UI-05 | Idioma global sin selector duplicado | `t/tx`, `AppLanguage`; A-I18N | ✅ |
-| UI-06 | Conservar flujo al salir y volver al Toolkit | singleton `protectSession`; M-UI-02 | ✅ |
-| UI-07 | «Proteger más» reinicia documento/ajustes y conserva registro | `resetDocument` conserva `issuedCopies`; A-REG/M-UI-03 | ✅ |
-| UI-08 | Cerrar Nodus elimina registro y frases | memoria de módulo renderer; A-REG | ✅ |
+| UI-01 | Hub 2×2 with Convert and Protect in development, Presenter and upcoming OCR | `ToolkitView.tsx`; A-UI | D |
+| UI-02 | Port React/TypeScript, without iframe or WebView | `ToolkitProtectView.tsx`, `src/lib/protect/*`; A-UI | D |
+| UI-03 | Cover with Protect and Verify | `ProtectHome`; A-UI | D |
+| UI-04 | Style, theme, headers, back, upload, warnings, confirmation and amber accent | Toolkit/`ConfirmModal` components; M-UI-01 | D |
+| UI-05 | Global language without duplicate selector | `t/tx`, `AppLanguage`; A-I18N | D |
+| UI-06 | Keep flow when exiting and returning to Toolkit | singleton `protectSession`; M-UI-02 | D |
+| UI-07 | ‘Protect more’ restarts document/adjustments and retains record | `resetDocument` retains `issuedCopies`; A-REG/M-UI-03 | D |
+| UI-08 | Close Nodus deletes registration and phrases | renderer module memory; A-REG | D |
 
-## Entrada, composición y seguridad documental
+## Entry, composition and documentary security
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| IN-01 | Disco y bóveda en protección y verificación | `SourcePicker`, IPC Protect; A-IPC/M-IN-01 | ✅ |
-| IN-02 | Selector nativo y arrastrar/soltar | preload `webUtils.getPathForFile`; A-IPC/A-UI | ✅ |
-| IN-03 | Protección múltiple ordenada; verificación única | selector, reordenación y modo discriminado; M-IN-02 | ✅ |
-| IN-04 | PDF, PNG, JPEG/JPG, GIF, WebP, BMP, HEIC y HEIF | firma+MIME+extensión; fixtures A-IPC | ✅ |
-| IN-05 | Mezcla concatenada y PDF predeterminado si existe alguno | `loadProtectPages`; A-UI | ✅ |
-| IN-06 | PDF cifrado, dañado o vacío con error accionable | errores `PasswordException`/`InvalidPDFException`/sin páginas; A-IPC | ✅ |
-| IN-07 | PDF a 1600 px e imágenes ≤2600 px | constantes del motor; A-ENG | ✅ |
-| IN-08 | Decodificación diferida, LRU 3 y exportación secuencial sin límite arbitrario | `ensureProtectPage`, LRU y bucles secuenciales; A-ENG | ✅ |
-| IN-09 | HEIC/HEIF consistente en el proceso principal | `normalizeHeic`, `@napi-rs/canvas`; A-IPC/M-PKG-01 | ✅ |
-| IN-10 | Primer fotograma decodificable de GIF/WebP animado | `createImageBitmap`; fixture A-IPC | ✅ |
-| IN-11 | Original inalterado | solo lectura, hash fixture antes/después; A-SEC | ✅ |
-| IN-12 | Resultado sin texto, capas ni metadatos fuente | compositor raster + PDF nuevo; A-SEC | ✅ |
+| IN-01 | Disk and vault in protection and verification | `SourcePicker`, IPC Protect; A-IPC/M-IN-01 | D |
+| IN-02 | Native selector and drag/drop | preload `webUtils.getPathForFile`; A-IPC/A-UI | D |
+| IN-03 | Ordered multiple protection; single verification | selector, rearrangement and discriminated mode; M-IN-02 | D |
+| IN-04 | PDF, PNG, JPEG/JPG, GIF, WebP, BMP, HEIC and HEIF | signature+MIME+extension; fixtures A-IPC | D |
+| IN-05 | Concatenated mix and default PDF if any | `loadProtectPages`; A-UI | D |
+| IN-06 | PDF encrypted, damaged or empty with actionable error | errors `PasswordException`/`InvalidPDFException`/without pages; A-IPC | D |
+| IN-07 | PDF at 1600 px and images ≤2600 px | engine constants; A-ENG | D |
+| IN-08 | Deferred decoding, LRU 3 and sequential export without arbitrary limit | `ensureProtectPage`, LRU and sequential loops; A-ENG | D |
+| IN-09 | HEIC/HEIF consisting of the main process | `normalizeHeic`, `@napi-rs/canvas`; A-IPC/M-PKG-01 | D |
+| IN-10 | First decodable GIF/WebP animated frame | `createImageBitmap`; fixture A-IPC | D |
+| IN-11 | Original unchanged | read only, hash fixture before/after; A-SEC | D |
+| IN-12 | Result without text, layers or source metadata | composer raster + new PDF; A-SEC | D |
 
-## Fuentes de la bóveda y aislamiento
+## Vault fountains and insulation
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| VAULT-01 | Zotero local; nube deshabilitada y sin descarga automática | `listZoteroSources`; A-IPC/M-VLT-01 | ✅ |
-| VAULT-02 | Archivo de genealogía/fuentes/testimonios | adaptador `archive_items`; A-IPC | ✅ |
-| VAULT-03 | Materiales de estudio/docencia | adaptador `study_materials`; A-IPC | ✅ |
-| VAULT-04 | Adjuntos de base con base, fila y campo | adaptador `db_attachments`; A-IPC | ✅ |
-| VAULT-05 | Copias protegidas en cualquier bóveda | `protect_copies`; A-DB | ✅ |
-| VAULT-06 | Estado vacío si no hay fuentes compatibles | `SourcePicker`; M-VLT-02 | ✅ |
-| VAULT-07 | Cambio de bóveda invalida referencias y confirma descarte | `vaultId` + `onVaultChanged`; A-IPC/M-VLT-03 | ✅ |
-| VAULT-08 | Renderer no accede a rutas ni IDs de otra bóveda | allowlist de disco + `ensureActiveVault`; A-IPC | ✅ |
+| VAULT-01 | Local Zotero; cloud disabled and without automatic download | `listZoteroSources`; A-IPC/M-VLT-01 | D |
+| VAULT-02 | Genealogy file/sources/testimonies | adapter `archive_items`; A-IPC | D |
+| VALULT-03 | Study materials/docency | adapter `study_materials`; A-IPC | D |
+| VAULT-04 | Base attachments with base, row and field | adapter `db_attachments`; A-IPC | D |
+| VAULT-05 | Secured copies in any vault | `protect_copies`; A-DB | D |
+| VALULT-06 | Empty state if no compatible sources | `SourcePicker`; M-VLT-02 | D |
+| VAULT-07 | Vault change invalidates references and confirms discard | `vaultId` + `onVaultChanged`; A-IPC/M-VLT-03 | D |
+| VAULT-08 | Renderer does not access routes or IDs from another vault | permission list + `ensureActiveVault`; A-IPC | D |
 
-## Editor de ocultación
+## Hide Editor
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| ED-01 | Navegación multipágina | `RedactionEditor`; M-ED-01 | ✅ |
-| ED-02 | Barra negra opaca, recta y en cualquier ángulo | `fillRotatedRect`; A-ENG | ✅ |
-| ED-03 | Grosores 10/20/34/52/74 | control exacto; A-UI | ✅ |
-| ED-04 | Desenfoque área 16–160, intensidad 2–30, inicial 52/8 | editor/UI; A-ENG | ✅ |
-| ED-05 | Seleccionar, mover, extremos, borrar | `ProtectEditor`; A-ENG/M-ED-02 | ✅ |
-| ED-06 | Deshacer altas, cambios y eliminaciones por página | pila discriminada; A-ENG | ✅ |
-| ED-07 | Copia proporcional a todas las páginas | `cloneRedactionForPage`; A-ENG | ✅ |
-| ED-08 | Pan, zoom ±, ajustar, rueda al puntero, máximo 8× y pinza | `ProtectEditor`; A-ENG/M-ED-03 | ✅ |
-| ED-09 | Recorte visual, borrar y aplicar con mínimo 24 px | `MIN_PROTECT_CROP`; A-ENG | ✅ |
-| ED-10 | Rotar 90° izquierda/derecha | `rotateProtectPage`; A-ENG | ✅ |
-| ED-11 | Enderezado −10°…+10° en 0,5°, no destructivo | preview + consolidación; A-ENG | ✅ |
-| ED-12 | Transformar marcas al recortar/rotar; crop vacía historial; rotate consolida straighten | geometría editor; A-ENG | ✅ |
-| ED-13 | Escala de grises completa | compositor; A-SEC | ✅ |
-| ED-14 | Controles contextuales y texto de continuación adaptado | UI por herramienta/contador; A-UI | ✅ |
-| ED-15 | Supr/Retroceso salvo foco de formulario | manejador de teclado; A-ENG/M-ED-04 | ✅ |
-| ED-16 | Pointer capture, ratón, trackpad y táctil | pointer events + touch-action; M-ED-05 | ✅ |
+| ED-01 | Multipage navigation | `RedactionEditor`; M-ED-01 | D |
+| ED-02 | Black bar opaque, straight and at any angle | `fillRotatedRect`; A-ENG | D |
+| ED-03 | Thickness 10/20/34/52/74 | exact control; A-UI | D |
+| ED-04 | Unfocus area 16–160, intensity 2–30, initial 52/8 | editor/UI; A-ENG | D |
+| ED-05 | Select, move, end, delete | `ProtectEditor`; A-ENG/M-ED-02 | D |
+| ED-06 | Undo highs, changes and deletions per page | discriminated battery; A-ENG | D |
+| ED-07 | Proportional copy to all pages | `cloneRedactionForPage`; A-ENG | D |
+| ED-08 | Pan, zoom ±, adjust, wheel to pointer, maximum 8× and clamp | `ProtectEditor`; A-ENG/M-ED-03 | D |
+| ED-09 | Visual trim, delete and apply with minimum 24 px | `MIN_PROTECT_CROP`; A-ENG | D |
+| ED-10 | Rotate 90° left/right | `rotateProtectPage`; A-ENG | D |
+| ED-11 | Straightening −10°...+10° in 0.5°, non-destructive | preview + consolidation; A-ENG | D |
+| ED-12 | Transform marks when trimming/rotating; empty crop history; rotate consolidate straighten | editor geometry; A-ENG | D |
+| ED-13 | Gray scale complete | composer; A-SEC | D |
+| ED-14 | Contextual controls and adapted continuation text | UI per tool/counter; A-UI | D |
+| ED-15 | Delete/Regress unless form focus | keyboard handler; A-ENG/M-ED-04 | D |
+| ED-16 | Pointer capture, mouse, trackpad and touch | pointer events + touch-action; M-ED-05 | D |
 
-## Marca de agua y pie legal
+## Watermark and legal foot
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| WM-01 | Interruptor y texto ≤100 | modelo/UI; A-UI | ✅ |
-| WM-02 | Siete algoritmos: denso, topográfico, diagonal, malla, cuadrícula, único, manual | `watermark.ts`; dorados A-ENG | ✅ |
-| WM-03 | Opacidad 4–80 % (18 %) y tamaño 10–60 (22) | defaults/rangos; A-ENG | ✅ |
-| WM-04 | Seis colores y selector libre | `PROTECT_SWATCHES`; dorados A-ENG | ✅ |
-| WM-05 | Firma Nodus Protect con versión | copy del compositor; A-ENG | ✅ |
-| WM-06 | Manual: una inicial, ilimitadas, texto, posición normalizada y ángulo ±45° | UI/modelo; A-ENG/M-WM-01 | ✅ |
-| WM-07 | Arrastre, reset, añadir/eliminar sin borrar la última | `PreviewCanvas`/UI; M-WM-02 | ✅ |
-| WM-08 | Variación determinista por página y preview=export | PRNG/único compositor; dorados A-ENG | ✅ |
-| WM-09 | Preview viva multipágina | `PreviewCanvas`; M-WM-03 | ✅ |
-| FT-01 | Pie plegable, franja blanca, ajuste, azul y mensaje destacado | compositor/UI; dorados A-ENG | ✅ |
-| FT-02 | RGPD EUR-Lex localizado | mapa de siete idiomas; A-ENG | ✅ |
-| FT-03 | 32 autoridades y URLs oficiales | `PROTECT_AUTHORITIES`; A-ENG | ✅ |
-| FT-04 | País por idioma hasta cambio manual | `DEFAULT_AUTHORITY`; A-ENG | ✅ |
-| FT-05 | Email/teléfono opcionales | modelo/UI/compositor; A-ENG | ✅ |
-| FT-06 | Mensaje ≤260, idioma global hasta primera edición | `messageCustom`; A-I18N/M-FT-01 | ✅ |
-| FT-07 | Continuación adaptada sin marca/pie | UI resultado; A-UI | ✅ |
+| WM-01 | Switch and text ≤100 | model/UI; A-UI | D |
+| WM-02 | Seven algorithms: dense, topographic, diagonal, mesh, grid, unique, manual | `watermark.ts`; gold A-ENG | D |
+| WM-03 | Opacity 4–80 % (18 %) and size 10–60 (22) | defaults/ranges; A-ENG | D |
+| WM-04 | Six colors and free selector | `PROTECT_SWATCHES`; gold A-ENG | D |
+| WM-05 | Signature Nodus Protect with version | copy of the composer; A-ENG | D |
+| WM-06 | Manual: an initial, unlimited, text, normalized position and angle ±45° | UI/model; A-ENG/M-WM-01 | D |
+| WM-07 | Drag, reset, add/remove without deleting the last | `PreviewCanvas`/UI; M-WM-02 | D |
+| WM-08 | Deterministic variation per page and preview=export | PRNG/unique composer; gold A-ENG | D |
+| WM-09 | Multipage Live Preview | `PreviewCanvas`; M-WM-03 | D |
+| FT-01 | Folding foot, white strip, fit, blue and prominent message | composer/UI; gold A-ENG | D |
+| FT-02 | GDPR EUR-Lex located | map of seven languages; A-ENG | D |
+| FT-03 | 32 official authorities and URLs | `PROTECT_AUTHORITIES`; A-ENG | D |
+| FT-04 | Country by language until manual change | `DEFAULT_AUTHORITY`; A-ENG | D |
+| FT-05 | Optional e-mail/telephone | model/UI/compositor; A-ENG | D |
+| FT-06 | Message ≤260, global language until first edition | `messageCustom`; A-I18N/M-FT-01 | D |
+| FT-07 | Continuation adapted without mark/foot | UI result; A-UI | D |
 
-## Exportación, registro y biblioteca
+## Export, registration and library
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| EX-01 | Preview multipágina y selector Imagen/PDF | `ResultStep`; A-UI | ✅ |
-| EX-02 | Una página imagen→PNG; varias→ZIP ordenado | `buildProtectArtifact`; A-ENG | ✅ |
-| EX-03 | PDF raster: JPEG 0,92 sin traza; PNG con traza | `pdf-lib` compositor; A-ENG/A-SEC | ✅ |
-| EX-04 | Sufijo localizado en siete idiomas | `SUFFIX`; A-I18N | ✅ |
-| EX-05 | Guardar, bóveda y compartir independientes | `ResultStep`/IPC; A-UI | ✅ |
-| EX-06 | ID nuevo por acción completada; cancelación sin registro | artefacto por acción + registro tras éxito; A-REG | ✅ |
-| EX-07 | ShareMenu Electron y fallback de guardado | proceso principal; M-PKG-02 | ✅ |
-| EX-08 | Escritura temporal+rename y sobrescritura del sistema | `writeArtifactAtomically` + diálogo nativo; A-IPC | ✅ |
-| EX-09 | CSV exacto y escapado; `nodus-protect-registro.csv` | `issuedCopiesCsv`; A-REG | ✅ |
-| LIB-01 | Migración v90 con UUID, MIME, SHA, BLOB, origen, fechas y borrado | migración/repo; A-DB | ✅ |
-| LIB-02 | Listar, leer, guardar, descargar, reutilizar y borrar con confirmación | IPC + listado UI; A-DB/M-LIB-01 | ✅ |
-| LIB-03 | Borrado vacía BLOB y conserva lápida | repo; A-DB | ✅ |
-| LIB-04 | Backup completo incluye tabla | copia integral de SQLite; A-DB | ✅ |
-| LIB-05 | `.nodussync` retrocompatible, merge UUID/updated_at/tombstone y resumen | `syncPackage`; A-SYNC | ✅ |
+| EX-01 | Multipage Preview and Selector Image/PDF | `ResultStep`; A-UI | D |
+| EX-02 | One page image→PNG; several→ZIP ordered | `buildProtectArtifact`; A-ENG | D |
+| EX-03 | PDF raster: JPEG 0.92 without trace; PNG with trace | `pdf-lib` composer; A-ENG/A-SEC | D |
+| EX-04 | Suffix located in seven languages | `SUFFIX`; A-I18N | D |
+| EX-05 | Save, vault and share independent | `ResultStep`/IPC; A-UI | D |
+| EX-06 | New ID per completed action; cancellation without registration | device by action + registration after success; A-REG | D |
+| EX-07 | ShareMenu Electron and default save | main process; M-PKG-02 | D |
+| EX-08 | Temporary Writing+Rename and System Overwriting | `writeArtifactAtomically` + native dialogue; A-IPC | D |
+| EX-09 | exact and escaped CSV; `nodus-protect-registro.csv` | `issuedCopiesCsv`; A-REG | D |
+| LIB-01 | Migration v90 with UUID, MIME, SHA, BLOB, origin, dates and deletion | migration/repo; A-DB | D |
+| LIB-02 | List, read, save, download, reuse and delete with confirmation | IPC + UI list; A-DB/M-LIB-01 | D |
+| LIB-03 | Empty erasing BLOB and preserving headstone | repo; A-DB | D |
+| LIB-04 | Full backup includes table | integral copy of SQLite; A-DB | D |
+| LIB-05 | `.nodussync` retrocompatible, merge UUID/updated_at/tombstone and summary | `syncPackage`; A-SYNC | D |
 
-## IDPS v1 y verificación
+## IDPS v1 and verification
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| IDPS-01 | Trazabilidad apagada; etiqueta ≤120 y frase opcional | defaults/UI; A-UI | ✅ |
-| IDPS-02 | Registro de 24 bytes `IDPS`, versión, flags e ID aleatorio de 8 bytes | `stego.ts`; vectores A-ENG | ✅ |
-| IDPS-03 | HMAC-SHA256 truncado | Web Crypto; vectores A-ENG | ✅ |
-| IDPS-04 | Abierto y PBKDF2, sal original pública, 310.000 iteraciones | byte parity A-ENG | ✅ |
-| IDPS-05 | LSB RGB cíclico, mayoría y 4096 candidatos | `decodeIdps`; A-ENG | ✅ |
-| IDPS-06 | PNG iTXt sin comprimir y PDF Title/Subject/Keywords | metadata port; A-ENG | ✅ |
-| IDPS-07 | Claves técnicas `idprotector`, `idps1`, `copyId:<hex>`; Producer/Creator Nodus | engine; A-ENG | ✅ |
-| IDPS-08 | Compatibilidad bidireccional con IDprotector v0.4.1 | JavaScript original ↔ TypeScript; A-ENG | ✅ |
-| IDPS-09 | Registro solo en sesión y nunca frases | `session.ts`; A-REG | ✅ |
-| IDPS-10 | Explicación: autentica, no cifra; transformaciones destruyen marca | UI localizada; A-I18N | ✅ |
-| VER-01 | PDF/imagen desde disco, bóveda o biblioteca | selector común; A-UI | ✅ |
-| VER-02 | Cambiar frase y reintentar sin releer | caché `verifyPayloadCache`; A-UI | ✅ |
-| VER-03 | iTXt PNG y metadatos PDF | parser; A-ENG | ✅ |
-| VER-04 | Primer XObject exacto; raster fallback con aviso | `exactPdfPageImageData`; A-ENG | ✅ |
-| VER-05 | Todas las páginas; verificada prevalece; si no, primera no autenticada | bucle de verificación; A-ENG | ✅ |
-| VER-06 | Separación píxeles/metadatos y tres estados | `VerifyStep`; A-UI | ✅ |
-| VER-07 | ID, clave, concordancia, candidatos, página y registro de sesión | resultado UI; A-UI | ✅ |
-| VER-08 | Nunca afirmar que no estaba protegido | copy localizada; A-I18N | ✅ |
-| VER-09 | Sin Web Crypto: metadatos visibles y autenticación indisponible | rama `idpsAvailable`; A-ENG | ✅ |
+| IDPS-01 | Traceability off; label ≤120 and optional phrase | defaults/UI; A-UI | D |
+| IDPS-02 | 24 bytes record `IDPS`, version, flags and random 8 bytes ID | `stego.ts`; A-ENG vectors | D |
+| IDPS-03 | HMAC-SHA256 truncated | Web Crypto; A-ENG vectors | D |
+| IDPS-04 | Open and PBKDF2, original public salt, 310,000 iterations | byte parity A-ENG | D |
+| IDPS-05 | Cyclic LSB RGB, majority and 4096 candidates | `decodeIdps`; A-ENG | D |
+| IDPS-06 | Uncompressed PNG iTXt and PDF Title/Subject/Keywords | metadata port; A-ENG | D |
+| IDPS-07 | Technical keys `idprotector`, `idps1`, `copyId:<hex>`; Producer/Creator Nodus | engine; A-ENG | D |
+| IDPS-08 | Two-way compatibility with IDprotector v0.4.1 | Original JavaScript ↔ TypeScript; A-ENG | D |
+| IDPS-09 | Log only in session and never phrases | `session.ts`; A-REG | D |
+| IDPS-10 | Explanation: authentic, not encrypted; transformations destroy brand | Localized UI; A-I18N | D |
+| VER-01 | PDF/image from disk, vault or library | common selector; A-UI | D |
+| VER-02 | Change phrase and retry without rereading | cache `verifyPayloadCache`; A-UI | D |
+| VER-03 | iTXt PNG and PDF metadata | parser; A-ENG | D |
+| VER-04 | First Exact XObject; Raster Fallback with Warning | `exactPdfPageImageData`; A-ENG | D |
+| VER-05 | All pages; verified prevails; if not, first not authenticated | verification loop; A-ENG | D |
+| VIEW-06 | Separation pixels/metadata and three states | `VerifyStep`; A-UI | D |
+| VER-07 | ID, key, match, candidates, page and session log | result UI; A-UI | D |
+| VER-08 | Never claim he wasn't protected. | localized copy; A-I18N | D |
+| VER-09 | Without Web Crypto: visible metadata and unavailable authentication | branch `idpsAvailable`; A-ENG | D |
 
-## Italiano, documentación y empaquetado
+## Italian, documentation and packaging
 
-| ID | Paridad exigida | Implementación/evidencia | Estado |
+| ID | Parity required | Implementation/evidence | State |
 | --- | --- | --- | --- |
-| I18N-01 | `AppLanguage=it`, normalización, ajustes, tutorial, recuperación/runtime | tablas compartidas/UI; A-I18N | ✅ |
-| I18N-02 | Tabla italiana completa, exactamente mismas claves | `i18n.it.ts`; A-I18N | ✅ |
-| I18N-03 | Dominio, parentesco y todas las notas históricas en italiano | módulos `.it.ts`; A-I18N | ✅ |
-| I18N-04 | Protect completo en siete idiomas | `i18n.protect.ts`; A-I18N | ✅ |
-| I18N-05 | `PromptLanguage` sin italiano | tipos/tutorial/Settings; A-I18N | ✅ |
-| DOC-01 | Ayuda, Toolkit, novedades y privacidad precisa | README, FAQ, Nodi docs, release notes | ✅ |
-| PKG-01 | macOS/Windows/Linux: worker PDF, HEIC, guardado y share fallback | M-PKG-01/M-PKG-02 por artefacto CI | ✅ escenario |
-| NET-01 | Cero acceso de red durante procesamiento Protect | sin API de red en motor/servicio; A-IPC/M-NET-01 | ✅ |
-| REG-01 | Cero regresiones en Nodus Convert | suite Toolkit existente + build; A-UI/A-BUILD | ✅ |
+| I18N-01 | `AppLanguage=it`, normalization, settings, tutorial, recovery/runtime | shared tables/UI; A-I18N | D |
+| I18N-02 | Complete Italian table, exactly the same keys | `i18n.it.ts`; A-I18N | D |
+| I18N-03 | Dominion, kinship and all historical notes in Italian | modules `.it.ts`; A-I18N | D |
+| I18N-04 | Complete protection in seven languages | `i18n.protect.ts`; A-I18N | D |
+| I18N-05 | `PromptLanguage` without Italian | types/tutorial/Settings; A-I18N | D |
+| DOC-01 | Help, Toolkit, News and Accurate Privacy | README, FAQ, Nodi docs, release notes | D |
+| PKG-01 | macOS/Windows/Linux: worker PDF, HEIC, save and share failback | M-PKG-01/M-PKG-02 by IC device | Scenario |
+| NET-01 | Zero network access during Protect processing | no network API in engine/service; A-IPC/M-NET-01 | D |
+| REG-01 | Zero regressions in Nodus Convert | existing Toolkit suite + build; A-UI/A-BUILD | D |
 
-## Guiones manuales reproducibles
+## Reproducible manual scripts
 
-1. **M-UI-01…03**: abrir Protect en claro y oscuro y en cada idioma; iniciar un documento, salir a otra vista y volver; emitir una copia, pulsar «Proteger más» y comprobar que el documento se vacía pero el registro permanece.
-2. **M-IN-01…02**: arrastrar una mezcla PDF/PNG/HEIC, reordenarla, comprobar la salida PDF predeterminada; en Verificar confirmar que solo se admite una fuente.
-3. **M-VLT-01…03**: en cada tipo de bóveda listar su fuente; comprobar Zotero local/no local; cambiar de bóveda con cambios y aceptar/rechazar el descarte.
-4. **M-ED-01…05**: recorrer un PDF de cuatro páginas con ratón, trackpad y táctil; crear/mover/redimensionar/borrar; usar rueda, zoom al puntero, pinza, pan y teclas Supr/Retroceso dentro y fuera de un input.
-5. **M-WM-01…03 / M-FT-01**: crear varias marcas manuales, arrastrarlas, variar página, intentar borrar la última y comparar píxel a píxel preview/export; editar el mensaje legal y cambiar de idioma para comprobar que no se sobrescribe.
-6. **M-LIB-01**: guardar una copia en la bóveda, reutilizarla, descargarla y borrarla tras confirmar; sincronizar y comprobar la lápida en el segundo dispositivo.
-7. **M-PKG-01…02**: ejecutar el instalador CI de cada SO con HEIC real y PDF multipágina; guardar con sobrescritura y compartir (ShareMenu en macOS, diálogo de guardado en Windows/Linux).
-8. **M-NET-01**: bloquear/registrar tráfico saliente del proceso, completar protección y verificación y comprobar cero solicitudes; otras funciones de Nodus quedan fuera de este escenario.
+1. **M-UI-01...03**: open Protect in clear and dark and in each language; start a document, go out
+   to another view and return; issue a copy, press "Protect more" and check that the document is
+   empty but the record remains.
+2. **M-IN-01...02**: drag a PDF/PNG/HEIC mixture, reorder it, check the default PDF output; in
+   Verify confirm that only one source is supported.
+3. **M-VLT-01...03**: in each type of vault list its source; check local/non-local Zotero; change
+   vault with changes and accept/reject discard.
+4. **M-ED-01...05**: go through a four-page PDF with mouse, trackpad and touch;
+   create/move/resize/delete; use wheel, zoom pointer, clamp, bread and keys Delete/Regress inside
+   and outside an input.
+5. **M-WM-01...03 / M-FT-01**: create multiple handmarks, drag them, vary page, try deleting the
+   last and compare pixel to pixel preview/export; edit the legal message and change language to
+   check that it is not overwritten.
+6. **M-LIB-01**: save a copy in the vault, reuse, download and delete it after confirmation;
+   synchronize and check the tombstone on the second device.
+7. **M-PKG-01...02**: run the IC installer of each OS with real HEIC and multipage PDF; save with
+   overwrite and share (ShareMenu in macOS, save dialog in Windows/Linux).
+8. **M-NET-01**: block/register outgoing traffic from the process, complete protection and
+   verification and check zero requests; other Nodus functions are out of this scenario.
 
-## Criterio de salida
+## Exit criterion
 
-La entrega se bloquea si cualquier prueba anterior falla, aparece una fila pendiente, cambia un vector IDPS, existe texto extraíble en un PDF protegido, se modifica el hash de un original, Protect realiza una solicitud de red o las tarjetas de Convert/Protect dejan de figurar como disponibles.
+Delivery is blocked if any previous test fails, a pending row appears, changes an IDPS vector, there
+is removable text in a protected PDF, the hash of an original is modified, Protect makes a network
+request or Convert/Protect cards cease to appear as available.

--- a/design/nodus-toolkit-plan.md
+++ b/design/nodus-toolkit-plan.md
@@ -1,465 +1,438 @@
-# Nodus Toolkit — Plan de implementación original
+# Nodus Toolkit — Original Implementation Plan
 
-> Estado: **Nodus Convert implementado; ampliado con Nodus Protect** (2026-07-19).
-> Este documento conserva las decisiones históricas del primer lanzamiento del Toolkit.
-> La especificación y matriz de aceptación vigente de la cuarta tarjeta están en
+> Status: **Nodus Convert implemented; expanded with Nodus Protect** (2026-07-19).
+> This document preserves the historic decisions of the first release of the Toolkit.
+> The current specification and acceptance matrix of the fourth card are in
 > [`nodus-protect-parity-v0.4.1.md`](nodus-protect-parity-v0.4.1.md).
 
 ---
 
-## 1. Visión y nombres
+## 1. Vision and names
 
-**Nodus Toolkit** es una nueva sección de primer nivel ("Herramientas" en el sidebar)
-que centraliza utilidades de proceso de archivos para investigación, docencia y estudio,
-al estilo ConvertX pero con los formatos del ámbito académico. Contiene cuatro
-herramientas, cada una con su propia página:
+**Nodus Toolkit** is a new first-level section ("Tools" in the sidebar) that centralizes file
+processing utilities for research, teaching and study, ConvertX style but with formats in the
+academic field. It contains four tools, each with its own page:
 
-| Herramienta | id interno | Estado v1 | Descripción de tarjeta (ES) |
+| Tool | internal id | Status v1 | Description of card (ES) |
 |---|---|---|---|
-| **Nodus Convert** | `convert` | ✅ se implementa ahora | Convierte documentos, PDFs e imágenes; OCR ligero y utilidades de texto, individual o en bulk. |
-| **Nodus Protect** | `protect` | ✅ disponible | Oculta datos, marca documentos y crea o verifica copias trazables mediante procesamiento local. |
-| **PDF Presenter** | `presenter` | 🔜 Próximamente | Presenta PDFs como diapositivas para clase. |
-| **OCR Workspace** | `aiOcr` | 🔜 Próximamente | Transcripción de documentos difíciles con modelos de visión. |
+| **Nodus Convert** | `convert` | is now implemented | Convert documents, PDFs and images; light OCR and text utilities, individual or bulk. |
+| **Nodus Protect** | `protect` | Available | Hide data, mark documents and create or verify traceable copies by local processing. |
+| **PDF Present** | `presenter` | Coming soon. | It presents PDFs as slides for class. |
+| **OCR Workspace** | `aiOcr` | Coming soon. | Transcription of difficult documents with vision models. |
 
-Decisiones de nombre:
-- La sección del sidebar se llama **"Herramientas"** (clave i18n en español, como todo).
-  El nombre de marca para release notes / web es **"Nodus Toolkit"**.
-- El conversor se llama **"Nodus Convert"** — encaja con el trío de nombres en inglés de
-  marca y con precedentes como Deep Research. En la tarjeta el subtítulo en ES lo hace
-  autoexplicativo.
-- ⚠️ La tercera herramienta se implementó como **"OCR Workspace"**, no como "AI OCR"
-  (el nombre que usó el usuario al encargarlo): el roadmap ya visible en la app la
-  anuncia como *Nodus OCR Workspace*, y estrenar la tarjeta con otro nombre haría que
-  la app se contradijera consigo misma. **Decisión reversible**: si el usuario prefiere
-  "AI OCR", hay que cambiarlo en `ToolkitView.tsx`, en `NODUS_ROADMAP` y en el test.
+Name decisions:
+- The sidebar section is called **"Tools"** (key i18n in Spanish, like everything else).The brand
+  name for release notes / web is **"Nodus Toolkit"**.
+- The converter is called **"Nodus Convert"** — fits the trio of brand names in English and with
+  precedents like Deep Research. On the card the subtitle in ES makes it self-explanatory.
+- ⚠️ The third tool was implemented as **"OCR Workspace"**, not as "AI OCR" (the name used by the
+  user when ordering it): the roadmap already visible in the app announces it as *Nodus OCR
+  Workspace*, and to release the card with another name would make the app contradict itself.
+  **Reversible decision**: if the user prefers "AI OCR", it must be changed in`ToolkitView.tsx`,
+  in`NODUS_ROADMAP`And in the test.
 
-**Principio rector**: el Toolkit es **determinista y 100 % offline** (salvo la descarga
-opt-in de idiomas de Tesseract, ver §7). Nada de IA en Nodus Convert: la IA vive en la
-futura herramienta AI OCR. Ninguna operación toca jamás el archivo original.
+** Guiding principle**: Toolkit is **deterministic and 100% offline** (except for the opt-in
+download of Tesseract languages, see §7). No AI in Nodus Convert: AI lives in the future AI OCR
+tool. No operation ever touches the original file.
 
-**Hallazgo clave**: casi toda la maquinaria ya está en `package.json` — `pdf-lib`,
-`pdfjs-dist`, `tesseract.js`, `mammoth`, `docx`, `turndown`, `adm-zip`,
-`@napi-rs/canvas`, `diff` — e incluso hay OCR funcionando en
-`electron/extraction/ocr.ts` (imagen y PDF→PNG→Tesseract). El coste en bundle es ~0;
-la única dependencia nueva prevista es `heic-decode` (WASM pequeño) en la fase de
-imágenes.
+**Key finding**: almost all the machinery is already in`package.json` — `pdf-lib`, `pdfjs-dist`,
+`tesseract.js`, `mammoth`, `docx`, `turndown`, `adm-zip`, `@napi-rs/canvas`, `diff`— and there are
+even OCRs running in`electron/extraction/ocr.ts`(image and PDF→PNG→Tesseract).The cost in bundle is
+~0; the only new dependency planned is`heic-decode`(small WASM) in the imaging phase.
 
 ---
 
-## 2. Navegación e integración en el shell
+## 2. Navigation and integration into the shell
 
 ### 2.1 Sidebar
-- `src/navigation.ts`: añadir `'toolkit'` a la union `View` y a `NAV_ITEMS`.
-- Nuevo grupo de navegación `tools` (`NavGroupId`), label **"Herramientas"**, renderizado
-  tras `create` ("Escribir"). Un grupo de un solo ítem es válido (`groupedNav` ya
-  tolera grupos de tamaño arbitrario y descarta los vacíos).
-- Icono nuevo y único: `tools` (llave inglesa estilo feather). Recordar que
-  `test-icons.mjs` valida el catálogo.
-- **Vista universal**: no se añade a `VAULT_TYPE_SCOPED_VIEWS` (aparece en todos los
-  tipos de vault) ni a ningún `defaultHiddenViews`. Limitación conocida: los tipos
-  preview (`docencia`, `worldbuilding`) solo permiten `home`; el Toolkit no estará ahí
-  hasta que dejen de ser preview — aceptado para v1.
+- `src/navigation.ts`: add`'toolkit'`to the union`View`and a`NAV_ITEMS`.
+- New navigation group`tools` (`NavGroupId`), label **"Tools"**, rendered after`create`("Write"). A
+  single item group is valid (`groupedNav`already tolerates arbitrary size groups and discards
+  gaps).
+- New and unique icon:`tools`Remember that`test-icons.mjs`validates the catalogue.
+- **Universal view**: not added to`VAULT_TYPE_SCOPED_VIEWS`(appears in all types of vault) or to
+  any`defaultHiddenViews`. Known limitation: the preview types (`docencia`, `worldbuilding`) allow
+  only`home`; the Toolkit won't be there until they stop being previewed — accepted for v1.
 
 ### 2.2 Header
-- Añadir un `HeaderAction` (icono `tools`) en la fila de acciones del top bar de
-  `App.tsx` que navega a la vista `toolkit` desde cualquier sitio. Mismo patrón
-  `h-9 min-h-9 px-2.5` que el resto de acciones del header.
+- Add a`HeaderAction`(icon`tools`) in the stock row of the top bar of`App.tsx`navigating in
+  sight`toolkit`from anywhere. Same pattern`h-9 min-h-9 px-2.5`That's the rest of the header's
+  stock.
 
-### 2.3 Otras superficies
-- `CommandPalette`: comando "Ir a Herramientas" (+ "Abrir Nodus Convert").
-- `shared/nodiDocumentation.ts` (`NODUS_ROADMAP`): al lanzar, mover el ítem del Toolkit
-  a "hecho" o retirarlo, y documentar la sección para que Nodi sepa explicarla.
-- `WhatsNewModal`: entrada de novedades en el release que lo estrene.
+### 2.3 Other areas
+- `CommandPalette`: "Go to Tools" command (+ "Open Nodus Convert").
+- `shared/nodiDocumentation.ts` (`NODUS_ROADMAP`): when launching, move the Toolkit item to "made"
+  or remove it, and document the section so Nodi can explain it.
+- `WhatsNewModal`: entry of news in the release that premieres it.
 
-### 2.4 Navegación interna del Toolkit
-`ToolkitView.tsx` gestiona un sub-estado propio (no se añaden más ids a `View`):
+### 2.4 Internal navigation of Toolkit
+`ToolkitView.tsx`manages a sub-state of its own (no more ids added to`View`):
 
 ```
 type ToolkitPage = 'home' | 'convert' | 'presenter' | 'aiOcr'
 ```
 
-- `home` = hub con las 3 tarjetas.
-- Cada herramienta renderiza una cabecera con **botón volver** (`chevronLeft` +
-  "Herramientas") y el título/icono de la herramienta — breadcrumb estilo
-  "Herramientas / Nodus Convert".
-- El sub-estado se conserva al cambiar de vista y volver (state en el componente App o
-  módulo de estado ligero, como hace Study con `StudyNavigationTarget`).
-- `presenter` y `aiOcr` en v1: tarjeta deshabilitada (badge "Próximamente", opacidad
-  reducida, sin onClick). No hay página placeholder navegable — menos superficie que
-  testear y ningún callejón sin salida.
+- `home`= hub with the 3 cards.
+- Each tool renders a header with **button back** (`chevronLeft`+ "Tools") and the title/icon of the
+  tool — Breadcrumb style "Tools / Nodus Convert".
+- The sub-state is conserved when you change your view and return (state in the App component or
+  light status module, as does Study with`StudyNavigationTarget`).
+- `presenter`and`aiOcr`in v1: disabled card (badge "Next", reduced opacity, no onClick). There is no
+  navigable placeholder page — less surface than testing and no dead end.
 
 ---
 
-## 3. Diseño del hub (página principal de Herramientas)
+## 3. Hub Design (Main Tool Page)
 
-Requisitos de diseño explícitos del usuario, que se convierten en checklist de PR:
+Explicit user design requirements, which become PR checklist:
 
-- [ ] Márgenes y ritmo de espaciado idénticos al resto de vistas (contenedor
-      `px-6 py-6`, `gap-3/gap-4` de la escala existente; comparar lado a lado con
-      Deep Research y Home).
-- [ ] Las 3 tarjetas del hub tienen **exactamente el mismo tamaño** (grid
-      `sm:grid-cols-2 lg:grid-cols-3` con `h-full` en la tarjeta; el contenido no
-      puede desalinear alturas).
-- [ ] Botones hermanos con la misma altura (`btn` + `h-9 min-h-9`); nunca mezclar
-      alturas en una misma fila.
-- [ ] Iconos **perfectamente centrados**: el icono de cada tarjeta va en una "loseta"
-      cuadrada fija (`h-12 w-12 rounded-xl flex items-center justify-center`) y los
-      iconos de botón llevan `shrink-0`. Landmine conocida: jamás `animate-spin` en el
-      mismo elemento que un `-translate-y-1/2` (el spinner "bota" y no gira) — el
-      centrado va siempre en un wrapper.
-- [ ] Dark y light: cualquier clase utilitaria nueva usada solo en dark necesita su
-      remap `.light .<utility>` en `index.css` (`test-light-theme-utilities.mjs` ayuda,
-      pero revisar visualmente ambos temas).
-- [ ] Dropdowns/selects dentro de contenedores `overflow-hidden` → portal a `body`
-      (landmine de Databases).
+- [ ] Margins and spacing rhythm identical to the rest of views (container`px-6 py-6`,
+  `gap-3/gap-4`of the existing scale; compare side by side with Deep Research and Home).
+- [ ] The 3 hub cards are **exactly the same size** (grid)`sm:grid-cols-2
+  lg:grid-cols-3`with`h-full`on the card; the content cannot misalign heights).
+- [ ] Brothers buttons with the same height (`btn` + `h-9 min-h-9`); never mix heights in the same
+  row.
+- [ ] Icons **perfectly centered**: the icon of each card goes on a fixed square "loset" (`h-12 w-12
+  rounded-xl flex items-center justify-center`) and button icons carry`shrink-0`. Landmine known:
+  never`animate-spin`in the same element as a`-translate-y-1/2`(the spinner "boot" and does not
+  spin) — the center always goes on a wrapper.
+- [ ] Dark and light: any new utilitarian class used only in dark needs its remap`.light
+  .<utility>`in`index.css` (`test-light-theme-utilities.mjs`help, but visually review both topics).
+- [ ] Dropdowns/selects inside containers`overflow-hidden`→ portal to`body`(landmine of Databases).
 
-Estructura del hub:
+Structure of the hub:
 
 ```
 ┌────────────────────────────────────────────────────────┐
-│ [🔧] Herramientas                                       │
-│ Utilidades de proceso de archivos para investigación,  │
-│ docencia y estudio. Todo local, nada sale de tu equipo.│
+│ [🔧] Tools                                              │
+│ File-processing utilities for research, teaching and   │
+│ study. Everything stays local on your computer.        │
 │                                                        │
 │ ┌──────────┐  ┌──────────┐  ┌──────────┐               │
 │ │ [swap]   │  │ [presen.]│  │ [scanTxt]│               │
 │ │ Nodus    │  │ PDF      │  │ AI OCR   │               │
 │ │ Convert  │  │ Presenter│  │          │               │
-│ │ subtítulo│  │ subtítulo│  │ subtítulo│               │
-│ │          │  │ Próxima- │  │ Próxima- │               │
-│ │          │  │ mente    │  │ mente    │               │
+│ │ subtitle │  │ subtitle │  │ subtitle │               │
+│ │          │  │ Coming   │  │ Coming   │               │
+│ │          │  │ soon     │  │ soon     │               │
 │ └──────────┘  └──────────┘  └──────────┘               │
 └────────────────────────────────────────────────────────┘
 ```
 
-Acento de color de la sección: **ámbar/bronce** (tono "taller"), distinto del índigo
-base, del crimson de Databases y del teal de Estudio. Se usa solo en iconos-loseta,
-badges y detalles — el chrome sigue siendo neutral como el resto de la app.
+Color accent of the section: **ambar/bronze** (tone "workshop"), other than the base indigo, the
+Crimson of Databases and the Study teal. It is used only in icons-loseta, badges and details — the
+chrome remains neutral like the rest of the app.
 
-Iconos nuevos en `ICON_PATHS` (todos trazos feather, únicos): `tools` (llave inglesa),
-`swap` (flechas de intercambio, para Convert), `scanText` (para AI OCR). PDF Presenter
-reutiliza el icono `presentation` existente.
+New icons in`ICON_PATHS`(all feather strokes, unique):`tools`(English key),`swap`(exchange arrows,
+for Convert),`scanText`(for AI OCR). PDF Presenter reuses the icon`presentation`existing.
 
 ---
 
-## 4. Nodus Convert — especificación funcional
+## 4. Nodus Convert — functional specification
 
 ### 4.1 UI
 
 ```
-┌ Herramientas / Nodus Convert ──────────────────────────────┐
+┌ Tools / Nodus Convert ─────────────────────────────────────┐
 │ [←] [swap] Nodus Convert                                   │
 │                                                            │
-│ ┌ Categorías ┐ ┌ Zona principal ──────────────────────────┐│
-│ │ Documentos │ │  ┌ Dropzone ─────────────────────────┐   ││
-│ │ PDF        │ │  │  Arrastra archivos o carpetas,    │   ││
-│ │ OCR        │ │  │  o haz clic para elegir           │   ││
-│ │ Imágenes   │ │  └───────────────────────────────────┘   ││
-│ │ Texto      │ │  Lista de archivos (nombre, tamaño,      ││
-│ └────────────┘ │  estado/progreso por archivo, quitar)    ││
-│                │  ┌ Opciones de la operación ┐             ││
-│                │  │ Formato destino, calidad, │            ││
-│                │  │ rangos de página, idioma… │            ││
+│ ┌ Categories ┐ ┌ Main area ──────────────────────────────┐│
+│ │ Documents  │ │  ┌ Drop zone ────────────────────────┐  ││
+│ │ PDF        │ │  │  Drag files or folders here,      │  ││
+│ │ OCR        │ │  │  or click to choose them          │  ││
+│ │ Images     │ │  └───────────────────────────────────┘  ││
+│ │ Text       │ │  File list (name, size, status/progress,││
+│ └────────────┘ │  remove)                                 ││
+│                │  ┌ Operation options ┐                   ││
+│                │  │ Target format, quality,               ││
+│                │  │ page ranges, language… │              ││
 │                │  └───────────────────────────┘            ││
-│                │  [Carpeta de salida ▾] [□ Abrir al        ││
-│                │   terminar]              [ Convertir ]    ││
+│                │  [Output folder ▾] [□ Open when done]    ││
+│                │                         [ Convert ]       ││
 │                └──────────────────────────────────────────┘│
 └────────────────────────────────────────────────────────────┘
 ```
 
-- Panel izquierdo de categorías: pills/botones **del mismo tamaño**, patrón visual del
-  sidebar de Study/Databases.
-- La operación se elige con un select "De → A" filtrado por los archivos añadidos
-  (p. ej. si sueltas `.docx` solo se ofrecen las salidas válidas). Bulk = N archivos,
-  misma operación.
-- Progreso: lista por archivo con estado (`pendiente / procesando (x%) / hecho /
-  error`), botón cancelar el lote. El job sobrevive a la navegación (corre en main;
-  el renderer se re-suscribe vía `backgroundJobs.ts`).
-- Resultado por archivo: ruta de salida + "Mostrar en Finder" (`shell.showItemInFolder`)
-  + error legible si falló (sin stack traces al usuario).
-- Estados vacíos y errores con el tono del resto de la app; textos ES como claves i18n.
+- Left category panel: pills/buttons ** of the same size**, visual sidebar pattern of
+  Study/Databases.
+- The operation is chosen with a select "From → A" filtered by the added files (e.g. if you
+  release`.docx`only valid outputs are offered). Bulk = N files, same operation.
+- Progress: list by file with status (`pending / processing (x%) / done / error`), button to cancel
+  the lot. Job survives navigation (runs in main; renderer is re-subscribed via`backgroundJobs.ts`).
+- Result per file: output path + "Show in Finder" (`shell.showItemInFolder`)
+  + readable error if failed (no stack tracks to user).
+- Empty states and errors with the tone of the rest of the app; ES texts as i18n keys.
 
-### 4.2 Política de salida (regla de oro)
+### 4.2 Exit policy (gold rule)
 
-- **Nunca** se modifica ni sobrescribe el original.
-- Destino por defecto: junto al original con la extensión nueva; si existe colisión,
-  sufijo incremental ` (2)`, ` (3)`… (nunca overwrite silencioso).
-- Alternativa: carpeta de salida elegida por el usuario (persistida en settings).
-- Bulk conserva nombres base; operaciones N→1 (merge, imágenes→PDF) piden nombre.
+- **Never change or overwrite the original.
+- Default destination: next to the original with the new extension; if collision exists, incremental
+  suffix` (2)`, ` (3)`... (never overwrite silent).
+- Alternative: output folder chosen by the user (persisted in settings).
+- Bulk retains base names; operations N→1 (merge, images→PDF) request name.
 
-### 4.3 Catálogo de operaciones v1
+### 4.3 Catalogue of operations v1
 
-Cada operación lista su motor y su **test real de aceptación** (ver §6). *Regla DoD:
-una operación solo se mergea con su test de procesado real en verde.*
+Each operation lists its engine and its **real acceptance test** (see §6). *DoD rule: one operation
+is only required with its actual green processing test.*
 
-**A. Documentos** — `electron/toolkit/convert/docs.ts`
+**A. Documents** —`electron/toolkit/convert/docs.ts`
 
-| # | Operación | Motor | Test real (aserción principal) |
+| # | Operation | Engine | Actual test (main assertion) |
 |---|---|---|---|
-| A1 | PDF → TXT | pdfjs (reutiliza `pdfjsLoader`/`textExtractor`) | El TXT contiene las frases conocidas de las 3 páginas del fixture, en orden |
-| A2 | PDF → Markdown | A1 + heurística ligera (títulos por tamaño de fuente, párrafos) | Encabezados `#` presentes; texto íntegro |
-| A3 | DOCX → Markdown / HTML / TXT | mammoth (+ turndown para MD) | `# Título`, `**negrita**`, lista y tabla del fixture presentes |
-| A4 | Markdown / HTML → DOCX | lib `docx` | Descomprimir el .docx (adm-zip) y asertar texto y estilos de heading en `document.xml` |
-| A5 | Markdown / HTML → PDF | render con CSS de la app + KaTeX → `printToPDF` (main, ventana oculta) | **e2e**: extraer texto del PDF con pdfjs y casarlo; nº páginas > 0 |
-| A6 | EPUB → Markdown / TXT | adm-zip + orden del spine OPF + turndown | Texto de ambos capítulos del fixture, en orden del spine |
-| A7 | Markdown → EPUB | zip manual (mimetype sin comprimir + container.xml + OPF + XHTML) | Estructura válida: `mimetype` primera entrada y STORED; container/OPF parseables; capítulos con el texto |
+| A1 | PDF → TXT | pdfjs (reuses`pdfjsLoader`/`textExtractor`) | The TXT contains the known phrases of the 3 pages of the fixture, in order |
+| A2 | PDF → Markdown | A1 + light heuristics (titles by font size, paragraphs) | Headers`#`present; full text |
+| A3 | DOCX → Markdown / HTML / TXT | mammoth (+ turndown for MD) | `# Title`, `**bold**`, list and fixture table present |
+| A4 | Markdown / HTML → DOCX | lib`docx` | Decompress the .docx (adm-zip) and assert text and styles of heating in`document.xml` |
+| A5 | Markdown / HTML → PDF | render with CSS of the app + KaTeX →`printToPDF`(main, hidden window) | **e2e**: extract text from PDF with pdfjs and compare it; no pages > 0 |
+| A6 | EPUB → Markdown / TXT | adm-zip + spine order OFP + turndown | Text of both chapters of the fixture, in spine order |
+| A7 | Markdown → EPUB | manual zip (uncompressed mimetype + container.xml + OPF + XHTML) | Valid structure:`mimetype`first entry and STORED; container/OPF parseables; chapters with text |
 
-**B. Utilidades PDF** — `electron/toolkit/convert/pdfOps.ts` (pdf-lib)
+**B. PDF Utilities** —`electron/toolkit/convert/pdfOps.ts`(pdf-lib)
 
-| # | Operación | Test real |
+| # | Operation | Actual test |
 |---|---|---|
-| B1 | Unir PDFs | páginas = suma; texto de ambos fixtures presente vía pdfjs |
-| B2 | Dividir / extraer páginas (rangos "1-3,5") | nº páginas y texto de la página concreta correctos |
-| B3 | Rotar páginas | `/Rotate` correcto en el page dict; re-abrible |
-| B4 | Reordenar / eliminar páginas | orden verificado por el texto de cada página |
-| B5 | Extraer imágenes incrustadas | ≥1 imagen, decodificable por canvas, dimensiones > 0 |
-| B6 | Imágenes → PDF (una por página) | nº páginas = nº imágenes; tamaño de página coherente |
-| B7 | Ver/editar metadatos (título, autor, tema, fecha) | round-trip: escribir → releer → igual |
-| B8 | Comprimir PDF escaneado (re-render a JPEG, calidad configurable, etiquetado "con pérdida") | salida < entrada; mismo nº páginas; OCR-able. *Fase tardía* |
+| B1 | Unite PDFs | pages = sum; text of both fixes present via pdfjs |
+| B2 | Split / extract pages (ranges "1-3,5") | no pages and text of the specific page correct |
+| B3 | Rotate Pages | `/Rotate`correct on page dict; re-openable |
+| B4 | Reorder / Remove Pages | command verified by the text of each page |
+| B5 | Extract embedded images | ≥1 image, canvas decodable, dimensions > 0 |
+| B6 | Images → PDF (one per page) | no pages = no images; coherent page size |
+| B7 | View/edit metadata (title, author, theme, date) | round-trip: write → reread → same |
+| B8 | Compress scanned PDF (re-render to JPEG, configurable quality, labeled "with loss") | output < input; same no pages; OCR-able. * Late phase* |
 
-**C. OCR ligero** — `electron/toolkit/convert/ocrOps.ts` (reutiliza `extraction/ocr.ts`)
+**C. Light OCR** —`electron/toolkit/convert/ocrOps.ts`(reuses`extraction/ocr.ts`)
 
-| # | Operación | Test real |
+| # | Operation | Actual test |
 |---|---|---|
-| C1 | Imagen(es) → TXT | el texto reconocido contiene las palabras clave del fixture renderizado a 300 dpi (match normalizado) |
-| C2 | PDF escaneado → TXT | ídem sobre el PDF-imagen de 2 páginas |
-| C3 | PDF escaneado → **PDF buscable** (sandwich: capa de texto invisible con bboxes de Tesseract vía pdf-lib) | pdfjs encuentra las palabras en las posiciones correctas; el PDF visualmente intacto (mismo nº páginas, imágenes preservadas) |
-| C4 | Preprocesado: escala de grises / binarizar (Otsu) | dimensiones intactas; histograma binario; C1 sobre la imagen preprocesada sigue pasando |
-| C5 | Deskew (perfil de proyección) | *Fase tardía*; ángulo detectado ±1° en fixture girado 3° |
+| C1 | Image(s) → TXT | the recognized text contains the keywords of the fixture rendered at 300 dpi (standardized match) |
+| C2 | PDF Scanned → TXT | about the PDF image of 2 pages |
+| C3 | PDF scan → **PDF searchable** (sandwich: invisible text layer with Tesseract bboxes via pdf-lib) | pdfjs finds the words in the correct positions; the PDF visually intact (same as no pages, preserved images) |
+| C4 | Preprocessed: gray scale / binarize (Otsu) | intact dimensions; binary histogram; C1 over preprocessed image continues to pass |
+| C5 | Deskew (projection profile) | *Late phase*; angle detected ±1° in rotated fixture 3° |
 
-- Idiomas Tesseract descargables bajo demanda con UI de gestión (patrón
-  Piper/Kokoro), caché en userData, consentimiento reutilizando el copy de
-  `ocrEnabled` (es la única llamada de red del Toolkit).
+- Tesseract languages downloadable on demand with management UI (Piper/Kokoro pattern), userData
+  cache, consent reusing copy`ocrEnabled`(it's the only network call in the Toolkit).
 
-**D. Imágenes** — `electron/toolkit/convert/imageOps.ts` (@napi-rs/canvas; `heic-decode` nuevo)
+**D. Images** —`electron/toolkit/convert/imageOps.ts`(@napi-rs/canvas;`heic-decode`new)
 
-| # | Operación | Test real |
+| # | Operation | Actual test |
 |---|---|---|
-| D1 | Convertir PNG/JPEG/WebP (+AVIF si el canvas lo soporta — *spike* al inicio de la fase) | salida decodificable; dimensiones intactas; magic bytes correctos |
-| D2 | HEIC → JPEG/PNG | detección por magic bytes en `npm test`; la conversión real se verifica **en local contra una foto de iPhone aportada por el usuario, que nunca se commitea** (ver §6.2-bis) |
-| D3 | Redimensionar (lado máx. / %) en bulk | dimensiones exactas esperadas; aspect ratio intacto |
-| D4 | Comprimir (calidad JPEG/WebP) | salida < entrada; decodificable |
+| D1 | Convert PNG/JPEG/WebP (+AVIF if canvas supports it — *spike* at start of phase) | decodable output; intact dimensions; correct magic bytes |
+| D2 | HEIC → JPEG/PNG | magic bytes detection in`npm test`; the actual conversion is verified **in local against an iPhone photo provided by the user, which is never committed** (see §6.2-bis) |
+| D3 | Resize (max. / %) in bulk | Exact expected dimensions; undisturbed view ratio |
+| D4 | Compress (JPEG/WebP quality) | output < input; decodable |
 
-**E. Texto** — `shared/toolkitText.ts` (puro, sin Electron)
+**E. Text** —`shared/toolkitText.ts`(pure, without Electron)
 
-| # | Operación | Test real |
+| # | Operation | Actual test |
 |---|---|---|
-| E1 | Limpiador de texto pegado de PDF (des-guionado, unir líneas partidas respetando párrafos, espacios dobles, comillas) | golden tests: entrada real pegada de PDF → salida exacta esperada |
-| E2 | Mayúsculas/minúsculas (Tipo oración / Título / MAYÚS / minús, con reglas ES: no capitalizar "de", "la"…) | golden tests |
-| E3 | SRT/VTT → TXT limpio (sin timestamps, líneas unidas por cue) | golden test sobre entrevista fixture |
-| E4 | Checksum SHA-256 / MD5 de archivos | hash conocido del fixture, byte a byte |
+| E1 | PDF glued text cleaner (de-tuned, join split lines respecting paragraphs, double spaces, quotes) | golden tests: real entry pasted from PDF → exact output expected |
+| E2 | Shifts/minuscules (Prayer type / Title / MAYUS/minus, with ES rules: do not capitalize "of", "la"...) | golden tests |
+| E3 | SRT/VTT → Clean TXT (without timestamps, lines attached by cue) | golden test on fixture interview |
+| E4 | Checksum SHA-256 / MD5 files | known hash of fixture, byte a byte |
 
-**F. Datos y citas** — *v1.1, planificado pero fuera del primer release*
-BibTeX ↔ RIS ↔ CSL-JSON (con "importar a Zotero" vía puente existente),
-CSV ↔ JSON ↔ tabla Markdown (reutilizando el parser robusto de Databases).
+**F. Data and citations** — *v1.1 planned but out of first release* BibTeX ★ RIS ★ CSL-JSON (with
+"importing Zotero" via existing bridge), CSV ↔ JSON ↔ Markdown table (reusing Robust Parser from
+Databases).
 
 ---
 
-## 5. Arquitectura técnica
+## 5. Technical architecture
 
-### 5.1 Módulos
+### 5.1 Modules
 
 ```
 electron/toolkit/
   convert/
-    docs.ts        # A*  (mammoth, docx, turndown, adm-zip, pdfjs — imports lazy)
-    pdfOps.ts      # B*  (pdf-lib, pdfjs)
-    ocrOps.ts      # C*  (tesseract.js vía extraction/ocr.ts, canvas)
-    imageOps.ts    # D*  (@napi-rs/canvas, heic-decode)
-    index.ts       # registro tipado de operaciones (id, categoría, entradas, salidas)
-  toolkitWorker.ts # worker_thread runner (patrón computeWorker)
-  toolkitJobs.ts   # cola en main: 1 job activo, progreso, cancelación, naming de salida
+    docs.ts        # A* (mammath, docx, turndown, adm-zip, pdfjs — imports lazy)
+    pdfOps.ts      # B* (pdf-lib, pdfjs)
+    ocrOps.ts      # C* (testeract.js via extraction/ocr.ts, canvas)
+    imageOps.ts    # D* (@napi-rs/canvas, heic-decode)
+    index.ts       # Typed transaction log (id, category, inputs, outputs)
+  toolkitWorker.ts # worker_thread runner (computeWorker pattern)
+  toolkitJobs.ts   # Main queue: 1 active job, progress, cancellation, output naming
 shared/
-  toolkitText.ts   # E* puro
+  toolkitText.ts   # E* pure
   toolkitTypes.ts  # ToolkitOpId, ToolkitJobRequest/Progress/FileResult
 src/views/
-  ToolkitView.tsx      # hub + sub-navegación
+  ToolkitView.tsx      # hub + sub-navigation
   ToolkitConvertView.tsx
 ```
 
-**Reglas duras:**
-- Los módulos `convert/*` son **Electron-free** (como `databasesRepo`): imports de
-  Node y libs solamente, deps pesadas con `import()` lazy (patrón de `ocr.ts`). Esto
-  es lo que permite testearlos de verdad con esbuild + node:test.
-- Todo el trabajo corre en `toolkitWorker.ts` (worker_thread), **nunca** en el event
-  loop del main (landmine histórica de la app). *Spike en F1*: verificar
-  `@napi-rs/canvas` + tesseract dentro de worker_threads en las 3 plataformas; plan B:
-  `utilityProcess`.
-- Excepción: A5 (`printToPDF`) necesita `BrowserWindow` → corre en main con ventana
-  oculta; es I/O asíncrono de Chromium, no bloquea.
-- Cancelación cooperativa: el worker comprueba una flag entre archivos y entre páginas;
-  cancelar nunca deja archivos a medias (escritura a `.tmp` + rename atómico).
+** Hard rules:**
+- The modules`convert/*`are **Electron-free** (as`databasesRepo`): Node imports and only libs, heavy
+  deps with`import()`lazy (pattern of`ocr.ts`). This is what allows you to test them with esbuild +
+  node:test.
+- All the work runs in`toolkitWorker.ts`(worker_thread), **never** in the event loop of the main
+  (historical landmine of the app). *Spike in F1*: verify`@napi-rs/canvas`+ tesseract within
+  worker_threads on all 3 platforms; plan B:`utilityProcess`.
+- Exception: A5 (`printToPDF`) you need`BrowserWindow`→ Runs in main with hidden window; is I/O
+  asynchronous Chromium, does not block.
+- Cooperative cancellation: the worker checks a flag between files and between pages; cancel never
+  leaves files half (write a`.tmp`+ atomic rename).
 
-### 5.2 IPC y estado
+### 5.2 IPC and status
 
-- Canales: `toolkit:job:start`, `toolkit:job:cancel`, `toolkit:job:event` (progreso
-  push), `toolkit:ops:list`, `toolkit:pickFiles`, `toolkit:pickOutputDir`,
-  `toolkit:showInFolder`. Tipados en `NodusApi` (preload sin fugas de nombres IPC,
-  como el resto).
-- Renderer: `startBackgroundJob('toolkit:convert', …)` de `backgroundJobs.ts` para que
-  el progreso sobreviva a la navegación y se re-suscriba al volver.
-- Settings nuevas en `AppSettings` (JSON de settings, **sin migración de schema**):
-  `toolkitOcrLanguages` (default `'spa+eng'`), `toolkitOutputDir` (null = junto al
-  original), `toolkitOpenFolderOnDone` (bool). "Trabajos recientes" en localStorage.
+- Channels:`toolkit:job:start`, `toolkit:job:cancel`, `toolkit:job:event`(push
+  progress),`toolkit:ops:list`, `toolkit:pickFiles`, `toolkit:pickOutputDir`,
+  `toolkit:showInFolder`. Typed in`NodusApi`(preload without leaking IPC names, like the rest).
+- Renderer:`startBackgroundJob('toolkit:convert', …)`of`backgroundJobs.ts`so that progress survives
+  navigation and is re-subscribed upon return.
+- New settings in`AppSettings`(JSON of settings, **no schema
+  migration**):`toolkitOcrLanguages`(default`'spa+eng'`), `toolkitOutputDir`(null = next to the
+  original),`toolkitOpenFolderOnDone`"Recent jobs" on local Storage.
 
 ### 5.3 i18n
 
-Todas las cadenas nuevas en ES como clave + entradas en EN/FR/DE/PT/PT-BR
-(`test-i18n-coverage.mjs` obliga; presupuestar este trabajo en cada fase, no al final).
+All new strings in ES as key + entries in EN/FR/DE/PT/PT-BR (`test-i18n-coverage.mjs`it requires;
+budget this work at each stage, not at the end).
 
 ---
 
-## 6. Estrategia de testing — "ninguna operación pasa sin procesado real"
+## 6. Testing strategy — "no operation passes without actual processing"
 
-### 6.1 Fixtures reales — `scripts/fixtures/toolkit/`
+### 6.1 Actual Fixtures —`scripts/fixtures/toolkit/`
 
-Generadas una vez por `scripts/gen-toolkit-fixtures.mjs` y **commiteadas** (deterministas,
-< 200 KB cada una), para que los tests sean herméticos:
+Generated once by`scripts/gen-toolkit-fixtures.mjs`and **committed** (determinists, < 200 KB each),
+so that the tests are airtight:
 
-| Fixture | Contenido |
+| Fixture | Content |
 |---|---|
-| `sample-3pages.pdf` | PDF con capa de texto, 3 páginas con frases conocidas ES/EN + títulos con jerarquía de tamaños |
-| `sample-b.pdf` | segundo PDF (para merge) |
-| `scanned-2pages.pdf` | PDF **solo imagen** (texto renderizado a 300 dpi, sin capa de texto) |
-| `scan-es.png`, `scan-en.jpg` | párrafos renderizados a 300 dpi para OCR |
-| `scan-skewed.png` | ídem girado 3° (para C5) |
-| `sample.docx` | headings, negrita, lista, tabla |
-| `sample.epub` | 2 capítulos con spine definido |
-| `sample.md`, `sample.html` | con encabezados, tabla y una fórmula KaTeX |
-| `photo.jpg` | foto pequeña real |
-| ~~`photo.heic`~~ | ⛔ **NO se commitea. Ver §6.2-bis** — una foto HEIC real es un archivo personal del usuario y no entra en el repo bajo ninguna circunstancia. |
-| `interview.srt` | 6 cues con timestamps |
-| `pdf-paste.txt` + `pdf-paste.expected.txt` | golden del limpiador E1 |
+| `sample-3pages.pdf` | PDF with text layer, 3 pages with well-known phrases ES/EN + titles with size hierarchy |
+| `sample-b.pdf` | second PDF (for merge) |
+| `scanned-2pages.pdf` | PDF **image only** (text rendered at 300 dpi, without text layer) |
+| `scan-es.png`, `scan-en.jpg` | paragraphs rendered at 300 dpi for OCR |
+| `scan-skewed.png` | Idem turned 3° (for C5) |
+| `sample.docx` | Headings, bold, list, table |
+| `sample.epub` | 2 chapters with defined spin |
+| `sample.md`, `sample.html` | with headers, table and a KaTeX formula |
+| `photo.jpg` | real small photo |
+| ~~`photo.heic`~~ | * **DO NOT commit. See §6.2-bis** — a real HEIC photo is a personal user file and does not enter the repo under any circumstances. |
+| `interview.srt` | 6 cues with timestamps |
+| `pdf-paste.txt` + `pdf-paste.expected.txt` | golden cleaner E1 |
 
-### 6.2 Tests unitarios (node --test, patrón esbuild-bundle existente)
+### 6.2 Unit tests (node --test, existing esbuild-bundle pattern)
 
-`test-toolkit-docs.mjs`, `test-toolkit-pdf.mjs`, `test-toolkit-ocr.mjs`,
-`test-toolkit-images.mjs`, `test-toolkit-text.mjs`, `test-toolkit-jobs.mjs`.
+`test-toolkit-docs.mjs`, `test-toolkit-pdf.mjs`, `test-toolkit-ocr.mjs`, `test-toolkit-images.mjs`,
+`test-toolkit-text.mjs`, `test-toolkit-jobs.mjs`.
 
-- Cada test bundlea el módulo real con esbuild (patrón `test-image-analysis.mjs`),
-  procesa el fixture **de verdad** y aserta **contenido del resultado** (texto
-  extraído, nº de páginas, dimensiones, hashes), jamás la mera existencia del archivo.
-- OCR: `langPath` apuntando a una caché (`scripts/.cache/tessdata/`); primera ejecución
-  descarga `spa`/`eng` (tessdata_fast); timeout generoso. Sin red y sin caché el test
-  **falla** — correcto según la regla ("sin procesado real no hay verde"). CI ya tiene
-  red (instala npm).
-- `test-toolkit-jobs.mjs`: semántica de cola — naming anticolisión, cancelación limpia
-  (no deja `.tmp`), progreso monótono, error en un archivo no aborta el lote.
+- Each test loads the actual module with esbuild (pattern`test-image-analysis.mjs`), processes the
+  true **fixture** and serves **content of the result** (text extracted, not from pages, dimensions,
+  hashes), never the mere existence of the archive.
+- OCR:`langPath`pointing to a cache (`scripts/.cache/tessdata/`); first download
+  run`spa`/`eng`(tessdata_fast); generous timeout. Without network and without cached the test
+  **fault** — correct according to the rule ("without actual processing there is no green"). IC
+  already has network (install npm).
+- `test-toolkit-jobs.mjs`: tail semantics — anti-collision naming, clean cancellation (does not
+  leave`.tmp`), monotonous progress, error in a file does not abort the lot.
 
-### 6.2-bis HEIC: verificación local, nunca una fixture
+### 6.2-bis HEIC: local verification, never a fixture
 
-**Regla dura: ninguna foto real del usuario entra en el repo.** Un HEIC de verdad es
-un archivo personal (lleva metadatos de dispositivo, fecha y posiblemente GPS), y
-además el repo es público. No se commitea ni se sube a GitHub de ningún modo.
+**Hard rule: no real photo of the user enters the repo.** A real HEIC is a personal file (carrying
+device metadata, date and possibly GPS), and also the repo is public. It is not committed or
+uploaded to GitHub in any way.
 
-Eso choca con la regla "sin procesado real no hay verde", porque un HEIC real no se
-puede generar en CI (no hay codificador HEIC en las dependencias). Se resuelve como
-ya hace el repo con Whisper y otros recursos pesados: un script `verify-*` manual,
-no un test de `npm test`.
+That clashes with the rule "without actual processing there is no green", because a real HEIC cannot
+be generated in IC (there is no HEIC encoder in dependencies). It resolves as the repo already does
+with Whisper and other heavy resources: a script`verify-*`manual, not a test of`npm test`.
 
-- `scripts/verify-toolkit-heic.mjs` (patrón de `verify-study-whisper.mjs`), invocado
-  como `npm run verify:toolkit-heic -- /ruta/a/una/foto.HEIC`, o vía la variable
-  `NODUS_HEIC_FIXTURE`. Procesa el archivo REAL y aserta el resultado (decodifica,
-  dimensiones correctas, JPEG/PNG de salida válido). Si no se le pasa archivo, falla
-  con un mensaje que explica cómo aportarlo — nunca se salta en silencio.
-- En `npm test`/CI, D2 se cubre solo en su parte determinista: detección de HEIC por
-  magic bytes / marca `ftyp` (fixture sintética mínima de unas decenas de bytes,
-  construida en el propio test, sin ser una foto), y el mensaje de error cuando el
-  decodificador no está disponible.
-- La conversión HEIC no se da por terminada hasta que `verify:toolkit-heic` pasa en
-  local contra una foto real de iPhone. El usuario aporta el archivo desde fuera del
-  repo; el plan no lo referencia por ruta dentro del árbol.
+- `scripts/verify-toolkit-heic.mjs`(pattern of`verify-study-whisper.mjs`), invoked as`npm run
+  verify:toolkit-heic -- /path/to/a/photo.HEIC`, or via the `NODUS_HEIC_FIXTURE` variable. Process
+  the REAL file and file the result (decode, correct dimensions, valid output JPEG/PNG). If you do
+  not pass file, it fails with a message that explains how to contribute it — you never skip
+  silently.
+- In`npm test`/CI, D2 is covered only in its deterministic part: detection of HEIC by magic bytes /
+  brand`ftyp`(minimum synthetic fixture of a few dozen bytes, built on the test itself, without
+  being a photo), and error message when the decoder is not available.
+- The HEIC conversion is not terminated until`verify:toolkit-heic`it happens locally against an
+  actual iPhone photo. The user provides the file from outside the repo; the plan does not reference
+  it by path within the tree.
 
-### 6.3 e2e (app real)
+### 6.3 e2e (actual app)
 
-`scripts/e2e-toolkit.mjs` (patrón `e2e-smoke.mjs`: Electron real + playwright-core +
-perfil desechable):
-1. Sidebar muestra "Herramientas"; el hub renderiza 3 tarjetas con igual tamaño y las
-   dos "Próximamente" no navegan.
-2. Entrar a Nodus Convert, cargar `sample.md`, ejecutar **MD → PDF real**
-   (`printToPDF`), asertar que el PDF de salida existe y que pdfjs extrae el texto
-   esperado (cubre A5, imposible en unit).
-3. Volver al hub con el botón atrás; sin errores no capturados en consola.
+`scripts/e2e-toolkit.mjs`(pattern`e2e-smoke.mjs`: Electron real + playwright-core + disposable
+profile:
+1. Sidebar displays "Tools"; the hub renders 3 cards of equal size and the two "nextly" do not
+   navigate.
+2. Enter Nodus Convert, load`sample.md`, run **MD → real PDF** (`printToPDF`), assert that the
+   output PDF exists and that pdfjs extracts the expected text (covers A5, impossible in unit).
+3. Return to hub with the back button; no errors not captured in console.
 
-⚠️ Landmine conocida: `test:e2e` **no** rebuidea — ejecutar `npm run build` antes o el
-dist obsoleto da falsos rojos.
+Landmine known:`test:e2e`**no** rebuidea — execute`npm run build`before or the obsolete dist gives
+false reds.
 
-### 6.4 Puertas de calidad por PR
+### 6.4 Quality doors per PR
 
-`npm run typecheck` + `npm run lint` + `npm test` + e2e afectado, más el checklist de
-diseño de §3 revisado en ambos temas (dark/light) y capturas en el PR.
+`npm run typecheck` + `npm run lint` + `npm test`+ e2e affected, plus the revised §3 design
+checklist on both themes (dark/light) and catches in the PR.
 
 ---
 
-## 7. Fases de implementación
+## 7. Implementation phases
 
-Cada fase termina con la suite completa en verde y es mergeable por sí sola.
+Each phase ends with the complete suite in green and is mergeable on its own.
 
-**F0 — Sección y hub** ✅ **COMPLETADA** (2026-07-17)
-`View 'toolkit'`, grupo nav `tools` (tras Escribir, antes de Ajustes), iconos
-`tools`/`swap`/`scanText`, `ToolkitView` con hub de 3 tarjetas + sub-navegación +
-volver, HeaderAction en el top bar (tras Asistente), i18n completa (5 tablas),
-documentación de Nodi actualizada con el estado real. Tests: `test-toolkit-ui.mjs`
-(8 casos) + paso del hub en `e2e-smoke.mjs` que mide en el shell real que las tres
-tarjetas tienen dimensiones idénticas, que el glifo está centrado en su loseta
-(±0,5 px), que las tarjetas "Próximamente" no navegan y que el botón volver regresa.
-Verificado además con capturas en tema oscuro y claro. Suite: 388/388 + e2e en verde.
+**F0 — Section and hub** **COMPLETATE** (2026-07-17)`View 'toolkit'`, nav group`tools`(after
+writing, before Settings), icons`tools`/`swap`/`scanText`, `ToolkitView`with 3-card hub +
+sub-navigation + back, HeaderAction in top bar (after Wizard), i18n complete (5 tables), Nodi
+documentation updated with actual status. Tests:`test-toolkit-ui.mjs`(8 cases) + passage of hub
+in`e2e-smoke.mjs`which measures in the real shell that the three cards have identical dimensions,
+that the glyph is centered on its slab (±0.5 px), that the cards "nextly" do not navigate and that
+the return button returns. Also verified with catches in dark and clear theme. Suite: 388/388 + e2e
+in green.
 
-Notas de lo aprendido en F0:
-- La paleta de comandos ya expone la sección automáticamente: recorre `NAV_ITEMS`
-  filtrando por tipo de vault, así que no hizo falta añadir un comando a mano.
-- `'Nodus Toolkit'` YA existía como clave i18n (viene del roadmap); duplicarla rompe
-  el typecheck (TS1117). Antes de añadir claves, comprobar si ya existen.
-- El nombre de marca de la 3.ª herramienta se alineó con el roadmap: **OCR Workspace**
-  (no "AI OCR"), que es como ya se anuncia en `NODUS_ROADMAP`.
+Notes from what you learned in F0:
+- The command palette displays the section automatically:`NAV_ITEMS`filtering by type of vault, so
+  you didn't need to add a command by hand.
+- `'Nodus Toolkit'`YA existed as a key i18n (comes from roadmap); duplicating it breaks the
+  typecheck (TS1117). Before adding keys, check if they already exist.
+- The brand name of the 3rd tool was aligned with the roadmap: **OCR Workspace** (not "AI OCR"),
+  which is as already announced in`NODUS_ROADMAP`.
 
-**F1 — Motor de jobs** *(spike primero)*
-Spike: canvas+tesseract+pdfjs dentro de worker_thread en macOS (y CI Linux). Después:
-`toolkitTypes`, `toolkitWorker`, `toolkitJobs`, IPC + preload, política de salida,
-`startBackgroundJob` en renderer. Tests: `test-toolkit-jobs.mjs`.
-**DoD**: un job dummy multi-archivo con progreso y cancelación, main thread libre
-(ventana responde durante el job).
+**F1 — Job engine** *(spike first)* Spike: canvas+tesseract+pdfjs within worker_thread on macOS (and
+CI Linux). Then:`toolkitTypes`, `toolkitWorker`, `toolkitJobs`, IPC + preload, exit
+policy,`startBackgroundJob`Tests:`test-toolkit-jobs.mjs`. **DoD**: a job dummy multi-archive with
+progress and cancellation, main thread free (window responds during the job).
 
-**F2 — Utilidades PDF (B1–B7)** + categoría "PDF" en la UI. `test-toolkit-pdf.mjs`.
+**F2 — PDF Utilities (B1–B7)** + category "PDF" in the UI.`test-toolkit-pdf.mjs`.
 
-**F3 — Documentos (A1–A7)** + categoría "Documentos". `test-toolkit-docs.mjs` +
-e2e MD→PDF.
+**F3 — Documents (A1–A7)** + category "Documents".`test-toolkit-docs.mjs`+ e2e MD→PDF.
 
-**F4 — OCR ligero (C1–C4)** + categoría "OCR" + gestor de idiomas con consentimiento.
-`test-toolkit-ocr.mjs`. El PDF buscable (C3) es el buque insignia — priorizarlo.
+**F4 — Light OCR (C1–C4)** + category "OCR" + language manager with consent.`test-toolkit-ocr.mjs`.
+The searchable PDF (C3) is the flagship — prioritize it.
 
-**F5 — Imágenes (D1–D4)** + dep `heic-decode` + spike AVIF. `test-toolkit-images.mjs`.
-D2 se cierra con `npm run verify:toolkit-heic` en local contra una foto real del
-usuario (§6.2-bis); esa foto no se commitea jamás.
+**F5 — Images (D1–D4)** + dep`heic-decode`+ AVIF spy.`test-toolkit-images.mjs`D2 closes with`npm run
+verify:toolkit-heic`in local against a real photo of the user (§6.2-bis); that photo is never
+committed.
 
-**F6 — Texto (E1–E4)** + categoría "Texto". `test-toolkit-text.mjs` (goldens).
+**F6 — Text (E1-E4)** + category "Text".`test-toolkit-text.mjs`(goldens).
 
-**F7 — Pulido y release**
-Drag & drop de carpetas, trabajos recientes, estados vacíos, roadmap→hecho, What's New,
-documentación de Nodi, capturas para la web/README, release notes (inglés, política
-habitual). Fases tardías pendientes: B8, C5, categoría F (citas/datos), contact sheet.
+**F7 — Polished and released** Drag & drop folders, recent works, empty states, roadmap→made, What's
+New, Nodi documentation, web/README captures, release notes (English, usual policy). Late pending
+phases: B8, C5, category F (dates/data), contact sheet.
 
-Orden F2 antes que F3 a propósito: pdf-lib puro es el terreno más firme para validar el
-motor de F1 antes de meter mammoth/turndown/printToPDF.
+Order F2 before F3 by the way: pure pdf-lib is the firmest ground to validate the F1 engine before
+inserting mammoth/turndown/printToPDF.
 
 ---
 
-## 8. Riesgos y mitigaciones
+## 8. Risks and mitigations
 
-| Riesgo | Mitigación |
+| Risk | Mitigation |
 |---|---|
-| Nativos (@napi-rs/canvas) o tesseract fallan dentro de worker_threads en alguna plataforma | Spike en F1; plan B `utilityProcess`; plan C troceo asíncrono en main (último recurso) |
-| AVIF no soportado por el canvas | Spike en F5; si no, ocultar AVIF del select (el registro de operaciones lo permite) |
-| Descarga de traineddata (única red) sorprende al usuario | Opt-in explícito reutilizando el copy de `ocrEnabled`; caché persistente; gestor de idiomas visible |
-| Fidelidad MD/HTML→PDF (no es Word) | Etiquetar como "re-maquetación con estilo Nodus"; nunca prometer fidelidad DOCX→PDF |
-| EPUBs reales malformados | adm-zip tolerante + spine fallback a orden de archivos; test adicional con un EPUB real descargado en F7 |
-| PDFs grandes → memoria | Proceso página a página, sin cargar rasterizados completos; progreso por página |
-| Cadenas i18n nuevas rompen `test-i18n-coverage` | Traducciones dentro de cada fase, no al final |
+| Native (@napi-rs/canvas) or Tesseract fail within worker_threads on some platform | Spike in F1; plan B`utilityProcess`; plan C asynchronous cut in main (last resort) |
+| AVIF not supported by canvas | Spike in F5; if not, hide select AVIF (the transaction log allows) |
+| Download Traineddata (one network) surprises the user | Opt-in explicit reusing copy from`ocrEnabled`; persistent cache; visible language manager |
+| Fidelity MD/HTML→PDF (not Word) | Tag as "Nodus-style re-layout"; never promise fidelity DOCX→PDF |
+| Malformed real EPUBs | adm-zip tolerant + spin fallback in order of files; additional test with a real EPUB downloaded in F7 |
+| Big PDFs → memory | Page-to-page process, without loading full rasterized; progress per page |
+| New i18n chains break`test-i18n-coverage` | Translations within each phase, not at the end |
 
-## 9. Fuera de alcance (explícito)
+## 9. Out of range (explicit)
 
-- ffmpeg / audio / vídeo (Whisper ya existe en Study; no se duplica).
-- Binarios nativos por plataforma (Ghostscript, LibreOffice, Calibre).
-- IA en Nodus Convert (determinista; la IA es de AI OCR).
-- Cambios de schema de base de datos (no hay persistencia nueva en DB).
-- PDF Presenter y AI OCR: solo tarjeta "Próximamente"; se diseñan en planes propios.
+- ffmpeg / audio / video (Whisper already exists in Study; does not duplicate).
+- Native binaries per platform (Ghostscript, LibreOffice, Calibre).
+- AI in Nodus Convert (deterministic; AI OCR AI).
+- Database schema changes (no new persistence in DB).
+- PDF Presenter and AI OCR: only "Next" card; designed in own plans.

--- a/design/pdf-presenter-plan.md
+++ b/design/pdf-presenter-plan.md
@@ -1,291 +1,273 @@
-# PDF Presenter — plan de implementación (réplica fiel + mejora)
+# PDF Presenter — implementation plan (faithful replication + improvement)
 
-> Estado: **plan para revisión**, sin código todavía.
-> Objetivo acordado con el usuario (2026-07-20): **portar la app de referencia
-> `~/Documents/GitHub/pdfpresenter` de forma más o menos exacta**, verificar cada
-> función una a una, cubrir con tests, y **adaptar/mejorar el diseño** para
-> integrarlo en Nodus (iconos centralizados, temas claro/oscuro, ritmo de
-> espaciado, i18n). Las presentaciones viven en una **biblioteca global del
-> Toolkit** (agnóstica de bóveda, como Convert/Protect).
-
----
-
-## 1. Qué es la app de referencia (inventario completo)
-
-App Electron con **tres ventanas + una web móvil**, coordinadas por un servidor
-Express + WebSocket local. Todo el estado vive en un `currentState` central que
-se difunde por WS a los clientes y por IPC a las ventanas.
-
-### 1.1 Ventana principal — biblioteca (`src/js/renderer.js`)
-- Importar PDF (se copia a `userData/presentations/<id>.pdf` + entrada en `meta.json`).
-- Lista con **búsqueda**, **orden** (añadido reciente / abierto reciente / nombre ↑↓) y selección.
-- **Carpetas**: crear, borrar (mueve su contenido a raíz), mover presentación, breadcrumb, contadores, filtro.
-- **Renombrar** en línea (sidebar) y desde el título de detalle.
-- **Borrar** con modal de confirmación.
-- **Rejilla de miniaturas** con carga perezosa (`IntersectionObserver`, concurrencia limitada, liberación fuera de pantalla) y **badges** por diapositiva (tiene nota / tiene vídeo); botones rápidos "presentar" / "modo presentador" desde una diapositiva concreta.
-- **Importar notas .pptx** (valida que el nº de diapositivas coincide con el PDF).
-- **Visor de notas** a pantalla completa: canvas por diapositiva + textarea, sidebar de miniaturas, **undo/redo** (⌘Z / ⌘⇧Z), autoguardado, navegación con teclado, panel de notas redimensionable.
-- **Editor de vídeo** por diapositiva: URL de YouTube + posición (x,y,ancho,alto en %) con overlay arrastrable/redimensionable y miniatura de previsualización.
-- **Editar diapositivas** (rejilla para saltar al editor de vídeo).
-- **QR**, **Ajustes** (idioma), **info de detalle** (nº de páginas, notas, vídeos).
-
-### 1.2 Ventana de audiencia (`src/presentation.html`)
-Render de diapositiva a canvas (ajuste, DPR, cancelación de render en carrera),
-overlays de herramientas (linterna, dibujo, puntero, lupa con aumento),
-**overlay de vídeo YouTube** + sincronía de seek, **pantalla en negro**,
-**zoom de diapositiva** (⌘+rueda / pinch), barra de herramientas autoocultable
-(colores, tamaños, slider, QR, cast, fullscreen), atajos de teclado, tamaño por
-rueda, indicador de tamaño, y emisión de estado al servidor y al presentador.
-
-### 1.3 Ventana de presentador (`src/presenter.html`)
-Barra superior (nombre, ‹ contador ›, **temporizador** play/pausa/reset,
-pantalla negra, QR, cast, **reloj del sistema**, finalizar), diapositiva actual
-+ mismas herramientas (colores, tamaño, botones de aumento de lupa),
-**previsualización de la siguiente**, **notas del presentador** (con control de
-tamaño de fuente), **carrusel de miniaturas**, divisores redimensionables
-(vertical y horizontal), atajos, zoom de diapositiva, controles de vídeo + seek,
-sincronía de temporizador al servidor, y espejo de controles a la audiencia.
-
-### 1.4 Móvil (`src/mobile/`)
-Pantallas conectar / esperando / mando + toast de reconexión. WS con **PIN**,
-canvas de previsualización, notas (tamaño de fuente), **puntos** de diapositiva
-(ventana deslizante), prev/next, **swipe**, **carrusel**, **modo vista local**
-(adelantarse en las notas sin mover la audiencia), herramientas táctiles
-(→ audiencia + eco en la previsualización), **popup de tamaños** (por herramienta
-+ aumento de lupa + **volumen del sistema** + silenciar), **pinch-zoom** on/off,
-pantalla negra, alternar vídeo, temporizador (toca para pausar / reset), y **modo
-apaisado/pantalla completa** con su propia barra inferior.
-
-### 1.5 Proceso principal (`main.js` / `server.js`)
-Directorio de datos + `meta.json`; importar/borrar/leer PDF; abrir/cerrar
-ventanas con **detección de pantalla externa**; **power-save blocker**; limpieza
-de User-Agent (para que YouTube no bloquee a Electron); icono de dock; **selector
-de cast** (osascript, macOS); **volumen** get/set (osascript, macOS); **puente**
-`setElectronCallback` que traduce WS ↔ IPC; **PIN**; **QR**; servido de PDF con
-guardia anti-traversal.
+> Status: **plan for revision**, no code yet.
+> Objective agreed with the user (2026-07-20): **port the reference app
+> `~/Documents/GitHub/pdfpresenter`more or less accurately**, verify each
+> function one by one, cover with tests, and **adapt/improve design** for
+> integrate it into Nodus (centralised icons, clear/dark themes, rhythm of
+> spaced, i18n). The presentations live in a **global library of the
+> Toolkit** (agnostic vault, such as Convert/Protect).
 
 ---
 
-## 2. Cómo encaja en Nodus (lo que se reutiliza)
+## 1. What is the reference app (full inventory)
 
-| Necesidad | En Nodus |
+App Electron with **three windows + a mobile web**, coordinated by a local Express + WebSocket
+server. The whole state lives in a`currentState`which is broadcast by WS to customers and by IPC to
+windows.
+
+### 1.1 Main Window — Library (`src/js/renderer.js`)
+- Import PDF (copy to`userData/presentations/<id>.pdf`+ entry into`meta.json`).
+- List with **search**, **sorting** (recently added/recently opened/name ↑↓) and selection.
+- ** Folders**: create, delete (move your content to root), move presentation, breadcrumb, counters,
+  filter.
+- **Rename** online (sidebar) and from the detail title.
+- **Delete** with confirmation modal.
+- ** Miniature grid** with lazy load (`IntersectionObserver`, limited attendance, off-screen
+  release) and **badges** per slide (notes/has video); quick buttons "present" / "presenter mode"
+  from a specific slide.
+- **Import notes .pptx** (validates that the number of slides matches the PDF).
+- **Full-screen notes viewer**: slide canvas + textarea, thumbnail sidebar, **undo/redo** (⌘Z /
+  ⌘⇧Z), autosave, keyboard navigation, resizable notes panel.
+- **Video editor** per slide: YouTube URL + position (x,y,width,high in %) with dragable/resizeable
+  overlay and preview thumbnail.
+- **Edit slides** (screw to jump to the video editor).
+- **QR**, **Adjustments** (language), **detail info** (no pages, notes, videos).
+
+### 1.2 Audience window (`src/presentation.html`)
+Slide render to canvas (adjustment, DPR, cancellation of render in race), tool overlays (ilterna,
+drawing, pointer, magnifying magnifying magnifier), **overlay video YouTube** + seek synchrony,
+**black screen**, **slidezoom** (=rueda/pinch), auto-ocultable toolbar (colors, sizes, slider, QR,
+cast, fullscreen), keyboard shortcuts, wheel size, size indicator, and status emission to the server
+and presenter.
+
+### 1.3 Presenter window (`src/presenter.html`)
+Top bar (name, ‹ counter ›, **timer** play/pause/reset, black screen, QR, cast, **system clock**,
+finish), current slide
++ same tools (colours, size, magnifying magnifier buttons), **previsualization of the following**,
+  **host notes** (with font size control), **miniature carousel**, resizeable dividers (vertical and
+  horizontal), shortcuts, slide zoom, video controls + seek, timer synchrony to the server, and
+  monitor mirror to the audience.
+
+### 1.4 Mobile (`src/mobile/`)
+Displays connect / wait / command + reconnect toast. WS with **PIN**, preview canvas, notes (source
+size), ** slide points** (sliding window), prev/next, **swipe**, **carousel**, **local view mode**
+(advance in notes without moving the audience), touch tools (→ audience + echo in preview), **size
+popup** (per tool
++ magnifying of magnifying glass + **system volume** + mute), **pinch-zoom** on/off, black screen,
+  alternate video, timer (touch to pause / reset), and **pinch-zoom mode/complete screen** with its
+  own lower bar.
+
+### 1.5 Main process (`main.js` / `server.js`)
+Data directory +`meta.json`; import/delete/read PDF; open/close windows with **external screen
+detection**; **power-save blocker**; User-Agent cleaning (so YouTube does not block Electron); dock
+icon; **cast selector** (script, macOS); **volume**get/set (script, macOS);
+**bridge**`setElectronCallback`which translates WS ↔ IPC; **PIN**; **QR**; served as PDF with
+anti-traversal guard.
+
+---
+
+## 2. How it fits in Nodus (which is reused)
+
+| Need | In Nodus |
 |---|---|
-| Render PDF **offline** | `pdfjs-dist@4.8.69` **bundleado** + worker local (`src/components/materials/PdfViewer.tsx`, `src/lib/protect/engine.ts`). La referencia usa pdf.js por CDN — lo eliminamos. |
-| Tarjeta + navegación | `src/navigation.ts` ya declara `presenter` (`state:'soon'`). Se pasa a `'wip'` y el sidebar/hub la pintan solos. |
-| Patrón de vista con "volver" | `ToolkitConvertView.tsx`, `ToolkitProtectView.tsx`. |
-| Ventana secundaria | `electron/mascotWindow.ts` (crear/gestionar ciclo de vida de un `BrowserWindow`). |
-| Multi-entrada Vite | `vite.config.ts` ya construye `main` + `mascot`; añadiremos las entradas de audiencia/presentador/mando. |
-| IPC + preload del Toolkit | `electron/ipc.ts` (`h('toolkit:…')`), `electron/preload.ts` (`runToolkitJob`, `pickToolkitFiles`, …). |
-| Iconos centralizados | `src/components/ui.tsx` (`ICON_PATHS` + `<Icon>`). Sustituye los SVG en línea de la referencia. |
-| Zip (para .pptx) | `adm-zip` ya está (+ `@types/adm-zip`). **Sin `jszip`/`xml2js`.** |
-| IDs | `uuid` ya está. |
-| Jobs en 2º plano, i18n (8 idiomas), tema claro/oscuro | ya existen. |
+| Render PDF **offline** | `pdfjs-dist@4.8.69`**bundled** + local worker (`src/components/materials/PdfViewer.tsx`, `src/lib/protect/engine.ts`). The reference uses pdf.js by CDN — we delete it. |
+| Card + Navigation | `src/navigation.ts`already declares`presenter` (`state:'soon'`). It is moved to`'wip'`and the sidebar/hub paint it alone. |
+| View pattern with "come back" | `ToolkitConvertView.tsx`, `ToolkitProtectView.tsx`. |
+| Secondary window | `electron/mascotWindow.ts`(create/manage life cycle of a`BrowserWindow`). |
+| Multi-entry Vite | `vite.config.ts`You're building.`main` + `mascot`; we will add the audience/presenter/command entries. |
+| IPC + Toolkit preload | `electron/ipc.ts` (`h('toolkit:…')`), `electron/preload.ts` (`runToolkitJob`, `pickToolkitFiles`, …). |
+| Centralised icons | `src/components/ui.tsx` (`ICON_PATHS` + `<Icon>`) Replaces the online SVGs from the reference. |
+| Zip (for .pptx) | `adm-zip`already (+`@types/adm-zip`). **No`jszip`/`xml2js`.** |
+| IDs | `uuid`That's it. |
+| Jobs in 2nd plane, i18n (8 languages), clear/dark theme | They already exist. |
 
-**Dependencias nuevas (mínimas):** `ws` (servidor WebSocket, estándar y pequeño)
-y `qrcode` (generación de QR). Ambas puramente locales. *(Alternativa evaluada:
-implementar el handshake WS a mano sobre `http` nativo — descartado por frágil;
-QR propio sin dependencia — posible pero `qrcode` es más fiable.)*
+**New (minimum) dependencies:**`ws`(WebSocket server, standard and small) and`qrcode`(QR
+generation). Both are purely local. *(Alternative evaluated: implement handshake WS by hand
+on`http`native — discarded by fragile; own QR without dependence — possible but`qrcode`is more
+reliable.)*
 
 ---
 
-## 3. Decisiones de arquitectura
+## 3. Architecture decisions
 
-1. **Gestión = vista React dentro de Nodus.** `ToolkitPresenterView` (+ subcomponentes)
-   siguiendo el patrón Convert/Protect. Se voltea la tarjeta a `state:'wip'`.
+1. **Management = React view within Nodus.**`ToolkitPresenterView`(+ subcomponents) following the
+   Convert/Protect pattern. The card is flipped to`state:'wip'`.
 
-2. **Audiencia y presentador = `BrowserWindow` propios, entradas Vite dedicadas**
-   (`presenterAudience.html`, `presenterView.html`), que **reutilizan el preload
-   `preload.cjs`** y hablan con `main` por **IPC** (no por el servidor). Cargan
-   pdfjs bundleado y el tema/i18n de Nodus, pero **no** montan la app completa ni
-   tocan la base de datos (rendimiento: "presentaciones básicas que no colapsen").
-   Patrón de creación = `mascotWindow.ts`.
+2. **Audience and presenter =`BrowserWindow`own, dedicated Vite tickets** (`presenterAudience.html`,
+   `presenterView.html`), which **reusing preload`preload.cjs`** and talk to`main`by **IPC** (not
+   the server). They load pdfjs bundled and Nodus theme/i18n, but **do not** mount the complete app
+   or touch the database (performance: "basic presentations that do not
+   collapse").`mascotWindow.ts`.
 
-3. **Mando móvil = entrada Vite `presenterRemote.html`** construida a `dist/`,
-   **servida por el servidor local** al navegador del teléfono. No usa preload;
-   habla solo por **WebSocket + fetch**. pdfjs se le **sirve desde el servidor
-   local** (desde `node_modules/pdfjs-dist`) → 100 % offline.
+3. **Mobile command = entrance Vite`presenterRemote.html`** constructed to`dist/`, **served by the
+   local server** to the phone browser. It does not use preload; it speaks only by **WebSocket +
+   fetch**. pdfjs it is **served from the local server** (from`node_modules/pdfjs-dist`) → 100%
+   offline.
 
-4. **`main` es el hub.** Traduce controles WS (teléfono) ↔ IPC (ventanas), igual
-   que el `setElectronCallback` de la referencia. El estado canónico vive en un
-   reductor **Electron-free** (`presenterState.ts`) para poder testearlo.
+4. **`main`is the hub.** Translates WS controls (telephone) ↔ IPC (windows), just like
+   the`setElectronCallback`The canonical state lives in a reducer **Electron-free**
+   (`presenterState.ts`) in order to test it.
 
-5. **Almacenamiento global del Toolkit.** `app.getPath('userData')/toolkit/presenter/`:
-   PDFs internos como `<id>.pdf` + `library.json` (`{ presentations, folders }`).
-   Los formatos de presentación externos se convierten localmente mediante una
-   suite instalada, tras advertir de la pérdida de animaciones. Módulo
-   **Electron-free** `presenterLibrary.ts` (CRUD puro dada una ruta) + envoltura IPC.
-   Nunca se toca el original: se **copia** al importar (regla de oro del Toolkit).
+5. **Overall storage of Toolkit.**`app.getPath('userData')/toolkit/presenter/`: Internal PDFs
+   as`<id>.pdf` + `library.json` (`{ presentations, folders }`). External presentation formats are
+   converted locally using an installed suite, after warning of loss of animations. **Electron-free
+   module**`presenterLibrary.ts`(pure CRUD given a path) + IPC wrapper. Never touch the original: it
+   is **copy** when importing (Golden rule of the Toolkit).
 
-6. **El servidor solo existe mientras se presenta.** Se arranca al iniciar la
-   presentación y se apaga al terminarla. Escucha en `0.0.0.0` (necesario para el
-   teléfono) con **PIN de 6 dígitos** obligatorio para conexiones no-loopback.
-   La app avisa de que el mando es accesible en la red local mientras dure.
+6. **The server only exists while it is presented.** It starts when the presentation starts and is
+   turned off when it is finished.`0.0.0.0`(required for phone) with **6-digit PIN** required for
+   non-loopback connections. The app warns that the controller is accessible on the local network
+   for the duration.
 
-### 3.1 Superficie IPC nueva (`presenter:*`)
-Espejo del `preload`/`ipc` del Toolkit, p. ej.:
-`presenter:library:get|save`, `presenter:import:pick|file`, `presenter:import:pptxNotes`,
-`presenter:pdf:getData`, `presenter:delete`, `presenter:start` /
-`presenter:startPresenterMode` / `presenter:stop`, `presenter:server:info`,
-`presenter:control` (audiencia↔presentador↔servidor), `presenter:state:update`,
+### 3.1 New IPC area (`presenter:*`)
+Mirror of the`preload`/`ipc`Toolkit, e.g.:`presenter:library:get|save`,
+`presenter:import:pick|file`, `presenter:import:pptxNotes`, `presenter:pdf:getData`,
+`presenter:delete`, `presenter:start` / `presenter:startPresenterMode` / `presenter:stop`,
+`presenter:server:info`, `presenter:control`(audience-presenter~server),`presenter:state:update`,
 `presenter:timer:sync`, `presenter:cast:show`, `presenter:volume:get|set`.
 
 ---
 
-## 4. Diseño / "mejorar" (lo que NO es copia literal)
+## 4. Design / "improve" (which is NOT literal copy)
 
-- **Iconos:** sustituir los SVG en línea de la referencia por `<Icon>` centralizado.
-  `presentation` y `scanText` ya existen; se añaden a `ICON_PATHS` (trazo feather,
-  únicos, validados por el test del catálogo): `flashlight`, `pencil`/`draw`,
-  `pointer`, `magnifier`/`zoom`, `timer`, `monitor`/`cast`, `qr`, `blackScreen`,
-  `nextSlide`, etc.
-- **Acento de sección:** ámbar/bronce del Toolkit en el chrome de gestión (coherente
-  con Convert/Protect). Las ventanas de audiencia/presentador usan un tema oscuro
-  neutro (convención de presentaciones) pero coherente con la paleta de Nodus.
-- **Temas claro/oscuro:** cualquier utilidad nueva usada solo en dark necesita su
-  remap `.light .<utility>` en `index.css` (test de utilidades de tema claro).
-- **Ritmo de espaciado** e idioma como claves i18n (español primero) igual que el
-  resto de vistas. Cobertura en los 8 idiomas.
-- **Dropdowns** dentro de contenedores `overflow-hidden` → portal a `body` (landmine
-  de Databases/Convert).
-- **Landmine de spinners:** nunca `animate-spin` en el mismo elemento que un
-  `-translate-y-1/2` (el centrado va en un wrapper).
+- **Icons:** replace the online SVG of the reference
+  with`<Icon>`Centralized.`presentation`and`scanText`already exist; add to`ICON_PATHS`(feather
+  stroke, unique, validated by the catalog test):`flashlight`, `pencil`/`draw`, `pointer`,
+  `magnifier`/`zoom`, `timer`, `monitor`/`cast`, `qr`, `blackScreen`, `nextSlide`etc.
+- **Section accent:** amber/bronze Toolkit in the management chrome (coherent with
+  Convert/Protect).The audience/presenter windows use a neutral dark theme (convention of
+  presentations) but consistent with the Nodus palette.
+- **Clear/dark themes:**any new utility used only in dark needs its remap`.light
+  .<utility>`in`index.css`(light theme utility test).
+- **Space rhythm** and language as i18n keys (Spanish first) as well as other views. Coverage in all
+  8 languages.
+- **Dropdowns** inside containers`overflow-hidden`→ portal to`body`(landmine de Databases/Convert).
+- **Landmine de spinners:** never`animate-spin`in the same element as a`-translate-y-1/2`(center
+  goes in a wrapper).
 
 ---
 
-## 5. Fases (cada una: funciona en la app real + test de lógica pura)
+## 5. Phases (each: works in the real app + pure logic test)
 
-> **DoD por fase:** la función se verifica **en la app real** (no solo test) y su
-> lógica Electron-free tiene un test que asevera **contenido real** (no mera
-> existencia de fichero), al estilo de `scripts/test-toolkit-*.mjs`.
+> **DoD per phase:** the function is verified **in the real app** (not just test) and its
+> Electron-free logic has a test that asserts **real content** (not mere)
+> file existence), in the style of`scripts/test-toolkit-*.mjs`.
 
-### F0 — Andamiaje + biblioteca
+### F0 — Scaffolding + library
 - `navigation.ts`: `presenter` → `state:'wip'`.
-- `src/views/ToolkitPresenterView.tsx` + subcomponentes (biblioteca: importar,
-  lista, búsqueda, orden, carpetas, renombrar, mover, borrar, rejilla de
-  miniaturas con badges, detalle).
-- `electron/toolkit/presenter/library.ts` (**Electron-free**: CRUD de
-  `library.json`, colisión de nombres, mover a carpeta, borrado).
-- IPC `presenter:library:*`, `presenter:import:pick|file`, `presenter:pdf:getData`,
-  `presenter:delete` + preload.
-- Miniaturas: reutilizar el motor perezoso de la referencia (IntersectionObserver
-  + concurrencia + liberación), portado a React con pdfjs bundleado.
-- **Tests:** `test-presenter-library.mjs` (crear/mover/borrar/colisión, backward-compat).
-- **Verificar:** importar un PDF y un PowerPoint reales, verlos en la lista con
-  miniaturas y comprobar la conversión y las notas.
+- `src/views/ToolkitPresenterView.tsx`+ subcomponents (library: import, list, search, order,
+  folders, rename, move, delete, thumbnail grid with badges, detail).
+- `electron/toolkit/presenter/library.ts`(**Electron-free**: CRUD of`library.json`, name collision,
+  move to folder, delete).
+- IPC`presenter:library:*`, `presenter:import:pick|file`, `presenter:pdf:getData`,
+  `presenter:delete`+ preload.
+- Thumbnails: reuse the reference sloth engine (IntersectionOsserver
+  + continuance + release), ported to React with pdfjs bundled.
+- **Tests:**`test-presenter-library.mjs`(create/move/delete/collision, backward-compat).
+- **Check:** import a real PDF and PowerPoint, view them in the thumbnail list and check the
+  conversion and notes.
 
-### F1 — Notas del presentador (núcleo pedido explícitamente)
-- Visor de notas a pantalla completa: canvas + textarea por diapositiva, sidebar
-  de miniaturas, **undo/redo**, autoguardado, navegación por teclado, panel
-  redimensionable.
-- **Importar notas .pptx**: `electron/toolkit/presenter/pptxNotes.ts`
-  (**Electron-free**, `adm-zip` + extractor de `<a:t>`/`<a:br>` por regex, sin
-  `xml2js`); valida nº de diapositivas.
-- **Tests:** `test-presenter-notes.mjs` — parsea un `.pptx` de fixture real y
-  asevera el texto de notas por diapositiva (incluidos saltos de línea) + el
-  reductor de undo/redo.
-- **Verificar:** escribir/editar/undo notas; importar un `.pptx` real.
+### F1 — Notes by the presenter (core explicitly requested)
+- Full-screen note viewer: canvas + texture per slide, miniature sidebar, **undo/round**,
+  self-saved, keyboard navigation, resizeable panel.
+- **Import notes .pptx**:`electron/toolkit/presenter/pptxNotes.ts`(**Electron-free**,`adm-zip`+
+  extractor of`<a:t>`/`<a:br>`by regex, without`xml2js`); validates no slides.
+- **Tests:**`test-presenter-notes.mjs`— parsea un`.pptx`real fixture and asserts the text of notes
+  per slide (including line breaks) + the undo/round reducer.
+- **Check:** type/edit/undo notes; import a`.pptx`real.
 
-### F2 — Ventanas de audiencia y presentador (sin móvil)
-- Entradas Vite `presenterAudience.html` / `presenterView.html` + su código
-  (React lean, canvas, sin DB).
-- `electron/toolkit/presenter/windows.ts`: creación con **detección de pantalla
-  externa** (`screen.getAllDisplays`), fullscreen, power-save blocker, ciclo de
-  vida (cerrar una cierra la otra), patrón `mascotWindow.ts`.
-- Render seguro (cancelación por generación, DPR, ajuste), siguiente diapositiva,
-  **temporizador**, **reloj**, **carrusel**, **pantalla negra**, **zoom de
-  diapositiva**, navegación por teclado, divisores redimensionables.
-- `electron/toolkit/presenter/presenterState.ts` (**Electron-free**: reductor de
-  navegar/timer/black-screen/zoom con clamping).
-- Bridge IPC audiencia↔presentador por `main`.
-- **Tests:** `test-presenter-state.mjs` (clamp de diapositiva, deriva de
-  temporizador, transiciones).
-- **Verificar:** iniciar presentación + modo presentador (con 1 y con 2 pantallas
-  si es posible); navegar, timer, negro, zoom.
+### F2 — Audience windows and presenter (without mobile phone)
+- Vite Tickets`presenterAudience.html` / `presenterView.html`+ your code (React read, canvas, no
+  DB).
+- `electron/toolkit/presenter/windows.ts`: creation with **external screen detection**
+  (`screen.getAllDisplays`), fullscreen, power-save blocker, life cycle (closing one closes the
+  other), pattern`mascotWindow.ts`.
+- Secure render (cancellation per generation, DPR, adjustment), next slide, **timer**, **clock**,
+  **carousel**, **blackscreen**, **slidezoom**, keyboard navigation, resizeable dividers.
+- `electron/toolkit/presenter/presenterState.ts`(**Electron-free**:
+  navigator/timer/black-screen/zoom with clamping).
+- Audience ↔ presenter IPC bridge through `main`.
+- **Tests:**`test-presenter-state.mjs`(slide clamp, timer drift, transitions).
+- **Check:** start presentation + presenter mode (with 1 and 2 screens if possible); navigate,
+  timer, black, zoom.
 
-### F3 — Herramientas de anotación
-- Linterna, dibujo (colores + tamaño), puntero, lupa (con aumento), sincronizadas
-  audiencia↔presentador por IPC. Tamaño por slider / rueda / "tips".
-- **Verificar:** cada herramienta, visualmente, en ambas ventanas.
+### F3 — Annotation tools
+- Flashlight, drawing (colors + size), pointer, magnifying magnifier, synchronized
+  audience ↔ presenter via IPC. Size controlled by slider/wheel/keyboard shortcuts.
+- **Check:** each tool, visually, in both windows.
 
-### F4 — Servidor + mando móvil (mayor superficie nueva)
-- `electron/toolkit/presenter/server.ts`: `http` nativo + `ws`, `0.0.0.0`, puerto
-  escaneado, **PIN**, arranque/parada atados a presentar. Sirve `/remote` (entrada
-  Vite `presenterRemote.html` construida), `/api/pdf/:id` (con guardia
-  anti-traversal), `/api/qr`, `/api/state`, y pdfjs desde `node_modules`.
-- Entrada Vite `presenterRemote.html` + su código: conectar/esperando/mando,
-  navegación, notas, puntos, carrusel, swipe, **modo vista local**, herramientas
-  táctiles, **popup de tamaños**, pinch-zoom, pantalla negra, temporizador,
-  **modo apaisado/fullscreen**.
-- Puente servidor↔IPC en `main` (traduce controles del teléfono a las ventanas).
-- Deps nuevas: `ws`, `qrcode`.
-- **Tests:** `test-presenter-server.mjs` (reductor de estado, autenticación por PIN,
-  guardia de ruta de `/api/pdf`) — Electron-free.
-- **Verificar:** escanear el QR con el teléfono (o abrir la URL LAN en otra
-  pestaña); navegar, ver notas, herramientas, timer, modo local.
+### F4 — Server + mobile controller (larger new surface area)
+- `electron/toolkit/presenter/server.ts`: `http`native +`ws`, `0.0.0.0`, scanned port, **PIN**,
+  start/stop tied to present.`/remote`(Entrada
+  Vite`presenterRemote.html`constructed),`/api/pdf/:id`(with anti-traversal guard),`/api/qr`,
+  `/api/state`, and pdfjs from`node_modules`.
+- Vite Entry`presenterRemote.html`+ your code: connect/waiting/command, navigation, notes, points,
+  carousel, swipe, **local view mode**, touch tools, **popup sizes**, pinch-zoom, black screen,
+  timer, **paisado/fullscreen mode**.
+- Server ↔IPC bridge in`main`(translates phone controls to windows).
+- New Deps:`ws`, `qrcode`.
+- **Tests:**`test-presenter-server.mjs`(state reducer, PIN authentication, route guard`/api/pdf`) —
+  Electron-free.
+- **Check:** scan the QR with your phone (or open the LAN URL in another tab); browse, view notes,
+  tools, timer, local mode.
 
-### F5 — Vídeos de YouTube
-- Editor de vídeo por diapositiva (posición/redimensión con overlay), overlay en
-  audiencia, **sincronía de play/pausa y seek** entre ventanas y móvil, limpieza
-  de User-Agent para YouTube.
-- **Verificar:** insertar un vídeo, reproducir/pausar/seek desde presentador y móvil.
+### F5 — YouTube videos
+- Video editor by slide (position/resize with overlay), overlay in audience, **play/pause synchrony
+  and seek** between windows and mobile, User-Agent cleaning for YouTube.
+- **Check:** insert a video, play/pause/seek from presenter and mobile.
 
-### F6 — Extras macOS + pulido + integración
-- **Volumen** (osascript, macOS), **cast/AirPlay** (osascript, macOS) — gated a
-  darwin, no-op elegante en otros SO; icono de dock; indicador de tamaño; ajustes.
-- **Integración de shell:** i18n en los 8 idiomas, remaps de tema claro, iconos
-  nuevos en el catálogo, entrada en `WhatsNewModal`, doc para Nodi
-  (`shared/nodiDocumentation.ts`), comandos en `CommandPalette`.
-- **Verificar:** suite completa (`npm test`) y build (`test:e2e`) en verde.
+### F6 — MacOS extras + polishing + integration
+- **Volume** (script, macOS), **cast/AirPlay** (script, macOS) — gated a Darwin, non-op elegant in
+  other OS; dock icon; size indicator; adjustments.
+- **Shell integration:** i18n in the 8 languages, light theme rivets, new icons in the catalog,
+  entry into`WhatsNewModal`, doc for Nodi (`shared/nodiDocumentation.ts`), commands
+  in`CommandPalette`.
+- **Verify:** full suite (`npm test`) and build (`test:e2e`) in green.
 
-### F7 — Auditoría de rendimiento (PDFs enormes)
-Garantizar que **ni con un PDF de cientos de diapositivas** la herramienta cuelga
-o colapsa el ordenador. Se audita, se mide y se corrige.
-- **Miniaturas:** confirmar que la rejilla (gestión), el carrusel (presentador) y
-  los puntos/carrusel (móvil) **nunca renderizan todas las páginas a la vez** —
-  carga perezosa por `IntersectionObserver`, concurrencia limitada y **liberación
-  de canvas fuera de pantalla** (los canvas fuera de vista se ponen a 0×0 para no
-  retener memoria). Medir memoria con 300–500 diapositivas.
-- **Render de diapositiva:** cancelación por generación al navegar rápido (no
-  acumular tareas pdfjs), `page.cleanup()` tras cada render, y un solo documento
-  pdfjs por ventana (destruir el anterior).
-- **Bucle de eventos de `main`:** el servidor/serialización de estado no debe
-  bloquear el hilo principal (landmine histórica de Nodus: `main` es un único
-  event loop). El broadcast WS y el puente IPC deben ser O(nº de clientes), no
-  O(nº de diapositivas).
-- **Navegación con teclado mantenida** (flecha derecha sostenida) no debe encolar
-  renders sin fin: coalescencia/última-gana.
-- **Método de medición:** contar trabajo con un proxy (nº de renders lanzados,
-  canvas vivos, round-trips) **en vez de asertar milisegundos de reloj** (landmine
-  del harness: los tests paralelos hacen que el tiempo de pared mienta). Un
-  `scripts/test-presenter-perf.mjs` que, sobre un PDF sintético de N=400 páginas,
-  asevere que abrir la biblioteca lanza ≤ concurrencia renders y que navegar 50
-  veces deja ≤ K canvas vivos.
-- **Verificar:** abrir un PDF real grande, hacer scroll a fondo, navegar rápido y
-  presentar; observar memoria y fluidez (la captura, no solo los números).
+### F7 — Performance audit (massive PDFs)
+Ensure that **ni with a PDF of hundreds of slides** the tool hangs or collapses the computer. It is
+audited, measured and corrected.
+- **Minatures:** confirm that grid (management), carousel (presenter) and points/carousel (mobile)
+  **never render all pages at once** — lazy load by`IntersectionObserver`, limited attendance and
+  **freezing of out-of-screen canvas** (out-of-view canvas are set to 0×0 to not retain memory).
+  Measure memory with 300–500 slides.
+- **Slide render:** cancellation per generation when sailing fast (do not accumulate pdfjs
+  tasks),`page.cleanup()`after each render, and a single pdfjs document by window (destroy the
+  previous one).
+- **Bucle de eventos de`main`:** the server/status serialization should not block the main thread
+  (Nodus historical landmine:`main`The broadcast WS and the IPC bridge must be O(no customers), not
+  O(no slides).
+- **Browsing with keyboard held** (right arrow held) should not glue endless renders:
+  coalescence/last-gain.
+- **Method of measurement:** count on work with a proxy (no released renders, live canvas,
+  round-trips) ** instead of asserting milliseconds of clock** (harness-landmine: parallel tests
+  make wall time lie).`scripts/test-presenter-perf.mjs`that, on a synthetic PDF of N=400 pages,
+  assevere that opening the library launches ≤ concurrent renders and that navigating 50 times
+  leaves ≤ K canvas alive.
+- **Verify:** Open a large real PDF, scroll in depth, navigate fast and present; observe memory and
+  fluidity (capture, not just numbers).
 
 ---
 
-## 6. Riesgos y landmines conocidas
-- **El servidor expone la LAN.** Única superficie con implicación de seguridad:
-  PIN obligatorio, apagado al terminar, aviso claro. El resto de servidores de
-  Nodus (copilot, MCP) son solo-localhost por diseño; este es la excepción
-  justificada por el mando móvil.
-- **Rendimiento.** Reutilizar la cancelación de render por generación, el DPR y la
-  carga perezosa/por lotes de la referencia; las ventanas no montan la app ni la
-  DB. Objetivo del usuario: "que no colapsen el ordenador".
-- **Tema oscuro por defecto** en las ventanas; cualquier utilidad dark-only necesita
-  su remap `.light`.
-- **`test:e2e` NO reconstruye** (dist obsoleto miente en migraciones): recordar
-  `npm run build` antes de e2e si toca algo compilado.
-- **pdfjs para el teléfono** debe servirse desde el servidor local (no CDN) para
-  mantener el principio offline.
-- **YouTube requiere red** (no es offline) — es la única función que sale a
-  Internet; el resto de la herramienta funciona sin conexión.
+## 6. Known risks and landmines
+- **The server exposes the LAN.** Unique surface with security implication: mandatory PIN, off at
+  completion, clear warning. The rest of Nodus servers (copilot, MCP) are single-localhost by
+  design; this is the exception justified by the mobile controller.
+- **Return.**Reuse the cancellation of render per generation, the DPR and the lazy/lot load of the
+  reference; the windows do not mount the app or DB.User objective: "don't collapse the computer".
+- **Default dark theme** on windows; any dark-only utility needs its remap`.light`.
+- **`test:e2e`DO NOT reconstruct** (dist obsolete lies in migrations): remember`npm run build`before
+  e2e if you touch something compiled.
+- **pdfjs for the phone** must be used from the local server (not CDN) to maintain the offline
+  principle.
+- **YouTube requires network** (it's not offline) — it's the only function that comes out on the
+  Internet; the rest of the tool runs offline.
 
 ---
 
-## 7. Entregable de esta fase
-Este documento. A la espera de tu visto bueno (o ajustes de orden/alcance de
-fases) antes de escribir código. Sugerencia: empezar por **F0 + F1** (biblioteca
-+ notas del presentador, que es lo que más te importa) y verificarlas juntas antes
-de seguir con las ventanas.
+## 7. Deliverable from this phase
+This document. Pending your approval (or order/phase range settings) before writing code.
+Suggestion: start with **F0 + F1** (library
++ presenter notes, which is what matters most to you) and verify them together before continuing
+  with the windows.

--- a/design/sync-hardening-phase2.md
+++ b/design/sync-hardening-phase2.md
@@ -1,191 +1,185 @@
-# Sincronización: borrados, cifrado y relojes
+# Synchronization: deleted, encrypted and clocks
 
-Propuesta de diseño · 2026-07-19 · continúa `backup-recovery-audit.md`
+Design proposal · 2026-07-19 · continues `backup-recovery-audit.md`
 
-Los tres puntos que quedaron conscientemente fuera de la primera corrección. No son
-independientes: **el mismo mecanismo que hace seguros los borrados hace seguro el sesgo
-de reloj**, así que conviene decidirlos juntos.
-
----
-
-## Principio rector
-
-Hoy la fusión es *newest-wins destructivo*: la versión que pierde la comparación
-desaparece sin dejar rastro. Eso es aceptable cuando los relojes coinciden y nadie borra
-nada; deja de serlo en cuanto una de las dos cosas falla.
-
-La propuesta se apoya en una sola idea:
-
-> **Que la fusión deje de destruir.** Si toda versión perdedora se conserva y se puede
-> recuperar, entonces un reloj mal puesto, un borrado a destiempo o una resolución
-> equivocada dejan de ser pérdida de datos y pasan a ser una decisión revisable.
-
-Con esa base, los tres problemas se vuelven tratables sin reescribir la app.
+The three points that were consciously left out of the first correction. They are not independent:
+**The same mechanism that makes the erased secure makes the clock bias** safe, so it is appropriate
+to decide them together.
 
 ---
 
-## 1 · Borrados (tombstones)
+## Guiding principle
 
-### El comportamiento actual
+Today the fusion is *newest-wins destructive*: the version that loses the comparison disappears
+without leaving a trace. That is acceptable when the clocks match and nobody erases anything; it
+ceases to be as soon as one of the two things fails.
 
-Notas, carpetas, búsquedas, borradores, veredictos y bases de datos se borran en duro.
-Al importar cualquier paquete anterior al borrado, la rama `INSERT` los revive con sus
-marcas originales — y lo repetirá en cada sincronización, en ambos sentidos.
-**No hay forma de borrar nada de manera definitiva entre dos equipos.**
+The proposal is based on a single idea:
 
-Las entidades de estudio son la excepción correcta: usan `deleted_at`, así que el borrado
-es una actualización y se propaga sola.
+> **Let the merger stop destroying.** If every losing version is preserved and can
+> recover, then a misplaced clock, a timeless erasing or a resolution
+> They cease to be data loss and become a reviewable decision.
 
-### Diseño propuesto
+On that basis, the three problems become treatable without rewriting the app.
 
-**Una tabla de lápidas, alimentada por triggers.**
+---
+
+## 1 · Deleted (tombstones)
+
+### Current behaviour
+
+Notes, folders, searches, drafts, verdicts and databases are deleted hard. When importing any
+package prior to deletion, the `INSERT` branch revives them with its original marks — and repeats it
+in each synchronization, in both directions. **There is no way to permanently delete anything
+between two computers.**
+
+Study entities are the correct exception: they use `deleted_at`, so deletion is an update and
+spreads itself.
+
+### Proposed design
+
+**A tablet board, powered by triggers.**
 
 ```sql
 CREATE TABLE sync_tombstones (
   table_name TEXT NOT NULL,
-  row_key    TEXT NOT NULL,          -- clave de identidad serializada
+  row_key    TEXT NOT NULL,          -- serialized identity key
   deleted_at TEXT NOT NULL,
   PRIMARY KEY (table_name, row_key)
 );
 ```
 
-Los triggers se generan **desde el registro de grupos de sync**, no a mano, en cada
-apertura de la base (`ensureTombstoneTriggers()`). Así una tabla nueva queda cubierta por
-el mismo mecanismo que ya obliga a clasificarla, y no hay forma de olvidarse.
+Triggers are generated ** from the recording of sync groups**, not by hand, in each opening of the
+base (`ensureTombstoneTriggers()`). Thus a new table is covered by the same mechanism that already
+forces to classify it, and there is no way to forget.
 
-> Verificado sobre la librería que usa la app: un `DELETE` en cascada **sí** dispara los
-> `AFTER DELETE` de las tablas hijas, con y sin `recursive_triggers`. Los triggers, por
-> tanto, capturan también los borrados en cascada — no hace falta razonar sobre árboles.
+> Checked on the library using the app: a `DELETE` cascaded **yes** shoots the
+> `AFTER DELETE` of the child tables, with and without `recursive_triggers`. The triggers, by
+> so much, they also capture those erased by waterfall — there is no need to reason on trees.
 
-**Reglas de fusión** (last-writer-wins, tratando el borrado como una escritura más):
+**Full Rules** (last-writer-wins, treating the deleted as one more writing):
 
-| Situación | Resultado |
+| Status | Outcome |
 |---|---|
-| Llega una fila desconocida y hay lápida con `deleted_at >= updated_at` | No se inserta. Se borró después de escribirse. |
-| Llega una fila desconocida y hay lápida con `deleted_at < updated_at` | Se inserta y se retira la lápida: el otro equipo la editó *después* del borrado, y esa edición es la última palabra. |
-| Llega una lápida más nueva que la fila local | Se borra la fila local y se guarda la lápida. **La fila borrada va a `sync_superseded`** (§4): un borrado remoto nunca destruye trabajo local sin retorno. |
-| Llega una lápida más antigua que la fila local | Se descarta: la fila se editó después de que el otro la borrara. |
+| An unknown row arrives and there is a tombstone with `deleted_at >= updated_at` | It was deleted after writing. |
+| An unknown row arrives and there is a tombstone with `deleted_at < updated_at` | The tombstone is inserted and removed: the other computer edited it *after* the deletion, and that edition is the last word. |
+| A newer tombstone arrives than the local row | The local row is deleted and the tombstone is saved. **The deleted row goes to `sync_superseded`** (§4): a remote deletion never destroys local work without return. |
+| There comes a tombstone older than the local row | It is discarded: the row was edited after the other one deleted it. |
 
-Las lápidas viajan en el paquete como una tabla más.
+The tombstones travel in the package as one more table.
 
-### El problema real: la recolección de lápidas
+### The real problem: tombstone collection
 
-Una lápida no puede vivir para siempre, y si se recoge antes de que un equipo rezagado
-sincronice, la fila resucita. Es una limitación inherente a la sincronización por
-ficheros, no un descuido.
+A tombstone cannot live forever, and if it is collected before a team lags behind syncs, the row
+resurrects. It is an inherent limitation to file synchronization, not an oversight.
 
-Propuesta: **horizonte de 180 días**, y —esto es lo importante— al importar un paquete
-construido hace más de ese horizonte, **avisar explícitamente** de que los borrados
-antiguos pueden reaparecer. El límite deja de ser una trampa silenciosa y pasa a ser
-información.
+Proposal: ** 180-day horizon**, and — this is important — when importing a package built more than
+that horizon, ** explicitly warn** that old erasers can reappear. The limit ceases to be a silent
+trap and becomes information.
 
 ---
 
-## 2 · Cifrado del `.nodussync`
+## 2 · Encryption of `.nodussync`
 
-### El comportamiento actual
+### Current behaviour
 
-Zip en claro. Contiene cuerpos de notas, documentos de estudio, calificaciones, evidencia
-genealógica y adjuntos. Convive en Ajustes con la copia cifrada por contraseña maestra,
-sin advertir de la asimetría.
+Zip in clear. It contains bodies of notes, study papers, grades, genealogical evidence and
+attachments. It lives in Settings with the copy encrypted by master password, without warning of
+asymmetry.
 
-### Diseño propuesto
+### Proposed design
 
-**Cifrar siempre. Sin casilla de «sin cifrar».** Una opción de conveniencia en claro es
-exactamente el camino por el que se filtran estos ficheros.
+**Always Encrypt. No "unencrypted" box.** A clear convenience option is exactly the way these files
+are filtered.
 
-Reutilizando las primitivas ya auditadas de `backupCrypto.ts` (scrypt N=32768 +
-AES-256-GCM), con un cambio necesario: **derivar la clave una sola vez**, no por entrada.
-scrypt cuesta ~100 ms; aplicado a 500 entradas serían casi un minuto. Se añaden
-`deriveBackupKey()` y `encryptWithKey()/decryptWithKey()` al módulo existente.
+Reusing the already audited primitives of `backupCrypto.ts` (scrypt N=32768 + AES-256-GCM), with a
+necessary change: **derivate the key once**, not per input. scrypt costs ~100 ms; applied to 500
+entries would be almost a minute. `deriveBackupKey()` and `encryptWithKey()/decryptWithKey()` are
+added to the existing module.
 
-**Estructura (formato v3)** — preserva la propiedad que arregló el límite de tamaño:
+**Structure (format v3)** — preserves the property that fixed the size limit:
 
 ```
-manifest.json     ← en claro: formato, versión, fecha, schemaVersion, parámetros KDF
-index.bin         ← cifrado: qué entrada corresponde a cada tabla y a cada blob
+manifest.json     ← plaintext: format, version, date, schemaVersion, KDF parameters
+index.bin         ← encrypted: which entry corresponds to each table and blob
 <id opaco>        ← cifrado: IV(12) ‖ authTag(16) ‖ ciphertext, uno por tabla y por blob
 ```
 
-Cada entrada se cifra por separado con su propio IV. **No hay ningún punto en el que el
-paquete entero exista como un solo búfer**, que es justo lo que hacía imposible
-sincronizar bóvedas grandes. Los nombres de tabla viven en `index.bin` cifrado, así que
-el fichero no revela que contiene, por ejemplo, calificaciones.
+Each entry is encrypted separately with its own IV. **There is no point at which the entire package
+exists as a single buffer**, which is just what made it impossible to synchronize large vaults.
+Table names live in `index.bin` encrypted, so the file does not reveal that it contains, for
+example, ratings.
 
-`schemaVersion` queda fuera a propósito: permite rechazar un paquete de una versión más
-reciente **sin pedir la contraseña**, que es mejor experiencia y no revela nada.
+`schemaVersion` is out on purpose: it allows you to reject a package from a newer version ** without
+asking for the password**, which is better experience and reveals nothing.
 
-### La credencial: aquí está la decisión de diseño
+### The credential: here is the design decision
 
-La exportación manual `.nodus` genera una clave aleatoria de un solo uso. **Para sync eso
-sería un error**: es una operación *recurrente*, y copiar una clave nueva en cada
-exportación se abandona a la tercera vez.
+Manual export `.nodus` generates a random single-use key. **For sync that would be an error**: it is
+a *recurrent* operation, and copying a new key on each export is abandoned the third time.
 
-Tampoco sirve reutilizar la contraseña maestra de copias: tras una restauración con clave
-de recuperación, Nodus **genera una contraseña maestra nueva y aleatoria**, así que los
-dos equipos tendrían credenciales distintas y el sync fallaría sin motivo aparente.
+It is also useless to reuse the master copy password: after a recovery key restoration, Nodus **
+generates a new, random master password**, so the two teams would have different credentials and the
+sync would fail for no apparent reason.
 
-Propuesta: **una «frase de sincronización» propia**, que el usuario fija una vez y
-escribe en ambos equipos. Se guarda con `safeStorage` como las demás. La exportación se
-niega si no está configurada; la importación la usa automáticamente y solo pregunta si no
-descifra. Explícita, estable, sin acoplarse al ciclo de vida de las copias.
+Proposal: **a proper "sync" phrase**, which the user fixes once and writes on both computers. It is
+saved with `safeStorage` like the others. Export is denied if it is not configured; import uses it
+automatically and only asks if it does not decrypt. Explicit, stable, without attaching to the life
+cycle of copies.
 
-Compatibilidad: se siguen **leyendo** paquetes v1 y v2 en claro; solo se **escribe** v3.
-
----
-
-## 3 · Sesgo de reloj
-
-### El comportamiento actual
-
-El ganador se decide comparando `updated_at` como cadenas. Un equipo con el reloj
-atrasado pierde **todas** las comparaciones, siempre, en silencio, y el resumen lo
-presenta como `skipped`, indistinguible de «ya estaba al día».
-
-### Lo que se puede y lo que no se puede detectar
-
-Conviene ser honesto: con paquetes de fichero en un solo sentido **no se puede medir el
-desfase de relojes**. Un paquete con fecha de hace tres días puede ser un paquete
-genuinamente antiguo o un reloj atrasado tres días; no hay forma de distinguirlos sin un
-viaje de ida y vuelta.
-
-Sí es detectable **una** dirección, que además es la peligrosa:
-
-- Fecha del paquete o marcas de fila **en el futuro** respecto al reloj local ⇒ el reloj
-  del emisor va adelantado. Ese equipo ganaría todas las comparaciones.
-
-La dirección contraria (emisor atrasado) es indistinguible de un paquete viejo.
-
-### Diseño propuesto: tres capas
-
-**Capa 1 — detectar lo detectable.** Si el paquete o sus filas vienen del futuro, avisar;
-si el desfase supera las 24 h, exigir confirmación explícita antes de fusionar.
-
-**Capa 2 — comparar sobre una línea temporal común.** Cuando se detecta un adelanto
-consistente, compensar las marcas entrantes por el desfase medido **solo a efectos de
-comparación**, sin reescribir nada, y registrar que se hizo.
-
-**Capa 3 — y esta es la que de verdad resuelve el problema — no destruir nunca al
-perdedor** (§4). Aunque un reloj mal puesto resuelva mal un conflicto, la versión que
-pierde se conserva y se puede recuperar. El sesgo de reloj deja de ser pérdida de datos y
-pasa a ser una resolución subóptima, revisable.
-
-### La alternativa de libro, y por qué no la recomiendo ahora
-
-Lo correcto en teoría son relojes lógicos por fila (Lamport/HLC): cada escritura
-incrementa un contador y la comparación deja de depender del reloj de pared.
-
-El coste real en este código: **una columna nueva en ~60 tablas** y tocar **todas** las
-rutas de escritura de ~70 repositorios, porque hoy cada una hace `updated_at = now()` por
-su cuenta. Es un cambio grande, transversal y con mucha superficie de regresión, para
-resolver un problema que la capa 3 vuelve inofensivo.
-
-Mi recomendación es hacer las tres capas ahora y dejar los relojes lógicos como evolución
-posterior: **`sync_superseded` es precisamente la base sobre la que se construirían**.
+Compatibility: still **read** packages v1 and v2 in clear; only **write** v3.
 
 ---
 
-## 4 · La pieza común: `sync_superseded`
+## 3 · Watch bias
+
+### Current behaviour
+
+The winner is chosen by comparing `updated_at` as strings. A team with the back clock loses **all**
+comparisons, always, silently, and the summary presents it as `skipped`, indistinguishable from
+"already up to date".
+
+### What can and cannot be detected
+
+You should be honest: with one-way file packages ** you can't measure the clock lag**. A
+three-day-old package can be a genuinely old package or a three-day-long clock; there's no way to
+distinguish them without a round trip.
+
+Yes it is detectable ** one** address, which is also the dangerous one:
+
+- Package date or row marks **in the future** with respect to the local clock the transmitter clock
+  is ahead. That team would win all comparisons.
+
+The opposite direction (retarded transmitter) is indistinguishable from an old package.
+
+### Proposed design: three layers
+
+**Capa 1 — detect the detectable.** If the package or its rows come from the future, warn; if the
+lag exceeds 24 h, require explicit confirmation before merging.
+
+**Capa 2 — compare over a common time line.** When a consistent advance is detected, compensate
+incoming marks for the time lag measured **only for comparison purposes**, without rewriting
+anything, and record that it was made.
+
+**Capa 3 — and this is the one that really solves the problem — never destroy the loser** (§4). Even
+if a misplaced watch missolves a conflict, the version that loses is preserved and can be recovered.
+Watch bias ceases to be data loss and becomes a suboptimal, reviewable resolution.
+
+### The book alternative, and why I don't recommend it now
+
+The correct thing in theory is logical clocks per row (Lamport/HLC): each writing increases a
+counter and the comparison ceases to depend on the wall clock.
+
+The actual cost in this code: **a new column in ~60 tables** and touch **all the write paths of ~70
+repositories, because today each makes `updated_at = now()` on its own. It is a big, cross-sectional
+change with a lot of regression surface, to solve a problem that layer 3 becomes harmless.
+
+My recommendation is to make the three layers now and leave the logical clocks as later evolution:
+**`sync_superseded` is precisely the basis on which they would be built**.
+
+---
+
+## 4 · The common piece: `sync_superseded`
 
 ```sql
 CREATE TABLE sync_superseded (
@@ -193,7 +187,7 @@ CREATE TABLE sync_superseded (
   table_name    TEXT NOT NULL,
   row_key       TEXT NOT NULL,
   origin        TEXT NOT NULL,   -- 'incoming-lost' | 'local-overwritten' | 'deleted-remotely'
-  row_json      TEXT NOT NULL,   -- la fila, sin columnas BLOB
+  row_json      TEXT NOT NULL,   -- row, no BLOB columns
   row_stamp     TEXT,
   winner_stamp  TEXT,
   package_date  TEXT,
@@ -201,179 +195,170 @@ CREATE TABLE sync_superseded (
 );
 ```
 
-Se escribe en **tres** situaciones, y la segunda es la más importante:
+It is written in **three** situations, and the second is the most important:
 
-1. La fila entrante pierde y su contenido difiere de la local (`incoming-lost`).
-2. La fila entrante gana y **sobrescribe** trabajo local distinto (`local-overwritten`)
-   ← el caso que hoy destruye trabajo del usuario sin dejar rastro.
-3. Una lápida remota borra una fila local (`deleted-remotely`).
+1. The incoming row loses and its content differs from the local one (`incoming-lost`).
+2. The incoming row wins and **overwrites** different local work (`local-overwritten`) ← the case
+   that today destroys user work without leaving a trace.
+3. A remote headstone deletes a local row (`deleted-remotely`).
 
-**Limitación honesta:** no se guardan las columnas BLOB (adjuntos, grabaciones, retratos).
-Duplicarlas multiplicaría el tamaño de la base. Para esas columnas se conserva la fila y
-un marcador, no los bytes. Recolección a los 90 días.
+** Honest limitation:** the BLOB columns (attaches, recordings, portraits) are not saved. Duplicate
+them would multiply the size of the base. For those columns the row and a marker are kept, not
+bytes. Collection at 90 days.
 
-**Superficie de usuario:** en Ajustes → Sincronización, «N versiones sustituidas»,
-con vista de detalle y acción de restaurar. Sin esa vista, la tabla es solo consuelo.
+**User surface:** in Settings → Synchronization, "N substituted versions", with view of detail and
+action to restore. Without that view, the table is just comfort.
 
 ---
 
-## Fases propuestas
+## Proposed phases
 
-| Fase | Contenido | Riesgo |
+| Phase | Content | Risk |
 |---|---|---|
-| **F1** ✅ | `sync_superseded` + registro en las tres situaciones + vista en Ajustes | Bajo. No cambia ninguna resolución, solo deja de destruir. |
-| **F2** ✅ | Tombstones: tabla, triggers generados, reglas de fusión, horizonte y aviso | Medio. Cambia el comportamiento observable del borrado. |
-| **F3** ✅ | Cifrado v3 + frase de sincronización + lectura de v1/v2 | Medio. Formato nuevo; conviene ir después de F1/F2 para no mezclar. |
-| **F4** ✅ | Capas 1 y 2 del reloj (detección, confirmación, compensación) | Bajo. |
+| **F1** | `sync_superseded` + record in all three situations + view in Settings | It doesn't change any resolution, it just stops destroying. |
+| **F2** | Tombstones: table, triggers generated, fusion rules, horizon and warning | Medium. Change the observable behavior of erasing. |
+| **F3** | Encryption v3 + synchronization phrase + v1/v2 reading | Medium. New format; it is advisable to go after F1/F2 so as not to mix. |
+| **F4** | Watch layers 1 and 2 (detection, confirmation, compensation) | Low. |
 
-**F1 primero, deliberadamente.** Es la que convierte cualquier error de las otras dos en
-recuperable, así que conviene tenerla antes de tocar borrados o resolución temporal. Cada
-fase es verificable por separado con el arnés de esquema real que ya existe.
-
----
-
-## F1 · Implementada (esquema v88)
-
-`scripts/test-superseded-versions.mjs`. 532/532 tests, build y smoke e2e sobre la app
-real (v88). Lo entregado:
-
-- Migración **88**, puramente aditiva: crea `sync_superseded` y no toca ninguna tabla
-  existente. Se construye una base **real en v87**, se puebla (notas, genealogía con
-  blob, calificaciones, bases de datos) y se comprueba que tras migrar **cada tabla
-  conserva su recuento exacto**, la integridad y las claves foráneas están limpias, los
-  bytes de la evidencia son idénticos, y volver a migrar no cambia nada.
-- Registro en las dos direcciones del conflicto, incluida la que antes destruía trabajo
-  sin dejar rastro: **la versión local sobrescrita por la del otro equipo**.
-- Restauración **reversible**: al promover una versión, la que desplaza se guarda a su
-  vez, así que restaurar por error también se deshace. Una fila borrada puede
-  recrearse desde su versión guardada.
-- `sync_superseded` es explícitamente **local**: no viaja en el paquete, porque el
-  registro de lo que *este* equipo descartó no tiene sentido en el otro.
-- Compatibilidad verificada en ambos sentidos: un `.nodussync` construido con esquema 87
-  sigue importándose, una copia de un esquema **más reciente** se rechaza sin tocar los
-  datos, y una de un esquema anterior se restaura con normalidad.
-
-### Defecto encontrado durante la implementación
-
-La primera versión guardaba **la misma versión perdedora en cada sincronización**: una
-fila que pierde una vez pierde en todas las importaciones futuras del mismo paquete, así
-que la lista habría crecido con un duplicado por sync hasta enterrar los conflictos
-reales. `recordSuperseded` deduplica y devuelve si llegó a almacenar; el contador del
-resumen solo cuenta lo realmente guardado.
-
-### Limitaciones asumidas
-
-- **No se guardan las columnas BLOB.** Duplicar adjuntos, grabaciones y retratos
-  multiplicaría el tamaño de la base. Se conserva la fila y un marcador con el tamaño; al
-  restaurar se mantienen los adjuntos actuales y se avisa de ello.
-- **No hay recolección automática.** Esta tabla *es* la red de seguridad, así que nada la
-  borra por tiempo: solo el usuario, de forma explícita. El crecimiento está acotado por
-  los conflictos reales, que son raros, y la deduplicación evita la repetición.
+**F1 first, deliberately.** It is the one that turns any error of the other two into recoverable, so
+it is convenient to have it before touching deleted or temporary resolution. Each phase is
+verifiable separately with the real scheme harness that already exists.
 
 ---
 
-## F2 · Implementada (esquema v89)
+## F1 · Implemented (scheme v88)
 
-`scripts/test-tombstones.mjs` (10 supuestos) + `scripts/test-source-hygiene.mjs`.
-534/534 tests, build y smoke e2e sobre la app real (v89).
+`scripts/test-superseded-versions.mjs`. 532/532 tests, build and smoke e2e on the real app (v88).
+Delivered:
 
-Un borrado deja de resucitar: se registra en `sync_tombstones` mediante triggers
-generados desde el mismo registro que decide qué se sincroniza, viaja en el paquete, se
-aplica antes de fusionar filas, y lo que elimina queda recuperable en `sync_superseded`.
+- Migration **88**, purely additive: creates `sync_superseded` and does not touch any existing
+  table. A real **base is constructed in v87**, it is populated (notes, genealogy with blob,
+  ratings, databases) and it is verified that after migrating **each table retains its exact
+  count**, the integrity and foreign keys are clean, the bytes of the evidence are identical, and
+  remigration does not change anything.
+- Recording in the two directions of the conflict, including the one that previously destroyed work
+  without leaving a trace: **the local version overwritten by the other team.**
+- Restore **reversible**: by promoting a version, the one that moves is saved in turn, so restoring
+  by mistake is also undone. A deleted row can be recreated from its saved version.
+- `sync_superseded` is explicitly **local**: does not travel in the package, because the record of
+  what *this* computer discarded makes no sense in the other.
+- Verified compatibility in both directions: a `.nodussync` built with scheme 87 continues to
+  matter, a copy of a newer ** scheme** is rejected without touching the data, and one of an earlier
+  scheme is restored normally.
 
-### La mitad peligrosa: lo que NO debe parecer un borrado
+### Default found during implementation
 
-Propagar borrados es fácil; lo difícil es no propagar los que no lo son. Cada uno de
-estos habría eliminado datos del usuario **en el otro equipo**:
+The first version kept **the same losing version at each synchronization**: a row that lost once
+lost in all future imports of the same package, so the list would have grown with a duplicate by
+sync until it buried the actual conflicts. `recordSuperseded` deduplicates and returns if it got to
+store; the summary counter only counts what is actually saved.
 
-- **Guardar borrando y reescribiendo.** El horario borra todos los periodos de un curso y
-  los reinserta con los mismos ids. Sin el trigger `AFTER INSERT` que retira la lápida,
-  un guardado normal habría dicho al otro equipo que borrara el horario. Verificado, y
-  verificado también que una fila que *sí* desaparece en ese reescrito sí se marca.
-- **La limpieza interna de la fusión.** Al soltar filas recién insertadas cuyas claves
-  foráneas quedan colgando, el trigger no distingue eso de un borrado del usuario: la
-  lápida se retira explícitamente.
-- **Restaurar una versión guardada.** Escribe una fila que una lápida da por muerta. Sin
-  una marca de tiempo nueva, la siguiente sincronización la habría vuelto a borrar y el
-  usuario habría visto cómo su recuperación se deshacía sola. Ahora restaurar es el hecho
-  más reciente sobre la fila.
+### Limitations assumed
 
-Y en sentido contrario: un borrado no es sagrado. Si el otro equipo editó la fila
-**después** del borrado, esa edición es el hecho más reciente y la fila vuelve.
+- **BLOB columns are not saved.** Duplicate attachments, recordings and portraits would multiply the
+  size of the base. The row and a marker with size are retained; current attachments are maintained
+  when restored and notice is given.
+- **There is no automatic collection.** This table *is* the safety net, so nothing erases it for
+  time: only the user, explicitly. Growth is limited by real conflicts, which are rare, and
+  deduplication prevents repetition.
 
-### Defecto encontrado durante la implementación
+---
 
-La clave de búsqueda de lápidas se construía en dos sitios, y en uno el separador acabó
-siendo un **byte NUL** en vez de un espacio. Resultado: la búsqueda no coincidía nunca,
-la supresión de resurrecciones no hacía nada, y **TypeScript compilaba sin quejarse**;
-`grep` además dejaba de encontrar el fichero porque pasaba a considerarlo binario.
+## F2 · Implemented (Scheme v89)
 
-Dos correcciones: la clave se construye ahora en **una sola función** (`tombstoneKey`), y
-`scripts/test-source-hygiene.mjs` rechaza caracteres de control y UTF-8 inválido en todo
-el código. Ese guard destapó tres ficheros ya en `main` que usan NUL como separador de
-claves compuestas de forma **deliberada y correcta** (`ideaDedupe`, `graph/lod`, `stats`):
-están en una lista explícita, no tocados, para que un NUL *nuevo* siga fallando.
+`scripts/test-tombstones.mjs` (10 assumptions) + `scripts/test-source-hygiene.mjs`. 534/534 tests,
+build and smoke e2e on the real app (v89).
 
-### Interacción conocida (documentada, no un fallo)
+A deletion ceases to resurrect: it is recorded in `sync_tombstones` by triggers generated from the
+same record that decides what is synchronized, travels in the package, applies before merging rows,
+and what it removes is recoverable in `sync_superseded`.
 
-Restaurar una copia anterior a un borrado devuelve la fila **y** retrocede el estado local
-de lápidas. Si el otro equipo sigue teniendo la suya, la siguiente sincronización volverá
-a aplicar el borrado, porque es el hecho más reciente. No se pierde nada: queda en
-«Versiones sustituidas» como *borrado en el otro equipo*.
+### The Dangerous Half: What Must NOT Look Like a Wipe
 
-### Limitaciones asumidas
+Propagating deleted is easy; it is difficult not to propagate those that are not. Each of these
+would have deleted user data ** on the other computer**:
 
-- **Horizonte de 180 días.** Pasado ese plazo la lápida se olvida y la fila podría volver
-  desde un equipo muy rezagado. Al importar un paquete más antiguo que el horizonte se
-  avisa explícitamente en el resumen.
-- **Una lápida por fila borrada.** Medido: 20.000 borrados en cascada con el trigger
-  cuestan 20 ms, así que el coste no es un problema; el tamaño lo acota el horizonte.
+- **Save by deleting and rewriting.**The schedule deletes all periods of a course and resets them
+  with the same ids. Without the trigger `AFTER INSERT` that removes the tombstone, a normal save
+  would have told the other computer to delete the schedule. Verified, and also verified that a row
+  that *yes* disappears in that rewrite is marked.
+- **The internal cleaning of the merge.** By dropping newly inserted rows whose foreign keys are
+  hanging, the trigger does not distinguish that from a user deletion: the tombstone is explicitly
+  removed.
+- **Restore a saved version.** Write a row that a tombstone gives for dead. Without a new time mark,
+  the following synchronization would have erased it again and the user would have seen how its
+  recovery was undone alone. Now restoring is the latest fact about the row.
+
+And in the opposite direction: one deleted is not sacred. If the other team edited the row **after**
+the deleted one, that edition is the most recent fact and the row returns.
+
+### Default found during implementation
+
+The tombstone search key was built in two places, and in one the separator ended up being a **byte
+NUL** instead of a space. Result: the search never coincided, the suppression of resurrections did
+nothing, and **TypeScript compiled without complaining**; `grep` also stopped finding the file
+because it was considered binary.
+
+Two corrections: the key is now built into ** a single function** (`tombstoneKey`), and
+`scripts/test-source-hygiene.mjs` rejects control characters and invalid UTF-8 throughout the code.
+That guard uncovered three files already in `main` that use NUL as a code separator composed of
+**deliberate and correct** (`ideaDedupe`, `graph/lod`, `stats`): they are in an explicit list, not
+touched, for a new *NUL* to continue to fail.
+
+### Known interaction (documented, not a failure)
+
+Restore a previous copy to a deleted one returns the row ** and** backs the local state of
+tombstones. If the other computer still has yours, the following synchronization will reapply the
+deleted one, because it is the most recent fact. Nothing is lost: it remains in "Replaced version"
+as *delete on the other computer*.
+
+### Limitations assumed
+
+- ** 180-day horizon.** After that time the tombstone is forgotten and the row could come back from
+  a very backward team. By importing an older package that the horizon is explicitly warned in the
+  summary.
+- **One stone per row deleted.** Measured: 20,000 erased by cascade with the trigger cost 20 ms, so
+  cost is not a problem; size is narrowed by the horizon.
 
 
 ---
 
-## F3 y F4 · Implementadas
+## F3 and F4 implemented
 
-`scripts/test-sync-package.mjs` (ampliado). 534/534 tests, build y smoke e2e (v89).
-**Sin cambio de esquema**: la frase vive en `safeStorage`, no en la base, así que estas
-dos fases no tocan los datos de nadie.
+`scripts/test-sync-package.mjs` (enlarged). 534/534 tests, build and smoke e2e (v89). **No schema
+change**: the phrase lives on `safeStorage`, not on the base, so these two phases do not touch
+anyone's data.
 
-### F3 · Cifrado (formato v3)
+### F3 · Encryption (format v3)
 
-Cada tabla y cada adjunto se sella por separado bajo una clave derivada **una sola vez**
-(scrypt N=32768 + AES-256-GCM, IV propio por entrada). Así el cifrado **no reintroduce**
-el búfer único que hacía imposible sincronizar bóvedas grandes. Los nombres de tabla
-viven en un índice cifrado y las entradas tienen nombres opacos: el fichero no anuncia
-que contiene un cuaderno de calificaciones.
+Each table and attachment is sealed separately under a derived key ** once** (scrypt N=32768 +
+AES-256-GCM, IV own per entry). Thus the encryption ** does not reintroduce** the unique buffer that
+made it impossible to synchronize large vaults. The table names live in an encrypted index and the
+entries have opaque names: the file does not announce that it contains a notebook of ratings.
 
-El manifiesto sigue en claro a propósito — permite rechazar un paquete incompatible o
-avisar de su antigüedad **sin pedir la frase**.
+The manifest is clear on purpose — it allows you to reject an incompatible package or warn of its
+antiquity ** without asking for the phrase**.
 
-**Compatibilidad verificada**: se siguen importando paquetes **v1** (JSON único con
-blobs en base64) y **v2** (una entrada por tabla, en claro), incluidos sus adjuntos. Solo
-se escribe v3.
+** Verified compatibility**: packages are still imported **v1** (JSON unique with base64 blobs) and
+**v2** (one entry per table, clear), including their attachments. Only v3 is written.
 
-**La credencial**: una «frase de sincronización» propia, no la contraseña maestra —
-restaurar con la clave de recuperación genera una contraseña maestra nueva y aleatoria,
-así que los dos equipos habrían acabado con credenciales distintas y el sync habría
-fallado sin motivo aparente. Queda incluida en el kit de recuperación. Al importar un
-paquete ajeno, la interfaz pide la frase del equipo que lo generó en vez de dejar al
-usuario atascado.
+**Credential**: a proper "sync" phrase, not the master password — restoring with the recovery key
+generates a new, random master password, so the two teams would have ended up with different
+credentials and the sync would have failed for no apparent reason. It is included in the recovery
+kit. When importing a foreign package, the interface asks for the phrase of the computer that
+generated it instead of leaving the user stuck.
 
-### F4 · Sesgo de reloj
+### F4 · Watch bias
 
-Se mide y se reporta lo único que un paquete de un solo sentido permite medir: que el
-reloj del emisor va **adelantado**. Un paquete con fecha antigua es indistinguible de un
-reloj atrasado, así que no se adivina — y el test comprueba explícitamente que un paquete
-viejo **no** se confunde con desfase.
+The only thing that a one-way package can measure is measured and reported: that the emitter clock
+is **advanced**. A packet with an old date is indistinguishable from a backward clock, so it is not
+guessed — and the test explicitly checks that an old package **no** is confused with a lag.
 
-Lo que de verdad resuelve el problema no es la detección, sino la F1: gane quien gane la
-comparación, la versión perdedora se conserva. Un reloj mal puesto cuesta una revisión,
-no el trabajo.
+What really solves the problem is not the detection, but the F1: win whoever wins the comparison,
+the losing version is preserved. A bad clock costs a review, not the job.
 
-### Aserciones que eran débiles
+### Assertions that were weak
 
-Las comprobaciones de privacidad buscaban el texto plano en el fichero completo. Un zip
-**comprime** sus entradas, así que pasaban igual sin cifrar nada. Ahora se hacen sobre
-los bytes **descomprimidos** de cada entrada, y se verificó que con `seal` desactivado el
-test falla.
+The privacy checks looked for the flat text in the entire file. A zip **compressed** its entries, so
+they passed the same without encrypting anything. Now they are done over the **decompressed** bytes
+of each entry, and it was verified that with `seal` disabled the test fails.

--- a/design/worldbuilding-analyze-plan.md
+++ b/design/worldbuilding-analyze-plan.md
@@ -1,81 +1,80 @@
-# Worldbuilding — el grupo «Analizar» (migración 99)
+# Worldbuilding — the group ‘Analyze’ (migration 99)
 
-> **Estado: el grupo «Analizar» está COMPLETO — A0–A10 implementados y verificados**
-> (2026-07-28). `SCHEMA_VERSION = 99`, 1160/1160 tests, lint 0 errores, typecheck,
-> `npm run build` y `npm run test:e2e` en verde. Lo único que A10 dejó deliberadamente
-> fuera es el historial de conversaciones: habría pedido una migración que el plan no
-> contempla, y el chat vive en la sesión.
+> ** Status: the "Analyze" group is COMPLETE — A0–A10 implemented and verified**
+> (2026-07-28). `SCHEMA_VERSION = 99`, 1160/1160 tests, Lint 0 errors, typecheck,
+> `npm run build`and`npm run test:e2e`The only thing A10 deliberately left behind
+> outside is the history of conversations: I would have asked for a migration that the plan does not
+> contemplate, and the chat lives in the session.
 >
-> Plan producido por un workflow de 12 agentes (5 diseños + 5 críticas «desde la mesa de un
-> novelista» + síntesis). Este documento es el resumen ejecutable; la enciclopedia (v98) va
-> aparte, en la sección correspondiente del historial.
+> Plan produced by a workflow of 12 agents (5 designs + 5 reviews «from the table of a
+> novelist» + synthesis. This document is the executable summary; the encyclopedia (v98) goes
+> in the relevant section of the history.
 
 ---
 
-## 1. La tesis (no volver a discutirla)
+## 1. The thesis (do not discuss it again)
 
-Las cinco secciones de «Analizar» **no son cinco informes**: son cinco lecturas de una sola
-afirmación que el vault no podía guardar — **«en esta escena, esto se mueve así»**. Una
-regla puesta a prueba, un conflicto que avanza y un arco que gira **son la misma fila**.
+The five sections of "Analyze" ** are not five reports**: they are five readings of a single
+statement that the vault could not keep — **"in this scene, this moves like this"**. A tested rule, a
+advancing conflict and a rotating arc **are the same row**.
 
-Por eso el corazón es una tabla, `world_beats`, y **una franja en la ficha de escena**
-(`SceneThreadsPanel` + `RulesInPlay`) que la rellena con un clic, con las filas ya
-prepobladas. El autor **nunca visita cinco secciones para alimentarlas**: alimenta la escena
-que está escribiendo y las cinco se llenan solas. Las vistas del menú son **informes de
-lectura**, no formularios.
+That's why the heart is a board,`world_beats`, and **a strip on the scene sheet**
+(`SceneThreadsPanel` + `RulesInPlay`) that fills it with a click, with the rows already
+prepopulated. The author **never visits five sections to feed them**: it feeds the scene that he is
+writing and the five are filled alone. The views of the menu are **read reports**, not forms.
 
-Corolario que decide la arquitectura: **la IA no calcula nada**. Todo diagnóstico es
-aritmética pura sobre lo que el autor tecleó. Solo sobreviven dos usos de modelo, por
-elemento y bajo botón, en cuarentena (§A9).
+Corollary that decides the architecture: **The AI does not calculate anything**. Every diagnosis is
+pure arithmetic about what the author typed. Only two uses of model survive, by element and under
+button, in quarantine (§A9).
 
 ---
 
-## 2. Lo que ya está hecho
+## 2. What is already done
 
-| Fase | Qué entregó |
+| Phase | What did he deliver? |
 |---|---|
-| **A0** | Migración **99** con 8 tablas: `world_scene_days`, `world_threads`, `thread_parties`, `world_beats`, `world_rules`, `world_questions`, `world_question_options`, `world_notice_mutes`. Tipos en `shared/types.ts`, alta en el grupo `worldbuilding` de `syncTables.ts`. |
-| **A1** | La **cadena de días**: `shared/worldSceneDays.ts`, `recomputeSceneDays()`/`reorderScene()` en `worldStoryRepo.ts`, `SceneDayChain` en la ficha de escena. Precondición de media Continuidad. |
-| **A2** | **Hilos y latidos**: `shared/worldThreads.ts` + `electron/db/worldThreadsRepo.ts` + `SceneThreadsPanel`. Ninguna vista nueva en el menú. |
-| **A3** | **Continuidad como insignia**: `shared/worldFindings.ts`, `shared/worldContinuity.ts`, `electron/db/worldContinuityRepo.ts`, `ContinuityBadge`/`ContinuityProvider` en cinco fichas. |
-| **A4** | **La vista de Continuidad**: `src/views/ContinuityView.tsx`, silencios enlatados, excepciones aceptadas, estado vacío con recuentos reales. «Consistencia» → **«Continuidad»**. |
-| **A5** | **Conflictos**: `src/views/ConflictsView.tsx` (tablero primero), `CharacterThreadsSection`, lealtades cruzadas, `conflict` como 7.ª `WorldEntryKind`, `checkThreads` en Continuidad. |
-| **A6** | **Arcos**: `src/views/ArcsView.tsx`, carriles SVG de solo lectura, tira de densidad, tramos inertes, orden de cierre, hoja de hitos. Se retiró «Tramas». |
-| **A10** | **Chat del mundo**: `shared/worldChatContext.ts` + `electron/ai/worldChat.ts` + `WorldChatView`. Nodus calcula las cinco lecturas y el modelo redacta; las citas se validan contra las entradas reales. |
-| **A9** | **Los dos usos de IA**: `shared/worldRuleContext.ts` + `electron/ai/worldRules.ts` (redactar el enunciado de una ley) y `shared/worldQuestionContext.ts` + `electron/ai/worldQuestionOptions.ts` (proponer tres respuestas). Nada más: la IA sigue sin calcular nada. |
-| **A8** | **Preguntas abiertas**: `shared/worldQuestions.ts`, `electron/db/worldQuestionsRepo.ts`, `QuestionsView`, la captura desde cualquier campo de prosa (`questionCapture.tsx` + `anchorOf` en el shell) y la franja `SceneQuestionBand` en la escena. |
-| **A7** | **Reglas**: `shared/worldRules.ts`, `electron/db/worldRulesRepo.ts`, `RulesView`, `RulesInPlay` en la escena, `rule` como 8.ª `WorldEntryKind`, «convertir en ley», `checkRules` en Continuidad. |
+| **A0** | Migration **99** with 8 tables:`world_scene_days`, `world_threads`, `thread_parties`, `world_beats`, `world_rules`, `world_questions`, `world_question_options`, `world_notice_mutes`. Types`shared/types.ts`, high in group`worldbuilding`of`syncTables.ts`. |
+| **A1** | The **day chain**:`shared/worldSceneDays.ts`, `recomputeSceneDays()`/`reorderScene()`in`worldStoryRepo.ts`, `SceneDayChain`on the scene sheet. Precondition of media Continuity. |
+| **A2** | **Threads and beats**:`shared/worldThreads.ts` + `electron/db/worldThreadsRepo.ts` + `SceneThreadsPanel`No new view on the menu. |
+| **A3** | **Continued as badge**:`shared/worldFindings.ts`, `shared/worldContinuity.ts`, `electron/db/worldContinuityRepo.ts`, `ContinuityBadge`/`ContinuityProvider`on five chips. |
+| **A4** | **The Continuity View**:`src/views/ContinuityView.tsx`, canned silences, accepted exceptions, empty state with real counts. «Consistency» → **«Continuousness»**. |
+| **A5** | **Conflicts**`src/views/ConflictsView.tsx`(table first),`CharacterThreadsSection`, cross loyalties,`conflict`like 7.a`WorldEntryKind`, `checkThreads`In Continuity. |
+| **A6** | **Arcos**:`src/views/ArcsView.tsx`, read-only SVG lanes, density strip, inert sections, closing order, milestone sheet. |
+| **A10** | **Chat of the world**:`shared/worldChatContext.ts` + `electron/ai/worldChat.ts` + `WorldChatView`Nodus calculates the five readings and the model writes; quotations are validated against actual entries. |
+| **A9** | **The two uses of AI**:`shared/worldRuleContext.ts` + `electron/ai/worldRules.ts`(drafting the wording of a law)`shared/worldQuestionContext.ts` + `electron/ai/worldQuestionOptions.ts`(propose three answers).Nothing else: AI still doesn't calculate anything. |
+| **A8** | **Open questions**:`shared/worldQuestions.ts`, `electron/db/worldQuestionsRepo.ts`, `QuestionsView`, capture from any prose field (`questionCapture.tsx` + `anchorOf`in the shell) and stripe`SceneQuestionBand`at the scene. |
+| **A7** | **Rules**:`shared/worldRules.ts`, `electron/db/worldRulesRepo.ts`, `RulesView`, `RulesInPlay`at the scene,`rule`as 8.a`WorldEntryKind`, ‘to become law’,`checkRules`In Continuity. |
 
 ---
 
-## 3. A8 — Preguntas abiertas (mínima, a propósito) — **HECHA**
+## 3. A8 — Open Questions (minimum, by the way) — **DONE**
 
-Las tablas ya existían (`world_questions`, `world_question_options`, migración 99); esta
-fase construyó todo lo demás **sin tocar el esquema**. Lo que sigue es el diseño tal como se
-implementó, más las desviaciones al final de la sección.
+The tables already existed (`world_questions`, `world_question_options`, migration 99); this phase
+built everything else ** without touching the schema**. What follows is the design as implemented,
+plus the deviations at the end of the section.
 
-### Alcance recortado
+### Cut-off range
 
-De las **siete** reglas de derivación que pedía el diseño original quedan **dos**:
+Of the **seven** referral rules requested by the original design, **two** remain:**
 
-- `author` — la que el autor teclea.
-- `placeholder` — `???`, `TBD`, `XXX`, `[…]` encontrados en la prosa que ya escribió.
+- `author`— which the author types.
+- `placeholder` — `???`, `TBD`, `XXX`, `[…]`found in the prose you already wrote.
 
-Las otras cinco **pertenecen a otra sección** y volverían a su dueño con un botón «convertir
-en pregunta abierta»: enlaces rojos y entradas sin desarrollar → Enciclopedia (que ya tiene
-`world_entry_proposals` con su propio libro de descartes; un segundo libro sobre los mismos
-hechos es un descarte que sigue vivo en el otro sitio), huecos de arco → Arcos,
-contradicciones → Continuidad, escenas sin fecha → Escenas, revelaciones → Secretos.
+The other five ** belong to another section** and would return to its owner with a button "to become
+an open question": red links and undeveloped entries → Encyclopedia (which already
+has`world_entry_proposals`with his own book of discards; a second book about the same facts is a
+discard that is still alive in the other site), arc holes → Arcos, contradictions → Continuity,
+scenes without date → Scenes, revelations → Secrets.
 
-Con eso desaparecen `WorldQuestionWorld` (que era el vault entero por IPC en cada apertura),
-`deriveQuestions` y `WorldDependencyIndex`.
+That's why they disappear.`WorldQuestionWorld`(which was the entire Vault by IPC at each
+opening),`deriveQuestions`and`WorldDependencyIndex`.
 
-### `shared/worldQuestions.ts` (puro)
+### `shared/worldQuestions.ts`(pure)
 
 ```ts
 export const WORLD_QUESTION_STATUS_LABEL, WORLD_QUESTION_ORIGIN_LABEL, WORLD_APPLY_MODE_LABEL;
 export function questionOriginKey(origin, ...parts): string;   // 'ph:character:prs_7:backstory'
-/** ???, TBD, XXX, […] — consciente de bloques de código; reutilizar el recorrido de la enciclopedia. */
+/** ???, TBD, XXX, [...] — aware of code blocks; reuse the encyclopedia path. */
 export function findPlaceholders(texts: WorldTextRef[]): PlaceholderHit[];
 export function mergeQuestionFeed(stored, derived, options): WorldQuestionFeedItem[];
 export function nextBlockedScene(anchor, scenes): { sceneId; title; narrativeOrder } | null;
@@ -83,124 +82,120 @@ export function questionUrgency(item): WorldQuestionUrgency;
 export function rankQuestionFeed(items): WorldQuestionFeedItem[];
 export function planApply(option, anchor, anchorField, currentText):
   { field; nextText; replacedText } | { create: 'article'; title; summary } | null;
-/** El deshacer solo es seguro si el campo sigue conteniendo lo que se aplicó. */
+/** Undoing is only safe if the field continues to contain what was applied. */
 export function canUndo(option, currentText): boolean;
 ```
 
-### La pantalla
+### The screen
 
-Reutiliza el shell con `presentation: 'list'`. `idOf` devuelve `questionId` o `originKey`.
+Reuse the shell with`presentation: 'list'`. `idOf`returns`questionId`o`originKey`.
 
-- **Dos facetas**: `anchorTitle` (distinct) y un interruptor «me bloquea». Fuera `origin` y
-  `status` como facetas.
-- Ficha: pregunta editable con `[[` → evidencia verbatim → línea de apalancamiento y escena
-  límite → **opciones en columnas**, cada una con un único botón que **nombra la escritura
-  antes de hacerla** («Se escribirá en Kaelen → Trasfondo») y que se convierte en «Deshacer»
-  mientras `replaced_text` esté presente y `canUndo()` sea cierto → tras aplicar, **la lista
-  de sitios que todavía dicen el texto viejo**.
-- Vista «decisiones tomadas» (`status='answered'`) que **muestra las opciones descartadas**:
-  la única memoria de *por qué* el mundo es como es.
+- **Two facets**:`anchorTitle`(different) and a switch ‘blocks me’.`origin`and`status`like facets.
+- File: editable question with`[[`→ verbatim evidence → leverage line and boundary scene → **options
+  in columns**, each with a single button that **names the writing before doing it** ("To be written
+  in Kaelen → Transfundo") and becomes "Undoing" while`replaced_text`is present and`canUndo()`be
+  true → after applying, **the list of sites that still say the old text**.
+- Having regard to ‘decisions taken’ (`status='answered'`) that **shows the discarded options**: the
+  only memory of *why* the world is as it is.
 
-### Lo que la hace usable
+### What makes it usable
 
-La **captura en una tecla** desde cualquier campo de prosa: seleccionar texto → «convertir en
-pregunta abierta», con el ancla y el campo **prerrellenados**. Toca `AutoSavingField` y
-`WorldEntryEditor`, que son componentes compartidos — es la parte cara de esta fase.
+The **capture in a key** from any prose field: select text → "turn into open question", with anchor
+and field **prerellenados**.`AutoSavingField`and`WorldEntryEditor`, which are shared components — is
+the expensive part of this phase.
 
-Más la banda «esta escena depende de N decisiones abiertas» en la ficha de escena.
+More the band "this scene depends on N open decisions" on the scene sheet.
 
-### Landmines propias
+### Landmines own
 
-- `planApply`/`canUndo` es **lo único de todo el grupo que escribe en fichas de otras
-  secciones** (el trasfondo de un personaje, un artículo). El deshacer tiene que ser correcto
-  de verdad: `canUndo` es falso en cuanto el campo dejó de contener lo aplicado.
-- El destino se **infiere** del ancla; jamás se elige en un formulario de tres widgets.
-- `apply_mode` tiene tres valores: `none | fill_field | create_article`. `none` es una
-  respuesta de primera clase: hay decisiones que se toman y simplemente se recuerdan.
-- El estado `parked` absorbe lo que el diseño llamaba `dismissed`: eran dos estados negativos
-  indistinguibles en la práctica.
+- `planApply`/`canUndo`is ** the only thing about the whole group that writes in tabs from other
+  sections** (the background of a character, an article). Undoing has to be really right:`canUndo`is
+  false as soon as the field stopped containing what was applied.
+- The destination is **inferred** from the anchor; it is never chosen on a three widget form.
+- `apply_mode`has three values:`none | fill_field | create_article`. `none`It is a first-class
+  answer: there are decisions that are made and simply remembered.
+- The state`parked`absorbs what the design called`dismissed`: were two negative states
+  indistinguishable in practice.
 
-### Lo que cambió al construirla
+### What changed when you built it
 
-- **`planApply` recibe la pregunta entera**, no solo `(option, anchor, anchorField)`: el
-  título del artículo que crea sale de la pregunta (`questionTitle`), y el ancla no lo sabe.
-- **Una decisión respondida NO desaparece de la lista**. La primera versión la borraba de la
-  pantalla en el mismo clic: sin confirmación de lo que se había escrito y sin el «Deshacer»
-  justo en el momento en que alguien lo quiere. Ahora se queda hasta que el autor sale de la
-  sección (un `Set` de ids en la vista, no un estado en la base de datos).
-- **`emptyLabel` no puede ser un ternario.** El colector de i18n lee el literal que sigue a
-  `emptyLabel:`, así que la otra lectura dice lo suyo desde `EmptyState`, que llama a `t()`.
-- **La captura viaja por contexto** (`WorldAnchorProvider` en `WorldWorkspace`, alimentado
-  por un `anchorOf?` nuevo en el descriptor de sección) en vez de por props: son ~20 campos
-  en seis fichas, y el que se olvidaría es el que se añada el año que viene.
-- **`stillSaying` se resolvió como `remainingHoles(optionId)`**: la marca se lee del
-  `replaced_text` de la propia opción, así que ninguna columna tiene que recordarla y sigue
-  funcionando después de que el hueco que rellenó haya desaparecido.
-- **Los perfiles se escriben con upsert.** `character_profiles` y `place_profiles` cuelgan de
-  su padre por LEFT JOIN en todas partes: un `UPDATE` contra una ficha sin fila diría que ha
-  escrito un párrafo y no habría escrito nada.
+- **`planApply`receives the whole question**, not just`(option, anchor, anchorField)`: the title of
+  the article you create leaves the question (`questionTitle`), and the anchor doesn't know.
+- **An answered decision does not disappear from the list**. The first version deleted it from the
+  screen in the same click: without confirmation of what had been written and without the "Undoing"
+  right when someone wanted it. Now it stays until the author leaves the section (a`Set`of ids in
+  the view, not a state in the database).
+- **`emptyLabel`cannot be a ternary.** The collector of i18n reads the literal that
+  follows`emptyLabel:`So the other reading says his thing since`EmptyState`, which calls for`t()`.
+- **The capture travels by context** (`WorldAnchorProvider`in`WorldWorkspace`, fed by
+  a`anchorOf?`new in the section descriptor) instead of by props: they are ~20 fields in six tiles,
+  and the one that would be forgotten is the one added next year.
+- **`stillSaying`was resolved as`remainingHoles(optionId)`**: the mark is read from`replaced_text`of
+  the option itself, so no column has to remember it and it still works after the gap it filled has
+  disappeared.
+- **Profiles are written with upsert.**`character_profiles`and`place_profiles`hang from their father
+  by LEFT JOIN everywhere: a`UPDATE`I'd say he wrote a paragraph and he wouldn't have written
+  anything.
 
 ---
 
-## 4. A9 — Los dos usos de IA — **HECHA**
+## 4. A9 — The two uses of AI — **DONE**
 
-Ambos **por elemento, bajo botón y en cuarentena**. Copiar el patrón de
-`electron/ai/worldArticleDraft.ts`, que ya funciona: prompt puro en `shared/`, llamada en
-`electron/ai/`, modelo `synthesisModel ?? extractionModel`.
+Both **by item, under button and quarantine**. Copy the pattern
+of`electron/ai/worldArticleDraft.ts`, which already works: prompt pure in`shared/`, call
+in`electron/ai/`model`synthesisModel ?? extractionModel`.
 
 1. **`draftWorldRule(ruleId)`** — `shared/worldRuleContext.ts` + `electron/ai/worldRules.ts`,
-   temperatura 0.8. Escribe en **`world_rules.proposed_text`**, nunca en `statement`. La
-   pantalla ya lo pinta y ya tiene Aceptar/Descartar (`rules:acceptDraft` / `rules:rejectDraft`
-   existen y funcionan). Ataca la página en blanco, que es el problema real.
+   temperature 0.8. Write in **`world_rules.proposed_text`**, never in`statement`. The screen
+   already paints it and already has OK/Discard (`rules:acceptDraft` / `rules:rejectDraft`It attacks
+   the blank page, which is the real problem.
 2. **`proposeQuestionOptions(questionId)`** — `shared/worldQuestionContext.ts` +
-   `electron/ai/worldQuestionOptions.ts`, temperatura 0.9. Escribe **3 opciones** con su
-   `implications` como filas `world_question_options` con `origin='ai'`. La cuarentena aquí
-   es **estructural**: una opción no es canon hasta que se elige y se aplica.
+   `electron/ai/worldQuestionOptions.ts`, temperature 0.9. Write **3 options** with
+   your`implications`as rows`world_question_options`with`origin='ai'`Quarantine here is
+   **structural**: an option is not canon until it is chosen and applied.
 
-Aceptar es **siempre una llamada aparte**. Ficha vacía → `noMaterial: true` sin error.
+Accept is **always a separate call**. Empty tab →`noMaterial: true`No mistake.
 
-**Lo que NO se construye**, y por qué: `auditRuleAgainstScenes`, `conflictProposals` y su
-bandeja, `generateArcDraft` en modo propose, `reviewWorldProse`, `world_ai_findings` con su
-`material_hash` y su caducidad. Su entrada real es `world_scenes.summary`, que es NULLABLE y
-en un vault real está vacío la mayor parte del tiempo. **No se paga un modelo por lo que
-contesta un JOIN.**
+**What is NOT built**, and why:`auditRuleAgainstScenes`, `conflictProposals`and his
+tray,`generateArcDraft`in propose mode,`reviewWorldProse`, `world_ai_findings`with
+his`material_hash`and its expiry. Its actual entry is`world_scenes.summary`, which is NULLABLE and
+in a real vault is empty most of the time. **No model is paid for so a JOIN answers.**
 
-### Lo que cambió al construirla
+### What changed when you built it
 
-- **Dos líneas etiquetadas (`OPCIÓN:` / `IMPLICA:`), no JSON.** `completeJson` escala
-  BAJANDO la temperatura hasta que el modelo obedece, y esta es la llamada más caliente de
-  la app (0.9): pagaría tres turnos para quedarse con la más sosa de las tres. Además, de
-  los modelos locales que un escritor corre de verdad, la mayoría envuelve su JSON en prosa.
-  Dos prefijos sobreviven a un preámbulo, a una lista numerada, a la negrita de Markdown y a
-  una despedida. El parser está en `shared/`, y **solo continúa una línea si va indentada**:
-  sin ese guard, el «espero que te sirvan» del modelo acaba dentro de la ficha de alguien.
-- **`hasWorldRuleMaterial` exige el título MÁS una señal** (un ámbito con nombre, una línea
-  empezada, una excepción, una escena que la pone a prueba, un texto que la menciona). Un
-  título a secas produce una frase que valdría para cualquier novela, y eso se borra una vez
-  y no se vuelve a pulsar el botón. El aviso dice cuál de las cinco falta.
-- **`blockedSceneFor(anchor)`** se exporta desde `worldQuestionsRepo` para que el prompt
-  sepa qué escena está bloqueando **sin pagar el escaneo de toda la prosa del vault** que
-  hace el feed.
-- **No hay paso de «aceptar» en las opciones**, y no es un olvido: una opción es una
-  escritura pendiente, así que elegirla y pulsar el botón que nombra lo que va a escribir ya
-  es el consentimiento. El único «Aceptar» del grupo es el de la ley, porque ahí el modelo
-  sí escribe en un campo.
+- **Two labeled lines (`OPTION:` / `IMPLIES:`), no JSON.** `completeJson` lowers the temperature
+  until the model obeys, and this is the hottest call on the app (0.9): I would pay three shifts to
+  keep the dullest of the three. In addition to the local models that a writer actually runs, most
+  wrap his JSON in prose. Two prefixes survive a preamble, a numbered list, the bold Markdown and a
+  farewell. Parser is in`shared/`, and **only one line continues if it is indented**: without that
+  guard, the model's "hope to be served" ends up inside someone's tab.
+- **`hasWorldRuleMaterial`requires the title MORE a sign** (a field with name, a line started, an
+  exception, a scene that tests it, a text that mentions it). A title just produces a phrase that
+  would be useful for any novel, and that is deleted once and the button is not pressed again. The
+  notice says which of the five missing ones.
+- **`blockedSceneFor(anchor)`** exported from`worldQuestionsRepo`so that the prompt knows which
+  scene is blocking **without paying for the scan of the entire prosa of the vault** that the feed
+  does.
+- **There is no step of "accepting" in the options**, and it is not an oblivion: an option is a
+  pending writing, so choosing it and pressing the button that names what you are going to write is
+  already consent. The only "accepting" of the group is that of the law, because there the model
+  does write in a field.
 
 ---
 
-## 5. A10 — Chat del mundo — **HECHO**
+## 5. A10 — World chat — **FACT**
 
-Se diseña **sabiendo que las otras cinco existen**, y eso cambia lo que es: **el chat no
-razona sobre el mundo — Nodus calcula y el modelo redacta**. Mismo reparto que la analítica
-del vault de bases de datos.
+It is designed ** knowing that the other five exist**, and that changes what it is: **the chat does
+not reason about the world — Nodus calculates and the model writes**. Same distribution as the
+analysis of the database vault.
 
-### `shared/worldChatContext.ts` (puro)
+### `shared/worldChatContext.ts`(pure)
 
 ```ts
 export interface WorldChatFacts {
-  focus: WorldEntryRef[];                                   // resuelto por el repo desde la pregunta
-  prose: { ref; field; text }[];                            // entryProse() de cada foco, verbatim
-  computed: {                                               // CALCULADO POR NODUS, no por el modelo
+  focus: WorldEntryRef[];                                   // resolved by the repo from the question
+  prose: { ref; field; text }[];                            // entryProse() of each focus, verbatim
+  computed: {                                               // CALLED BY NODUS, NOT BY THE MODEL
     effectiveRules?: { rule; ruleId; overriddenBy: string[] }[];
     presenceAt?: { personId; personName; placeName; worldDay }[];
     beatsAtScene?: { threadKind; threadTitle; mark; text }[];
@@ -213,78 +208,76 @@ export function composeWorldChatContext(facts: WorldChatFacts): string;
 export function hasWorldChatMaterial(facts: WorldChatFacts): boolean;
 ```
 
-**El *system* dice tres cosas y solo tres:** (1) los bloques «CALCULADO» son hechos de Nodus
-y no se discuten ni se recalculan; (2) toda afirmación sobre el mundo debe citar; (3) si el
-material no contiene la respuesta, se dice — no se inventa un mundo plausible.
+**The *system* says three things and only three:** (1) the blocks "CALKLED" are made of Nodus and
+are not discussed or recalculated; (2) every affirmation about the world must quote; (3) if the
+material does not contain the answer, it is said — a plausible world is not invented.
 
-### Cómo cita
+### How to quote
 
-Con la sintaxis que ya recorre el vault: `[Marca de sangre](nodus://world/rule/rul_7)`.
-`src/components/Markdown.tsx` **ya la enruta** (rama `onWorldEntry`, añadida por la
-enciclopedia), así que cada cita es un clic a la ficha. El repo **valida las citas contra
-`entryLookup()`** antes de pintarlas y **degrada a texto plano las inventadas** — el mismo
-tratamiento que un enlace rojo.
+With the syntax that already runs through the vault:`[Marca de sangre](nodus://world/rule/rul_7)`.
+`src/components/Markdown.tsx`**and the route** (branch`onWorldEntry`, added by the encyclopedia), so
+each quote is a click on the tab. The repo **validates quotations against`entryLookup()`** before
+painting them and **degrades the invented ones to plain text** — the same treatment as a red link.
 
-### Lo que podrá responder, y hoy es imposible
+### What you can answer, and today is impossible
 
-| Pregunta | Qué la contesta |
+| Question | What's the answer? |
 |---|---|
-| «¿Podía Kaelen invocar la Marca el día 4 120?» | `effectiveRules()` + pertenencia de ese día + `knowersAt` |
-| «¿Qué tiene que moverse en la escena 41?» | `beatsForScene()` sobre `world_beats` |
-| «¿Quién de mi reparto no quiere nada de nadie?» | `findStakeGaps()` |
-| «¿Dónde se me hunde el libro?» | `findInertScenes()` + `beatDensity()` |
-| «¿Esto contradice algo?» | `runWorldContinuity()` filtrado por los focos |
-| «¿Qué me falta decidir antes de escribir la 42?» | `nextBlockedScene()` (necesita A8) |
+| "Could Kaelen invoke the Mark on the 4th day 120?" | `effectiveRules()`+ belonging to that day +`knowersAt` |
+| «What has to move on scene 41?» | `beatsForScene()`on`world_beats` |
+| «Who in my cast wants nothing from anyone?» | `findStakeGaps()` |
+| «Where does the book sink to me?» | `findInertScenes()` + `beatDensity()` |
+| "Does this contradict anything?" | `runWorldContinuity()`filtered by spotlights |
+| «What do I need to decide before writing 42?» | `nextBlockedScene()`(needs A8) |
 
-### Lo que el chat NO hace
+### What chat does NOT do
 
-No escribe canon (sus sugerencias se copian a mano o se convierten en `world_questions`), no
-ve el vault entero (solo los focos y sus hechos calculados, que es además la única forma de
-que quepa en el contexto).
+He does not write canon (his suggestions are copied by hand or become`world_questions`), he does not
+see the whole vault (only the spotlights and their calculated facts, which is also the only way it
+fits into the context).
 
-### Lo que cambió al construirlo
+### What changed when you built it
 
-- **Sin foco no se calcula NADA**, y esto lo cazó el e2e: `rulesReaching` con sujeto nulo
-  devuelve todas las leyes de ámbito mundial —alcanzan a todo el mundo por definición—, así
-  que una pregunta que no nombraba nada llegaba al modelo con el código legal del mundo
-  adjunto y respondía sobre él. Un chat que no puede decir de qué habla tiene que decir eso.
-- **El día se lee en `shared/`, no en el modelo** (`readWorldDay`): todo lo que va después
-  es aritmética SOBRE ese número, y un modelo que lee «el día 4 120» como 4 se equivoca con
-  seguridad en las cinco lecturas. Acepta el separador de millares español (espacio y punto).
-- **El foco más largo suprime al que contiene**: «Kaelen Vor» en la pregunta no es una
-  mención del personaje llamado «Vor», y dejar entrar a los dos llena el foco —y la ventana
-  del modelo— con una ficha que nadie ha pedido. Dos nombres de la MISMA longitud no se
-  suprimen: dos cosas pueden llamarse igual.
-- **Se le entrega el enlace ya escrito** («Kaelen Vor → `[Kaelen Vor](nodus://…)`»), en vez
-  de esperar que componga la URL. Y aun así `validateCitations` degrada a texto plano lo
-  que no exista: se conserva la frase y se retira la promesa.
-- **Tránsito y «antes de su primera aparición» se dicen en voz alta.** Aplanar una posición
-  a un nombre de lugar convertiría «iba de camino» en «estaba en Vael», que es exactamente
-  la respuesta confiada y falsa que todo este diseño existe para evitar.
-- **Sin historial de conversaciones**: habría necesitado tabla y migración, y el plan de
-  A10 no lo pide. El chat vive en la sesión.
+- **No focus is not calculated NADA**, and this was hunted by e2e:`rulesReaching`With null subject
+  returns all the laws of the world—they reach everyone by definition—so a question that did not
+  name anything came to the model with the legal code of the world attached and answered about it. A
+  chat that cannot say what it speaks of has to say that.
+- **The day is read in`shared/`, not in the model** (`readWorldDay`): All that goes after is
+  arithmetic ABOUT that number, and a model that reads "day 4 120" as 4 is surely wrong in the five
+  readings. Accept the Spanish thousands separator (space and point).
+- **The longer focus deletes the one it contains**: "Kaelen Vor" in the question is not a mention of
+  the character called "Vor", and let the two fill the focus — and the model window — with a tab
+  that no one has asked for. Two names of the same length are not deleted: two things can be called
+  the same.
+- **The link already written is given** (Kaelen Vor →`[Kaelen Vor](nodus://…)`), rather than waiting
+  for it to compose the URL. And yet`validateCitations`degrades to plain text what does not exist:
+  the phrase is retained and the promise is withdrawn.
+- **Transito and "before their first appearance" are said out loud.** Flattening a position to a
+  place name would turn "I was on the way" into "I was in Vael", which is exactly the confident and
+  false answer that all this design exists to avoid.
+- **No conversation history**: I would have needed table and migration, and the A10 plan does not
+  ask for it. Chat lives in the session.
 
 ---
 
-## 6. Landmines vigentes para las tres fases
+## 6. Landmines in force for the three phases
 
-1. **Ni una clave foránea ni un `ON DELETE CASCADE` en una migración nueva.** `foreign_keys`
-   está ON, así que un `REFERENCES` sin acción declarada usa NO ACTION y **aborta el borrado
-   del padre**; y `isCreateOnly()` rechaza cualquier cuerpo que contenga la palabra `DELETE`,
-   lo que descalifica la migración de sus **dos** caminos de reparación. La propiedad la
-   imponen las transacciones del repo.
-2. **Toda tabla nueva al grupo `worldbuilding` de `syncTables.ts`**, o no viaja y sus
-   borrados resucitan.
-3. **Clave derivada del contenido** en cualquier conjunto que se reescriba vaciando e
-   insertando, o cada guardado deja una lápida permanente por fila.
-4. **Los textos que llegan a `t()` por variable necesitan clave + variables**, nunca una
-   frase interpolada, y hay que registrarlos en `INDIRECT_KEY_SOURCES`. Un patrón ahí
-   necesita **dos grupos de captura** (comilla y contenido).
-5. **`npm run typecheck` sí cubre `electron/`.** Lo que solo caza `npm run build` son las
-   **claves i18n duplicadas (TS1117)** — comprobar las tres formas de comilla antes de añadir.
-6. **`npm run test:e2e` NO reconstruye**: `npm run build` antes, siempre.
-7. Al graduar una sección hay que **mover el control de «sección inerte»** del e2e a otra que
-   siga sin construir; su fallo significa eso, no una regresión.
-8. **Probar a mano con perfil aislado**
-   (`NODUS_USERDATA=/tmp/nodus-x ./node_modules/.bin/electron .`), **nunca sobre un vault
-   real**: un build con distinta numeración de migraciones los corrompe.
+1. **Neither a foreign key nor a foreign key`ON DELETE CASCADE`in a new
+   migration.**`foreign_keys`there's ON, so a`REFERENCES`without declared action uses NO ACTION and
+   **aborts the deletion of the father**; and`isCreateOnly()`rejects any body containing the
+   word`DELETE`, which disqualifies the migration of its **two** repair roads. Property is imposed
+   by repo transactions.
+2. **All new table to the group`worldbuilding`of`syncTables.ts`**, or he doesn't travel and his
+   erased ones resurrect.
+3. **Cave derived from content** in any set that is rewritten by emptying and inserting, or each
+   saved leaves one permanent tombstone per row.
+4. **Texts arriving at`t()`per variable need key + variables**, never an interpolated phrase, and
+   must be recorded in`INDIRECT_KEY_SOURCES`. A pattern there needs **two capture groups** (quote
+   and content).
+5. **`npm run typecheck`yes it covers`electron/`.** What I only hunt`npm run build`are the
+   **duplicate i18n keys (TS1117)** — check all three form of quotation marks before adding.
+6. **`npm run test:e2e`DO NOT reconstruct**:`npm run build`before, always.
+7. When you graduate a section you have to **move the control of "inert section"** of the e2e to
+   another that remains unbuilt; its failure means that, not a regression.
+8. **Hand test with isolated profile** (`NODUS_USERDATA=/tmp/nodus-x ./node_modules/.bin/electron
+   .`), **never on a real vault**: a build with different migration numbers corrupts them.

--- a/design/worldbuilding-characters-plan.md
+++ b/design/worldbuilding-characters-plan.md
@@ -1,130 +1,143 @@
-# Vault de Worldbuilding — Sección **Personajes**
+# Vault of Worldbuilding — Section **Persons**
 
-> Estado: **F0–F7, la cola Q1–Q8 y el calendario del mundo (W1) implementados y
-> verificados, SIN commitear** (2026-07-27).
-> `npm test` 875/875 · `eslint` 0 errores · `typecheck` limpio · `build` + `test:e2e`
-> en verde con `database at schema v93`.
+> Status: **F0–F7, the Q1–Q8 queue and the world calendar (W1) implemented and
+> verified, UNCOMMITTED** (2026-07-27).
+> `npm test` 875/875 · `eslint` 0 errors · `typecheck` clean · `build` + `test:e2e`
+> in green with `database at schema v93`.
 >
-> **Pendiente, con el diseño ya decidido (§16):** W2 facciones y culturas + pertenencias,
-> W3 secretos y quién los sabe, W4 escenas y apariciones. No están bloqueadas: cada una
-> es la versión mínima de una sección anunciada que un escritor necesita de verdad.
+> **Pending, with the design already decided (§16):** W2 factions and cultures + belongings,
+> W3 secrets and who knows them, W4 scenes and apparitions. They are not blocked: each
+> is the minimum version of an advertised section that a writer really needs.
 >
-> Tres cosas que no estaban en el plan y hubo que hacer:
+> Three things that weren't in the plan and had to be done:
 >
-> 1. **`shared/types.ts` — `HistoricalEventType` ampliada** con el vocabulario de ficción
->    (`first_appearance`, `oath`, `betrayal`, `battle`, `journey`, `ascension`, `exile`,
->    `transformation`, `bond`, `loss`, `revelation`). Es seguro porque ningún consumidor
->    recorre la unión de forma exhaustiva: todos son listas explícitas
->    (`EVENT_TYPE_OPTIONS`, el `Set` de `recordsExtraction`, el `satisfies` del MCP), así
->    que los dos vocabularios comparten columna sin cruzarse nunca en un mismo selector.
-> 2. **`electron/db/syncTables.ts` — grupo de sync `worldbuilding`.** El motor de
->    `.nodussync` exige que TODA tabla esté clasificada como sincronizada o excluida, y
->    `test-sync-package` / `test-superseded-versions` lo hacen cumplir. Sin registrar
->    `character_profiles` y `event_world_dates`, la mitad de ficción de cada personaje
->    no habría viajado entre máquinas. Clave nueva en `SyncGroupKey`; los tombstones de
->    borrado se generan de esa misma lista, así que se arreglan solos.
-> 3. **`scripts/test-protect-persistence.mjs`** fijaba `SCHEMA_VERSION === 90` como
->    número literal, así que cualquier migración posterior lo rompía sin decir nada sobre
->    Protect. Ahora comprueba la coherencia de los tres valores y `>= 90`.
+> 1. **`shared/types.ts` — `HistoricalEventType` amplified** with fiction vocabulary
+> (`first_appearance`, `oath`, `betrayal`, `battle`, `journey`, `ascension`, `exile`,
+> `transformation`, `bond`, `loss`, `revelation`). It is safe because no consumer
+> goes through the union in an exhaustive way: all are explicit lists
+> (`EVENT_TYPE_OPTIONS`, the `Set` of `recordsExtraction`, the `satisfies` of the MCP), thus
+> that the two vocabularies share column without ever crossing into one selector.
+> 2. **`electron/db/syncTables.ts` — sync group `worldbuilding`.** The engine of
+> `.nodussync` requires that ALL table is classified as synchronized or excluded, and
+> `test-sync-package` / `test-superseded-versions` enforce it. Unregistered
+> `character_profiles` and `event_world_dates`, half the fiction of each character
+> would not have traveled between machines. New key in `SyncGroupKey`; the tombstones of
+> deleted are generated from that same list, so they fix themselves.
+> 3. **`scripts/test-protect-persistence.mjs`** fixed `SCHEMA_VERSION === 90` as
+> literal number, so any subsequent migration broke it without saying anything about
+> Protect. Now check the consistency of the three values and `>= 90`.
 >
-> Y una desviación deliberada: **`WorldbuildingHome` se adelantó de F6 a F2**, porque es
-> parte de graduar el vault (sin ella, quitar el Inicio de preview dejaba el árbol sin
-> compilar). F6 quedó reducida a la paleta de comandos, que sale gratis: se deriva de
-> `NAV_ITEMS` filtrada por `isViewAllowedForVaultType`.
+> And a deliberate deviation: **`WorldbuildingHome` was advanced from F6 to F2**, because it is
+> part of graduating the vault (without it, removing the Preview Start left the tree without
+> compile). F6 was reduced to the command palette, which comes out free: derived from
+> `NAV_ITEMS` filtered by `isViewAllowedForVaultType`.
 
-<details>
-<summary>Plan original (2026-07-27)</summary>
-> Primera sección real del vault `worldbuilding`, que hoy es sólo una cáscara *preview*.
-> Se construye sobre la ontología de registros de genealogía (`persons`, `events`,
-> `relationships`, `social_relations`, `places`) mediante una tabla de superposición,
-> sin tocar el comportamiento del vault de genealogía.
+<details> <summary>Original plan (2026-07-27)</summary>
+> First real section of the vault `worldbuilding`, which today is just a shell * preview*.
+> It is built on the ontology of genealogy records (`persons`, `events`,
+> `relationships`, `social_relations`, `places`) using an overlap table,
+> without touching the behavior of the genealogy vault.
 
 ---
 
-## 1. Alcance y decisiones cerradas
+## 1. Scope and decisions closed
 
-### 1.1 Decisiones tomadas
+### 1.1 Decisions taken
 
-| Decisión | Elección | Consecuencia |
+| Decision | Election | Consequence |
 |---|---|---|
-| **Almacenamiento** | Reutilizar `persons` + tabla overlay `character_profiles` (1:1) | Eventos, parentesco, relaciones sociales, lugares, retrato, fusión y —más adelante— árbol, cronología y mapa se heredan gratis. Genealogía no se modifica. |
-| **Fechas del mundo** | Texto libre para mostrar + entero opcional para ordenar | Cualquier calendario inventado funciona con una columna. Sin sistema de eras (queda en cola). |
-| **Extra de fase 1** | Sólo la **cuadrícula de fichas** | Galería multi‑imagen, entrevistar al personaje y aviso de nombres confundibles quedan en cola (§13). |
+| **Storage** | Reuse `persons` + overlay table `character_profiles` (1:1) | Events, kinship, social relations, places, portrait, fusion and — later on — tree, chronology and map are inherited for free. Genealogy is not modified. |
+| **Dates of the world** | Free text to display + optional integer to sort | Any invented calendar works with a column. No era system (stays in line). |
+| **Extra phase 1** | Only the ** chip grid** | Multi-image gallery, interviewing the character and warning of confusing names stand in line (§13). |
 
-### 1.2 Qué entra en la fase 1
+### 1.2 Entering Phase 1
 
-Paridad con la ficha de personas de genealogía, adaptada a ficción:
+Parity with the genealogy file, adapted to fiction:
 
-- Crear, editar, buscar y borrar personajes.
-- Nombres y **alias tipados** (nombre verdadero, de nacimiento, epíteto/título, apodo, alias, nombre en otra lengua).
-- **Eventos de su vida** (tipos de ficción) con lugar, notas y orden en el calendario del mundo.
-- **Parentesco** (reutiliza `KinshipEditor`) y **relaciones** (reutiliza `RelationsSection`).
-- **Descripción**: Apariencia · Personalidad · Trasfondo, más **semilla visual**.
-- **Biografía generada con IA** a partir de la ficha.
-- **Retrato generado con IA**, y subida/encuadre de imagen propia.
-- Notas en Markdown.
-- **Vista en cuadrícula** de fichas con retrato, filtrable.
-- Graduar `worldbuilding` de tipo *preview* a vault real, con su sidebar, su acento violeta y su Inicio.
+- Create, edit, search and delete characters.
+- Names and **typed aliases** (true name, birth, epithet/title, nickname, alias, name in another
+  language).
+- **Events of his life** (types of fiction) with place, notes and order on the calendar of the
+  world.
+- **Parents** (reuse `KinshipEditor`) and **relations** (reuse `RelationsSection`).
+- **Description**: Appearance · Personality · Transfundo, plus **visual seed**.
+- **Biography generated with AI** from the tab.
+- **Portrait generated with AI**, and own image upload/frame.
+- Markdown notes.
+- **View in grid** of tokens with portrait, filterable.
+- Graduate `worldbuilding` of type *preview* a valid real, with its sidebar, its violet accent and
+  its Home.
 
-### 1.3 Qué NO entra
+### 1.3 NOT Entering
 
-Cronología, mapa, árbol, enciclopedia, facciones, culturas, escenas, tramas y manuscritos siguen sin construir: aparecen en el sidebar como secciones anunciadas (§8.4). El resto, en §13.
-
----
-
-## 2. Lo que no encaja de genealogía (y por qué se cambia)
-
-Cinco puntos concretos, todos verificados en el código actual:
-
-1. **`persons.sex` es `male|female|unknown`.** No describe a un dios, un dragón ni una IA. Se sustituye en la ficha por `species`, `gender` y `pronouns` en el overlay. La columna `sex` se queda a `'unknown'` en worldbuilding y **no se muestra nunca**.
-2. **Las fechas.** `finishCore` en [genealogyDates.ts:86](../shared/genealogyDates.ts) rechaza cualquier año fuera de 1–3000 y sólo entiende meses reales; «342 T.E.» o «13 de Lluvia de 1204» devuelven `sortKey: null`. Sin sort key, la lista de eventos de la ficha queda en orden arbitrario **sin avisar**. Por eso el año del mundo es un entero aparte (§3.2).
-3. **La epistemología está invertida.** Genealogía prohíbe inventar y exige evidencia documental (`BIOGRAPHY_SYSTEM`, `hasBiographyEvidence`). En ficción el autor *es* la fuente: la biografía se escribe desde la ficha, no desde citas. Prompts nuevos (§5.1).
-4. **El generador de retratos está redactado como algo a evitar** — «No recomendado… no es una fotografía real» ([PersonDossier.tsx:951](../src/components/PersonDossier.tsx)) y `buildReferencePortraitPrompt` fuerza *sepia y tonos heritage* ([decorativeImages.ts:407](../electron/ai/decorativeImages.ts)). En worldbuilding es una función de primera clase con estilo elegible.
-5. **`persons.national_id`** no aplica; simplemente no se expone.
+Chronology, map, tree, encyclopedia, factions, cultures, scenes, plots and manuscripts remain
+unbuilt: they appear in the sidebar as announced sections (§8.4). The rest, in §13.
 
 ---
 
-## 3. Modelo de datos — migración **91**
+## 2. What does not fit genealogy (and why is changed)
 
-`SCHEMA_VERSION` pasa de 90 a 91 en [migrations.ts:10](../electron/db/migrations.ts).
-Migración **sólo CREATE**, sin `ALTER`, para que sea reproducible por el mecanismo de
-backfill de `isCreateOnly`.
+Five specific points, all verified in the current code:
+
+1. ** `persons.sex` is `male|female|unknown`.** It does not describe a god, a dragon or an AI. It is
+   replaced on the tab by `species`, `gender` and `pronouns` on the overlay. The `sex` column
+   remains at `'unknown'` on worldbuilding and ** is never shown**.
+2. **Dates.** `finishCore` in [genealogyDates.ts:86](../shared/genealogyDates.ts) rejects any year
+   outside 1–3000 and only understands real months; <342 T.E.» or <13 of Rain of 1204» return
+   `sortKey: null`. Without sort key, the list of events on the tab is in arbitrary order ** without
+   warning**. That is why the year of the world is a separate whole (§3.2).
+3. **Epistemology is inverted.** Genealogy forbids inventing and demands documentary evidence
+   (`BIOGRAPHY_SYSTEM`, `hasBiographyEvidence`). In fiction the author *is* the source: biography is
+   written from the tab, not from citations. New prompts (§5.1).
+4. **The portrait generator is written as something to avoid** — «Not recommended... is not a real
+   photograph» ([PersonDossier.tsx:951](../src/components/PersonDossier.tsx)) and
+   `buildReferencePortraitPrompt` force *sepia and heritage* tones
+   ([decorativeImages.ts:407](../electron/ai/decorativeImages.ts)). In worldbuilding it is a first
+   class function with an eligible style.
+5. **`persons.national_id`** does not apply; it is simply not exposed.
+
+---
+
+## 3. Data model — migration **91**
+
+`SCHEMA_VERSION` goes from 90 to 91 in [migrations.ts:10](../electron/db/migrations.ts). Migration
+**only CREATE**, without `ALTER`, to be reproducible by the backfill mechanism of `isCreateOnly`.
 
 ### 3.1 `character_profiles`
 
 ```sql
--- Superposición de ficción sobre `persons`. Un personaje ES una persona (así hereda
--- eventos, parentesco, relaciones, lugares y retrato); esta tabla guarda lo que sólo
--- tiene sentido en un mundo inventado. En un vault de genealogía nunca tiene filas.
+-- Superposition of fiction over `persons`. A character IS a person (so inherits
+-- events, kinship, relationships, places and portrait); this table saves what only
+-- It makes sense in an invented world. In a genealogy vault it never has rows.
 CREATE TABLE character_profiles (
   person_id        TEXT PRIMARY KEY REFERENCES persons(person_id) ON DELETE CASCADE,
 
-  -- Identidad: sustituye a persons.sex, que no describe a un dios ni a un dragón.
+  -- Identity: it replaces persons.sex, who do not describe a god or a dragon.
   species          TEXT,
   gender           TEXT,
   pronouns         TEXT,
 
-  -- Estado narrativo en vez de nacimiento+defunción a secas.
+  -- Narrative status instead of birth + death to dry.
   -- unknown | alive | dead | missing | undead | immortal | unborn
   life_status      TEXT NOT NULL DEFAULT 'unknown',
 
   -- protagonist | antagonist | secondary | tertiary | cameo
   narrative_role   TEXT,
-  -- Token de la paleta de etiquetas (no un hex), para la cuadrícula.
+  -- Token from the label palette (not a hex), for the grid.
   accent           TEXT,
 
-  -- La descripción biográfica, partida en tres para que el prompt de imagen no
-  -- reciba también el carácter y el pasado.
+  -- The biographical description, starting in three so that the image prompt does not
+  -- receive also character and the past.
   appearance       TEXT,
   personality      TEXT,
   backstory        TEXT,
 
-  -- Prompt canónico de apariencia, reinyectado en TODAS las generaciones de imagen.
-  -- Es lo único que consigue que el personaje se parezca a sí mismo entre imágenes.
+  -- Prompt canonical appearance, re-injected into ALL generations of image.
+  -- It's the only thing that gets the character to look like himself between images.
   visual_seed      TEXT,
 
-  -- Año del mundo. La fecha legible sigue en persons.birth_date / death_date tal como
-  -- la escriba el autor; estos enteros (pueden ser negativos) son lo único que ordena.
+  -- Year of the world. The readable date is still in persons.birth_date / death_date such as
+  -- the author writes it; these integers (may be negative) are the only thing that commands.
   birth_year_sort  INTEGER,
   death_year_sort  INTEGER,
 
@@ -137,28 +150,28 @@ CREATE INDEX idx_character_profiles_birth ON character_profiles(birth_year_sort)
 ### 3.2 `event_world_dates`
 
 ```sql
--- Orden de un evento en un calendario inventado. Tabla aparte y no una columna en
--- `events` para que la migración siga siendo sólo-CREATE y para no cargar el
--- ontología de genealogía con una columna que nunca usará.
+-- Order of an event in an invented calendar. Table apart and not a column in
+-- `events` for the migration to remain only-CREATE and not to load the
+-- genealogy ontology with a column you will never use.
 CREATE TABLE event_world_dates (
   event_id    TEXT PRIMARY KEY REFERENCES events(event_id) ON DELETE CASCADE,
   world_year  INTEGER,
-  -- Desempate dentro del mismo año (estación, día, capítulo) sin obligar al autor a
-  -- inventarse un calendario completo.
+  -- Dispatching within the same year (season, day, chapter) without forcing the author to
+  -- Inventing a full calendar.
   world_order INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX idx_event_world_dates_year ON event_world_dates(world_year, world_order);
 ```
 
-### 3.3 Lo que **no** cambia
+### 3.3 What **does not** change
 
-- Los alias tipados usan `person_names.kind`, que ya es texto libre. **Sin migración.**
-- El retrato usa `persons.portrait_*` y `setPersonPortrait`, ya existentes.
-- Notas → `persons.notes`. Biografía → `persons.biography` / `biography_at`.
+- Typing aliases use `person_names.kind`, which is already free text. **No migration.**
+- The portrait uses `persons.portrait_*` and `setPersonPortrait`, already existing.
+- Notes → `persons.notes`. Biography → `persons.biography` / `biography_at`.
 
 ---
 
-## 4. Tipos compartidos — `shared/types.ts`
+## 4. Shared rates — `shared/types.ts`
 
 ```ts
 export type CharacterLifeStatus =
@@ -185,7 +198,7 @@ export interface CharacterProfile {
   updatedAt: string;
 }
 
-/** Un personaje = la fila compartida de `persons` más su superposición de ficción. */
+/** A character = the shared row of `persons` plus its fiction overlap. */
 export interface Character extends Person {
   profile: CharacterProfile;
 }
@@ -202,7 +215,7 @@ export interface CharacterInput {
   personality?: string | null;
   backstory?: string | null;
   visualSeed?: string | null;
-  birthDate?: string | null;      // texto libre, como lo escriba el autor
+  birthDate?: string | null;      // free text, as written by the author
   deathDate?: string | null;
   birthYearSort?: number | null;
   deathYearSort?: number | null;
@@ -215,8 +228,8 @@ export interface CharacterFilter {
 }
 ```
 
-Nuevo fichero `shared/characterLabels.ts` (paralelo a `src/components/personLabels.ts`,
-pero compartido porque el prompt de la IA también los necesita):
+New `shared/characterLabels.ts` file (parallel to `src/components/personLabels.ts`, but shared
+because the AI prompt also needs them):
 
 ```ts
 export const CHARACTER_LIFE_STATUS_LABEL: Record<CharacterLifeStatus, string>;
@@ -226,69 +239,68 @@ export const CHARACTER_NAME_KINDS: { id: string; label: string }[];
 export const CHARACTER_ACCENTS: { id: string; hex: string }[];
 ```
 
-**Tipos de evento de ficción** (sustituyen a `EVENT_TYPE_OPTIONS` de genealogía; se
-guardan en la misma columna `events.type`, que es texto libre):
-`birth`, `death`, `first_appearance`, `oath`, `betrayal`, `battle`, `journey`,
-`ascension`, `exile`, `transformation`, `bond`, `loss`, `revelation`, `other`.
+**Types of fictional event** (replace `EVENT_TYPE_OPTIONS` from genealogy; are saved in the same
+column `events.type`, which is free text): `birth`, `death`, `first_appearance`, `oath`, `betrayal`,
+`battle`, `journey`, `ascension`, `exile`, `transformation`, `bond`, `loss`, `revelation`, `other`.
 
-**Estados**: sin determinar · vivo · muerto · desaparecido · no‑muerto · inmortal · aún no nace.
-**Tipos de nombre**: nombre verdadero · nombre de nacimiento · epíteto o título · apodo · alias · nombre en otra lengua.
+**States**: undetermined · alive · dead · missing · undead · immortal · not yet born. **Types of
+name**: true name · birth name · epithet or title · nickname · alias · name in another language.
 
 ---
 
-## 5. Capa de datos — `electron/db/charactersRepo.ts`
+## 5. Data layer — `electron/db/charactersRepo.ts`
 
 ```ts
 listCharacters(filter?: CharacterFilter): Character[]
 getCharacter(personId: string): Character | null
 createCharacter(input: CharacterInput): Character
 updateCharacter(personId: string, patch: Partial<CharacterInput>): Character | null
-deleteCharacter(personId: string): void          // delega en deletePerson; CASCADE limpia el overlay
+deleteCharacter(personId: string): void          // delegate to deletePerson; CASCADE cleans overlay
 listCharacterEvents(personId: string): HistoricalEvent[]
 setEventWorldDate(eventId: string, worldYear: number | null, worldOrder: number): void
 characterCounts(): { total: number; byRole: Record<string, number>; byStatus: Record<string, number> }
 ```
 
-**Reglas de implementación, no negociables:**
+** Implementing rules, non-negotiable:**
 
-- **Nunca asumir que existe la fila del overlay.** Un `Person` creado por otra vía (import,
-  fusión, sincronización) no la tendrá. Todas las lecturas hacen `LEFT JOIN character_profiles`
-  y **sintetizan los valores por defecto** en memoria; las escrituras usan
-  `INSERT … ON CONFLICT(person_id) DO UPDATE`. No hay un `ensureProfile()` que llamar y
-  olvidar: si se olvida, la ficha aparece vacía sin error.
-- **Búsqueda por alias**, no sólo por `display_name`: `listCharacters({search})` hace
-  `EXISTS (SELECT 1 FROM person_names …)` igual que `listPersons`.
-- **Orden de los eventos**: `ORDER BY world_year IS NULL, world_year, world_order, date_sort, created_at`.
-  El `IS NULL` primero evita que SQLite ponga los nulos delante y desordene la ficha.
-- `updateCharacter` toca `persons` **y** el overlay en **una transacción**.
+- **Never assume that the overlay row exists.** A `Person` created by another way (import, fusion,
+  synchronization) will not have it. All readings do `LEFT JOIN character_profiles` and **synthesize
+  the default values** in memory; the scriptures use `INSERT … ON CONFLICT(person_id) DO UPDATE`.
+  There is no `ensureProfile()` to call and forget: if forgotten, the tab appears empty without
+  error.
+- **Seek by alias**, not only by `display_name`: `listCharacters({search})` does `EXISTS (SELECT 1
+  FROM person_names …)` as `listPersons`.
+- **Events order**: `ORDER BY world_year IS NULL, world_year, world_order, date_sort, created_at`.
+  The `IS NULL` first prevents SQLite from putting null in front and messing up the tab.
+- `updateCharacter` touches `persons` ** and** the overlay in **a transaction**.
 
 ---
 
-## 6. IA
+## 6. AI
 
-### 6.1 Biografía — `shared/characterBiographyContext.ts` + `electron/ai/characterBiography.ts`
+### 6.1 Biography — `shared/characterBiographyContext.ts` + `electron/ai/characterBiography.ts`
 
-Espejo de [personBiography.ts](../electron/ai/personBiography.ts), con tres diferencias:
+Mirror of [personBiography.ts](../electron/ai/personBiography.ts), with three differences:
 
-1. **La fuente es la ficha**, no la evidencia: apariencia, personalidad, trasfondo,
-   alias, estado, eventos, parentesco y relaciones. `hasCharacterMaterial()` devuelve
-   `true` con sólo una descripción — en genealogía eso no existía y el usuario recibía
-   «no hay evidencia suficiente» con la ficha llena.
-2. **Prompt nuevo.** Reglas: prosa narrativa continua, 150–250 palabras; **usar
-   literalmente los pronombres y el nombre indicados**; no contradecir nada de la ficha;
-   no introducir hechos, nombres ni lugares que no estén en ella; sin encabezados ni viñetas.
-3. **La biografía generada no es canon automático.** Se guarda en `persons.biography`
-   como hoy, pero la ficha la etiqueta como generada, con su fecha y un botón de regenerar.
-   (El modo «proponer y rellenar huecos» queda en cola, §13.)
+1. **The source is the tab**, not the evidence: appearance, personality, background, alias, status,
+   events, kinship and relationships. `hasCharacterMaterial()` returns `true` with only one
+   description — in genealogy that did not exist and the user received <there is not enough
+   evidence» with the full tab.
+2. **New Prompt.**Rules: continuous narrative prose, 150–250 words; **literally use the pronouns and
+   name indicated**; do not contradict anything on the tab; do not enter facts, names or places that
+   are not in it; without headings or cartoons.
+3. **The generated biography is not automatic canon.** It is saved in `persons.biography` as it is
+   today, but the tab the label as generated, with its date and a regenerating button. (The "propose
+   and fill holes" mode is in queue, §13.)
 
-Modelo: `synthesisModel ?? extractionModel`, como en genealogía.
+Model: `synthesisModel ?? extractionModel`, as in genealogy.
 
-### 6.2 Retrato — `electron/ai/decorativeImages.ts`
+### 6.2 Portrait — `electron/ai/decorativeImages.ts`
 
-Nueva exportación `generateCharacterPortrait(personId, opts: { style, extra? })`, junto a
-`generatePersonPortraitFromDescription` (que se queda intacta para genealogía).
+New export `generateCharacterPortrait(personId, opts: { style, extra? })`, next to
+`generatePersonPortraitFromDescription` (which remains intact for genealogy).
 
-Construcción del prompt, en `shared/characterImagePrompt.ts`:
+Prompt construction, in `shared/characterImagePrompt.ts`:
 
 ```
 [plantilla de estilo elegido de DECORATIVE_IMAGE_STYLES]
@@ -298,31 +310,31 @@ Construcción del prompt, en `shared/characterImagePrompt.ts`:
 . no text, no letters, no numbers, no logos, no watermark
 ```
 
-- El estilo sale del selector ya existente `DECORATIVE_IMAGE_STYLES`; no hay maquinaria nueva.
-- `vaultTypeImagePrompt('worldbuilding')` se queda en `''` **a propósito**: el estilo lo
-  elige el autor por personaje, no lo impone el vault.
-- Reutiliza `callImageProvider` → `optimizedJpegs` → `setPersonPortrait(..., generated=true)`,
-  con lo que el `AiBadge` de `PersonPortrait` sigue funcionando.
-- Si no hay `imageProvider`/`imageModel`, el mismo error accionable que ya se lanza.
+- The style comes out of the existing selector `DECORATIVE_IMAGE_STYLES`; there is no new machine.
+- `vaultTypeImagePrompt('worldbuilding')` stays in `''` ** on purpose**: the style is chosen by the
+  author per character, it is not imposed by the vault.
+- Reuse `callImageProvider` → `optimizedJpegs` → `setPersonPortrait(..., generated=true)`, so the
+  `AiBadge` of `PersonPortrait` still works.
+- If there is no `imageProvider`/`imageModel`, the same actuable error is already launched.
 
-### 6.3 `promptPack` del tipo de vault — `shared/vaultTypes.ts`
+### 6.3 `promptPack` of the type of vault — `shared/vaultTypes.ts`
 
-Hoy está vacío. Se redacta (en español, como los demás):
+Today it is empty. It is written (in Spanish, like the others):
 
-> **CONTEXTO DEL VAULT — MODO WORLDBUILDING.** Este vault construye un mundo de ficción.
-> A diferencia de un corpus documental, aquí **el autor es la fuente de verdad**: lo que
-> consta en las fichas es canon y no se contradice ni se «corrige». No introduzcas
-> hechos, nombres, lugares ni parentescos que no estén en el material aportado, y cuando
-> propongas algo, dilo explícitamente en vez de presentarlo como establecido. Respeta
-> literalmente los nombres, epítetos y pronombres tal como el autor los escribe: no los
-> traduzcas, normalices ni sustituyas. Ten en cuenta que los personajes pueden no ser
-> humanos y que el calendario, la geografía y las reglas del mundo son inventados.
+> **VALULT CONTEXT — WORLDBUILDING MODE.** This Vault builds a world of fiction.
+> Unlike a documentary corpus, here ** the author is the source of truth**: what
+> is canon and is not contradicted or ‘corrected’.
+> facts, names, places or kinship that are not in the material provided, and when
+> propose something, say it explicitly instead of presenting it as established.
+> literally the names, epithets and pronouns as the author writes them:
+> translate, normalize, or replace. Note that characters may not be
+> and that the calendar, geography and rules of the world are invented.
 
 ---
 
 ## 7. IPC · preload · `NodusApi`
 
-| Canal | Handler | Firma en `window.nodus` |
+| Channel | Handler | Signature in `window.nodus` |
 |---|---|---|
 | `characters:list` | `listCharacters` | `listCharacters(filter?): Promise<Character[]>` |
 | `characters:get` | `getCharacter` | `getCharacter(id): Promise<Character \| null>` |
@@ -335,352 +347,350 @@ Hoy está vacío. Se redacta (en español, como los demás):
 | `characters:generateBiography` | `generateCharacterBiography` | `generateCharacterBiography(id): Promise<{biography, noMaterial}>` |
 | `characters:generatePortrait` | `generateCharacterPortrait` | `generateCharacterPortrait(id, style): Promise<Character \| null>` |
 
-Se reutilizan sin tocar: `addPersonName`, `setPersonPortraitFromFile`, `getPersonPortrait`,
+They are reused without touching: `addPersonName`, `setPersonPortraitFromFile`, `getPersonPortrait`,
 `updatePortraitFocus`, `clearPersonPortrait`, `createEvent`, `updateEvent`, `deleteEvent`,
 `findOrCreatePlace`, `addRelationship`, `kinOf`, `createSocialRelation`.
 
-Tres ficheros a tocar en paralelo, siempre los tres: [ipc.ts](../electron/ipc.ts),
-[preload.ts](../electron/preload.ts) y la interfaz `NodusApi` en `shared/types.ts`.
+Three files to play in parallel, always all three: [ipc.ts](../electron/ipc.ts),
+[preload.ts](../electron/preload.ts) and the `NodusApi` interface in `shared/types.ts`.
 
 ---
 
-## 8. Interfaz
+## 8. Interface
 
-### 8.1 `src/views/CharactersView.tsx` — la cuadrícula
+### 8.1 `src/views/CharactersView.tsx` — grid
 
-Sustituye al patrón lista‑22rem + detalle de `PersonasView`: una rejilla quiere el ancho completo.
+Replaces the list-22rem pattern + detail of `PersonasView`: a grid wants the full width.
 
-- **Cabecera**: título · contador · buscador · `Nuevo personaje` · dos selectores de filtro (rol, estado).
-- **Rejilla**: `grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(11rem,1fr))]`.
-- **Tarjeta** (`data-testid="character-card"`):
-  - retrato en `aspect-[3/4]` con `<PersonPortrait fill rounded="md" />`;
-  - franja de acento arriba con el color de `profile.accent`;
-  - nombre; debajo, el epíteto (primer alias de tipo *epíteto/título*) o el estado;
-  - insignia de rol narrativo en la esquina;
-  - punto de estado (muerto/desaparecido en gris apagado).
-- **Vacío**: «Aún no hay personajes» + el botón de crear.
-- **Detalle**: al pulsar una tarjeta, la ficha ocupa el panel con un botón de volver.
-  Se mantiene el scroll de la rejilla al regresar.
-- **Virtualización**: innecesaria por debajo de ~500 tarjetas; por encima, aplicar el
-  mismo patrón que la galería ya virtualizada. Se anota, no se implementa.
+- ** Head**: title · counter · search engine · `Nuevo personaje` · two filter selectors (rol,
+  status).
+- ** Grid**: `grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(11rem,1fr))]`.
+- ** Card** (`data-testid="character-card"`):
+  - portrait in `aspect-[3/4]` with `<PersonPortrait fill rounded="md" />`;
+  - accent strip above with the color of `profile.accent`;
+  - name; under, the epithet (first alias of type *epite/title*) or status;
+  - narrative role badge on the corner;
+  - status point (dead/disappeared in grey off).
+- **Empty**: «There are no characters yet» + the create button.
+- **Detail**: When pressing a card, the tab occupies the panel with a return button. The scroll of
+  the grid is maintained upon return.
+- **Virtualization**: unnecessary below ~500 cards; above, apply the same pattern as the gallery
+  already virtualized. Note, not implemented.
 
-> **Detalle de retrato**: con `fill`, el marcador de posición de `PersonPortrait` dibuja
-> `<Icon name="user" size={size * 0.5} />` con el `size` **por defecto de 48**, o sea un
-> icono diminuto en una tarjeta grande ([PersonPortrait.tsx:102](../src/components/PersonPortrait.tsx)).
-> Hay que pasarle un `size` coherente o darle un marcador propio. Además, la silueta por
-> defecto se elige a partir de `persons.sex`: con `sex='unknown'` cae en el marcador
-> neutro, que es lo correcto aquí — **no** hay que "arreglarlo" mapeando `gender` a las
-> siluetas humanas, porque un personaje puede no ser humano.
+> **Portrait detail**: with `fill`, the `PersonPortrait` position marker draws
+> `<Icon name="user" size={size * 0.5} />` with `size` ** by default of 48**, i.e. a
+> tiny icon on a large card ([PersonPortrait.tsx:102](../src/components/PersonPortrait.tsx)).
+> You have to pass a coherent `size` or give it your own marker. Also, the silhouette by
+> default is chosen from `persons.sex`: with `sex='unknown'` falls on the marker
+> neutral, which is right here — **no** you have to "fix" it by mapping `gender` to the
+> human silhouettes, because a character may not be human.
 
-### 8.2 `src/components/CharacterDossier.tsx` — la ficha
+### 8.2 `src/components/CharacterDossier.tsx` — tab
 
-Secciones en orden, reutilizando `PERSON_DOSSIER_SECTION_CLASS`,
-`PERSON_DOSSIER_ACTION_BUTTON_CLASS` y `PERSON_DOSSIER_ADD_BUTTON_CLASS`:
+Sections in order, reusing `PERSON_DOSSIER_SECTION_CLASS`, `PERSON_DOSSIER_ACTION_BUTTON_CLASS` and
+`PERSON_DOSSIER_ADD_BUTTON_CLASS`:
 
-1. **Cabecera** — retrato con sus acciones (subir · encuadrar · generar con IA · quitar),
-   nombre, epíteto, `pronouns · species · estado`, botones editar/eliminar/cerrar.
-2. **Descripción** — tres editores con autoguardado: *Apariencia*, *Personalidad*, *Trasfondo*.
-   Debajo, plegado, **Semilla visual** con la explicación de para qué sirve y un botón
-   «Usar la apariencia como semilla».
-3. **Biografía** — igual que en genealogía: generar/regenerar, texto, fecha, etiqueta de generada.
-4. **Nombres y alias** — chips; el modal de alta lleva un `<select>` de tipo en vez del
-   `'variante'` fijo que usa hoy `NameVariantsEditor`.
-5. **Eventos de su vida** — misma tabla que genealogía, con dos campos extra en el
-   formulario: *año del mundo* (entero, admite negativos) y *orden dentro del año*.
-   Los tipos son los de ficción.
-6. **Parentesco** — `KinshipEditor` + resumen `KinRow`, reutilizados tal cual.
-7. **Relaciones** — `RelationsSection`, reutilizada tal cual.
-8. **Notas** — `MarkdownNotesEditor` sobre `persons.notes`.
+1. ** Head** — portrait with its actions (up · frame · generate with AI · remove), name, epithet,
+   `pronouns · species · status`, edit/delete/close buttons.
+2. **Description** — three self-saved editors: *Appearance*, *Personality*, *Background*. Below,
+   folded, **Visual Seed** with the explanation of what it serves and a button "Use appearance as
+   seed".
+3. **Biography** — as in genealogy: generate/regenerate, text, date, generated label.
+4. **Names and aliases** — chips; the high modal carries a type `<select>` instead of the fixed
+   `'variante'` used today `NameVariantsEditor`.
+5. **Events of his life**—the same table as genealogy, with two extra fields in the form: *year of
+   the world* (integer, he admits negatives) and *order within the year*.
+6. **Partnership** — `KinshipEditor` + abstract `KinRow`, reused as it is.
+7. **Relations** — `RelationsSection`, reused as it is.
+8. **Notes** — `MarkdownNotesEditor` over `persons.notes`.
 
-Editor de datos básicos (`CharacterBasicsEditor`): nombre, especie, género, pronombres,
-estado, rol narrativo, acento, fecha de nacimiento y de muerte (texto libre) y sus dos
-años del mundo.
+Basic data editor (`CharacterBasicsEditor`): name, species, gender, pronouns, status, narrative
+role, accent, date of birth and death (free text) and his two years of the world.
 
-**No se portan**: sugerencias de identidad (fusión), parentescos sugeridos por evidencia,
-hechos en conflicto, documentos vinculados, evidencia citada e identificador nacional.
-Son superficies de prueba documental que no tienen sentido con un autor como fuente.
+**Don't behave**: suggestions of identity (fusion), kinship suggested by evidence, conflicting
+facts, linked documents, cited evidence and national identifier. They are documentary evidence
+surfaces that make no sense with an author as a source.
 
 ### 8.3 `src/views/WorldbuildingHome.tsx`
 
-Pequeña, al estilo de `TeachingHome`: contador de personajes, «Crear personaje», los
-últimos personajes tocados, y un aviso sobrio de que el resto de secciones está en construcción.
+Small, `TeachingHome` style: character counter, «Create character», the last characters played, and
+a sober warning that the rest of sections are under construction.
 
 ### 8.4 `src/components/WorldbuildingSidebar.tsx`
 
-Sustituye a [PreviewVaultSidebar.tsx](../src/components/PreviewVaultSidebar.tsx), que se
-elimina (worldbuilding era su único usuario). Sigue el patrón de
-[TeachingSidebar.tsx](../src/components/TeachingSidebar.tsx): los ítems con `view` navegan,
-los demás quedan **deshabilitados con tooltip «Disponible próximamente»**.
+Replaces [PreviewVaultSidebar.tsx](../src/components/PreviewVaultSidebar.tsx), which is deleted
+(worldbuilding was its only user). Follow the
+[TeachingSidebar.tsx](../src/components/TeachingSidebar.tsx) pattern: items with `view` navigate,
+the others are **disabled with tooltip «Available soon»**.
 
-- **Explorar**: Enciclopedia · **Personajes → `characters`** · Lugares · Facciones · Culturas · Cronología · Mapa · Relaciones
-- **Analizar**: Chat del mundo · Grafo del mundo · Reglas del mundo · Conflictos · Arcos narrativos · Consistencia · Preguntas abiertas
-- **Crear**: **Notas → `notes`** (existe ya, es universal) · Escenas · Tramas · Manuscritos
+- **Explore**: Encyclopedia · **Persons → `characters`** · Places · Factions · Cultures · Chronology
+  · Map · Relationships
+- **Analyze**: World Chat · World Graph · World Rules · Conflicts · Narrative Arcs · Consistency ·
+  Open Questions
+- **Create**: **Notes → `notes`** (exist already, is universal) · Scenes · Traits · Manuscripts
 
-> **Decisión pendiente, no bloqueante.** Docencia convirtió sus secciones no construidas en
-> hilos permanentes de GitHub (`ROADMAP_THREADS`, issues #68‑73) para que la gente las
-> moldeara antes de existir. Aquí serían **18 issues nuevas**, así que la fase 1 las deja
-> como botones inertes. Subirlas a hilo después es una línea por sección.
+> ** Decision pending, not blocking.** Teaching turned its unbuilt sections into
+> GitHub's permanent threads (`ROADMAP_THREADS`, issues #68‐73) for people to
+> mold before it exists. Here would be **18 new issues**, so phase 1 leaves them
+> as inert buttons. Uploading them to thread then is one line per section.
 
-### 8.5 Cableado en `src/App.tsx`
+### 8.5 Wiring in `src/App.tsx`
 
 - `const isWorldbuilding = activeVault?.type === 'worldbuilding';`
 - `document.documentElement.classList.toggle('worldbuilding', isWorldbuilding)`.
-- Logo: nuevo `src/assets/nodus-logo-violet.svg` y su entrada en `data-vault-logo`.
-- Rama de sidebar junto a la de `isDocencia`: `WorldbuildingSidebar` + **sólo** el grupo
-  `tools` de `navGroups` (si no, Explorar/Analizar/Escribir salen duplicados).
-- Rama de Inicio: `view === 'home' && isWorldbuilding` → `WorldbuildingHome`; y **añadir
-  `&& !isWorldbuilding`** a la condición del `HomeView` genérico ([App.tsx:1354](../src/App.tsx)).
-- Ruta nueva: `view === 'characters'` → `CharactersView` (carga diferida con `lazy`,
-  como el resto de vistas por tipo de vault).
-- Entrada en la paleta de comandos: «Personajes».
+- Logo: new `src/assets/nodus-logo-violet.svg` and its entry in `data-vault-logo`.
+- Sidebar branch next to that of `isDocencia`: `WorldbuildingSidebar` + ** only** the `tools` group
+  of `navGroups` (if not, Explore/Analyze/Write are duplicated).
+- Start branch: `view === 'home' && isWorldbuilding` → `WorldbuildingHome`; and **add `&&
+  !isWorldbuilding`** to the generic `HomeView` condition ([App.tsx:1354](../src/App.tsx)).
+- New path: `view === 'characters'` → `CharactersView` (load deferred with `lazy`, like the rest of
+  views per type of vault).
+- Entry into the command palette: «People».
 
-### 8.6 `src/index.css` — acento violeta
+### 8.6 `src/index.css` — violet accent
 
-Bloque `.worldbuilding` calcado del de `.docencia` (líneas 1405‑1540, 136 reglas), con
-`#7c3aed` y su escala. **Y su gemelo `.dark.worldbuilding`**: `.docencia` no remapea las
-utilidades `dark:`, y los componentes de personas están llenos de ellas.
+Block `.worldbuilding` decaling of `.docencia` (lines 1405‐1540, 136 rules), with `#7c3aed` and its
+scale. **And its twin `.dark.worldbuilding`**: `.docencia` does not replace the utilities `dark:`,
+and the components of people are filled with them.
 
 ### 8.7 `src/navigation.ts`
 
-- `View` gana `'characters'`.
-- `NAV_ITEMS`: `{ id: 'characters', label: 'Personajes', icon: 'users', group: 'explore' }`.
-  Comparte icono con `persons` y `teachingGroups`, que es aceptable porque nunca coinciden
-  en el mismo vault.
+- `View` wins `'characters'`.
+- `NAV_ITEMS`: `{ id: 'characters', label: 'Personajes', icon: 'users', group: 'explore' }`. Share
+  icon with `persons` and `teachingGroups`, which is acceptable because they never match the same
+  value.
 
 ### 8.8 `shared/vaultTypes.ts`
 
-- `PREVIEW_VAULT_TYPES` → `[]`. Se **conserva el mecanismo** (lo reutilizarán
-  `primary_sources` y `testimonios` cuando se anuncien), pero deja de tener usuarios: las
-  ~12 guardas `!isPreviewVault` de `App.tsx` pasan a ser siempre verdaderas. Limpiarlas es
-  un follow‑up aparte, no parte de esta fase.
+- `PREVIEW_VAULT_TYPES` → `[]`. **preserves the mechanism** (reusing it `primary_sources` and
+  `testimonios` when advertised), but stops having users: the ~12 `!isPreviewVault` saves of
+  `App.tsx` become always true. Cleaning them is a separate follow-up, not part of this phase.
 - `VAULT_TYPE_SCOPED_VIEWS`: `characters: ['worldbuilding']`.
-- `defaultHiddenViews` de `worldbuilding`: la misma lista que `docencia` **menos `notes`**
-  (que el sidebar sí ofrece).
-- `promptPack`: el texto de §6.3.
+- `defaultHiddenViews` from `worldbuilding`: the same list as `docencia` **less `notes`** (which the
+  sidebar does offer).
+- `promptPack`: the text of §6.3.
 
 ---
 
 ## 9. i18n
 
-Todas las cadenas nuevas se escriben en español y se traducen en las **7** tablas:
-`en`, `fr`, `de`, `it`, `pt`, `pt-BR`, `tr`.
+All new strings are written in Spanish and translated into the **7** tables: `en`, `fr`, `de`, `it`,
+`pt`, `pt-BR`, `tr`.
 
-`scripts/test-i18n-coverage.mjs` sólo ve las claves que puede recolectar. Las tablas de
-etiquetas (`CHARACTER_LIFE_STATUS_LABEL`, `CHARACTER_ROLE_LABEL`,
-`CHARACTER_EVENT_TYPE_LABEL`, `CHARACTER_NAME_KINDS`) se renderizan como `t(LABEL[x])`, o sea
-**indirectamente**, así que hay que añadir `shared/characterLabels.ts` a
-`INDIRECT_KEY_SOURCES` ([test-i18n-coverage.mjs:114](../scripts/test-i18n-coverage.mjs)) o
-sus traducciones faltarán en silencio — exactamente el fallo con el que se lanzó el vault
-de genealogía. Lo mismo para `WorldbuildingSidebar.tsx` si sus etiquetas viven en un array.
+`scripts/test-i18n-coverage.mjs` sees only the keys you can collect. Label tables
+(`CHARACTER_LIFE_STATUS_LABEL`, `CHARACTER_ROLE_LABEL`, `CHARACTER_EVENT_TYPE_LABEL`,
+`CHARACTER_NAME_KINDS`) are rendered as `t(LABEL[x])`, i.e. **indirectly**, so you have to add
+`shared/characterLabels.ts` to `INDIRECT_KEY_SOURCES`
+([test-i18n-coverage.mjs:114](../scripts/test-i18n-coverage.mjs)) or your translations will be
+missing in silence — exactly the bug with which the genealogy vault was launched. The same for
+`WorldbuildingSidebar.tsx` if your tags live on an array.
 
 ---
 
 ## 10. Tests
 
-### A modificar
+### To be amended
 
-| Fichero | Cambio |
+| File | Change |
 |---|---|
-| `scripts/test-vault-types.mjs` | `worldbuilding` deja de ser preview: quitar del bucle de `PREVIEW_VAULT_TYPES`, `isViewAllowedForVaultType('settings','worldbuilding')` pasa a `true`, y la prueba «the worldbuilding preview exposes its complete inert bilingual sidebar» se reescribe contra `WorldbuildingSidebar`. Añadir que `characters` sólo está permitida en `worldbuilding`. |
-| `scripts/test-vault-onboarding-ui.mjs` | Revisar; el icono `globe` y el color `#7c3aed` no cambian. |
-| `scripts/test-i18n-coverage.mjs` | Añadir la fuente indirecta nueva. |
+| `scripts/test-vault-types.mjs` | `worldbuilding` ceases to be preview: remove from the loop of `PREVIEW_VAULT_TYPES`, `isViewAllowedForVaultType('settings','worldbuilding')` passes to `true`, and the test "the worldbuilding preview exhibitions its complete bilingual inert sidebar" is rewritten against `WorldbuildingSidebar`. Add that `characters` is only allowed in `worldbuilding`. |
+| `scripts/test-vault-onboarding-ui.mjs` | Check; icon `globe` and color `#7c3aed` do not change. |
+| `scripts/test-i18n-coverage.mjs` | Add new indirect font. |
 
-### A crear — `scripts/test-worldbuilding-characters.mjs`
+### To be created — `scripts/test-worldbuilding-characters.mjs`
 
-Contra un vault real en `mkdtemp` con las migraciones de verdad:
+Against a real vault in `mkdtemp` with real migrations:
 
-1. `createCharacter` escribe `persons` y el overlay, y `getCharacter` los devuelve unidos.
-2. **Un `Person` sin fila de overlay** se lee como personaje con los valores por defecto (la trampa del §5).
-3. Los eventos se ordenan por `world_year`/`world_order`, y **un evento sin año no se cuela al principio**.
-4. `deleteCharacter` limpia el overlay por CASCADE y no deja `event_world_dates` huérfanos.
-5. La búsqueda encuentra por alias, no sólo por nombre visible.
-6. `updateCharacter` es atómico: si falla la parte del overlay, no queda escrita la de `persons`.
+1. `createCharacter` writes `persons` and the overlay, and `getCharacter` returns them together.
+2. **A `Person` without overlay row** is read as a character with default values (the trap of §5).
+3. Events are ordered by `world_year`/`world_order`, and **an event without a year does not run at
+   first**.
+4. `deleteCharacter` cleans the overlay by CASCADE and does not leave `event_world_dates` orphans.
+5. The search finds by alias, not just by visible name.
+6. `updateCharacter` is atomic: if the overlay part fails, the `persons` part is not written.
 
-### Comprobaciones finales
+### Final checks
 
-`npm run lint` · `npx tsc --noEmit` · `npm test` · `npm run build` **antes** de `npm run test:e2e`.
+`npm run lint` · `npx tsc --noEmit` · `npm test` · `npm run build` ** before** `npm run test:e2e`.
 
 ---
 
-## 11. Orden de trabajo
+## 11. Order of work
 
-| Fase | Contenido | Hecho cuando |
+| Phase | Content | Done when |
 |---|---|---|
-| **F0** | Migración 91, tipos compartidos, `characterLabels`, `charactersRepo` | `test-worldbuilding-characters.mjs` en verde |
-| **F1** | IPC + preload + `NodusApi` | `tsc --noEmit` limpio |
-| **F2** | Graduación del tipo de vault: `vaultTypes`, `navigation`, `WorldbuildingSidebar`, CSS violeta, logo, ramas de `App.tsx` | Un vault worldbuilding nuevo abre con su sidebar y su acento, y «Personajes» navega a una vista vacía |
-| **F3** | `CharactersView` (cuadrícula, buscador, filtros, alta) | Se crean y se listan personajes |
-| **F4** | `CharacterDossier`: básicos, descripción, alias, eventos, parentesco, relaciones, notas | Ficha completa editable |
-| **F5** | IA: biografía y retrato | Ambos generan con un proveedor configurado y fallan con un mensaje accionable sin él |
-| **F6** | `WorldbuildingHome` + entrada en la paleta de comandos | Inicio del vault útil |
-| **F7** | i18n de las 7 tablas + tests actualizados + lint/tsc/test/build/e2e | Todo verde |
+| **F0** | Migration 91, shared types, `characterLabels`, `charactersRepo` | `test-worldbuilding-characters.mjs` in green |
+| **F1** | IPC + preload + `NodusApi` | `tsc --noEmit` clean |
+| **F2** | Vault type graduation: `vaultTypes`, `navigation`, `WorldbuildingSidebar`, violet CSS, logo, `App.tsx` branches | A new Vault worldbuilding opens with its sidebar and accent, and "People" navigates to an empty view |
+| **F3** | `CharactersView` (grid, search engine, filters, high) | Characters created and listed |
+| **F4** | `CharacterDossier`: basics, description, alias, events, kinship, relationships, notes | Editable complete sheet |
+| **F5** | AI: biography and portrait | Both generate with a configured provider and fail with an actionable message without it |
+| **F6** | `WorldbuildingHome` + command palette entry | Start of useful vault |
+| **F7** | i18n of the 7 tables + updated tests + lint/tsc/test/build/e2e | All green |
 
 ---
 
 ## 12. Landmines
 
-1. **`test:e2e` no reconstruye.** Con `SCHEMA_VERSION` a 91 y un `dist` rancio, el fallo
-   es `90 !== 91` y parece un error de migración. Siempre `npm run build` antes.
-2. **No abrir vaults reales con este build.** Probar ramas con numeración de migraciones
-   distinta sobre vaults de verdad los corrompe (tabla futura ya presente + `user_version`
-   viejo → «table X already exists» al cambiar de vault). Usar un `NODUS_USERDATA` aislado.
-3. **Graduar de *preview* enciende cosas.** `isPreviewVault` hoy silencia el onboarding, el
-   asistente de recuperación, el tutorial básico y el tour. Al dejar de ser preview, un
-   vault worldbuilding ya creado los verá aparecer de golpe. Es correcto —le pasó a
-   docencia— pero hay que esperarlo y probarlo con un vault worldbuilding preexistente.
-4. **`.worldbuilding` no remapea `dark:`.** Hace falta `.dark.worldbuilding` explícito.
-   Los componentes de personas usan `dark:` a menudo.
-5. **`t()` dinámico se escapa del test de cobertura.** §9.
-6. **El worktree no lleva `node_modules` propio**: enlazar simbólicamente desde `main`, no
-   `npm install` (rompe `better-sqlite3`); si hace falta, `npx electron-builder install-app-deps`.
-7. **Nunca llevar nada a `main` sin confirmación explícita**, y los commits sin coautoría.
+1. **`test:e2e` does not reconstruct.** With `SCHEMA_VERSION` at 91 and a `dist` rancid, the bug is
+   `90 !== 91` and looks like a migration error. Always `npm run build` before.
+2. **Do not open real valts with this build.** Test branches with different migration numbering on
+   true valts corrupts them (future table already present + `user_version` old → "table X already
+   exist" when changing vault). Use an isolated `NODUS_USERDATA`.
+3. **Graduate from *preview* lights things up.** `isPreviewVault` Today silences the onboarding,
+   recovery assistant, basic tutorial and tour. When you stop being preview, an already created
+   worldbuilding vault will see them appear at once. It is correct — it passed to teaching — but you
+   have to wait and try it with a pre-existing worldbuilding vault.
+4. ** `.worldbuilding` does not recap `dark:`.** `.dark.worldbuilding` is required explicitly.
+   People's components often use `dark:`.
+5. ** `t()` dynamic escapes from the coverage test.** §9.
+6. **The worktree does not have its own `node_modules`**: symbolically link from `main`, no `npm
+   install` (break `better-sqlite3`); if necessary, `npx electron-builder install-app-deps`.
+7. **Never take anything to `main` without explicit confirmation**, and commit without co-authoring.
 
 ---
 
-## 15. W1 — El calendario del mundo (migración **93**)
+## 15. W1 — The calendar of the world (migration **93**)
 
-Un vault es **un mundo**, igual que en genealogía un vault es una familia. Por eso el
-calendario es del vault y no necesita columna de propietario.
+A Vault is **a world**, just like in genealogy a Vault is a family. That’s why the calendar is from
+the Vault and does not need owner column.
 
-**Es opcional, y eso es la decisión de diseño principal.** Nadie debería tener que
-inventarse doce nombres de mes antes de escribir su primer personaje. Sin calendario, el
-entero del año ordena la cronología exactamente como antes; definirlo añade orden exacto
-*dentro* de cada año y un selector de fecha en vez de una caja de texto.
+**It is optional, and that is the main design decision.**No one should have to invent twelve names
+of the month before writing their first character. Without calendar, the entire year orders the
+chronology exactly as before; defining it adds exact order *within* each year and a date selector
+instead of a text box.
 
-- `world_calendar` (fila única, con `CHECK (id = 1)`), `world_calendar_eras`,
-  `world_calendar_months`; `event_world_dates` gana `era_id`, `month_index`, `day` y
-  `world_day`.
-- **`world_day` es DERIVADO y almacenado**, porque SQLite tiene que poder `ORDER BY` con
-  él. El precio es el mantenimiento: *cualquier* edición del calendario lo invalida —
-  alargar un mes un día mueve todas las fechas posteriores— así que toda mutación termina
-  en `recomputeWorldDays()`. Sin eso la cronología se pudre en silencio: seguiría
-  ordenada, solo que mal, que es la peor forma de estar mal.
-- **`world_day` es el desempate DENTRO del año, nunca la clave principal.** El año siempre
-  significa algo; `world_day` solo existe si hay calendario. Ordenar por él primero
-  mezclaría dos escalas en cuanto un vault tuviera hechos fechados y hechos con solo año.
-- **Sin años bisiestos.** Son un accidente de la órbita terrestre; modelarlos volvería
-  condicional toda la aritmética de días para algo que casi ningún calendario inventado
-  quiere. Un año es la suma de sus meses, siempre.
-- Una fecha con solo año cae en el día 0 de ese año, así que ordena **antes** que todo lo
-  fechado dentro de él, que es lo que espera quien lee «1229» junto a «13 de Lluvia, 1229».
-- Días y meses fuera de rango se **recortan**: un valor malo no puede producir un día
-  absoluto que caiga en otro año.
+- `world_calendar` (single row, with `CHECK (id = 1)`), `world_calendar_eras`,
+  `world_calendar_months`; `event_world_dates` wins `era_id`, `month_index`, `day` and `world_day`.
+- **`world_day` is DERIVATED and stored**, because SQLite has to be able to `ORDER BY` with it. The
+  price is maintenance: *any* edition of the calendar invalidates it — lengthen a month a day moves
+  all subsequent dates—so every mutation ends in `recomputeWorldDays()`. Without that the chronology
+  rots silently: it would remain orderly, only wrong, which is the worst way to be wrong.
+- ** `world_day` is the tiebreaker IN the year, never the main key.** The year always means
+  something; `world_day` only exists if there is a calendar. Sorting by it first would mix two
+  scales as soon as a vault had dated and year-only facts.
+- **No leap years.** They are an accident of the Earth's orbit; modeling them would make all the
+  arithmetic of days conditional for something that almost no invented calendar wants. One year is
+  the sum of its months, always.
+- A single-year date falls on the day 0 of that year, so he orders **before** that everything dated
+  within him, which is what those who read "1229" next to "13 of Rain, 1229" expect.
+- Days and months out of range are **cut**: a bad value cannot produce an absolute day falling into
+  another year.
 
-`shared/worldCalendar.ts` es puro y está cubierto por 13 casos, incluida la ida y vuelta
-`worldDayOf` ⇄ `fromWorldDay`. Verificado por mutación: quitar el recorte del día hace
-fallar «out-of-range days and months are clamped».
+`shared/worldCalendar.ts` is pure and is covered by 13 cases, including the round-trip `worldDayOf`
+`fromWorldDay`. Verified by mutation: removing the day cut makes "out-of-range days and months are
+clamped" fail.
 
 ---
 
-## 16. Pendiente, con el diseño decidido
+## 16. Pending, with the design decided
 
-Ninguna está bloqueada: cada una es la versión mínima de una sección anunciada.
+None is blocked: each is the minimum version of an announced section.
 
-- **W2 — Facciones y culturas + pertenencias.** `world_groups` (facción · cultura ·
-  religión · casa · orden) + `character_affiliations` (personaje, grupo, rango, periodo en
-  días del mundo). Enciende dos secciones del sidebar y desbloquea el ítem «pertenencias».
-- **W3 — Secretos y quién los sabe.** `world_secrets` (texto, dueño opcional) +
-  `secret_knowers` (personaje, desde qué evento o día del mundo, cómo se enteró). El
-  «desde qué capítulo» se resuelve con el evento, sin necesidad de Manuscritos.
-- **W4 — Escenas y apariciones.** `world_scenes` (título, resumen, fecha del mundo, lugar,
-  estado borrador/escrita, orden narrativo) + `scene_characters`. La escena es la unidad
-  de trabajo real de un escritor, y da la sección «Apariciones» de la ficha.
+- **W2 — fractions and cultures + belongings.** `world_groups` (faction · culture · religion · home
+  · order) + `character_affiliations` (person, group, range, period in days of the world). Turn on
+  two sections of the sidebar and unlock the item «membership».
+- **W3 — Secrets and who knows them.** `world_secrets` (text, optional owner) + `secret_knowers`
+  (personage, from what event or day of the world, how did you find out).The "from what chapter" is
+  resolved with the event, without the need for Manuscripts.
+- **W4 — Scenes and apparitions.** `world_scenes` (title, summary, date of the world, place,
+  draft/written state, narrative order) + `scene_characters`. The scene is the real work unit of a
+  writer, and gives the "Appearances" section of the tab.
 
 ---
 
-## 13. Cola original de la fase 1 (ya implementada, salvo lo bloqueado en §15)
+## 13. Original phase 1 tail (already implemented except blocked in §15)
 
-Por orden aproximado de valor:
+In approximate order of value:
 
-- **Galería multi‑imagen** por personaje (retrato, cuerpo entero, expresiones, edades),
-  cada imagen con su prompt guardado y una marcada como avatar. `decorative_images` ya
-  guarda prompt, proveedor, modelo y una ranura `prev_*`.
-- **Entrevistar al personaje**: chat en su voz, alimentado por la ficha.
-- **Aviso de nombres confundibles** entre personajes (distancia de cadenas).
-- **Biografía en modo propuesta**: rellena huecos y lo marca como sugerencia hasta aceptarlo.
-- **Alias secretos**: marca de *secreto* y «quién lo conoce» (necesita columna en `person_names`).
-- **Arco**: quiere · necesita · defecto · mentira que se cree · herida.
-- **Relaciones con valencia y asimetría**, y cómo cambian a partir de un evento.
-- **Voz**: registro, tics, muletillas y muestra de diálogo — audible con el TTS que ya hay.
-- **Coherencia**: participar en un evento después de muerto, edades imposibles, dos «único heredero».
-- **Habilidades con coste y límite.**
-- **Pertenencias**: facción + rango + periodo, cultura de origen (espera a que existan esas secciones).
-- **Ficha exportable** a una página (hay tubería HTML→PDF).
-- **Sistema de calendario con eras** propio del mundo, que sustituiría al entero de orden.
-- **Plantillas de arquetipo** y generación de personaje coherente con el mundo.
-- **Secretos y estado de conocimiento**: quién sabe qué y desde qué capítulo.
-- **Apariciones en escenas y manuscrito.**
-- Reactivar cronología, árbol y mapa para `worldbuilding` (ya funcionan; sólo hay que
-  ampliar `VAULT_TYPE_SCOPED_VIEWS` y darles el año del mundo como criterio de orden).
+- **Multi-image Gallery** per character (portrait, whole body, expressions, ages), each image with
+  its saved prompt and one marked as avatar. `decorative_images` already saves prompt, supplier,
+  model and slot `prev_*`.
+- **Interview the character**: chat in his voice, fed by the tab.
+- **Notice of confusing names** between characters (distance of strings).
+- **Biography in proposed mode**: fills in gaps and marks it as a suggestion until accepted.
+- **Alias secret**: mark of *secret* and "who knows it" (needs column in `person_names`).
+- **Arco**: wants · needs · defect · lie believed · wound.
+- **Relationships with valence and asymmetry**, and how they change from an event.
+- **Voice**: record, tics, crutches and dialog display — audible with the TTS that already exists.
+- **Coherence**: to participate in an event after death, impossible ages, two "only heir".
+- **Skills with cost and limit.**
+- **Relevances**: faction + range + period, culture of origin (wait for these sections).
+- **Exportable date** to one page (there is HTML→PDF pipe).
+- **World-specific calendar system**, which would replace the whole of order.
+- **Archetype plants** and character generation consistent with the world.
+- ** Secrets and state of knowledge**: who knows what and from what chapter.
+- **Appearances in scenes and manuscript.**
+- Reactivate chronology, tree and map for `worldbuilding` (they already work; just expand
+  `VAULT_TYPE_SCOPED_VIEWS` and give them the year of the world as an order criterion).
 
 </details>
 
 ---
 
-## 14. Lo que quedó construido
+## 14. What was built
 
-| Capa | Ficheros |
+| Layer | Files |
 |---|---|
-| Esquema | `electron/db/migrations.ts` (v91: `character_profiles`, `event_world_dates`) |
-| Tipos | `shared/types.ts` (`Character`, `CharacterProfile`, `CharacterEvent`, …), `shared/characterLabels.ts` |
-| Datos | `electron/db/charactersRepo.ts`, `electron/db/syncTables.ts` |
-| IA | `shared/characterBiographyContext.ts`, `shared/characterImagePrompt.ts`, `electron/ai/characterBiography.ts`, `generateCharacterPortrait` en `electron/ai/decorativeImages.ts` |
-| Puente | `electron/ipc.ts`, `electron/preload.ts` |
-| Vault | `shared/vaultTypes.ts`, `src/navigation.ts`, `src/components/WorldbuildingSidebar.tsx` (sustituye a `PreviewVaultSidebar.tsx`, eliminado), `src/index.css`, `src/assets/nodus-logo-violet.svg`, `src/App.tsx` |
+| Scheme | `electron/db/migrations.ts` (v91: `character_profiles`, `event_world_dates`) |
+| Types | `shared/types.ts` (`Character`, `CharacterProfile`, `CharacterEvent`, ...), `shared/characterLabels.ts` |
+| Data | `electron/db/charactersRepo.ts`, `electron/db/syncTables.ts` |
+| AI | `shared/characterBiographyContext.ts`, `shared/characterImagePrompt.ts`, `electron/ai/characterBiography.ts`, `generateCharacterPortrait` in `electron/ai/decorativeImages.ts` |
+| Bridge | `electron/ipc.ts`, `electron/preload.ts` |
+| Vault | `shared/vaultTypes.ts`, `src/navigation.ts`, `src/components/WorldbuildingSidebar.tsx` (replaces `PreviewVaultSidebar.tsx`, deleted), `src/index.css`, `src/assets/nodus-logo-violet.svg`, `src/App.tsx` |
 | UI | `src/views/CharactersView.tsx`, `src/views/WorldbuildingHome.tsx`, `src/components/CharacterDossier.tsx`, `src/components/CharacterPortrait.tsx`, `src/components/CharacterPortraitEditor.tsx`, `src/components/NewCharacterModal.tsx` |
-| i18n | 115 claves × 7 tablas; `shared/characterLabels.ts` registrado en `INDIRECT_KEY_SOURCES` |
-| Tests | `scripts/test-worldbuilding-characters.mjs` (nuevo), `scripts/test-vault-types.mjs`, `scripts/test-i18n-coverage.mjs`, `scripts/test-protect-persistence.mjs`, caso de worldbuilding en `scripts/e2e-smoke.mjs` |
+| i18n | 115 keys × 7 tables; `shared/characterLabels.ts` recorded in `INDIRECT_KEY_SOURCES` |
+| Tests | `scripts/test-worldbuilding-characters.mjs` (new), `scripts/test-vault-types.mjs`, `scripts/test-i18n-coverage.mjs`, `scripts/test-protect-persistence.mjs`, worldbuilding case in `scripts/e2e-smoke.mjs` |
 
-### Segunda ronda: la cola del §13 (migración **92**)
+### Second round: the tail of §13 (migration **92**)
 
-Todo lo que tocaba esquema fue a **una** migración en vez de cinco.
+All I played scheme was to **one** migration instead of five.
 
-| Ítem | Dónde |
+| Item | Where |
 |---|---|
-| Galería multi-imagen | `character_images` + `CharacterGallery.tsx`; cada imagen guarda su prompt, proveedor y modelo |
-| Arco y voz | columnas en `character_profiles` + `CharacterCraftSections.tsx`; la muestra de diálogo se puede **escuchar** |
-| Habilidades con coste y límite | `character_abilities`; la ficha señala la habilidad sin límite |
-| Alias secretos | `person_names.secret` / `known_by`; **nunca** salen en la cuadrícula |
-| Valencia de relaciones | `social_relations.valence` / `since_event_id`; `RelationsSection` gana un `showValence` que genealogía no enciende |
-| Nombres confundibles y coherencia | `shared/characterChecks.ts`, puro y testeado; la sección solo existe si tiene algo que decir |
-| Biografía en modo propuesta | `biography_proposed`, prompt propio que exige marcar entre corchetes, y aceptar/descartar explícito |
-| Entrevistar al personaje | `shared/characterInterview.ts` + `CharacterInterviewModal.tsx`; efímero a propósito |
-| Ficha exportable | `shared/characterSheetExport.ts` → Markdown, **sin secretos ni notas privadas** |
-| Plantillas de arquetipo | `shared/characterTemplates.ts` |
-| Cronología, mapa, relaciones y dinastías | reutilizadas; solo la cronología necesitó adaptarse al año del mundo |
+| Multi-image gallery | `character_images` + `CharacterGallery.tsx`; each image saves its prompt, supplier and model |
+| Arc and voice | columns in `character_profiles` + `CharacterCraftSections.tsx`; dialog can be **listen** |
+| Skills with cost and limit | `character_abilities`; tab points to limitless ability |
+| Secret aliases | `person_names.secret` / `known_by`; **never** come out on the grid |
+| Valencia de relaciones | `social_relations.valence` / `since_event_id`; `RelationsSection` wins a `showValence` that genealogy does not ignite |
+| Confused names and consistency | `shared/characterChecks.ts`, pure and tested; the section only exists if you have something to say |
+| Biography in proposed mode | `biography_proposed`, own prompt requiring bracketing, and accepting/discarding explicit |
+| Interview the character | `shared/characterInterview.ts` + `CharacterInterviewModal.tsx`; ephemeral on purpose |
+| Exportable sheet | `shared/characterSheetExport.ts` → Markdown, **no secrets or private notes** |
+| Archetype templates | `shared/characterTemplates.ts` |
+| Chronology, map, relationships and dynasties | reused; only the chronology needed to adapt to the year of the world |
 
-Tres decisiones que merecen explicación:
+Three decisions that deserve an explanation:
 
-1. **El avatar se COPIA, no se referencia.** `person_portraits` sigue siendo la única
-   fuente de verdad del avatar (lo leen la cuadrícula, el árbol y la cabecera, y es quien
-   posee el encuadre no destructivo). Un blob duplicado es más barato que dos respuestas
-   distintas a «cuál es la imagen de este personaje», y borrar la imagen de la galería no
-   deja el avatar en blanco.
-2. **Las plantillas no escriben prosa.** La primera versión rellenaba los campos con
-   preguntas en español; había que borrarlas para escribir la respuesta, y eran texto
-   castellano incrustado en la base de datos, fuera del alcance del i18n. Ahora una
-   plantilla solo fija rol y color y dice qué campos del arco y la voz importan: quien
-   pregunta son los *hints*, que son UI y ya están traducidos.
-3. **La entrevista no se guarda.** Es una herramienta de pensamiento; lo que produzca se
-   convierte en canon editando la ficha. Persistir transcripciones crearía un segundo
-   relato del personaje que nada más lee ni mantiene.
+1. **The avatar is COPIED, not referenced.** `person_portraits` remains the only source of
+   truth of the avatar (read the grid, the tree and the header, and it is the one who owns the
+   non-destructive frame). A duplicate blob is cheaper than two different answers to "what is the
+   image of this character", and deleting the image of the gallery does not leave the avatar blank.
+2. **The templates do not write prose.**The first version filled in the fields with questions in
+   Spanish; they had to be deleted to write the answer, and they were Spanish text embedded in the
+   database, outside the scope of the i18n. Now a template only fixes role and color and says which
+   fields of the arch and voice matter: who asks are the *hints*, which are UI and are already
+   translated.
+3. **The interview is not saved.** It is a tool of thought; what it produces becomes canon by
+   editing the tab. Persisting transcriptions would create a second story of the character that
+   nothing else reads or maintains.
 
-### Mutaciones con las que se comprobó que los tests sirven
+### Mutations with which tests were found to serve
 
-Un test que pasa no prueba nada hasta verlo fallar. Se rompieron a propósito y los tres
-fallaron como debían:
+A passing test proves nothing until it fails. They broke on purpose and all three failed as they
+should:
 
-1. Quitar `(w.world_year IS NULL)` del `ORDER BY` → falla «events sort by world year…».
-2. Hacer que `getCharacter` devuelva `null` sin fila de overlay → falla «a person without
-   an overlay is still a character».
-3. Anular el `classList.toggle('worldbuilding', …)` de `App.tsx` → falla el e2e.
-4. Parchear el arco de golpe en vez de campo a campo → falla «patching one arc field
-   leaves its siblings alone». Es el fallo que produciría que cada blur borrase los
-   cuatro campos que no estabas editando.
-5. Hacer que borrar una imagen de la galería borre el avatar → falla. La primera versión
-   de esa aserción reventaba con un `TypeError` en vez de nombrar el invariante; se
-   reescribió con una comprobación de presencia previa.
-6. Quitar el filtro de secreto de `characterEpithet` → **la primera versión NO lo cazaba**:
-   el epíteto público ganaba por orden alfabético, no por el filtro. Corregido dándole al
-   secreto un nombre que ordena antes («Ala Rota» < «El Cuervo de Vael»); ahora fallan
-   tanto el test unitario como el e2e.
+1. Remove `(w.world_year IS NULL)` from `ORDER BY` → fails «events sort by world year...».
+2. Make `getCharacter` return `null` without overlay row → fails «a person without an overlay is
+   still a character».
+3. Cancel the `classList.toggle('worldbuilding', …)` of `App.tsx` → the e2e fails.
+4. Patching the arc from stroke to field to field → fails «patching one arc field leaves its
+   siblings alone». It is the failure that would cause each blur to erase the four fields you were
+   not editing.
+5. Getting an image deleted from the gallery deletes the avatar → fails. The first version of that
+   assertion burst with a `TypeError` instead of naming the invariant; it was rewritten with a
+   previous presence check.
+6. Remove the secret filter from `characterEpithet` → **the first version did NOT hunt it**: the
+   public epithet won in alphabetical order, not by the filter. Corrected giving the secret a name
+   that it ordered before ("The Broken Wing" < "The Raven of Vael"); now both the unitary test and
+   the e2e fail.

--- a/design/worldbuilding-collections-plan.md
+++ b/design/worldbuilding-collections-plan.md
@@ -1,137 +1,137 @@
-# Worldbuilding — Colecciones, lugares y filtros
+# Worldbuilding — Collections, Places and Filters
 
-> ## Por dónde iba (handoff)
+> ## Where I was going (handoff)
 >
-> **Schema v96.** Todo verde: `npm test` 891/891, `tsc --noEmit`, `eslint` (0 errores),
-> i18n en 7 idiomas, `npm run build` y `npm run test:e2e`.
+> **Schema v96.** All green: `npm test` 891/891, `tsc --noEmit`, `eslint` (0 errors),
+> i18n in 7 languages, `npm run build` and `npm run test:e2e`.
 >
-> Terminado: F0–F7 y la cola Q1–Q8 (ver el plan de personajes), W1 calendario del mundo,
-> W2 facciones y culturas, W3 secretos, W4 escenas, y C0–C6 de este plan.
+> Finished: F0–F7 and the Q1–Q8 queue (see the character plan), W1 world calendar,
+> W2 factions and cultures, W3 secrets, W4 scenes, and C0–C6 of this plan.
 >
-> **Lo que NO está hecho**, por si retomas: no hay demo de worldbuilding (como sí la hay
-> para genealogía o docencia), no hay tour guiado del vault, y las secciones Enciclopedia,
-> Chat del mundo, Grafo del mundo, Reglas del mundo, Conflictos, Arcos narrativos,
-> Consistencia, Preguntas abiertas, Tramas y Manuscritos siguen inertes en el sidebar a
-> propósito.
+> **What is NOT done**, in case you return: there is no demo of worldbuilding (as there is
+> for genealogy or teaching), there is no guided tour of the Vault, and the Encyclopedia sections,
+> World Chat, World Graph, World Rules, Conflicts, Narrative Arches,
+> Consistency, Open Questions, Traits and Manuscripts remain inert in the sidebar to
+> purpose.
 >
-> **Para probarlo hace falta un perfil aislado.** Este build lleva seis migraciones nuevas
-> (91→96) y abrir un vault real con él lo corrompe:
+> **It takes an isolated profile to prove it.**This build leads to six new migrations
+> (91→96) and opening a real vault with him corrupts him:
 >
-> ```
+> D
 > NODUS_USERDATA=/tmp/nodus-worldbuilding ./node_modules/.bin/electron .
-> ```
+> D
 
-> Estado: **C0–C5 implementadas y verificadas; C6 (verificación final) pendiente** (2026-07-27).
-> **Schema v95.** `npm test` 891/891 · typecheck, lint e i18n (7 idiomas) limpios ·
-> `build` + `test:e2e` en verde con `database at schema v95`.
+> Status: **C0–C5 implemented and verified; C6 (final verification) pending** (2026-07-27).
+> **Schema v95.** `npm test` 891/891 · typecheck, lint and i18n (7 languages) clean ·
+> `build` + `test:e2e` in green with `database at schema v95`.
 >
-> **C3 hecha:** Lugares como árbol, `place_profiles` (v95), 37 tipos con escala, aviso de
-> escala, guardián de ciclos antes de escribir, y borrado que DESPRENDE lo contenido en
-> vez de arrastrarlo. La galería se extrajo a `worldImagesRepo` + `WorldGallery` y
-> `charactersRepo` delega: una sola implementación de «las imágenes de una cosa».
+> **C3 made:** Places like tree, `place_profiles` (v95), 37 types with scale, warning of
+> scale, cycle keeper before writing, and delete that it LEARNS the content in
+> the gallery was extracted to `worldImagesRepo` + `WorldGallery` and
+> `charactersRepo` delegates: a single implementation of "the images of a thing".
 >
-> **C4 y C5 hechas:** Facciones y Culturas como dos vistas filtradas de `world_groups`
-> desde un único descriptor parametrizado, sección de Pertenencias en la ficha de
-> personaje, y facetas de facción y cultura en la cuadrícula. Las pertenencias viajan con
-> la lista en UNA consulta agrupada, no una por personaje.
+> **C4 and C5 made:**Factions and Cultures as two filtered views of `world_groups`
+> from a single parameterized descriptor, section of Belonging on the
+> character, and facets of faction and culture in the grid. The belongings travel with
+> the list in ONE query grouped, not one per character.
 >
-> Verificado por mutación: el guardián de ciclos, y mandar `language` al lado de las
-> facciones (el reparto ingenuo por `!== 'culture'`) — los dos fallan como deben.
+> Verified by mutation: the cycle keeper, and send `language` next to the
+> factions (the naive distribution by `!== 'culture'`) — both fail as they should.
 >
-> **C1 hecha:** `src/components/world/WorldWorkspace.tsx` (cabecera, buscador, facetas,
-> colección en rejilla/árbol/lista y ficha) + `WorldFilterBar.tsx`. `CharactersView` pasa
-> de 220 líneas a un descriptor: sólo conserva lo que es de verdad de personajes (la
-> tarjeta, las facetas y qué ficha abre). El layout queda como se propuso en el §1.1:
-> colección a ancho completo sin selección, raíl izquierdo + ficha al seleccionar.
+> **C1 made:** `src/components/world/WorldWorkspace.tsx` (head, finder, facets,
+> collection in grid/tree/list and tab) + `WorldFilterBar.tsx`. `CharactersView` pass
+> of 220 lines to a descriptor: only retains what is truly characters (the
+> The layout is as proposed in §1.1:
+> Full width collection without selection, left rail + tab when selecting.
 >
-> La prueba de que el refactor no cambió el comportamiento es que **el e2e de personajes
-> pasó sin tocarlo**. Después se le añadió una aserción para el layout partido, que es lo
-> único nuevo, verificada por mutación (volver al comportamiento de sustituir la colección
-> hace fallar el e2e).
+> The proof that the refactor didn't change the behavior is that **e2e of characters
+> went by without touching it**. Then a assertion was added for the party layout, which is what
+> unique new, tested by mutation (return to the behavior of replacing the collection
+> causes the e2e to fail).
 >
-> También se registró `CharactersView.tsx` en `INDIRECT_KEY_SOURCES`: los textos del
-> descriptor llegan por `t(section.title)` y pasaban de milagro, porque ya estaban
-> traducidos de cuando eran llamadas directas a `t()`.
-> **Schema v94.** `npm test` 891/891 · typecheck y lint limpios · `build` + `test:e2e` en
-> verde con `database at schema v94`.
+> `CharactersView.tsx` was also recorded in `INDIRECT_KEY_SOURCES`: the texts of the
+> descriptor arrive by `t(section.title)` and passed by by by miracle, because they were already
+> translated from when they were direct calls to `t()`.
+> **Schema v94.** `npm test` 891/891 · clean typecheck and lint · `build` + `test:e2e` en
+> green with `database at schema v94`.
 >
-> **C2 hecha:** `world_images` (con la copia desde `character_images` y el borrado de esa
-> tabla), `world_groups` y `character_affiliations`, más `electron/db/worldGroupsRepo.ts`.
-> Facciones y culturas comparten tabla, como propone el §4.
+> **C2 made:** `world_images` (with copy from `character_images` and deletion of that
+> table), `world_groups` and `character_affiliations`, plus `electron/db/worldGroupsRepo.ts`.
+> Factions and cultures share table, as proposed in §4.
 >
-> Dos cosas que costó ver:
+> Two things it took to see:
 >
-> 1. Al hacer `world_images.entity_id` polimórfica **se pierde el `ON DELETE CASCADE`** que
->    daba `character_images`. `deleteCharacter` borra la galería a mano; olvidarlo filtra
->    todas las imágenes de cada personaje borrado, y de forma invisible porque ya nadie las
->    lee. Verificado por mutación.
-> 2. La primera versión del test **no probaba la copia de datos en absoluto**: creaba la BD
->    directamente en v94, donde `character_images` nunca existió, así que quitar el
->    `INSERT…SELECT` entero no rompía nada. Ahora hay un caso que levanta una BD en **v93**,
->    le mete una imagen y aplica la 94 — la única ruta que prueba lo que le pasará a un
->    vault real al actualizarse.
-> Hechos: `shared/worldFilters.ts` (facetas aditivas) y `shared/placeKinds.ts` (vocabulario
-> con escala, padre sugerido, chequeo de escala y detección de ciclos), con 16 casos en
+> 1. When making `world_images.entity_id` polymorphic ** the `ON DELETE CASCADE`** is lost
+> give `character_images`. `deleteCharacter` deletes gallery by hand; forget filter
+> all the images of each character deleted, and invisiblely because no one
+> Check by mutation.
+> 2. The first version of the test ** did not prove the data copy at all**: it created the database
+> directly in v94, where `character_images` never existed, so remove the
+> `INSERT…SELECT` integer didn't break anything. Now there's a case that raises a BD in **v93**,
+> puts in an image and applies the 94 — the only route that proves what will happen to a
+> actual vault when updated.
+> Facts: `shared/worldFilters.ts` (additive faces) and `shared/placeKinds.ts` (vocabulary
+> with scale, suggested parent, scale check and cycle detection), with 16 cases in
 > `scripts/test-world-collections.mjs`. `npm test` 891/891.
-> Verificados por mutación: combinar dimensiones con OR en vez de AND, y quitar el
-> conjunto de visitados del detector de ciclos — los dos fallan como deben.
+> Mutation checks: combine dimensions with OR instead of AND, and remove the
+> set of cycle detector visitors — both fail as they should.
 >
-> Las decisiones del §6 quedan aplicadas en el diseño de estas dos piezas: el modelo de
-> filtros es el de bases de datos con interfaz de facetas, y la escala de lugares ya
-> alimenta padre sugerido y coherencia.
-> Continúa [`worldbuilding-characters-plan.md`](worldbuilding-characters-plan.md), que dejó
-> hechos F0–F7, la cola Q1–Q8 y W1 (calendario) sobre **schema v93**.
+> The decisions of §6 are applied in the design of these two pieces:
+> filters is that of databases with facet interface, and the scale of places already
+> Feeds suggested father and consistency.
+> Continue [`worldbuilding-characters-plan.md`](worldbuilding-characters-plan.md), which left
+> F0–F7, tail Q1–Q8 and W1 (calendar) on **schema v93**.
 >
-> Objetivo: generalizar la vista de Personajes a las demás colecciones del vault
-> (Lugares, Facciones, Culturas y, más adelante, Escenas), con un buscador y filtros
-> facetados aditivos compartidos.
+> Objective: To generalize the Characters view to the other collections of the Vault
+> (Places, Factions, Cultures and, later, Scenes), with a search engine and filters
+> facetated additives shared.
 
 ---
 
-## 1. La idea central: una colección, una ficha
+## 1. The central idea: a collection, a tab
 
-Hoy `CharactersView` mezcla tres cosas distintas: cómo se **cargan** los personajes, cómo
-se **presentan** y cómo es su **ficha**. Las tres se repetirían literalmente en Lugares,
-Facciones y Culturas. Se extrae un contenedor único, `WorldWorkspace`, parametrizado por
-un descriptor de sección.
+Today `CharactersView` mixes three different things: how the characters are loaded**, how they are
+presented** and how their **fiche** is. All three would be repeated literally in Places, Factions
+and Cultures. A single container, `WorldWorkspace`, is extracted, parameterized by a section
+descriptor.
 
-### 1.1 El layout, y una discrepancia que conviene resolver ahora
+### 1.1 Layout, and a discrepancy to be resolved now
 
-Pediste «a la izquierda lo que hemos ido añadiendo y a la derecha los formularios». La
-sección de Personajes hoy **no** hace eso: la cuadrícula ocupa todo el ancho y la ficha la
-*sustituye*. Las dos formas son buenas para cosas distintas —la rejilla ancha para
-*mirar* el reparto, el partido para *trabajar* saltando entre elementos— así que propongo
-quedarnos con las dos en un solo componente:
+You asked "on the left what we have been adding and on the right the forms." The Characters section
+today ** doesn't** do that: the grid occupies the whole width and the tab replaces it*. The two
+forms are good for different things — the wide grid to *see* the cast, the game to *work* jumping
+between elements — so I propose to stay with the two in one component:
 
 ```
 ┌──────────────────────────────────────────────┐   ┌──────────┬───────────────────────┐
 │  buscador · facetas · nuevo                  │   │ buscador │  ficha                │
 ├──────────────────────────────────────────────┤   ├──────────┤  (formulario de la    │
-│  ▢ ▢ ▢ ▢ ▢   colección a ancho completo      │ → │ ▢ ▢      │   sección)            │
+│  ▢ ▢ ▢ ▢ ▢   full-width collection           │ → │ ▢ ▢      │   section)            │
 │  ▢ ▢ ▢ ▢ ▢   (nada seleccionado)             │   │ ▢ ▢      │                       │
 └──────────────────────────────────────────────┘   └──────────┴───────────────────────┘
 ```
 
-Sin selección, la colección ocupa todo el ancho. Al seleccionar, se **encoge a un raíl
-de 18–22 rem a la izquierda** y la ficha aparece a la derecha. Un botón fija el raíl
-plegado o desplegado, y la preferencia se recuerda por sección.
+Without selection, the collection occupies the entire width. When selected, it **shrews to a rail of
+18–22 rem to the left** and the tile appears to the right. A button fixes the rail folded or
+deployed, and the preference is remembered by section.
 
-> **Decisión que necesito de ti:** si prefieres el partido fijo siempre (raíl + ficha,
-> sin modo ancho), es una línea menos de estado. Lo he diseñado con los dos porque para
-> Personajes la rejilla ancha es lo que hace que el vault se sienta un mundo y no una
-> tabla, pero es tu llamada.
+> **Decision that I need from you:** if you prefer the fixed match always (rail + chip,
+> without wide mode), it is a less state line. I designed it with both because for
+> Characters the wide grid is what makes the Vault feel a world and not a
+> board, but it's your call.
 
-### 1.2 Tres presentaciones, una por naturaleza del dato
+### 1.2 Three presentations, one by nature of the data
 
-La colección se pinta de tres formas, y cada sección elige la suya porque **el dato manda**:
+The collection is painted in three ways, and each section chooses theirs because **the data
+commands**:
 
-| Presentación | Secciones | Por qué |
+| Presentation | Sections | Why |
 |---|---|---|
-| **Rejilla de tarjetas** | Personajes, Facciones, Culturas | Se navegan por imagen: cara, emblema, motivo. |
-| **Árbol jerárquico** | Lugares | Un lugar *está dentro de* otro. Una rejilla plana de 200 lugares es inservible; el árbol es el navegador natural. |
-| **Lista cronológica** | Escenas (W4) | Se navegan por orden narrativo, no por aspecto. |
+| **Card grid** | Characters, Factions, Cultures | They navigate by image: face, emblem, motif. |
+| **hierarchical tree** | Locations | One place *is inside* another. A flat grid of 200 places is useless; the tree is the natural browser. |
+| **Chronological list** | Scenes (W4) | They navigate in narrative order, not by aspect. |
 
-### 1.3 El descriptor de sección
+### 1.3 The section descriptor
 
 ```ts
 // src/components/world/worldSections.ts
@@ -141,7 +141,7 @@ export interface WorldSectionDef<T> {
   labels: { title: string; empty: string; create: string; searchPlaceholder: string };
   presentation: 'grid' | 'tree' | 'list';
   load: (filter: WorldFilterState) => Promise<T[]>;
-  /** Sólo para 'tree': de dónde cuelga cada elemento. */
+  /** Only for 'tree': where each item hangs from. */
   parentOf?: (item: T) => string | null;
   idOf: (item: T) => string;
   facets: WorldFacetDef[];
@@ -151,146 +151,144 @@ export interface WorldSectionDef<T> {
 }
 ```
 
-`CharactersView` pasa a ser `WorldWorkspace` + el descriptor de personajes. Es una
-refactorización a coste real pero acotada, y es la que evita escribir cuatro veces el
-mismo buscador, la misma barra de filtros y la misma gestión de selección.
+`CharactersView` becomes `WorldWorkspace` + the character descriptor. It is a refactoring at real
+cost but limited, and it is the one that avoids writing four times the same search engine, the same
+filter bar and the same selection management.
 
 ---
 
-## 2. Filtros facetados
+## 2. Faceted filters
 
-### 2.1 Qué se reutiliza y qué no
+### 2.1 What is reused and what is not
 
-Describes filtros «aditivos, con buscador y varios valores por tipo». Eso es exactamente
-el comportamiento de la **barra de facetas del Archivo**
-([`ArchiveFilterBar.tsx`](../src/components/ArchiveFilterBar.tsx)), no el constructor de
-condiciones de las bases de datos. Pero el **modelo** de bases de datos
-([`databaseFilters.ts`](../shared/databaseFilters.ts)) ya tiene lo que hace falta:
-`FilterCondition` con operadores `isAnyOf` / `isNoneOf` / `isEmpty`.
+You describe "additive, searchable and various values per type" filters. That is exactly the
+behavior of the **face bar of the File**
+([`ArchiveFilterBar.tsx`](../src/components/ArchiveFilterBar.tsx)), not the builder of database
+conditions. But the **model** of databases ([`databaseFilters.ts`](../shared/databaseFilters.ts))
+already has what it takes: `FilterCondition` with operators `isAnyOf` / `isNoneOf` / `isEmpty`.
 
-Propuesta: **modelo de bases de datos, interfaz de facetas.**
+Proposal: **database model, facet interface.**
 
-- Cada faceta activa se guarda como una `FilterCondition` con `op: 'isAnyOf'`.
-- La barra por defecto muestra un chip por dimensión; cada chip abre un
-  `SearchableMultiSelect` (el que ya usan las relaciones sociales).
-- Al ser el mismo modelo, más adelante caben gratis las **vistas guardadas** y un modo
-  avanzado de condiciones, sin migrar nada.
+- Each active facet is saved as a `FilterCondition` with `op: 'isAnyOf'`.
+- The default bar shows a chip per dimension; each chip opens a `SearchableMultiSelect` (the one
+  that already uses social relationships).
+- As it is the same model, the **saved views** and an advanced mode of conditions, without migrating
+  anything, are later available free of charge.
 
 ```ts
 // shared/worldFilters.ts
 export interface WorldFacetDef {
   id: string;
   label: string;
-  /** De dónde salen los valores: un vocabulario fijo o los valores presentes en el vault. */
+  /** Where the values come from: a fixed vocabulary or values present in the vault. */
   source: 'vocabulary' | 'distinct';
   vocabulary?: { id: string; label: string }[];
 }
 export interface WorldFilterState {
   search: string;
-  /** dimensión → valores seleccionados. Vacío = sin filtrar por esa dimensión. */
+  /** dimension → selected values. Empty = unfiltered by that dimension. */
   facets: Record<string, string[]>;
 }
 ```
 
-**Aditivas entre dimensiones (AND), acumulativas dentro de una (OR).** «Rol: protagonista
-o antagonista» **y** «Cultura: Vael» es lo que un escritor espera al pinchar dos valores
-en un chip y uno en otro.
+**Additives between dimensions (AND), cumulative within a (OR).** «Rol: protagonist or antagonist»
+** and** «Culture: Vael» is what a writer expects when he clicks two values on one chip and one on
+another.
 
-### 2.2 Facetas por sección
+### 2.2 Facets per section
 
-| Sección | Facetas |
+| Section | Facets |
 |---|---|
-| Personajes | Rol narrativo · Estado vital · Especie · Facción · Cultura · Etiqueta de color |
-| Lugares | Tipo de lugar · Escala · Dentro de · Con imágenes |
-| Facciones | Tipo · Estado (activa / extinta / latente) · Alineamiento |
-| Culturas | Tipo · Lengua |
-| Escenas | Estado (borrador / escrita) · Lugar · Personaje que aparece |
+| Characters | Narrative role · Vital state · Species · Faction · Culture · Color label |
+| Locations | Type of place · Scale · Inside · With images |
+| Factions | Type · Status (active / extinct / latent) · Alignment |
+| Cultures | Type · Language |
+| Scenes | Status (delete/written) · Place · Character appearing |
 
-Las de `source: 'distinct'` (especie, lengua, dentro de) se calculan de lo que hay en el
-vault: un mundo con tres especies no debe ofrecer una lista de treinta.
+Those of `source: 'distinct'` (species, language, within) are calculated from what is in the vault: a
+world with three species should not offer a list of thirty.
 
-### 2.3 Contador honesto
+### 2.3 Honest accountant
 
-La cabecera muestra `12 de 87` cuando hay filtros activos, y un botón de quitarlos. Un
-recuento filtrado que se presenta como el total es la forma más fácil de que alguien crea
-que ha perdido la mitad de su mundo.
+The header shows `12 de 87` when there are active filters, and a button to remove them. A filtered
+count that is presented as the total is the easiest way for anyone to believe that they have lost
+half of their world.
 
 ---
 
-## 3. Lugares
+## 3. Places
 
-### 3.1 Lo que ya existe (y es mucho)
+### 3.1 What already exists (and is a lot)
 
-`places` tiene **`parent_id` y `kind` desde la migración 33**. La jerarquía y el
-clasificador no necesitan esquema nuevo: necesitan un vocabulario y una vista.
+`places` has **`parent_id` and `kind` since migration 33**. The hierarchy and classifier do not need
+a new schema: they need a vocabulary and a view.
 
-### 3.2 El vocabulario de tipos, con escala
+### 3.2 Type vocabulary, with scale
 
-`shared/placeKinds.ts`, con una **escala numérica** por tipo:
+`shared/placeKinds.ts`, with a numerical **scale** by type:
 
-| Escala | Tipos |
+| Scale | Types |
 |---|---|
-| 0 | Plano · Universo |
-| 1 | Galaxia · Cúmulo |
-| 2 | Sistema · Estrella |
-| 3 | Planeta · Luna |
-| 4 | Continente · Océano |
-| 5 | Región · Cordillera · Bosque · Desierto · Mar |
-| 6 | País · Reino · Imperio |
-| 7 | Provincia · Comarca · Condado |
-| 8 | Ciudad · Pueblo · Aldea |
-| 9 | Barrio · Distrito · Fortaleza · Templo · Ruina |
-| 10 | Edificio · Posada · Sala · Cámara |
+| 0 | Plano · Universe |
+| 1 | Galaxy · Cluster |
+| 2 | System · Star |
+| 3 | Planet · Moon |
+| 4 | Continent · Ocean |
+| 5 | Region · Cordillera · Forest · Desert · Sea |
+| 6 | Country · Kingdom · Empire |
+| 7 | Province · County · County |
+| 8 | City · Village · Village |
+| 9 | Barrio · District · Fortress · Temple · Ruin |
+| 10 | Building · Inn · Room · Camera |
 
-La escala **no es decorativa**: da tres cosas gratis.
+The **scale is not decorative**: it gives three things for free.
 
-1. **Padre por defecto** al crear: desde una Ciudad, el tipo sugerido para un hijo es Barrio.
-2. **Chequeo de coherencia**, en la misma línea que los de personajes: «Un Continente
-   dentro de una Ciudad» es casi siempre un error de arrastre, y detectarlo cuesta una
-   comparación de enteros. Aviso, no error: un mundo puede tener una ciudad que contiene
-   un plano entero, y eso es una decisión, no una errata.
-3. **Agrupación del árbol** y sangrado coherente.
+1. **Father by default** when creating: from a City, the type suggested for a child is Barrio.
+2. **Consistency check**, in the same line as the characters: «A Continent within a City» is almost
+   always a drag error, and detecting it costs a comparison of integers. Notice, no error: a world
+   can have a city that contains an entire plane, and that is a decision, not a mistake.
+3. **Aggregation of the tree** and consistent bleeding.
 
-> **Landmine:** `places` es **compartida con genealogía**, que ya escribe
-> `kind: 'municipality'`. Los dos vocabularios comparten columna y **nunca** comparten
-> selector — exactamente el patrón que ya usan los tipos de evento
-> (`EVENT_TYPE_OPTIONS` frente a `CHARACTER_EVENT_TYPES`). El selector de worldbuilding
-> lista sólo tipos de ficción; el de genealogía, sólo los suyos.
+> **Landmine:** `places` is **shared with genealogy**, which already writes
+> `kind: 'municipality'`. The two vocabulary shares column and **never share**
+> selector — exactly the pattern already used by event types
+> (`EVENT_TYPE_OPTIONS` versus `CHARACTER_EVENT_TYPES`). The worldbuilding selector
+> list only types of fiction; genealogy, only yours.
 
-### 3.3 Galería del lugar
+### 3.3 Gallery of the place
 
-Arriba de la ficha, como pediste. Dos contenidos:
+Top of the tab, as you asked.
 
-- **Imágenes del lugar**, con la misma maquinaria que la galería de personajes, incluida
-  la **semilla visual**: sin ella, dos imágenes de la misma ciudad no se parecen entre sí.
-- **Escenas transcurridas ahí**, cuando llegue W4. Hasta entonces la tira no se dibuja
-  (una sección permanentemente vacía enseña al ojo a saltársela).
+- **Images of the place**, with the same machinery as the gallery of characters, including the
+  visual seed**: without it, two images of the same city do not resemble each other.
+- **Scenes spent there**, when W4. Until then the strip is not drawn (a permanently empty section
+  teaches the eye to skip it).
 
-**Esto exige generalizar `character_images`.** Hoy es específica de personajes; la misma
-tabla debe servir a lugares, facciones y culturas. Propuesta: migración que crea
-`world_images(entity_kind, entity_id, …)`, copia las filas existentes con
-`entity_kind = 'character'` y elimina `character_images`. Una tabla por concepto, no dos.
+**This requires generalizing `character_images`.** Today it is character-specific; the same table
+should serve places, factions and cultures. Proposal: migration that creates
+`world_images(entity_kind, entity_id, …)`, copies existing rows with `entity_kind = 'character'` and
+removes `character_images`. A table by concept, not two.
 
-> **Coste que hay que aceptar:** esa migración **no es sólo-CREATE**, así que no la puede
-> reproducir el mecanismo de backfill. Y si ya has creado un vault de worldbuilding con
-> este build, la copia se hace sobre datos reales. Es la razón de hacerlo **ahora**, con
-> la galería recién puesta y casi sin filas, y no dentro de tres secciones.
+> **Cost to accept:** that migration **is not just-CREATE**, so you can't
+> play the backfill mechanism. And if you have already created a worldbuilding vault with
+> this build, the copy is made over real data. It is the reason to do it **now**, with
+> the gallery just put in and almost without rows, and not within three sections.
 
-### 3.4 Ficha de lugar
+### 3.4 Location sheet
 
-Cabecera con galería · Descripción (Apariencia · Atmósfera · Historia) y semilla visual ·
-Tipo y lugar padre · Habitantes (los personajes con `person_places` apuntando aquí —
-**ya existe**, es lo que genealogía usa para residencias) · Hechos ocurridos aquí (los
-`events` con `place_id`, **ya existe**) · Facciones y culturas presentes · Notas.
+Header with gallery · Description (Appearance · Atmosphere · History) and visual seed · Type and
+place parent · Inhabitants (characters with `person_places` pointing here — **already exists**, is
+what genealogy uses for residences) · Events occurring here (the `events` with `place_id`, **already
+exists**) · Factions and cultures present · Notes.
 
-Casi toda la ficha se alimenta de tablas que ya están pobladas.
+Almost the entire tab feeds on tables that are already populated.
 
 ---
 
-## 4. Facciones y culturas: una tabla, no dos
+## 4. Factions and cultures: one table, not two
 
-Facción y Cultura tienen la misma forma: nombre, tipo, descripción, imagen, miembros,
-periodo de existencia. Diseñarlas por separado duplicaría todo.
+Faction and Culture have the same form: name, type, description, image, members, period of
+existence. Designing them separately would duplicate everything.
 
 ```sql
 CREATE TABLE world_groups (
@@ -313,69 +311,67 @@ CREATE TABLE character_affiliations (
 );
 ```
 
-**Facciones y Culturas pasan a ser dos vistas filtradas de una misma colección**, con el
-mismo descriptor y distinto `kind`. Añadir «Religiones» o «Casas» después cuesta una
-entrada en el vocabulario y una del sidebar. Y las facetas *Facción* y *Cultura* de
-Personajes salen de aquí sin trabajo extra.
+**Factions and Cultures become two filtered views of the same collection**, with the same descriptor
+and different `kind`. Add «Religions» or «Houses» then costs an entry in the vocabulary and one of
+the sidebar. And the facets *Faction* and *Culture* of Characters leave here without extra work.
 
 ---
 
-## 5. Fases
+## 5. Phases
 
-| Fase | Contenido | Hecho cuando |
+| Phase | Content | Done when |
 |---|---|---|
-| **C0** | `shared/worldFilters.ts` + `WorldFilterBar` (facetas con buscador) | Tests puros del filtrado en verde |
-| **C1** | `WorldWorkspace` + descriptores; **Personajes migrado a él** sin cambio funcional | El e2e de personajes sigue pasando sin tocarlo |
-| **C2** | Migración: `world_images` (con copia desde `character_images`) + `world_groups` + `character_affiliations` | Test de repo; la galería de personajes sigue funcionando |
-| **C3** | Lugares: vocabulario con escala, árbol, ficha con galería, chequeo de escala | Se crea una jerarquía y se navega |
-| **C4** | Facciones y culturas sobre `world_groups` + pertenencias en la ficha de personaje | Un personaje pertenece a una facción con rango y periodo |
-| **C5** | Facetas nuevas de Personajes (facción, cultura, especie) | Filtrado combinado |
-| **C6** | i18n ×7, tests, lint, typecheck, build, e2e | Todo verde |
+| **C0** | `shared/worldFilters.ts` + `WorldFilterBar` (search engine faces) | Pure green filtering tests |
+| **C1** | `WorldWorkspace` + descriptors; **Persons migrated to it** without functional change | The character e2e keeps going without touching it |
+| **C2** | Migration: `world_images` (with copy from `character_images`) + `world_groups` + `character_affiliations` | Repo test; character gallery still works |
+| **C3** | Places: vocabulary with scale, tree, tab with gallery, scale check | A hierarchy is created and navigated |
+| **C4** | Factions and cultures about `world_groups` + belongings on the character tab | A character belongs to a faction with rank and period |
+| **C5** | New Facets of Characters (faction, culture, species) | Combined filtering |
+| **C6** | i18n ×7, tests, lint, typecheck, build, e2e | All green |
 
-W3 (secretos) y W4 (escenas) siguen después, ya con el contenedor y los filtros hechos.
-
----
-
-## 6. Mis sugerencias
-
-Las que me parecen más pertinentes, en orden:
-
-1. **Fusionar Facciones y Culturas en una tabla** (§4). Es lo que más trabajo ahorra y lo
-   que hace que añadir Religiones o Casas sea trivial. Recomendada con fuerza.
-2. **Generalizar `character_images` → `world_images` ahora** (§3.3), mientras la galería
-   tiene cuatro filas. En tres secciones costará una migración de datos de verdad.
-3. **Escala numérica en los tipos de lugar** (§3.2). Un campo que da padre sugerido,
-   chequeo de coherencia y agrupación del árbol.
-4. **Modelo de bases de datos con interfaz de facetas** (§2.1), no uno u otro: el
-   comportamiento que pides es el de facetas, pero guardarlo como `FilterCondition` deja
-   la puerta abierta a vistas guardadas sin migrar nada.
-5. **Reutilizar `person_places` para los habitantes** de un lugar en vez de inventar una
-   tabla: ya existe, ya tiene rol y periodo, y ya la puebla la ficha de personaje.
-6. **Semilla visual también en lugares.** Es lo único que hace que dos imágenes de la
-   misma ciudad se parezcan, igual que en personajes.
-7. **Un solo `SearchView` del mundo, después.** Con las facetas ya definidas por sección,
-   un buscador global que devuelva personajes, lugares y facciones juntos es casi gratis.
-   No lo metería en estas fases, pero conviene no cerrarle la puerta.
-
-Y dos cosas que **no** haría:
-
-- **No** poner un mapa en la ficha de lugar todavía. La vista Mapa existe y funciona sobre
-  coordenadas reales de un gazetteer terrestre; un mundo inventado necesita un mapa de
-  imagen con chinchetas, que es otra funcionalidad entera.
-- **No** dar a los lugares eventos propios separados de `events`. Un hecho ocurre en un
-  lugar *y* le pasa a alguien; duplicar el concepto crea dos cronologías que se
-  contradicen.
+W3 (secrets) and W4 (scenes) continue afterwards, with the container and filters made.
 
 ---
 
-## 7. Landmines conocidos
+## 6. My suggestions
 
-- **Ciclos en el árbol de lugares.** «A dentro de B dentro de A» cuelga el render. El
-  guardado tiene que rechazar el ciclo, y el árbol tiene que defenderse igualmente con un
-  conjunto de visitados.
-- **`places.kind` es compartida con genealogía** (§3.2): dos vocabularios, un selector cada uno.
-- **`world_images` no es sólo-CREATE**: no la replica el backfill (§3.3).
-- **El e2e de personajes es la red de seguridad de C1.** Migrar la vista al contenedor
-  compartido sin tocar ese test es justo lo que prueba que no ha cambiado el comportamiento.
-- **`tsc --noEmit` no cubre `electron/`**: verificar siempre con `npm run build`.
-- Toda tabla nueva va a `syncTables.ts` o no viaja entre máquinas.
+The ones I find most relevant, in order:
+
+1. **Fussion Factions and Cultures on a table** (§4). It is what saves the most work and what makes
+   adding Religions or Houses trivial. Strongly recommended.
+2. **Generalize `character_images` → `world_images` now** (§3.3), while the gallery has four rows.
+   In three sections it will cost a real data migration.
+3. **Number scale in place types** (§3.2). A field that gives suggested parent, consistency check
+   and tree grouping.
+4. **Base model with facet interface** (§2.1), not one or the other: the behavior you ask for is
+   facet, but save it as `FilterCondition` leaves the door open to saved views without migrating
+   anything.
+5. **Reusing `person_places` for the inhabitants** of a place instead of inventing a table: it
+   already exists, it already has a role and period, and it is already populated by the character
+   tab.
+6. **Visual seed also in places.** It's the only thing that makes two images of the same city look
+   like characters.
+7. **A single `SearchView` of the world, then.**With the facets already defined by section, a global
+   search engine that returns characters, places and factions together is almost free. I would not
+   put it in these phases, but it is advisable not to close the door.
+
+And two things that **no** would do:
+
+- **No** put a map on the location tab yet. The Map View exists and works on real coordinates of a
+  ground gazetteer; an invented world needs an image map with chink, which is another whole
+  functionality.
+- **No** give places own events separate from `events`. A fact occurs in a place *and* happens to
+  someone; duplicating the concept creates two chronologies that contradict each other.
+
+---
+
+## 7. Known Landmines
+
+- **Ciclos in the tree of places.** "A within B within A" hangs the render. The keeper has to reject
+  the cycle, and the tree has to defend itself equally with a group of visitors.
+- **`places.kind` is shared with genealogy** (§3.2): two vocabulary, one selector each.
+- **`world_images` is not only-CREATE**: it is not replicated by the backfill (§3.3).
+- **The e2e of characters is the safety net of C1.** Migrating the view to the shared container
+  without touching that test is just what proves that the behavior hasn't changed.
+- **`tsc --noEmit` does not cover `electron/`**: always check with `npm run build`.
+- Any new table goes to `syncTables.ts` or does not travel between machines.

--- a/design/worldbuilding-families-plan.md
+++ b/design/worldbuilding-families-plan.md
@@ -1,137 +1,137 @@
-# Vault de Worldbuilding — Sección **Familias**
+# Vault of Worldbuilding — Section **Families**
 
-> Estado: **plan, sin implementar** (2026-07-27).
-> Segunda sección del vault `worldbuilding`, sobre la de [Personajes](worldbuilding-characters-plan.md).
-> Una familia agrupa personajes y da un árbol genealógico **por familia**, con las mismas
-> funciones que el árbol de genealogía, más un emblema propio.
+> Status: **plan, unimplemented** (2026-07-27).
+> Second section of the vault`worldbuilding`, on the[Personajes](worldbuilding-characters-plan.md).
+> A family groups characters and gives a family tree **per family**, with the same
+> functions than the genealogy tree, plus a proper emblem.
 
 ---
 
-## 1. Lo que hay que decidir antes de escribir código
+## 1. What to decide before writing code
 
-Cuatro decisiones que condicionan todo lo demás. Las tres primeras las he resuelto en el
-plan; la cuarta te la dejo marcada porque cambia el alcance.
+Four decisions that condition everything else. The first three I have resolved in the plan; the
+fourth I leave it marked because it changes the scope.
 
-### 1.1 «Familia» ya significa otra cosa en el código
+### 1.1 ‘Family’ already means something else in the code
 
-`shared/treeFamilies.ts` define **`TreeFamily`**, y no es una casa ni un linaje: es la
-unidad de dibujo *pareja + sus hijos*, con sus carriles y sus conectores. Es el motor del
-árbol actual y se va a reutilizar tal cual.
+`shared/treeFamilies.ts`defines **`TreeFamily`**, and it is not a house or a lineage: it is the unit
+of drawing *pair + its children*, with its lanes and connectors. It is the engine of the current
+tree and will be reused as it is.
 
-Si la familia nueva se llama `Family` en el código, cualquiera que lea `treeFamilies.ts`
-dentro de seis meses va a mezclar las dos.
+If the new family is called`Family`in the code, anyone reading`treeFamilies.ts`Six months from now,
+he's gonna mix both.
 
-> **Decisión.** En la UI la palabra es **Familia** (que es la correcta en español y la que
-> pediste). En el código el tipo es **`CharacterFamily`** y la tabla `character_families`,
-> nunca `Family` a secas. `TreeFamily` se queda como está.
+> **Decision.** In the UI the word is **Family** (which is correct in Spanish and which
+> In the code the type is **`CharacterFamily`** and table`character_families`,
+> never`Family`It's dry.`TreeFamily`It stays the way it is.
 
-### 1.2 Un personaje pertenece a UNA familia… pero se casa con otra
+### 1.2 One character belongs to ONE family... but marries another
 
-Pediste «asignar cada personaje a una familia (o a ninguna)», y así se implementa: la
-pertenencia tiene el `person_id` como clave primaria, o sea **una familia como máximo**.
+You asked "to assign each character to a family (or none)", and this is how it is implemented:
+membership has the`person_id`as a primary key, i.e. ** a maximum family**.
 
-Pero en cuanto haya un matrimonio entre casas aparece la pregunta: si un personaje solo
-pertenece a la casa A, ¿qué pasa con su cónyuge de la casa B cuando miras el árbol de A?
-Si el árbol filtra duro por pertenencia, **el cónyuge desaparece y la arista de matrimonio
-queda colgando de la nada**, que es justo lo que hace ilegible un árbol dinástico.
+But as soon as there is a marriage between houses the question arises: if a character only belongs
+to house A, what happens to his spouse in house B when you look at the tree of A? If the tree
+filters hard by belonging, **the spouse disappears and the side of marriage hangs from nothing**,
+which is just what makes a dynastic tree unreadable.
 
-> **Decisión.** La familia define el **conjunto raíz** del árbol, no un filtro duro. Se
-> dibujan sus miembros **y** todo personaje conectado a ellos por parentesco, marcando
-> visualmente a los de fuera (emblema pequeño de su casa, o gris si no tienen). Es lo que
-> hace cualquier software de genealogía y elimina el problema de raíz.
+> **Decision.**The family defines the **root set** of the tree, not a hard filter.
+> They draw their members ** and** every character connected to them by kinship, marking
+> visually to the outsiders (small emblema of your home, or gray if you don't have it).
+> does any genealogy software and eliminates the root problem.
 >
-> Además la pertenencia guarda **cómo** se pertenece — `born | married | adopted | sworn |
-> other` — así que casarse con la casa A es representable sin dejar de ser de la casa B:
-> el personaje es miembro `married` de A, y en el árbol de B aparece como externo.
+> In addition, belonging keeps **how** one belongs — `born | married | adopted | sworn |
+> other` — so marrying House A is representative while still being from House B:
+> the character is a member`married`of A, and in the tree of B appears as external.
 >
-> Si más adelante quieres pertenencia múltiple, basta con cambiar la PK por una compuesta
-> `(person_id, family_id)`. Es un cambio contenido y lo dejo anotado en el DDL.
+> If you later want multiple membership, simply switch the PK to a composite
+> `(person_id, family_id)`. It is a content change and I leave it noted in the DDL.
 
-### 1.3 El color de rama paterna/materna NO funciona en worldbuilding
+### 1.3 The father/mother branch color does NOT work in worldbuilding
 
-Éste es el hallazgo importante y lo he verificado en el código.
+This is the important finding and I checked it in the code.
 
-`deriveTreeKinship` decide la rama así ([treeKinship.ts:532](../shared/treeKinship.ts)):
+`deriveTreeKinship`decides the branch like this ([treeKinship.ts:532](../shared/treeKinship.ts)):
 
 ```ts
 const father = focusParents.find((id) => sexOf.get(id) === 'male');
 const mother = focusParents.find((id) => sexOf.get(id) === 'female');
 ```
 
-Un personaje **nunca** fija `persons.sex` — se queda en `'unknown'` a propósito, porque
-esa columna no describe a un dios ni a un dragón. Resultado: no hay raíz paterna ni
-materna, **todas las ramas salen `neutral`, el árbol entero se dibuja en un solo gris y
-los dos selectores de color no hacen absolutamente nada**.
+A character **never fixed**`persons.sex`— stays in`'unknown'`by the way, because that column does
+not describe a god or a dragon. Result: there is no father or mother root, ** all branches come
+out`neutral`, the whole tree is drawn in a single gray and the two color selectors do absolutely
+nothing**.
 
-Mapear el campo libre `gender` a male/female sería la solución fácil y es la equivocada:
-reimpone un binario que la ficha quitó a propósito, y falla con cualquier personaje que no
-encaje en él.
+Map the free field`gender`a male/female would be the easy solution and it is the wrong one: it
+reimposes a binary that it deliberately removed, and fails with any character that does not fit in
+it.
 
-> **Decisión, y es lo que hace que esta sección valga la pena.** En worldbuilding las ramas
-> se colorean **por familia**, no por sexo. En un árbol dinástico eso es más útil de lo que
-> nunca fue paterno/materno: de un vistazo ves de qué casa viene cada línea de ancestros.
-> Los dos selectores de color se sustituyen por la leyenda de familias, y cada familia usa
-> su propio acento (la paleta `CHARACTER_ACCENTS` que ya existe).
+> **Decision, and that's what makes this section worthwhile.** In worldbuilding branches
+> are colored **per family**, not by sex. In a dynastic tree that is more useful than
+> It was never paternal/motherly: at a glance you see which house each line of ancestors comes from.
+> The two color selectors are replaced by the legend of families, and each family uses
+> your own accent (the palette`CHARACTER_ACCENTS`that already exists).
 >
-> El modelo de rama del *layout* (`branchByPerson`, tres valores) se deja intacto: solo
-> influye en el orden de los carriles y degradar a `neutral` es inocuo. El color pasa a
-> venir de un mapa `familyByPerson` separado. Es una separación limpia y de bajo riesgo:
-> no se toca `treeKinship.ts`.
+> The *layout* branch model (`branchByPerson`, three values) is left intact: only
+> influence the order of the lanes and degrade to`neutral`It's harmless.
+> coming from a map`familyByPerson`It is a clean and low-risk separation:
+> no touching`treeKinship.ts`.
 
-### 1.4 Lo que te dejo por decidir
+### 1.4 What I leave to you to decide
 
-**¿Las familias son solo de worldbuilding, o también de genealogía?** El plan las scopea a
-`worldbuilding`. Genealogía tiene el mismo problema (agrupar por apellido/casa) y la tabla
-serviría igual, pero su árbol ya usa paterno/materno y su vocabulario es otro. Meterlas en
-genealogía sería una segunda decisión de producto, no una consecuencia de ésta.
-
----
-
-## 2. Alcance
-
-### 2.1 Entra
-
-- Crear, editar, ordenar y borrar familias.
-- Asignar un personaje a una familia **desde las dos puntas**: desde la sección Familias
-  (añadir miembros) y desde la ficha del personaje (elegir familia, o crear una nueva sin
-  salir de la ficha). Ambas escriben lo mismo.
-- Tipo de pertenencia (`born | married | adopted | sworn | other`) y rango dentro de la casa.
-- **Emblema** por familia: generado con IA (catálogo de estilos, §6) o subido a mano.
-- **Árbol por familia**: selector de familia, personajes de fuera dibujados y marcados,
-  ramas coloreadas por casa. Todas las funciones del árbol de genealogía (§5.2).
-- Lema, descripción, estado, sede y fundador.
-- Sugerencia de familias a partir del parentesco ya registrado (§7.1).
-
-### 2.2 No entra
-
-Alianzas entre casas como grafo propio, herencia de títulos, cronología dinástica y
-generación de una casa entera con IA. Quedan en §11.
+**Are families only from worldbuilding, or also from genealogy?** The plan`worldbuilding`Genealogy
+has the same problem (grouping by surname/house) and the table would serve the same, but its tree
+already uses paternal/motherly and its vocabulary is another. Putting them into genealogy would be a
+second product decision, not a consequence of it.
 
 ---
 
-## 3. Modelo de datos — migración **93**
+## 2. Scope
 
-`SCHEMA_VERSION` 92 → 93. Migración **solo CREATE**, sin `ALTER`.
+### 2.1 Enter
+
+- Create, edit, sort and delete families.
+- Assign a character to a family **from both ends**: from the Families section (add members) and
+  from the character tab (choose family, or create a new one without leaving the tab). Both write
+  the same.
+- Type of membership (`born | married | adopted | sworn | other`) and range inside the house.
+- **Emblem** per family: generated with AI (style catalog, §6) or uploaded by hand.
+- ** Tree by family**: family selector, outside characters drawn and marked, branches colored by
+  house. All functions of the genealogy tree (§5.2).
+- Lema, description, state, headquarters and founder.
+- Suggestion of families from the already registered kinship (§7.1).
+
+### 2.2 Does not enter
+
+Alliances between houses such as own graph, inheritance of titles, dynastic chronology and
+generation of an entire house with AI. They remain in §11.
+
+---
+
+## 3. Data model — migration **93**
+
+`SCHEMA_VERSION`92 → 93. Migration **CREATE** only, without`ALTER`.
 
 ```sql
--- Una familia: una casa, un clan, un linaje. Agrupa personajes y da un árbol propio.
+-- A family: a house, a clan, a lineage. It groups characters and gives a tree of its own.
 --
--- NO confundir con `TreeFamily` de shared/treeFamilies.ts, que es la unidad de dibujo
--- «pareja + hijos» del motor del árbol y no tiene nada que ver con esto.
+-- DO NOT confuse with`TreeFamily`of shared/treeFamilies.ts, which is the drawing unit
+-- ‘partner + children’ of the tree engine and has nothing to do with this.
 CREATE TABLE character_families (
   family_id         TEXT PRIMARY KEY,
   name              TEXT NOT NULL,
-  -- Las palabras de la casa. Corto a propósito: es un lema, no una descripción.
+  -- The words of the house. Short by the way: it is a motto, not a description.
   motto             TEXT,
   description       TEXT,
   -- unknown | ruling | declining | exiled | extinct | ascendant
   status            TEXT NOT NULL DEFAULT 'unknown',
-  -- Token de CHARACTER_ACCENTS. Es lo que colorea las ramas de esta casa en el árbol,
-  -- así que dos familias con el mismo acento son un problema de lectura: la UI avisa.
+  -- Token de CHARACTER_ACCENTS. It is what colors the branches of this house in the tree,
+  -- So two families with the same accent are a reading problem: the UI warns.
   accent            TEXT,
   seat_place_id     TEXT REFERENCES places(place_id) ON DELETE SET NULL,
-  -- El personaje por el que se centra el árbol al abrir la familia. SET NULL, no CASCADE:
-  -- borrar al fundador no debe borrar la casa.
+  -- The character for whom the tree is centered when the family opens. SET NULL, no CASCADE:
+  -- erasing the founder should not erase the house.
   founder_person_id TEXT REFERENCES persons(person_id) ON DELETE SET NULL,
   sort_order        INTEGER NOT NULL DEFAULT 0,
   created_at        TEXT NOT NULL,
@@ -139,32 +139,32 @@ CREATE TABLE character_families (
 );
 CREATE INDEX idx_character_families_sort ON character_families(sort_order, name);
 
--- Pertenencia. `person_id` es la PK, o sea UNA familia por personaje como máximo, que es
--- lo pedido. Tabla propia y no una columna en `character_profiles` por dos razones: la
--- pertenencia lleva datos suyos (cómo se pertenece y con qué rango), y pasar a pertenencia
--- múltiple algún día es solo cambiar esta PK por (person_id, family_id).
+-- Belonging.`person_id`is the PK, i.e. ONE family per character at most, which is
+-- the request. Own table and not a column in`character_profiles`for two reasons:
+-- belonging carries your data (how you belong and with what rank), and move on to belonging
+-- multiple one day is just to change this PK for (person_id, family_id).
 CREATE TABLE character_family_members (
   person_id  TEXT PRIMARY KEY REFERENCES persons(person_id) ON DELETE CASCADE,
   family_id  TEXT NOT NULL REFERENCES character_families(family_id) ON DELETE CASCADE,
   -- born | married | adopted | sworn | other
   membership TEXT NOT NULL DEFAULT 'born',
-  -- Rango o título dentro de la casa: texto libre, cada mundo tiene los suyos.
+  -- Range or title within the house: free text, each world has its own.
   rank       TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
 CREATE INDEX idx_character_family_members_family ON character_family_members(family_id);
 
--- El emblema, en tabla aparte y no en columnas de `character_families`, exactamente por la
--- misma razón que `person_portraits` está separada de `persons`: un BLOB en la fila
--- principal convierte cualquier listado en una transferencia de megabytes, y quitar el
--- emblema debe ser un DELETE y no siete UPDATE a NULL.
+-- The emblem, in separate table and not in columns of`character_families`, exactly for the
+-- same reason as`person_portraits`is separated from`persons`: a BLOB in the row
+-- main converts any listing into a megabyte transfer, and remove the
+-- emblem must be a DELETE and not seven UPDATE to NULL.
 CREATE TABLE character_family_emblems (
   family_id  TEXT PRIMARY KEY REFERENCES character_families(family_id) ON DELETE CASCADE,
   mime_type  TEXT NOT NULL DEFAULT 'image/jpeg',
   bytes      INTEGER NOT NULL DEFAULT 0,
   blob       BLOB,
-  -- El prompt que lo generó, para poder iterar en vez de volver a adivinar.
+  -- The prompt that generated it, to be able to iterate instead of guessing again.
   prompt     TEXT,
   provider   TEXT,
   model      TEXT,
@@ -174,13 +174,13 @@ CREATE TABLE character_family_emblems (
 );
 ```
 
-**Registrar las tres tablas en `electron/db/syncTables.ts`**, grupo `worldbuilding`. Sin
-eso, `test-sync-package` y `test-superseded-versions` fallan con «unclassified» — y con
-razón: una casa que no viaja entre máquinas es media bóveda perdida.
+**Register the three tables in`electron/db/syncTables.ts`**, group`worldbuilding`Without
+that,`test-sync-package`and`test-superseded-versions`They fail with “unclassified” — and rightly so:
+a house that does not travel between machines is half a lost vault.
 
 ---
 
-## 4. Tipos compartidos
+## 4. Shared rates
 
 ```ts
 export type FamilyStatus = 'unknown' | 'ruling' | 'ascendant' | 'declining' | 'exiled' | 'extinct';
@@ -194,11 +194,11 @@ export interface CharacterFamily {
   status: FamilyStatus;
   accent: string | null;
   seatPlaceId: string | null;
-  seatPlaceName: string | null;   // resuelto por conveniencia, como en SocialRelation
+  seatPlaceName: string | null;   // resolved by convenience, as in SocialRelation
   founderPersonId: string | null;
   founderName: string | null;
   sortOrder: number;
-  /** Solo el hecho de que exista, nunca los bytes: el listado no los carga. */
+  /** Just the fact that it exists, never bytes: the list does not charge them. */
   hasEmblem: boolean;
   memberCount: number;
   createdAt: string;
@@ -214,7 +214,7 @@ export interface FamilyMembership {
   rank: string | null;
 }
 
-/** Un miembro tal como lo lista la ficha de la familia. */
+/** A member as listed in the family file. */
 export interface FamilyMember extends FamilyMembership {
   displayName: string;
   epithet: string | null;
@@ -224,78 +224,78 @@ export interface FamilyMember extends FamilyMembership {
 }
 ```
 
-Y en `shared/characterLabels.ts`: `FAMILY_STATUS_LABEL`, `FAMILY_MEMBERSHIP_LABEL`, con
-sus arrays de orden. Recuerda registrarlos en `INDIRECT_KEY_SOURCES` — ya está el fichero,
-pero los patrones actuales cogen `label:`/`hint:` y las claves de los `Record`, así que
-estas entran solas.
+And in`shared/characterLabels.ts`: `FAMILY_STATUS_LABEL`, `FAMILY_MEMBERSHIP_LABEL`Remember to
+register them in`INDIRECT_KEY_SOURCES`— there's the file, but the current patterns
+take`label:`/`hint:`and the keys to`Record`So these go in alone.
 
 ---
 
-## 5. Interfaz
+## 5. Interface
 
-### 5.1 `src/views/FamiliesView.tsx` — la sección
+### 5.1 `src/views/FamiliesView.tsx`— the section
 
-Misma forma que Personajes, por coherencia: cuadrícula arriba, detalle que la sustituye.
+Same shape as Characters, by coherence: grid above, detail that replaces it.
 
-- **Cuadrícula de casas**: tarjeta con el emblema (cuadrado, no 3:4 como los personajes),
-  nombre, lema en cursiva, franja del acento, y contadores (miembros, generaciones).
-- **Detalle de la familia**, en este orden:
-  1. Cabecera: emblema grande + nombre + lema + estado + sede + acciones.
-  2. **Emblema** (§6): generar / subir / quitar, con su prompt guardado y visible.
-  3. Descripción (campo autoguardado, reutiliza `AutoSavingField`).
-  4. **Miembros**: lista con retrato, tipo de pertenencia y rango, editable en línea;
-     botón de añadir que abre un selector de personajes (reutiliza `PersonMultiSelect`).
-  5. **Árbol de la familia**: botón que lleva a la vista de árbol ya scopeada a esta casa.
-  6. Fundador y sede.
+- **House Grid**: badge with emblem (square, no.3:4 as characters), name, motto in italics, accent
+  strip, and accountants (members, generations).
+- **Detail of the family**, in this order:
+  1. Header: large emblem + name + motto + state + headquarters + actions.
+  2. **Emblem** (§6): generate / upload / remove, with your prompt saved and visible.
+  3. Description (self-saved field, reused`AutoSavingField`).
+  4. **Members**: list with portrait, type of belonging and rank, editable online; add button that
+     opens a character selector (reuses`PersonMultiSelect`).
+  5. **Family tree**: button that leads to the view of a tree that has already been seen in this
+     house.
+  6. Founder and headquarters.
 
-### 5.2 El árbol por familia
+### 5.2 Tree by family
 
-`TreeView` gana una prop `family` y, cuando está presente:
+`TreeView`wins a prop.`family`and, when present:
 
-| Función del árbol de genealogía | Qué pasa en el árbol por familia |
+| Function of the genealogy tree | What happens in the tree per family |
 |---|---|
-| Selector de persona para centrar | **Se antepone un selector de FAMILIA.** Al cambiar de casa, el foco salta a su fundador (o al miembro más antiguo por año del mundo). Es la iteración entre familias que pediste. |
-| Buscar en el árbol | Igual, sobre el conjunto ya scopeado |
-| Invertir orientación | Igual (`treeOrientation`) |
-| **Colores paterno/materno** | **Sustituidos por la leyenda de familias** (§1.3). Cada casa con su acento; sin casa, gris |
-| Zoom y paneo | Igual |
-| Clic en nodo → panel lateral | Igual: marco, `KinshipEditor`, ficha completa, centrar aquí. **Más**: pertenencia y rango en esta casa |
-| Leyenda de líneas | Igual |
-| Aviso de edad de progenitor | Igual, pero comparando **años del mundo** (§9, landmine 2) |
-| Marco de madera por persona | Igual. *Sugerencia*: que el marco por defecto se pueda fijar **por familia**, no solo por bóveda — es una forma barata de que cada casa se vea distinta |
+| Person Selector to Center | **A FAMILY selector is put before him.** When changing houses, the focus jumps to its founder (or to the oldest member per year in the world).Iteration between families you asked for. |
+| Search the Tree | Same, on the already scoped set |
+| Reverse guidance | Equal (`treeOrientation`) |
+| **Paterno/Maternal colours** | **Substituted by the legend of families** (§1.3). Each house with its accent; without house, gray |
+| Zoom and panning | Same |
+| Click on node → side panel | Same: frame,`KinshipEditor`, complete tab, focus here. **More**: membership and rank in this house |
+| Legend of lines | Same |
+| Parental age warning | Same, but comparing **years of the world** (§9, landmine 2) |
+| Wooden frame per person | The same. *Suggestion*: that the default frame can be fixed **per family**, not just by vault — is a cheap way for each house to look different |
 
-**Personajes de fuera de la casa**: se dibujan (si no, las aristas de matrimonio cuelgan de
-la nada) con el emblema pequeño de su propia familia en la esquina del nodo, o en gris si
-no tienen. Un conmutador «solo miembros» permite ocultarlos para exportar o imprimir.
+**People from outside the house**: they are drawn (if not, the marriage edges hang from nowhere)
+with the small emblem of their own family in the corner of the node, or in grey if they do not have.
+A switch "members only" allows them to be hidden for export or printing.
 
-### 5.3 Desde la ficha del personaje
+### 5.3 From the character tab
 
-Una sección **Familia** en `CharacterDossier`, entre Descripción y Galería:
+One section **Family** in`CharacterDossier`, between Description and Gallery:
 
-- Selector de familia con opción **«Crear familia nueva…»** en la propia lista, que abre el
-  modal de alta y asigna al personaje al guardar. Ésta es la mitad de «¿desde personajes o
-  desde familias?»: las dos.
-- Tipo de pertenencia y rango.
-- Enlace a la casa y botón para abrir el árbol centrado en este personaje.
+- Family selector with option **"Create new family..."** in the list itself, which opens the high
+  modal and assigns the character when saving. This is half of "from characters or from families?":
+  both.
+- Type of membership and rank.
+- Link to the house and button to open the tree centered on this character.
 
 ### 5.4 Sidebar
 
-`WorldbuildingSidebar`: **«Familias»** (icono `users` está cogido por Personajes; usar
-`network` o `shield`) va en Explorar justo debajo de Personajes. Y **«Dinastías»**, que hoy
-apunta a `tree`, pasa a llamarse igual pero abre el árbol con el selector de familia.
+`WorldbuildingSidebar`: **‘Families’** (icon`users`is taken by Characters; use`network`o`shield`)
+goes on to Explore just below Characters. And **"Dynasties"**, which today points to`tree`He goes on
+to call himself the same, but he opens the tree with the family selector.
 
 ---
 
-## 6. El emblema y sus prompts
+## 6. The emblem and its prompts
 
-Igual que el retrato del personaje: el estilo lo elige el autor, el prompt se guarda junto
-a los bytes, y se puede subir una imagen propia.
+Just like the character's portrait: the style is chosen by the author, the prompt is saved next to
+the bytes, and you can upload your own image.
 
-### 6.1 Catálogo — `shared/familyEmblemStyles.ts`
+### 6.1 Catalogue —`shared/familyEmblemStyles.ts`
 
 ```ts
 export const FAMILY_EMBLEM_STYLES = [
-  { id: 'heraldic_shield', label: 'Escudo heráldico',
+  { id: 'heraldic_shield', label: 'Heraldic shield',
     prompt: 'a heraldic coat of arms on a shield, flat vector heraldry, bold tinctures, clean divisions of the field, crisp edges, perfectly symmetrical' },
   { id: 'sigil', label: 'Sigilo',
     prompt: 'a single bold sigil, minimal solid silhouette, extreme contrast, iconic and instantly readable at small size' },
@@ -307,161 +307,161 @@ export const FAMILY_EMBLEM_STYLES = [
     prompt: 'a finely engraved crest, dense line hatching, antique bookplate feel, monochrome ink on aged paper' },
   { id: 'monogram', label: 'Monograma',
     prompt: 'an ornate interlaced monogram of abstract strokes, calligraphic, symmetrical, a single colour' },
-  { id: 'totem', label: 'Tótem',
+  { id: 'totem', label: 'Totem',
     prompt: 'a carved wood and stone totem emblem, tribal geometry, weathered surface, one central motif' },
   { id: 'arcane_glyph', label: 'Glifo arcano',
     prompt: 'a luminous arcane glyph, concentric sacred geometry, fine glowing lines, deep dark field' },
   { id: 'industrial_mark', label: 'Marca industrial',
     prompt: 'a stamped industrial maker\'s mark, stencil geometry, worn painted metal, one colour' },
-  { id: 'organic_crest', label: 'Emblema orgánico',
+  { id: 'organic_crest', label: 'Organic crest',
     prompt: 'an emblem grown from living matter: branches, bone, coral or chitin, biological symmetry, natural pigments' },
 ];
 ```
 
-### 6.2 Cómo se compone — `buildFamilyEmblemPrompt(style, { charges, tinctures, extra })`
+### 6.2 How it is composed —`buildFamilyEmblemPrompt(style, { charges, tinctures, extra })`
 
 ```
-[plantilla del estilo]
-. [charges: lo que aparece — «un cuervo negro sobre una torre partida»]
-. [tinctures: los colores — «negro y oro sobre gules»]
-. [extra: solo para esta imagen]
+[style template]
+. [charges: what appears — "a black raven over a broken tower"]
+. [tinctures: the colors — "black and gold on gules"]
+. [extra: only for this image]
 . a single emblem, centred, square composition, plain flat background, no scene, no landscape
 . no text, no words, no letters, no numbers, no motto, no banner scroll, no signature, no watermark
 ```
 
-Dos cosas deliberadas y las dos importan:
+Two deliberate things and both matter:
 
-1. **El nombre de la familia NO entra en el prompt.** Si le das «Casa Vandrek» al modelo,
-   escribe «Casa Vandrek» dentro del escudo. Un blasón con texto inventado y medio
-   ilegible es inservible, y por eso la cláusula anti-texto es la más larga del prompt y
-   menciona explícitamente el pergamino del lema, que es donde los modelos insisten en
-   escribir.
-2. **`charges` y `tinctures` van separados**, no en un campo libre único. La heráldica es
-   *qué figura* y *de qué color*, y separarlos hace que el resultado sea reproducible: se
-   puede cambiar el color sin que el modelo redibuje otro animal.
+1. **The name of the family does NOT enter the prompt.** If you give "Vandrek House" to the model,
+   write "Vandrek House" within the shield. A blazon with invented text and unreadable medium is
+   useless, and so the anti-text clause is the longest of the prompt and explicitly mentions the
+   scroll of the motto, which is where the models insist on writing.
+2. **`charges`and`tinctures`are separated**, not in a single free field. The heraldic is *what
+   figure* and *of what color*, and separating them makes the result reproducible: you can change
+   the color without the model redrawing another animal.
 
-**Cuadrado, no 16:9.** `callImageProvider` pide `aspect_ratio: '16:9'` a Google
-([decorativeImages.ts:143](../electron/ai/decorativeImages.ts)); un escudo panorámico sale
-con dos tercios de fondo vacío. Hay que parametrizar la relación de aspecto — es el único
-cambio que esta sección exige en código compartido con otras funciones, así que debe ser
-un parámetro opcional con el valor actual por defecto, no un cambio de comportamiento.
-
----
-
-## 7. Sugerencias mías
-
-Ordenadas por lo que aportan frente a lo que cuestan. Ninguna es obligatoria.
-
-### 7.1 Detectar familias a partir del parentesco *(barata, alta)*
-
-Los personajes ya tienen parentesco. Recorrer las componentes conexas por aristas de
-progenitor da, gratis, los grupos que **ya son** una familia. La sección propone: «6
-personajes conectados y sin familia: Kaelen, Serel… ¿crear una casa con ellos?».
-
-Convierte la asignación de un mundo ya empezado de media hora de clics en dos. Y es puro:
-`shared/familySuggestions.ts`, testeable sin base de datos.
-
-### 7.2 Aviso de acento repetido *(trivial, alta)*
-
-Si el color de las ramas identifica la casa, dos casas con el mismo acento hacen el árbol
-mentir. Un aviso al elegir el color lo evita, y es una comprobación de tres líneas.
-
-### 7.3 Lema y estado *(triviales, media)*
-
-Ya están en el DDL. El lema es la línea que más carácter da por menos esfuerzo, y alimenta
-la IA. El estado (`reinante`, `en declive`, `exiliada`, `extinta`) da a la cuadrícula una
-lectura de un vistazo que un simple listado alfabético no tiene.
-
-### 7.4 Fundador como foco por defecto *(trivial, media)*
-
-Sin él, cambiar de familia centra el árbol en un personaje arbitrario y hay que recolocarse
-a mano cada vez. Con él, iterar entre casas es un solo clic — que es justo lo que pediste.
-
-### 7.5 Marco de madera por familia *(barata, media)*
-
-`effectiveFrame(personFrame, vaultFrame)` ya resuelve dos niveles. Meter la familia en
-medio — `persona → familia → bóveda` — hace que cada casa se vea distinta sin tocar ningún
-personaje. Una línea en `effectiveFrame` y un selector en la ficha de la familia.
-
-### 7.6 Panel de alianzas *(media, media)* — yo lo dejaría para después
-
-Qué casas están unidas por matrimonio y por cuántos vínculos. Se deduce entero de lo que ya
-hay (aristas de cónyuge cruzando pertenencias) y no necesita esquema. Es la semilla natural
-de la sección **Facciones**, así que igual conviene esperar a construirla ahí.
-
-### 7.7 Exportar el árbol como imagen *(media, media)*
-
-El árbol ya es un `<svg>`. Serializarlo a PNG o SVG es contenido, no motor. Encaja con la
-ficha exportable que ya existe para personajes.
+** Square, no 16:9.**`callImageProvider`request`aspect_ratio: '16:9'`to Google
+([decorativeImages.ts:143](../electron/ai/decorativeImages.ts)); a panoramic shield comes out with
+two thirds of an empty background. The aspect ratio must be parameterized — it is the only change
+that this section requires in code shared with other functions, so it must be an optional parameter
+with the current default value, not a change of behavior.
 
 ---
 
-## 8. Fases
+## 7. Suggestions from me
 
-| Fase | Contenido | Hecho cuando |
+Ordained by what they contribute against what they cost. None is mandatory.
+
+### 7.1 Detect families from kinship *(barata, high)*
+
+The characters already have kinship. Strolling the related components by progenitor edges gives, for
+free, the groups that ** already are** a family. The section proposes: «6 connected and familyless
+characters: Kaelen, Serel... create a house with them?».
+
+It turns the allocation of a world already started from half an hour of clicks into two. And it is
+pure:`shared/familySuggestions.ts`Testeable without database.
+
+### 7.2 Repeated accent warning *(trivial, high)*
+
+If the color of the branches identifies the house, two houses with the same accent make the tree
+lie. A warning when choosing the color avoids it, and is a three-line check.
+
+### 7.3 Motto and status *(trivial, half a day)*
+
+They are already in the DDL. The motto is the line that gives the most character for less effort,
+and feeds the AI. The state (`reinante`, `en declive`, `exiliada`, `extinta`) gives the grid a
+reading at a glance that a simple alphabetical listing does not have.
+
+### 7.4 Founder as default focus *(trivial, medium)*
+
+Without him, changing the family centers the tree into an arbitrary character and you have to
+reposition by hand each time. With him, iteration between houses is a single click — that’s just
+what you asked for.
+
+### 7.5 Wood frame per family *(barato, media)*
+
+`effectiveFrame(personFrame, vaultFrame)`It already solves two levels. Getting the family in between
+—`person → family → vault`— makes each house look different without touching any
+character.`effectiveFrame`and a selector on the family file.
+
+### 7.6 Alliance panel *(media, medium)* — I would leave it for later
+
+Which houses are united by marriage and by how many bonds. It is deduced whole from what already
+exists (spouse aristists crossing belongings) and does not need scheme. It is the natural seed of
+the section **Factions**, so it is better to wait to build it there.
+
+### 7.7 Export the tree as an image *(mean, mean)*
+
+The tree is already a`<svg>`Serializing it to PNG or SVG is content, not motor. It fits the
+exportable chip that already exists for characters.
+
+---
+
+## 8. Phases
+
+| Phase | Content | Done when |
 |---|---|---|
-| **G0** | Migración 93, tipos, `charactersRepo`/`familiesRepo`, `syncTables` | `test-worldbuilding-families.mjs` en verde |
-| **G1** | IPC + preload + `NodusApi` | `npm run build` limpio (ojo: `tsc --noEmit` no cubre `electron/`) |
-| **G2** | `FamiliesView`: cuadrícula, alta, ficha, miembros | Se crean casas y se les asignan personajes |
-| **G3** | Sección Familia en la ficha del personaje, con «crear familia nueva…» | Asignación desde las dos puntas |
-| **G4** | Emblema: catálogo, generación, subida, relación de aspecto | Emblema generado y subido, con su prompt visible |
-| **G5** | Árbol por familia: selector, externos marcados, color por casa, año del mundo | Se itera entre familias y el árbol sale coloreado por casa |
-| **G6** | Sugerencia de familias (§7.1) + aviso de acento (§7.2) | Propone casas sobre un mundo ya poblado |
-| **G7** | i18n en los 7 idiomas, tests, `lint`/`typecheck`/`test`/`build`/`e2e` | Todo verde |
+| **G0** | Migration 93 types,`charactersRepo`/`familiesRepo`, `syncTables` | `test-worldbuilding-families.mjs`green |
+| **G1** | IPC+preload+`NodusApi` | `npm run build`clean (eye:`tsc --noEmit`does not cover`electron/`) |
+| **G2** | `FamiliesView`: grid, high, tab, members | Building houses and assigning characters to them |
+| **G3** | Family section on the character tab, with "create new family..." | Allocation from both ends |
+| **G4** | Emblem: catalog, generation, rise, aspect ratio | Emblem generated and uploaded, with its prompt visible |
+| **G5** | Tree by family: selector, external marked, color by house, year of the world | Iterates between families and the tree comes out colored by house |
+| **G6** | Suggestion from families (§7.1) + accent warning (§7.2) | Proposes houses on an already populated world |
+| **G7** | i18n in all 7 languages, tests,`lint`/`typecheck`/`test`/`build`/`e2e` | All green |
 
 ---
 
 ## 9. Landmines
 
-Los tres primeros los he verificado en el código; el resto ya me han mordido en esta bóveda.
+The first three I checked in the code; the rest have already bitten me in this vault.
 
-1. **`sex` es `'unknown'` en todo personaje**, así que paterno/materno no existe (§1.3). No
-   «arreglarlo» mapeando `gender`.
-2. **El año de nacimiento del árbol sale de `parseHistoricalDate(p.birthDate).year`**
-   ([TreeView.tsx:99](../src/views/TreeView.tsx)), que con un calendario inventado devuelve
-   `null`. Consecuencias: las parejas se ordenan por id (arbitrario) y el aviso de edad de
-   progenitor no salta nunca. Hay que alimentarlo con `profile.birthYearSort`.
-3. **`TreeFamily` ya existe y significa otra cosa** (§1.1).
-4. **La generación de imágenes pide 16:9**; un escudo necesita 1:1 (§6.2).
-5. **Toda tabla nueva va a `syncTables.ts`** o los tests de sync fallan — y con razón.
-6. **`tsc --noEmit` no cubre `electron/`**: solo `npm run build` type-checkea el main.
-7. **Clave i18n duplicada = TS1117**, y las claves antiguas pueden estar **sin comillas**
-   (`Galería:`), así que un detector que solo mire `'clave':` no las ve.
-8. **`test:e2e` no reconstruye**: con `dist` rancio el fallo es `92 !== 93` y parece un
-   error de migración.
-9. **No abrir bóvedas reales con este build** mientras la numeración de migraciones difiera.
+1. **`sex`It's`'unknown'`in every character**, so paternal/maternal does not exist (§1.3). Do not
+   "fix" mapping`gender`.
+2. **The year of birth of the tree comes from`parseHistoricalDate(p.birthDate).year`**
+   ([TreeView.tsx:99](../src/views/TreeView.tsx)), which with a invented calendar returns`null`.
+   Consequences: couples are ordered by id (arbitrary) and the parent age warning never jumps. It
+   must be fed with`profile.birthYearSort`.
+3. **`TreeFamily`already exists and means something else** (§1.1).
+4. **The generation of images requires 16:9**; a shield needs 1:1 (§6.2).
+5. **Every new table is going to`syncTables.ts`** or sync tests fail — and rightly so.
+6. **`tsc --noEmit`does not cover`electron/`**: only`npm run build`type-check the main.
+7. **Duplicate i18n key = TS1117**, and old keys may be **without quotation marks** (`Gallery:`),
+   so a detector that only looks`'clave':`He doesn't see them.
+8. **`test:e2e`does not reconstruct**: with`dist`rancid the judgment is`92 !== 93`And it looks like
+   a migration error.
+9. **Do not open royal vaults with this build** as long as migration numbers differ.
 
 ---
 
 ## 10. Tests
 
-**Nuevo `scripts/test-worldbuilding-families.mjs`** (repo, con migraciones reales):
+**New`scripts/test-worldbuilding-families.mjs`** (repo, with real migrations):
 
-1. Crear familia, asignar miembro, leerlo unido con su nombre y su rango.
-2. Un personaje solo puede estar en una familia: reasignar **mueve**, no duplica.
-3. Borrar la familia deja a los personajes **vivos y sin familia** (no los borra).
-4. Borrar un personaje limpia su pertenencia y no deja emblemas ni miembros huérfanos.
-5. `listFamilies` **no** trae los bytes del emblema.
-6. El conjunto del árbol de una casa incluye a los cónyuges de fuera, marcados como externos.
-7. `founderPersonId` sobrevive al borrado del fundador puesto a `NULL`, sin borrar la casa.
+1. Create family, assign member, read it together with your name and rank.
+2. A character can only be in a family: reassign **move**, not duplicate.
+3. Clear the family leaves the characters ** alive and without family** (does not delete them).
+4. Clear a character cleans his or her membership and leaves no emblems or orphaned members.
+5. `listFamilies`**no** brings the bytes of the emblem.
+6. The whole tree of a house includes the outside spouses, marked as external.
+7. `founderPersonId`survives the erasing of the founder`NULL`Without erasing the house.
 
-**Nuevo `scripts/test-family-suggestions.mjs`** (puro): componentes conexas, y sobre todo
-lo que **no** debe proponer (dos personajes unidos solo por matrimonio no son una casa).
+**New`scripts/test-family-suggestions.mjs`** (pure): related components, and above all what **no**
+should propose (two characters united only by marriage are not a house).
 
-**A modificar**: `test-vault-types.mjs` (vista `families` scopeada y cableada en el
-sidebar), `test-i18n-coverage.mjs`, y el caso de worldbuilding del `e2e-smoke.mjs` — crear
-una casa, asignarle dos personajes, comprobar que el árbol se centra en el fundador y que
-el nodo del cónyuge externo aparece marcado.
+**To be amended**:`test-vault-types.mjs`(view`families`scanned and wired on the
+sidebar),`test-i18n-coverage.mjs`, and the case of worldbuilding of`e2e-smoke.mjs`— create a house,
+assign it two characters, check that the tree is centered on the founder and that the external
+spouse's node appears marked.
 
-Y como siempre: **romper a propósito** al menos la exclusión del blob en el listado, el
-«una sola familia» y el color por casa, y ver los tres fallar antes de darlos por buenos.
+And as always: **break on purpose** at least the exclusion of the blob from the list, the "one
+family" and the color at home, and see the three fail before they are considered good.
 
 ---
 
-## 11. Fuera de alcance
+## 11. Out of reach
 
-- Alianzas entre casas como grafo propio → espera a **Facciones** (§7.6).
-- Herencia de títulos y línea de sucesión.
-- Cronología dinástica (qué casa reinaba en cada año) → espera a **Cronología**.
-- Generar una casa entera con IA (fundador, tres generaciones, lema y emblema de una vez).
-- Pertenencia múltiple → cambio de PK, contenido, cuando haga falta (§1.2).
+- Alliances between houses as own graph → waits for **Factions** (§7.6).
+- Title inheritance and line of succession.
+- Dinastic chronology (which house reigned in each year) → waits for **chronology**.
+- Generate an entire house with AI (founder, three generations, motto and emblem at once).
+- Multiple membership → PK change, content, when needed (§1.2).

--- a/design/worldbuilding-manuscript-plan.md
+++ b/design/worldbuilding-manuscript-plan.md
@@ -1,90 +1,89 @@
-# Worldbuilding — «Manuscritos» (migración 100)
+# Worldbuilding — ‘Manuscripts’ (migration 100)
 
-> **Estado: COMPLETO. M0–M9 implementadas y verificadas** (2026-07-28).
-> `SCHEMA_VERSION = 101`, 1180/1180 tests, lint 0 errores, typecheck, `npm run build` y
-> `npm run test:e2e` en verde. Con esto **el vault de worldbuilding no tiene ni una sección
-> inerte** y su sección de escritura está terminada.
-
----
-
-## 1. La tesis (no volver a discutirla)
-
-**El manuscrito no es un documento nuevo: es la columna que le falta a la escena.**
-
-Una novela es sus escenas en orden de relato. Este vault ya sabe cuáles son, en qué orden
-van, qué día ocurren, quién sale, qué se mueve en cada una, qué leyes las rigen y qué
-decisiones las bloquean. Lo único que no sabe es **qué dice el texto**.
-
-De ahí se sigue todo lo demás, y en particular lo que esta sección **no** es: escribir la
-novela en un documento aparte crearía una segunda fuente de verdad sobre la misma historia —
-exactamente el fallo que este vault lleva cinco secciones evitando (no hay tabla de
-hallazgos, no hay copia del trasfondo de un personaje, las proyecciones de la enciclopedia
-se calculan y no se guardan). Un capítulo que existe a la vez como escena y como sección de
-un documento se desincroniza el primer día que alguien corta un párrafo.
-
-Corolario que decide el producto: **Nodus no compite con Scrivener ni con Word.** No hay
-control de cambios, ni comentarios, ni WYSIWYG, ni edición colaborativa. Lo que ofrece —y no
-puede ofrecer ningún editor de textos— es escribir la escena **con el mundo delante**: los
-latidos que tiene que dar, las leyes que la rigen, las preguntas que la bloquean y los avisos
-de continuidad, todos ya calculados, en el margen derecho mientras se escribe. Esa es la
-única razón para escribir aquí en vez de en otro sitio, y por tanto es la sección entera.
-
-Segundo corolario: **la IA no escribe la novela.** Ni una línea. El vault entero sostiene que
-el autor es la fuente de verdad; una sección donde un modelo redacta prosa que después es
-canon lo contradiría de raíz. (Lo que sí se abre, y se discute en §7, es una revisión que A9
-rechazó **por falta de entrada** y que esta fase crea.)
+> **State: COMPLETE. M0–M9 implemented and verified** (2026-07-28).
+> `SCHEMA_VERSION = 101`, 1180/1180 tests, Lint 0 errors, typecheck,`npm run build`and
+> `npm run test:e2e`in green. With this **worldbuilding vault has not a single section
+> Inert** and its writing section is finished.
 
 ---
 
-## 2. Lo que ya existe, y lo que falta
+## 1. The thesis (do not discuss it again)
 
-| Ya está | Dónde |
+**The manuscript is not a new document: it is the missing column of the scene.**
+
+A novel is his scenes in order of story. This Vault already knows what they are, in what order they
+go, what day they happen, who comes out, what moves in each, what laws govern them and what
+decisions they block them. The only thing he doesn’t know is ** what the text says**.
+
+Hence everything else follows, and in particular what this section **no** is: writing the novel in a
+separate document would create a second source of truth about the same story — exactly the flaw that
+this Vault has five sections avoiding (no table of findings, no copy of the background of a
+character, the projections of the encyclopedia are calculated and not saved). A chapter that exists
+as a scene at the same time and as a section of a document is desyncronized on the first day that
+someone cuts a paragraph.
+
+A corollary that defines the product: **Nodus does not compete with Scrivener or Word.** There is no
+control of changes, nor comments, nor WYSIWYG, nor collaborative editing. What offers—and cannot
+offer any text editor—is to write the scene **with the world ahead**: the beats you have to give,
+the laws that govern it, the questions that block it and the continuity notices, all already
+calculated, in the right margin while writing. That is the only reason to write here instead of
+elsewhere, and therefore is the entire section.
+
+Second corollary: **the AI does not write the novel.**Not a line. The entire vault holds that the
+author is the source of truth; a section where a model writes prose that is later canon would
+contradict it at its root. (What does open, and is discussed in §7, is a review that A9 rejected
+**for lack of entry** and that this phase creates.)
+
+---
+
+## 2. What already exists, and what is missing
+
+| That's it. | Where |
 |---|---|
-| El orden del relato | `world_scenes.narrative_order`, denso y total; `reorderScene()` renumera **todas** |
-| Qué pasa en la escena | `world_scenes.summary` — el plan, no el texto |
-| Cuándo ocurre | la cadena de días (`world_scene_days`) → `world_day` canónico |
-| Qué se mueve | `world_beats` + la franja `SceneThreadsPanel` |
-| Qué leyes rigen | `rulesInPlay(sceneId)` + `RulesInPlay` |
-| Qué la bloquea | `sceneQuestionLoad(sceneId)` + `SceneQuestionBand` |
-| Qué choca | `ContinuityBadge` sobre la instantánea de continuidad |
-| Enlaces `[[…]]` a cualquier cosa del mundo | `promoteWorldLinks` + `world_links` + retroenlaces |
-| Exportar un documento largo | `worldBibleExport` (MD y PDF con `professionalReportPdf`) |
+| The order of the story | `world_scenes.narrative_order`, dense and total;`reorderScene()`renumbered **all** |
+| What's going on at the scene? | `world_scenes.summary`— plan, not text |
+| When It Happens | the chain of days (`world_scene_days`) → `world_day`canonical |
+| What's moving | `world_beats`+ Strip`SceneThreadsPanel` |
+| What laws govern | `rulesInPlay(sceneId)` + `RulesInPlay` |
+| What blocks it | `sceneQuestionLoad(sceneId)` + `SceneQuestionBand` |
+| What's the matter? | `ContinuityBadge`on the snapshot of continuity |
+| Links`[[…]]`to anything in the world | `promoteWorldLinks` + `world_links`+ backlinks |
+| Export a Long Document | `worldBibleExport`(MD and PDF with`professionalReportPdf`) |
 
-**Falta una sola cosa: el texto.** Y con él, tres cosas que sólo tienen sentido cuando el
-texto existe: contar palabras, agrupar en capítulos y compilar.
+**There is only one thing missing: the text.** And with it, three things that only make sense when
+the text exists: count words, group into chapters and compile.
 
 ---
 
-## 3. El modelo de datos (migración 100)
+## 3. The data model (migration 100)
 
-Tres tablas nuevas, **todas CREATE-only**. `isCreateOnly()` rechaza cualquier cuerpo con
-`ALTER`, `DROP`, `INSERT`, `UPDATE`, `DELETE` o `REPLACE`, y una migración que las use pierde
-**los dos** caminos de reparación (`backfillMissingCreateOnly` y la reejecución sobre una base
-migrada con otra numeración). Eso significa, literalmente, que **no se puede añadir una
-columna a `world_scenes`**: ni `text`, ni `chapter_id`, ni `word_count`. Todo va en tablas
-nuevas con `scene_id` como clave.
+Three new boards, **all CREATE-only**.`isCreateOnly()`rejects any body with`ALTER`, `DROP`,
+`INSERT`, `UPDATE`, `DELETE`o`REPLACE`, and a migration that uses them loses ** both** repair paths
+(`backfillMissingCreateOnly`and re-execution on a migrated basis with another numbering). That
+literally means that **cannot be added a column to`world_scenes`**: nor`text`, or`chapter_id`,
+or`word_count`. Everything goes on new boards with`scene_id`as a key.
 
 ```sql
--- La prosa. Tabla APARTE y no una columna de world_scenes, por dos razones distintas y
--- ambas suficientes: la migración no puede hacer ALTER, y —más importante— una novela de
--- 120 000 palabras son ~700 KB que `listScenes()` arrastraría en CADA lectura, y esa lista
--- la leen la vista de escenas, el feed de preguntas, los arcos y la cadena de días. Misma
--- regla que ya sigue world_maps con sus bytes: el cuerpo NUNCA viaja con la lista.
+-- The prose. APART table and not a column of world_scenes, for two different reasons and
+-- migration cannot make ALTER, and — more importantly — a novel by
+-- 120 000 words are ~700 KB that`listScenes()`I'd drag in EVERY read, and that list
+-- the view of scenes, the feed of questions, the arches and the chain of days.
+-- rule that already follows world_maps with its bytes: the body NEVER travels with the list.
 CREATE TABLE world_scene_text (
-  scene_id     TEXT PRIMARY KEY,      -- sin REFERENCES: foreign_keys está ON y NO ACTION
-  text         TEXT,                  --   abortaría "corta esta escena"
-  -- Denormalizado a propósito: es lo único que la espina, el objetivo y el contador del día
-  -- necesitan, y calcularlo exige leer el texto entero de todas las escenas.
+  scene_id     TEXT PRIMARY KEY,      -- without REFERENCES: foreign_keys is ON and NO ACTION
+  text         TEXT,                  --   I'd abort "cut this scene."
+  -- Denormalized on purpose: it's the only thing that thorn, target and counter of the day
+  -- They need to, and calculate it requires reading the entire text of all scenes.
   word_count   INTEGER NOT NULL DEFAULT 0,
   created_at   TEXT NOT NULL,
   updated_at   TEXT NOT NULL
 );
 
--- Un capítulo es DONDE EMPIEZA un capítulo. No hay tabla de capítulos con su propio orden:
--- eso sería un segundo eje de ordenación junto a narrative_order, y los dos discreparían el
--- primer día que alguien mueva una escena (la cadena de días y los carriles de los arcos ya
--- dependen de que ese orden sea denso y total). Aquí el capítulo se mueve moviendo sus
--- escenas, que es lo que un autor hace de todas formas.
+-- A chapter is WHERE A chapter starts. There is no chapter table with its own order:
+-- that would be a second axis of ordination together with narrative_order, and the two would disagree on
+-- first day someone moves a scene (the chain of days and lanes of arches already
+-- depend on that order being dense and total.) Here the chapter moves its
+-- scenes, which is what an author does anyway.
 CREATE TABLE world_chapter_breaks (
   scene_id  TEXT PRIMARY KEY,
   title     TEXT,
@@ -93,9 +92,9 @@ CREATE TABLE world_chapter_breaks (
   updated_at TEXT NOT NULL
 );
 
--- Cuántas palabras había al cerrar cada día. El delta se calcula contra el día anterior y
--- PUEDE SER NEGATIVO: un día de podar es un día de trabajo, y un contador que sólo sabe
--- sumar convierte cortar en un castigo.
+-- How many words were there at the close of every day. The delta is calculated against the day before and
+-- CAN BE NEGATIVE: a day of pruning is a day of work, and an accountant who only knows
+-- Adding turns cutting into punishment.
 CREATE TABLE world_word_days (
   day          TEXT PRIMARY KEY,      -- 'YYYY-MM-DD' local
   total_words  INTEGER NOT NULL,
@@ -104,252 +103,239 @@ CREATE TABLE world_word_days (
 );
 ```
 
-Las tres al grupo `worldbuilding` de `syncTables.ts`, o no viajan y sus borrados resucitan.
-La propiedad la imponen las transacciones del repo: `deleteScene()` borra su fila de texto y
-su marca de capítulo, como ya borra sus latidos.
+All three to the group.`worldbuilding`of`syncTables.ts`The property is imposed by the repo
+transactions:`deleteScene()`deletes your text row and your chapter mark, as you already erase your
+heartbeat.
 
-### Un manuscrito por vault (de momento)
+### One manuscript per vault (for now)
 
-`narrative_order` es global. Una trilogía en un mismo mundo necesitaría un orden por
-manuscrito, y eso toca el eje del que ya cuelgan la cadena de días, los carriles de los arcos
-y el «tramo inerte». **Fase 1 = un manuscrito**, y la etiqueta del sidebar pasa de
-«Manuscritos» a «Manuscrito» (mismo precedente que «Consistencia» → «Continuidad»). Varios
-manuscritos es M7, diseñado abajo y explícitamente no ahora.
-
----
-
-## 4. Las fases
-
-### M0 — La prosa tiene sitio
-
-Migración 100, tipos en `shared/types.ts`, alta en `syncTables.ts`,
-`electron/db/worldManuscriptRepo.ts` (`getSceneText`, `saveSceneText`, `setChapterBreak`,
-`manuscriptSpine`), IPC `manuscript:*` y preload. **Sin UI todavía**, salvo el botón
-«Escribir» de la ficha de escena.
-
-`saveSceneText` hace tres cosas además de guardar: promociona los `[[…]]` a enlaces
-resueltos (`promoteWorldLinks`), reindexa los enlaces de la escena, y recalcula
-`word_count` con `countWords()` (§6).
-
-Test: que `listScenes()` sigue sin traer una sola palabra de prosa.
-
-### M1 — El escritorio de escritura
-
-`src/views/ManuscriptView.tsx`, tres columnas:
-
-- **La espina** (izquierda): capítulos y escenas en orden de relato, con su recuento y un
-  punto de estado (esbozo · borrador · escrita). Es la tabla de contenidos y el navegador.
-- **El texto** (centro): el editor. Medida cómoda (~65ch), serifa, interlínea generosa —
-  esto no es decoración, es la diferencia entre escribir aquí y no hacerlo. Autoguardado al
-  salir del campo y al cambiar de escena, nunca con debounce (una escritura por pausa en una
-  frase). `⌘↑`/`⌘↓` saltan de escena sin soltar el teclado.
-- **Lo que esta escena tiene que hacer** (derecha, plegable): los latidos declarados, las
-  leyes en juego, las preguntas abiertas que la bloquean y la insignia de continuidad. Todo
-  ya calculado por «Analizar»; aquí sólo se muestra.
-
-El autocompletado de `[[` se **extrae** de `WorldEntryEditor` a un hook compartido
-(`useWorldLinkAutocomplete`) y el editor del manuscrito se construye sobre él. No se dobla
-`WorldEntryEditor`: sus botones Guardar/Cancelar son los de un artículo, y un manuscrito
-autoguarda.
-
-### M2 — Capítulos
-
-Marcar una escena como «aquí empieza un capítulo», con título y epígrafe opcionales. La
-espina agrupa. Mover o renombrar un capítulo es mover o renombrar sus escenas: **un solo eje
-de ordenación, para siempre**. Una escena de esbozo sirve de marcador de capítulo por
-escribir, que es lo que un autor ya hace.
-
-### M3 — El contador honesto
-
-Palabras por escena, por capítulo y del manuscrito; objetivo opcional; barra de avance por
-estado (esbozo/borrador/escrita, con la cuenta real de cada uno, nunca una proyección). Y el
-**delta del día** desde `world_word_days`, con su signo: un día de podar aparece en negativo
-y con esas palabras. El estado de la escena lo sigue poniendo el autor: no se deriva
-«escrita» de un umbral de palabras — nada de lo que el autor declara se recalcula a su
-espalda.
-
-### M4 — La prosa entra en el mundo
-
-La fase que justifica todo el diseño, y la de mayor radio de acción. Con el texto en una
-tabla del vault, **toda la maquinaria existente se aplica sola**:
-
-- **Retroenlaces**: `[[Kaelen]]` en el capítulo 12 aparece en la ficha de Kaelen.
-- **Búsqueda a texto completo**: `searchWorldBodies` gana la columna de la escena.
-- **Huecos**: un `???` en el manuscrito es una decisión sin tomar, y aparece en Preguntas
-  abiertas sin una línea de código nueva.
-- **Chat del mundo**: puede citar el texto en vez de sólo el resumen.
-- **Continuidad** gana una comprobación pura y nueva: *«aparece en el texto y no está en el
-  reparto»* — el enlace resuelto dice qué personajes se mencionan; el reparto dice cuáles se
-  declararon. Aritmética, sin modelo.
-
-**El punto delicado**: `entryProse()` NO debe devolver el manuscrito. Esa función alimenta
-también el panel de lectura de la enciclopedia y el **export de la biblia del mundo**, y
-meter ahí la prosa convertiría la biblia en la novela entera. Se añade una función aparte
-—`entryIndexableProse()`— que es `entryProse()` **más** el texto, y sólo la usan los
-indexadores (enlaces, búsqueda, huecos). Los dos consumidores viejos quedan intactos por
-construcción, no por acordarse.
-
-### M5 — Compilar
-
-Exportar el manuscrito como un solo archivo, reutilizando `markdownRender` +
-`professionalReportPdf`:
-
-- **Qué se incluye**: todo, o sólo lo escrito; con o sin los resúmenes de las escenas sin
-  escribir como marcadores (`[por escribir: …]`), que es como se manda un borrador parcial.
-- **Formato**: portada, capítulos con su epígrafe, separador entre escenas, numeración.
-- **Landmine central**: la prosa guardada contiene enlaces resueltos
-  (`[Kaelen](nodus://world/character/prs_7)`). Un manuscrito que se manda a alguien **no
-  puede llevarlos**: la compilación los degrada a su etiqueta. Es la operación inversa de
-  `toRenderableBody()` y hay que escribirla y probarla explícitamente.
-
-### M6 — Verificación y graduación
-
-Tests puros (`countWords`, la espina, el degradado de enlaces, la comprobación de reparto),
-tests de repo contra un vault migrado, i18n en siete idiomas, y e2e.
-
-**Landmine de la graduación**: «Manuscritos» es el **último** ítem inerte del sidebar. La
-aserción del e2e que dice «una sección sin construir no debe poder pulsarse» se queda sin
-sujeto: hay que **sustituirla**, no moverla, por la contraria — que todos los ítems del
-sidebar navegan. Y `test-vault-types.mjs` pasa a dieciocho vistas cableadas.
+`narrative_order`It is global. A trilogy in the same world would need an order per manuscript, and
+that touches the axis from which the chain of days, the lanes of the arches and the "inert line"
+hang. **Phase 1 = a manuscript**, and the label of the sidebar moves from "Manuscripts" to
+"Manuscript" (same previous as "Consistence" → "Continuity"). Several manuscripts is M7, designed
+below and explicitly not now.
 
 ---
 
-## 5. Lo que NO se construye, y por qué
+## 4. The phases
 
-- **Control de cambios y comentarios.** Son de un flujo de trabajo con editor externo, no del
-  de escribir. Quien los necesita exporta y usa Word, que es donde su editorial ya está.
-- **WYSIWYG.** Markdown, como el resto del vault. Un segundo formato de texto en la misma
-  base de datos es un segundo conjunto de reglas de escapado y una fuente permanente de
-  «esto se ve distinto aquí».
-- **Instantáneas / versiones de escena.** Valiosas, pero son otra tabla y otra pantalla; y el
-  editor de estudio ya tiene versionado que se podría reutilizar. → M8.
-- **Varios manuscritos.** → M7.
-- **Objetivos diarios con racha y recordatorios.** Gamificación; el delta honesto del día ya
-  da el 90 % del valor sin convertir escribir en una obligación con castigo.
-- **Que la IA escriba prosa.** Nunca. Ver §1.
+### M0 — The prose has room
+
+Migration 100, rates`shared/types.ts`, high`syncTables.ts`, `electron/db/worldManuscriptRepo.ts`
+(`getSceneText`, `saveSceneText`, `setChapterBreak`, `manuscriptSpine`), IPC`manuscript:*`and
+preload. **No UI yet**, except the "Write" button on the scene sheet.
+
+`saveSceneText`does three things besides saving: promotes the`[[…]]`to resolved links
+(`promoteWorldLinks`), reindexes the links of the scene, and
+recalculates`word_count`with`countWords()` (§6).
+
+Test: that`listScenes()`Still don't bring a single word of prose.
+
+### M1 — The Writing Desktop
+
+`src/views/ManuscriptView.tsx`, three columns:
+
+- **The spine** (left): chapters and scenes in order of story, with their count and a state point
+  (draft · written). It is the table of contents and the browser.
+- **The text** (center): the editor. Comfortable measure (~65ch), serif, generous interline — this
+  is not decoration, it is the difference between writing here and not doing it. Self-saved when
+  leaving the field and changing the scene, never with debounce (a paused writing in a
+  sentence).`⌘↑`/`⌘↓`They jump from the scene without dropping the keyboard.
+- **What this scene has to do** (right, foldable): the declared beats, the laws at stake, the open
+  questions blocking it and the continuity badge. All already calculated by "Analyze"; here it is
+  only shown.
+
+The Auto Completion of`[[`**extracted** from`WorldEntryEditor`to a shared hook
+(`useWorldLinkAutocomplete`) and the manuscript editor is built on it.`WorldEntryEditor`: its
+Save/Cancel buttons are those of an article, and a self-saved manuscript.
+
+### M2 — Chapters
+
+Marking a scene as "here begins a chapter", with optional title and heading. Spina groups. Moving or
+renaming a chapter is moving or renaming its scenes: **a single ordination axis, forever**. A sketch
+scene serves as a chapter marker to be written, which is what an author already does.
+
+### M3 — The honest accountant
+
+Words by scene, by chapter and by manuscript; optional target; advance bar by status (draw/write,
+with the actual account of each, never a projection). And the **delta of the day**
+from`world_word_days`, with its sign: a day of pruning appears in negative and with those words. The
+state of the scene is still put by the author: it is not derived "written" from a threshold of words
+— nothing that the author declares is recalculated behind his back.
+
+### M4 — Prosa enters the world
+
+The phase that justifies the entire design, and the one of greater radius of action. With the text
+in a table of the vault, **all the existing machinery is applied alone**:
+
+- **Retrolinks**:`[[Kaelen]]`in chapter 12 it appears on Kaelen's file.
+- **Full text search**:`searchWorldBodies`wins the column of the scene.
+- **Woes**: a`???`in the manuscript is an unmade decision, and appears in Open Questions without a
+  new code line.
+- **Chat of the world**: you can quote the text instead of just the summary.
+- **Continuity** wins a pure and new check: *"appears in the text and is not in the cast"* — the
+  resolved link says which characters are mentioned; the cast says which were declared. Arithmetic,
+  without model.
+
+**The delicate point**:`entryProse()`You must NOT return the manuscript. That function also feeds
+the reading panel of the encyclopedia and the **export of the world Bible**, and putting the prose
+there would make the Bible into the entire novel. A separate function is added
+—`entryIndexableProse()`— which is`entryProse()`**more** the text, and only the indexers use it
+(links, search, gaps).The two old consumers remain intact by construction, not by remembering.
+
+### M5 — Compile
+
+Export the manuscript as a single file, reusing`markdownRender` + `professionalReportPdf`:
+
+- **What is included**: all, or only written; with or without summaries of unwritten scenes as
+  bookmarks (`[por escribir: …]`), which is how you send a partial draft.
+- **Format**: cover, chapters with their heading, separator between scenes, numbering.
+- **Central Landmine**: Saved prose contains solved links
+  (`[Kaelen](nodus://world/character/prs_7)`). A manuscript that is sent to someone ** cannot carry
+  them**: the compilation degrades them to their label. It is the reverse operation
+  of`toRenderableBody()`and you have to write it and prove it explicitly.
+
+### M6 — Verification and graduation
+
+Pure tests (`countWords`, the spine, the degradation of links, the casting test), repo tests against
+a migrated vault, i18n in seven languages, and e2e.
+
+**Landmine of graduation**: «Manuscripts» is the **ultimate** inert item of the sidebar. The
+assertion of the e2e that says «an unbuilt section must not be able to be pulsated» is left without
+subject: it must be replaced**, not moved, on the contrary — that all items of the sidebar
+sail.`test-vault-types.mjs`passes to eighteen wired views.
 
 ---
 
-## 5 bis. Lo que cambió al construirlo
+## 5. What is NOT built, and why
 
-- **El meta-test del catálogo se desarma solo al graduar una comprobación a otro fichero.**
-  `test-world-analyze.mjs` recorría las funciones de `shared/worldContinuity.ts` buscando
-  cada `id` de `CONTINUITY_CHECKS`; `manuscript.uncastMention` vive en
-  `shared/worldManuscript.ts`, así que el guardián habría pasado en verde sobre un catálogo
-  que promete algo que nadie implementa. Ahora recorre los dos módulos.
-- **`WorldEntryEditor` se reescribió sobre el hook compartido**, no se copió: lo difícil del
-  autocompletado no es el desplegable, es que el disparador se busca **hacia atrás desde el
-  cursor**, que es lo que lo mantiene correcto cuando el autor vuelve a un enlace a medio
-  escribir. Una segunda copia de eso deriva, y la deriva sale en el editor que esa semana
-  nadie estaba probando.
-- **Una sola puerta al mismo texto**: «Escribir» en la ficha de escena **navega** al
-  manuscrito posicionado en esa escena (`localStorage`), en vez de abrir un segundo editor.
-  De paso, el manuscrito reabre donde lo dejaste.
-- **`loadedFor` guarda el único caso peligroso del autoguardado**: escribir el texto de la
-  escena anterior dentro de la que se acaba de seleccionar. Sin ese guardián, cambiar de
-  escena rápido pisa un capítulo con otro.
-- **El enlace se llama `sourceField`, no `field`.** Cuesta un e2e en rojo averiguarlo.
-
-## 6. Landmines conocidas antes de empezar
-
-1. **Migración CREATE-only o no hay reparación.** Nada de `ALTER`: la prosa, el capítulo y el
-   contador van en tablas nuevas, no en columnas de `world_scenes`.
-2. **Ni una clave foránea con acción declarada.** `foreign_keys` está ON: un `REFERENCES` sin
-   acción usa NO ACTION y **aborta** el borrado del padre. «Corta esta escena» se convertiría
-   en un error de base de datos. La propiedad la imponen las transacciones del repo.
-3. **El texto nunca viaja con la lista de escenas.** Es la regla que ya siguen los mapas con
-   sus bytes, y aquí la violan cuatro consumidores distintos si se descuida.
-4. **Contar palabras es una función pura y NO es `split(' ')`.** El texto lleva enlaces
-   resueltos: contar `nodus://world/character/prs_7` como palabras infla cada recuento y el
-   objetivo entero. `countWords()` quita primero las URL de los enlaces (conservando la
-   etiqueta), los marcadores de Markdown y los bloques de código.
-5. **`entryProse()` no puede crecer.** Alimenta la biblia del mundo; el manuscrito entra por
-   `entryIndexableProse()`. Sin esa separación, exportar la biblia exporta la novela.
-6. **El escaneo de huecos leerá ahora toda la novela.** `questionFeed()` recorre
-   `allWorldBodies()` en cada apertura, y `sceneQuestionLoad()` una vez por ficha de escena.
-   Con 700 KB de prosa hay que **medirlo** antes de decidir nada; si duele, la salida es
-   escanear al guardar, no una caché de hallazgos (que sería la segunda verdad de siempre).
-7. **Un capítulo no es un eje de ordenación.** Si en algún momento se añade `sort_order` a
-   los capítulos, habrá dos órdenes que discrepan, y el día de la escena pasará a depender de
-   cuál se lea primero.
-8. **El autoguardado va al salir del campo, no con debounce.** Un debounce escribe una vez por
-   pausa en una frase; sobre un capítulo entero eso son cientos de escrituras y un historial
-   de sincronización inútil.
-9. **`test:e2e` no reconstruye.** `npm run build` antes, siempre.
-10. **Al graduar la última sección, la aserción de «sección inerte» se queda sin sujeto.**
-    Se sustituyó por la contraria —ningún botón del sidebar está deshabilitado— tanto en el
-    e2e como en `test-vault-types.mjs`, que ahora afirma que **ningún ítem carece de vista**.
-11. **Probar a mano con perfil aislado** (`NODUS_USERDATA=/tmp/nodus-x`), nunca sobre un vault
-    real: un build con distinta numeración de migraciones los corrompe.
+- **Controlling changes and comments.** They are from a workflow with external editor, not the one
+  of writing. Those who need them export and use Word, which is where their publisher is already.
+- **WYSIWYG.** Markdown, like the rest of the vault. A second text format in the same database is a
+  second set of escape rules and a permanent source of "this looks different here".
+- **Instant / scene versions.** Valiosas, but they are another table and another screen; and the
+  studio editor already has versioned that could be reused. → M8.
+- **Several manuscripts.** → M7.
+- **Daily goals with streaks and reminders.**Gamification; the honest delta of the day already gives
+  90% of the value without turning writing into an obligation with punishment.
+- ** May the AI write prose.** Never. See §1.
 
 ---
 
-## 7. M7, M8 y M9 — **HECHAS** (migración 101)
+## 5 bis. What changed when you built it
 
-- **M7 — El estante.** El diseño de arriba —`world_manuscripts` + pertenencia de la escena +
-  `narrative_order` por manuscrito— **se descartó al construirlo**, y la razón es la misma
-  que ya había decidido los capítulos: sería un segundo eje de ordenación junto al del
-  relato, del que cuelgan la cadena de días, los carriles de los arcos y la escena límite de
-  las preguntas abiertas. **Un libro es DÓNDE empieza un libro**: `world_manuscript_starts`,
-  la misma forma que `world_chapter_breaks`. Cero cambios en el orden, cero migración de
-  datos, cero riesgo. El precio —los libros son tramos contiguos del orden— es exactamente
-  lo que es un estante. La cadena de días sigue siendo global a propósito: en una trilogía
-  de un mismo mundo el día 4120 es el día 4120, y un libro que abre otra era ancla su
-  primera escena.
-- **M8 — Instantáneas.** `world_scene_snapshots`, a mano y **automáticas cuando el texto se
-  reduce a menos de la mitad** — el momento en que nadie se acuerda de pulsar nada (un
-  pegado sobre el capítulo seleccionado). Restaurar guarda antes lo que hay, porque un
-  deshacer que no se puede deshacer es una trampa, y pasa por `saveSceneText`, así que un
-  capítulo restaurado no es de segunda: se le promocionan e indexan los enlaces igual.
-  Tope de 20 por escena, y sale la más vieja.
-- **M9 — `reviewWorldProse`.** La revisión que A9 rechazó por falta de entrada. Bajo botón,
-  por escena, temperatura 0.2: de los latidos que el autor declaró, cuáles están en la
-  página. **No opina sobre la prosa, no reescribe, no sugiere frases.** Un latido sin
-  respuesta vuelve como `present: null` — decirle al autor que algo está escrito cuando
-  nadie lo ha comprobado es justo el error que esta comprobación existe para no cometer.
+- **The meta-test of the catalog is disarmed only when you graduate a check to another
+  file.**`test-world-analyze.mjs`the functions of`shared/worldContinuity.ts`looking for
+  every`id`of`CONTINUITY_CHECKS`; `manuscript.uncastMention`lives in`shared/worldManuscript.ts`So
+  the guardian would have gone green on a catalog that promises something that no one implements.
+  Now it runs through the two modules.
+- **`WorldEntryEditor`it was rewritten on the shared hook**, it was not copied: the difficulty of
+  autocompletion is not the drop-down, it is that the trigger is sought back ** from the cursor**,
+  which is what keeps it right when the author returns to a half-write link. A second copy of that
+  derives, and the drift comes out in the editor that that week no one was testing.
+- **One door to the same text**: "Write" on the scene sheet **naviga** to the manuscript positioned
+  in that scene (`localStorage`), instead of opening a second editor. By the way, the manuscript
+  reopens where you left it.
+- **`loadedFor`saves the only dangerous case of the self-saved**: write the text of the previous
+  scene within which you have just selected. Without that guardian, change the scene quickly steps
+  one chapter with another.
+- **The link is called`sourceField`, no`field`It costs a red e2e to find out.
 
-### Lo que enseñó construirlas
+## 6. Landmines known before you start
 
-- **`\b` es ASCII, y eso borra el español.** El parser daba por no leídos TODOS los «sí»:
-  detrás de `í` y delante de `:` no hay frontera de palabra para JS. La condición correcta es
-  «no le sigue otra letra», con `(?![\p{L}\p{N}])` y el flag `u`.
-- **Dos sitios que saben qué posee una escena es un sitio de más.** `deleteScene()` repetía
-  la lista de tablas del manuscrito, y al crecer con dos más de la v101 se quedó vieja: las
-  instantáneas sobrevivían al borrado de su escena. Ahora delega en `deleteManuscriptFor()`.
-- **Una marca ausente no es una marca nula.** `scene.book !== null` convierte un `undefined`
-  —de cualquier llamante que omita el campo— en «aquí empieza un libro»: cada escena abría
-  el suyo. Se comprueba con `Boolean(...)`.
+1. **Migration CREATE-only or no repair.**`ALTER`: prose, chapter and counter go on new boards, not
+   columns of`world_scenes`.
+2. **Neither a foreign key with declared action.**`foreign_keys`is ON: a`REFERENCES`without action
+   uses NO ACTION and **aborts** the deletion of the father. "Cut this scene" would become a
+   database error. Property is imposed by repo transactions.
+3. **The text never travels with the list of scenes.** It is the rule that maps already follow with
+   their bytes, and here it is violated by four different consumers if neglected.
+4. ** Counting words is a pure function and it is NOT`split(' ')`.** Text has solved links:
+   count`nodus://world/character/prs_7`like words inflates every count and the entire
+   target.`countWords()`first remove the URLs from the links (preserving the tag), Markdown
+   bookmarks and code blocks.
+5. **`entryProse()`cannot grow.** Feeds the Bible of the world; the manuscript enters
+   by`entryIndexableProse()`Without that separation, export the Bible exports the novel.
+6. **Scanning holes will now read the whole novel.**`questionFeed()`Go on.`allWorldBodies()`at each
+   opening; and`sceneQuestionLoad()`Once per scene sheet. With 700 KB of prose you have to **measure
+   it** before deciding anything; if it hurts, the output is scanning when saving, not a cache of
+   findings (which would be the second usual truth).
+7. **A chapter is not an ordination axis.** If at any time it is added`sort_order`to the chapters,
+   there will be two orders that differ, and the day of the scene will become dependent on which one
+   is read first.
+8. **The autosave goes out of the field, not with debounce.** A debounce writes once per pause in a
+   sentence; over an entire chapter that is hundreds of scriptures and a useless synchronization
+   history.
+9. **`test:e2e`does not reconstruct.**`npm run build`before, always.
+10. **When graduating the last section, the assertion of 'inert section' is left without subject.**
+    It was replaced by the opposite — no sidebar button is disabled — both in the e2e and in
+    the`test-vault-types.mjs`, which now states that **no item is sightless**.
+11. **Hand test with isolated profile** (`NODUS_USERDATA=/tmp/nodus-x`), never on a real vault: a
+    build with different migration numbers corrupts them.
 
-## 8. Modo máquina de escribir — **HECHO**
+---
 
-La línea que se escribe se queda a la altura de los ojos (banda al 42 %, ligeramente por
-encima del centro: centrado exacto deja media pantalla de texto ya escrito ocupando el sitio
-de lo que viene). Fuera la espina y el margen derecho; `Esc` devuelve la pantalla entera.
+## 7. M7, M8 and M9 — **DONE** (migration 101)
 
-Tres cosas que decidieron la implementación:
+- **M7 — The shelf.** The design above —`world_manuscripts`+ belonging to the scene
+  +`narrative_order`by manuscript— ** was discarded when building it**, and the reason is the same
+  as the chapters had already decided: it would be a second axis of ordination next to the story,
+  from which hang the chain of days, the lanes of the arches and the boundary scene of the open
+  questions. **A book is WHERE a book begins**:`world_manuscript_starts`, the same way
+  that`world_chapter_breaks`. Zero changes in order, zero migration of data, zero risk. The price —
+  books are adjacent sections of the order — is exactly what a shelf is. The chain of days remains
+  global on purpose: in a trilogy of the same world the day 4120 is the day 4120, and a book that
+  opens another was anchoring its first scene.
+- **M8 — Instant.**`world_scene_snapshots`, by hand and **automatic when the text is reduced to less
+  than half** — the moment no one remembers to press anything (one pasted on the selected chapter).
+  Restore saves before there is, because a undo that cannot be undone is a trap, and passes
+  by`saveSceneText`So a restored chapter is not second-rate: you are promoted and indexed the same
+  links. Top 20 per scene, and it comes out the oldest.
+- **M9 —`reviewWorldProse`.** The revision that A9 rejected for lack of entry. Under button, by
+  scene, temperature 0.2: of the beats that the author declared, which are on the page. **Does not
+  think about prose, does not rewrite, does not suggest phrases.** A heartbeat without response
+  returns as`present: null`— tell the author that something is written when no one has proved it is
+  just the error that this check exists not to commit.
 
-- **Un `<textarea>` no sabe decir en qué píxel está su cursor.** Da `selectionStart`, un
-  índice en la cadena, y nada más. La única forma de averiguarlo es pintar el mismo texto
-  hasta el cursor en un `div` invisible con EXACTAMENTE los mismos estilos que deciden dónde
-  se parte una línea, pegarle una marca y preguntarle a la marca. La lista de estilos es el
-  punto débil: si el espejo difiere en una sola, el texto se parte por otro sitio y el error
-  **crece línea a línea** — a mitad de un capítulo la medición apunta a otro párrafo. Un
-  editor `contenteditable` daría la posición exacta con `Range.getClientRects()`, pero
-  costaría el autocompletado de `[[` (vive de `selectionStart`), la pila de deshacer nativa y
-  el IME; no se paga eso por colocar una línea.
-- **Sin relleno inferior el modo se muere justo donde siempre está el autor.** Al final de lo
-  escrito no hay nada debajo que empujar, así que la última línea no puede subir a la banda y
-  el efecto desaparece precisamente mientras se escribe. El modo añade
-  `viewportHeight * (1 - band)` de relleno.
-- **Sin zona muerta el texto TIEMBLA bajo las manos**: cada pulsación corrige uno o dos
-  píxeles. Cuatro píxeles de tolerancia y se acabó.
+### What he taught to build them
 
-Y una limitación asumida: **no se atenúan los párrafos uno a uno**, porque un `<textarea>` no
-puede dar estilo a partes de su propio texto y un editor falso encima sería otro producto. Lo
-que sí es honesto —y hace el mismo trabajo— es velar lo que queda lejos de la banda con un
-degradado, que además no cuesta ni un cálculo por pulsación porque la línea siempre está en
-el mismo sitio.
+- **`\b`is ASCII, and that erases the Spanish.** The parser considered not read ALL the "yes":
+  behind`í`in front of`:`there is no word frontier for JS. The correct condition is "no other letter
+  follows", with`(?![\p{L}\p{N}])`and the flag`u`.
+- **Two sites that know what owns a scene is an extra site.**`deleteScene()`He repeated the list of
+  tables of the manuscript, and as he grew up with two more of v101 he became old: the snapshots
+  survived the erasure of his scene.`deleteManuscriptFor()`.
+- **An absent mark is not a null mark.**`scene.book !== null`converts a`undefined`—of any caller who
+  omits the field — in ‘here begins a book’: each scene opened his own.`Boolean(...)`.
 
-## 9. Después (no diseñado a fondo)
+## 8. Typewriter mode — **FACT**
 
-- **`reviewWorldProse` en lote**, para leer un capítulo entero de una vez.
+The line that is written stays at the height of the eyes (band at 42 %, slightly above the center:
+precise centered leaves half a screen of text already written occupying the site of what is coming).
+Outside the spine and the right margin;`Esc`returns the entire screen.
+
+Three things that decided on implementation:
+
+- **A`<textarea>`doesn't know what pixel his cursor is in.** Da`selectionStart`The only way to find
+  out is to paint the same text until the cursor in a`div`Invisible with EXACTLY the same styles
+  that decide where a line is broken, paste a mark on it and ask the brand. The list of styles is
+  the weak point: if the mirror differs in a single one, the text is split by another site and the
+  error **grows line by line** — in the middle of a chapter the measurement points to another
+  paragraph.`contenteditable`would give the exact position with`Range.getClientRects()`but it would
+  cost the auto-completion of`[[`(lives from`selectionStart`), the native undo stack and the IME;
+  you don't pay that to place a line.
+- **Without lower filling the mode dies right where the author is always.** At the end of the
+  writing there is nothing below to push, so the last line cannot climb into the band and the effect
+  disappears precisely while it is written.`viewportHeight * (1 - band)`filler.
+- **No dead zone the TIME text under your hands**: each pulsation corrects one or two pixels. Four
+  pixels of tolerance and is over.
+
+And a limitation assumed: ** the paragraphs are not attenuated one by one**, because
+a`<textarea>`You can’t style parts of your own text and a fake editor on top would be another
+product. What’s honest — and does the same job — is to watch what’s far from the band with a
+gradient, which also doesn’t cost a pulsation calculation because the line is always in the same
+place.
+
+## 9. After (not thoroughly designed)
+
+- **`reviewWorldProse`in batch**, to read an entire chapter at once.

--- a/design/worldbuilding-maps-plan.md
+++ b/design/worldbuilding-maps-plan.md
@@ -1,180 +1,179 @@
-# Worldbuilding — Mapas
+# Worldbuilding — Maps
 
-> Estado: **M0–M7 implementados. El plan está completo** (2026-07-27). Schema en **v97**.
-> `npm test` 1023/1023 · typecheck, lint (0 errores), i18n (7 idiomas) y `build` en verde.
-> **SIN commitear.**
+> Status: **M0–M7 implemented. The plan is complete** (2026-07-27). Schema in **v97**.
+> `npm test`1023/1023 · typecheck, lint (0 errors), i18n (7 languages) and`build`Green.
+> ** WITHOUT COMMIT.**
 >
-> | Fase | Qué entrega |
+> | Phase | Deliverable |
 > |---|---|
-> | M0 | Migración v97 (5 tablas), `shared/worldMapGeometry.ts` puro, dos repos, IPC, ruta de imagen propia, `syncTables` |
-> | M1 | Sección Mapas (sustituye a «Mapa» en worldbuilding), rejilla, subir imagen, visor Leaflet `CRS.Simple`, migas de pan |
-> | M2 | Calibración por dos puntos, barra de escala y rosa de los vientos nativas, regla con tiempos de viaje, modos de viaje |
-> | M3 | Punto → círculo → polígono → ruta con edición de vértices a mano, capas, vínculo bidireccional con lugares |
-> | M4 | `shared/worldPresence.ts` (escenas + eventos + residencia como fondo), línea temporal con reproducción, tránsitos interpolados |
-> | M5 | `resolveMapFocus`, autoseguimiento de un personaje, tira de reparto con salto entre mapas |
-> | M6 | `shared/mapPrompt.ts` (10 estilos), capacidades por proveedor con degradación honesta, recorte sin IA, zoom con IA, outpainting, anotación por visión |
-> | M7 | Escenas en el mapa, viajes imposibles, buscador de encuentros, exportación a PNG |
+> | M0 | Migration v97 (5 tables), pure `shared/worldMapGeometry.ts`, two repositories, IPC, dedicated image path, `syncTables` |
+> | M1 | Maps section (replaces "Map" in worldbuilding), grid, image upload, Leaflet `CRS.Simple` viewer, breadcrumbs |
+> | M2 | Two-point calibration, native scale bar and compass rose, distance ruler with travel times, travel modes |
+> | M3 | Point → circle → polygon → route with manual vertex editing, layers, bidirectional links to places |
+> | M4 | `shared/worldPresence.ts` (scenes + events + residence as background), playback timeline, interpolated travel |
+> | M5 | `resolveMapFocus`, automatic character following, cast strip with jumps between maps |
+> | M6 | `shared/mapPrompt.ts` (10 styles), per-provider capabilities with honest fallback, non-AI cropping, AI zoom, outpainting, vision annotation |
+> | M7 | Scenes on the map, impossible journeys, encounter finder, PNG export |
 >
-> Verificado **en pantalla** además de por tests: clic → coordenada normalizada exacto en
-> cinco pruebas; 224 km medidos sobre un mapa de 400 km con 8,9/4,1/1,9 días; barra de
-> escala exacta a tres niveles de zoom; y un vértice arrastrado de (0,45 · 0,25) a
-> (0,622 · 0,162) con un solo commit.
+> Verified **on screen** in addition to tests: click → exact normalized coordinate in
+> five tests; 224 km measured on a map of 400 km with 8,9/4,1/1,9 days;
+> exact scale at three zoom levels; and a dragged vertex from (0.45 · 0.25) to
+> (0,622 · 0.162) with a single commit.
 >
-> **Cinco bugs reales cazados mirando la pantalla, ninguno por los tests:**
-> 1. `@napi-rs/canvas` usa calidad WebP **0–100, no 0–1**: con `0.88` un mapa de 4096 px
->    salía a 16 KB de puré.
-> 2. La barra de escala dependía de `setTick` (estable) en vez de `tick`: se calculaba una
->    vez y nunca más.
-> 3. El `fitBounds` inicial corría con el contenedor aún sin tamaño → zoom mínimo. Carrera.
-> 4. `pointsRef.current = points` asignado en el render: **arrastrar un vértice no
->    guardaba nada**.
-> 5. `mapCoverage` colisionaba con el del mapa de investigación — y `tsc --noEmit` no
->    cubre `electron/`, así que sólo lo vio el build.
+> **Five real bugs caught watching the screen, none for the tests:**
+> 1. `@napi-rs/canvas`use WebP quality **0–100, no 0–1**: with`0.88`a map of 4096 px
+> I was going out 16 kb of puree.
+> 2. The scale bar depended on`setTick`(stable) instead of`tick`: calculated as one
+> time and never again.
+> 3. The`fitBounds`initial ran with container still without size → zoom minimum. Race.
+> 4. `pointsRef.current = points`assigned in render: **drag a vertex no
+> He kept nothing**.
+> 5. `mapCoverage`collided with the research map — and`tsc --noEmit`no
+> cover`electron/`So only the build saw it.
 >
-> **Dos huecos de test que sólo se vieron mutando** y que llevaron a reescribir código:
-> el comparador de `sortPresences` era *inconsistente* con nulos (el resultado dependía
-> del algoritmo interno de V8, así que ahora particiona en vez de comparar), y el guard de
-> nulos de `buildJourneys` no se ejercitaba con todas las presencias sin fecha.
+> **Two test gaps that were only mutating** and led to rewrite code:
+> the comparator of`sortPresences`was *inconsistent* with null (the result depended on
+> of the internal algorithm of V8, so now it participates instead of comparing), and the guard of
+> nil`buildJourneys`was not exercised with all the presences without date.
 >
-> Lo que NO se ha podido ejercitar con un gesto real: añadir un vértice arrastrando un
-> punto intermedio y borrarlo con Alt+clic. Cubiertos por tests unitarios de
-> `insertVertex`/`removeVertex`/`midpoints` y por aserciones sobre los manejadores.
+> What you could NOT exercise with a real gesture: add a vertex dragging a
+> intermediate point and delete it with Alt+click. Covered by unit tests of
+> `insertVertex`/`removeVertex`/`midpoints`and by assertions about the handlers.
 
-> Diseño original (2026-07-27). Schema actual **v96**; este plan introduce **v97**.
+> Original design (2026-07-27). Current schema **v96**; this plan introduces **v97**.
 >
-> Las cinco decisiones abiertas se resolvieron el 2026-07-27 y están aplicadas en el
-> cuerpo del documento; el §13 las recoge con su motivo.
+> The five open decisions were resolved on 2026-07-27 and are implemented in the
+> the body of the document; §13 collects them with its motif.
 >
-> Precedentes: [worldbuilding-characters-plan.md](worldbuilding-characters-plan.md),
+> Precedents:[worldbuilding-characters-plan.md](worldbuilding-characters-plan.md),
 > [worldbuilding-collections-plan.md](worldbuilding-collections-plan.md),
 > [worldbuilding-families-plan.md](worldbuilding-families-plan.md).
 
 ---
 
-## 0. Sobre qué se construye (lo que YA existe)
+## 0. On what is built (what YA exists)
 
-Antes de inventar nada conviene fijar qué hay, porque la mitad de este diseño consiste en
-**no duplicarlo**.
+Before inventing anything, it is best to fix what is there, because half of this design consists of
+**do not duplicate it**.
 
-| Pieza | Dónde | Qué aporta |
+| Piece | Where | What does it bring? |
 |---|---|---|
-| `places` + `place_profiles` (v95) | `electron/db/worldPlacesRepo.ts` | Los lugares, su jerarquía (`parent_id`), su clasificador (`kind`) y la capa de ficción (aspecto, atmósfera, historia, `visual_seed`, acento). |
-| `person_places` | genealogía | Persona ↔ lugar con `label` y `date`/`date_sort`. **La columna se llama `label`, no `role`.** |
-| `events` + `event_participants` + `event_world_dates` | genealogía + v91 | Un hecho con `place_id`, sus participantes y su `world_day` absoluto. |
-| `world_scenes` + `scene_characters` (v96) | `worldStoryRepo.ts` | La unidad real de trabajo del escritor: lugar, `world_day`, `narrative_order`, estado. |
-| `worldCalendar.ts` | `shared/` | Eras, meses, y la conversión fecha inventada ↔ `world_day` absoluto. Sin años bisiestos, por diseño. |
-| `world_images` (v94) | `worldImagesRepo.ts` | Galería polimórfica (`entity_kind`/`entity_id`) con blobs. |
-| `callImageProvider` | `electron/ai/decorativeImages.ts` | Google / OpenAI / OpenRouter / Nodus local, `(provider, model, prompt) → bytes`. |
-| `aiClient` con `images` | `electron/ai/aiClient.ts` | Entrada **multimodal**: un modelo de texto puede *mirar* una imagen. |
-| Leaflet 1.9.4 | `src/components/PlacesMap.tsx` | Ya es dependencia. Genealogía lo usa con teselas OSM reales. |
-| `WorldWorkspace` + `worldFilters` | `src/components/world/` | Cabecera, buscador, facetas y ficha: la carcasa de toda colección del vault. |
+| `places` + `place_profiles`(v95) | `electron/db/worldPlacesRepo.ts` | The places, their hierarchy (`parent_id`), its sorter (`kind`) and the layer of fiction (appearance, atmosphere, history,`visual_seed`, accent). |
+| `person_places` | genealogy | Person ↔ place with`label`and`date`/`date_sort`. **The column is called`label`, no`role`.** |
+| `events` + `event_participants` + `event_world_dates` | genealogy + v91 | A fact with`place_id`their participants and their`world_day`Absolutely. |
+| `world_scenes` + `scene_characters`(v96) | `worldStoryRepo.ts` | The writer's real unity of work: place,`world_day`, `narrative_order`, status. |
+| `worldCalendar.ts` | `shared/` | You were, months, and the date conversion invented.`world_day`No leap years, by design. |
+| `world_images`(v94) | `worldImagesRepo.ts` | Polymorphic gallery (`entity_kind`/`entity_id`) with blobs. |
+| `callImageProvider` | `electron/ai/decorativeImages.ts` | Google / OpenAI / OpenRouter / Nodus local,`(provider, model, prompt) → bytes`. |
+| `aiClient`with`images` | `electron/ai/aiClient.ts` | Entry **multimodal**: a text model can *see* an image. |
+| Leaflet 1.9.4 | `src/components/PlacesMap.tsx` | Genealogy uses it with real OSM tiles. |
+| `WorldWorkspace` + `worldFilters` | `src/components/world/` | Header, finder, facets and tab: the housing of all Vault collection. |
 
-**Lo que hay que tirar.** Hoy la entrada «Mapa» del sidebar de worldbuilding apunta a
-`MapView`, el mapa de genealogía, que proyecta lat/lon sobre teselas de OpenStreetMap. En
-un mundo inventado los lugares no tienen coordenadas de gacetero, así que esa vista sale
-**siempre vacía**: no es que sea mejorable, es que no puede funcionar.
+**What to throw away.**Today the "Map" entry of the worldbuilding sidebar points to`MapView`, the
+genealogy map, which projects lat/lon on OpenStreetMap tessels. In a invented world places do not
+have gacetero coordinates, so that view comes out **always empty**: it is not that it is
+improveable, it cannot work.
 
-**Decidido: la sustituye.** «Mapa» pasa a ser la vista nueva y no hay segunda entrada.
-`MapView` se queda intacto y sigue siendo la de genealogía —`VAULT_TYPE_SCOPED_VIEWS` ya
-sabe repartir vistas por tipo de vault, que es exactamente el mecanismo que hace falta.
+**Decided: replaces it.** "Map" becomes the new view and there is no second entry.`MapView`remains
+intact and remains that of genealogy —`VAULT_TYPE_SCOPED_VIEWS`you already know how to distribute
+views by type of vault, which is exactly the mechanism that is needed.
 
-El caso que perdemos —ficción histórica sobre lugares reales geocodificados— tiene salida
-sin una segunda entrada en el menú: un mapa con `projection = 'globe'` y una lámina real
-de fondo hace el mismo trabajo dentro de la vista nueva. Si algún día aparece demanda de
-verdad, la forma correcta no es duplicar la sección sino admitir un origen de teselas como
-un `kind` más de mapa.
-
----
-
-## 1. El modelo conceptual
-
-### 1.1 Un mapa es un lienzo, no un lugar
-
-La decisión estructural de todo el diseño. Un **mapa** es una imagen con un sistema de
-coordenadas; un **lugar** es una entidad del mundo. No son lo mismo y la relación entre
-ellos es de muchos a muchos:
-
-- Una ciudad **aparece como chincheta** en el mapa del continente, en el mapa del reino y
-  en el mapa de rutas comerciales.
-- Esa misma ciudad **tiene su propio mapa**, y ese mapa contiene chinchetas de sus barrios.
-- Un mapa puede no ser de ningún lugar: «las posiciones de la batalla de Vael, día 3».
-
-De ahí sale el requisito del usuario («se podrán crear tantos mapas como lugares haya
-incluso»): no es que cada lugar *tenga* un mapa, es que **cualquier lugar puede tener
-uno**, y el mapa se ancla al lugar con `world_maps.place_id`.
-
-### 1.2 La jerarquía de mapas
-
-`world_maps.parent_map_id` + el rectángulo que ocupa dentro del padre
-(`parent_x0/y0/x1/y1`, en coordenadas normalizadas del padre). Esto da tres cosas gratis:
-
-1. **Navegación por profundidad.** Doble clic en la chincheta de Aldermoor → se abre el
-   mapa de Aldermoor. Volver → migas de pan `Mundo › Norte › Aldermoor › La Ciudadela`.
-2. **Herencia de escala** (§3.3).
-3. **Reproyección de chinchetas** al hacer zoom con IA (§7.4): las chinchetas que caen
-   dentro del rectángulo aparecen ya colocadas en el mapa hijo.
-
-La jerarquía de mapas **no está obligada a coincidir** con la de lugares. Coincidirá casi
-siempre, pero un mapa de «rutas de la seda» cruza cinco reinos y no cuelga de ninguno.
-
-### 1.3 Coordenadas: normalizadas, siempre
-
-Todas las coordenadas (chinchetas, vértices, rectángulos, calibración) se guardan como
-**reales 0..1** relativos al ancho y alto de la imagen, nunca en píxeles.
-
-Motivo: la imagen base **va a cambiar**. Se regenera con otro estilo, se sube una versión
-en más resolución, se amplía por un borde. Con píxeles, cada uno de esos gestos mueve
-todas las chinchetas. Con coordenadas normalizadas, sólo el *outpainting* las mueve — y ahí
-la transformación es una afín conocida y explícita (§7.5).
-
-`world_maps` guarda además `width_px`/`height_px` nativos, porque para medir distancias hay
-que corregir la relación de aspecto: un desplazamiento de 0.1 en X y otro de 0.1 en Y no
-son la misma distancia salvo que la imagen sea cuadrada.
+The case we lose — historical fiction of geocoded real places — has exit without a second entry in
+the menu: a map with`projection = 'globe'`and a real background film does the same work within the
+new view. If one day demand for truth appears, the correct way is not to duplicate the section but
+to admit a tessela origin as a`kind`more map.
 
 ---
 
-## 2. Esquema (migración v97)
+## 1. The conceptual model
+
+### 1.1 A map is a canvas, not a place
+
+The structural decision of the whole design. A **map** is an image with a coordinate system; a
+**place** is an entity of the world. They are not the same and the relationship between them is from
+many to many:
+
+- A city ** appears as a chincheta** on the map of the continent, on the map of the kingdom and on
+  the map of trade routes.
+- That same city **has its own map**, and that map contains bedbugs from its neighborhoods.
+- A map may not be from anywhere: "the positions of the battle of Vael, day 3".
+
+Hence the user requirement ("as many maps as there are places can be created even"): it is not that
+each place *has* a map, it is that **anywhere can have one**, and the map is anchored to the place
+with`world_maps.place_id`.
+
+### 1.2 The map hierarchy
+
+`world_maps.parent_map_id`+ the rectangle it occupies within the parent (`parent_x0/y0/x1/y1`This
+gives three free things:
+
+1. **Deep navigation.** Double click on the Aldermoor china → opens the map of Aldermoor. Back →
+   breadcrumbs`Mundo › Norte › Aldermoor › La Ciudadela`.
+2. **Scale inheritance** (§3.3).
+3. **Pinch projection** when zooming with AI (§7.4): the bedbugs falling inside the rectangle are
+   already placed on the child map.
+
+The hierarchy of maps ** is not required to coincide** with that of places. It will coincide almost
+always, but a map of "silk paths" crosses five kingdoms and does not hang from any.
+
+### 1.3 Coordinates: standardized, always
+
+All coordinates (chinchetas, vertices, rectangles, calibration) are stored as **real 0.1** relative
+to the width and height of the image, never in pixels.
+
+Reason: the base image ** is going to change**. It regenerates with another style, it uploads a
+version in more resolution, it expands by an edge. With pixels, each of those gestures moves all the
+chinks. With standardized coordinates, only the *outpainting* moves them — and there the
+transformation is a familiar and explicit affin (§7.5).
+
+`world_maps`saves also`width_px`/`height_px`natives, because to measure distances it is necessary to
+correct the aspect ratio: a displacement of 0.1 in X and another of 0.1 in Y are not the same
+distance unless the image is square.
+
+---
+
+## 2. Scheme (migration v97)
 
 ```sql
--- ── Los mapas ────────────────────────────────────────────────────────────────
+-- ── Maps ────────────────────────────────────────────────────────────────────
 CREATE TABLE world_maps (
   map_id        TEXT PRIMARY KEY,
   name          TEXT NOT NULL,
   -- world | continent | region | city | town | building | interior | dungeon
   -- | battle | route | schematic | other
   kind          TEXT NOT NULL DEFAULT 'region',
-  -- «Este mapa ES el de este lugar». SET NULL: borrar el lugar no debe llevarse el
-  -- mapa, que puede seguir teniendo valor como lámina.
+  -- ‘This map is that of this place’. SET NULL: erasing the place should not take the
+  -- map, which can still have value as a foil.
   place_id      TEXT REFERENCES places(place_id) ON DELETE SET NULL,
 
   parent_map_id TEXT REFERENCES world_maps(map_id) ON DELETE SET NULL,
-  -- Dónde cae este mapa dentro del padre, en coordenadas normalizadas del padre.
+  -- Where this map falls within the father, in normalized coordinates of the father.
   parent_x0 REAL, parent_y0 REAL, parent_x1 REAL, parent_y1 REAL,
 
-  image_id      TEXT,               -- → map_images.image_id (base actual)
+  image_id      TEXT,               -- → map_images.image_id (current base)
   width_px      INTEGER NOT NULL DEFAULT 0,
   height_px     INTEGER NOT NULL DEFAULT 0,
 
-  -- Calibración: «este segmento mide tanto». Se guardan los DOS extremos, no una
-  -- longitud, para que sobreviva a cualquier renormalización (§3.1).
+  -- Calibration: ‘this segment measures so much’.
+  -- length, to survive any renormalization (§3.1).
   scale_x0 REAL, scale_y0 REAL, scale_x1 REAL, scale_y1 REAL,
-  scale_distance REAL,              -- cuánto mide ese segmento…
-  scale_unit     TEXT,              -- …en esta unidad (km, mi, league, m, ft, custom)
+  scale_distance REAL,              -- How much that segment measures...
+  scale_unit     TEXT,              -- ...in this unit (km, mi, league, m, ft, custom)
 
-  -- flat (por defecto) | globe. `globe` trata la imagen como equirectangular sobre
-  -- un planeta de radio dado y mide con haversine.
+  -- flat (default) | globe. `globe` treats the image as equirectangular over
+  -- a given radio planet and measure with havingsine.
   projection     TEXT NOT NULL DEFAULT 'flat',
   planet_radius  REAL,
   planet_radius_unit TEXT,
 
-  -- Un mapa puede ser de una época: «el Imperio en el año 300».
+  -- A map can be of one epoch: "the Empire in the year 300".
   from_world_day INTEGER,
   to_world_day   INTEGER,
 
-  -- Ancla de consistencia visual, igual que `place_profiles.visual_seed`.
+  -- Visual consistency anchor, as well as`place_profiles.visual_seed`.
   visual_seed    TEXT,
-  style          TEXT,              -- el estilo cartográfico con el que se generó
-  -- 0 = Nodus rotula (por defecto); 1 = se le pide al modelo que escriba los nombres.
+  style          TEXT,              -- the cartographic style with which it was generated
+  -- 0 = Nodus marker (default); 1 = the model is asked to write the names.
   model_labels   INTEGER NOT NULL DEFAULT 0,
   notes          TEXT,
   sort_order     INTEGER NOT NULL DEFAULT 0,
@@ -184,14 +183,14 @@ CREATE TABLE world_maps (
 CREATE INDEX idx_world_maps_place  ON world_maps(place_id);
 CREATE INDEX idx_world_maps_parent ON world_maps(parent_map_id);
 
--- ── Las imágenes ─────────────────────────────────────────────────────────────
--- Tabla propia y NO `world_images`: los mapas necesitan resolución nativa alta y
--- `optimizedJpegs` recorta a 1280 px (§12, landmine nº1). Además aquí guardamos el
--- historial de versiones, que una galería no tiene.
+-- ── Images ──────────────────────────────────────────────────────────────────
+-- Own table and NO`world_images`: maps need high native resolution and
+-- `optimizedJpegs`cut to 1280 px (§12, landmine no1). Also here we save the
+-- version history, which a gallery doesn't have.
 CREATE TABLE map_images (
   image_id   TEXT PRIMARY KEY,
   map_id     TEXT NOT NULL REFERENCES world_maps(map_id) ON DELETE CASCADE,
-  -- base | previous | reference   (`previous` = deshacer una regeneración)
+  -- base | previous | reference   (`previous`= undo a regeneration)
   role       TEXT NOT NULL DEFAULT 'base',
   mime_type  TEXT NOT NULL DEFAULT 'image/webp',
   width      INTEGER NOT NULL DEFAULT 0,
@@ -208,7 +207,7 @@ CREATE TABLE map_images (
 );
 CREATE INDEX idx_map_images_map ON map_images(map_id, role);
 
--- ── Capas ────────────────────────────────────────────────────────────────────
+-- • Layers
 CREATE TABLE map_layers (
   layer_id   TEXT PRIMARY KEY,
   map_id     TEXT NOT NULL REFERENCES world_maps(map_id) ON DELETE CASCADE,
@@ -224,27 +223,27 @@ CREATE TABLE map_layers (
 );
 CREATE INDEX idx_map_layers_map ON map_layers(map_id, sort_order);
 
--- ── Chinchetas y formas ──────────────────────────────────────────────────────
+-- ── Markers and shapes ──────────────────────────────────────────────────────
 CREATE TABLE map_markers (
   marker_id     TEXT PRIMARY KEY,
   map_id        TEXT NOT NULL REFERENCES world_maps(map_id) ON DELETE CASCADE,
   layer_id      TEXT REFERENCES map_layers(layer_id) ON DELETE SET NULL,
 
-  -- El vínculo con el mundo. NULL = chincheta decorativa o todavía sin asignar.
+  -- The link to the world. NULL = decorative chink or still unallocated.
   place_id      TEXT REFERENCES places(place_id) ON DELETE SET NULL,
-  -- Doble clic entra aquí. Normalmente el mapa del mismo lugar, pero no obligatorio.
+  -- Double click enter here. Normally the map of the same place, but not mandatory.
   child_map_id  TEXT REFERENCES world_maps(map_id) ON DELETE SET NULL,
-  label         TEXT,               -- override; NULL = usar el nombre del lugar
+  label         TEXT,               -- override; NULL = use place name
 
   -- point | circle | polygon | path
   geometry_kind TEXT NOT NULL DEFAULT 'point',
-  x REAL NOT NULL, y REAL NOT NULL, -- ancla (centroide en las formas)
-  radius REAL,                      -- círculo; normalizado contra el eje X
-  points TEXT,                      -- JSON [[x,y],…] para polygon/path
+  x REAL NOT NULL, y REAL NOT NULL, -- anchor (centroid in shapes)
+  radius REAL,                      -- circle; normalised against X-axis
+  points TEXT,                      -- JSON [[x,y],...] for polygon/path
 
   icon  TEXT,
   color TEXT,
-  -- Validez temporal: las fronteras se mueven, las ciudades caen.
+  -- Temporary validity: borders move, cities fall.
   from_world_day INTEGER,
   to_world_day   INTEGER,
 
@@ -256,10 +255,10 @@ CREATE TABLE map_markers (
 CREATE INDEX idx_map_markers_map   ON map_markers(map_id, sort_order);
 CREATE INDEX idx_map_markers_place ON map_markers(place_id);
 
--- ── Modos de viaje (del vault, no de un mapa) ────────────────────────────────
+-- Travel modes (from the Vault, not from a map)
 CREATE TABLE map_travel_modes (
   mode_id    TEXT PRIMARY KEY,
-  name       TEXT NOT NULL,          -- «a pie», «a caballo», «carro», «barco»
+  name       TEXT NOT NULL,          -- ‘foot’, ‘horse’, ‘carro’, ‘boat’
   distance_per_day REAL NOT NULL,
   unit       TEXT NOT NULL,
   icon       TEXT,
@@ -269,570 +268,542 @@ CREATE TABLE map_travel_modes (
 );
 ```
 
-**No hay tabla de «posiciones de personaje».** Es deliberado y es la decisión más
-importante del §6: dónde está un personaje ya está registrado tres veces (eventos, escenas,
-`person_places`). Una cuarta tabla sería una cuarta respuesta a la misma pregunta y
-divergiría en una semana.
+**There is no table of "character positions".** It is deliberate and is the most important decision
+of §6: where a character is already registered three times (events, scenes,`person_places`A fourth
+table would be a fourth answer to the same question and would diverge within a week.
 
-**Sincronización:** las cuatro tablas nuevas van al grupo `worldbuilding` de
-`electron/db/syncTables.ts`. Una tabla que no está ahí no viaja *y sus borrados
-resucitan* (§12, landmine nº4).
+**Synchronization:** the four new tables go to the
+group`worldbuilding`of`electron/db/syncTables.ts`. A table that is not there does not travel . . . .
+and its erased ones resurrect . . . . . . . . . . . . . . . . . . . . .
 
 ---
 
-## 3. Escalas: generación y cálculo
+## 3. Scales: generation and calculation
 
-El usuario pide explícitamente que la escala cuente **tanto al generar como al calcular**.
-Son dos usos del mismo dato y conviene tratarlos juntos.
+The user explicitly asks that the scale count ** both when generating and when calculating**. They
+are two uses of the same data and should be treated together.
 
-### 3.1 Calibrar
+### 3.1 Calibrate
 
-El autor traza un segmento sobre el mapa y escribe cuánto mide: «esto son 200 leguas».
-Se guardan los dos extremos normalizados más distancia y unidad. La conversión es:
+The author traces a segment on the map and writes how much it measures: «this is 200 leagues». The
+two standard ends plus distance and unit are saved. The conversion is:
 
 ```
 pixelLength = hypot((x1-x0) * width_px, (y1-y0) * height_px)
 unitsPerPixel = scale_distance / pixelLength
 ```
 
-Guardar los extremos y no la longitud es lo que hace que la calibración **sobreviva a una
-regeneración de la imagen en otra resolución**: los extremos siguen siendo los mismos dos
-puntos del dibujo.
+Saving the ends and not the length is what makes the calibration ** survive an image regeneration in
+another resolution**: the ends are still the same two points in the drawing.
 
-Si no hay calibración, la vista no miente: la barra de escala muestra «sin escala» y las
-herramientas de distancia se ofrecen desactivadas con un enlace a calibrar. Nunca una
-distancia inventada.
+If there is no calibration, the view does not lie: the scale bar shows "no scale" and the distance
+tools are offered disabled with a link to calibrate. Never a invented distance.
 
-### 3.2 Proyección
+### 3.2 Projection
 
-- **`flat`** (por defecto): geometría euclídea. Es lo correcto para casi todo — una
-  región, una ciudad, una mazmorra.
-- **`globe`**: la imagen se interpreta como equirectangular sobre un planeta de radio
-  `planet_radius`. X ↦ longitud [-180, 180], Y ↦ latitud [90, -90], distancias por
-  haversine. Sólo tiene sentido en un mapamundi, y ahí importa: en plano, la distancia
-  entre dos puntos árticos sale disparatada. Permite además decir «mi mundo es 0,8 Tierras»,
-  que es una decisión que los escritores toman y luego no pueden usar para nada.
+- **`flat`** (default): Euclidean geometry. It is the right thing for almost everything — a region,
+  a city, a dungeon.
+- **`globe`**: the image is interpreted as equirectangular on a planet with radius
+  `planet_radius`. X ↔ longitude [-180, 180], Y ↔ latitude [90, -90], with Haversine distances. It only makes sense on a
+  world map, and there it matters: in plane, the distance between two arctic points goes wild. It
+  also allows to say "my world is 0.8 Earths", which is a decision that writers make and then they
+  cannot use at all.
 
-Reutiliza el vocabulario de `shared/mapProjection.ts`; la lógica nueva vive en
-`shared/worldMapGeometry.ts`, pura y con tests.
+Reuse the vocabulary of`shared/mapProjection.ts`; new logic lives in`shared/worldMapGeometry.ts`,
+pure and with tests.
 
-### 3.3 Herencia y coherencia entre mapas
+### 3.3 Inheritance and consistency between maps
 
-Un mapa hijo con `parent_map_id` y rectángulo conocido **puede derivar su escala del
-padre** sin que el autor calibre nada:
+A map son with`parent_map_id`and known rectangle ** can derive its scale from the father** without
+the author calibre anything:
 
 ```
 childUnitsPerPixel = parentUnitsPerPixel * (parent_x1 - parent_x0) * parentWidthPx / childWidthPx
 ```
 
-Y cuando hay las dos —heredada y calibrada a mano— Nodus **avisa si no cuadran**:
+And when there are both—inherited and calibrated by hand—Nodus **tell if they don't fit**:
 
-> «El mapa de Aldermoor está calibrado a 4 km de ancho, pero su huella en *El Norte* mide
-> 40 km. Uno de los dos está mal.»
+> «The map of Aldermoor is calibrated to 4 km wide, but its footprint on *The North* measures
+> 40 km. One of the two is wrong."
 
-Este chivato es barato (una comparación) y caza un error que si no se descubre tres meses
-después, escribiendo una escena de persecución.
+This snitch is cheap (a comparison) and hunts down a mistake that if not discovered three months
+later, writing a chase scene.
 
-### 3.4 La escala en el prompt
+### 3.4 The scale in the prompt
 
-Al generar (§7) el autor dice la extensión pretendida: «una región de unos 600 km de
-ancho». Eso hace dos cosas:
+In generating (§7) the author says the intended extension: «a region about 600 km wide». That does
+two things:
 
-1. Entra en el prompt. Un modelo dibuja cosas distintas si le pides 600 km (cordilleras,
-   varios reinos) o 6 km (un valle, un pueblo y sus campos). Sin ese dato salen mapas con
-   la densidad de detalle equivocada, que es el fallo más común de los mapas generados.
-2. **Precalibra el mapa resultante**: `scale_distance` = 600 km sobre el segmento
-   (0,0.5)→(1,0.5). El mapa nace medible. El autor puede recalibrar si el modelo se
-   desvió, pero no parte de cero.
+1. Enter the prompt. A model draws different things if you ask for 600 km (cordilleras, several
+   kingdoms) or 6 km (a valley, a village and its fields). Without that data come maps with the
+   wrong detail density, which is the most common failure of the generated maps.
+2. **Precalibrates the resulting map**:`scale_distance`= 600 km above the segment (0.0.5)→(1.0.5).
+   The map is measurable. The author can recalibrate if the model deviated, but not part of zero.
 
 ---
 
-## 4. Chinchetas: del punto a la forma exacta
+## 4. Chinches: from point to exact shape
 
-El usuario pide: chinchetas, radio de acción aproximado, radio ajustable a mano, poder
-**añadir puntos de ajuste** y editarlos «para adaptarse a la forma de un lugar a la
-perfección». Eso es una escalera de cuatro peldaños, y el diseño la hace continua:
+The user asks: chinches, approximate radius of action, hand adjustable radius, be able to **add
+adjustment points** and edit them "to fit the shape of a place to perfection". That is a four-step
+ladder, and the design makes it continuous:
 
-| Peldaño | `geometry_kind` | Gesto |
+| Sling | `geometry_kind` | Gesto |
 |---|---|---|
-| 1. Un punto | `point` | Clic en el mapa. |
-| 2. Un radio | `circle` | Arrastrar el tirador del borde, o escribir «12 km» en la ficha. |
-| 3. Una forma | `polygon` | «Convertir en forma» → el círculo se convierte en un polígono de 12 vértices arrastrables. |
-| 4. Una forma exacta | `polygon` | Arrastrar vértices; los **tiradores intermedios** (uno en el punto medio de cada arista) añaden vértice al arrastrarlos; `Alt`+clic elimina. |
-| — | `path` | Línea abierta: ríos, carreteras, murallas, la ruta de una marcha. |
+| 1. One point | `point` | Click on the map. |
+| 2. A radio | `circle` | Drag the edge shooter, or type "12 km" on the tab. |
+| 3. A form | `polygon` | «Convert into shape» → the circle becomes a polygon of 12 drawable vertices. |
+| 4. An exact form | `polygon` | Drag vertices; the **intermediate pullers** (one at the midpoint of each edge) add vertex by dragging them;`Alt`+click removes. |
+| — | `path` | Open line: rivers, roads, walls, the route of a march. |
 
-El punto 3 es la clave de que esto se sienta como *una* herramienta y no cuatro: el
-polígono **nace del círculo**, con los vértices ya en su sitio. Nadie empieza a dibujar el
-contorno de un bosque desde cero; lo que quiere es abollar un círculo.
+Point 3 is the key to this feeling as *one* tool and not four: the polygon ** is born from the
+circle**, with the vertices already in place. No one begins to draw the contour of a forest from
+scratch; what they want is to dent a circle.
 
-El radio se guarda normalizado contra el eje X y se muestra en unidades del mundo cuando
-hay escala. Un radio en km escrito a mano se convierte al guardar.
+The radius is stored against the X-axis and displayed in units of the world when there is a scale. A
+radius in km written by hand is converted when saved.
 
-**Decidido: edición de vértices a mano, sin dependencia nueva.** `leaflet-editable` o
-`leaflet-draw` resolverían esto, pero son ~40 KB y una API que hay que domar para el 20 %
-que usaríamos, y su aspecto no es el del resto de la app. Un `L.marker` arrastrable por
-vértice más otro por punto medio son ~200 líneas con control total, y encaja con cómo esta
-base de código ha resuelto el motor de tours o el centrado del badge: a mano, medido, sin
-dependencia.
+**Decided: edition of vertices by hand, without new
+dependence.**`leaflet-editable`o`leaflet-draw`they would solve this, but they are ~40 KB and an API
+that needs to be tamed for the 20% we would use, and their appearance is not that of the rest of the
+app.`L.marker`Towable by vertex plus another by midpoint are ~200 lines with total control, and it
+fits with how this code base has solved the tour engine or the center of the badge: by hand,
+measured, without dependency.
 
-Lo que hay que hacer bien para que salga a cuenta, y que va en los tests:
+What you have to do right to make it count, and that goes in the tests:
 
-- **Deshacer por gesto**, no por vértice: arrastrar y soltar es UNA acción. Sin esto,
-  deshacer un contorno de treinta puntos es treinta pulsaciones.
-- **Umbral de arrastre** (~4 px) antes de mover: sin él, un clic para seleccionar desplaza
-  el vértice uno o dos píxeles y el contorno se degrada solo con mirarlo.
-- **Los tiradores no se reescalan con el zoom** (van en píxeles de pantalla, no en unidades
-  del mapa), o al alejar se vuelven inalcanzables.
-- **`Alt`+clic elimina**, con mínimo de 3 vértices en polígonos y 2 en rutas.
-
----
-
-## 5. El vínculo con los lugares
-
-### 5.1 Del mapa al lugar
-
-Clic en una chincheta sin lugar → un buscador de los lugares ya guardados (el mismo
-`SearchableMultiSelect` que usan las escenas), con «crear lugar nuevo» al final. Es
-exactamente el flujo que pide el usuario: *«cuando el usuario clique en una chincheta
-añadirá un lugar de los que ya ha guardado previamente»*.
-
-Al asignar, la chincheta hereda nombre, icono por `kind` y color del acento del lugar
-(`place_profiles.accent`), y **el kind sugiere la geometría**: un `city` nace círculo, un
-`river` nace `path`, un `realm` nace polígono. Sugerencia, no imposición.
-
-### 5.2 Del lugar al mapa
-
-La ficha de lugar gana una sección **«En los mapas»**: miniatura recortada alrededor de su
-chincheta en cada mapa donde aparece, y un botón «Crear el mapa de este lugar» que crea un
-`world_maps` con `place_id` puesto y `parent_map_id` al mapa donde ya está pinchado, con el
-rectángulo tomado del radio de la chincheta. La ida y la vuelta son simétricas.
-
-### 5.3 Navegación
-
-Migas de pan por `parent_map_id`. Doble clic en una chincheta con `child_map_id` desciende.
-Un minimapa en la esquina muestra el rectángulo del mapa actual dentro de su padre —
-lo que en un atlas es el recuadro «usted está aquí».
+- **Undo by gesture**, not by vertex: drag and drop is ONE action. Without this, undoing an outline
+  of thirty points is thirty pulsations.
+- **Track threshold** (~4 px) before moving: without it, a click to select scrolls the vertex one or
+  two pixels and the contour degrades only by looking at it.
+- **The shooters do not re-escalate with zoom** (they go in screen pixels, not in map units), or
+  when they move away they become unreachable.
+- **`Alt`+click removes**, with at least 3 vertices in polygons and 2 in routes.
 
 ---
 
-## 6. La capa temporal
+## 5. Linking to places
 
-El corazón de lo que pide el usuario, y donde este diseño se separa del mapa de genealogía:
-allí la línea temporal barre **años**; aquí barre **días del mundo**, y los personajes no
-aparecen y desaparecen, **se mueven**.
+### 5.1 From map to location
 
-### 6.1 Resolver dónde está alguien: `shared/worldPresence.ts`
+Click on a chinheta without place → a search engine for the places already saved (the
+same`SearchableMultiSelect`that use the scenes), with "create new place" at the end. It is exactly
+the flow that the user asks for: *"when the user clicks on a chinheta will add a place that he has
+already saved"*.
 
-Una función pura que une las tres fuentes que ya existen y devuelve, por personaje, una
-lista ordenada de presencias:
+When assigning, the chinheta inherits name, icon by`kind`and accent colour of the place
+(`place_profiles.accent`), and ** the kind suggests geometry**: a`city`is born circle, a`river`is
+born`path`, a`realm`is born polygon. Suggestion, not imposition.
+
+### 5.2 From place to map
+
+The location tab wins a section **"On the maps"**: thumbnail cut around your chinheta on each map
+where it appears, and a "Create the map of this place" button that creates
+a`world_maps`with`place_id`post and`parent_map_id`to the map where it is already punctured, with the
+rectangle taken from the radius of the chincheta. The back and back are symmetrical.
+
+### 5.3 Navigation
+
+Breadcrumbs by`parent_map_id`. Double click on a chincheta with`child_map_id`a minimap in the corner
+shows the rectangle of the current map inside your father — what in an atlas is the box "you are
+here".
+
+---
+
+## 6. The Temporary Layer
+
+The heart of what the user asks, and where this design is separated from the genealogy map: there
+the time line sweeps **years**; here sweeps **days of the world**, and the characters do not appear
+and disappear, ** move**.
+
+### 6.1 Resolve where someone is:`shared/worldPresence.ts`
+
+A pure function that unites the three existing fonts and returns, per character, an ordered list of
+presences:
 
 ```ts
 interface Presence {
   personId: string;
   placeId: string;
-  worldDay: number | null;      // null = sin fechar
+  worldDay: number | null;      // null = dateless
   source: 'scene' | 'event' | 'residence';
   sourceId: string;
-  label: string | null;         // «residencia», el título de la escena…
+  label: string | null;         // ‘residency’, the title of the scene...
 }
 ```
 
-- `world_scenes` ⋈ `scene_characters` → la fuente principal para un novelista.
-- `events` ⋈ `event_participants` ⋈ `event_world_dates` → nacimientos, batallas, viajes.
-- `person_places` → residencias de larga duración (llegan sin `world_day`; ver §6.5).
+- `world_scenes` ⋈ `scene_characters`→ the main source for a novelist.
+- `events` ⋈ `event_participants` ⋈ `event_world_dates`→ births, battles, trips.
+- `person_places`→ Long term residences (come without`world_day`; see §6.5).
 
-Reglas, todas testeables sin base de datos:
+Rules, all testable without database:
 
-1. **Presencias consecutivas en el mismo lugar se colapsan** en un intervalo — igual que
-   `buildMigrationPath` colapsa las paradas repetidas. Estar no es moverse.
-2. Entre dos presencias en lugares distintos hay un **tránsito**: `[díaSalida, díaLlegada]`
-   de A a B. El personaje no teletransporta, viaja.
-3. Una presencia sin fecha no se descarta: se ancla al final, visible pero fuera del barrido
-   (mismo criterio que `buildMigrationPath`).
+1. ** Consecutive presences in the same place collapse** in an interval — just
+   like`buildMigrationPath`The repeated stops collapse. Being is not moving.
+2. Between two presences in different places there is a **transit**: `[departureDay, arrivalDay]` from A
+   to B. The character doesn't teleport, travels.
+3. A presence without a date is not ruled out: it anchors at the end, visible but outside the sweep
+   (same criterion that`buildMigrationPath`).
 
-### 6.2 Reproducción
+### 6.2 Reproduction
 
-Un cabezal sobre `world_day`, no sobre el año. Controles: reproducir/pausa, velocidad
-(×0,5 ×1 ×2 ×5), paso día a día, y **saltar al siguiente suceso** — porque en un mundo con
-360 días por año, avanzar de uno en uno entre dos escenas separadas por medio año es
-insufrible. El rango por defecto va del primer al último suceso del reparto seleccionado,
-no del calendario entero.
+A head on`world_day`, not over the year. Controls: play/pause, speed (×0.5 ×1 ×2 ×5), step by day,
+and **jump to the next event** — because in a world with 360 days per year, advance one by one
+between two scenes separated by half a year is insufferable. The default range goes from the first
+to the last event of the selected cast, not from the entire calendar.
 
-Durante un tránsito la chincheta del personaje se **interpola** por el trayecto y se dibuja
-la estela discontinua. Si hay un `path` (una carretera) entre los dos lugares, el trayecto
-la sigue; si no, recta.
+During a transit the character's chincheta is **interpola** along the path and the discontinuous
+trail is drawn. If there is a`path`(a road) between the two places, the path follows it; if not,
+straight.
 
-Sin calendario definido, todo degrada a `world_year` + `world_order`, exactamente como ya
-hace `TimelineView`. El mapa funciona el primer día, sin que el autor haya inventado doce
-meses.
+No defined calendar, all degrades to`world_year` + `world_order`, exactly as it already
+does`TimelineView`The map works on the first day, without the author having invented twelve months.
 
-### 6.3 Seguir a un personaje entre mapas
+### 6.3 Follow a character between maps
 
-El requisito más específico del usuario: *«si clicamos en reproducir temporalmente y
-estamos en un mapa pero el personaje salta a otro, nosotros también lo haremos»*.
+The user's most specific requirement: *"if we click to play temporarily and we are on one map but
+the character jumps to another, we will do it too"*.
 
-El cabezal es **global**, no del mapa. La vista resuelve en cada instante qué mapa mira,
-con una función pura `resolveMapFocus(placeId, maps, markers, currentMapId)`:
+The head is **global**, not the map. The view solves in each instant which map it looks at, with a
+pure function`resolveMapFocus(placeId, maps, markers, currentMapId)`:
 
-1. Sube por la cadena de ancestros del lugar (`places.parent_id`), de lo más específico a lo
-   más general.
-2. Para cada ancestro, busca mapas donde ese lugar tenga chincheta **válida en ese día**.
-3. Prefiere, por este orden: **el mapa actual** (no cambiar si no hace falta) → el mapa cuyo
-   `place_id` sea el ancestro más específico → el más recientemente usado.
+1. Climb the chain of ancestors of the place (`places.parent_id`), from the most specific to the
+   most general.
+2. For each ancestor, look for maps where that place has chinheta **valid on that day**.
+3. He prefers, in this order: **the current map** (do not change if not necessary) → the map
+   whose`place_id`be the most specific ancestor → the most recently used.
 
-El punto 3 importa: sin él, la vista salta de mapa cada dos días y marea.
+Point 3 matters: without it, the view jumps off the map every two days and tidal.
 
-**Autoseguimiento: interruptor, activo por defecto sólo con UN personaje seleccionado.**
-Con cinco personajes en cuatro mapas, seguir automáticamente sería un baile de pantallas.
-Con varios seleccionados aparece en su lugar una **tira de reparto**: un chip por personaje
-con su retrato, dónde está y en qué mapa; los que están fuera del mapa actual se muestran
-atenuados y con el nombre del mapa, y un clic salta allí. Se ve todo sin que nada se mueva
-solo.
+**Autotracking: switch, active by default only with A selected character.** With five characters on
+four maps, following automatically would be a screen dance. With several selected ones appears
+instead a ** delivery strip**: a chip per character with his portrait, where he is and on which map;
+those outside the current map are shown attenuated and with the name of the map, and a click jumps
+there. It is seen all without anything moving alone.
 
-La transición entre mapas es un cross-fade con el nombre del mapa nuevo, no un corte: si no,
-es imposible saber que has cambiado de sitio.
+The transition between maps is a cross-fade with the name of the new map, not a cut: if not, it is
+impossible to know that you have changed places.
 
-### 6.4 Fronteras que cambian
+### 6.4 Changing borders
 
-`map_markers.from_world_day` / `to_world_day` no son sólo para chinchetas: un **polígono**
-con validez temporal es una frontera. Al mover el cabezal, el imperio se expande, la ciudad
-cae, el bosque arde. Es la misma maquinaria y hace que la línea temporal sobre el mapa sea
-mucho más que puntos moviéndose.
+`map_markers.from_world_day` / `to_world_day`They are not only for chinchettes: a **polygon** with
+temporary validity is a border. When moving the head, the empire expands, the city falls, the forest
+burns. It is the same machinery and makes the timeline on the map much more than moving points.
 
-### 6.5 Presencias de larga duración
+### 6.5 Long-term presences
 
-`person_places` no tiene `world_day` (guarda `date`/`date_sort`, formato Tierra).
+`person_places`has no`world_day`(save`date`/`date_sort`, Earth format).
 
-**Decidido: la residencia es el FONDO.** Dónde está alguien cuando ninguna escena ni
-evento dice otra cosa, sin fecha propia. No toca esquema, y una residencia es
-conceptualmente un estado por defecto, no un suceso.
+**Decided: the residence is the FUND.** Where someone is when no scene or event says anything else,
+without a proper date. It does not touch scheme, and a residence is conceptually a default state,
+not an event.
 
-Consecuencia en `worldPresence.ts`: la residencia entra con `worldDay: null` y prioridad
-más baja. Al resolver un día concreto gana siempre la escena o el evento fechado; la
-residencia sólo rellena los huecos y **no genera tránsitos** (no se puede interpolar un
-viaje contra algo que no tiene fecha). Se dibuja atenuada y con el rótulo «residencia»,
-para que se vea que es una suposición y no un dato.
+As a result`worldPresence.ts`: the residence enters with`worldDay: null`When solving a particular
+day, it always wins the scene or the dated event; the residence only fills the gaps and ** does not
+generate transits** (you cannot interpolate a trip against something that has no date). It is drawn
+attenuated and with the label "residency", so that it is seen to be an assumption and not a data.
 
-Si en uso real se echa de menos poder decir «vivió en Vael del día 200 al 900», la salida
-es una tabla puente `person_place_world_dates` análoga a `event_world_dates`. Es aditiva:
-no migra nada de lo que el autor haya escrito para entonces.
+If in real use it is missed to say "lived in Vael from the day 200 to 900", the exit is a bridge
+table`person_place_world_dates`analogous to`event_world_dates`. It is additive: it does not migrate
+anything that the author has written by then.
 
 ---
 
-## 7. Generación con IA
+## 7. Generation with AI
 
-### 7.1 Estilos cartográficos
+### 7.1 Cartographic Styles
 
-`shared/mapPrompt.ts`, puro y con tests, calcado en estructura a
-`shared/characterImagePrompt.ts` (donde lo único que importa es el ORDEN):
+`shared/mapPrompt.ts`, pure and with tests, shaped in structure
+to`shared/characterImagePrompt.ts`(where only ORDEN matters):
 
 ```
-estilo → visual_seed del mundo → encuadre por tipo de mapa → contenido exigido
-       → escala pretendida → política de etiquetas → negativos
+style → world visual_seed → framing by map type → required content
+       → intended scale → label policy → negative prompts
 ```
 
-Estilos: `parchment` (pergamino clásico), `inked_atlas` (grabado a plumilla),
-`painted_fantasy`, `watercolour`, `satellite`, `blueprint`, `isometric`,
-`hand_drawn_sketch`, `dark_grimoire`, `nautical_chart`.
+Styles:`parchment`(classical pergamino),`inked_atlas`(recorded to down),`painted_fantasy`,
+`watercolour`, `satellite`, `blueprint`, `isometric`, `hand_drawn_sketch`, `dark_grimoire`,
+`nautical_chart`.
 
-Encuadres por `kind`: mundo / continente / región / ciudad amurallada vista cenital /
-plano de planta / mazmorra / interior / despliegue de batalla / mapa de rutas.
+Frames by`kind`: world / continent / region / walled city zenith view / floor plan / dungeon /
+interior / battle deployment / route map.
 
-**`visual_seed` a nivel de mapa y de mundo.** Igual que el retrato de un personaje se ancla
-en su `visual_seed`, aquí hay dos anclas: la del mundo (paleta, altura de las montañas,
-tipo de costa) para que todos los mapas del vault parezcan del mismo atlas, y la del mapa
-para que regenerarlo no lo convierta en otro sitio.
+**`visual_seed`at the level of map and world.** Just as the portrait of a character is anchored in
+his`visual_seed`, here are two anchors: the one of the world (pallet, height of mountains, type of
+coast) so that all the maps of the Vault seem of the same atlas, and the map so that it regenerates
+it does not make it another place.
 
-### 7.2 Las etiquetas NO las dibuja el modelo (por defecto)
+### 7.2 Labels are NOT drawn by the model (default)
 
-La decisión de producto que más se va a notar. **Decidido: las dibuja Nodus por defecto,
-con una casilla por mapa para dejárselas al modelo.**
+The product decision that will be most noticeable. **Decided: Nodus draws by default, with a box per
+map to leave to the model.**
 
-Los modelos de imagen escriben texto ilegible o con faltas, y un mapa está lleno de texto.
-Por defecto el prompt lleva un negativo explícito —«sin texto, sin letras, sin rótulos, sin
-leyenda, sin rosa de los vientos, sin marco»— y **Nodus dibuja las etiquetas encima**,
-tomadas de los nombres reales de los lugares.
+The image models write unreadable or faulty text, and a map is full of text. By default the prompt
+has an explicit negative — "without text, without letters, without signs, without legend, without
+wind rose, without frame" — and **Nodus draws the labels above**, taken from the real names of the
+places.
 
-Ventajas que no son sólo estéticas: las etiquetas quedan **correctas**, buscables,
-traducibles, ocultables por capa, y siguen bien cuando el autor renombra un lugar. La rosa
-de los vientos y la barra de escala también se dibujan nativas, y por tanto siguen siendo
-correctas después de una ampliación.
+Advantages that are not only aesthetic: the labels remain **right**, searchable, translatable,
+hidden by layer, and continue well when the author renames a place. The rose of the winds and the
+scale bar are also drawn natively, and therefore remain correct after an enlargement.
 
-La casilla «deja que el modelo escriba los nombres» (`world_maps.model_labels`) es para
-quien quiera el look de un mapa antiguo rotulado a mano. Cuando está activa, Nodus **no
-apaga sus etiquetas**: las deja ocultables por capa, porque el resultado del modelo puede
-salir ilegible y hay que poder recuperar los nombres sin regenerar. Junto a la casilla, un
-aviso de una línea de que los nombres los escribe el modelo y pueden salir con faltas.
+The box ‘let the model write the names’ (`world_maps.model_labels`) is for anyone who wants the look
+of an old hand-printed map. When it is active, Nodus **does not turn off their tags**: it leaves
+them hidden per layer, because the result of the model can be unreadable and you have to be able to
+recover the names without regenerating. Next to the box, a notice of a line that the names write the
+model and can come out with faults.
 
-### 7.3 Contenido exigido: el mapa sabe qué mundo dibuja
+### 7.3 Required content: the map knows which world it draws
 
-El prompt de creación incorpora los lugares que el autor marque para incluir, con su tipo
-y —si ya están pinchados en un mapa padre— **su disposición relativa**: «Aldermoor, ciudad
-portuaria amurallada al noroeste; Vael, fortaleza de montaña al sudeste; el Bosque Cano
-entre ambas». Eso es lo que hace que regenerar un mapa dé un mapa *del mismo mundo* y no de
-otro cualquiera.
+The creation prompt incorporates the places that the author marks to include, with their type and
+—if they are already punctured on a parent map — **their relative disposition**: «Aldermoor, port
+city walled to the northwest; Vael, mountain fortress to the southeast; the Cano Forest between
+them». That is what makes regenerate a map give a map *of the same world* and not of any other.
 
-### 7.4 Ampliación: los tres caminos
+### 7.4 Enlargement: the three roads
 
-El usuario pregunta «habría que ver cómo generar la ampliación». Hay tres respuestas
-distintas y las tres tienen sitio:
+The user asks, "You should see how to generate enlargement." There are three different answers and
+all three have room:
 
-**(1) Recorte, sin IA — el que debe ofrecerse primero.**
-El autor traza un rectángulo; Nodus recorta la imagen base a resolución nativa y crea el
-mapa hijo con esos píxeles. Es instantáneo, gratis, funciona sin conexión y es
-**geográficamente exacto**. Pierde detalle, sí; pero para quien ha encargado su mapa a un
-ilustrador es exactamente lo que quiere, y para todos los demás es la base sobre la que
-luego pedir detalle.
+**(1) Cut, without AI — the one to be offered first.** The author traces a rectangle; Nodus cuts the
+base image to native resolution and creates the son map with those pixels. It is instant, free,
+works offline and is **geographically accurate**. It loses detail, yes; but for those who have
+commissioned their map to an illustrator it is exactly what they want, and for all others it is the
+basis on which to then ask for detail.
 
-**(2) Zoom con IA (detalle) — el recorte, mejorado.**
-El recorte anterior se manda como **imagen de referencia** junto a un prompt de detalle:
-«un mapa más detallado de esta región; conserva costas, ríos y relieve exactamente;
-añade el detalle propio de una escala de X km». Sale un mapa hijo nuevo.
+**(2) Zoom with AI (detail) — trimming, improved.** The above cut is sent as **reference image**
+along with a prompt detail: «a more detailed map of this region; preserves coasts, rivers and relief
+exactly; adds the detail proper to a scale of X km». A new son map comes out.
 
-**(3) Extensión del lienzo (outpainting) — el mapa crece por un borde.**
-El autor elige borde (N/S/E/O) y cuánto. Nodus compone un lienzo mayor con la imagen
-existente colocada en su sitio y pide la continuación.
+**(3) Canvas extension (outpainting) — the map grows by an edge.** The author chooses border
+(N/S/E/O) and how much. Nodus composes a larger canvas with the existing image placed on its site
+and asks for continuation.
 
-En **(1)** y **(2)**, las chinchetas que caen dentro del rectángulo se **reproyectan
-automáticamente** al hijo:
+In **(1)** and **(2)**, bedbugs falling inside the rectangle are automatically reprojected** to the
+child:
 
 ```
 xHijo = (xPadre - parent_x0) / (parent_x1 - parent_x0)
 ```
 
-Eso es lo que hace que el gesto se sienta mágico: amplías el noroeste y las tres ciudades
-que ya tenías pinchadas aparecen colocadas en el mapa nuevo, sin tocar nada.
+That's what makes the gesture feel magical: you expand the northwest and the three cities that you
+already had flattened appear placed on the new map, without touching anything.
 
-### 7.5 El outpainting y la transformación afín
+### 7.5 Outpainting and related transformation
 
-**La operación más peligrosa de toda la funcionalidad.** Al crecer el lienzo, *todas* las
-coordenadas normalizadas del mapa dejan de ser válidas: chinchetas, vértices de polígonos,
-puntos de rutas, extremos de la calibración y el rectángulo dentro del padre.
+**The most dangerous operation of all functionality.**As the canvas grows, *all* normalized
+coordinates of the map cease to be valid: chinches, vertices of polygons, route points, calibration
+ends and rectangle within the parent.
 
-La transformación es conocida y simple —una afín de escala y desplazamiento— pero tiene que
-aplicarse **a todo, en una sola transacción**, y merece su propio test con un mapa que
-tenga las cuatro geometrías, calibración y un padre. Si falla a medias, el mapa queda
-inservible y el autor no tiene forma de repararlo a mano.
+The transformation is known and simple — a similar scale and displacement — but it has to be applied
+**to everything, in a single transaction**, and deserves its own test with a map that has all four
+geometries, calibration and a parent. If it fails halfway, the map is useless and the author has no
+way to repair it by hand.
 
-Además, la calibración se conserva sola: al mantener los extremos como puntos (§3.1) y
-transformarlos con el resto, la escala del mapa ampliado sigue siendo correcta sin
-recalibrar. Ése es el rédito de haberla guardado así.
+In addition, calibration is preserved by itself: by keeping the ends as points (§3.1) and
+transforming them with the rest, the scale of the expanded map remains correct without
+recalibrating. That is the return of having kept it this way.
 
-### 7.6 Capacidades por proveedor: la parte honesta
+### 7.6 Capabilities per Provider: The Honest Part
 
-`callImageProvider(provider, model, prompt)` hoy no acepta imagen de entrada. Hay que
-ampliarlo a `callImageProvider(provider, model, prompt, { referenceImages })` **y declarar
-qué proveedor puede hacerlo**:
+`callImageProvider(provider, model, prompt)`Today it does not accept input image. It has to be
+extended to`callImageProvider(provider, model, prompt, { referenceImages })`** and declare which
+provider can do so**:
 
-| Proveedor | Texto→imagen | Imagen→imagen | Notas |
+| Provider | Text→image | Image→image | Notes |
 |---|---|---|---|
-| Google (Gemini) | sí | sí | `interactions.create` acepta imagen de entrada. |
-| OpenAI | sí | sí | `/v1/images/edits`, endpoint distinto al de generación. |
-| OpenRouter | sí | **depende del modelo** | Hay que degradar por modelo, no por proveedor. |
-| Nodus local | sí | probablemente no | Verificar antes de prometerlo. |
+| Google (Gemini) | Yes | Yes | `interactions.create`accepts input image. |
+| OpenAI | Yes | Yes | `/v1/images/edits`, different endpoint from generation. |
+| OpenRouter | Yes | **depends on the model** | We have to degrade by model, not by supplier. |
+| Local Nodus | Yes | probably not. | Check before you promise. |
 
-Cuando el proveedor elegido **no** puede tomar referencia, el camino degradado —y honesto—
-es: un modelo de **visión** (que `aiClient` ya soporta) describe el recorte en prosa, y esa
-descripción entra en un prompt de texto a imagen. Sale peor y hay que **decirlo en la
-interfaz**, no simularlo en silencio: «Tu modelo de imagen no puede partir de una
-referencia; el resultado se parecerá al recorte sólo aproximadamente».
+When the chosen provider **no** can take reference, the degraded — and honest — path is: a model of
+**vision** (which`aiClient`already supports) describes the trimming in prose, and that description
+enters a prompt from text to image. It comes out worse and you have to **tell it in the interface**,
+do not simulate it silently: "Your image model cannot start from a reference; the result will look
+like the trimming only approximately".
 
-### 7.7 Resolución
+### 7.7 Resolution
 
-Los mapas **no pasan por `optimizedJpegs`** (recorta a 1280 px). Camino propio: hasta
-~4096 px de lado mayor, WebP con calidad ~88 (bastante más pequeño que JPEG a igual
-calidad), más miniatura de 480 px para las rejillas. Un mapa de
-4096 px ronda 3–6 MB; diez mapas, ~50 MB en el `.db`, que además viajan en las copias y en
-`.nodussync`. Hay que decirlo en la interfaz y ofrecer «reducir resolución» por mapa.
+Maps ** do not pass through`optimizedJpegs`** (cuts to 1280 px). Own path: up to ~4096 px on the
+larger side, WebP with quality ~88 (quite smaller than JPEG at equal quality), plus 480 px miniature
+for grids. A map of 4096 px round 3–6 MB; ten maps, ~50 MB on the`.db`, which also travel in copies
+and in`.nodussync`. It has to be said in the interface and offered to "reduce resolution" by map.
 
-**Ojo con el codificador:** `nativeImage` de Electron sólo sabe `toPNG()` y `toJPEG()`; no
-tiene WebP. El WebP hay que sacarlo de `@napi-rs/canvas` (`canvas.toBuffer('image/webp')`),
-que ya es dependencia y que `decorativeImages.ts` sólo usa hoy como plan B para rasterizar.
-Comprobado en este árbol: png, jpeg, webp y avif responden. Si se prefiere no depender de
-canvas en la ruta principal, la alternativa es JPEG con `nativeImage` y ~30 % más de bytes.
+** Eye with the encoder:**`nativeImage`Electron only knows`toPNG()`and`toJPEG()`; does not have
+WebP. The WebP must be removed from`@napi-rs/canvas` (`canvas.toBuffer('image/webp')`), which is
+already dependent and that`decorativeImages.ts`only uses today as plan B to rasterize. Checked on
+this tree: png, jpeg, webp and avif respond. If you prefer not to rely on canvas on the main route,
+the alternative is JPEG with`nativeImage`and ~30 % more bytes.
 
-### 7.8 Anotar un mapa con visión
+### 7.8 Write down a map with vision
 
-El prompt que no genera imagen y que probablemente sea el más útil de todos: un modelo
-multimodal **mira el mapa** —subido o generado— y propone chinchetas: «veo una bahía aquí,
-una cordillera aquí, tres asentamientos aquí». El autor acepta las que quiera y las asigna
-a lugares existentes o crea los que falten.
+The prompt that does not generate image and is probably the most useful of all: a multimodal model
+** looks at the map** — uploaded or generated — and proposes chinchetas: «I see a bay here, a
+mountain range here, three settlements here». The author accepts the ones he wants and assigns them
+to existing places or creates those missing.
 
-Es la forma rápida de pasar de «tengo un PNG» a «tengo un mapa vivo», y usa una capacidad
-(`aiClient` con `images`) que ya está pagada y probada. Precisión modesta, pero como se
-trata de sugerencias que el autor acepta una a una, el coste de un fallo es un clic.
-
----
-
-## 8. Adjuntar un mapa propio
-
-Arrastrar o elegir PNG / JPG / WebP. Se guardan los **bytes nativos**, sin recomprimir por
-encima de 4096 px. Al terminar, un asistente de dos pasos que no se puede saltar sin
-querer:
-
-1. **Calibra** («traza una línea sobre la barra de escala del mapa y dime cuánto mide»).
-2. **Coloca tus lugares** — la lista de lugares del vault que aún no están en ningún mapa,
-   para ir pinchándolos; o el atajo de §7.8.
-
-Un mapa sin calibrar y sin chinchetas es una lámina bonita e inerte; estos dos pasos son
-los que lo convierten en un mapa.
-
-Extra barato: un PDF de una sola página se puede pasar por el convertidor del Toolkit, que
-ya existe.
+It is the quick way to move from "I have a PNG" to "I have a living map", and it uses a capacity
+(`aiClient`with`images`) that is already paid and proven. Modest precision, but since it is a
+question of suggestions that the author accepts one by one, the cost of a bug is a click.
 
 ---
 
-## 9. Renderizado
+## 8. Attach your own map
 
-**Leaflet con `L.CRS.Simple`** y `L.imageOverlay`. Sin servidor de teselas, sin red, sin
-atribución. Los límites se fijan en `[[0,0],[1000, 1000·aspect]]` para que las coordenadas
-normalizadas sean una multiplicación.
+Drag or choose PNG / JPG / WebP. The native **bytes** are saved, without recompressing above 4096
+px. Upon completion, a two-step wizard that cannot jump unintentionally:
 
-- Chinchetas: `L.marker` con `divIcon` (retrato del personaje, icono del lugar).
-- Círculos: `L.circle` (radio en unidades del mapa; escala bien con el zoom, a diferencia de
-  `circleMarker`).
-- Formas y rutas: `L.polygon` / `L.polyline`.
-- Etiquetas: `divIcon` propio con anticolisión sencilla (si dos etiquetas se solapan al
-  nivel de zoom actual, gana la del lugar más importante por `kind`; la otra aparece al
-  acercarse). Ésta es la clase de detalle que separa un mapa de un diagrama.
-- **Modo oscuro:** `.pm-dark .leaflet-tile` aplica hoy un filtro de inversión a las teselas
-  OSM. Ese selector **alcanzaría también al `imageOverlay`** de un mapa autoral y lo
-  destrozaría. Hay que acotarlo (`.pm-dark .leaflet-tile-pane .leaflet-tile`, o una clase
-  propia en el contenedor del mapa del mundo). Está en la lista de landmines por algo.
+1. **Calibra** ("trace a line over the map scale bar and tell me how much it measures").
+2. **Place your places** — the list of places in the vault that are not yet on any map, to click on
+   them; or the §7.8 shortcut.
+
+An uncalibrated map without chinks is a beautiful and inert sheet; these two steps make it a map.
+
+Extra cheap: a single page PDF can be passed through the Toolkit converter, which already exists.
 
 ---
 
-## 10. Extras para el escritor
+## 9. Rendering
 
-Más allá de lo pedido. Todo lo de aquí sale casi gratis del modelo ya descrito, que es
-precisamente el criterio para proponerlo.
+**Leaflet with`L.CRS.Simple`** and`L.imageOverlay`. No tessela server, no network, no attribution.
+Limits are set at`[[0,0],[1000, 1000·aspect]]`so that the standard coordinates are a multiplication.
 
-1. **Regla y calculadora de viaje.** Clic en dos chinchetas → distancia en las unidades del
-   mundo y **tiempo de viaje por modo** (`map_travel_modes`). Si hay una ruta (`path`) que
-   los une, se mide por la ruta. Es la utilidad que todo escritor de fantasía acaba haciendo
-   a mano en una servilleta.
-
-2. **Aviso de viaje imposible.** Con presencias fechadas y escala, Nodus puede comprobar
-   cada tránsito: *«Kestra está en Aldermoor el día 120 y en Vael el 122; son 400 leguas,
-   20 días a caballo»*. Un informe de consistencia con los viajes imposibles del manuscrito.
-   Esto **sólo es posible porque hay escala**, y justifica por sí solo todo el §3.
-
-3. **Capa de conocimiento (niebla de guerra narrativa).** Un mapa *tal y como lo conoce un
-   personaje*: regiones marcadas como desconocidas para X hasta el día D. Sirve para no
-   hacer que el protagonista mencione un reino del que no ha oído hablar. Es la misma idea
-   que `secret_knowers`, aplicada al espacio.
-
-4. **Buscador de encuentros.** Con varios personajes seleccionados, lista los días en que
-   dos de ellos coinciden en el mismo lugar: *«¿cuándo pudieron conocerse Kestra y Doran?»*.
-   Intersección de intervalos, función pura, y responde una pregunta que hoy sólo se puede
-   contestar releyendo.
-
-5. **Las escenas, en el mapa.** Filtra por capítulo o por acto y mira **dónde ocurre tu
-   historia**. Un escritor descubre en dos segundos que todo el segundo acto pasa en la
-   misma habitación, o que hay un continente entero al que nunca ha ido nadie.
-
-6. **Mapa de calor de presencia.** Dónde pasa el tiempo un personaje en el intervalo
-   seleccionado. Delata protagonistas sedentarios y secundarios ubicuos.
-
-7. **Leyenda automática** a partir de las capas y los `kind` de lugar presentes, y
-   **exportación a PNG** con etiquetas, rutas y barra de escala incrustadas, a resolución de
-   impresión. Un mapa que el autor pueda mandar a su editor o poner en la guarda del libro.
-
-8. **Comparar dos momentos** en paralelo: el mismo mapa el día 100 y el día 900, con las
-   fronteras de cada uno. La historia del mundo, de un vistazo.
-
-9. **Capa de batalla.** Chinchetas con «bando» y validez temporal por turnos: mover el
-   cabezal reproduce el desarrollo de la batalla. Es la misma maquinaria del §6, con otra
-   escala de tiempo.
-
-10. **Nombres coherentes.** Al crear un lugar desde el mapa, sugerir el nombre con el modelo
-    de texto usando la **cultura** del lugar contenedor (`world_groups` de tipo `culture`,
-    ya existe). Las montañas del norte suenan a norte.
+- Chinches:`L.marker`with`divIcon`(Character portrait, icon of the place).
+- Circles:`L.circle`(radio in map units; scale well with zoom, unlike`circleMarker`).
+- Forms and routes:`L.polygon` / `L.polyline`.
+- Tags:`divIcon`own with simple anti-collision (if two tags overlap at the current zoom level, wins
+  the most important place by`kind`This is the kind of detail that separates a map from a diagram.
+- **Dark mode:**`.pm-dark .leaflet-tile`today applies an inversion filter to OSM tiles. That
+  selector ** would also reach the`imageOverlay`** of an authoral map and would destroy it.`.pm-dark
+  .leaflet-tile-pane .leaflet-tile`It's on the list of landmines for something.
 
 ---
 
-## 11. Fases
+## 10. Extras for the writer
 
-| Fase | Alcance | Entregable comprobable |
+Beyond the request. Everything here comes almost free of charge from the model already described,
+which is precisely the criterion for proposing it.
+
+1. **Rule and travel calculator.** Click on two chinks → distance in world units and **time travel
+   per mode** (`map_travel_modes`). If there is a route (`path`) that unites them, is measured by
+   the route. It is the utility that every fantasy writer ends up making by hand in a napkin.
+
+2. **Notice of impossible travel.** With dated presences and stopover, Nodus can check every
+   transit: *"Kestra is in Aldermoor on the 120th and in Vael on the 122nd; they are 400 leagues, 20
+   days on horseback"*. A report of consistency with the impossible journeys of the manuscript. This
+   ** is only possible because there is a stopover**, and justifies the whole §3 alone.
+
+3. **Capa of knowledge (narrative war fog).** A map *as a character knows it*: regions marked as
+   unknown to X until day D. It serves not to make the protagonist mention a kingdom that he has not
+   heard of. It is the same idea that`secret_knowers`, applied to space.
+
+4. **Finder of encounters.** With several selected characters, lists the days when two of them
+   coincide in the same place: *«When could Kestra and Doran be known?»*. Intersection of intervals,
+   pure function, and answers a question that can only be answered today by rereading.
+
+5. **The scenes, on the map.** Filter by chapter or by act and see **where your story occurs.** A
+   writer discovers in two seconds that the entire second act happens in the same room, or that
+   there is an entire continent that no one has ever gone to.
+
+6. **Hot map of presence.**Where time passes a character in the selected interval. It reveals
+   sedentary and secondary ubiquitous protagonists.
+
+7. **Automatic legend** from layers and`kind`place present, and **export to PNG** with embedded
+   tags, paths and scale bar, to print resolution. A map that the author can send to his editor or
+   put in the book keeper.
+
+8. **Compare two moments** in parallel: the same map on day 100 and day 900, with the borders of
+   each. The history of the world, at a glance.
+
+9. **Battle cap.** Chinches with "bando" and temporary validity in turns: moving the head reproduces
+   the development of the battle. It is the same machine of §6, with another time scale.
+
+10. **Coherent names.** When creating a place from the map, suggest the name with the text model
+    using the **culture** of the container site (`world_groups`of a kind`culture`The mountains of
+    the north sound north.
+
+---
+
+## 11. Phases
+
+| Phase | Scope | Verifiable deliverable |
 |---|---|---|
-| **M0** | Esquema v97, repos (`worldMapsRepo`, `mapMarkersRepo`), IPC, `syncTables`. `shared/worldMapGeometry.ts` puro. | Tests de esquema y de geometría; el vault abre a v97. |
-| **M1** | Sección **Mapas** en el sidebar (sustituye a `MapView` en worldbuilding): rejilla de mapas sobre `WorldWorkspace`, crear mapa **subiendo imagen**, visor Leaflet `CRS.Simple`, migas de pan. | Subir un PNG y verlo con zoom. |
-| **M2** | Calibración, barra de escala, rosa de los vientos, regla de distancia, `map_travel_modes`. | Medir dos puntos y obtener km y días a caballo. |
-| **M3** | Chinchetas: punto → círculo → polígono → ruta, edición de vértices, capas, vínculo con lugares en los dos sentidos, «En los mapas» en la ficha de lugar. Cierra con la **anotación por visión** (§7.8), que sólo necesita que existan las chinchetas. | Dibujar el contorno de un bosque y asignarlo a un lugar; subir un PNG y que la IA proponga las chinchetas. |
-| **M4** | `shared/worldPresence.ts`, línea temporal con reproducción, selección de uno o varios personajes, estelas e interpolación de tránsitos, validez temporal de marcadores. | Reproducir y ver moverse a un personaje entre dos ciudades. |
-| **M5** | Multi-mapa temporal: `resolveMapFocus`, autoseguimiento, tira de reparto, transición entre mapas. | Reproducir y que la vista salte de mapa siguiendo al personaje. |
-| **M6** | Generación con IA: `shared/mapPrompt.ts`, estilos, `callImageProvider` con referencias + capacidades por proveedor, creación desde cero, recorte sin IA, zoom con IA, outpainting con la transformación afín. | Generar un mapa, ampliar una región y ver las chinchetas reproyectadas. |
-| **M7** | Extras del §10, en el orden de abajo. | El informe de consistencia lista un viaje imposible real. |
+| **M0** | Scheme v97, rests (`worldMapsRepo`, `mapMarkersRepo`), IPC,`syncTables`. `shared/worldMapGeometry.ts`Pure. | Schema and geometry tests; the vault opens to v97. |
+| **M1** | Section **Maps** on sidebar (replaces`MapView`in worldbuilding: grid of maps on`WorldWorkspace`, create map **upping image**, Leaflet viewer`CRS.Simple`Breadcrumbs. | Upload a PNG and zoom it in. |
+| **M2** | Calibration, scale bar, wind rose, distance rule,`map_travel_modes`. | Measure two points and get km and days on horseback. |
+| **M3** | Chinches: point → circle → polygon → route, vertice editing, layers, link with places in both directions, «On maps» on the place tab. Close with the **annotation by vision** (§7.8), which only needs the chinches to exist. | Draw the outline of a forest and assign it to a place; climb a PNG and have AI propose the chinkets. |
+| **M4** | `shared/worldPresence.ts`, time line with reproduction, selection of one or more characters, steles and interpolation of transits, temporary validity of markers. | Play and watch a character move between two cities. |
+| **M5** | Multi-temporal map:`resolveMapFocus`, self-following, delivery strip, transition between maps. | Play and have the view jump from map following the character. |
+| **M6** | Generation with AI:`shared/mapPrompt.ts`styles,`callImageProvider`with references + capabilities per provider, creation from scratch, cutting without AI, zooming with AI, outsourcing with related transformation. | Generate a map, expand a region, and see the reworked chinchettes. |
+| **M7** | Extras from §10, in the order below. | The consistency report lists a real impossible journey. |
 
-M1–M5 no dependen de la IA en absoluto: quien suba su propio mapa tiene producto completo
-al final de M5. M6 es aditivo. Esa separación es deliberada — la funcionalidad no puede
-quedar rehén de que el autor tenga clave de un proveedor de imagen.
+M1–M5 does not depend on AI at all: whoever uploads his own map has complete product at the end of
+M5. M6 is additive. Such separation is deliberate — functionality cannot be held hostage by the
+author having key from an image provider.
 
-### 11.1 Orden dentro de M7
+### 11.1 Order within M7
 
-El criterio es doble: **primero lo que reutiliza el motor de presencias de M4 mientras está
-fresco**, y dentro de eso, lo más barato antes.
+The criterion is twofold: **first what the M4 presence engine reuses while it is cool**, and within
+that, cheaper before.
 
-| # | Extra | Por qué ahí |
+| # | Extra | Why there? |
 |---|---|---|
-| 1 | **Escenas en el mapa** (§10.5) | Lo más barato de todo: las escenas ya tienen `place_id` y `world_day`, y M4 ya las lee. Es una capa y un filtro. Y es lo que el escritor abre a diario. |
-| 2 | **Viajes imposibles** (§10.2) | La pieza estrella, y la que justifica todo el §3. Necesita escala (M2), modos de viaje (M2) y presencias (M4): las tres están listas y ninguna otra cosa las combina. |
-| 3 | **Buscador de encuentros** (§10.4) | Intersección de los mismos intervalos que acaba de construir el punto 2. Hacerlo aquí es casi gratis; hacerlo en otra fase obliga a releer todo el motor. |
-| 4 | **Exportar a PNG** (§10.7) | Independiente de la temporalidad: sólo necesita etiquetas, rutas y barra de escala (M2–M3). Cierra el ciclo — un mapa que se puede mandar al editor. |
-| 5 | Niebla de conocimiento, mapa de calor, comparar dos momentos, capa de batalla, nombres por cultura | Fase posterior. Los cuatro son buenos, pero cada uno abre su propio modelo (quién sabe qué, agregación, vista partida, bandos) y ninguno es prerrequisito de nada. |
+| 1 | **Scenes on the map** (§10.5) | The cheapest of all: the scenes already have`place_id`and`world_day`It's a layer and a filter, and that's what the writer opens every day. |
+| 2 | **Impossible travel** (§10.2) | The star piece, and the one that justifies the whole §3. Needs scale (M2), modes of travel (M2) and presences (M4): all three are ready and nothing else combines them. |
+| 3 | **Meeting seeker** (§10.4) | Intersection of the same intervals that just built point 2. Doing it here is almost free; doing it in another phase forces you to reread the whole engine. |
+| 4 | **Export to PNG** (§10.7) | Regardless of temporality: you only need tags, paths and scale bar (M2–M3). Close the cycle — a map that can be sent to the editor. |
+| 5 | Fog of knowledge, heat map, compare two moments, battle layer, names by culture | The four are good, but each opens its own model (who knows what, aggregation, split view, sides) and none is prerequisite for anything. |
 
-**La anotación por visión (§7.8) se adelanta y NO va en M7.** Al ordenar esto queda claro
-que no depende de M6 en absoluto: usa `aiClient` con `images` (un modelo de visión), no
-`callImageProvider`. Su único requisito es que existan las chinchetas, o sea **M3**. Y ahí
-es donde vale diez veces más: es el atajo de «tengo un PNG» a «tengo un mapa vivo»,
-justamente el momento en que el autor acaba de subir su mapa y tiene por delante media hora
-de pinchar lugares a mano. Va al final de M3.
+**The annotation by vision (§7.8) is advanced and does NOT go into M7.** When ordering this it is
+clear that it does not depend on M6 at all: use`aiClient`with`images`(a vision model),
+no`callImageProvider`. Their only requirement is that there be chinches, i.e. **M3**. And that's
+where it's worth ten times as much: it's the shortcut from "I have a PNG" to "I have a living map",
+just when the author has just uploaded his map and has a half hour ahead of him to puncture places
+by hand. It goes at the end of M3.
 
 ---
 
 ## 12. Landmines
 
-1. **`optimizedJpegs` recorta a 1280 px.** Reusar la ruta de imágenes decorativas
-   convertiría cualquier mapa en una miniatura borrosa. Camino propio (§7.7).
-2. **El outpainting mueve TODAS las coordenadas.** Chinchetas, vértices, rutas, extremos de
-   calibración y el rectángulo en el padre. Una transacción, un test con las cuatro
-   geometrías (§7.5).
-3. **`.pm-dark .leaflet-tile` alcanzaría al `imageOverlay`** e invertiría el mapa del autor.
-   Acotar el selector antes de escribir la vista (§9).
-4. **Tabla que no está en `syncTables.ts` no viaja** — y sus borrados resucitan, porque los
-   tombstones se generan de esa misma lista. Las cuatro tablas nuevas, al grupo
-   `worldbuilding`.
-5. **Sin calendario, `world_day` es NULL.** Ya mordió en el vault de personajes. Todo el §6
-   tiene que degradar a `world_year` + `world_order` sin ramas especiales por todas partes:
-   una sola función de orden que devuelva la clave correcta.
-6. **`person_places` usa `label`, no `role`.** Ya costó un fallo en tiempo de ejecución.
-7. **`tsc --noEmit` no cubre `electron/`.** Los repos nuevos hay que comprobarlos con el
-   build.
-8. **El tamaño del `.db`.** Diez mapas grandes son ~50 MB que entran en copias, en
-   `.nodussync` y en el arranque. Medir y avisar.
-9. **No todos los proveedores hacen imagen→imagen.** Degradar por *modelo* en OpenRouter, no
-   por proveedor, y decirlo en la interfaz (§7.6).
-10. **Probar con perfil aislado.** Este plan sube el esquema; abrir un vault real con un
-    build de numeración distinta lo corrompe:
-    `NODUS_USERDATA=/tmp/nodus-maps ./node_modules/.bin/electron .`
+1. **`optimizedJpegs`trims to 1280 px.** Reusing the decorative image path would turn any map into a
+   blurred miniature. Own path (§7.7).
+2. **Outpainting moves ALL coordinates.** Chinches, vertices, routes, calibration ends and rectangle
+   in the parent. A transaction, a test with the four geometries (§7.5).
+3. **`.pm-dark .leaflet-tile`would reach the`imageOverlay`** and would reverse the author's map. To
+   narrow down the selector before writing the view (§9).
+4. **Table not in`syncTables.ts`does not travel** — and their erased ones resurrect, because the
+   tombstones are generated from that same list.`worldbuilding`.
+5. **No calendar,`world_day`is NULL.** Already bitten on the character vault. All §6 has to degrade
+   to`world_year` + `world_order`no special branches everywhere: a single command function that
+   returns the correct key.
+6. **`person_places`use`label`, no`role`.** It already cost a failure in execution time.
+7. **`tsc --noEmit`does not cover`electron/`.** New repos need to be checked with the build.
+8. **The size of the`.db`.** Ten large maps are ~50 MB entering copies, in`.nodussync`and at the
+   start. Measure and warn.
+9. **Not all providers make image→image.** Degrade by *model* in OpenRouter, not by supplier, and
+   say so in the interface (§7.6).
+10. **Prove with isolated profile.**This plan uploads the schema; opening a real vault with a
+    different numbering build corrupts it:`NODUS_USERDATA=/tmp/nodus-maps
+    ./node_modules/.bin/electron .`
 
 ---
 
-## 13. Decisiones tomadas (2026-07-27)
+## 13. Decisions taken (2026-07-27)
 
-| # | Decisión | Motivo | Dónde |
+| # | Decision | Reason | Where |
 |---|---|---|---|
-| 1 | La **residencia es el fondo**, sin fecha propia. No hay tabla puente. | Una residencia es un estado por defecto, no un suceso. No toca esquema, y la salida (`person_place_world_dates`) es aditiva si algún día hace falta. | §6.5 |
-| 2 | La nueva sección **sustituye** a «Mapa» en worldbuilding. Sin segunda entrada. | La vista de genealogía sale siempre vacía en un mundo inventado: no es mejorable, no puede funcionar. `VAULT_TYPE_SCOPED_VIEWS` ya reparte vistas por tipo de vault. | §0 |
-| 3 | **Nodus rotula por defecto**, con casilla por mapa (`model_labels`) para dejárselo al modelo. | Los modelos escriben texto ilegible o con faltas y un mapa es casi todo texto. Rotulando nosotros, los nombres quedan correctos, buscables, traducibles y siguen al renombrar un lugar. | §7.2 |
-| 4 | **Edición de vértices a mano**, sin `leaflet-editable`. | ~200 líneas con control total del gesto frente a 40 KB y una API que domar para el 20 % que usaríamos. Mismo criterio que el motor de tours. Los cuatro detalles que hay que clavar están listados. | §4 |
-| 5 | Orden de M7: **escenas en el mapa → viajes imposibles → encuentros → exportar PNG**; el resto, después. La **anotación por visión se adelanta a M3**. | Primero lo que reutiliza el motor de presencias de M4 mientras está fresco, y dentro de eso lo más barato antes. La anotación no depende de M6 (usa visión, no generación de imagen) y vale diez veces más justo cuando el autor acaba de subir su mapa. | §11.1 |
+| 1 | The **residency is the background**, with no date of its own. There is no bridge table. | A residence is a default state, not an event. It does not touch scheme, and output (`person_place_world_dates`) is additive if any day is needed. | §6.5 |
+| 2 | The new section ** replaces** to "Map" in worldbuilding. No second entry. | The view of genealogy is always empty in an invented world: it is not improveable, it cannot work.`VAULT_TYPE_SCOPED_VIEWS`already distributes views by type of vault. | §0 |
+| 3 | **Nodus marker by default**, with box by map (`model_labels`) to leave it to the model. | Models write unreadable text or with faults and a map is almost all text. By labeling us, the names are correct, searchable, translatable and follow when renaming a place. | §7.2 |
+| 4 | **Edition of vertices by hand**, without`leaflet-editable`. | ~200 lines with total gesture control versus 40 KB and an API to tame for the 20% we would use. Same criterion as the tour engine. The four details to nail are listed. | §4 |
+| 5 | Order of M7: **scenes on the map → impossible trips → encounters → export PNG**; the rest, later. **annotation by vision advances to M3**. | First what reuses the M4 presences engine while cool, and within that cheaper before. The annotation does not depend on M6 (use vision, not image generation) and is worth ten times more just when the author has just uploaded his map. | §11.1 |
 
-### Lo que sigue abierto, pero no bloquea
+### What's still open, but doesn't block
 
-- **§6.5** — si en uso real se echa de menos «vivió en Vael del día 200 al 900», entra la
-  tabla puente. Decisión aplazada a propósito: es aditiva.
-- **§3.2** — `projection = 'globe'` está en el esquema desde el principio pero puede
-  implementarse en M2 o esperar; sólo importa en un mapamundi.
-- **§7.6** — qué modelos concretos de OpenRouter aceptan imagen de referencia hay que
-  comprobarlo contra la API, no decidirlo aquí.
+- **§6.5** — if in real use it is missed «lived in Vael from the day 200 to 900», the bridge board
+  enters. Decision postponed on purpose: it is additive.
+- **§3.2** — `projection = 'globe'`is in the schema from the beginning but can be implemented in M2
+  or wait; it only matters on a world map.
+- **§7.6** — which specific OpenRouter models accept a reference image, it must be checked against
+  the API, not decided here.

--- a/docs/IMAGE_GENERATION.md
+++ b/docs/IMAGE_GENERATION.md
@@ -4,7 +4,7 @@ Verified against provider documentation on 2026-07-10.
 
 ## Behavior and persistence
 
-Decorative images are opt-in per Inmersión or Deep Research generation. When
+Decorative images are opt-in per Immersion or Deep Research generation. When
 disabled, Nodus neither asks the text model for visual context nor calls an image
 provider. When enabled, the complete main content is generated and committed
 first; image work is then queued independently in the Electron main process.

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -36,7 +36,7 @@ test('the image is non-root, health-checked and visibly experimental', () => {
   assert.match(dockerfile, /USER node/);
   assert.match(dockerfile, /HEALTHCHECK/);
   assert.match(dockerfile, /app\.nodus\.stability="experimental"/);
-  assert.match(read('server/README.md'), /Experimental e inestable/);
+  assert.match(read('server/README.md'), /Experimental and unstable/);
 });
 
 test('desktop settings include a beginner-friendly server deployment guide', () => {
@@ -51,5 +51,5 @@ test('desktop settings include a beginner-friendly server deployment guide', () 
   assert.match(settings, /Nunca expongas 7443 directamente a Internet/);
   assert.match(settings, /ChatGPT o Claude/);
   assert.match(translations, /Step-by-step installation guide/);
-  assert.match(read('server/README.md'), /Mi cuenta/);
+  assert.match(read('server/README.md'), /My account/);
 });

--- a/scripts/test-privacy-compliance.mjs
+++ b/scripts/test-privacy-compliance.mjs
@@ -64,13 +64,13 @@ test('the policy states the real local and controller boundaries without an inva
   const policy = await read('PRIVACY.md');
   const normalized = policy.replace(/\s+/g, ' ');
   for (const marker of [
-    'no incorpora publicidad, telemetría, analítica remota',
-    'no usa IA para puntuar, calificar, clasificar, perfilar ni evaluar',
-    'no crea por sí solo una base jurídica',
-    'no elimina obligaciones legales imperativas',
-    'artículos 13 y 14 del RGPD',
-    'artículo 28 RGPD',
-    'evaluación de impacto',
+    'does not incorporate advertising, telemetry, remote analytics',
+    'does not use AI to rate, grade, rank, profile, or evaluate',
+    'does not in itself create a legal basis',
+    'does not eliminate mandatory legal obligations',
+    'Articles 13 and 14 of the GDPR',
+    'Article 28 GDPR',
+    'impact assessment',
     'https://eur-lex.europa.eu/eli/reg/2016/679/oj',
     'https://www.aepd.es/',
   ]) assert.match(normalized, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));

--- a/scripts/tutorial/PITFALLS.md
+++ b/scripts/tutorial/PITFALLS.md
@@ -1,135 +1,130 @@
-# Fallos que ya han costado tomas
+# Judgements that have already cost shots
 
-Todo lo de aquí ocurrió de verdad haciendo los cuatro primeros tutoriales. Están
-ordenados por lo caro que salió cada uno. Léelo antes de grabar.
+Everything here really happened by doing the first four tutorials. They are ordered by how expensive
+each one came out. Read it before recording.
 
 ---
 
-## 1. Lo que tapa la app y se traga los clics
+## 1. What covers the app and swallows the clicks
 
-Un modal abierto convierte cada clic siguiente en un no-op **silencioso**: la
-grabación termina, informa de éxito, y son veinte planos de un fondo gris.
+An open modal turns each next click into a non-op **silent**: the recording ends, reports success,
+and is twenty plans of a grey background.
 
-| Qué lo abría | Cómo se calla |
+| Open it. | How he shuts up |
 |---|---|
-| Modal de Novedades | `localStorage['nodus.lastSeenVersion']` = la versión real. Se abre cuando difiere; poner `'9999.0.0'` lo abre siempre, no lo cierra |
-| Modal de actualización al arrancar | `sessionStorage['nodus.startupUpdateChecked'] = '1'`. `NODUS_E2E_UPDATE_STATUS` **no** basta |
-| Asistente de recuperación | `recoverySetupVersion: 9999`. Lo destapa `basicsTutorialVersion: 9999` |
-| Elección de Nodi | `mascotStyleChosen: true` |
-| Aviso de copias de seguridad | clic en `.backup-health-dismiss` |
+| Modal de Novedades | `localStorage['nodus.lastSeenVersion']` = the actual version. It opens when it differs; putting `'9999.0.0'` always opens it, does not close it |
+| Update mode when booting | `sessionStorage['nodus.startupUpdateChecked'] = '1'`. `NODUS_E2E_UPDATE_STATUS` **not** enough |
+| Recovery Wizard | `recoverySetupVersion: 9999`. Uncovers `basicsTutorialVersion: 9999` |
+| Election of Nodi | `mascotStyleChosen: true` |
+| Backup Notice | click on `.backup-health-dismiss` |
 
-El motor ya hace todo esto (`BASE_SETTINGS`) y además **se niega a filmar** si algo
-grande cubre la app al arrancar.
+The engine already does all this (`BASE_SETTINGS`) and also ** refuses to film** if something big
+covers the app when it starts.
 
-## 2. Cerrar un modal: no adivines su botón
+## 2. Close a modal: do not guess your button
 
-Tres intentos seguidos fallaron y los tres informaron de éxito:
+Three successive attempts failed and all three reported success:
 
-- Clic en (24, 24) para "dar al fondo" → cae en los **botones de ventana de macOS**.
-- `button:has-text("✕")` → engancha el chip de monitorización, no el modal.
-- Comprobar el cierre en un punto tapado por el propio fondo → `closest('[role=dialog]')`
-  del fondo es `null`, así que "no hay diálogo".
+- Click on (24, 24) to "give to the bottom" → falls on the **macOS window buttons**.
+- `button:has-text("✕")` → engages the monitoring chip, not the modal.
+- Checking the closure at a point covered by the background itself → `closest('[role=dialog]')` from
+  the background is `null`, so "there is no dialogue".
 
-Lo que funciona, y está en `closeAnyDialog`: buscar la capa fija a pantalla completa
-con `z-index ≥ 40` y, dentro, **un botón pequeño cerca de su borde superior**. Se
-busca por **forma**, no por texto: el ✕ suele ser un SVG con `textContent` vacío.
+What works, and is in `closeAnyDialog`: Find the layer fixed to full screen with `z-index ≥ 40` and,
+inside, **a small button near its top edge**. Searched by **form**, not by text: the ☆☆☆☆☆ is
+usually an SVG with `textContent` empty.
 
-## 3. La IA "no funciona" y la app miente sobre por qué
+## 3. The AI "does not work" and the app lies about why
 
-Síntoma: el escaneo se pausa con *"This message could not be translated"*.
-Causa real: `Falta la clave de IA para gemini`.
+Symptom: Scan is paused with *"This message could not be translated"*. Real cause:
+`Missing AI key for Gemini`.
 
-Nodus cifra las claves con `safeStorage`, pero descifrarlas pide permiso al Llavero
-y **nadie lo concede** en una sesión automatizada. La UI dice "clave guardada" y el
-motor no puede leerla. La salida: escribir el archivo en formato legible.
+Nodus encrypts the keys with `safeStorage`, but decrypting them asks permission from the Keychain
+and **nobody grants it** in an automated session. The UI says "saved key" and the engine cannot read
+it. The output: write the file in readable format.
 
 ```js
 await writeFile(path.join(userData, 'secrets', `ai_key_${provider}.bin`),
   `b64:${Buffer.from(key, 'utf8').toString('base64')}`, 'utf8');
 ```
 
-El motor refleja el `stderr` del proceso principal para que el motivo real se vea.
+The engine reflects the `stderr` of the main process so that the actual motif is seen.
 
-## 4. El aislamiento del perfil es una ilusión si no copias el vault
+## 4. Profile isolation is an illusion if you don't copy the Vault
 
-`vaults.json` guarda la **ruta absoluta** de la base de datos del vault. Copiar el
-perfil copia el puntero, no el vault: todas las tomas leen y escriben el mismo
-archivo, y el estado se filtra de una a otra. Así apareció un vault ya emparejado con
-Nodus Server, sin formulario de conexión, en una toma que debía empezar limpia.
+`vaults.json` saves the **absolute path** of the Vault database. Copying the profile copies the
+pointer, not the vault: all the shots read and write the same file, and the status is filtered from
+one to the other. Thus a Vault already paired with Nodus Server appeared, without a connection form,
+in a shot that had to start clean.
 
-El motor copia el vault y reescribe el registro. Si añades otro almacén, comprueba si
-también guarda rutas absolutas.
+The engine copies the Vault and rewrites the log. If you add another store, check to see if it also
+saves absolute routes.
 
-## 5. Esperar a que termine un trabajo: un instante de calma no es el final
+## 5. Waiting for a job to end: an instant of calm is not the end
 
-El escaneo encadena fases (ligera, profunda, resumen, embeddings, pasajes, puentes) y
-cada una encola la siguiente. Un `done >= total` momentáneo entre dos fases **es
-idéntico a haber terminado**. Filmar ahí da un grafo vacío.
+Scanning chains phases (light, deep, summary, embeddings, passages, bridges) and each glues the next
+one. A momentary `done >= total` between two phases **is identical to having finished**. Filming
+there gives an empty graph.
 
-Exige calma **sostenida**: 20 sondeos de 3 s (un minuto). 21 segundos no bastaron.
+It demands calm **sustained**: 20 surveys of 3 s (one minute). 21 seconds were not enough.
 
-Y el reverso: una cola que sigue vacía a los 45 s es un trabajo terminado, no uno
-pendiente. Sin esa salida, un temporizador posterior se queda 45 minutos filmando una
-app quieta.
+And the reverse: a queue that remains empty at 45 s is a finished job, not a slope. Without that
+output, a subsequent timer stays 45 minutes filming a still app.
 
-## 6. Elementos que existen aunque no se vean
+## 6. Elements that exist but are not visible
 
-Los botones del menú radial de Nodi (`.nodi-node`) están en el DOM **abierto o
-cerrado**: cerrados se apilan bajo el orbe. Contarlos para saber si el menú está
-abierto siempre da "abierto", nunca se abre, y cada clic cae sobre el orbe.
+The buttons in the Nodi radial menu (`.nodi-node`) are in the DOM **open or closed**: closed are
+stacked under the orb. Counting them to know if the menu is always open gives "open", never opens,
+and each click falls on the orb.
 
-Mira el estado (`.nodi-node.open`), no la existencia. Y prefiere identificadores
-estables (`[data-nodi-action="chat"]`) a posiciones.
+Look at the state (`.nodi-node.open`), not the existence. And prefer stable identifiers
+(`[data-nodi-action="chat"]`) to positions.
 
-## 7. `data-testid` no siempre envuelve lo que parece
+## 7. `data-testid` does not always wrap what it looks like
 
-`[data-testid="mcp-settings-card"]` envuelve solo la cajita de ChatGPT; la casilla y
-los botones de MCP son **hermanos** suyos. Buscar dentro del testid da cero casillas y
-un solo botón. Lo correcto: `section.card:has([data-testid="mcp-settings-card"])`.
+`[data-testid="mcp-settings-card"]` wraps only the ChatGPT box; the box and the MCP buttons are
+**hermans** yours. Search within the testid gives zero boxes and one button. The correct thing:
+`section.card:has([data-testid="mcp-settings-card"])`.
 
-## 8. Guardas que no comprueban nada
+## 8. Guards that check nothing
 
-- Medir el **texto de la página** para saber si una búsqueda funcionó: la página
-  siempre es larga, así que pasa aunque no se haya escrito nada. Comprueba
-  `inputValue()`.
-- Registrar `current.state` cuando `current` solo trae `{title, kind}`: un escaneo en
-  marcha se lee como parado.
-- Un ayudante que no verifica su efecto deja que la toma "triunfe" con el fallo
-  dentro. Cada ayudante debe afirmar lo que hizo y avisar si no lo hizo.
+- Measure the **text of the page** to see if a search worked: the page is always long, so it happens
+  even if nothing has been written. Check `inputValue()`.
+- Register `current.state` when `current` only brings `{title, kind}`: a running scan is read as
+  stopped.
+- An assistant who does not verify its effect lets the take "triunfe" with the fault inside. Each
+  assistant must affirm what he did and warn if he did not.
 
-## 9. El idioma de la IA es un ajuste aparte
+## 9. The AI language is a separate setting
 
-`uiLanguage` **no** arrastra a `promptLanguage`, que viene en español por defecto. Con
-interfaz en inglés, todas las ideas extraídas salieron en español. Solo se ve mirando
-fotogramas. `BASE_SETTINGS` ya fija los dos.
+`uiLanguage` **no** drags to `promptLanguage`, which comes in default Spanish. With English
+interface, all the ideas extracted came out in Spanish. You can only see frames. `BASE_SETTINGS`
+already fixes the two.
 
-## 10. La cámara apunta fuera de pantalla
+## 10. The camera points off-screen
 
-`boundingBox()` devuelve coordenadas de elementos que están bajo el pliegue, y el
-zoom se va a un hueco vacío. Hay que hacer `scrollIntoViewIfNeeded` y comprobar
-visibilidad antes de medir.
+`boundingBox()` returns coordinates of elements under the fold, and the zoom goes to an empty slot.
+You have to do `scrollIntoViewIfNeeded` and check visibility before measuring.
 
-## 11. ffmpeg: `crop` no anima
+## 11. ffmpeg: `crop` does not animate
 
-`crop` evalúa `w`/`h` una sola vez: no hay movimiento de cámara. Lo que sí anima es
-`zoompan`.
+`crop` evaluates `w`/`h` once: there is no camera movement. What it does animates is `zoompan`.
 
-## 12. Difuminar de más es tan malo como difuminar de menos
+## 12. More blurring is as bad as blurring less.
 
-Tapar el elemento entero dejó ilegible todo el bloque de configuración de Claude
-Desktop, porque el token vive dentro. Envuelve **solo** los caracteres del secreto en
-un `<span>` propio (ver `TOKEN_BLUR` en el mazo `mcp`).
+Covering the entire element left unreadable the entire configuration block of Claude Desktop,
+because the token lives inside. It wraps **only** the characters of the secret in an own `<span>`
+(see `TOKEN_BLUR` in the mallet `mcp`).
 
-Y al revés: una regla de difuminado que no encaja con el marcado **no da error**. En
-una toma quedaron legibles todas las colecciones de Zotero del usuario porque la
-regla buscaba dentro de un `[role="dialog"]` que ese modal no tiene. Compruébalo
-mirando fotogramas.
+And the other way around: a blur rule that doesn't fit the **mark makes no mistake**. In one shot
+all the user's Zotero collections were read because the rule looked within a `[role="dialog"]` that
+modal doesn't have. Check it by looking at frames.
 
-## 13. `window.nodus` no admite reasignación
+## 13. `window.nodus` does not support reassignment
 
-Viene del *contextBridge*. Sobrescribir `window.nodus.nodiChatStream` desde la página
-falla **en silencio** y responde el modelo de verdad — con su coste. Para guionizar
-una respuesta hay que sustituir el manejador IPC en el **proceso principal**:
+It comes from *contextBridge*. Overwrite `window.nodus.nodiChatStream` from the page fails **in
+silence** and responds to the true model — at its cost. To script a response you have to replace the
+IPC handler in the main **process**:
 
 ```js
 await app.evaluate(({ ipcMain }, text) => {
@@ -138,21 +133,19 @@ await app.evaluate(({ ipcMain }, text) => {
 }, answer);
 ```
 
-## 14. La voz y la pantalla se descuadran sin avisar
+## 14. The voice and screen are broken without warning
 
-Casos reales: la voz decía "cada nodo es una idea" mientras se veían 7 temas; y decía
-"Gemini 2.5" con 3.1 en pantalla. Ningún log lo detecta.
+Real cases: the voice said "each node is an idea" while 7 themes were seen; and it said "Gemini 2.5"
+with 3.1 on screen. No log detects it.
 
-Como la narración manda el reloj, **una línea se puede rehacer sin volver a grabar**:
-cambia el texto, vuelve a narrar (solo esa frase, por la caché) y vuelve a montar.
+As the narration commands the clock, **a line can be redone without re-recording**: it changes the
+text, re-narrates (only that phrase, by the cache) and re-assembles.
 
-## 15. Cosas de la tubería que muerden
+## 15. Pipeline things that bite
 
-- **El montaje no reconstruye la app.** Si tocas código de Nodus, `npm run build`
-  antes de grabar.
-- **Cada mazo escribe en su carpeta.** Antes no era así y las tarjetas de un vídeo
-  sobrescribieron el vídeo final de otro.
-- **La caché de voz es por texto.** Sin ella, cambiar una palabra revocaba el mazo
-  entero.
-- **Un aviso en la grabación casi siempre se ve en el vídeo.** No montes con avisos
-  pendientes sin mirar antes ese momento del metraje.
+- **Assembly does not rebuild the app.** If you change Nodus code, run `npm run build` before recording.
+- **Each deck writes in its folder.** Before it was not so and the cards of one video overwrote the
+  final video of another.
+- **The voice cache is for text.** Without it, changing a word overturned the entire deck.
+- **A notice visible in the recording is almost always visible in the video.** Do not assemble with pending notices
+  without looking earlier at that moment of the footage.

--- a/scripts/tutorial/README.md
+++ b/scripts/tutorial/README.md
@@ -1,156 +1,153 @@
-# Tutoriales en vídeo de Nodus
+# Video tutorials by Nodus
 
-Motor para grabar tutoriales narrados **desde la aplicación real**, con voz en off en
-inglés, subtítulos en varios idiomas, tarjeta de inicio, tarjeta de cierre y música
-de fondo. No usa captura manual ni *computer use*: conduce la app con Playwright y
-captura los fotogramas por CDP.
+Engine to record narrated tutorials **from the actual application**, with voice off in English,
+subtitles in multiple languages, starter card, closing card and background music. Do not use manual
+capture or *computer use*: drive the app with Playwright and capture frames by CDP.
 
-Con esto se han hecho cuatro vídeos: introducción general (7:00), bóveda académica
-(4:58), Nodi (1:59) y MCP + Nodus Server (3:00).
-
----
-
-## Si eres el modelo que va a hacer el vídeo, empieza aquí
-
-1. Lee este archivo entero y después [PITFALLS.md](PITFALLS.md). El segundo es la
-   lista de fallos que ya han costado tomas enteras; casi todos reaparecen.
-2. Pregunta al usuario **qué debe contar el vídeo** y en qué orden, antes de escribir
-   una sola línea de guion.
-3. **Pide las claves de API si no las tienes.** Hacen falta dos, y no están en el
-   repositorio:
-   - **OpenRouter** — para la voz en off (TTS) y, en los vídeos que analizan corpus,
-     para los *embeddings*. Se lee de `~/.config/nodus/openrouter.key`, o de
-     `~/.config/nodus/openrouter-app.key`, o de `OPENROUTER_API_KEY`.
-   - **Google Gemini** — para el análisis de documentos en los vídeos que escanean.
-     Se lee de `~/.config/nodus/gemini-app.key`.
-
-   Si alguno no existe, **pregunta al usuario y espera**. No supongas que hay saldo,
-   y no escribas ninguna clave en el repositorio ni en un comentario: es público.
-4. **Nunca toques el Nodus instalado del usuario.** Toda grabación corre sobre un
-   `NODUS_USERDATA` desechable. El motor ya lo hace; no lo cambies.
-5. Ensaya con `--dry` antes de gastar en voz. Es gratis y caza casi todo.
+With this, four videos have been made: general introduction (7:00), academic vault (4:58), Nodi
+(1:59) and MCP + Nodus Server (3:00).
 
 ---
 
-## Requisitos
+## If you're the model that's going to make the video, start here.
+
+1. Read this whole file and then[PITFALLS.md](PITFALLS.md)The second is the list of failures that
+   have already cost whole shots; almost everyone reappears.
+2. Ask the user ** what the video should count** and in what order, before writing a single line of
+   script.
+3. **Ask for API keys if you don't have them.** It takes two, and they're not in the repository:
+   - **OpenRouter** — for voice-over (TTS) and, in the videos that analyze corpus, for
+     *embeddeds*.`~/.config/nodus/openrouter.key`, or`~/.config/nodus/openrouter-app.key`,
+     or`OPENROUTER_API_KEY`.
+   - **Google Gemini** — for document analysis in scanning videos. Read
+     from`~/.config/nodus/gemini-app.key`.
+
+If any does not exist, **ask the user and wait**.Do not suppose there is a balance, and do not write
+any keys in the repository or in a comment: it is public.
+4. **Never touch the user's installed Nodus.**All recording runs on a`NODUS_USERDATA`The engine
+   already does; don't change it.
+5. Test with`--dry`It's free and hunts almost everything.
+
+---
+
+## Requirements
 
 ```bash
 npm run build
 ```
 
-- `ffmpeg` y `ffprobe` en el PATH (`brew install ffmpeg`).
-- La app compilada: el grabador conduce `dist-electron/main.js`, no el código fuente.
-- Un tema de fondo en `scripts/tutorial/music/` (ver [music/README.md](music/README.md)).
+- `ffmpeg`and`ffprobe`in the PATH (`brew install ffmpeg`).
+- The compiled app: the recorder drives`dist-electron/main.js`Not the source code.
+- A theme in the background`scripts/tutorial/music/`(see[music/README.md](music/README.md)).
 
 ---
 
-## Las seis fases
+## The Six Phases
 
-Cada una es un comando. `--deck=<nombre>` elige el vídeo; la salida va siempre a
-`.tutorial-out/<nombre>/`, fuera del control de versiones.
+Each is a command.`--deck=<nombre>`choose the video; the output always goes
+to`.tutorial-out/<nombre>/`Out of version control.
 
-| # | Fase | Comando | Qué hace |
+| # | Phase | Command | What's he doing? |
 |---|------|---------|----------|
-| 1 | **Guion** | editas `decks/<deck>/shots.mjs` | Una frase por plano y lo que la app hace mientras |
-| 2 | **Voz** | `node scripts/tutorial/engine/narrate.mjs --deck=<deck>` | Un clip por frase, medido con ffprobe |
-| 3 | **Grabación** | `node scripts/tutorial/decks/<deck>/record.mjs` | Conduce la app y captura fotogramas |
-| 4 | **Subtítulos** | `node scripts/tutorial/engine/subtitles.mjs --deck=<deck>` | `.srt` y `.vtt`, normales y para YouTube |
-| 5 | **Montaje** | `node scripts/tutorial/engine/assemble.mjs --deck=<deck>` | Cámara, cortes y voz sobre los fotogramas |
-| 6 | **Tarjetas** | `node scripts/tutorial/engine/cards.mjs --deck=<deck>` | Inicio, cierre, música y pistas de subtítulos |
+| 1 | **Guion** | edits`decks/<deck>/shots.mjs` | One sentence per plane and what the app does while |
+| 2 | **Voice** | `node scripts/tutorial/engine/narrate.mjs --deck=<deck>` | One clip per sentence, measured with ffprobe |
+| 3 | **Recording** | `node scripts/tutorial/decks/<deck>/record.mjs` | Drive the app and capture frames |
+| 4 | **Subtitles** | `node scripts/tutorial/engine/subtitles.mjs --deck=<deck>` | `.srt`and`.vtt`, normal and for YouTube |
+| 5 | **Assembly** | `node scripts/tutorial/engine/assemble.mjs --deck=<deck>` | Camera, cuts and voice over frames |
+| 6 | **Cards** | `node scripts/tutorial/engine/cards.mjs --deck=<deck>` | Home, closing, music and subtitle tracks |
 
-Y para la descripción de YouTube:
+And for the description of YouTube:
 
 ```bash
 node scripts/tutorial/engine/describe.mjs --deck=<deck>
 ```
 
-### La regla que lo gobierna todo: **la narración manda el reloj**
+### The rule that governs everything: **narration commands the clock**
 
-Cada plano dura exactamente lo que dura su frase. De ahí se sigue:
+Each plane lasts exactly how long your phrase lasts. Hence follows:
 
-- **La voz se sintetiza ANTES de grabar.** Sin `narration.json` el grabador no sabe
-  cuánto aguantar cada plano y se niega a arrancar (salvo con `--dry`).
-- **Se puede rehacer una frase sin volver a grabar.** El montaje recorta cada clip a
-  la duración de su cue: cambias la línea, vuelves a narrar y a montar. Esto salvó
-  una toma en la que la voz decía "Gemini 2.5" y la pantalla mostraba 3.1.
-- **Si una acción tarda más que su frase, el plano se corta a media acción.** Ajusta
-  la acción, no la frase.
+- **The voice is synthesized BEFORE recording.**No`narration.json`the recorder does not know how
+  long to endure each plane and refuses to start (except with`--dry`).
+- **You can redo a sentence without re-recording.** The assembly step cuts each clip to the length of your
+  cue: you change the line, you re-narrify and assemble.This saved a shot in which the voice said
+  "Gemini 2.5" and the screen showed 3.1.
+- **If an action takes longer than its sentence, the plane is cut to half action.** Adjust the
+  action, not the phrase.
 
 ---
 
-## Hacer un vídeo nuevo, paso a paso
+## Make a new video, step by step
 
 ```bash
 cp -r scripts/tutorial/decks/_template scripts/tutorial/decks/miVideo
 ```
 
-1. **Escribe el guion** en `decks/miVideo/shots.mjs`. Una frase por plano, en inglés
-   hablado. Deletrea las siglas como suenan: `'M C P'`, `'H T T P S'`, `'P D F'`.
-2. **Escribe los ayudantes** en `decks/miVideo/record.mjs`. Cada uno debe
-   **verificar** lo que hizo (ver PITFALLS).
-3. **Ensaya gratis**: `node scripts/tutorial/decks/miVideo/record.mjs --dry`.
-   Objetivo: **cero avisos**. Cada `⚠` acaba viéndose en el vídeo de una forma u otra.
-4. **Sintetiza la voz**: `node scripts/tutorial/engine/narrate.mjs --deck=miVideo`.
-5. **Graba de verdad** y vuelve a exigir cero avisos.
-6. **Subtítulos, montaje y tarjetas** (fases 4-6).
-7. **Revisa fotogramas del vídeo YA MONTADO**, no del guion ni de los logs:
+1. **Writes the script** in`decks/miVideo/shots.mjs`. A phrase by plane, spoken in English. Spell
+   the acronyms as they sound:`'M C P'`, `'H T T P S'`, `'P D F'`.
+2. **Write the assistants** in`decks/miVideo/record.mjs`. Each one must **verify** what he did (see
+   PITFALLS).
+3. **Teach free**:`node scripts/tutorial/decks/miVideo/record.mjs --dry`Objective: **zero
+   notices**.`⚠`ends up being seen in the video one way or another.
+4. **Synthesizes the voice**:`node scripts/tutorial/engine/narrate.mjs --deck=miVideo`.
+5. **Really recorded** and again demanded zero notices.
+6. **Subtitles, assembly and cards** (phases 4-6).
+7. **Checks video frames YA MONTADO**, not script or log frames:
 
    ```bash
    ffmpeg -ss 90 -i .tutorial-out/miVideo/nodus-tutorial-miVideo-en-final.mp4 -frames:v 1 -y /tmp/check.png
    ```
 
-   Este paso ha destapado tres fallos que ningún log mostraba: ideas extraídas en
-   español bajo interfaz inglesa, una barra de progreso cruzando todas las vistas de
-   análisis, y una narración que hablaba de nodos mientras la pantalla mostraba temas.
+This step has uncovered three flaws that no log showed: ideas extracted in Spanish under English
+interface, a progress bar across all the analysis views, and a narrative that spoke of nodes while
+the screen showed themes.
 
 ---
 
-## Convenciones de la serie
+## Series conventions
 
-Se mantienen entre vídeos para que parezcan una colección y no cuatro cosas sueltas.
+They keep between videos to look like a collection and not four loose things.
 
-**Cámara.** Acercamiento (`focus`) **solo** para modales y para Nodi. Todo lo demás
-lleva aro (`highlight`). El zoom continuo marea.
+**Camera.** Approach (`focus`) ** only** for manners and for Nodi. Everything else carries a hoop
+(`highlight`). The continuous tide zoom.
 
-**Tarjeta de inicio.** Fondo claro, la N de Nodus centrada y debajo el título, 5
-segundos. El título sale de `TITLE` en el `shots.mjs` del mazo.
+**Start card.** Clear background, the N of Nodus centered and below the title, 5 seconds. The title
+comes out of`TITLE`in the`shots.mjs`The mallet.
 
-**Tarjeta de cierre.** 8 segundos, adaptación clara del cierre de marca.
+**Closing card.** 8 seconds, clear adaptation of the mark closure.
 
-Ambas se generan en `engine/cards.mjs` desde HTML, que queda en
-`.tutorial-out/<deck>/cards/` (`title.html`, `end.html`): se editan ahí y se ven al
-instante en el navegador.
+Both are generated in`engine/cards.mjs`from HTML, which is left in`.tutorial-out/<deck>/cards/`
+(`title.html`, `end.html`): they are edited there and seen instantly in the browser.
 
-**Música.** Un solo tema en bucle, con fundidos y **compresión lateral** para que la
-voz vaya siempre por delante (`MUSIC_GAIN = 0.16`). No debe pisar la narración nunca.
+**Music.**One single theme in loop, with casts and **side compression** for the voice to always go
+ahead (`MUSIC_GAIN = 0.16`) You should never step on the narrative.
 
-**Voz.** Siempre la misma, para que los vídeos suenen a una serie:
+**Voice.** Always the same, for videos to sound like a series:
 
 | | |
 |---|---|
-| Proveedor | **OpenRouter** (`/api/v1/audio/speech`) |
-| Modelo | **`deepgram/aura-2`** |
-| Voz | **`aura-2-thalia-en`** |
-| Idioma | inglés |
+| Provider | **OpenRouter** (`/api/v1/audio/speech`) |
+| Model | **`deepgram/aura-2`** |
+| Voice | **`aura-2-thalia-en`** |
+| Language | English |
 
-Queda registrado en `.tutorial-out/<deck>/narration.json` (`provider`, `model`,
-`voice`) en cada vídeo, y `describe.mjs` lo imprime. Se puede cambiar con
-`--voice=<id>` o `--model=<id>`, y hay rutas alternativas (`--provider=hume`,
-`--provider=openai`, `--local` para una voz de relleno sin coste).
+You are registered in`.tutorial-out/<deck>/narration.json` (`provider`, `model`, `voice`) in each
+video; and`describe.mjs`you can change it with`--voice=<id>`o`--model=<id>`, and there are
+alternative routes (`--provider=hume`, `--provider=openai`, `--local`for a voice filler without
+cost).
 
-Dos alternativas se probaron y se descartaron, por si vuelven a tentar:
+Two alternatives were tested and discarded, in case they were tempted again:
 
-- **`openai/gpt-audio-mini`** — es un modelo de chat, no de locución: **parafrasea el
-  guion**. Como los subtítulos se generan del guion, la voz y el texto dejan de
-  coincidir en todos los idiomas. El selector exige `output_modalities=speech`.
-- **Hume Octave** — la voz se cortaba a mitad de frase (minuto 0:52 del primer vídeo).
+- **`openai/gpt-audio-mini`** — is a chat model, not a speech: **paraphrases the script**. As
+  subtitles are generated from the script, the voice and text cease to match in all
+  languages.`output_modalities=speech`.
+- **Hume Octave** — the voice was cut in the middle of a sentence (minute 0:52 of the first video).
 
-**Subtítulos.** El inglés se lee del propio guion, así que voz y subtítulo no pueden
-desincronizarse. Los demás idiomas van en `decks/<deck>/captions.mjs`. Se generan dos
-juegos: uno normal y otro en `subtitles/youtube/` **desplazado +5 s** para compensar
-la tarjeta de inicio, con nombres BCP-47 listos para subir.
+**Subtitles.** English is read from the script itself, so voice and subtitle cannot be
+disinchronized.`decks/<deck>/captions.mjs`. Two games are generated: one normal and the other
+in`subtitles/youtube/`**displaced +5 s** to compensate the start card, with names BCP-47 ready to
+upload.
 
-**Miniatura.** Un fotograma de la tarjeta de inicio:
+**Minature.** A frame of the start card:
 
 ```bash
 ffmpeg -ss 2 -i .tutorial-out/<deck>/nodus-tutorial-<deck>-en-final.mp4 -frames:v 1 -q:v 2 -y miniatura.jpg
@@ -158,72 +155,69 @@ ffmpeg -ss 2 -i .tutorial-out/<deck>/nodus-tutorial-<deck>-en-final.mp4 -frames:
 
 ---
 
-## Privacidad — no negociable
+## Privacy — non-negotiable
 
-El repositorio es **público** y los vídeos se publican en YouTube.
+The repository is **public** and the videos are posted on YouTube.
 
-- **Claves de API y tokens: siempre difuminados.** El motor trae la clase
-  `.nodus-blur`; el mazo `mcp` enseña cómo tapar **solo** los caracteres del token
-  dejando legible el JSON que lo rodea.
-- **Colecciones de Zotero ajenas al vídeo: difuminadas desde el primer fotograma.**
-  Un temporizador que arranca al abrir el diálogo deja varios cientos de
-  milisegundos legibles, y esos fotogramas acaban publicados. Usa un
-  `MutationObserver`.
-- **Nada de fotos ni documentos personales del usuario en el repositorio.**
-- Verifica la privacidad **mirando fotogramas del vídeo montado**, no leyendo el
-  código: una regla de difuminado que no encaja con el marcado no da ningún error.
+- ** API keys and tokens: always faded.** Engine brings class`.nodus-blur`; the mallet`mcp`teaches
+  how to cover **only** the characters of the token leaving the JSON around it legible.
+- **Zoter's collections outside the video: blurred from the first frame.** A timer that starts when
+  the dialog opens leaves several hundred milliseconds legible, and those frames end up
+  published.`MutationObserver`.
+- **No photos or personal documents of the user in the repository.**
+- Verify privacy **by looking at frames from the assembled video**, not by reading the code: a blur rule that
+  doesn't fit the markup doesn't give any error.
 
 ---
 
-## Coste
+## Cost
 
-Grabar es gratis. Lo que se paga es la voz y, en los vídeos que analizan, el modelo.
+Recording is free. What you pay for is the voice and, in the videos you analyze, the model.
 
-- `--dry` no gasta nada: úsalo hasta que no queden avisos.
-- La voz **cachea por texto**: cambiar una frase cuesta una llamada, no el mazo entero.
-- **Reutiliza corpus ya escaneados** (`masterProfile`) en lugar de volver a analizar.
-- Las respuestas de chat de un tutorial deben ir **guionizadas**, no generadas: un
-  tutorial tiene que enseñar lo mismo cada vez, y además así no gasta.
+- `--dry` does not use any paid services. Use it until there are no warnings.
+- The voice **caches for text**: changing a phrase costs a call, not the whole mallet.
+- **Reuse already scanned corpus** (`masterProfile`) rather than re-analysing.
+- Tutorial chat responses should be **scripted**, not generated: a tutorial must teach
+  the same thing every time and should not consume API credits.
 
 ---
 
-## Estructura
+## Structure
 
 ```
 scripts/tutorial/
-  README.md              este archivo
-  PITFALLS.md            los fallos que ya han costado tomas
+  README.md              this file
+  PITFALLS.md            mistakes that have already ruined takes
   engine/
-    recorder.mjs         conduce la app y captura (lo comparten los mazos)
-    cursor.mjs           cursor sintético y aro de resalte
-    narrate.mjs          voz en off, una frase por plano, con caché
-    assemble.mjs         cámara, cortes y voz
-    cards.mjs            tarjetas, música y pistas de subtítulos
-    subtitles.mjs        .srt/.vtt, normales y para YouTube
-    describe.mjs         capítulos y guion para la descripción
+    recorder.mjs         drives and captures the app (shared by the decks)
+    cursor.mjs           synthetic cursor and highlight ring
+    narrate.mjs          voice-over, one sentence per shot, with caching
+    assemble.mjs         camera, cuts and voice
+    cards.mjs            cards, music and subtitle tracks
+    subtitles.mjs        standard and YouTube .srt/.vtt files
+    describe.mjs         chapters and description script
   decks/
-    _template/           punto de partida para un vídeo nuevo
-    intro/ academic/ nodi/ mcp/    los cuatro ya hechos, como ejemplos
-  probes/                sondas: interrogar la app sin grabar ni gastar
-  music/                 el tema de fondo
+    _template/           starting point for a new video
+    intro/ academic/ nodi/ mcp/    the four completed examples
+  probes/                probes: inspect the app without recording or spending
+  music/                 the background theme
 ```
 
-`intro` y `academic` son **anteriores** a la extracción del motor: sus `record.mjs`
-llevan su propio andamiaje. Funcionan y se conservan como referencia, sobre todo
-`academic`, que es el único que importa de Zotero y escanea de verdad. Los mazos
-`nodi` y `mcp` ya usan el motor y son el patrón a copiar.
+`intro`and`academic`are **anterior** to engine extraction: their`record.mjs`carry their own
+scaffolding. They function and are preserved as a reference, especially`academic`He's the only one
+who cares about Zotero and really scans the mallets.`nodi`and`mcp`They already use the engine and
+are the pattern to copy.
 
-`.tutorial-out/` (fotogramas, audio, perfiles, vídeos) está ignorado por git: es
-material de trabajo, pesa gigabytes y no pertenece al repositorio.
+`.tutorial-out/`(photograms, audio, profiles, videos) is ignored by git: it is working material,
+weighs gigabytes and does not belong to the repository.
 
 ---
 
-## Sondas
+## Probes
 
-`probes/` sirve para responder preguntas sobre la app **sin grabar**: qué selectores
-existen, cómo se llama un botón en inglés, si una vista devuelve resultados. Tardan
-segundos y no gastan nada.
+`probes/`is used to answer questions about the **unrecorded app**: what selectors exist, what a
+button is called in English, if a view returns results. It takes seconds and spends nothing.
 
-La regla que más tiempo ahorra: **cuando algo no funcione, vuelca el DOM real en vez
-de deducir el marcado**. Tres intentos seguidos de cerrar un modal fallaron por
-suponer cómo era su botón de cerrar; el cuarto, tras mirarlo, acertó a la primera.
+The rule that saves the most time: **when something doesn't work, flips the real DOM instead of
+deducing the dial**. Three attempts followed to close a modal failed to assume what its closing
+button looked like; the fourth, after looking at it, hit the first one.

--- a/scripts/tutorial/cards-examples/README.md
+++ b/scripts/tutorial/cards-examples/README.md
@@ -1,29 +1,28 @@
-# Tarjetas de inicio y de cierre
+# Start and close cards
 
-Ejemplos reales, tomados del tutorial de MCP.
+Real examples, taken from the MCP tutorial.
 
-| Archivo | Qué es |
+| File | What is it? |
 |---|---|
-| `title.html` / `title.png` | Tarjeta de apertura, **5 s**: la N de Nodus centrada y debajo el título |
-| `end.html` / `end.png` | Tarjeta de cierre, **8 s**: adaptación clara del cierre de marca |
+| `title.html` / `title.png` | Opening card, **5 s**: Nodus N centered and below the title |
+| `end.html` / `end.png` | Closing card, **8 s**: clear adaptation of the mark closure |
 
-Las genera `engine/cards.mjs` en cada montaje, dentro de
-`.tutorial-out/<deck>/cards/`. El HTML se renderiza sobre un escenario de 1280×720
-escalado desde una maqueta de 1920×1080 (si la ventana es más baja que la pantalla,
-se recorta el escalado).
+`engine/cards.mjs` generates them for each build in `.tutorial-out/<deck>/cards/`. The HTML is
+rendered on a 1280×720 scenario scaled from a 1920×1080 model (if the window is lower than the
+screen, the scaling is cut off).
 
-## Cómo cambiarlas
+## How to change them
 
-El HTML está incrustado en `engine/cards.mjs`. Para probar sin montar el vídeo
-entero, abre en el navegador el `title.html` que quedó del último montaje, ajusta a
-gusto y traslada el cambio al generador.
+The HTML is embedded in `engine/cards.mjs`. To test without assembling the entire video, open the
+`title.html` from the last build in a browser, adjust it as needed, and transfer the change
+to the generator.
 
-El **título** no se toca aquí: sale de `TITLE`, en el `shots.mjs` de cada mazo, para
-que cada vídeo lleve el suyo sin duplicar la maqueta.
+The **title** is not played here: it comes out of `TITLE`, in the `shots.mjs` of each deck, so that
+each video carries its own without duplicating the model.
 
-## Miniatura de YouTube
+## YouTube Thumbnail
 
-Es un fotograma de la tarjeta de inicio del vídeo ya montado:
+It is a frame from the opening card of the assembled video:
 
 ```bash
 ffmpeg -ss 2 -i .tutorial-out/<deck>/nodus-tutorial-<deck>-en-final.mp4 -frames:v 1 -q:v 2 -y miniatura.jpg

--- a/scripts/tutorial/music/README.md
+++ b/scripts/tutorial/music/README.md
@@ -1,41 +1,40 @@
-# Música de fondo
+# Background music
 
-Los cuatro tutoriales usan **un solo tema en bucle**, con fundido de entrada y de
-salida y compresión lateral, de modo que la voz siempre va por delante.
+The four tutorials use **a single theme in loop**, with input and output cast and lateral
+compression, so that the voice always goes ahead.
 
-## Dónde se busca
+## Where to look
 
-`engine/cards.mjs` lo resuelve en este orden:
+`engine/cards.mjs` resolves it in this order:
 
 1. `NODUS_TUTORIAL_MUSIC=/ruta/al/tema.mp3`
-2. el primer archivo de audio que haya **en esta carpeta**
-3. `~/Desktop/Quiet Dashboard Glow.mp3`, de donde lo tomaron los primeros vídeos
+2. the first audio file **in this folder**
+3. `~/Desktop/Quiet Dashboard Glow.mp3`, where the first videos took it
 
-Si no encuentra ninguno, monta el vídeo **sin música** y lo dice por consola en vez
-de fallar.
+If none is found, assemble the video **without music** and report it in the console instead of failing.
 
-## Por qué el audio no está en el repositorio
+## Why audio is not in the repository
 
-Este repositorio es público y el tema usado hasta ahora es un archivo personal del
-autor, sin licencia declarada para redistribución. Añadirlo aquí sería publicarlo.
+This repository is public and the theme used so far is a personal file of the author, without a
+license declared for redistribution. Adding it here would be to publish it.
 
-Deja tu tema en esta carpeta (queda ignorado por git) o apunta a él con
-`NODUS_TUTORIAL_MUSIC`. Si en algún momento se elige una pista con licencia libre,
-este es su sitio y basta con quitarla del `.gitignore` de al lado.
+Leave your theme in this folder (it is ignored by git) or point to it with `NODUS_TUTORIAL_MUSIC`.
+If you choose a free-licensed track at any time, this is your site and just remove it from the
+`.gitignore` next door.
 
-## Cómo se mezcla
+## How it mixes
 
-Los parámetros están en `engine/cards.mjs` y conviene no tocarlos a ojo:
+The parameters are in `engine/cards.mjs` and should not be touched by eye:
 
-- `MUSIC_GAIN = 0.16` — el lecho, muy por debajo de la voz.
-- `sidechaincompress` — la música cede automáticamente cuando hay narración.
-- `acrossfade` — el bucle se encadena consigo mismo, sin corte audible.
-- Fundidos de entrada y salida en los extremos del vídeo.
+- `MUSIC_GAIN = 0.16` — the bed, far below the voice.
+- `sidechaincompress` — music automatically yields when there is narration.
+- `acrossfade` — the loop is chained to itself, without audible cutting.
+- Input and output funds at the ends of the video.
 
-El encargo original era claro: *"bajita y estable, sin cambios raros y sin solapar la
-voz bajo ninguna circunstancia"*. Cualquier cambio debe seguir cumpliéndolo.
+The original order was clear: *"low and stable, without unusual changes and without overlap of voice
+under any circumstances".* Any change must continue to fulfill it.
 
-## Duración
+## Duration
 
-No importa que el tema sea más corto que el vídeo: se repite en bucle y se recorta a
-la duración exacta del montaje.
+It doesn't matter that the theme is shorter than the video: it repeats in loop and is cut to the
+exact duration of the assembly.

--- a/server/README.md
+++ b/server/README.md
@@ -1,97 +1,112 @@
 # Nodus Server
 
-> **Experimental e inestable.** Esta versión solo está destinada a pruebas.
-> Conserva copias de seguridad, no la utilices todavía como único acceso a
-> materiales importantes y espera cambios incompatibles antes de la versión estable.
+> **Experimental and unstable.** This version is intended for testing only.
+> Keep backups, don't use it as your only access to
+> important materials and expect incompatible changes before the stable version.
 
-Nodus Server permite compartir una proyección de un vault con estudiantes o investigadores. Es independiente de Nodus Desktop: el servidor vive en Docker y la aplicación de escritorio solo realiza conexiones HTTPS salientes. No se publica el puerto del MCP local ni se copia la base SQLite original.
+Nodus Server allows you to share a Vault projection with students or researchers. It is independent
+of Nodus Desktop: the server lives on Docker and the desktop application only makes outgoing HTTPS
+connections. The local MCP port is not published and the original SQLite base is not copied.
 
-## Qué necesitas
+## What you need
 
-- Un ordenador que permanezca encendido o un VPS con Windows, macOS o Linux.
-- Docker Desktop (Windows/macOS) o Docker Engine con el complemento Compose (Linux).
-- Un dominio o subdominio apuntando a la IP pública del servidor, por ejemplo `nodus.universidad.es`.
-- Los puertos 80 y 443 accesibles si vas a usar el Caddy incluido.
+- A computer that remains on or a VPS with Windows, macOS or Linux.
+- Docker Desktop (Windows/macOS) or Docker Engine with Compose (Linux) plugin.
+- A domain or subdomain pointing to the public IP of the server, for example `nodus.universidad.es`.
+- Ports 80 and 443 accessible if you are going to use the Caddy included.
 
-La instalación recomendada define la cuenta administradora como variables del Stack y abre directamente la página de login. Como alternativa, puede utilizarse un token temporal y el asistente `/setup`. La gestión diaria de espacios, usuarios, permisos y dispositivos se hace por web.
+The recommended installation defines the administrator account as Stack variables and opens the
+login page directly. Alternatively, a temporary token and `/setup` wizard can be used. The daily
+management of spaces, users, permissions and devices is done by web.
 
-## Prueba desde Portainer
+## Test from Portainer
 
-El workflow `Nodus Server image (experimental)` prueba y publica desde `main`
-una imagen multi-arquitectura en GitHub Container Registry. Crea un Stack con
-`portainer-stack.yml` mediante el editor web. Portainer descargará siempre:
+The workflow `Nodus Server image (experimental)` tests and publishes from `main` a
+multi-architecture image in GitHub Container Registry. Create a Stack with `portainer-stack.yml` via
+the web editor. Portainer will always download:
 
 - `ghcr.io/drakonis96/nodus-server:main`
 
-La etiqueta `main` es móvil e inestable. Cada compilación también se publica con
-una etiqueta `main-<sha>` para poder fijar o restaurar una prueba concreta. Define
-estas variables en el Stack:
+The `main` tag moves and is unstable. Each build is also published with a `main-<sha>` tag so you can
+able to set or restore a particular test. Define these variables in the Stack:
 
-- `NODUS_DOMAIN`: dominio sin `https://`, por ejemplo `nodus.ejemplo.es`.
-- `NODUS_ADMIN_EMAIL`: correo de la cuenta administradora.
-- `NODUS_ADMIN_PASSWORD`: contraseña única y larga, de al menos 12 caracteres.
+- `NODUS_DOMAIN`: domain without `https://`, for example `nodus.example.com`.
+- `NODUS_ADMIN_EMAIL`: email address for the administrator account.
+- `NODUS_ADMIN_PASSWORD`: unique and long password, of at least 12 characters.
 
-Estas dos variables deben definirse juntas. En el primer arranque crean la cuenta; en despliegues posteriores actualizan el correo o rotan la contraseña si cambias sus valores. La contraseña nunca se escribe en `state.json`: solo se conserva su hash. Mientras mantengas estas variables, sus valores son la fuente autoritativa y volverán a aplicarse en cada reinicio.
+These two variables must be defined together. In the first boot they create the account; in later
+deployments they update the mail or rotate the password if you change their values. The password is
+never written in `state.json`: only your hash is preserved. As long as you maintain these variables,
+their values are the authoritative source and will be applied again at each restart.
 
-Como alternativa, deja ambas vacías y define `NODUS_SETUP_TOKEN` con un valor aleatorio temporal de al menos 16 caracteres. En ese caso completarás `/setup` manualmente y deberás borrar el token después.
+Alternatively, leave both empty and define `NODUS_SETUP_TOKEN` with a temporary random value of at least
+16 characters. In that case you will complete `/setup` manually and you will have to delete the
+token later.
 
-El workflow termina cerrando la sesión de GHCR y leyendo el manifiesto como usuario
-anónimo. Así falla si el paquete no es público o si falta `amd64` o `arm64`; una
-ejecución verde significa que Portainer puede descargar la etiqueta sin credenciales.
+The workflow ends by closing the GHCR session and reading the manifest as an anonymous user. Thus,
+it fails if the package is not public or if `amd64` or `arm64` is missing; a green run means that
+Portainer can download the label without credentials.
 
-Este Stack incluye Caddy y requiere que 80/443 estén libres. Si ya existe un
-reverse proxy, despliega únicamente `nodus-server`, conéctalo a la red Docker del
-proxy y configura como destino HTTP `nodus-server:7443`.
+This Stack includes Caddy and requires 80/443 to be free. If a proxy reverse already exists, display
+only `nodus-server`, connect it to the proxy Docker network and set HTTP `nodus-server:7443`
+destination.
 
-## Opción A: no tienes Caddy, Nginx ni otro proxy
+## Option A: You don't have Caddy, Nginx or another proxy
 
-1. Descarga esta carpeta `server` y abre una terminal dentro de ella.
-2. Copia `.env.example` como `.env`.
-3. Edita `.env`: cambia `NODUS_DOMAIN` y `NODUS_PUBLIC_URL`, introduce `NODUS_ADMIN_EMAIL` y genera una contraseña única para `NODUS_ADMIN_PASSWORD` (por ejemplo, con `openssl rand -base64 32`). Protege el archivo `.env` y no lo subas a Git.
-4. Ejecuta:
+1. Download this folder `server` and open a terminal inside it.
+2. Copy `.env.example` as `.env`.
+3. Edits `.env`: changes `NODUS_DOMAIN` and `NODUS_PUBLIC_URL`, inserts `NODUS_ADMIN_EMAIL` and
+   generates a unique password for `NODUS_ADMIN_PASSWORD` (for example, with `openssl rand -base64
+   32`). Protects the `.env` file and does not upload it to Git.
+4. Runs:
 
 ```sh
 docker compose --profile proxy pull
 docker compose --profile proxy up -d
 ```
 
-5. Abre `https://tu-dominio`: Nodus te enviará directamente al login y podrás entrar con esas credenciales.
-6. Para rotarlas, cambia las dos variables y vuelve a desplegar el contenedor. Se cerrarán las sesiones y conexiones OAuth anteriores si cambia la contraseña.
+5. Open `https://tu-dominio`: Nodus will send you directly to the login and you can enter with those
+   credentials.
+6. To rotate them, change the two variables and re-deploy the container. Previous OAuth sessions and
+   connections will be closed if the password changes.
 
-Caddy obtiene y renueva automáticamente el certificado HTTPS. Los datos quedan en el volumen Docker `nodus_data`; recrear o actualizar el contenedor no los borra.
+Caddy automatically obtains and renews the HTTPS certificate. The data is left in the Docker
+`nodus_data` volume; recreating or updating the container does not erase them.
 
-## Opción B: ya tienes Caddy o Nginx en el servidor
+## Option B: you already have Caddy or Nginx on the server
 
-Ejecuta solo Nodus Server:
+Run Nodus Server only:
 
 ```sh
 docker compose pull
 docker compose up -d
 ```
 
-Docker publica Nodus exclusivamente en `127.0.0.1:7443`. Así no ocupa 80/443, no queda accesible directamente desde Internet y no interfiere con tu proxy actual. Configura el dominio en ese proxy y reenvíalo a `http://127.0.0.1:7443`.
+Docker posts Nodus exclusively in `127.0.0.1:7443`. So it does not occupy 80/443, it is not directly
+accessible from the Internet and does not interfere with your current proxy. Set the domain in that
+proxy and forward it to `http://127.0.0.1:7443`.
 
-### Caddy ya instalado en el sistema
+### Caddy already installed in the system
 
 ```caddy
-nodus.ejemplo.es {
+nodus.example.com {
   encode zstd gzip
   reverse_proxy 127.0.0.1:7443
 }
 ```
 
-Recarga Caddy después de guardar la configuración.
+Reload Caddy after saving the settings.
 
-### Nginx ya instalado en el sistema
+### Nginx already installed in the system
 
 ```nginx
 server {
     listen 443 ssl http2;
-    server_name nodus.ejemplo.es;
+    server_name nodus.example.com;
 
-    # Conserva aquí las rutas de certificado que ya gestione tu instalación.
-    ssl_certificate /etc/letsencrypt/live/nodus.ejemplo.es/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/nodus.ejemplo.es/privkey.pem;
+    # Keep the certificate paths managed by your installation here.
+    ssl_certificate /etc/letsencrypt/live/nodus.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/nodus.example.com/privkey.pem;
 
     client_max_body_size 100m;
     location / {
@@ -108,58 +123,90 @@ server {
 }
 ```
 
-Si tu Caddy/Nginx también está dentro de Docker, conecta ambos proyectos a una misma red Docker externa y usa `nodus-server:7443` como destino. No cambies el puerto 7443 a `0.0.0.0`: el único servicio público debe ser el proxy HTTPS.
+If your Caddy/Nginx is also inside Docker, connect both projects to the same external Docker network
+and use `nodus-server:7443` as your destination. Do not change port 7443 to `0.0.0.0`: the only
+public service must be HTTPS proxy.
 
-## Dominio y URL pública
+## Public domain and URL
 
-`NODUS_PUBLIC_URL` debe ser exactamente el origen que usarán las personas, sin ruta final: `https://nodus.ejemplo.es`. La URL que se añade en ChatGPT y Claude será `https://nodus.ejemplo.es/mcp`.
+`NODUS_PUBLIC_URL` must be exactly the source that people will use, without final path:
+`https://nodus.example.com`. The URL added in ChatGPT and Claude will be
+`https://nodus.example.com/mcp`.
 
-Si cambias el dominio, actualiza `NODUS_DOMAIN`, `NODUS_PUBLIC_URL`, el DNS y el proxy; después ejecuta de nuevo `docker compose up -d`. No uses una IP pública con HTTP. Nodus Desktop rechaza HTTP salvo para pruebas en `localhost`.
+If you change the domain, update `NODUS_DOMAIN`, `NODUS_PUBLIC_URL`, DNS and proxy; then run `docker
+compose up -d` again. Do not use a public IP with HTTP. Nodus Desktop rejects HTTP except for tests
+in `localhost`.
 
-## Credenciales por entorno y Docker secrets
+## Credentials by environment and Docker secrets
 
-La opción sencilla para Portainer y Compose es `NODUS_ADMIN_EMAIL` + `NODUS_ADMIN_PASSWORD`. Quien tenga permisos para inspeccionar o editar el contenedor podrá ver sus variables, por lo que el acceso a Docker/Portainer debe limitarse a administradores.
+The simple option for Portainer and Compose is `NODUS_ADMIN_EMAIL` + `NODUS_ADMIN_PASSWORD`. Anyone
+who has permission to inspect or edit the container will be able to view its variables, so access to
+Docker/Portainer should be limited to administrators.
 
-Si tu plataforma admite secretos montados como archivos, puedes usar `NODUS_ADMIN_EMAIL_FILE` y `NODUS_ADMIN_PASSWORD_FILE` en lugar de los valores directos. No configures simultáneamente una variable directa y su variante `_FILE`. Nodus lee el archivo al arrancar y nunca registra el contenido.
+If your platform supports secrets mounted as files, you can use `NODUS_ADMIN_EMAIL_FILE` and
+`NODUS_ADMIN_PASSWORD_FILE` instead of the direct values. Do not simultaneously configure a direct
+variable and its variant `_FILE`. Nodus reads the file when booting and never records the content.
 
-## Conectar un vault de Nodus Desktop
+## Connect a Nodus Desktop Vault
 
-1. Entra como administrador en `https://tu-dominio`.
-2. Crea un espacio.
-3. Pulsa «Crear código para Nodus»; el código caduca en 15 minutos y solo funciona una vez.
-4. En Nodus Desktop abre **Ajustes → Servidor**, escribe la URL base y el código, y pulsa «Conectar vault».
-5. La primera publicación se hace inmediatamente. Después Nodus comprueba un contador SQLite cada 30 segundos y solo vuelve a publicar cuando hay cambios, ha transcurrido un minuto sin actividad y se respeta un mínimo de dos minutos entre envíos.
+1. Enter as administrator in `https://tu-dominio`.
+2. Create a space.
+3. Click "Create code for Nodus"; the code expires in 15 minutes and only works once.
+4. In Nodus Desktop opens **Adjustments → Server**, type the base URL and code, and press "Connect
+   Vault".
+5. The first publication is made immediately. After that Nodus checks a SQLite counter every 30
+   seconds and only reposts when there are changes, a minute has passed without activity and a
+   minimum of two minutes between submissions is respected.
 
-Por defecto se publican referencias y conocimiento académico derivado. PDF, credenciales, rutas, embeddings, listas de alumnos, grupos, calificaciones y resultados de evaluación nunca se publican. Las notas/proyectos/materiales docentes y los pasajes extraídos tienen interruptores separados.
+By default, references and derived academic knowledge are published. PDF, credentials, routes,
+embeddings, student lists, groups, grades and evaluation results are never published. Teacher
+notes/projects/materials and extracted passages have separate switches.
 
-## Dar acceso a estudiantes o investigadores
+## Provide access to students or researchers
 
-1. Desde la administración web crea una cuenta lectora con contraseña temporal y asígnala a un espacio.
-2. La persona inicia sesión y abre **Mi cuenta** para cambiar esa contraseña. Se cerrarán sus demás sesiones y se revocarán sus conexiones OAuth anteriores.
-3. Puedes conceder a esa cuenta acceso lector a otros espacios, revocarlo o restablecer su contraseña temporal desde la tabla de usuarios. Un restablecimiento administrativo cierra todas las sesiones y conexiones OAuth de esa cuenta.
-4. La persona añade `https://tu-dominio/mcp` como conector MCP personalizado en ChatGPT o Claude.
-5. El cliente abre la pantalla OAuth de Nodus Server. La persona inicia sesión y autoriza el permiso de lectura.
+1. From the web administration it creates a reading account with a temporary password and assigns it
+   to a space.
+2. The person signs in and opens **My account** to change that password. Your other sessions will be
+   closed and your previous OAuth connections will be revoked.
+3. You can grant that account reader access to other spaces, revoke it or reset your temporary
+   password from the user table. An administrative reset closes all sessions and OAuth connections
+   to that account.
+4. The person adds `https://tu-dominio/mcp` as a custom MCP connector in ChatGPT or Claude.
+5. The client opens the Nodus Server OAuth screen. The person log in and authorizes the reading
+   permission.
 
-Cada token está vinculado a esa persona y a esta URL MCP. Las herramientas comprueban la membresía del espacio en cada llamada. La versión actual es deliberadamente de solo lectura; las ediciones remotas no se mezclan con el vault local ni pueden sobrescribirlo.
+Each token is linked to that person and to this MCP URL. The tools check the membership of the space
+on each call. The current version is deliberately read-only; remote editions are not mixed with the
+local vault nor can they overwrite it.
 
-## Seguridad y operación
+## Security and operation
 
-- No expongas 7443 a Internet ni uses el servidor sin HTTPS.
-- Mantén Docker, Caddy/Nginx y la imagen de Nodus actualizados.
-- Usa contraseñas únicas; el servidor exige entre 12 y 1024 caracteres.
-- El login limita intentos simultáneamente por IP, por cuenta (mediante un identificador hash que no revela el correo) y en todo el servidor. Las cuentas inexistentes ejecutan la misma verificación criptográfica que las existentes para evitar su enumeración por tiempos de respuesta.
-- `/setup`, el emparejamiento, el registro OAuth y el intercambio de tokens tienen límites propios y límites globales. Los cuerpos de autenticación están acotados, las sesiones activas por cuenta se limitan y los registros internos de rate limiting no pueden crecer sin límite.
-- Caddy o Nginx debe conservar la IP real del cliente mediante `X-Forwarded-For`; no coloques otro proxy no confiable directamente delante del puerto interno.
-- Cambia tu propia contraseña desde **Mi cuenta**. El administrador solo puede restablecer contraseñas de cuentas lectoras; no puede ver las contraseñas existentes.
-- Revoca desde la web cualquier dispositivo perdido. Desconectar el vault en Desktop detiene los envíos, pero el administrador debe eliminar la publicación retenida cuando corresponda.
-- Haz copias periódicas del volumen `nodus_data` y prueba su restauración. El estado y las publicaciones están bajo `/data` dentro del contenedor.
-- La copia de seguridad debe protegerse como los materiales que contiene. Para datos institucionales, documenta alojamiento, conservación, accesos, encargados y transferencias conforme a tu política y al RGPD.
+- Do not expose 7443 to the Internet or use the server without HTTPS.
+- Keep Docker, Caddy/Nginx and Nodus image updated.
+- Use unique passwords; the server requires between 12 and 1024 characters.
+- The login limits attempts simultaneously by IP, by account (through a hash identifier that does
+  not reveal the mail) and across the server. Non-existent accounts perform the same cryptographic
+  verification as existing ones to avoid their enumeration by response times.
+- `/setup`, pairing, OAuth record and token exchange have their own limits and global limits.
+  Authentication bodies are limited, active sessions on their own are limited and internal rate
+  limiting records cannot grow without limit.
+- Caddy or Nginx must keep the client's actual IP via `X-Forwarded-For`; do not place another
+  unreliable proxy directly in front of the internal port.
+- Change your own password from **My account**. The administrator can only reset passwords for
+  reader accounts; you cannot view existing passwords.
+- It revokes any lost device from the web. Disconnecting the Vault on Desktop stops submissions, but
+  the administrator must remove the retained posting when appropriate.
+- Make periodic copies of the volume `nodus_data` and test its restoration. The status and
+  publications are under `/data` within the container.
+- The backup should be protected as the materials it contains. For institutional data, document
+  accommodation, conservation, accesses, managers and transfers according to your policy and GDPR.
 
-Comprobación rápida:
+Quick check:
 
 ```sh
 curl https://tu-dominio/healthz
 docker compose logs -f nodus-server
 ```
 
-El endpoint de salud debe responder con `{"ok":true,...}`. Para validar MCP y OAuth de extremo a extremo durante una instalación técnica puede utilizarse MCP Inspector.
+The health endpoint must respond with `{"ok":true,...}`. To validate MCP and OAuth end-to-end during
+a technical installation MCP Inspector can be used.

--- a/word-addin/README.md
+++ b/word-addin/README.md
@@ -1,89 +1,83 @@
-# Nodus Copilot — complemento de escritura para Word (beta)
+# Nodus Copilot — Word writing plugin (beta)
 
-> **Beta oficial desde v1.7.0**: se instala directamente desde la app empaquetada
-> (Ajustes → Integraciones), sin herramientas de desarrollo. El panel sigue el
-> idioma de la interfaz de Nodus (español/inglés).
+> **Official bet since v1.7.0**: installed directly from the packaged app
+> (Adjustments → Integrations), without development tools. The panel follows the
+> Nodus interface language (English/Spanish).
 
-Un complemento (task pane) de Microsoft Word que, mientras escribes, muestra en el
-panel lateral cómo el **párrafo actual** se relaciona con tu biblioteca de Nodus,
-permite buscar ideas/autores/obras **y pasajes citables del texto completo**, ver
-cada idea con sus conexiones y pedir a la IA configurada en Nodus que inserte una
-idea parafraseada con cita autor-año. Sobre la **selección** puede además
-**reescribir**, **ampliar** o redactar un **contraargumento** citado, e insertar
-cualquier resultado **en el cuerpo o como nota al pie**.
+A Microsoft Word add-on (task pane) that, while you write, shows in the side panel how the current
+**paragraph** relates to your Nodus library, allows you to search for ideas/authors/works **and
+quotationable passages from the full text**, see each idea with its connections and ask the IA
+configured in Nodus to insert a paraphrased idea with author-year quote. On the **selection** can
+also **rewrite**, **enlarge** or write a **contraargument** cited, and insert any result **in the
+body or as a footnote**.
 
-No reimplementa nada del cerebro de Nodus: el add-in es solo una segunda cara. El
-análisis (embeddings + relaciones tipadas) lo hace tu app de Nodus, que sirve el
-complemento y una pequeña API JSON **en el mismo origen HTTPS local**
-(`https://localhost:4320`), así que no hay problemas de CORS ni de contenido mixto.
+It doesn't reimplement anything from Nodus' brain: the add-in is just a second face. The analysis
+(embeddings + typical relationships) is done by your Nodus app, which serves the add-in and a small
+JSON API ** at the same local HTTPS source** (`https://localhost:4320`), so there are no CORS or
+mixed content problems.
 
-## Cómo funciona
-- `taskpane.html/.js/.css` — panel lateral en JS plano (Office.js desde CDN).
-  - Al mover el cursor (evento de selección, con *debounce*) lee el párrafo actual,
-    lo manda a `POST /api/relations` y pinta las relaciones tipadas. Cachea por
-    párrafo y cancela peticiones obsoletas (gana la última).
-  - **Insertar (Autor, año)** → inserta el autor-año en el cursor.
-  - **Citar en Zotero** → abre Zotero con el item seleccionado (`zotero://select`,
-    lanzado por Nodus) y copia una cadena de búsqueda precisa al portapapeles para
-    pegarla en "Add Citation" de Zotero (donde pones páginas/prefijos/sufijos).
-- `manifest.xml` — apunta a `https://localhost:4320/addin/taskpane.html`.
-- El servidor vive en `electron/copilot/` dentro de Nodus.
+## How it works
+- `taskpane.html/.js/.css` — Side panel in flat JS (Office.js from CDN).
+  - When you move the cursor (selection event, with *debounce*) you read the current paragraph, send
+    it to `POST /api/relations` and paint the typical relationships. Cache per paragraph and cancel
+    obsolete requests (win the last).
+  - **Insert (Author, year)** → insert the author-year into the cursor.
+  - **Cite in Zotero** → opens Zotero with the selected item (`zotero://select`, released by Nodus)
+    and copies a precise search string to the clipboard to paste into Zotero's "Add Citation" (where
+    you post pages/prefixes/suffixes).
+- `manifest.xml` — points to `https://localhost:4320/addin/taskpane.html`.
+- The server lives in `electron/copilot/` within Nodus.
 
-## Puesta en marcha (una vez)
-1. **Certificado**: en Nodus → Ajustes → "Copiloto de escritura (Word)" pulsa
-   *Generar certificado*. Nodus genera su propia CA local (10 años) y un
-   certificado hoja para `https://localhost` (1 año, renovado en silencio antes
-   de caducar), y confía la CA para tu usuario con un diálogo del sistema
-   (`security` en macOS, `Import-Certificate` en Windows). Solo una vez por
-   equipo; si ya tenías el certificado de `office-addin-dev-certs` de una
-   instalación de desarrollo, se reutiliza tal cual.
-2. **Activa** el toggle "Activar copiloto para Word". Verás `Activo:
+## Start-up (once)
+1. **Certified**: in Nodus → Settings → "Write Copilot (Word)" press *Certified Generate*. Nodus
+   generates its own local CA (10 years) and a certificate sheet for `https://localhost` (1 year,
+   renewed silently before expiry), and trust the CA for your user with a system dialog (`security`
+   in macOS, `Import-Certificate` on Windows). Only once per computer; if you already had the
+   `office-addin-dev-certs` certificate for a development installation, it is reused as it is.
+2. **Activate** the toggle "Activate copilot for Word". You'll see `Activo:
    https://localhost:4320/addin/taskpane.html`.
-3. Pulsa **Instalar/actualizar en Word**. Nodus copia un manifiesto con el puerto
-   actual al catálogo local de Word (`…/com.microsoft.Word/Data/Documents/wef` en
-   macOS) y actualiza su versión, que es la vía admitida para que Office recoja un
-   manifiesto cambiado. **Nodus no toca la caché de complementos de Office**:
-   borrar archivos sueltos de ella está documentado como algo que puede dejar de
-   cargar *todos* los complementos.
-4. Cierra Word del todo (`Cmd+Q`) y vuelve a abrirlo — Word solo lee ese catálogo
-   al arrancar. El complemento aparece en **Inicio → Complementos**; al abrirlo la
-   primera vez añade su pestaña propia **Nodus** con el botón **Nodus Copilot**.
+3. Press **Install/update in Word**. Nodus copies a manifest with the current port to the Word local
+   catalog (`…/com.microsoft.Word/Data/Documents/wef` in macOS) and updates its version, which is
+   the supported way for Office to collect a changed manifest. **Nodus does not touch the Office**
+   plugin cache: deleting loose files from it is documented as something that can stop loading *
+   all* plugins.
+4. Close Word at all (`Cmd+Q`) and open it again — Word only reads that catalog when booting. Plugin
+   appears in **Start → Add-ons**; when opening the first time it adds its own tab **Nodus** with
+   the **Nodus Copilot** button.
 
-> **Si no aparece en la lista de complementos**: no es el manifiesto. Office para
-> Mac arrastra desde la versión 16.100 una regresión de complementos web, y hay un
-> fallo abierto ([office-js#6597](https://github.com/OfficeDev/office-js/issues/6597))
-> que afecta **solo a cuentas de trabajo/estudios**: el catálogo se queda vacío y
-> no registra ningún complemento, ni de carpeta local ni de la tienda. Se
-> reconoce en que tampoco aparecen los complementos de tienda que sí tenías. El
-> vaciado completo de caché que documenta Microsoft no lo resuelve; probar con
-> una cuenta personal sí distingue el caso.
+> **If it does not appear in the plugin list**: it is not the manifest. Office for
+> Mac drags a web plugin regression from version 16.100, and there is a
+> open ([office-js#6597](https://github.com/OfficeDev/office-js/issues/6597))
+> which affects ** only work accounts/studies**: the catalogue is left empty and
+> does not record any plugins, either local folder or store.
+> recognize that there are no store accessories that you did have either.
+> Complete cache emptying documented by Microsoft does not solve it; try with
+> a personal account does distinguish the case.
 
-## Uso diario
-- Abre Nodus (con el copiloto activado) y Word. En la pestaña **Nodus**, abre el
-  panel **Nodus Copilot**.
-- Escribe. Al pausar, el panel muestra las ideas relacionadas del párrafo.
-- Usa el buscador para filtrar por idea, autor u obra indexada. Con el conmutador
-  **Ideas / Pasajes** cambias a la búsqueda semántica sobre el **texto completo**:
-  cada pasaje trae su cita y un botón **Insertar cita** (lo pega entre comillas con
-  el autor-año).
-- Abre **Detalles** para ver fuentes y conexiones; **Abrir en Nodus** abre el
-  desarrollo completo de la idea en la sección **Ideas**; **Insertar con IA**
-  añade una paráfrasis citada al texto.
-- Con texto seleccionado, la fila **Selección** ofrece **Reescribir** (sustituye la
-  selección), **Ampliar** (continúa el texto) y **Rebatir** (redacta un
-  contraargumento citado a partir de las ideas que la contradicen o matizan).
-- El selector **Insertar en** manda las inserciones y contraargumentos al **cuerpo**
-  o a una **nota al pie** (requiere Word con WordApi 1.5; si no, la opción se
-  desactiva). *Reescribir* siempre trabaja sobre el cuerpo.
+## Daily use
+- Open Nodus (with copilot enabled) and Word. In the **Nodus** tab, open the **Nodus Copilot**
+  panel.
+- Write. When paused, the panel displays the related ideas of the paragraph.
+- Use the search engine to filter by idea, author, or indexed work. With the **Ideas / Passages**
+  switch to the semantic search on the **full text**: each passage brings its quote and a **Insert
+  quote** button (sticks it in quotes with the author-year).
+- Opens **Details** to see sources and connections; **Opens in Nodus** opens the full development of
+  the idea in section **Ideas**; ** Inserting with AI** adds a quoted paraphrase to the text.
+- With selected text, the **Selection** row offers **Rewrite** (replaces selection), **Enlarge**
+  (continues text) and **Rebate** (reforms a counterargument cited from ideas that contradict or
+  nuance it).
+- The selector ** Insert into** sends the inserts and counterarguments to the **body** or to a
+  **footnote** (requires Word with WordApi 1.5; if not, the option is disabled). *Rewrite* always
+  works on the body.
 
-## Requisitos
-- Nodus en marcha con un proveedor de **embeddings** configurado (la biblioteca debe
-  estar indexada). Sin embeddings el panel lo indica.
-- Word de escritorio, Zotero y el plugin de Zotero para Word.
+## Requirements
+- Nodus running with a **embeddings** provider configured (the library must be indexed). Without
+  embeddings the panel indicates it.
+- Desktop Word, Zotero and Zotero plugin for Word.
 
-## Notas / límites
-- Office no tiene evento "por tecla": el disparador es el **cambio de cursor** (nivel
-  de párrafo) + botón *Analizar párrafo*.
-- No hay Better BibTeX por defecto, así que el puente a Zotero usa `zotero://select`
-  + cadena de búsqueda al portapapeles (la cita real la pones en el diálogo de
-  Zotero, que conserva los campos vivos de Zotero — lo correcto para una tesis).
+## Notes/limits
+- Office has no "key" event: the trigger is the **change of cursor** (paragraph level) + button
+  *Analyze paragraph*.
+- No Better BibTeX by default, so the bridge to Zotero uses `zotero://select`
+  + search string to clipboard (the actual quote is put in the dialogue of Zotero, which preserves
+    the living fields of Zotero — the right thing for a thesis).


### PR DESCRIPTION
## Summary

- translate all Spanish-only project documentation into English
- normalize the remaining mixed-language wording in the changelog and image-generation guide
- update documentation-content tests to assert the new English wording

## Validation

- `npm run citation:check`
- `npm run lint` (passes with 5 pre-existing warnings)
- `npm run build`
- `npm test` (1269/1269 passing)
- `git diff --check`

Closes #268