### PR TITLE
Correct the Zotero local API label and prune dead client code

### DIFF
--- a/electron/zotero/zoteroClient.ts
+++ b/electron/zotero/zoteroClient.ts
@@ -1,19 +1,24 @@
 import { fileURLToPath } from 'node:url';
 import type { ZoteroAttachmentInfo, ZoteroCollection, ZoteroItem, ZoteroLibrary, WorkMeta } from '@shared/types';
 
-// Read-only client for the Zotero 7 local API. Never writes to Zotero, never
-// touches zotero.sqlite directly.
+// Read-only client for Zotero's local API: the desktop app's local implementation
+// of Web API v3, served from port 23119 since Zotero 7. There is no "Zotero 7 API" —
+// the API version is 3, and Zotero supports exactly one version at a time. Requires
+// Zotero 7 or newer. Never writes to Zotero, never touches zotero.sqlite directly.
 
 const BASE = process.env.NODUS_ZOTERO_API_BASE?.trim() || 'http://localhost:23119/api';
 
-// The Zotero 7 local API always addresses the local library as `users/0`,
-// regardless of the account's real numeric userID.
+// The local API accepts `0` as the user ID (the real numeric userID works too;
+// anything else answers 400), so we always address the local library as `users/0`.
 export const LOCAL_USER_ID = '0';
 export const PERSONAL_LIBRARY: ZoteroLibrary = { type: 'user', id: LOCAL_USER_ID, name: 'Mi biblioteca' };
 
 const HEADERS: Record<string, string> = {
-  // Required: Zotero rejects requests with a Mozilla/* User-Agent (Electron's) unless
-  // this header is present. https://www.zotero.org/support/dev/web_api/v3/basics
+  // Load-bearing, do not remove: this is Zotero's DNS-rebinding guard. Against a
+  // Mozilla/* User-Agent (Electron's) without this header, Zotero closes the TCP
+  // connection outright — not a 403, so callers see a socket error rather than an
+  // HTTP status. Verified against Zotero 9.0.6.
+  // https://www.zotero.org/support/dev/web_api/v3/basics
   'Zotero-Allowed-Request': '1',
 };
 
@@ -270,9 +275,10 @@ export async function itemChildren(userId: string, itemKey: string): Promise<Zot
   if (!res.ok) return [];
   const data = (await res.json()) as any[];
   return data
-    // Zotero's local API answers /items/<unknown>/children with a 200 listing
-    // of UNRELATED library items instead of a 404. Requiring parentItem to
-    // match keeps a stale/foreign key from resolving to someone else's file.
+    // Defensive: older Zotero builds answered /items/<unknown>/children with a 200
+    // listing of UNRELATED library items instead of a 404 (9.0.6 returns an empty
+    // array). Requiring parentItem to match keeps a stale/foreign key from ever
+    // resolving to someone else's file, whichever behaviour the client has.
     .filter((c) => c.data?.itemType === 'attachment' && c.data?.parentItem === parsed.rawKey)
     .map((c) => ({
       key: canonicalKey(parsed.library, c.data.key),
@@ -359,22 +365,10 @@ export async function itemAsAttachment(userId: string, itemKey: string): Promise
   };
 }
 
-/** Incremental diff: items changed since a library version. */
-export async function itemsSince(userId: string, since: number): Promise<{ items: ZoteroItem[]; version: number }> {
-  const out: ZoteroItem[] = [];
-  let start = 0;
-  const limit = 100;
-  let version = since;
-  for (;;) {
-    const res = await zfetch(`${BASE}/users/${userId}/items/top?since=${since}&limit=${limit}&start=${start}`);
-    if (!res.ok) throw new Error(`Zotero since HTTP ${res.status}`);
-    const v = res.headers.get('Last-Modified-Version');
-    if (v) version = parseInt(v, 10);
-    const data = (await res.json()) as any[];
-    for (const it of data) out.push(mapItem(it, { ...PERSONAL_LIBRARY, id: userId }));
-    const total = parseInt(res.headers.get('Total-Results') ?? '0', 10);
-    start += limit;
-    if (data.length < limit || start >= total) break;
-  }
-  return { items: out, version };
-}
+// An `itemsSince()` incremental diff used to live here, unreferenced by any caller.
+// It was removed rather than fixed: it built `users/<id>` by hand instead of going
+// through libraryPrefix(), so it could never have served a group library, and its
+// `since=0` contract shifted under it (Zotero 8 made since=0 return everything —
+// zotero/zotero#5011). Sync reads the library version via libraryVersion() and
+// re-walks collections; a real incremental path should be written against the
+// current API rather than resurrected from this.

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -1937,8 +1937,8 @@ export const DE: Record<string, string> = {
   'Bienvenido a Nodus': 'Willkommen bei Nodus',
   'Teje tu biblioteca de Zotero en un grafo navegable de ideas y autores. Todo es local.':
     'Verweben Sie Ihre Zotero-Bibliothek zu einem navigierbaren Graphen aus Ideen und Autoren. Alles bleibt lokal.',
-  'Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.':
-    'Nodus verwendet die lokale API von Zotero 7 (nur Lesezugriff). Öffnen Sie Zotero und überprüfen Sie die Verbindung.',
+  'Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.':
+    'Nodus verwendet die lokale Zotero-API im Nur-Lese-Modus (erfordert Zotero 7 oder neuer). Öffnen Sie Zotero und überprüfen Sie die Verbindung.',
   'Verificar conexión': 'Verbindung überprüfen',
   'Conectado (userID {id})': 'Verbunden (Benutzer-ID {id})',
   'No disponible: {msg}': 'Nicht verfügbar: {msg}',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -1961,8 +1961,8 @@ export const EN: Record<string, string> = {
   'Bienvenido a Nodus': 'Welcome to Nodus',
   'Teje tu biblioteca de Zotero en un grafo navegable de ideas y autores. Todo es local.':
     'Weave your Zotero library into a navigable graph of ideas and authors. Everything is local.',
-  'Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.':
-    'Nodus uses the local Zotero 7 API (read-only). Open Zotero and verify the connection.',
+  'Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.':
+    'Nodus uses the local Zotero API in read-only mode (requires Zotero 7 or newer). Open Zotero and verify the connection.',
   'Verificar conexión': 'Verify connection',
   'Conectado (userID {id})': 'Connected (userID {id})',
   'No disponible: {msg}': 'Unavailable: {msg}',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -1936,8 +1936,8 @@ export const FR: Record<string, string> = {
   'Bienvenido a Nodus': 'Bienvenue dans Nodus',
   'Teje tu biblioteca de Zotero en un grafo navegable de ideas y autores. Todo es local.':
     'Tissez votre bibliothèque Zotero en un graphe navigable d\'idées et d\'auteurs. Tout est local.',
-  'Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.':
-    'Nodus utilise l\'API locale de Zotero 7 (lecture seule). Ouvrez Zotero et vérifiez la connexion.',
+  'Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.':
+    'Nodus utilise l\'API locale de Zotero en lecture seule (nécessite Zotero 7 ou une version ultérieure). Ouvrez Zotero et vérifiez la connexion.',
   'Verificar conexión': 'Vérifier la connexion',
   'Conectado (userID {id})': 'Connecté (userID {id})',
   'No disponible: {msg}': 'Indisponible : {msg}',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -1722,7 +1722,7 @@ export const IT: Record<string, string> = {
   "Tu bóveda está lista. El panel de Inicio te guiará en los primeros pasos.": "Il tuo caveau è pronto. Il pannello Home guiderà i tuoi primi passi.",
   "Bienvenido a Nodus": "Benvenuti a Nodus",
   "Teje tu biblioteca de Zotero en un grafo navegable de ideas y autores. Todo es local.": "Intreccia la tua libreria Zotero in un grafico navigabile di idee e autori. Tutto è locale.",
-  "Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.": "Nodus utilizza l'API locale Zotero 7 (sola lettura). Apri Zotero e verifica la connessione.",
+  "Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.": "Nodus utilizza l'API locale di Zotero in sola lettura (richiede Zotero 7 o successivo). Apri Zotero e verifica la connessione.",
   "Verificar conexión": "Verificare la connessione",
   "Conectado (userID {id})": "Connesso (ID utente {id})",
   "No disponible: {msg}": "Non disponibile: {msg}",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -1922,8 +1922,8 @@ export const PT_BR: Record<string, string> = {
   'Bienvenido a Nodus': 'Bem-vindo ao Nodus',
   'Teje tu biblioteca de Zotero en un grafo navegable de ideas y autores. Todo es local.':
     'Teça sua biblioteca do Zotero em um grafo navegável de ideias e autores. Tudo é local.',
-  'Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.':
-    'O Nodus usa a API local do Zotero 7 (somente leitura). Abra o Zotero e verifique a conexão.',
+  'Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.':
+    'O Nodus usa a API local do Zotero somente em modo de leitura (requer Zotero 7 ou posterior). Abra o Zotero e verifique a conexão.',
   'Verificar conexión': 'Verificar conexão',
   'Conectado (userID {id})': 'Conectado (userID {id})',
   'No disponible: {msg}': 'Indisponível: {msg}',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -1919,8 +1919,8 @@ export const PT: Record<string, string> = {
   'Bienvenido a Nodus': 'Bem-vindo ao Nodus',
   'Teje tu biblioteca de Zotero en un grafo navegable de ideas y autores. Todo es local.':
     'Teça a sua biblioteca do Zotero num grafo navegável de ideias e autores. Tudo é local.',
-  'Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.':
-    'O Nodus usa a API local do Zotero 7 (apenas leitura). Abra o Zotero e verifique a ligação.',
+  'Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.':
+    'O Nodus usa a API local do Zotero apenas em modo de leitura (requer Zotero 7 ou posterior). Abra o Zotero e verifique a ligação.',
   'Verificar conexión': 'Verificar ligação',
   'Conectado (userID {id})': 'Ligado (userID {id})',
   'No disponible: {msg}': 'Não disponível: {msg}',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -2105,7 +2105,7 @@ export const TR: Record<string, string> = {
   "Tu bóveda está lista. El panel de Inicio te guiará en los primeros pasos.": "Kasanız hazır. Ana panel ilk adımlarda size yol gösterecektir.",
   "Bienvenido a Nodus": "Nodus'a hoş geldiniz",
   "Teje tu biblioteca de Zotero en un grafo navegable de ideas y autores. Todo es local.": "Zotero kitaplığınızı gezinilebilir bir fikir ve yazar grafiğine dönüştürün. Her şey yereldir.",
-  "Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.": "Nodus, yerel Zotero 7 API'sini (salt okunur) kullanır. Zotero'yu açın ve bağlantıyı doğrulayın.",
+  "Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.": "Nodus, yerel Zotero API'sini salt okunur modda kullanır (Zotero 7 veya üzeri gerekir). Zotero'yu açın ve bağlantıyı doğrulayın.",
   "Verificar conexión": "Bağlantıyı doğrula",
   "Conectado (userID {id})": "Bağlandı (kullanıcı kimliği {id})",
   "No disponible: {msg}": "Mevcut değil: {msg}",

--- a/src/views/Onboarding.tsx
+++ b/src/views/Onboarding.tsx
@@ -335,7 +335,7 @@ export function Onboarding({
         {step === 0 && !simple && (
           <div className="space-y-4">
             <p className="text-sm">
-              {t('Nodus usa la API local de Zotero 7 (solo lectura). Abre Zotero y verifica la conexión.')}
+              {t('Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.')}
             </p>
             <button className="btn btn-primary" onClick={checkZotero}>
               {t('Verificar conexión')}


### PR DESCRIPTION
Closes #282

## Summary

- reword the onboarding string so it names the API correctly — Zotero's local API, read-only — while keeping the real requirement (Zotero 7 or newer) visible, across the Spanish source and all seven translation tables
- document in `zoteroClient.ts` what the local API actually is, so the wrong name does not get reintroduced by the next person to read the file
- correct the `/children` comment: an unknown item key returns an empty array on Zotero 9.0.6, not the unrelated-items listing the comment asserted
- mark the `Zotero-Allowed-Request` header as load-bearing and describe its real failure mode
- remove `itemsSince()`, which no caller referenced

## Why

There is no "Zotero 7 API". The client talks to Zotero's local implementation of **Web API v3**, served from port 23119. That implementation arrived *in* Zotero 7, which is where the label came from, but 7 was never the API's version — the API version is 3, and Zotero supports exactly one at a time. On a current Zotero the old string reads as an integration two majors behind, which is the opposite of true.

Upstream, Zotero **8.0** did change the local HTTP API (annotations returned, `/fulltext` endpoints added, `since=0` returns everything — [zotero/zotero#5011](https://github.com/zotero/zotero/issues/5011)). Zotero **9.0** documents no local-API changes. None of it broke us; the `/fulltext` addition turned a defensive fallback into a real fast path.

Two comments had drifted from the client's actual behaviour, which matters because both guard something. The `/children` filter is cheap insurance against a stale or foreign key resolving to another item's file and should stay — but its comment justified it with behaviour Zotero no longer has. The `Zotero-Allowed-Request` header is more critical than its comment implied: without it, against Electron's `Mozilla/*` User-Agent, Zotero closes the TCP connection outright rather than returning 403, so it is the single thing standing between Nodus and no Zotero connection at all. Neither should read as removable.

`itemsSince()` was removed rather than repaired. It built `users/<id>` by hand instead of going through `libraryPrefix()`, so it could never have served a group library, and it rested on the `since=0` contract Zotero 8 changed. A genuine incremental-sync path deserves to be written against the current API; a comment marks the spot and the reasoning.

## Impact

User-facing text only, plus a dead export. No behavioural change to the Zotero integration. The public site already said `Zotero 7+` and needed no edit.

## Validation

- verified against a **live Zotero 9.0.6**: the edited client module was bundled and executed against the running app — `ping`, `libraries`, `topCollections`, `collectionItems`, `libraryVersion`, `itemAttachments`, `getFulltext`, `attachmentFilePath`, `resolvePdfAttachmentKey` all correct, including the `/file` redirect to a `file://` path, and `itemsSince` confirmed gone from the exports
- `npm run citation:check`
- `npm run lint` — 0 errors
- `npm run build` (includes typecheck) — clean
- `node --test scripts/test-i18n-coverage.mjs` — 21/21, seven languages
- `node --test scripts/test-zotero-group-libraries.mjs` — 1/1
- `npm test` — full suite
