### PR TITLE
Give the release build the same heap limit CI already has

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,13 @@ jobs:
         run: npm ci
 
       - name: Build renderer + main
+        env:
+          # The main-process bundle is ~1,000 modules and 6.4 MB, and rolling it up
+          # peaks above Node's default heap on the macOS arm64 runner — which is the
+          # smallest of the three and dies at ~2 GB with "Reached heap limit".
+          # ci.yml has carried this same bump since it hit the wall; release.yml
+          # never got it, so the mismatch only ever surfaced at release time.
+          NODE_OPTIONS: --max-old-space-size=4096
         run: npm run build
 
       - name: Build and publish Windows installer


### PR DESCRIPTION
## What happened

The macOS job of the v3.0.0 release failed:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
sh: line 1: 4602 Abort trap: 6           vite build
```

It died rolling up the main-process bundle — ~1,000 modules and 6.4 MB after the four new vaults landed in this cycle. The macOS arm64 runner is the smallest of the three, and Node's default old-space cap there is about 2 GB; the crash log shows it topping out at 2,023 MB.

## Why it only showed up now

The two workflows disagree about how much memory the same command needs:

```yaml
# ci.yml
- name: Build (includes typecheck)
  env:
    NODE_OPTIONS: --max-old-space-size=4096
  run: npm run build

# release.yml
- name: Build renderer + main
  run: npm run build          # ← no NODE_OPTIONS
```

`ci.yml` has carried that bump since it hit the same wall. `release.yml` never got it. So CI passes on every branch and the failure is invisible until a tag is pushed — the one moment where it is most expensive to discover.

## Verification

Reproduced and fixed locally:

| Heap cap | Result |
|---|---|
| `--max-old-space-size=2048` | fails at the same stage, same message |
| `--max-old-space-size=4096` | builds cleanly, `main-*.js` 6,494 kB |

Also reproduced the 2 GB failure with the `vite.config.ts` from *before* the IPC split, which rules out the per-window preload builds added in #295: the main bundle has simply outgrown the default. The three preload builds complete in about 5 s combined and are not where the memory goes.

## Note for later

4096 restores headroom rather than creating much of it — the bundle grew past 2 GB during one release cycle. If it keeps growing, the durable fix is code-splitting the main process (electron-builder does not require a single file) rather than raising this number again.

Blocks the v3.0.0 release.
