### PR TITLE
Connect the Zotero sidebar to Nodus without a manual test

### DIFF
--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -3,7 +3,9 @@
 // them in a vm sandbox with minimal stubs (ChromeUtils/Zotero/document) and
 // exercise the parts that don't need a live Zotero or a real DOM.
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -169,6 +171,198 @@ test('util: sampleDocText keeps head AND tail of long docs', () => {
   assert.ok(r.sentChars <= 200 + 60, 'roughly within budget');
   assert.equal(r.totalChars, big.length);
   assert.ok(r.ratio > 0 && r.ratio < 1);
+});
+
+// ─────────────────────────────────────────── auto-connect
+test('util: reconnection backs off while down and idles while connected', () => {
+  const { NodusUtil } = loadModule('util.js');
+  const d = (attempts) => NodusUtil.nextConnectDelay({ connected: false, attempts });
+  assert.equal(d(0), NodusUtil.CONNECT_DELAYS.first, 'first retry is eager — Nodus was probably just launched');
+  assert.ok(d(1) > d(0) && d(2) > d(1), 'backs off instead of hammering the port');
+  assert.equal(d(50), NodusUtil.CONNECT_DELAYS.max, 'capped: a Zotero left open for hours still retries');
+  assert.equal(
+    NodusUtil.nextConnectDelay({ connected: true, attempts: 0 }),
+    NodusUtil.CONNECT_DELAYS.connected,
+    'an established link is only re-validated occasionally',
+  );
+});
+
+test('util: a restarted Nodus (new port or token) invalidates the cached bridge config', () => {
+  const { NodusUtil } = loadModule('util.js');
+  const cfg = { port: 4321, token: 'abc' };
+  assert.equal(NodusUtil.bridgeConfigChanged(cfg, { port: 4321, token: 'abc' }), false);
+  assert.equal(NodusUtil.bridgeConfigChanged(cfg, { port: 4322, token: 'abc' }), true, 'restarted on another port');
+  assert.equal(NodusUtil.bridgeConfigChanged(cfg, { port: 4321, token: 'zzz' }), true, 'token rotated');
+  assert.equal(NodusUtil.bridgeConfigChanged(cfg, null), true, 'bridge file disappeared');
+  assert.equal(NodusUtil.bridgeConfigChanged(null, cfg), true, 'bridge file appeared — Nodus just started');
+  assert.equal(NodusUtil.bridgeConfigChanged(null, null), false);
+});
+
+test('sidebar: the link is established without the user pressing "Test connection"', () => {
+  const src = readSource('zotero-plugin/content/sidebar.js');
+  // The background loop must be armed at boot and re-armed after every attempt,
+  // or the sidebar would go back to needing a manual click.
+  assert.match(src, /scheduleConnectionCheck\(\);\s*\n\s*await refreshItem/, 'boot arms the auto-connect loop');
+  assert.match(src, /connTimer = setTimeout\([\s\S]*?connect\(\)[\s\S]*?scheduleConnectionCheck\)/, 'each attempt schedules the next');
+  assert.match(src, /window\.addEventListener\("focus", retryConnectionNow\)/, 'refocusing Zotero retries immediately');
+  // Sending must try to connect first: "not connected" to a message the user
+  // just typed is exactly the failure this replaces.
+  const send = src.slice(src.indexOf('async function send(text)'), src.indexOf('async function generateAssistant'));
+  assert.ok(send.indexOf('ensureConnected()') < send.indexOf('chat.offline'), 'send() reconnects before refusing');
+  assert.ok(!/state\.mode === "connected" && !state\.connected/.test(send), 'no bare offline gate left in send()');
+  // The token is checked against a guarded endpoint: /health is tokenless.
+  const probe = src.slice(src.indexOf('async function probeConfig'), src.indexOf('let connectInFlight'));
+  assert.match(probe, /\/api\/z\/health/);
+  assert.match(probe, /\/api\/z\/models/, 'a stale token must not read as "connected"');
+});
+
+// ── the sidebar, running for real against a fake Nodus server ────────────────
+// sidebar.js is a plain chrome:// script: its top-level `function`s land on the
+// sandbox global, and `const state` stays visible to later scripts evaluated in
+// the same realm. That is enough to boot the real thing over stub DOM/Zotero
+// and watch it connect on its own.
+function stubEl(doc, tag) {
+  const attrs = {};
+  return {
+    tagName: String(tag || 'div').toUpperCase(), ownerDocument: doc, children: [],
+    className: '', id: '', value: '', textContent: '', innerHTML: '', hidden: false, disabled: false,
+    style: {}, dataset: {},
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    appendChild(c) { this.children.push(c); return c; },
+    insertBefore(c) { this.children.push(c); return c; },
+    removeChild() {}, remove() {}, focus() {}, blur() {}, scrollIntoView() {},
+    setAttribute(k, v) { attrs[k] = v; }, getAttribute: (k) => (k in attrs ? attrs[k] : null), removeAttribute(k) { delete attrs[k]; },
+    addEventListener() {}, removeEventListener() {},
+    querySelector: () => null, querySelectorAll: () => [],
+    getBoundingClientRect: () => ({ top: 0, left: 0, width: 0, height: 0 }),
+  };
+}
+function stubDoc() {
+  const byId = new Map();
+  const doc = {
+    createElement: (tag) => stubEl(doc, tag),
+    createTextNode: (text) => ({ nodeType: 3, textContent: String(text) }),
+    createDocumentFragment: () => stubEl(doc, 'fragment'),
+    getElementById(id) { if (!byId.has(id)) byId.set(id, stubEl(doc, 'div')); return byId.get(id); },
+    querySelector(sel) { return doc.getElementById(String(sel)); },
+    querySelectorAll: () => [],
+    addEventListener() {}, removeEventListener() {},
+  };
+  doc.body = stubEl(doc, 'body');
+  doc.documentElement = stubEl(doc, 'html');
+  return doc;
+}
+const FAKE_STORE = {
+  getMode: () => 'connected', setMode() {}, getLang: () => 'en', setLang() {},
+  getModel: () => null, setModel() {}, getMaxTokens: () => 8192, setMaxTokens() {},
+  getReasoning: () => 'default', setReasoning() {},
+  getHlColors: () => ({ high: '#ff6666', medium: '#ffd400' }), setHlColors() {},
+  getContext: () => ({ useIdeas: true, useCorpus: true, useFulltext: true, strategy: 'auto', ocr: 'off', repair: 'auto', agenticRounds: 1, fullTextThreshold: 48000 }),
+  setContext() {}, getKey: () => '', setKey() {}, getLocalBase: () => '', setLocalBase() {},
+  getPinned: () => [], setPinned() {}, isPinned: () => false, togglePinned: () => [],
+  getCustomPrompts: () => [], addCustomPrompt: () => [], removeCustomPrompt() {},
+  getAutoUpdate: () => false, setAutoUpdate() {}, getAgent: () => false, setAgent() {},
+  getAgentAuto: () => false, setAgentAuto() {},
+  getManual: () => ({ port: 0, token: '' }), setManual() {},
+  loadConversations: async () => [], saveConversations: async () => {},
+  saveEvidenceIndex: async () => {}, loadEvidenceIndex: async () => null,
+  newId: () => 'conv-1', compactAudit: (a) => a,
+};
+// A stand-in for electron/zotero-plugin/server.ts with the property that
+// matters here: /health is tokenless, everything else demands the bearer token.
+const openServers = new Set();
+function fakeNodus(token) {
+  const hits = { total: 0 };
+  const server = http.createServer((req, res) => {
+    hits.total++;
+    const send = (code, body) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(body)); };
+    const url = (req.url || '/').split('?')[0];
+    if (url === '/api/z/health') return send(200, { ok: true, app: 'nodus', vault: 'Test', corpusSize: 3 });
+    if (req.headers.authorization !== `Bearer ${token}`) return send(401, { error: 'bad token' });
+    if (url === '/api/z/models') return send(200, { models: [{ provider: 'openai', model: 'gpt-test' }], default: null });
+    return send(404, {});
+  });
+  openServers.add(server);
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve({ server, hits, port: server.address().port })));
+}
+// A failed assertion must FAIL the run, not hang it: an open listener keeps the
+// test process alive forever, so every server is closed from the after hook.
+const closeServers = async () => {
+  for (const s of openServers) await new Promise((r) => s.close(() => r()));
+  openServers.clear();
+};
+const waitFor = async (fn, ms = 4000) => {
+  const deadline = Date.now() + ms;
+  for (;;) {
+    if (await fn()) return true;
+    if (Date.now() > deadline) return false;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+};
+
+test('sidebar: connects to Nodus by itself, follows a restart, and refuses a stale token', async (t) => {
+  const home = mkdtempSync(path.join(os.tmpdir(), 'nodus-zotero-'));
+  mkdirSync(path.join(home, '.nodus'), { recursive: true });
+  const bridge = path.join(home, '.nodus', 'zotero-bridge.json');
+  const writeBridge = (port, token) => writeFileSync(bridge, JSON.stringify({ port, token, updatedAt: 'now' }));
+
+  const doc = stubDoc();
+  const Zotero = { logError() {}, launchURL() {}, getMainWindow: () => null };
+  const sandbox = {
+    window: { NodusStore: FAKE_STORE, addEventListener() {}, removeEventListener() {}, parent: null },
+    document: doc, console, Zotero,
+    ChromeUtils: { importESModule: () => ({ Zotero }) },
+    Components: { interfaces: { nsIFile: {} } },
+    Services: { dirsvc: { get: () => ({ path: home }) } },
+    PathUtils: { join: (...parts) => path.join(...parts) },
+    IOUtils: { readUTF8: async (p) => readFileSync(p, 'utf8') },
+    fetch, AbortController, AbortSignal, TextDecoder, URL,
+    setTimeout, clearTimeout, setInterval, clearInterval, queueMicrotask,
+  };
+  vm.createContext(sandbox);
+  const run = (code) => vm.runInContext(code, sandbox);
+  t.after(async () => {
+    try { run('stopConnectionWatch(); clearInterval(state.pollTimer);'); } catch (e) {}
+    await closeServers();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  // Nodus is NOT running and there is no bridge file: exactly the situation in
+  // which the plugin used to sit until the user pressed "Test connection".
+  for (const file of ['util.js', 'sidebar.js']) vm.runInContext(readFileSync(path.join(contentDir, file), 'utf8'), sandbox, { filename: file });
+  run('NU.CONNECT_DELAYS.first = 30; NU.CONNECT_DELAYS.max = 60; NU.CONNECT_DELAYS.connected = 60;');
+  assert.equal(await waitFor(async () => run('state.connAttempts') >= 1, 2000), true, 'the loop keeps trying while Nodus is down');
+  assert.equal(run('state.connected'), false);
+
+  // Nodus starts. Nothing in the UI is touched — only the bridge file appears.
+  const token = 'tok-first';
+  const first = await fakeNodus(token);
+  writeBridge(first.port, token);
+  assert.equal(await waitFor(async () => run('state.connected'), 4000), true, 'the sidebar connects with no user action');
+  assert.equal(run('state.config.port'), first.port);
+  assert.equal(await waitFor(async () => run('state.modelsConnected.length') === 1, 2000), true, 'models arrive too, so the composer is usable');
+
+  // Watching must be nearly free: while the link is up and the bridge file is
+  // untouched, the loop reads a local file and leaves Nodus's main process
+  // alone. Measured as requests served, not as elapsed time.
+  const settled = first.hits.total;
+  const tick = run('NU.CONNECT_DELAYS.connected');
+  await new Promise((r) => setTimeout(r, 400)); // ~6 ticks at the 60ms test cadence
+  assert.equal(first.hits.total, settled, `an idle connected sidebar does not poll the server (tick=${tick}ms)`);
+  assert.equal(run('state.connected'), true, 'and it stays connected while idle');
+
+  // Nodus restarts on another port with a fresh token: the cached config is
+  // stale and must be replaced without anyone clicking anything.
+  await new Promise((r) => { openServers.delete(first.server); first.server.close(() => r()); });
+  const second = await fakeNodus('tok-second');
+  writeBridge(second.port, 'tok-second');
+  assert.equal(await waitFor(async () => run('state.connected && state.config.port') === second.port, 4000), true, 'follows a restarted Nodus to its new port');
+
+  // A wrong token still passes the tokenless /health, so the link must be
+  // judged by an endpoint that actually checks it.
+  writeBridge(second.port, 'tok-wrong');
+  assert.equal(await waitFor(async () => run('state.connected') === false, 4000), true, 'a stale token does not read as connected');
+  await new Promise((r) => { openServers.delete(second.server); second.server.close(() => r()); });
 });
 
 // ─────────────────────────────────────────── evidence retrieval
@@ -1047,7 +1241,7 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '2.7.0');
+  assert.equal(manifest.version, '3.0.0', 'bumped so installed plugins pull the auto-connect fix via updates.json');
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -64,7 +64,8 @@ const I18N = {
     "confirm.agentOn": "Enable Agent mode? Nodus will be able to act on your Zotero library (create notes, highlight, tag). Each action still asks for approval unless auto-approve is on.",
     "modal.delOne": "Delete this conversation? This cannot be undone.", "modal.delAll": "Delete ALL conversations? This cannot be undone.",
     "conn.on": "Connected", "conn.off": "Not connected",
-    "conn.detailOn": "Connected to Nodus on port", "conn.detailOff": "Nodus server not found. Enable it in Nodus → Settings → Nodus for Zotero.",
+    "conn.detailOn": "Connected to Nodus on port", "conn.detailOff": "Looking for Nodus… Start the app and enable Nodus → Settings → Nodus for Zotero; the sidebar connects on its own.",
+    "conn.autoOn": "Connected to Nodus.", "conn.autoOff": "Lost the connection to Nodus. Retrying automatically.",
     "item.none": "Select a document in Zotero.", "item.analyzed": "Full analysis in Nodus", "item.notAnalyzed": "Not analyzed in Nodus", "item.ideas": "ideas",
     "prompt.summary": "Summary", "prompt.ideas": "Main ideas", "prompt.connections": "Connections", "prompt.selection": "Explain selection", "prompt.quotes": "Key quotes",
     "p.summary": "Summarize this document.", "p.ideas": "What are the main ideas of this document?",
@@ -161,7 +162,8 @@ const I18N = {
     "confirm.agentOn": "¿Activar el modo Agente? Nodus podrá actuar sobre tu biblioteca de Zotero (crear notas, subrayar, etiquetar). Cada acción pide aprobación salvo que la aprobación automática esté activada.",
     "modal.delOne": "¿Eliminar esta conversación? No se puede deshacer.", "modal.delAll": "¿Eliminar TODAS las conversaciones? No se puede deshacer.",
     "conn.on": "Conectado", "conn.off": "Sin conexión",
-    "conn.detailOn": "Conectado a Nodus en el puerto", "conn.detailOff": "No se encontró el servidor de Nodus. Actívalo en Nodus → Ajustes → Nodus para Zotero.",
+    "conn.detailOn": "Conectado a Nodus en el puerto", "conn.detailOff": "Buscando Nodus… Abre la app y actívalo en Nodus → Ajustes → Nodus para Zotero; la barra se conecta sola.",
+    "conn.autoOn": "Conectado con Nodus.", "conn.autoOff": "Se perdió la conexión con Nodus. Reintentando automáticamente.",
     "item.none": "Selecciona un documento en Zotero.", "item.analyzed": "Análisis completo en Nodus", "item.notAnalyzed": "Sin analizar en Nodus", "item.ideas": "ideas",
     "prompt.summary": "Resumen", "prompt.ideas": "Ideas principales", "prompt.connections": "Conexiones", "prompt.selection": "Explicar selección", "prompt.quotes": "Citas clave",
     "p.summary": "Haz un resumen de este documento.", "p.ideas": "¿Cuáles son las ideas principales de este documento?",
@@ -226,6 +228,7 @@ const I18N = {
 
 const state = {
   mode: "connected", lang: "en", connected: false, config: null,
+  connAttempts: 0, connMisses: 0, connOkAt: 0,
   modelsConnected: [], model: null,
   item: null, attachmentKey: null, selection: "", ideaLabels: {},
   conversations: [], conv: null, busy: false, lastItemKey: null, abort: null,
@@ -262,13 +265,119 @@ async function api(pathname, opts) {
 }
 async function apiJson(pathname, opts) { const r = await api(pathname, opts); if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); }
 
-async function connect() {
-  state.connected = false; state.config = null;
-  if (state.mode === "connected") {
-    state.config = await loadConfig();
-    if (state.config) { try { const h = await apiJson("/api/z/health"); state.connected = Boolean(h && h.ok); } catch (e) {} }
+// Probe a candidate config WITHOUT committing it to state.config, so a failed
+// attempt never tears down a link that still works. Short timeout: the server
+// is on 127.0.0.1, so anything slow is a hang, not latency.
+const HEALTH_TIMEOUT_MS = 4000;
+function timeoutSignal(ms) {
+  try { if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) return AbortSignal.timeout(ms); } catch (e) {}
+  try { const c = new AbortController(); setTimeout(() => { try { c.abort(); } catch (e) {} }, ms); return c.signal; } catch (e) { return undefined; }
+}
+async function probeGet(cfg, pathname) {
+  const r = await fetch("http://127.0.0.1:" + cfg.port + pathname, {
+    method: "GET",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer " + cfg.token },
+    signal: timeoutSignal(HEALTH_TIMEOUT_MS),
+  });
+  if (!r.ok) return null;
+  return r.json();
+}
+async function probeConfig(cfg) {
+  if (!cfg || !cfg.port || !cfg.token) return false;
+  try {
+    // /health is tokenless (it only proves *something* Nodus-shaped is on that
+    // port), so the token is validated against a guarded endpoint: otherwise a
+    // stale manual token would show "connected" and 401 on every real call.
+    const h = await probeGet(cfg, "/api/z/health");
+    if (!h || !h.ok || (h.app && h.app !== "nodus")) return false;
+    const m = await probeGet(cfg, "/api/z/models");
+    return Boolean(m && Array.isArray(m.models));
+  } catch (e) { return false; }
+}
+
+// One connection attempt. Always re-reads the bridge file first, so a Nodus
+// that restarted on another port (or rotated its token) is picked up without
+// the user touching anything. Returns nothing; state + UI are updated in place.
+let connectInFlight = null;
+async function connect(opts) {
+  if (connectInFlight) return connectInFlight;
+  connectInFlight = (async () => {
+    try { await attemptConnect(opts); } catch (e) { try { Zotero.logError(e); } catch (x) {} }
+  })();
+  try { await connectInFlight; } finally { connectInFlight = null; }
+}
+async function attemptConnect(opts) {
+  const wasConnected = state.connected;
+  if (state.mode !== "connected") {
+    state.connected = false; state.config = null; state.connMisses = 0; state.connAttempts = 0;
+    renderConn();
+    return;
+  }
+  const cfg = await loadConfig();
+  const moved = NU && NU.bridgeConfigChanged ? NU.bridgeConfigChanged(state.config, cfg) : false;
+  // A live link whose bridge file hasn't changed needs nothing from the server:
+  // /health counts rows in SQLite on Nodus's single main-process event loop, so
+  // the loop watches the (local, cheap) bridge file and only re-validates over
+  // HTTP once in a while. `force` is the user asking explicitly.
+  const revalidateMs = (NU && NU.CONNECT_DELAYS && NU.CONNECT_DELAYS.revalidate) || 300000;
+  if (state.connected && !moved && !(opts && opts.force) && Date.now() - state.connOkAt < revalidateMs) return;
+  const ok = await probeConfig(cfg);
+  state.config = cfg;
+  if (ok) {
+    state.connected = true; state.connMisses = 0; state.connAttempts = 0; state.connOkAt = Date.now();
+  } else {
+    state.connAttempts++;
+    state.connMisses++;
+    // Tolerate ONE miss on an established link (a busy server, a bridge file
+    // being rewritten) so the composer doesn't flicker off mid-conversation.
+    // A config change is not a hiccup: drop the link immediately.
+    if (!wasConnected || moved || state.connMisses >= 2) state.connected = false;
   }
   renderConn();
+  // `quiet` = the caller (boot, mode switch, Test button) refreshes the model
+  // list itself and the user knows what they did. Only the background loop
+  // reports a link that came up or went down on its own.
+  if (state.connected !== wasConnected && !(opts && opts.quiet)) {
+    await loadModelsForMode();
+    showToast(t(state.connected ? "conn.autoOn" : "conn.autoOff"));
+  }
+}
+
+// ── auto-connect loop ────────────────────────────────────────────────────────
+// Nodus is not necessarily running when Zotero starts, and it may be restarted
+// at any time. Instead of asking the user to press "Test connection", the
+// sidebar keeps looking for the server in the background with a backoff, and
+// re-validates the link periodically once it is up.
+let connTimer = null;
+function scheduleConnectionCheck() {
+  if (connTimer) { clearTimeout(connTimer); connTimer = null; }
+  if (state.mode !== "connected") return; // standalone talks to providers directly
+  const delay = NU && NU.nextConnectDelay
+    ? NU.nextConnectDelay({ connected: state.connected, attempts: state.connAttempts })
+    : 15000;
+  connTimer = setTimeout(() => {
+    connTimer = null;
+    connect().catch(() => {}).then(scheduleConnectionCheck);
+  }, delay);
+}
+function stopConnectionWatch() { if (connTimer) { clearTimeout(connTimer); connTimer = null; } }
+// Before an action that needs the server, give the link one immediate chance
+// instead of waiting out the backoff: the user may have launched Nodus a
+// second ago. Returns true when the action can proceed.
+async function ensureConnected() {
+  if (state.mode !== "connected" || state.connected) return true;
+  state.connAttempts = 0;
+  await connect({ quiet: true });
+  scheduleConnectionCheck();
+  if (state.connected) await loadModelsForMode();
+  return state.connected;
+}
+// Immediate retry on a user-visible moment (focus, opening Settings): the user
+// has typically just launched Nodus and shouldn't wait out the backoff.
+function retryConnectionNow() {
+  if (state.mode !== "connected" || state.connected || connectInFlight) return;
+  state.connAttempts = 0;
+  connect().catch(() => {}).then(scheduleConnectionCheck);
 }
 function renderConn() {
   const chip = $("#nd-conn");
@@ -1283,8 +1392,8 @@ async function fetchHighlightsConnected(doc, signal) {
 }
 async function autoHighlight() {
   if (state.busy || !NH) return;
+  if (!(await ensureConnected())) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.offline")); return; }
   if (!currentModel()) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.noModel")); return; }
-  if (state.mode === "connected" && !state.connected) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.offline")); return; }
   if (!NH.getReaderPdf()) { if (!state.conv) startNewConversation(); addMessage("assistant", t("hl.noReader")); return; }
   if (!state.conv) startNewConversation();
   state.busy = true; state.abort = new AbortController(); updateSendEnabled();
@@ -1325,8 +1434,10 @@ function renderHighlightResult(bodyEl, res) {
 // ─────────────────────────────────────────── send
 async function send(text) {
   if (!text || !text.trim() || state.busy) return;
+  // Connection first: if Nodus started after Zotero, this reconnects in place
+  // instead of answering "not connected" to a message the user just typed.
+  if (!(await ensureConnected())) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.offline")); return; }
   if (!currentModel()) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.noModel")); return; }
-  if (state.mode === "connected" && !state.connected) { if (!state.conv) startNewConversation(); addMessage("assistant", t("chat.offline")); return; }
   if (!state.conv) startNewConversation();
   const uidx = state.conv.messages.push({ role: "user", content: text }) - 1;
   addMessage("user", text, uidx);
@@ -1336,8 +1447,8 @@ async function send(text) {
 // Streams an assistant reply for the current conversation tail (which must end
 // in a user message). Shared by send() and regenerateFrom().
 async function generateAssistant() {
+  if (!(await ensureConnected())) { addMessage("assistant", t("chat.offline")); return; }
   if (!currentModel()) { addMessage("assistant", t("chat.noModel")); return; }
-  if (state.mode === "connected" && !state.connected) { addMessage("assistant", t("chat.offline")); return; }
   state.busy = true; state.abort = new AbortController(); updateSendEnabled();
 
   // Wrapped in try/finally so state.busy ALWAYS resets — otherwise a throw in the
@@ -1668,8 +1779,10 @@ function renderMode() {
 async function setMode(m) {
   state.mode = m === "standalone" ? "standalone" : "connected"; NS.setMode(state.mode);
   renderMode();
-  await connect();
+  state.connAttempts = 0;
+  await connect({ quiet: true });
   await loadModelsForMode();
+  scheduleConnectionCheck(); // stops the loop in standalone, (re)starts it in link mode
   startNewConversation();
 }
 // Swap the static toolbar/composer/header glyphs for inline SVG icons.
@@ -1795,6 +1908,9 @@ function switchTab(name) {
   $$(".nd-tab").forEach((b) => b.classList.toggle("nd-tab--active", b.getAttribute("data-tab") === name));
   $$(".nd-panel").forEach((p) => p.classList.toggle("nd-panel--active", p.getAttribute("data-panel") === name));
   if (name === "providers") renderProviders();
+  // Opening Settings usually means "why isn't it connected?" — retry now
+  // instead of making the user press the button to find out.
+  if (name === "settings") retryConnectionNow();
 }
 
 function wire() {
@@ -1871,7 +1987,16 @@ function wire() {
     finally { state.busy = false; state.abort = null; updateSendEnabled(); }
   });
   $("#nd-visual-btn").addEventListener("click", () => analyzeCurrentPage());
-  $("#nd-test").addEventListener("click", () => { NS.setManual($("#nd-port").value, $("#nd-token").value.trim()); connect().then(loadModelsForMode); });
+  // Manual override (custom port/token). The sidebar connects by itself, so
+  // this is only needed for a non-default setup — it forces an attempt now.
+  $("#nd-test").addEventListener("click", async () => {
+    NS.setManual($("#nd-port").value, $("#nd-token").value.trim());
+    state.connAttempts = 0;
+    await connect({ quiet: true, force: true });
+    await loadModelsForMode();
+    showToast(t(state.connected ? "conn.autoOn" : "conn.detailOff"));
+    scheduleConnectionCheck();
+  });
   window.addEventListener("message", (e) => {
     if (!e.data || e.data.type !== "nodus-selection") return;
     state.selection = String(e.data.text || ""); state.selectionDraft = e.data.draft || null;
@@ -1901,6 +2026,8 @@ function wire() {
   // public event for. Tab switches and item edits arrive instantly via the
   // Notifier below, so this can be slow.
   state.pollTimer = setInterval(() => scheduleRefresh(false), 2000);
+  // Coming back to Zotero is the moment right after "I just opened Nodus".
+  window.addEventListener("focus", retryConnectionNow);
 }
 function saveContext() {
   state.contextStrategy = $("#nd-ctx-strategy").value;
@@ -1940,6 +2067,7 @@ function registerNotifier() {
     window.addEventListener("unload", () => {
       try { if (state.notifierID) Zotero.Notifier.unregisterObserver(state.notifierID); } catch (e) {}
       try { if (state.pollTimer) clearInterval(state.pollTimer); } catch (e) {}
+      try { stopConnectionWatch(); } catch (e) {}
     });
   } catch (e) { try { Zotero.logError(e); } catch (x) {} }
 }
@@ -1979,8 +2107,11 @@ async function boot() {
   renderMode();
   state.conversations = await NS.loadConversations();
   startNewConversation();
-  await connect();
+  await connect({ quiet: true });
   await loadModelsForMode();
+  // Keep looking for Nodus in the background: it may not be running yet (or may
+  // be restarted later), and the user should never have to press a button.
+  scheduleConnectionCheck();
   await refreshItem(true);
 }
 boot().catch((e) => { try { Zotero.logError(e); } catch (x) {} });

--- a/zotero-plugin/content/util.js
+++ b/zotero-plugin/content/util.js
@@ -72,5 +72,33 @@
     return fallback === "es" ? "Spanish" : "English";
   }
 
-  window.NodusUtil = { sampleDocText, conversationToHtml, buildItemsSummary, detectLanguage };
+  // ---- auto-connect policy ----
+  // The sidebar must latch onto the Nodus server on its own: the app may be
+  // launched after Zotero, restarted on another port, or have rotated its
+  // token. Pressing "Test connection" is a manual override, never the normal
+  // path. These two helpers are the pure decisions behind the retry loop.
+
+  // Backoff for the reconnection loop: eager right after a failure (Nodus was
+  // probably just launched), then calm. `connected` is how often an established
+  // link looks at the bridge file (cheap, local); `revalidate` is how rarely it
+  // actually calls the server, because /health counts rows in SQLite on Nodus's
+  // single main-process event loop and must not be polled every few seconds.
+  const CONNECT_DELAYS = { first: 1500, max: 15000, connected: 20000, revalidate: 300000 };
+  function nextConnectDelay(status) {
+    if (status && status.connected) return CONNECT_DELAYS.connected;
+    const attempts = Math.max(0, Math.floor(Number(status && status.attempts) || 0));
+    return Math.min(CONNECT_DELAYS.max, CONNECT_DELAYS.first * Math.pow(2, attempts));
+  }
+
+  // Did the bridge file (port/token) change under us? A restarted Nodus writes
+  // a new port, and the cached config must be dropped even while "connected".
+  function bridgeConfigChanged(a, b) {
+    if (!a || !b) return Boolean(a) !== Boolean(b);
+    return Number(a.port) !== Number(b.port) || String(a.token) !== String(b.token);
+  }
+
+  window.NodusUtil = {
+    sampleDocText, conversationToHtml, buildItemsSummary, detectLanguage,
+    nextConnectDelay, bridgeConfigChanged, CONNECT_DELAYS,
+  };
 })();

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "2.7.0",
+  "version": "3.0.0",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",
   "icons": {


### PR DESCRIPTION
Closes #285.

The Zotero sidebar read `~/.nodus/zotero-bridge.json` once, while it booted, and never looked again. Since Nodus is normally started *after* Zotero, the usual outcome was a sidebar stuck on "not connected" until the user opened Settings and pressed **Test connection**.

## What changed

A background loop keeps looking for the server with a backoff (1.5s → 15s) and re-reads the bridge file on every attempt, so a Nodus that starts late, restarts on another port or rotates its token is picked up on its own — models included, so the composer becomes usable with no click. It also retries immediately at the moments that matter: Zotero regaining focus, Settings being opened, and **before sending a message** (that path used to answer "not connected" to a message the user had just typed).

**Test connection** stays, now only as a manual override for a custom port/token.

Two properties of the server shaped the design:

1. `/api/z/health` is deliberately tokenless, so a health probe alone reports "connected" for a stale token and then 401s on every real call. The probe validates the token against `/api/z/models` too (accepting an empty `models` array — an unconfigured Nodus is still connected).
2. Probing health is not free: it counts rows in SQLite on the main process's single event loop. While the link is up, the loop watches the (local, cheap) bridge file and only re-validates over HTTP every five minutes.

The retry policy lives in `zotero-plugin/content/util.js` as two pure functions (`nextConnectDelay`, `bridgeConfigChanged`) so it is unit-testable.

Plugin version → **3.0.0**, so installed copies pull the fix through `updates.json`. The app version is untouched (`citation:check` still reports 2.8.0); the release bump is a separate step.

## Verification

`node --test scripts/test-zotero-plugin.mjs` → 66/66. Four new tests, including an integration test that boots the **real sidebar** in a vm sandbox (stub DOM/Zotero) with no server running, then brings up a fake Nodus and asserts that the link establishes itself, follows a restart to a new port, and refuses a stale token. Idle cost is measured by **counting requests served**, not elapsed time.

Each new guarantee was checked by breaking it on purpose — boot not arming the loop, no token validation, no bridge re-read, probing on every tick — and confirming the matching assertion fails.
