### PR TITLE
Limit the upload and the expanded publication separately

### DIFF
--- a/electron/serverSync/serverSyncService.ts
+++ b/electron/serverSync/serverSyncService.ts
@@ -72,6 +72,19 @@ function ensureRuntime(vaultId: string): VaultRuntime {
   return rt;
 }
 
+// A rejection for size is the one publish failure the user can act on from the app,
+// so it says how big this vault actually is and which switch shrinks it. The server
+// only knows the compressed upload; the uncompressed figure lives here.
+function tooLargeMessage(config: VaultServerConfig, serverError: string, rawBytes: number): string {
+  const size = `Esta bóveda ocupa ${(rawBytes / (1024 * 1024)).toFixed(1)} MiB sin comprimir.`;
+  const lever = config.includePassages
+    ? 'Desactiva «Incluir pasajes extraídos» para dejar fuera el texto completo de las obras.'
+    : config.includeUserContent
+      ? 'Desactiva «Incluir contenido creado por mí» para dejar fuera notas, proyectos y borradores.'
+      : 'Pide a quien administra el servidor que amplíe NODUS_MAX_SNAPSHOT_JSON_BYTES.';
+  return `${serverError || 'El servidor ha rechazado la publicación por su tamaño.'} ${size} ${lever}`;
+}
+
 function normalizeUrl(value: string): string {
   const clean = value.trim().replace(/\/+$/, '');
   let parsed: URL;
@@ -290,6 +303,7 @@ async function publishVault(vaultId: string): Promise<void> {
       rt.pending = false;
       return;
     }
+    if (response.status === 413) throw new Error(tooLargeMessage(config, result.error || '', snapshot.buffer.length));
     if (!response.ok) throw new Error(result.error || `El servidor respondió con HTTP ${response.status}.`);
     rt.lastRevision = snapshot.revision;
     rt.dirtySince = 0;

--- a/scripts/test-nodus-server.mjs
+++ b/scripts/test-nodus-server.mjs
@@ -71,6 +71,7 @@ function serverEnvironment(overrides = {}) {
   for (const name of [
     'NODUS_ADMIN_EMAIL', 'NODUS_ADMIN_PASSWORD', 'NODUS_ADMIN_EMAIL_FILE', 'NODUS_ADMIN_PASSWORD_FILE',
     'NODUS_SETUP_TOKEN', 'NODUS_PUBLIC_URL', 'NODUS_DATA_DIR', 'NODUS_HOST', 'NODUS_PORT',
+    'NODUS_MAX_SNAPSHOT_BYTES', 'NODUS_MAX_SNAPSHOT_JSON_BYTES',
   ]) delete env[name];
   return { ...env, ...overrides };
 }
@@ -280,6 +281,132 @@ test('partial environment administrator configuration fails closed', { timeout: 
     assert.match(logs.join(''), /must be configured together/);
     assert.ok(!logs.join('').includes('partial-admin@example.test'));
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('an unusable publication limit stops the server instead of rejecting every publication', { timeout: 10_000 }, async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-server-limit-env-test-'));
+  const child = spawn(process.execPath, ['server/server.mjs'], {
+    cwd: path.resolve('.'),
+    env: serverEnvironment({
+      NODUS_DATA_DIR: root,
+      NODUS_HOST: '127.0.0.1',
+      NODUS_PORT: String(await freePort()),
+      // "0 means no limit" everywhere else; here it used to reach zlib and make every
+      // upload fail as if it were corrupt.
+      NODUS_MAX_SNAPSHOT_BYTES: '0',
+    }),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const logs = [];
+  child.stdout.on('data', (chunk) => logs.push(chunk.toString()));
+  child.stderr.on('data', (chunk) => logs.push(chunk.toString()));
+  try {
+    const exitCode = await new Promise((resolve) => child.once('exit', resolve));
+    assert.notEqual(exitCode, 0);
+    assert.match(logs.join(''), /NODUS_MAX_SNAPSHOT_BYTES must be a whole number of bytes/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('the upload limit and the expanded-publication limit are enforced separately', { timeout: 20_000 }, async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-server-snapshot-size-test-'));
+  const port = await freePort();
+  const origin = `http://127.0.0.1:${port}`;
+  const setupToken = 'size-test-setup-token-very-long';
+  const uploadLimit = 64 * 1024;
+  const expandedLimit = 1024 * 1024;
+  const logs = [];
+  const child = spawn(process.execPath, ['server/server.mjs'], {
+    cwd: path.resolve('.'),
+    env: serverEnvironment({
+      NODUS_DATA_DIR: root,
+      NODUS_HOST: '127.0.0.1',
+      NODUS_PORT: String(port),
+      NODUS_PUBLIC_URL: origin,
+      NODUS_SETUP_TOKEN: setupToken,
+      NODUS_MAX_SNAPSHOT_BYTES: String(uploadLimit),
+      NODUS_MAX_SNAPSHOT_JSON_BYTES: String(expandedLimit),
+    }),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (chunk) => logs.push(chunk.toString()));
+  child.stderr.on('data', (chunk) => logs.push(chunk.toString()));
+
+  const publish = (body, revision) => fetch(`${origin}/api/v1/spaces/${spaceId}/snapshot`, {
+    method: 'PUT',
+    headers: {
+      authorization: `Bearer ${deviceToken}`,
+      'content-type': 'application/vnd.nodus.snapshot+json',
+      'content-encoding': 'gzip',
+      'x-nodus-revision': revision,
+    },
+    body,
+  });
+  const snapshotWithAbstract = (length) => JSON.stringify({
+    format: 'nodus.server-snapshot',
+    formatVersion: 1,
+    generatedAt: new Date().toISOString(),
+    vault: { id: 'vault-size', name: 'Corpus grande', type: 'academic' },
+    tables: { works: [{ nodus_id: 'work-1', title: 'Obra extensa', abstract: 'p'.repeat(length) }] },
+  });
+
+  let spaceId;
+  let deviceToken;
+  try {
+    await waitForHealth(origin, child, logs);
+    const setup = await postForm(`${origin}/setup`, {
+      setupToken, name: 'Nodus Size', publicUrl: origin, email: 'admin@example.test', password: 'admin-password-strong',
+    });
+    assert.equal(setup.status, 303);
+    const adminCookie = cookieFrom(setup);
+    const csrf = hidden(await (await fetch(`${origin}/`, { headers: { cookie: adminCookie } })).text(), 'csrf');
+    assert.equal((await postForm(`${origin}/admin/spaces`, { csrf, name: 'Corpus', description: '' }, { headers: { cookie: adminCookie } })).status, 303);
+    const dashboard = await (await fetch(`${origin}/`, { headers: { cookie: adminCookie } })).text();
+    spaceId = dashboard.match(/<code>([0-9a-f-]{36})<\/code>/)?.[1];
+    assert.ok(spaceId);
+    const pairingHtml = await (await postForm(`${origin}/admin/pairing`, { csrf, spaceId }, { headers: { cookie: adminCookie } })).text();
+    const paired = await (await fetch(`${origin}/api/v1/pair`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: pairingHtml.match(/<h2><code>([^<]+)<\/code><\/h2>/)?.[1], deviceName: 'Size test desktop' }),
+    })).json();
+    deviceToken = paired.accessToken;
+    assert.ok(deviceToken);
+
+    // The regression: 200 KiB of JSON is far past the 64 KiB upload cap yet gzips to a
+    // few hundred bytes, so it must publish. Reusing the upload cap as the expansion
+    // cap rejected exactly this case as an invalid publication.
+    const roomy = await publish(gzipSync(Buffer.from(snapshotWithAbstract(200 * 1024))), 'revision-roomy');
+    assert.equal(roomy.status, 200, 'a small upload that expands past the upload cap still fits the expansion cap');
+    assert.equal((await roomy.json()).unchanged, false);
+
+    const expandedTooBig = await publish(gzipSync(Buffer.from(snapshotWithAbstract(2 * 1024 * 1024))), 'revision-huge');
+    assert.equal(expandedTooBig.status, 413);
+    const expandedError = await expandedTooBig.json();
+    assert.equal(expandedError.limitBytes, expandedLimit);
+    assert.ok(expandedError.expandedBytes > expandedLimit, 'the rejection names the real expanded size');
+    assert.match(expandedError.error, /expands to 2\.0 MiB .* up to 1\.0 MiB/);
+
+    // Random base64 does not compress, so this one is rejected on the wire instead.
+    const uploadTooBig = await publish(gzipSync(randomBytes(120 * 1024).toString('base64')), 'revision-wire');
+    assert.equal(uploadTooBig.status, 413);
+    assert.equal((await uploadTooBig.json()).limitBytes, uploadLimit);
+
+    const corrupt = await publish(Buffer.from('this is not gzip at all'), 'revision-corrupt');
+    assert.equal(corrupt.status, 400);
+    assert.match((await corrupt.json()).error, /must be gzipped JSON/);
+
+    const notJson = await publish(gzipSync(Buffer.from('{"format": broken')), 'revision-not-json');
+    assert.equal(notJson.status, 400);
+
+    // Every rejection above left the accepted publication in place.
+    const state = JSON.parse(await readFile(path.join(root, 'state.json'), 'utf8'));
+    assert.equal(state.spaces[0].revision, 'revision-roomy');
+  } finally {
+    await stopServer(child);
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/server/README.md
+++ b/server/README.md
@@ -165,6 +165,22 @@ and current manuscript prose. Private chats, AI proposals, manuscript snapshots,
 credentials, local paths, embeddings and binary files are never published. Teacher
 notes/projects/materials and extracted academic passages have separate switches.
 
+### Publication size
+
+A publication travels gzipped and is expanded into JSON in memory, and that JSON is around ten
+times larger than the upload. The two sizes therefore have separate limits:
+
+- `NODUS_MAX_SNAPSHOT_BYTES`: largest gzipped upload accepted, 100 MiB by default. Keep your proxy
+  in agreement with it (`client_max_body_size` in Nginx).
+- `NODUS_MAX_SNAPSHOT_JSON_BYTES`: largest expanded publication accepted, 384 MiB by default. This
+  is what a big vault runs into first, and it is what bounds the memory the server needs to read a
+  space. It can never go past 512 MiB, the largest string Node can build.
+
+Both accept a whole number of bytes, at least 65536; a value the server cannot use (`0`, `200m`)
+stops the boot instead of making every publication fail. When a vault no longer fits, the desktop
+says how large it is and which switch to turn off ("Include extracted passages" is usually most of
+the weight).
+
 ## Provide access to students or researchers
 
 1. From the web administration it creates a reading account with a temporary password and assigns it

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -2,6 +2,7 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { constants as bufferLimits } from 'node:buffer';
 import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
@@ -10,12 +11,32 @@ import { body, contentSecurityPolicy, cookies, escapeHtml, form, html, json, jso
 import { normalizeServerLanguage, serverTranslator } from './lib/i18n.mjs';
 import { helpTip, languagePicker, nodusMark, WEB_STYLES } from './lib/webUi.mjs';
 
+// A zero, a `200m`-style unit or a value past what Node can hold in a single buffer
+// would otherwise reach zlib and turn every publication into an opaque rejection, so
+// an unusable limit stops the server at boot the way a half-configured admin does.
+function byteLimit(name, fallback, ceiling) {
+  const configured = String(process.env[name] ?? '').trim();
+  if (!configured) return fallback;
+  const value = Number(configured);
+  if (!Number.isSafeInteger(value) || value < 64 * 1024 || value > ceiling) {
+    throw new Error(`${name} must be a whole number of bytes between ${64 * 1024} and ${ceiling}.`);
+  }
+  return value;
+}
+
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = process.env.NODUS_DATA_DIR || path.join(ROOT, 'data');
 const PORT = Number(process.env.NODUS_PORT || 7443);
 const HOST = process.env.NODUS_HOST || '0.0.0.0';
 const SETUP_TOKEN = process.env.NODUS_SETUP_TOKEN || '';
-const MAX_SNAPSHOT_BYTES = Number(process.env.NODUS_MAX_SNAPSHOT_BYTES || 100 * 1024 * 1024);
+/** How large the gzipped upload may be on the wire. Mirror it in your proxy. */
+const MAX_SNAPSHOT_BYTES = byteLimit('NODUS_MAX_SNAPSHOT_BYTES', 100 * 1024 * 1024, bufferLimits.MAX_LENGTH);
+// A publication travels gzipped but is expanded into one JSON string before parsing,
+// and JSON of this shape shrinks around ten times over: the upload cap says nothing
+// about the memory the expanded projection needs, so it gets a ceiling of its own
+// rather than borrowing the one meant for the wire. Sharing a single number made a
+// perfectly ordinary vault fail as if its upload had been corrupt.
+const MAX_SNAPSHOT_JSON_BYTES = byteLimit('NODUS_MAX_SNAPSHOT_JSON_BYTES', 384 * 1024 * 1024, bufferLimits.MAX_STRING_LENGTH);
 const store = new Store(DATA_DIR);
 const snapshotCache = new Map();
 const rateBuckets = new Map();
@@ -199,13 +220,48 @@ function oauthChallenge(res, scope = 'materials.read') {
   });
 }
 
+function mib(value) {
+  return `${(value / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+/** Expanded size a gzip stream declares in its trailer, or null when it is not gzip. */
+function declaredGzipSize(bytes) {
+  return bytes.length >= 18 && bytes[0] === 0x1f && bytes[1] === 0x8b ? bytes.readUInt32LE(bytes.length - 4) : null;
+}
+
+/**
+ * Expand an uploaded publication, keeping the two ways it can fail apart: too big to
+ * hold in memory, or not readable gzipped JSON at all. The trailer is only a hint —
+ * it costs nothing, it names the real size in the rejection, and `maxOutputLength`
+ * still enforces the limit when a client lies about it.
+ */
+function expandSnapshot(bytes) {
+  const declared = declaredGzipSize(bytes);
+  if (declared !== null && declared > MAX_SNAPSHOT_JSON_BYTES) return { reason: 'too-large', expanded: declared };
+  let text;
+  try {
+    text = gunzipSync(bytes, { maxOutputLength: MAX_SNAPSHOT_JSON_BYTES }).toString('utf8');
+  } catch (error) {
+    if (error?.code === 'ERR_BUFFER_TOO_LARGE' || error?.code === 'ERR_STRING_TOO_LONG') return { reason: 'too-large', expanded: declared };
+    return { reason: 'invalid' };
+  }
+  try {
+    return { value: JSON.parse(text) };
+  } catch {
+    return { reason: 'invalid' };
+  }
+}
+
 function readSnapshot(spaceId) {
   const target = store.snapshotPath(spaceId);
   if (!fs.existsSync(target)) return null;
   const stat = fs.statSync(target);
   const cached = snapshotCache.get(spaceId);
   if (cached?.mtimeMs === stat.mtimeMs) return cached.value;
-  const value = JSON.parse(gunzipSync(fs.readFileSync(target), { maxOutputLength: MAX_SNAPSHOT_BYTES }).toString('utf8'));
+  // Stored publications passed the publish-time limit already, so read them against
+  // the hard ceiling: lowering NODUS_MAX_SNAPSHOT_JSON_BYTES must not make a space
+  // that is already on disk unreadable to every MCP client.
+  const value = JSON.parse(gunzipSync(fs.readFileSync(target), { maxOutputLength: bufferLimits.MAX_STRING_LENGTH }).toString('utf8'));
   snapshotCache.set(spaceId, { mtimeMs: stat.mtimeMs, value });
   return value;
 }
@@ -807,9 +863,18 @@ async function route(req, res) {
     if (req.headers['content-encoding'] !== 'gzip') return json(res, 415, { error: 'The publication must be gzip-compressed.' });
     const revision = String(req.headers['x-nodus-revision'] || '');
     if (revision && revision === space.revision) return json(res, 200, { ok: true, unchanged: true, updatedAt: space.updatedAt });
+    const announced = Number(req.headers['content-length'] || 0);
+    if (announced > MAX_SNAPSHOT_BYTES) {
+      return json(res, 413, { error: `The compressed publication is ${mib(announced)} and this server accepts uploads of up to ${mib(MAX_SNAPSHOT_BYTES)} (NODUS_MAX_SNAPSHOT_BYTES).`, limitBytes: MAX_SNAPSHOT_BYTES, uploadBytes: announced });
+    }
     const bytes = await body(req, MAX_SNAPSHOT_BYTES);
-    let snapshot;
-    try { snapshot = JSON.parse(gunzipSync(bytes, { maxOutputLength: MAX_SNAPSHOT_BYTES }).toString('utf8')); } catch { return json(res, 400, { error: 'The compressed publication is invalid or exceeds the size limit.' }); }
+    const expanded = expandSnapshot(bytes);
+    if (expanded.reason === 'too-large') {
+      const size = expanded.expanded === null ? 'past the limit' : `to ${mib(expanded.expanded)}`;
+      return json(res, 413, { error: `The publication expands ${size} and this server accepts up to ${mib(MAX_SNAPSHOT_JSON_BYTES)} of expanded data (NODUS_MAX_SNAPSHOT_JSON_BYTES).`, limitBytes: MAX_SNAPSHOT_JSON_BYTES, expandedBytes: expanded.expanded });
+    }
+    if (expanded.reason) return json(res, 400, { error: 'The compressed publication is not readable: the body must be gzipped JSON.' });
+    const snapshot = expanded.value;
     if (snapshot?.format !== 'nodus.server-snapshot' || snapshot?.formatVersion !== 1) return json(res, 400, { error: 'Unsupported publication format.' });
     store.writeSnapshot(space.id, bytes); snapshotCache.delete(space.id);
     space.updatedAt = new Date().toISOString(); space.revision = revision || snapshot.revision || ''; space.vault = snapshot.vault; space.bytes = bytes.length;


### PR DESCRIPTION
Closes #297.

A publication travels gzipped and is expanded into JSON before it is parsed, and JSON of this shape shrinks around ten times over. `server/server.mjs` limited both with the same number, so `maxOutputLength` was effectively an *expanded* cap of 100 MiB: a vault that uploaded 10 MiB was rejected for holding 120 MiB of JSON, and the single `catch` reported it with the same sentence it used for a corrupt body.

## What changed

**`server/server.mjs`**

- `NODUS_MAX_SNAPSHOT_BYTES` keeps its meaning — the gzipped upload, 100 MiB, the number the README already tells you to mirror in Nginx. `NODUS_MAX_SNAPSHOT_JSON_BYTES` is new and limits the expanded publication (384 MiB, hard-clamped to `buffer.constants.MAX_STRING_LENGTH`, which is the largest string Node can build and therefore the real ceiling).
- `expandSnapshot()` keeps "too large" and "not readable gzipped JSON" apart. The size in the rejection comes from the gzip trailer, which costs nothing to read; `maxOutputLength` still enforces the limit when a client lies about it. Too-large is now `413` with `limitBytes` and the size it saw; unreadable stays `400`.
- A limit the server cannot use (`0`, `200m`, anything past `kMaxLength`) now stops the boot, the way a half-configured administrator already does. Before, it reached zlib and made every publication fail as if it were corrupt — `0` being the natural way to write "no limit".
- Stored publications are read back against the hard ceiling rather than the configured one, so lowering the limit cannot make a space that is already on disk unreadable to every MCP client.

**`electron/serverSync/serverSyncService.ts`** — on a `413`, the desktop appends what only it knows: how large the vault is uncompressed, and the switch that shrinks it (*Incluir pasajes extraídos*, then *Incluir contenido creado por mí*, then "ask the admin to raise the limit").

**`server/README.md`** — a short *Publication size* section documenting both variables.

## Tests

Two new cases in `scripts/test-nodus-server.mjs`, on a server booted with a 64 KiB upload cap and a 1 MiB expanded cap:

- 200 KiB of JSON gzips to a few hundred bytes and must publish. **This fails on `main`** (`413`, or `400` before this branch's status change) — it is the reported bug at small scale. Verified by re-pointing the expanded limit at the upload limit and watching it go red.
- 2 MiB of JSON is rejected `413` naming both sizes; an incompressible 120 KiB upload is rejected on the wire against the other limit; a non-gzip body and gzipped non-JSON are rejected `400`; and the accepted publication survives all four rejections.
- Plus a boot test: `NODUS_MAX_SNAPSHOT_BYTES=0` exits non-zero instead of starting.

`npm test` is green except `test-prosopography-e2e.mjs`, which fails the same way on a clean checkout of this branch's base.
