### PR TITLE
Fix character chat toggle and avatars

### DIFF
--- a/scripts/test-character-chat-ui.mjs
+++ b/scripts/test-character-chat-ui.mjs
@@ -18,6 +18,9 @@ test('character chat exposes persistent history, image opt-in and destructive co
   assert.match(modal, /data-testid="character-chat-history-toggle"/);
   assert.match(modal, /data-testid="character-chat-image-toggle"/);
   assert.match(modal, /role="switch"/);
+  assert.match(modal, /absolute left-0\.5 top-0\.5/, 'the switch thumb is anchored inside its track');
+  assert.match(modal, /PersonPortrait/);
+  assert.match(modal, /data-testid="character-chat-character-avatar"/);
   assert.match(modal, /listCharacterChatConversations/);
   assert.match(modal, /getCharacterChatConversation/);
   assert.match(modal, /deleteCharacterChatConversation/);

--- a/src/components/CharacterInterviewModal.tsx
+++ b/src/components/CharacterInterviewModal.tsx
@@ -8,6 +8,7 @@ import type {
 import { Icon, AiBadge } from './ui';
 import { ConfirmModal } from './ConfirmModal';
 import { ImageLightbox } from './ImageLightbox';
+import { PersonPortrait } from './PersonPortrait';
 import { characterChatImageUrl, characterChatThumbnailUrl } from '../lib/imageUrl';
 import { t, tx } from '../i18n';
 
@@ -288,8 +289,8 @@ export function CharacterInterviewModal({
                 onClick={() => void toggleImages()}
               >
                 <span
-                  className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
-                    imageEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                  className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                    imageEnabled ? 'translate-x-4' : 'translate-x-0'
                   }`}
                 />
               </button>
@@ -339,13 +340,22 @@ export function CharacterInterviewModal({
             {messages.map((message) => (
               <div
                 key={message.id}
-                className={message.role === 'author' ? 'flex justify-end' : 'flex justify-start'}
+                className={message.role === 'author' ? 'flex justify-end' : 'flex items-end gap-2.5'}
               >
+                {message.role === 'character' && (
+                  <div
+                    className="mb-0.5 shrink-0 rounded-full ring-2 ring-white shadow-sm dark:ring-neutral-900"
+                    data-testid="character-chat-character-avatar"
+                    title={character.displayName}
+                  >
+                    <PersonPortrait person={character} size={34} />
+                  </div>
+                )}
                 <div
-                  className={`max-w-[88%] overflow-hidden rounded-xl text-sm leading-6 ${
+                  className={`overflow-hidden text-sm leading-6 ${
                     message.role === 'author'
-                      ? 'bg-indigo-600 px-3 py-2 text-white'
-                      : 'border border-neutral-200 bg-white text-neutral-800 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-neutral-200'
+                      ? 'max-w-[82%] rounded-2xl rounded-br-md bg-indigo-600 px-3.5 py-2 text-white shadow-sm'
+                      : 'max-w-[78%] rounded-2xl rounded-bl-md border border-neutral-200 bg-white text-neutral-800 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-neutral-200 sm:max-w-[80%]'
                   }`}
                 >
                   <p className={message.role === 'author' ? 'whitespace-pre-wrap' : 'whitespace-pre-wrap px-3 py-2'}>
@@ -369,9 +379,14 @@ export function CharacterInterviewModal({
               </div>
             ))}
             {busy && (
-              <p className="flex items-center gap-2 text-xs text-neutral-500">
-                <Icon name="sync" size={12} className="animate-spin" /> {t('Pensando…')}
-              </p>
+              <div className="flex items-end gap-2.5">
+                <div className="mb-0.5 shrink-0 rounded-full ring-2 ring-white shadow-sm dark:ring-neutral-900">
+                  <PersonPortrait person={character} size={34} />
+                </div>
+                <p className="flex items-center gap-2 rounded-2xl rounded-bl-md border border-neutral-200 bg-white px-3 py-2 text-xs text-neutral-500 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70">
+                  <Icon name="sync" size={12} className="animate-spin" /> {t('Pensando…')}
+                </p>
+              </div>
             )}
           </div>
 

--- a/visual-tests/character-chat-harness.html
+++ b/visual-tests/character-chat-harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Character chat visual harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/visual-tests/character-chat-harness.tsx"></script>
+  </body>
+</html>

--- a/visual-tests/character-chat-harness.tsx
+++ b/visual-tests/character-chat-harness.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import type { Character, CharacterChatConversation, NodusApi } from '../shared/types';
+import { CharacterInterviewModal } from '../src/components/CharacterInterviewModal';
+import '../src/index.css';
+
+const createdAt = '2026-07-30T08:00:00.000Z';
+const character: Character = {
+  personId: 'character-ines',
+  displayName: 'Inés Valcárcel',
+  nationalId: null,
+  sex: 'female',
+  birthDate: 'Año 312 de la Concordia',
+  deathDate: null,
+  notes: null,
+  names: [],
+  portrait: null,
+  frameStyle: null,
+  biography: null,
+  biographyAt: null,
+  createdAt,
+  updatedAt: createdAt,
+  profile: {
+    personId: 'character-ines',
+    species: 'Humana',
+    gender: 'Mujer',
+    pronouns: 'ella',
+    lifeStatus: 'alive',
+    narrativeRole: 'protagonist',
+    accent: 'violet',
+    appearance: 'Cabello oscuro, mirada firme y abrigo de viaje.',
+    personality: 'Observadora, directa y leal.',
+    backstory: 'Custodia el último mapa del archipiélago.',
+    visualSeed: null,
+    birthYearSort: 312,
+    deathYearSort: null,
+    arc: { want: null, need: null, flaw: null, lie: null, wound: null },
+    voice: { register: 'Sereno', tics: null, sample: null },
+    biographyProposed: null,
+    biographyProposedAt: null,
+    createdAt,
+    updatedAt: createdAt,
+  },
+};
+
+const conversation: CharacterChatConversation = {
+  id: 'chat-ines',
+  personId: character.personId,
+  title: 'El mapa y la tormenta',
+  imageEnabled: true,
+  messageCount: 4,
+  imageCount: 0,
+  createdAt,
+  updatedAt: '2026-07-30T08:04:00.000Z',
+  messages: [
+    {
+      id: 'message-1',
+      role: 'author',
+      content: '¿Por qué sigues guardando el mapa si ya no confías en el Consejo?',
+      image: null,
+      createdAt: '2026-07-30T08:01:00.000Z',
+    },
+    {
+      id: 'message-2',
+      role: 'character',
+      content: 'Porque desconfiar de ellos no vuelve menos real lo que hay al otro lado del mar. El mapa no les pertenece.',
+      image: null,
+      createdAt: '2026-07-30T08:02:00.000Z',
+    },
+    {
+      id: 'message-3',
+      role: 'author',
+      content: '¿Y a quién se lo entregarías?',
+      image: null,
+      createdAt: '2026-07-30T08:03:00.000Z',
+    },
+    {
+      id: 'message-4',
+      role: 'character',
+      content: 'A alguien dispuesto a cruzar la tormenta sin convertir lo que encuentre en una conquista.',
+      image: null,
+      createdAt: '2026-07-30T08:04:00.000Z',
+    },
+  ],
+};
+
+const api = {
+  listCharacterChatConversations: async () => [conversation],
+  getCharacterChatConversation: async () => conversation,
+  setCharacterChatImagesEnabled: async (_id: string, enabled: boolean) => ({
+    ...conversation,
+    imageEnabled: enabled,
+  }),
+  createCharacterChatConversation: async () => conversation,
+  sendCharacterChatMessage: async () => ({ conversation, imageError: null }),
+  deleteCharacterChatConversation: async () => undefined,
+} as unknown as NodusApi;
+
+window.nodus = api;
+document.documentElement.classList.add('light', 'worldbuilding');
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <main className="min-h-screen bg-gradient-to-br from-violet-100 via-neutral-100 to-white">
+      <CharacterInterviewModal character={character} onClose={() => undefined} />
+    </main>
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Qué cambia

- Ancla el círculo del interruptor de imágenes dentro de su pista en ambos estados.
- Muestra el retrato circular del personaje junto a cada respuesta y durante el estado «Pensando…».
- Ajusta las burbujas para distinguir mejor los mensajes del autor y del personaje.
- Añade cobertura de regresión y un harness visual reproducible para el chat.

## Motivo

El círculo del interruptor usaba una posición horizontal implícita, por lo que al activarse podía desplazarse fuera de la pista. Además, las respuestas carecían de una referencia visual clara al personaje.

## Impacto

El control queda alineado y el chat identifica visualmente quién habla usando el retrato configurado o la silueta de respaldo.

## Validación

- `npm run typecheck`
- `npm run build`
- `npx eslint src/components/CharacterInterviewModal.tsx visual-tests/character-chat-harness.tsx`
- `node --test scripts/test-character-chat-ui.mjs`
- Revisión visual del interruptor activado y de dos avatares circulares en el harness