### PR TITLE
Fix Pages workflow permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,11 +55,6 @@ jobs:
           git commit -m "Update GitHub release download totals"
           git push origin HEAD:main
 
-      - name: Use GitHub Actions as the Pages source
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api --method PUT "repos/${GITHUB_REPOSITORY}/pages" -f build_type=workflow
-
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
 

--- a/scripts/test-site-layout.mjs
+++ b/scripts/test-site-layout.mjs
@@ -90,8 +90,8 @@ test('the dedicated Pages worker owns the website and its scheduled cache refres
 
   assert.match(pagesWorkflow, /path:\s*site\b/);
   assert.match(pagesWorkflow, /actions\/deploy-pages@v5/);
-  assert.match(pagesWorkflow, /pages" -f build_type=workflow/);
   assert.match(pagesWorkflow, /node scripts\/github-release-downloads\.mjs/);
   assert.match(pagesWorkflow, /git add site\/data\/github-release-downloads\.json/);
+  assert.doesNotMatch(pagesWorkflow, /repos\/\$\{GITHUB_REPOSITORY\}\/pages/);
   assert.doesNotMatch(releaseWorkflow, /pages\/builds|github-release-downloads|docs\/data\//);
 });


### PR DESCRIPTION
## Summary

- remove the repository settings mutation from the Pages workflow
- keep the source migration as a one-time authenticated repository administration action
- add regression coverage that rejects future attempts to update the Pages repository endpoint from `GITHUB_TOKEN`

## Root cause

The first Pages run from #281 failed because GitHub Actions returned `403 Resource not accessible by integration` when the workflow tried to change the repository's Pages source. The workflow's `pages: write` permission authorizes Pages deployments, but `GITHUB_TOKEN` cannot perform that repository administration update.

The repository Pages source has now been changed to `workflow` through an authenticated owner session, so the deployment worker only needs to configure, package, and deploy `site/`.

## Validation

- `node --test scripts/test-site-layout.mjs` — 3 passed
- `.github/workflows/pages.yml` parses as valid YAML
- `git diff --check`

Follow-up to #280 and #281.