### PR TITLE
Performance audit: unblock the main process, stop Nodi animating at rest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,13 @@ release/
 
 # esbuild smoke-test bundles (generated at repo root)
 .smoke-*.mjs
+# Bundles the perf benches build next to the sources they import (esbuild needs the
+# output inside the repo for --packages=external to resolve).
+.bench-*.cjs
+.bench-*.cjs.map
+.bench-*.mjs
+.dump*.cjs
+.tmpbench/
 build/NodusDockTile.docktileplugin/
 
 # Local tooling / caches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 3.0.1 — 2026-07-30
+
+A performance release, from an audit run against a real 465 MB academic vault.
+No new surface; three causes behind the app feeling slow, plus the tooling that
+found them so the other vault types can be measured the same way.
+
+### Fixed
+
+- **Sections that blocked the whole window now open promptly.** Every read path
+  runs to completion on the single main-process event loop that also answers the
+  renderer, so a slow query is not slow rendering — it is a frozen application.
+  The graph bound one placeholder per idea into its aggregate queries, making
+  SQLite's cost grow with ideas x works (2,745 ms -> 170 ms). The argument map
+  loaded 9,721 nodes and 34,531 edges to fill a picker that shows sixty and never
+  reads an edge (448 ms -> 16 ms, and its IPC payload 10.0 MB -> 2.4 MB). Debates
+  rebuilt each side once per edge and fetched works one at a time through a batch
+  API (261 ms -> 87 ms). The reading path assembled every gap statement in the
+  corpus to display three (212 ms -> 157 ms). Author dossiers ran the same theme
+  query once per related author (397 ms -> 69 ms).
+- **Nodi no longer animates when nothing is happening.** Its SVG repainted every
+  frame forever, costing about half a core with the application idle and warming
+  the machine. It now holds its pose a few seconds after the last activity and
+  wakes on hover, on a state change or on a notification; the animations are
+  paused, not removed, so they resume exactly where they stopped.
+- **The extracted-text cache is bounded.** It was written with an upsert and never
+  pruned, reaching a quarter of the vault file and entering every backup archive.
+  It is capped at 64 MB, newest first; evicted text is re-extracted on demand.
+
+### Added
+
+- Six benchmarks under `scripts/bench-*` that measure main-process blocking, idle
+  CPU per helper process, per-section render cost in the real window, and SQL
+  attribution per statement. They run against a copy of a profile, never the live
+  one.
+
 ## 3.0.0 — 2026-07-30
 
 Four new vault types arrived in this cycle, which is what moves the major. A

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.0.0"
+version: "3.0.1"
 date-released: "2026-07-30"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"

--- a/electron/ai/authorDossier.ts
+++ b/electron/ai/authorDossier.ts
@@ -216,18 +216,38 @@ function themesByIdeaForAuthor(authorId: string): Map<string, string[]> {
   return map;
 }
 
-/** The distinct set of theme labels an author touches (for shared-theme overlap). */
-function authorThemeSet(authorId: string): Set<string> {
+/**
+ * The distinct theme labels each of these authors touches, for shared-theme overlap.
+ *
+ * Takes the whole set at once because the caller needs it for the author plus every
+ * counterpart it is related to. Asked one author at a time it cost about 4 ms each,
+ * and a well-connected author has dozens of counterparts — 190 ms of the 197 ms an
+ * author dossier took was this one query run 47 times.
+ *
+ * The ORDER BY is load-bearing, not decoration. Per author, the old query happened
+ * to come back alphabetical, so the shared-theme lists the UI shows were alphabetical
+ * too — by accident of the plan, never by request. Grouping several authors into one
+ * query changes that accident. Asking for the order makes it a guarantee instead.
+ */
+function authorThemeSets(authorIds: string[]): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  if (authorIds.length === 0) return result;
   const rows = getDb()
     .prepare(
-      `SELECT DISTINCT t.label AS label
+      `SELECT DISTINCT wa.author_id AS authorId, t.label AS label
          FROM work_authors wa
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN themes t ON t.theme_id = itl.theme_id
-        WHERE wa.author_id = ?`
+        WHERE wa.author_id IN (${authorIds.map(() => '?').join(',')})
+        ORDER BY t.label`
     )
-    .all(authorId) as { label: string }[];
-  return new Set(rows.map((r) => r.label));
+    .all(...authorIds) as { authorId: string; label: string }[];
+  for (const row of rows) {
+    const set = result.get(row.authorId) ?? new Set<string>();
+    set.add(row.label);
+    result.set(row.authorId, set);
+  }
+  return result;
 }
 
 function loadIdeas(authorId: string): AuthorDossierIdea[] {
@@ -315,15 +335,15 @@ function loadRelations(authorId: string): AuthorDossierRelation[] {
       (a) => [a.author_id, a.name] as const
     )
   );
-  const mine = authorThemeSet(authorId);
-  const themeCache = new Map<string, Set<string>>();
+  const counterparts = rows.map((r) => (r.from_author === authorId ? r.to_author : r.from_author));
+  const themeCache = authorThemeSets([...new Set([authorId, ...counterparts])]);
+  const mine = themeCache.get(authorId) ?? new Set<string>();
 
   // aggregate per counterpart + relation type
   const agg = new Map<string, AuthorDossierRelation>();
   for (const r of rows) {
     const other = r.from_author === authorId ? r.to_author : r.from_author;
-    if (!themeCache.has(other)) themeCache.set(other, authorThemeSet(other));
-    const shared = [...themeCache.get(other)!].filter((t) => mine.has(t));
+    const shared = [...(themeCache.get(other) ?? [])].filter((t) => mine.has(t));
     const key = `${other}::${r.type}`;
     const cur = agg.get(key) ?? {
       author_id: other,

--- a/electron/db/extractionCacheRepo.ts
+++ b/electron/db/extractionCacheRepo.ts
@@ -1,7 +1,20 @@
 import { getDb } from './database';
+import { planExtractionCacheEviction } from '@shared/extractionCachePrune';
 import type { PdfAnalysis, SourceType } from '@shared/types';
 
 export const EXTRACTION_CACHE_VERSION = 1;
+
+/** How much extracted text the cache may hold before the oldest entries go. */
+const MAX_CACHE_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Reading every row's `length(text)` means touching all the cached text, so the
+ * prune is throttled rather than run on every extraction. It stays off the app's
+ * critical paths entirely: it only ever runs right after a document was extracted,
+ * which already cost seconds of PDF parsing.
+ */
+const PRUNE_INTERVAL_MS = 5 * 60_000;
+let lastPruneAt = 0;
 
 interface OcrCacheOptions {
   enabled: boolean;
@@ -107,6 +120,39 @@ export function upsertExtractionCache(key: CacheKey, doc: ExtractionCacheDoc): v
       now,
       now
     );
+  maybePruneExtractionCache();
+}
+
+/**
+ * Trim the cache to `maxBytes`, keeping the most recently extracted text. Returns
+ * what it removed so callers and tests can assert on it.
+ */
+export function pruneExtractionCache(maxBytes = MAX_CACHE_BYTES): { removed: number; freedBytes: number } {
+  const db = getDb();
+  const rows = db
+    .prepare(`SELECT file_path, length(text) AS bytes, updated_at FROM extraction_cache`)
+    .all() as { file_path: string; bytes: number | null; updated_at: string }[];
+  const plan = planExtractionCacheEviction(
+    rows.map((row) => ({ filePath: row.file_path, bytes: row.bytes ?? 0, updatedAt: row.updated_at })),
+    { maxBytes }
+  );
+  if (plan.remove.length === 0) return { removed: 0, freedBytes: 0 };
+  const remove = db.prepare(`DELETE FROM extraction_cache WHERE file_path = ?`);
+  db.transaction((paths: string[]) => {
+    for (const filePath of paths) remove.run(filePath);
+  })(plan.remove);
+  return { removed: plan.remove.length, freedBytes: plan.freedBytes };
+}
+
+function maybePruneExtractionCache(): void {
+  const now = Date.now();
+  if (now - lastPruneAt < PRUNE_INTERVAL_MS) return;
+  lastPruneAt = now;
+  try {
+    pruneExtractionCache();
+  } catch {
+    // A cache that failed to shrink must never fail the extraction that filled it.
+  }
 }
 
 function parseAnalysis(value: string | null): PdfAnalysis | undefined {

--- a/electron/db/ideasRepo.ts
+++ b/electron/db/ideasRepo.ts
@@ -21,6 +21,7 @@ import type {
   IdeaPage,
   IdeaPageRequest,
   IdeaPickerItem,
+  WorkView,
 } from '@shared/types';
 import { DEFAULT_EMBEDDING_MODELS, normalizeEmbeddingModel } from '@shared/providers';
 import { getWorksByIds } from './worksRepo';
@@ -713,7 +714,14 @@ export function pruneDormantIdeas(maxAgeDays = 30): number {
 
 // ── Detail panels ───────────────────────────────────────────────────────────
 
-export function getIdeaDetail(globalId: string): IdeaDetail | null {
+/**
+ * @param worksCache Works already loaded by the caller. `getWorksByIds` is a batch
+ *   API, but called from here it only ever gets one idea's worth of ids at a time —
+ *   usually a single one — so a caller assembling many ideas pays its four queries
+ *   once per idea. Handing in a map built by that same function for the whole set
+ *   collapses them to four in total; the values are identical either way.
+ */
+export function getIdeaDetail(globalId: string, worksCache?: Map<string, WorkView>): IdeaDetail | null {
   const db = getDb();
   const idea = getIdeaSummary(globalId);
   if (!idea) return null;
@@ -726,10 +734,12 @@ export function getIdeaDetail(globalId: string): IdeaDetail | null {
   }[];
   // Batch-load all works for the occurrences in 2 queries instead of N+1
   // (previously each occurrence called getWork() → 2 queries each).
-  const worksById = getWorksByIds(occRows.map((o) => o.nodus_id));
+  const needed = worksCache ? occRows.map((o) => o.nodus_id).filter((id) => !worksCache.has(id)) : occRows.map((o) => o.nodus_id);
+  const fetched = needed.length ? getWorksByIds(needed) : null;
+  const worksById = (id: string) => worksCache?.get(id) ?? fetched?.get(id);
   const occurrences = occRows
     .map((o) => {
-      const work = worksById.get(o.nodus_id);
+      const work = worksById(o.nodus_id);
       return work ? { ...o, work } : null;
     })
     .filter((x): x is NonNullable<typeof x> => x !== null);

--- a/electron/db/ideasRepo.ts
+++ b/electron/db/ideasRepo.ts
@@ -20,6 +20,7 @@ import type {
   IdeaListItem,
   IdeaPage,
   IdeaPageRequest,
+  IdeaPickerItem,
 } from '@shared/types';
 import { DEFAULT_EMBEDDING_MODELS, normalizeEmbeddingModel } from '@shared/providers';
 import { getWorksByIds } from './worksRepo';
@@ -734,6 +735,30 @@ export function getIdeaDetail(globalId: string): IdeaDetail | null {
     .filter((x): x is NonNullable<typeof x> => x !== null);
   const evidence = db.prepare('SELECT * FROM evidence WHERE global_id = ?').all(globalId) as Evidence[];
   return { idea, occurrences, evidence };
+}
+
+/**
+ * Every idea the graph would show, with only the fields a picker reads.
+ *
+ * Same population as the ideas lens — an idea counts once at least one
+ * un-archived, deep-analysed work carries it — expressed as EXISTS rather than a
+ * join plus DISTINCT, so no statement text has to be sorted to deduplicate.
+ */
+export function listPickerIdeas(): IdeaPickerItem[] {
+  return getDb()
+    .prepare(
+      `SELECT i.global_id, i.type, i.label, i.statement
+         FROM ideas i
+        WHERE EXISTS (
+          SELECT 1
+            FROM idea_occurrences io
+            JOIN works w ON w.nodus_id = io.nodus_id
+           WHERE io.global_id = i.global_id
+             AND w.archived = 0
+             AND w.deep_status = 'done'
+        )`
+    )
+    .all() as IdeaPickerItem[];
 }
 
 export function listIdeasPage(request: IdeaPageRequest): IdeaPage {

--- a/electron/graph/graphService.ts
+++ b/electron/graph/graphService.ts
@@ -126,17 +126,25 @@ export async function buildIdeaGraph(): Promise<GraphData> {
   // single query for ideas and another for themes, then aggregate in memory.
   // This is the main reason the graph took ages to load on large corpora.
   const ideaIds = ideas.map((i) => i.global_id);
+  // Both aggregates below restrict to the ideas selected above. Binding that set
+  // as an `IN (?,?,…)` list of one placeholder per idea is what made the graph
+  // take seconds: with ~9,700 placeholders SQLite drives the join from the id
+  // list and probes (global_id, nodus_id) once per id × per matching work, so the
+  // cost grows with ideas × works instead of with rows. Joining `ideas` instead
+  // expresses the same restriction — the id list *is* that join — and lets the
+  // planner drive from `works`. Measured on a 9,707-idea corpus: 6.9 s → 74 ms
+  // and 8.9 s → 49 ms, row-for-row identical (scripts/bench-graph-in-clause.ts).
   const ideaWorkRows = ideaIds.length
     ? (db
         .prepare(
           `SELECT io.global_id, w.nodus_id, w.year, w.authors_json, w.read_tag
              FROM idea_occurrences io
              JOIN works w ON w.nodus_id = io.nodus_id
-            WHERE io.global_id IN (${ideaIds.map(() => '?').join(',')})
-              AND w.archived = 0
+             JOIN ideas i ON i.global_id = io.global_id
+            WHERE w.archived = 0
               AND w.deep_status = 'done'`
         )
-        .all(...ideaIds) as { global_id: string; nodus_id: string; year: number | null; authors_json: string; read_tag: number }[])
+        .all() as { global_id: string; nodus_id: string; year: number | null; authors_json: string; read_tag: number }[])
     : [];
   const ideaAggById = new Map<string, { works: Set<string>; unread: boolean; years: number[]; authors: Set<string> }>();
   // maxConfidence comes from idea_occurrences.confidence; fetch in a second tiny query.
@@ -146,12 +154,12 @@ export async function buildIdeaGraph(): Promise<GraphData> {
           `SELECT io.global_id, MAX(io.confidence) AS c
              FROM idea_occurrences io
              JOIN works w ON w.nodus_id = io.nodus_id
-            WHERE io.global_id IN (${ideaIds.map(() => '?').join(',')})
-              AND w.archived = 0
+             JOIN ideas i ON i.global_id = io.global_id
+            WHERE w.archived = 0
               AND w.deep_status = 'done'
             GROUP BY io.global_id`
         )
-        .all(...ideaIds) as { global_id: string; c: number | null }[])
+        .all() as { global_id: string; c: number | null }[])
     : [];
   const ideaConfById = new Map(ideaConfRows.map((r) => [r.global_id, r.c ?? 0]));
   for (const row of ideaWorkRows) {

--- a/electron/graph/graphService.ts
+++ b/electron/graph/graphService.ts
@@ -868,7 +868,27 @@ function clip(value: string, max: number): string {
  */
 const DEBATE_LIST_EVIDENCE_PER_WORK = 1;
 
-function buildDebateSide(ideaId: string, opts: { lean?: boolean } = {}): DebateSide | null {
+/**
+ * Sides already built during this one `getDebates()` call.
+ *
+ * An idea can sit on either end of several contradiction edges, and each debate
+ * rebuilt its sides from scratch: measured on a real corpus, 1,147 debate edges
+ * asked for 2,294 sides drawn from only 1,310 distinct ideas, and every one of
+ * those asks costs ~6 queries through getIdeaDetail. The map is per call and
+ * never outlives it — nothing writes to the database while debates assemble, so
+ * within one call the answer for an idea cannot change.
+ */
+type DebateSideCache = Map<string, DebateSide | null>;
+
+function buildDebateSide(ideaId: string, opts: { lean?: boolean; cache?: DebateSideCache } = {}): DebateSide | null {
+  const cached = opts.cache?.get(ideaId);
+  if (cached !== undefined) return cached;
+  const side = assembleDebateSide(ideaId, opts);
+  opts.cache?.set(ideaId, side);
+  return side;
+}
+
+function assembleDebateSide(ideaId: string, opts: { lean?: boolean }): DebateSide | null {
   const detail = getIdeaDetail(ideaId);
   if (!detail) return null;
   const evidenceByWork = new Map<string, Evidence[]>();
@@ -927,7 +947,7 @@ function assembleDebate(
   clusterSize: number,
   supportCount: Map<string, number>,
   themesByIdea: Map<string, Set<string>>,
-  opts: { lean?: boolean } = {}
+  opts: { lean?: boolean; cache?: DebateSideCache } = {}
 ): Debate | null {
   const sideA = buildDebateSide(row.from_id, opts);
   const sideB = buildDebateSide(row.to_id, opts);
@@ -1035,11 +1055,12 @@ export function getDebates(): Debate[] {
   const { clusterId, clusterSize } = clusterDebateEdges(rows);
   const supportCount = loadSupportCounts(db);
   const themesByIdea = loadThemesByIdea(db);
+  const cache: DebateSideCache = new Map();
 
   const debates = rows
     .map((row) => {
       const root = clusterId.get(row.id)!;
-      return assembleDebate(row, root, clusterSize.get(root) ?? 1, supportCount, themesByIdea, { lean: true });
+      return assembleDebate(row, root, clusterSize.get(root) ?? 1, supportCount, themesByIdea, { lean: true, cache });
     })
     .filter((d): d is Debate => d !== null);
 

--- a/electron/graph/graphService.ts
+++ b/electron/graph/graphService.ts
@@ -605,8 +605,10 @@ function normalizeText(text: string | null | undefined): string {
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
+    // No `\s+` pass after this one: `[^a-z0-9ñ]+` is greedy and whitespace is
+    // itself outside the class, so every run of it has already become exactly one
+    // space. scripts/bench-normalize-text.ts checks that on the vault's own strings.
     .replace(/[^a-z0-9ñ]+/gi, ' ')
-    .replace(/\s+/g, ' ')
     .trim();
 }
 
@@ -1078,6 +1080,9 @@ export function getDebate(edgeId: string): Debate | null {
   return assembleDebate(row, row.from_id, 1, loadSupportCounts(db), loadThemesByIdea(db));
 }
 
+/** How many related gaps a reading-path entry shows. */
+const RELATED_GAPS_SHOWN = 3;
+
 const DEFAULT_READING_LIMIT = 72;
 const MIN_READING_LIMIT = 18;
 const MAX_READING_LIMIT = 180;
@@ -1309,10 +1314,18 @@ function toReadingEntry(
   };
   const diversityKey = themes[0] ?? null;
   const gapThemes = themes.filter((theme) => opts.gapSignals.themeLabels.has(normalizeThemeLabel(theme)));
-  const relatedGaps = unique([
-    ...gapStatements,
-    ...gapThemes.flatMap((theme) => opts.gapSignals.statementsByTheme.get(normalizeThemeLabel(theme)) ?? []),
-  ]).slice(0, 3);
+  // Only three of these are ever shown. Building the whole deduplicated list
+  // first meant normalising every gap statement of every theme this work touches
+  // — measured at 114 ms of the reading path's 212 ms on a corpus with 11,119
+  // gaps — and then throwing all but three away. Yielding the candidates lazily
+  // lets unique() stop at the third.
+  const relatedGaps = unique(
+    (function* gapCandidates() {
+      yield* gapStatements;
+      for (const theme of gapThemes) yield* opts.gapSignals.statementsByTheme.get(normalizeThemeLabel(theme)) ?? [];
+    })(),
+    RELATED_GAPS_SHOWN
+  );
   const gapIdeaHit = ideaIds.some((id) => opts.gapSignals.ideaIds.has(id));
   const gapScore = clamp01(
     (row.gap_count > 0 ? 0.36 : 0) +
@@ -1726,10 +1739,19 @@ function splitGapStatements(value: string | null): string[] {
   );
 }
 
-function unique(values: string[]): string[] {
+/**
+ * Distinct values in order, comparing them normalised.
+ *
+ * Takes an iterable and a limit so a caller that only wants the first few can
+ * stop the normalisation there. `unique(xs).slice(0, n)` and `unique(xs, n)`
+ * return the same thing — the function preserves input order, so the first n
+ * distinct values are the same either way — but the second stops looking.
+ */
+function unique(values: Iterable<string>, limit = Infinity): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   for (const value of values) {
+    if (out.length >= limit) break;
     const key = normalizeText(value);
     if (!key || seen.has(key)) continue;
     seen.add(key);

--- a/electron/graph/graphService.ts
+++ b/electron/graph/graphService.ts
@@ -19,8 +19,10 @@ import type {
   ReadingPathRequest,
   ReadingPathStrategy,
   ReadingPathEntry,
+  WorkView,
 } from '@shared/types';
 import { getEdgeDetail, getEdgeTrace, getIdeaDetail, currentEmbeddingConfig } from '../db/ideasRepo';
+import { getWorksByIds } from '../db/worksRepo';
 import { listGraphThemes, normalizeThemeLabel } from '../db/themesRepo';
 import { computeThemeMatches } from './computeHost';
 import { centroidF32, type LabeledVector } from './similarityCore';
@@ -882,7 +884,7 @@ const DEBATE_LIST_EVIDENCE_PER_WORK = 1;
  */
 type DebateSideCache = Map<string, DebateSide | null>;
 
-function buildDebateSide(ideaId: string, opts: { lean?: boolean; cache?: DebateSideCache } = {}): DebateSide | null {
+function buildDebateSide(ideaId: string, opts: { lean?: boolean; cache?: DebateSideCache; works?: Map<string, WorkView> } = {}): DebateSide | null {
   const cached = opts.cache?.get(ideaId);
   if (cached !== undefined) return cached;
   const side = assembleDebateSide(ideaId, opts);
@@ -890,8 +892,8 @@ function buildDebateSide(ideaId: string, opts: { lean?: boolean; cache?: DebateS
   return side;
 }
 
-function assembleDebateSide(ideaId: string, opts: { lean?: boolean }): DebateSide | null {
-  const detail = getIdeaDetail(ideaId);
+function assembleDebateSide(ideaId: string, opts: { lean?: boolean; works?: Map<string, WorkView> }): DebateSide | null {
+  const detail = getIdeaDetail(ideaId, opts.works);
   if (!detail) return null;
   const evidenceByWork = new Map<string, Evidence[]>();
   for (const ev of detail.evidence) {
@@ -949,7 +951,7 @@ function assembleDebate(
   clusterSize: number,
   supportCount: Map<string, number>,
   themesByIdea: Map<string, Set<string>>,
-  opts: { lean?: boolean; cache?: DebateSideCache } = {}
+  opts: { lean?: boolean; cache?: DebateSideCache; works?: Map<string, WorkView> } = {}
 ): Debate | null {
   const sideA = buildDebateSide(row.from_id, opts);
   const sideB = buildDebateSide(row.to_id, opts);
@@ -1047,6 +1049,21 @@ function loadThemesByIdea(db: ReturnType<typeof getDb>): Map<string, Set<string>
  * grouped into clusters (connected components over shared ideas) so multi-sided
  * debates surface together. Pure DB reads — no AI, no new persistence.
  */
+/** Every idea on either side of a contradiction, as a subquery rather than a bound id list. */
+const DEBATE_IDEA_IDS = `SELECT from_id FROM visible_edges WHERE type IN ('contradicts','refutes')
+                          UNION SELECT to_id FROM visible_edges WHERE type IN ('contradicts','refutes')`;
+
+/**
+ * Every work cited by any debate, in one batch, so getIdeaDetail does not re-run
+ * its four work queries once per idea.
+ */
+function loadDebateWorks(db: ReturnType<typeof getDb>): Map<string, WorkView> {
+  const rows = db
+    .prepare(`SELECT DISTINCT nodus_id FROM idea_occurrences WHERE global_id IN (${DEBATE_IDEA_IDS})`)
+    .all() as { nodus_id: string }[];
+  return getWorksByIds(rows.map((r) => r.nodus_id));
+}
+
 export function getDebates(): Debate[] {
   const db = getDb();
   const rows = db
@@ -1058,11 +1075,12 @@ export function getDebates(): Debate[] {
   const supportCount = loadSupportCounts(db);
   const themesByIdea = loadThemesByIdea(db);
   const cache: DebateSideCache = new Map();
+  const works = loadDebateWorks(db);
 
   const debates = rows
     .map((row) => {
       const root = clusterId.get(row.id)!;
-      return assembleDebate(row, root, clusterSize.get(root) ?? 1, supportCount, themesByIdea, { lean: true, cache });
+      return assembleDebate(row, root, clusterSize.get(root) ?? 1, supportCount, themesByIdea, { lean: true, cache, works });
     })
     .filter((d): d is Debate => d !== null);
 

--- a/electron/ipc/academic.ts
+++ b/electron/ipc/academic.ts
@@ -516,6 +516,7 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
   h('graph:overview', async () => buildIdeaGraphOverview());
   h('graph:theme', async (_e, theme: string, cap?: number) => buildIdeaThemeGraph(theme, cap));
   h('ideas:listPage', async (_e, request) => ideas.listIdeasPage(request));
+  h('ideas:picker', async () => ideas.listPickerIdeas());
   h('ideas:connections', async (_e, globalId: string) => ideas.listIdeaConnections(globalId));
   h('graph:ideaDetail', async (_e, globalId: string) => ideas.getIdeaDetail(globalId));
   h('ideas:delete', async (_e, globalId: string) => ideas.deleteIdea(globalId));

--- a/electron/preload/academic.ts
+++ b/electron/preload/academic.ts
@@ -71,6 +71,7 @@ export const academicApi: AcademicApi = {
   getGraphOverview: () => ipcRenderer.invoke('graph:overview'),
   getGraphTheme: (theme, cap) => ipcRenderer.invoke('graph:theme', theme, cap),
   listIdeasPage: (request) => ipcRenderer.invoke('ideas:listPage', request),
+  listPickerIdeas: () => ipcRenderer.invoke('ideas:picker'),
   listIdeaConnections: (globalId) => ipcRenderer.invoke('ideas:connections', globalId),
   getIdeaDetail: (globalId) => ipcRenderer.invoke('graph:ideaDetail', globalId),
   deleteIdea: (globalId) => ipcRenderer.invoke('ideas:delete', globalId).then(() => undefined),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/bench-graph-in-clause.ts
+++ b/scripts/bench-graph-in-clause.ts
@@ -1,0 +1,101 @@
+// Differential test for the two `IN (?,?,…9700 more)` queries in buildIdeaGraph.
+//
+// It times the current form against a rewrite that replaces the bound id list
+// with the join that produced the list in the first place, and — the part that
+// matters — asserts the two return byte-identical result sets. A faster query
+// that returns something else is not a fix.
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+const userData = process.env.NODUS_TEST_USERDATA;
+if (!userData) throw new Error('NODUS_TEST_USERDATA is required');
+const db = new Database(path.join(userData, 'nodus.sqlite'), { readonly: true });
+db.pragma('temp_store = MEMORY');
+db.pragma('cache_size = -32768');
+db.pragma('mmap_size = 268435456');
+
+const ideaIds = (
+  db
+    .prepare(
+      `SELECT DISTINCT i.global_id
+         FROM ideas i
+         JOIN idea_occurrences io ON io.global_id = i.global_id
+         JOIN works w ON w.nodus_id = io.nodus_id
+        WHERE w.archived = 0 AND w.deep_status = 'done'`
+    )
+    .all() as { global_id: string }[]
+).map((r) => r.global_id);
+
+console.log(`ideas en el grafo: ${ideaIds.length}\n`);
+
+function time<T>(label: string, fn: () => T): { ms: number; value: T } {
+  const started = process.hrtime.bigint();
+  const value = fn();
+  const ms = Number(process.hrtime.bigint() - started) / 1e6;
+  console.log(`  ${label.padEnd(34)} ${ms.toFixed(1).padStart(8)} ms`);
+  return { ms, value };
+}
+
+function canonical(rows: unknown[]): string {
+  return JSON.stringify(rows.map((r) => JSON.stringify(r)).sort());
+}
+
+const placeholders = ideaIds.map(() => '?').join(',');
+
+// ── Query A: idea → work aggregation ────────────────────────────────────────
+console.log('A) filas idea×obra');
+const aCurrentSql = `SELECT io.global_id, w.nodus_id, w.year, w.authors_json, w.read_tag
+     FROM idea_occurrences io
+     JOIN works w ON w.nodus_id = io.nodus_id
+    WHERE io.global_id IN (${placeholders})
+      AND w.archived = 0
+      AND w.deep_status = 'done'`;
+const aRewriteSql = `SELECT io.global_id, w.nodus_id, w.year, w.authors_json, w.read_tag
+     FROM idea_occurrences io
+     JOIN works w ON w.nodus_id = io.nodus_id
+     JOIN ideas i ON i.global_id = io.global_id
+    WHERE w.archived = 0
+      AND w.deep_status = 'done'`;
+const aCurrent = time('actual  IN (?×N)', () => db.prepare(aCurrentSql).all(...ideaIds) as unknown[]);
+const aRewrite = time('reescrita  JOIN ideas', () => db.prepare(aRewriteSql).all() as unknown[]);
+const aSame = canonical(aCurrent.value) === canonical(aRewrite.value);
+console.log(`  filas: ${aCurrent.value.length} vs ${aRewrite.value.length} — identicas: ${aSame ? 'SI' : 'NO'}`);
+console.log(`  aceleracion: ${(aCurrent.ms / aRewrite.ms).toFixed(0)}x\n`);
+
+// ── Query B: max confidence per idea ────────────────────────────────────────
+console.log('B) confianza maxima por idea');
+const bCurrentSql = `SELECT io.global_id, MAX(io.confidence) AS c
+     FROM idea_occurrences io
+     JOIN works w ON w.nodus_id = io.nodus_id
+    WHERE io.global_id IN (${placeholders})
+      AND w.archived = 0
+      AND w.deep_status = 'done'
+    GROUP BY io.global_id`;
+const bRewriteSql = `SELECT io.global_id, MAX(io.confidence) AS c
+     FROM idea_occurrences io
+     JOIN works w ON w.nodus_id = io.nodus_id
+     JOIN ideas i ON i.global_id = io.global_id
+    WHERE w.archived = 0
+      AND w.deep_status = 'done'
+    GROUP BY io.global_id`;
+const bCurrent = time('actual  IN (?×N)', () => db.prepare(bCurrentSql).all(...ideaIds) as unknown[]);
+const bRewrite = time('reescrita  JOIN ideas', () => db.prepare(bRewriteSql).all() as unknown[]);
+const bSame = canonical(bCurrent.value) === canonical(bRewrite.value);
+console.log(`  filas: ${bCurrent.value.length} vs ${bRewrite.value.length} — identicas: ${bSame ? 'SI' : 'NO'}`);
+console.log(`  aceleracion: ${(bCurrent.ms / bRewrite.ms).toFixed(0)}x\n`);
+
+// ── Why ─────────────────────────────────────────────────────────────────────
+console.log('plan actual (A):');
+for (const row of db.prepare(`EXPLAIN QUERY PLAN ${aCurrentSql}`).all(...ideaIds) as { detail: string }[]) {
+  console.log(`  ${row.detail}`);
+}
+console.log('plan reescrito (A):');
+for (const row of db.prepare(`EXPLAIN QUERY PLAN ${aRewriteSql}`).all() as { detail: string }[]) {
+  console.log(`  ${row.detail}`);
+}
+
+if (!aSame || !bSame) {
+  console.error('\nLa reescritura NO es equivalente — no aplicar.');
+  process.exit(1);
+}
+console.log('\nAmbas reescrituras son equivalentes fila a fila.');

--- a/scripts/bench-graph-sql.ts
+++ b/scripts/bench-graph-sql.ts
@@ -65,11 +65,15 @@ proto.prepare = function patchedPrepare(sql: string) {
 async function main(): Promise<void> {
   const { buildIdeaGraph, buildIdeaGraphOverview } = await import('../electron/graph/graphService');
   const { getAcademicHomeStats } = await import('../electron/db/homeRepo');
+  const { getDebates } = await import('../electron/graph/graphService');
+  const { buildReadingPath } = await import('../electron/graph/graphService');
 
   const target = process.env.BENCH_TARGET ?? 'graph';
   const run = async () => {
     if (target === 'overview') return buildIdeaGraphOverview();
     if (target === 'home') return getAcademicHomeStats();
+    if (target === 'debates') return getDebates();
+    if (target === 'reading') return buildReadingPath();
     return buildIdeaGraph();
   };
 

--- a/scripts/bench-graph-sql.ts
+++ b/scripts/bench-graph-sql.ts
@@ -1,0 +1,107 @@
+// Attributes the cost of one main-process call to individual SQL statements, by
+// wrapping better-sqlite3's prepare/all/get/run. `prepare` is timed separately
+// from execution on purpose: a statement whose placeholder count varies with the
+// corpus size cannot be reused by SQLite's cache and pays full parse cost on every
+// call, which shows up as prepare time rather than query time.
+//
+// Built and run by scripts/run-bench-graph-sql.sh.
+import Database from 'better-sqlite3';
+
+interface Entry {
+  sql: string;
+  prepares: number;
+  prepareMs: number;
+  execs: number;
+  execMs: number;
+  rows: number;
+}
+
+const stats = new Map<string, Entry>();
+
+function key(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+/** Collapse a long `IN (?,?,?,…)` list so the same query shape aggregates. */
+function shape(sql: string): string {
+  return key(sql).replace(/\?(\s*,\s*\?){3,}/g, '?,?,…');
+}
+
+function entry(sql: string): Entry {
+  const k = shape(sql);
+  let e = stats.get(k);
+  if (!e) {
+    e = { sql: k, prepares: 0, prepareMs: 0, execs: 0, execMs: 0, rows: 0 };
+    stats.set(k, e);
+  }
+  return e;
+}
+
+const proto = Database.prototype as unknown as { prepare: (sql: string) => unknown };
+const originalPrepare = proto.prepare;
+
+proto.prepare = function patchedPrepare(sql: string) {
+  const e = entry(sql);
+  const started = process.hrtime.bigint();
+  const statement = originalPrepare.call(this, sql) as Record<string, unknown>;
+  e.prepareMs += Number(process.hrtime.bigint() - started) / 1e6;
+  e.prepares += 1;
+  for (const method of ['all', 'get', 'run', 'pluck', 'raw'] as const) {
+    const original = statement[method];
+    if (typeof original !== 'function') continue;
+    statement[method] = function patched(...args: unknown[]) {
+      if (method === 'pluck' || method === 'raw') return (original as (...a: unknown[]) => unknown).apply(this, args);
+      const t0 = process.hrtime.bigint();
+      const result = (original as (...a: unknown[]) => unknown).apply(this, args);
+      e.execMs += Number(process.hrtime.bigint() - t0) / 1e6;
+      e.execs += 1;
+      if (Array.isArray(result)) e.rows += result.length;
+      return result;
+    };
+  }
+  return statement;
+} as never;
+
+async function main(): Promise<void> {
+  const { buildIdeaGraph, buildIdeaGraphOverview } = await import('../electron/graph/graphService');
+  const { getAcademicHomeStats } = await import('../electron/db/homeRepo');
+
+  const target = process.env.BENCH_TARGET ?? 'graph';
+  const run = async () => {
+    if (target === 'overview') return buildIdeaGraphOverview();
+    if (target === 'home') return getAcademicHomeStats();
+    return buildIdeaGraph();
+  };
+
+  await run(); // warm the page cache so the numbers describe steady state
+  stats.clear();
+
+  const started = process.hrtime.bigint();
+  const result = await run();
+  const totalMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+  const rows = [...stats.values()].sort((a, b) => b.prepareMs + b.execMs - (a.prepareMs + a.execMs));
+  const sqlTotal = rows.reduce((sum, r) => sum + r.prepareMs + r.execMs, 0);
+
+  console.log(`objetivo: ${target}`);
+  console.log(`total: ${totalMs.toFixed(0)} ms  ·  en SQL: ${sqlTotal.toFixed(0)} ms  ·  fuera de SQL (JS): ${(totalMs - sqlTotal).toFixed(0)} ms`);
+  const nodes = (result as { nodes?: unknown[] }).nodes?.length;
+  const edges = (result as { edges?: unknown[] }).edges?.length;
+  if (nodes !== undefined) console.log(`grafo devuelto: ${nodes} nodos, ${edges} aristas`);
+  console.log();
+  console.log(`${'prepare'.padStart(9)}  ${'exec'.padStart(9)}  ${'n'.padStart(4)}  ${'filas'.padStart(7)}  sql`);
+  console.log('-'.repeat(120));
+  for (const r of rows.slice(0, 15)) {
+    console.log(
+      `${r.prepareMs.toFixed(1).padStart(7)}ms  ${r.execMs.toFixed(1).padStart(7)}ms  ${String(r.execs).padStart(4)}  ${String(r.rows).padStart(7)}  ${r.sql.slice(0, 96)}`
+    );
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  }
+);

--- a/scripts/bench-graph-sql.ts
+++ b/scripts/bench-graph-sql.ts
@@ -66,6 +66,7 @@ async function main(): Promise<void> {
   const { buildIdeaGraph, buildIdeaGraphOverview } = await import('../electron/graph/graphService');
   const { getAcademicHomeStats } = await import('../electron/db/homeRepo');
   const { getDebates } = await import('../electron/graph/graphService');
+  const { buildAuthorDossier } = await import('../electron/ai/authorDossier');
   const { buildReadingPath } = await import('../electron/graph/graphService');
 
   const target = process.env.BENCH_TARGET ?? 'graph';
@@ -73,6 +74,7 @@ async function main(): Promise<void> {
     if (target === 'overview') return buildIdeaGraphOverview();
     if (target === 'home') return getAcademicHomeStats();
     if (target === 'debates') return getDebates();
+    if (target === 'author') return buildAuthorDossier(process.env.BENCH_AUTHOR ?? '');
     if (target === 'reading') return buildReadingPath();
     return buildIdeaGraph();
   };

--- a/scripts/bench-idle-cpu.mjs
+++ b/scripts/bench-idle-cpu.mjs
@@ -1,0 +1,94 @@
+// Measures what a *completely idle* Nodus costs, per helper process.
+//
+// It launches the built app against NODUS_USERDATA, lets it settle, then reads
+// each process's cumulative CPU time twice and reports the delta over the window.
+// Cumulative CPU time is the right metric here: unlike a %CPU snapshot it does not
+// depend on what else the machine happens to be doing during the sample.
+//
+// BENCH_MASCOT=0|1 rewrites `mascotEnabled` in the profile before launching, so
+// the two runs differ in exactly one thing.
+//
+//   node scripts/bench-idle-cpu.mjs
+import { spawn, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const userData = process.env.NODUS_USERDATA;
+if (!userData) throw new Error('NODUS_USERDATA is required');
+const settleMs = Number(process.env.BENCH_SETTLE_MS ?? 25_000);
+const windowMs = Number(process.env.BENCH_WINDOW_MS ?? 15_000);
+const mascot = process.env.BENCH_MASCOT !== '0';
+
+const prefsPath = path.join(userData, 'app-prefs.json');
+const prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf8'));
+prefs.mascotEnabled = mascot;
+fs.writeFileSync(prefsPath, JSON.stringify(prefs, null, 2));
+console.log(`perfil: ${userData}\nmascota Nodi: ${mascot ? 'ACTIVADA' : 'desactivada'}`);
+
+const electron = path.join(process.cwd(), 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron');
+const child = spawn(electron, ['.'], {
+  cwd: process.cwd(),
+  env: { ...process.env, NODUS_USERDATA: userData, NODUS_DISABLE_AUTO_UPDATE: '1' },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+child.stdout.on('data', () => {});
+child.stderr.on('data', () => {});
+
+/** Every process in the launched app's tree, with its cumulative CPU seconds. */
+function tree() {
+  const out = execSync(
+    `ps -Ao pid=,ppid=,time=,command= | grep -F "${userData}" | grep -v grep || true`,
+    { encoding: 'utf8', maxBuffer: 8 << 20 }
+  );
+  const rows = new Map();
+  for (const line of out.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+([\d:.]+)\s+(.*)$/);
+    if (!match) continue;
+    const [, pid, , time, command] = match;
+    const parts = time.split(':').map(Number);
+    const seconds = parts.length === 3 ? parts[0] * 3600 + parts[1] * 60 + parts[2] : parts[0] * 60 + parts[1];
+    const type = /--type=([a-z-]+)/.exec(command)?.[1] ?? 'main';
+    const sub = /--utility-sub-type=([^ ]+)/.exec(command)?.[1];
+    rows.set(pid, { seconds, label: sub ? `${type} (${sub.split('.').pop()})` : type });
+  }
+  return rows;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+await sleep(settleMs);
+const before = tree();
+if (before.size === 0) {
+  console.error('la app no arranco (ningun proceso encontrado)');
+  child.kill('SIGKILL');
+  process.exit(1);
+}
+await sleep(windowMs);
+const after = tree();
+
+const rows = [];
+let total = 0;
+for (const [pid, entry] of after) {
+  const start = before.get(pid);
+  if (!start) continue;
+  const cpuMs = (entry.seconds - start.seconds) * 1000;
+  total += cpuMs;
+  rows.push({ pid, label: entry.label, pct: (cpuMs / windowMs) * 100 });
+}
+rows.sort((a, b) => b.pct - a.pct);
+
+console.log(`\nventana en reposo: ${windowMs / 1000} s\n`);
+console.log(`${'proceso'.padEnd(30)}  ${'%CPU'.padStart(7)}`);
+console.log('-'.repeat(40));
+for (const row of rows) console.log(`${row.label.padEnd(30)}  ${row.pct.toFixed(1).padStart(6)}%`);
+console.log('-'.repeat(40));
+console.log(`${'TOTAL'.padEnd(30)}  ${((total / windowMs) * 100).toFixed(1).padStart(6)}%`);
+
+child.kill('SIGKILL');
+await sleep(1500);
+try {
+  execSync(`pkill -f "${userData}" || true`);
+} catch {
+  /* already gone */
+}
+process.exit(0);

--- a/scripts/bench-in-clause-audit.ts
+++ b/scripts/bench-in-clause-audit.ts
@@ -1,0 +1,99 @@
+// Sweeps every read-only IPC channel and reports the SQL statements that bind a
+// corpus-sized `IN (?,?,…)` list.
+//
+// There are ~127 places that build such a list. Almost all of them bind a handful
+// of ids and are entirely fine; the ones that matter bind thousands, because SQLite
+// then drives the join from the id list and the cost grows with ids × rows. Rather
+// than guess which is which, this runs the real handlers against a real vault and
+// lets the database say.
+import Database from 'better-sqlite3';
+import { HANDLERS } from 'electron';
+import { registerIpc } from '../electron/ipc';
+
+/** A statement is interesting past this many placeholders. */
+const PLACEHOLDER_FLOOR = 64;
+
+interface Hit {
+  sql: string;
+  placeholders: number;
+  ms: number;
+  channels: Set<string>;
+}
+
+const hits = new Map<string, Hit>();
+let currentChannel = '';
+
+function placeholderRun(sql: string): number {
+  let longest = 0;
+  for (const match of sql.matchAll(/\?(\s*,\s*\?)+/g)) longest = Math.max(longest, (match[0].match(/\?/g) ?? []).length);
+  return longest;
+}
+
+const proto = Database.prototype as unknown as { prepare: (sql: string) => unknown };
+const originalPrepare = proto.prepare;
+proto.prepare = function patchedPrepare(sql: string) {
+  const statement = originalPrepare.call(this, sql) as Record<string, unknown>;
+  const placeholders = placeholderRun(sql);
+  if (placeholders < PLACEHOLDER_FLOOR) return statement;
+  const shape = sql.replace(/\s+/g, ' ').trim().replace(/\?(\s*,\s*\?)+/g, `?×${placeholders}`);
+  for (const method of ['all', 'get', 'run'] as const) {
+    const original = statement[method];
+    if (typeof original !== 'function') continue;
+    statement[method] = function patched(...args: unknown[]) {
+      const started = process.hrtime.bigint();
+      const result = (original as (...a: unknown[]) => unknown).apply(this, args);
+      const ms = Number(process.hrtime.bigint() - started) / 1e6;
+      const hit = hits.get(shape) ?? { sql: shape, placeholders, ms: 0, channels: new Set<string>() };
+      hit.ms += ms;
+      hit.placeholders = Math.max(hit.placeholders, placeholders);
+      hit.channels.add(currentChannel);
+      hits.set(shape, hit);
+      return result;
+    };
+  }
+  return statement;
+} as never;
+
+/** Verbs that change something, cost money, or start a job. Never swept. */
+const UNSAFE =
+  /(create|update|delete|remove|merge|import|export|apply|restore|clear|prune|start|stop|pause|resume|retry|cancel|kill|install|download|scan|rescan|embed|summar|synthes|analy|generate|reprocess|seed|demo|save|set|move|rename|reorder|enqueue|open|login|logout|upload|write|send|process|deepen|convert|record|transcribe|translate|chat|research|suggest|improve|verify|decompose|map|route|tutor|draft|compose|ask|answer|question)/i;
+const READ = /(:list|:get$|:count|:status|:tree|:aggregate|health|overview|facets|snapshot|:all|:detail|:stats|:summary|:page)/i;
+
+async function main(): Promise<void> {
+  registerIpc(() => null as never, async () => ({ status: 'idle' }) as never, () => undefined);
+
+  const channels = [...HANDLERS.keys()].filter((c) => READ.test(c) && !UNSAFE.test(c)).sort();
+  console.log(`barriendo ${channels.length} canales de lectura de ${HANDLERS.size}\n`);
+
+  let ran = 0;
+  for (const channel of channels) {
+    currentChannel = channel;
+    try {
+      await HANDLERS.get(channel)!({} as never);
+      ran += 1;
+    } catch {
+      // Most skipped channels simply require an argument this sweep has no value for.
+    }
+  }
+  console.log(`ejecutados sin argumentos: ${ran}\n`);
+
+  const rows = [...hits.values()].sort((a, b) => b.ms - a.ms);
+  if (rows.length === 0) {
+    console.log(`Ninguna sentencia ató ${PLACEHOLDER_FLOOR}+ parametros en estos canales.`);
+    return;
+  }
+  console.log(`${'parametros'.padStart(11)}  ${'ms'.padStart(9)}  canal / sql`);
+  console.log('-'.repeat(110));
+  for (const row of rows) {
+    console.log(`${String(row.placeholders).padStart(11)}  ${row.ms.toFixed(1).padStart(7)}ms  ${[...row.channels].join(', ')}`);
+    console.log(`${' '.repeat(23)}${row.sql.slice(0, 84)}`);
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  }
+);

--- a/scripts/bench-ipc-latency.ts
+++ b/scripts/bench-ipc-latency.ts
@@ -1,0 +1,136 @@
+// Measures how long each main-process IPC handler blocks, against whatever vault
+// NODUS_TEST_USERDATA points at. Every handler runs on the single main-process
+// event loop that also services the renderer's invokes, so a handler that takes
+// N ms is N ms during which the UI cannot get an answer to anything.
+//
+// The `electron` module is aliased to a stub that captures ipcMain.handle instead
+// of registering it, so the real handlers can be called directly here.
+//
+// Run via scripts/run-bench-ipc.mjs (it does the esbuild + Electron-node dance).
+import { HANDLERS } from 'electron';
+import { registerIpc } from '../electron/ipc';
+
+interface Case {
+  channel: string;
+  args?: unknown[];
+  label: string;
+}
+
+const REPEATS = Number(process.env.BENCH_REPEATS ?? 5);
+
+function stats(samples: number[]): { min: number; med: number; max: number } {
+  const sorted = [...samples].sort((a, b) => a - b);
+  return {
+    min: sorted[0],
+    med: sorted[Math.floor(sorted.length / 2)],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+/**
+ * The number that decides whether a slow handler is *felt*: a 10 ms heartbeat
+ * records the longest gap between two ticks while the handler runs. That gap is
+ * exactly how long the renderer's next `invoke` would sit unanswered — i.e. how
+ * long the window is frozen. A handler that awaits between chunks keeps this
+ * near 10 ms no matter how long it takes overall.
+ */
+function startLoopLagProbe(): () => { worst: number; ticks: number } {
+  let last = process.hrtime.bigint();
+  let worst = 0;
+  let ticks = 0;
+  const timer = setInterval(() => {
+    const now = process.hrtime.bigint();
+    const gap = Number(now - last) / 1e6;
+    if (gap > worst) worst = gap;
+    last = now;
+    ticks += 1;
+  }, 10);
+  return () => {
+    clearInterval(timer);
+    // A fully blocking handler starves the timer so hard it never fires once, so
+    // `worst` would stay 0 — the *opposite* of the truth. The stretch from the
+    // last tick (or from the start) to right now is itself a gap, and it is the
+    // one that matters. Fold it in before reporting.
+    const tail = Number(process.hrtime.bigint() - last) / 1e6;
+    return { worst: Math.max(worst, tail), ticks };
+  };
+}
+
+async function main(): Promise<void> {
+  registerIpc(
+    () => null as never,
+    async () => ({ status: 'idle' }) as never,
+    () => undefined
+  );
+  console.log(`handlers registered: ${HANDLERS.size}\n`);
+  if (process.env.BENCH_LIST) {
+    for (const channel of [...HANDLERS.keys()].sort()) console.log(channel);
+    return;
+  }
+
+  const requested = (process.env.BENCH_CHANNELS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  const cases: Case[] = requested.length
+    ? requested.map((channel) => ({ channel, label: channel }))
+    : JSON.parse(process.env.BENCH_CASES ?? '[]');
+
+  const rows: { label: string; min: number; med: number; max: number; freeze: number; note: string }[] = [];
+
+  // Controls that prove the probe discriminates: one handler that burns 250 ms of
+  // CPU without yielding, one that waits 250 ms asynchronously. If these two do
+  // not come out far apart, no other row in the table means anything.
+  HANDLERS.set('__control:blocking', async () => {
+    const until = Date.now() + 250;
+    while (Date.now() < until) {
+      /* deliberately starving the loop */
+    }
+  });
+  HANDLERS.set('__control:yielding', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+
+  for (const testCase of cases) {
+    const handler = HANDLERS.get(testCase.channel);
+    if (!handler) {
+      rows.push({ label: testCase.label, min: 0, med: 0, max: 0, freeze: 0, note: 'NO EXISTE' });
+      continue;
+    }
+    const samples: number[] = [];
+    let freeze = 0;
+    let note = '';
+    for (let i = 0; i < REPEATS; i++) {
+      const stopProbe = startLoopLagProbe();
+      const started = process.hrtime.bigint();
+      try {
+        await handler({} as never, ...(testCase.args ?? []));
+      } catch (error) {
+        note = `error: ${error instanceof Error ? error.message : String(error)}`.slice(0, 70);
+      }
+      samples.push(Number(process.hrtime.bigint() - started) / 1e6);
+      const lag = stopProbe();
+      if (lag.worst > freeze) freeze = lag.worst;
+      if (note) break;
+    }
+    const s = stats(samples);
+    rows.push({ label: testCase.label, ...s, freeze, note });
+  }
+
+  rows.sort((a, b) => b.freeze - a.freeze);
+  const width = Math.max(...rows.map((r) => r.label.length), 10);
+  console.log(
+    `${'canal'.padEnd(width)}  ${'mediana'.padStart(10)}  ${'max'.padStart(9)}  ${'CONGELADO'.padStart(11)}  nota`
+  );
+  console.log('-'.repeat(width + 46));
+  for (const row of rows) {
+    console.log(
+      `${row.label.padEnd(width)}  ${row.med.toFixed(1).padStart(8)}ms  ${row.max.toFixed(1).padStart(7)}ms  ${row.freeze.toFixed(1).padStart(9)}ms  ${row.note}`
+    );
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  }
+);

--- a/scripts/bench-normalize-text.ts
+++ b/scripts/bench-normalize-text.ts
@@ -1,0 +1,92 @@
+// What normalizeText actually costs, and the negative result that matters:
+// profiling `reading:path` blamed ~133 ms of its 212 ms on this function, but
+// normalising every string the vault holds takes about 8 ms. The function was
+// never slow — it was being called tens of thousands of times by a caller that
+// built a full deduplicated list to show three items. Optimising the normaliser
+// would have bought almost nothing; this file is here so nobody tries again.
+//
+// It does check one real simplification: the trailing `\s+` pass cannot match,
+// because the class before it has already collapsed every whitespace run into a
+// single space. Candidates are timed on the vault's own strings and must return
+// exactly what the original returns for every one of them — a normaliser that
+// differs on a single accent silently changes which works count as cited.
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+const userData = process.env.NODUS_TEST_USERDATA;
+if (!userData) throw new Error('NODUS_TEST_USERDATA is required');
+const db = new Database(path.join(userData, 'nodus.sqlite'), { readonly: true });
+
+const corpus = [
+  ...(db.prepare('SELECT cited_work AS v FROM external_refs').all() as { v: string | null }[]),
+  ...(db.prepare('SELECT title AS v FROM works').all() as { v: string | null }[]),
+  ...(db.prepare('SELECT authors_json AS v FROM works').all() as { v: string | null }[]),
+].map((r) => r.v);
+
+console.log(`cadenas del vault: ${corpus.length}\n`);
+
+/** The implementation as it stands. */
+function original(text: string | null | undefined): string {
+  if (!text) return '';
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9ñ]+/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// `[^a-z0-9ñ]+` already collapses every run of non-alphanumerics — spaces
+// included — into a single space, so the `\s+` pass that follows it can only ever
+// match single spaces and rewrite them as themselves.
+function withoutRedundantPass(text: string | null | undefined): string {
+  if (!text) return '';
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9ñ]+/gi, ' ')
+    .trim();
+}
+
+const candidates: [string, (t: string | null | undefined) => string][] = [
+  ['original', original],
+  ['sin la pasada \\s+ redundante (aplicada)', withoutRedundantPass],
+];
+
+// ── equivalence first: a faster wrong answer is not a result ─────────────────
+const expected = corpus.map(original);
+for (const [name, fn] of candidates) {
+  let mismatch = -1;
+  for (let i = 0; i < corpus.length; i++) {
+    if (fn(corpus[i]) !== expected[i]) {
+      mismatch = i;
+      break;
+    }
+  }
+  if (mismatch >= 0) {
+    console.error(`${name}: DIFIERE en la cadena ${mismatch}`);
+    console.error(`  entrada:  ${JSON.stringify(String(corpus[mismatch]).slice(0, 90))}`);
+    console.error(`  esperado: ${JSON.stringify(expected[mismatch].slice(0, 90))}`);
+    console.error(`  obtenido: ${JSON.stringify(fn(corpus[mismatch]).slice(0, 90))}`);
+    process.exit(1);
+  }
+}
+console.log('todas las variantes coinciden con la original en las ' + corpus.length + ' cadenas\n');
+
+// ── then speed ──────────────────────────────────────────────────────────────
+const ROUNDS = 12;
+for (const [name, fn] of candidates) {
+  for (const s of corpus) fn(s); // warm
+  const samples: number[] = [];
+  for (let round = 0; round < ROUNDS; round++) {
+    const started = process.hrtime.bigint();
+    for (const s of corpus) fn(s);
+    samples.push(Number(process.hrtime.bigint() - started) / 1e6);
+  }
+  samples.sort((a, b) => a - b);
+  const median = samples[Math.floor(samples.length / 2)];
+  console.log(`  ${name.padEnd(40)} ${median.toFixed(1).padStart(7)} ms`);
+}
+process.exit(0);

--- a/scripts/bench-picker-ideas.ts
+++ b/scripts/bench-picker-ideas.ts
@@ -1,0 +1,53 @@
+// Differential test for the argument map's seed picker.
+//
+// The picker used to be fed by the whole ideas graph, filtered in the renderer to
+// the nodes that are neither themes nor authors. It is now fed by a dedicated
+// query. The two must select the same ideas and carry the same label and
+// statement for each — a cheaper list that quietly drops or renames candidates
+// would be a regression the user only meets when a search comes up empty.
+import { buildIdeaGraph } from '../electron/graph/graphService';
+import { listPickerIdeas } from '../electron/db/ideasRepo';
+
+function time<T>(label: string, fn: () => T): T {
+  const started = process.hrtime.bigint();
+  const value = fn();
+  console.log(`  ${label.padEnd(34)} ${(Number(process.hrtime.bigint() - started) / 1e6).toFixed(1).padStart(8)} ms`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const started = process.hrtime.bigint();
+  const graph = await buildIdeaGraph();
+  console.log(`  ${'grafo entero (lo de antes)'.padEnd(34)} ${(Number(process.hrtime.bigint() - started) / 1e6).toFixed(1).padStart(8)} ms`);
+  const picker = time('listPickerIdeas (lo de ahora)', () => listPickerIdeas());
+
+  const fromGraph = graph.nodes
+    .filter((n) => n.type !== 'theme' && n.type !== 'author')
+    .map((n) => `${n.id} | ${n.label} | ${n.statement ?? ''}`)
+    .sort();
+  const fromPicker = picker.map((i) => `${i.global_id} | ${i.label} | ${i.statement ?? ''}`).sort();
+
+  console.log(`\n  ideas: ${fromGraph.length} (grafo) vs ${fromPicker.length} (selector)`);
+  console.log(`  aristas cargadas y nunca leidas: ${graph.edges.length}`);
+
+  const same = fromGraph.length === fromPicker.length && fromGraph.every((v, i) => v === fromPicker[i]);
+  console.log(`  identicas (id + etiqueta + enunciado): ${same ? 'SI' : 'NO'}`);
+  if (!same) {
+    const graphOnly = fromGraph.filter((v) => !fromPicker.includes(v)).slice(0, 3);
+    const pickerOnly = fromPicker.filter((v) => !fromGraph.includes(v)).slice(0, 3);
+    console.error(`  solo en el grafo:    ${JSON.stringify(graphOnly)}`);
+    console.error(`  solo en el selector: ${JSON.stringify(pickerOnly)}`);
+    process.exit(1);
+  }
+
+  const bytes = (value: unknown) => (JSON.stringify(value)?.length ?? 0) / 1048576;
+  console.log(`\n  payload IPC: ${bytes(graph).toFixed(1)} MB -> ${bytes(picker).toFixed(1)} MB`);
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  }
+);

--- a/scripts/bench-renderer-profile.mjs
+++ b/scripts/bench-renderer-profile.mjs
@@ -1,0 +1,113 @@
+// CPU-profiles the renderer while one sidebar section opens.
+//
+// bench-section-render.mjs says *which* section blocks the window; this says what
+// the renderer was doing while it did. It drives the real app over CDP, records a
+// V8 profile across the click, and reports self time by function against the
+// build's source map, so the names are the app's own rather than minified ones.
+//
+//   NODUS_USERDATA=<copy> BENCH_SECTION=Projects node scripts/bench-renderer-profile.mjs
+import { spawn, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import WebSocket from 'ws';
+
+const userData = process.env.NODUS_USERDATA;
+if (!userData) throw new Error('NODUS_USERDATA is required (point it at a COPY of the profile)');
+const section = process.env.BENCH_SECTION ?? 'Projects';
+const port = Number(process.env.BENCH_CDP_PORT ?? 9336);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const child = spawn(`${process.cwd()}/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron`, ['.', `--remote-debugging-port=${port}`], {
+  cwd: process.cwd(),
+  env: { ...process.env, NODUS_USERDATA: userData, NODUS_DISABLE_AUTO_UPDATE: '1' },
+  stdio: 'ignore',
+});
+function cleanup(code) {
+  try { child.kill('SIGKILL'); } catch { /* gone */ }
+  try { execSync(`pkill -f "${userData}" || true`); } catch { /* gone */ }
+  process.exit(code);
+}
+
+await sleep(Number(process.env.BENCH_BOOT_MS ?? 30_000));
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const main = targets.find((t) => t.url.includes('index.html'));
+if (!main) { console.error('no se encontro la ventana principal'); cleanup(1); }
+
+const ws = new WebSocket(main.webSocketDebuggerUrl);
+await new Promise((r) => ws.once('open', r));
+let nextId = 0;
+const pending = new Map();
+ws.on('message', (raw) => {
+  const msg = JSON.parse(raw);
+  if (msg.id && pending.has(msg.id)) { pending.get(msg.id)(msg.result); pending.delete(msg.id); }
+});
+const send = (method, params = {}) =>
+  new Promise((resolve) => {
+    const id = ++nextId;
+    pending.set(id, resolve);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+const evaluate = async (expression) =>
+  (await send('Runtime.evaluate', { expression, returnByValue: true }))?.result?.value;
+
+await evaluate(`(() => {
+  for (const sel of ['.startup-update-primary', '.startup-update-close', '.whats-new-close']) {
+    const el = document.querySelector(sel);
+    if (el) { el.click(); return sel; }
+  }
+  return null;
+})()`);
+await sleep(2500);
+
+const SECTION_BUTTONS = `[...document.querySelectorAll('nav[data-testid="resizable-sidebar"] button')].filter((b) => !b.hasAttribute('aria-expanded'))`;
+const LABEL = `(b) => (b.textContent || '').replace(/\\s+/g,' ').trim().slice(0, 26)`;
+const click = () => evaluate(`(() => {
+  const b = ${SECTION_BUTTONS}.find((x) => (${LABEL})(x) === ${JSON.stringify(section)});
+  if (!b) return false;
+  b.click();
+  return true;
+})()`);
+
+// Visit once so the lazy chunk is loaded: the profile should show the section's
+// steady-state cost, not a one-off module evaluation.
+if (!(await click())) { console.error(`seccion "${section}" no encontrada`); cleanup(1); }
+await sleep(3000);
+await evaluate(`${SECTION_BUTTONS}.find((x) => (${LABEL})(x) === 'Home')?.click()`);
+await sleep(2000);
+
+await send('Profiler.enable');
+await send('Profiler.setSamplingInterval', { interval: 100 });
+await send('Profiler.start');
+await click();
+await sleep(Number(process.env.BENCH_PROFILE_MS ?? 4000));
+const { profile } = await send('Profiler.stop');
+
+const outDir = process.env.BENCH_OUT_DIR ?? '.';
+fs.writeFileSync(path.join(outDir, 'renderer.cpuprofile'), JSON.stringify(profile));
+
+const nodes = new Map(profile.nodes.map((n) => [n.id, n]));
+const self = new Map();
+for (let i = 0; i < profile.samples.length; i++) {
+  const delta = profile.timeDeltas[i] ?? 0;
+  const id = profile.samples[i];
+  self.set(id, (self.get(id) ?? 0) + Math.max(delta, 0));
+}
+const total = [...self.values()].reduce((a, b) => a + b, 0);
+const rows = [...self.entries()]
+  .map(([id, us]) => {
+    const frame = nodes.get(id).callFrame;
+    const file = (frame.url || '').split('/').pop() || '';
+    return { ms: us / 1000, label: `${frame.functionName || '(anon)'}  [${file}:${(frame.lineNumber ?? 0) + 1}]` };
+  })
+  .sort((a, b) => b.ms - a.ms);
+
+console.log(`\nseccion: ${section}  ·  muestreado: ${(total / 1000).toFixed(0)} ms de CPU en el renderer\n`);
+console.log(`${'self ms'.padStart(9)}  funcion`);
+console.log('-'.repeat(92));
+for (const row of rows.slice(0, 20)) {
+  if (row.ms < 2) break;
+  console.log(`${row.ms.toFixed(1).padStart(9)}  ${row.label.slice(0, 78)}`);
+}
+
+ws.close();
+cleanup(0);

--- a/scripts/bench-section-render.mjs
+++ b/scripts/bench-section-render.mjs
@@ -1,0 +1,216 @@
+// Clicks through the sidebar in the real window and times what the user sees.
+//
+// The IPC bench measures the main process; this measures the renderer. They fail
+// differently: a slow query makes the new section arrive late, while a long task
+// in the renderer makes the whole window stop responding — the spinning beachball
+// — even after the data is already there. So the headline number here is not the
+// total but `peor tarea`: the longest single stretch the renderer's main thread
+// went without yielding. Anything over ~50 ms drops frames; over ~200 ms feels
+// like the app hung.
+//
+// Two passes: the first visit to a section also pays for its lazy-loaded chunk,
+// the second is what navigating around actually costs.
+//
+//   NODUS_USERDATA=<copy> node scripts/bench-section-render.mjs
+import { spawn, execSync } from 'node:child_process';
+import WebSocket from 'ws';
+
+const userData = process.env.NODUS_USERDATA;
+if (!userData) throw new Error('NODUS_USERDATA is required (point it at a COPY of the profile)');
+const port = Number(process.env.BENCH_CDP_PORT ?? 9333);
+const settleMs = Number(process.env.BENCH_SETTLE_MS ?? 500);
+const timeoutMs = Number(process.env.BENCH_TIMEOUT_MS ?? 12_000);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const child = spawn(`${process.cwd()}/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron`, ['.', `--remote-debugging-port=${port}`], {
+  cwd: process.cwd(),
+  env: { ...process.env, NODUS_USERDATA: userData, NODUS_DISABLE_AUTO_UPDATE: '1' },
+  stdio: 'ignore',
+});
+
+function cleanup(code) {
+  try { child.kill('SIGKILL'); } catch { /* already gone */ }
+  try { execSync(`pkill -f "${userData}" || true`); } catch { /* already gone */ }
+  process.exit(code);
+}
+process.on('SIGINT', () => cleanup(1));
+
+await sleep(Number(process.env.BENCH_BOOT_MS ?? 30_000));
+
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const main = targets.find((t) => t.url.includes('index.html'));
+if (!main) {
+  console.error('no se encontro la ventana principal');
+  cleanup(1);
+}
+
+const ws = new WebSocket(main.webSocketDebuggerUrl);
+await new Promise((r) => ws.once('open', r));
+let nextId = 0;
+function evaluate(expression, awaitPromise = false) {
+  return new Promise((resolve, reject) => {
+    const id = ++nextId;
+    const onMessage = (raw) => {
+      const msg = JSON.parse(raw);
+      if (msg.id !== id) return;
+      ws.off('message', onMessage);
+      if (msg.result?.exceptionDetails) reject(new Error(msg.result.exceptionDetails.text));
+      else resolve(msg.result?.result?.value);
+    };
+    ws.on('message', onMessage);
+    ws.send(JSON.stringify({ id, method: 'Runtime.evaluate', params: { expression, returnByValue: true, awaitPromise } }));
+  });
+}
+
+// ── instrumentation, installed once in the page ─────────────────────────────
+await evaluate(`
+(() => {
+  const bench = { longTasks: [], mutations: 0, lastMutation: 0, frames: 0, t0: 0 };
+  window.__bench = bench;
+  new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) bench.longTasks.push({ start: entry.startTime, duration: entry.duration });
+  }).observe({ entryTypes: ['longtask'] });
+  new MutationObserver(() => { bench.mutations += 1; bench.lastMutation = performance.now(); })
+    .observe(document.body, { childList: true, subtree: true, characterData: true, attributes: true });
+  const tick = () => { bench.frames += 1; requestAnimationFrame(tick); };
+  requestAnimationFrame(tick);
+  // A renderer long task and a blocked main process both show as a frozen window,
+  // but only the first appears in PerformanceObserver: while the main process is
+  // busy the renderer is simply idle, waiting for an IPC reply that is not coming.
+  // So poll a trivial channel and record the worst round trip — that is the wait
+  // the user actually sits through.
+  bench.ipc = [];
+  (async () => {
+    for (;;) {
+      const started = performance.now();
+      try { await window.nodus.getQueue(); } catch { /* vault switching */ }
+      bench.ipc.push({ start: started, rtt: performance.now() - started });
+      if (bench.ipc.length > 4000) bench.ipc.splice(0, 2000);
+      await new Promise((r) => setTimeout(r, 30));
+    }
+  })();
+  window.__benchReset = () => {
+    bench.longTasks.length = 0;
+    bench.mutations = 0;
+    bench.frames = 0;
+    bench.ipc.length = 0;
+    bench.t0 = performance.now();
+    bench.lastMutation = bench.t0;
+    return bench.t0;
+  };
+  window.__benchRead = () => ({
+    now: performance.now(),
+    t0: bench.t0,
+    mutations: bench.mutations,
+    lastMutation: bench.lastMutation,
+    frames: bench.frames,
+    longTasks: bench.longTasks.filter((t) => t.start >= bench.t0).map((t) => t.duration),
+    ipc: bench.ipc.filter((s) => s.start >= bench.t0).map((s) => s.rtt),
+  });
+  return true;
+})()
+`);
+
+// Any startup modal sits over the sidebar and would swallow the clicks.
+await evaluate(`(() => {
+  for (const sel of ['.startup-update-primary', '.startup-update-close', '.whats-new-close', '.roadmap-close']) {
+    const el = document.querySelector(sel);
+    if (el) { el.click(); return sel; }
+  }
+  return null;
+})()`);
+await sleep(2500);
+
+// A sidebar button is either a section or a group toggle; only the toggles carry
+// aria-expanded. Clicking a toggle reshuffles everything below it, which is why
+// this matches on label rather than position and skips the toggles entirely.
+const SECTION_BUTTONS = `[...document.querySelectorAll('nav[data-testid="resizable-sidebar"] button')].filter((b) => !b.hasAttribute('aria-expanded'))`;
+const LABEL = `(b) => (b.textContent || '').replace(/\\s+/g,' ').trim().slice(0, 26)`;
+
+const listSections = () => evaluate(`JSON.stringify(${SECTION_BUTTONS}.map(${LABEL}).filter(Boolean))`).then((s) => JSON.parse(s || '[]'));
+
+// Expand every collapsed group first, so the list is stable for both passes and a
+// click never lands on a header that reshuffles everything below it.
+for (let round = 0; round < 4; round++) {
+  const before = (await listSections()).length;
+  for (const label of await listSections()) {
+    await evaluate(`(() => {
+      for (const b of document.querySelectorAll('nav[data-testid="resizable-sidebar"] button[aria-expanded="false"]')) b.click();
+      return true;
+    })()`);
+  }
+  await sleep(300);
+  if ((await listSections()).length === before) break;
+}
+const items = (await listSections()).map((label) => ({ label }));
+console.log(`secciones encontradas en la barra lateral: ${items.length}\n`);
+
+async function visit(item) {
+  await evaluate(`window.__benchReset()`);
+  const clicked = await evaluate(`(() => {
+    const b = ${SECTION_BUTTONS}.find((x) => (${LABEL})(x) === ${JSON.stringify(item.label)});
+    if (!b) return false;
+    b.click();
+    return true;
+  })()`);
+  if (!clicked) return null;
+
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    await sleep(150);
+    last = await evaluate(`JSON.stringify(window.__benchRead())`).then((s) => JSON.parse(s));
+    if (last.mutations > 0 && last.now - last.lastMutation >= settleMs) break;
+  }
+  if (!last) return null;
+  // Proof the click navigated rather than, say, being swallowed by an overlay: the
+  // sidebar paints the active section. Without this check a row of zeros reads as
+  // "instant" when it really means "nothing happened".
+  const active = await evaluate(`(() => {
+    const b = ${SECTION_BUTTONS}.find((x) => x.className.includes('bg-indigo'));
+    return b ? (${LABEL})(b) : null;
+  })()`);
+  const total = Math.max(0, last.lastMutation - last.t0);
+  const tasks = last.longTasks;
+  return {
+    label: item.label,
+    total,
+    blocked: tasks.reduce((sum, d) => sum + d, 0),
+    worst: tasks.length ? Math.max(...tasks) : 0,
+    tasks: tasks.length,
+    ipcWorst: last.ipc.length ? Math.max(...last.ipc) : 0,
+    mutations: last.mutations,
+    landed: active === item.label,
+    timedOut: last.now - last.lastMutation < settleMs,
+  };
+}
+
+function table(title, rows) {
+  console.log(`\n${title}`);
+  const width = Math.max(...rows.map((r) => r.label.length), 12);
+  console.log(`${'seccion'.padEnd(width)}  ${'render'.padStart(9)}  ${'peor tarea UI'.padStart(14)}  ${'peor espera IPC'.padStart(16)}`);
+  console.log('-'.repeat(width + 48));
+  for (const r of [...rows].sort((a, b) => Math.max(b.worst, b.ipcWorst) - Math.max(a.worst, a.ipcWorst))) {
+    console.log(
+      `${r.label.padEnd(width)}  ${r.total.toFixed(0).padStart(7)}ms  ${r.worst.toFixed(0).padStart(12)}ms  ${r.ipcWorst.toFixed(0).padStart(14)}ms${r.landed ? '' : '   (NO navego)'}${r.timedOut ? '   (no se estabiliza)' : ''}`
+    );
+  }
+}
+
+const first = [];
+for (const item of items) {
+  const result = await visit(item);
+  if (result) first.push(result);
+}
+table('PRIMERA visita (incluye la carga del chunk de la vista)', first);
+
+const second = [];
+for (const item of items) {
+  const result = await visit(item);
+  if (result) second.push(result);
+}
+table('SEGUNDA visita (navegacion normal)', second);
+
+ws.close();
+cleanup(0);

--- a/scripts/stub-electron-capture.mjs
+++ b/scripts/stub-electron-capture.mjs
@@ -1,0 +1,134 @@
+// `electron` stub that CAPTURES every ipcMain.handle registration, so a bench can
+// invoke the real main-process handlers headlessly against a copied vault.
+//
+// Separate from scripts/stub-electron.mjs, which exists for pure-DB smoke tests and
+// throws ipcMain registrations away. This one keeps them in HANDLERS, which is what
+// lets scripts/bench-ipc-latency.ts and scripts/bench-in-clause-audit.ts call all
+// ~1,200 channels without booting a window. It is deliberately generous about what
+// it exports: registerIpc pulls in most of the main process, and every missing
+// electron export is a build error rather than a runtime one.
+const tmp = process.env.NODUS_TEST_USERDATA || '/tmp/nodus-smoke-userdata';
+
+export const HANDLERS = new Map();
+export const LISTENERS = new Map();
+
+export const ipcMain = {
+  handle: (channel, fn) => { HANDLERS.set(channel, fn); },
+  handleOnce: (channel, fn) => { HANDLERS.set(channel, fn); },
+  removeHandler: (channel) => { HANDLERS.delete(channel); },
+  on: (channel, fn) => { LISTENERS.set(channel, fn); },
+  once: (channel, fn) => { LISTENERS.set(channel, fn); },
+  removeAllListeners: () => undefined,
+  emit: () => undefined,
+};
+
+export const app = {
+  getPath: () => tmp,
+  getName: () => 'Nodus',
+  setName: () => undefined,
+  getVersion: () => '3.0.0',
+  getAppPath: () => process.cwd(),
+  isPackaged: false,
+  on: () => undefined,
+  once: () => undefined,
+  whenReady: async () => undefined,
+  quit: () => undefined,
+  exit: () => undefined,
+  relaunch: () => undefined,
+  setLoginItemSettings: () => undefined,
+  getLoginItemSettings: () => ({ openAtLogin: false }),
+  requestSingleInstanceLock: () => true,
+  setAsDefaultProtocolClient: () => true,
+  addRecentDocument: () => undefined,
+  dock: { setIcon: () => undefined, setBadge: () => undefined, bounce: () => 0 },
+  getLocale: () => 'es',
+};
+
+export const safeStorage = {
+  isEncryptionAvailable: () => false,
+  encryptString: (s) => Buffer.from(String(s)),
+  decryptString: (b) => Buffer.from(b).toString(),
+};
+
+export const dialog = {
+  showSaveDialog: async () => ({ canceled: true, filePath: undefined }),
+  showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
+  showMessageBox: async () => ({ response: 0 }),
+  showErrorBox: () => undefined,
+};
+
+export class BrowserWindow {
+  static getAllWindows() { return []; }
+  static fromWebContents() { return null; }
+  constructor() {
+    this.webContents = {
+      send: () => undefined,
+      on: () => undefined,
+      once: () => undefined,
+      session: { setPermissionRequestHandler: () => undefined, webRequest: { onBeforeSendHeaders: () => undefined } },
+      setWindowOpenHandler: () => undefined,
+      executeJavaScript: async () => undefined,
+    };
+  }
+  on() { return this; }
+  once() { return this; }
+  loadURL() { return Promise.resolve(); }
+  loadFile() { return Promise.resolve(); }
+  show() {}
+  hide() {}
+  close() {}
+  destroy() {}
+  isDestroyed() { return false; }
+  setBounds() {}
+  getBounds() { return { x: 0, y: 0, width: 1440, height: 900 }; }
+}
+
+export const shell = {
+  openExternal: async () => undefined,
+  openPath: async () => '',
+  showItemInFolder: () => undefined,
+  trashItem: async () => undefined,
+};
+
+export const nativeTheme = { shouldUseDarkColors: false, on: () => undefined, themeSource: 'system' };
+export const Menu = { setApplicationMenu: () => undefined, buildFromTemplate: () => ({ popup: () => undefined }) };
+export const MenuItem = class {};
+export const Tray = class { constructor() {} setToolTip() {} setContextMenu() {} on() {} destroy() {} };
+export const screen = {
+  getPrimaryDisplay: () => ({ workArea: { x: 0, y: 0, width: 1440, height: 900 }, bounds: { x: 0, y: 0, width: 1440, height: 900 }, scaleFactor: 2 }),
+  getAllDisplays: () => [{ workArea: { x: 0, y: 0, width: 1440, height: 900 }, bounds: { x: 0, y: 0, width: 1440, height: 900 }, scaleFactor: 2 }],
+  getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+  getDisplayNearestPoint: () => ({ workArea: { x: 0, y: 0, width: 1440, height: 900 }, bounds: { x: 0, y: 0, width: 1440, height: 900 }, scaleFactor: 2 }),
+  on: () => undefined,
+};
+export const session = { defaultSession: { setPermissionRequestHandler: () => undefined, webRequest: { onBeforeSendHeaders: () => undefined } }, fromPartition: () => ({}) };
+export const protocol = {
+  registerSchemesAsPrivileged: () => undefined,
+  handle: () => undefined,
+  registerFileProtocol: () => true,
+};
+export const net = { fetch: async () => { throw new Error('net disabled in bench'); } };
+export const powerMonitor = { on: () => undefined };
+export const powerSaveBlocker = { start: () => 0, stop: () => undefined, isStarted: () => false };
+export const systemPreferences = { getMediaAccessStatus: () => 'granted', askForMediaAccess: async () => true };
+export const nativeImage = { createFromPath: () => ({ isEmpty: () => true, resize: () => ({}), toPNG: () => Buffer.alloc(0) }), createFromBuffer: () => ({ isEmpty: () => true, resize: () => ({}), toPNG: () => Buffer.alloc(0) }), createEmpty: () => ({ isEmpty: () => true }) };
+export const clipboard = { writeText: () => undefined, readText: () => '' };
+export const globalShortcut = { register: () => true, unregisterAll: () => undefined };
+export const desktopCapturer = { getSources: async () => [] };
+export const webContents = { getAllWebContents: () => [], fromId: () => null };
+export const utilityProcess = { fork: () => ({ on: () => undefined, postMessage: () => undefined, kill: () => undefined }) };
+
+export default {
+  app, safeStorage, dialog, ipcMain, BrowserWindow, shell, nativeTheme, Menu, MenuItem, Tray,
+  screen, session, protocol, net, powerMonitor, powerSaveBlocker, systemPreferences,
+  nativeImage, clipboard, globalShortcut, desktopCapturer, webContents, utilityProcess,
+};
+
+export const ShareMenu = class { constructor() {} popup() {} closePopup() {} };
+export const Notification = class { constructor() {} show() {} close() {} on() {} static isSupported() { return false; } };
+export const crashReporter = { start: () => undefined };
+export const inAppPurchase = {};
+export const contextBridge = { exposeInMainWorld: () => undefined };
+export const ipcRenderer = { invoke: async () => undefined, send: () => undefined, on: () => undefined };
+export const webFrame = {};
+export const webFrameMain = { fromId: () => null };

--- a/scripts/test-extraction-cache-prune.mjs
+++ b/scripts/test-extraction-cache-prune.mjs
@@ -1,0 +1,94 @@
+// The eviction policy for the extracted-text cache.
+//
+// That cache is written with an upsert and, until this branch, never read back
+// out again: on a real library it held 105 MB of PDF text across 211 rows — about
+// a quarter of the vault file, copied whole into every backup. Nothing in it is
+// authoritative, so the only thing worth testing is that the policy frees what it
+// promises and never keeps more than the cap.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const dir = mkdtempSync(path.join(tmpdir(), 'nodus-extraction-prune-'));
+const bundle = path.join(dir, 'extractionCachePrune.cjs');
+
+execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
+  path.join(repoRoot, 'shared/extractionCachePrune.ts'),
+  '--bundle',
+  '--platform=node',
+  '--format=cjs',
+  `--outfile=${bundle}`,
+]);
+
+const { planExtractionCacheEviction } = createRequire(import.meta.url)(bundle);
+
+const MB = 1024 * 1024;
+/** `n` entries of `bytes` each, oldest first. */
+function entries(n, bytes) {
+  return Array.from({ length: n }, (_, i) => ({
+    filePath: `/docs/${String(i).padStart(3, '0')}.pdf`,
+    bytes,
+    updatedAt: new Date(Date.UTC(2026, 0, 1 + i)).toISOString(),
+  }));
+}
+
+test('keeps everything when the cache is under the cap', () => {
+  const plan = planExtractionCacheEviction(entries(10, MB), { maxBytes: 64 * MB });
+  assert.deepEqual(plan.remove, []);
+  assert.equal(plan.freedBytes, 0);
+  assert.equal(plan.keptBytes, 10 * MB);
+});
+
+test('trims to the cap keeping the newest', () => {
+  // 10 MB of entries, 4 MB cap: the four newest survive.
+  const plan = planExtractionCacheEviction(entries(10, MB), { maxBytes: 4 * MB });
+  assert.equal(plan.keptBytes, 4 * MB);
+  assert.equal(plan.freedBytes, 6 * MB);
+  assert.deepEqual(
+    plan.remove.sort(),
+    ['/docs/000.pdf', '/docs/001.pdf', '/docs/002.pdf', '/docs/003.pdf', '/docs/004.pdf', '/docs/005.pdf']
+  );
+});
+
+test('never keeps more than the cap — the property the 105 MB cache violated', () => {
+  for (const [count, size, cap] of [
+    [211, 512 * 1024, 64 * MB],
+    [1, 200 * MB, 64 * MB],
+    [50, 3 * MB, 10 * MB],
+    [0, 0, 64 * MB],
+  ]) {
+    const plan = planExtractionCacheEviction(entries(count, size), { maxBytes: cap });
+    assert.ok(plan.keptBytes <= cap, `kept ${plan.keptBytes} > cap ${cap}`);
+    assert.equal(plan.keptBytes + plan.freedBytes, count * size);
+  }
+});
+
+test('a single oversized entry is evicted rather than kept over the cap', () => {
+  // Guards the boundary the obvious implementation gets wrong: subtracting until
+  // the total fits leaves one entry that is itself larger than the whole budget.
+  const plan = planExtractionCacheEviction(
+    [{ filePath: '/docs/huge.pdf', bytes: 200 * MB, updatedAt: '2026-07-01T00:00:00.000Z' }],
+    { maxBytes: 64 * MB }
+  );
+  assert.deepEqual(plan.remove, ['/docs/huge.pdf']);
+  assert.equal(plan.keptBytes, 0);
+});
+
+test('the plan is deterministic when timestamps tie', () => {
+  const tied = ['b', 'a', 'c'].map((name) => ({
+    filePath: `/docs/${name}.pdf`,
+    bytes: MB,
+    updatedAt: '2026-07-01T00:00:00.000Z',
+  }));
+  const first = planExtractionCacheEviction(tied, { maxBytes: 2 * MB });
+  const again = planExtractionCacheEviction([...tied].reverse(), { maxBytes: 2 * MB });
+  assert.deepEqual(first.remove, again.remove);
+});
+
+test.after(() => rmSync(dir, { recursive: true, force: true }));

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,21 +25,28 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.0.0');
+  assert.equal(currentRelease?.version, '3.0.1');
   assert.equal(currentRelease?.date, '2026-07-30');
+  // A performance release: one highlight per cause, not one per query fixed.
+  assert.equal(currentRelease?.highlights.length, 3);
+
+  // The vault introductions live in 3.0.0 and must keep their shape as newer
+  // releases land on top of them — hence looked up by version, not as `[0]`.
+  const vaultsRelease = RELEASE_NOTES.find((note) => note.version === '3.0.0');
+  assert.equal(vaultsRelease?.date, '2026-07-30');
   // One highlight per new vault, not one per refinement inside it — see the note
   // above RELEASE_3_0_0_HIGHLIGHTS.
-  assert.equal(currentRelease?.highlights.length, 16);
+  assert.equal(vaultsRelease?.highlights.length, 16);
   const newVaults = ['prosopography', 'primary_sources', 'testimonios', 'worldbuilding'];
   for (const scope of newVaults) {
     assert.equal(
-      currentRelease.highlights.filter((h) => h.scope === scope).length,
+      vaultsRelease.highlights.filter((h) => h.scope === scope).length,
       1,
       `${scope} must introduce itself once, not once per refinement`,
     );
   }
   // And they lead, in the order shared/vaultTypes.ts declares them.
-  assert.deepEqual(currentRelease.highlights.slice(0, 4).map((h) => h.scope), newVaults);
+  assert.deepEqual(vaultsRelease.highlights.slice(0, 4).map((h) => h.scope), newVaults);
   // 2.8.0 was authored and never published; its highlights live inside 3.0.0 now, so
   // no entry may claim that version or the picker would offer a release nobody ran.
   assert.ok(!RELEASE_NOTES.some((note) => note.version === '2.8.0'));

--- a/shared/api/academic.ts
+++ b/shared/api/academic.ts
@@ -78,6 +78,7 @@ import type {
   IdeaDetail,
   IdeaPage,
   IdeaPageRequest,
+  IdeaPickerItem,
   ImmersionAnswerRequest,
   ImmersionAnswerResult,
   ImmersionProgress,
@@ -247,6 +248,8 @@ export interface AcademicApi {
   /** Bounded theme backbone plus cross-theme bridges. */
   getGraphTheme(theme: string, cap?: number): Promise<GraphData>;
   listIdeasPage(request: IdeaPageRequest): Promise<IdeaPage>;
+  /** Every graph idea, with only the fields a picker shows and searches. */
+  listPickerIdeas(): Promise<IdeaPickerItem[]>;
   listIdeaConnections(globalId: string): Promise<IdeaConnection[]>;
   getIdeaDetail(globalId: string): Promise<IdeaDetail | null>;
   deleteIdea(globalId: string): Promise<void>;

--- a/shared/extractionCachePrune.ts
+++ b/shared/extractionCachePrune.ts
@@ -1,0 +1,75 @@
+// Which rows of the extracted-text cache to drop.
+//
+// `extraction_cache` holds the full text pulled out of every PDF ever scanned,
+// keyed by file path, written with an upsert and never deleted. On a real library
+// it reached 105 MB across 211 rows — a quarter of the whole vault file — and it
+// grows with every document the user ever opens. It is also copied verbatim into
+// every backup archive.
+//
+// The policy is deliberately kept out of the repository so it can be tested
+// without a database: give it the rows and it says which paths to remove.
+
+export interface ExtractionCacheEntry {
+  filePath: string;
+  /** Size of the cached text in bytes. */
+  bytes: number;
+  /** ISO timestamp of the last write for this path. */
+  updatedAt: string;
+}
+
+export interface ExtractionCachePruneOptions {
+  /** Cap for the total cached text kept. */
+  maxBytes: number;
+}
+
+export interface ExtractionCachePrunePlan {
+  /** Paths to delete, in no particular order. */
+  remove: string[];
+  /** Bytes the deletions free. */
+  freedBytes: number;
+  /** Bytes left after the deletions. */
+  keptBytes: number;
+}
+
+/**
+ * Decide what to evict: keep entries newest-first until `maxBytes` is reached and
+ * drop the rest.
+ *
+ * Recency here is the last *write*, which is when the text was extracted. There is
+ * no read timestamp to do true LRU with, and adding one would mean writing to the
+ * database on every cache *hit* — a worse trade than evicting slightly wrong.
+ *
+ * Deliberately NOT a rule: "drop entries whose document no longer exists". It reads
+ * as the obvious first pass, but a Zotero attachment on a cloud-synced or removable
+ * volume is missing exactly when the volume is, and throwing its text away costs a
+ * full re-extraction — OCR included — for no gain the size cap does not already
+ * give. A cache that is merely bounded is enough.
+ *
+ * Nothing here is load-bearing for correctness: every evicted entry is re-derived
+ * from its PDF the next time that document is scanned.
+ */
+export function planExtractionCacheEviction(
+  entries: ExtractionCacheEntry[],
+  { maxBytes }: ExtractionCachePruneOptions
+): ExtractionCachePrunePlan {
+  const remove: string[] = [];
+  let freedBytes = 0;
+  let keptBytes = 0;
+
+  // Newest first. Ties break on path so the plan is deterministic — two entries
+  // written in the same millisecond must not evict differently between runs.
+  const ordered = [...entries].sort((a, b) =>
+    a.updatedAt === b.updatedAt ? a.filePath.localeCompare(b.filePath) : a.updatedAt < b.updatedAt ? 1 : -1
+  );
+
+  for (const entry of ordered) {
+    if (keptBytes + entry.bytes <= maxBytes) {
+      keptBytes += entry.bytes;
+      continue;
+    }
+    remove.push(entry.filePath);
+    freedBytes += entry.bytes;
+  }
+
+  return { remove, freedBytes, keptBytes };
+}

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -58,7 +58,14 @@ export const RELEASE_2_7_0_IT: string[] = [
 ];
 
 /** Italian history, indexed by release and highlight order. */
+const RELEASE_3_0_1_IT: string[] = [
+  "Le sezioni che restavano a pensare ora si aprono subito. Il grafo, la mappa degli argomenti, i dibattiti, il percorso di lettura e le schede d'autore si caricavano percorrendo l'intera biblioteca e bloccavano tutta l'applicazione mentre lo facevano; ora chiedono solo ciò che mostrano. In una cassaforte di quasi 10.000 idee il grafo passa da 2,7 secondi di finestra congelata a meno di 0,2.",
+  "Nodi resta fermo quando non ha nulla da dire e torna a muoversi appena ce l'ha. La sua animazione non si fermava mai, nemmeno con l'applicazione a riposo: costava in permanenza mezzo core e scaldava la macchina. Ora mantiene la posa qualche secondo dopo l'ultima attività e si sveglia al passaggio del mouse, a un cambio di stato o all'arrivo di una notifica. Nessuna animazione è stata rimossa.",
+  "La cache del testo estratto dai PDF ora ha un limite. Veniva scritta e mai ripulita, arrivando a occupare un quarto del file della cassaforte, che per giunta finisce intero in ogni backup. Ora è limitata a 64 MB conservando il più recente; nulla va perso, perché qualsiasi testo scartato viene riestratto dal suo PDF quando serve.",
+];
+
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.0.1": RELEASE_3_0_1_IT,
   "3.0.0": RELEASE_3_0_0_IT,
   "2.7.0": RELEASE_2_7_0_IT,
   "2.6.3": RELEASE_2_6_3_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -1,4 +1,11 @@
+const RELEASE_3_0_1_TR: string[] = [
+  "Eskiden takılan bölümler artık anında açılıyor. Grafik, argüman haritası, tartışmalar, okuma rotası ve yazar dosyaları tüm kütüphaneyi dolaşarak yükleniyor ve bu sırada uygulamanın tamamını donduruyordu; artık yalnızca gösterdiklerini istiyorlar. Yaklaşık 10.000 fikirlik bir kasada grafik 2,7 saniyelik donmuş pencereden 0,2 saniyenin altına indi.",
+  "Nodi söyleyecek bir şeyi yokken duruşunu koruyor, olduğu anda yeniden hareket ediyor. Animasyonu hiç durmuyordu, uygulama boştayken bile: bu sürekli olarak yarım çekirdeğe mal oluyor ve makineyi ısıtıyordu. Artık son etkinlikten birkaç saniye sonra duruluyor; imleç üzerine gelince, durum değişince veya bir bildirim gelince uyanıyor. Hiçbir animasyon kaldırılmadı.",
+  "PDF'lerden çıkarılan metin önbelleği artık sınırlı. Yazılıyor ama hiç budanmıyordu ve kasa dosyasının dörtte birine ulaşıyordu; üstelik bu dosya her yedeğe olduğu gibi kopyalanıyor. Artık en yenisi korunarak 64 MB ile sınırlı; hiçbir şey kaybolmuyor, çünkü atılan metin gerektiğinde PDF'inden yeniden çıkarılıyor.",
+];
+
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.0.1": RELEASE_3_0_1_TR,
   // Index-matched with RELEASE_3_0_0_HIGHLIGHTS — keep this order.
   "3.0.0": [
     "Tarihsel toplulukları kişi kişi incelemek için yeni Prosopografi kasası. Kaynak yakalama ve eleştirisi, kimlik çözümleme, kanıtıyla birlikte olgucuklar, topluluklar, kohortlar ve anketler, arama, katmanlı ağ çözümlemesi ve veri alışverişi: kanıt, verinin arkasında durmak yerine ona yapışık gelir.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -36,6 +36,40 @@ export interface ReleaseNote {
 
 interface RawReleaseNote extends Omit<ReleaseNote, 'highlights'> { highlights: RawReleaseHighlight[] }
 
+/**
+ * 3.0.1 is a performance release: no new surface, three things that were making
+ * the app feel slow on a large vault. One highlight per cause, not one per query.
+ */
+const RELEASE_3_0_1_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'academic',
+    es: 'Las secciones que se quedaban pensando ahora abren de inmediato. El grafo, el mapa de argumentos, los debates, la ruta de lectura y las fichas de autor cargaban recorriendo la biblioteca entera y bloqueaban la aplicación entera mientras lo hacían; ahora piden solo lo que muestran. En una bóveda de casi 10.000 ideas, el grafo pasa de 2,7 segundos de congelación a menos de 0,2.',
+    en: 'Sections that used to hang now open straight away. The graph, argument map, debates, reading path and author dossiers each loaded by walking the whole library, freezing the entire app while they did it; now they ask only for what they show. On a vault of nearly 10,000 ideas the graph went from 2.7 seconds of frozen window to under 0.2.',
+    fr: 'Les sections qui restaient bloquées s’ouvrent désormais immédiatement. Le graphe, la carte d’arguments, les débats, le parcours de lecture et les fiches d’auteur se chargeaient en parcourant toute la bibliothèque et figeaient l’application entière ; ils ne demandent plus que ce qu’ils affichent. Sur une bibliothèque de près de 10 000 idées, le graphe passe de 2,7 secondes de fenêtre figée à moins de 0,2.',
+    de: 'Abschnitte, die sich aufhängten, öffnen jetzt sofort. Graph, Argumentkarte, Debatten, Lesepfad und Autorendossiers luden jeweils die gesamte Bibliothek und blockierten dabei die ganze Anwendung; jetzt fragen sie nur noch ab, was sie anzeigen. In einem Tresor mit fast 10.000 Ideen sank der Graph von 2,7 Sekunden eingefrorenem Fenster auf unter 0,2.',
+    pt: 'As secções que ficavam a pensar abrem agora de imediato. O grafo, o mapa de argumentos, os debates, o percurso de leitura e as fichas de autor carregavam percorrendo toda a biblioteca e bloqueavam a aplicação inteira enquanto o faziam; agora pedem apenas o que mostram. Num cofre com quase 10 000 ideias, o grafo passou de 2,7 segundos de janela congelada para menos de 0,2.',
+    'pt-BR': 'As seções que ficavam travadas agora abrem na hora. O grafo, o mapa de argumentos, os debates, a trilha de leitura e as fichas de autor carregavam percorrendo a biblioteca inteira e travavam o aplicativo todo enquanto isso; agora pedem apenas o que exibem. Em um cofre com quase 10.000 ideias, o grafo caiu de 2,7 segundos de janela congelada para menos de 0,2.',
+  },
+  {
+    scope: 'nodi',
+    es: 'Nodi se queda quieto cuando no tiene nada que decir, y vuelve a moverse en cuanto lo tiene. Su animación no paraba nunca, ni siquiera con la aplicación en reposo: eso costaba la mitad de un núcleo de forma permanente y calentaba el equipo. Ahora mantiene la pose unos segundos después de la última actividad y despierta al pasar el ratón, al cambiar de estado o al llegar un aviso. Ninguna animación se ha eliminado.',
+    en: 'Nodi holds its pose when it has nothing to say, and moves again the moment it does. Its animation never stopped, not even with the app idle: that cost half a core permanently and warmed the machine. It now settles a few seconds after the last activity and wakes on hover, on a change of state or on a notification. No animation was removed.',
+    fr: 'Nodi garde la pose quand il n’a rien à dire, et repart dès qu’il a quelque chose. Son animation ne s’arrêtait jamais, même application au repos : cela coûtait en permanence un demi-cœur et chauffait la machine. Il se fige désormais quelques secondes après la dernière activité et se réveille au survol, à un changement d’état ou à une notification. Aucune animation n’a été supprimée.',
+    de: 'Nodi hält seine Pose, wenn es nichts zu sagen hat, und bewegt sich wieder, sobald doch. Seine Animation hörte nie auf, auch nicht bei ruhender App: das kostete dauerhaft einen halben Kern und erwärmte das Gerät. Jetzt kommt es einige Sekunden nach der letzten Aktivität zur Ruhe und erwacht beim Überfahren, bei einem Zustandswechsel oder bei einer Benachrichtigung. Es wurde keine Animation entfernt.',
+    pt: 'O Nodi mantém a pose quando não tem nada a dizer e volta a mover-se assim que tem. A sua animação nunca parava, nem com a aplicação em repouso: isso custava permanentemente meio núcleo e aquecia o equipamento. Agora assenta alguns segundos após a última atividade e acorda ao passar o rato, ao mudar de estado ou ao chegar um aviso. Nenhuma animação foi removida.',
+    'pt-BR': 'O Nodi mantém a pose quando não tem nada a dizer e volta a se mexer assim que tem. Sua animação nunca parava, nem com o aplicativo em repouso: isso custava meio núcleo permanentemente e esquentava a máquina. Agora ele descansa alguns segundos após a última atividade e acorda ao passar o mouse, ao mudar de estado ou ao chegar um aviso. Nenhuma animação foi removida.',
+  },
+  {
+    scope: 'general',
+    es: 'La caché de texto extraído de los PDF ya tiene un tope. Se escribía sin borrarse nunca y llegaba a ocupar una cuarta parte del archivo de la bóveda, que además se copia entera en cada copia de seguridad. Ahora se limita a 64 MB conservando lo más reciente; nada se pierde, porque cualquier texto descartado se vuelve a extraer del PDF cuando hace falta.',
+    en: 'The cache of text extracted from PDFs is now bounded. It was written and never pruned, growing to a quarter of the vault file — which is copied whole into every backup. It is now capped at 64 MB keeping the most recent; nothing is lost, because any discarded text is extracted from its PDF again when needed.',
+    fr: 'Le cache du texte extrait des PDF est désormais borné. Il était écrit sans jamais être purgé et atteignait un quart du fichier de la bibliothèque, lui-même copié en entier dans chaque sauvegarde. Il est maintenant limité à 64 Mo en conservant le plus récent ; rien n’est perdu, car tout texte écarté est réextrait de son PDF au besoin.',
+    de: 'Der Cache des aus PDFs extrahierten Texts ist jetzt begrenzt. Er wurde geschrieben und nie bereinigt und erreichte ein Viertel der Tresordatei, die vollständig in jede Sicherung kopiert wird. Er ist nun auf 64 MB begrenzt und behält das Neueste; nichts geht verloren, denn verworfener Text wird bei Bedarf erneut aus seinem PDF extrahiert.',
+    pt: 'A cache do texto extraído dos PDF passa a ter um limite. Era escrita sem nunca ser purgada e chegava a ocupar um quarto do ficheiro do cofre, que é copiado por inteiro em cada cópia de segurança. Agora está limitada a 64 MB mantendo o mais recente; nada se perde, porque qualquer texto descartado é extraído de novo do PDF quando for preciso.',
+    'pt-BR': 'O cache do texto extraído dos PDFs agora tem limite. Ele era gravado e nunca podado, chegando a ocupar um quarto do arquivo do cofre, que é copiado inteiro em cada backup. Agora está limitado a 64 MB mantendo o mais recente; nada se perde, porque qualquer texto descartado é extraído do PDF de novo quando necessário.',
+  },
+];
+
 // v2.6.0 shipped with only three Zotero highlights, silently dropping every other
 // change merged since 2.5.4 (Nodus Apps, Nodus Translate, local image generation,
 // professional PDF exports, the experimental Nodus Server, and the rest of the
@@ -434,6 +468,11 @@ const RELEASE_2_7_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.0.1',
+    date: '2026-07-30',
+    highlights: RELEASE_3_0_1_HIGHLIGHTS,
+  },
   {
     version: '3.0.0',
     date: '2026-07-30',

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4124,6 +4124,18 @@ export interface IdeaListItem {
   connectionCount: number;
 }
 
+/**
+ * The least an idea picker needs: enough to show it and to search it, nothing else.
+ * Views that only let the user *choose* an idea used to load the whole ideas graph
+ * for this, edges included.
+ */
+export interface IdeaPickerItem {
+  global_id: string;
+  type: IdeaType;
+  label: string;
+  statement: string;
+}
+
 export interface IdeaPageRequest {
   offset: number;
   limit: number;

--- a/src/components/nodi/Nodi.tsx
+++ b/src/components/nodi/Nodi.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, type CSSProperties } from 'react';
+import { useId, useMemo, type CSSProperties, type PointerEventHandler } from 'react';
 import './nodi.css';
 
 export type NodiState =
@@ -78,6 +78,8 @@ export function Nodi({
   raiseArm = false,
   className,
   style,
+  onPointerEnter,
+  onPointerLeave,
 }: {
   state?: NodiState;
   role?: NodiRole;
@@ -87,6 +89,8 @@ export function Nodi({
   raiseArm?: boolean;
   className?: string;
   style?: CSSProperties;
+  onPointerEnter?: PointerEventHandler<SVGSVGElement>;
+  onPointerLeave?: PointerEventHandler<SVGSVGElement>;
 }) {
   const mesh = useMemo(buildMesh, []);
   // Namespace the gradient/filter/clip IDs so several Nodi can coexist in one document.
@@ -104,6 +108,8 @@ export function Nodi({
       aria-label="Nodi"
       data-state={state}
       data-role={role}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
     >
       <defs>
         <radialGradient id={u('bodyG')} cx="40%" cy="30%" r="75%">

--- a/src/components/nodi/NodiAvatar.tsx
+++ b/src/components/nodi/NodiAvatar.tsx
@@ -4,6 +4,42 @@ import { orbHue } from '@shared/nodiOrb';
 import { Nodi, type NodiRole, type NodiState } from './Nodi';
 import { NodiOrb } from './NodiOrb';
 
+/** How long Nodi keeps breathing after the last thing that happened to it. */
+const REST_DELAY_MS = 6_000;
+
+/** States in which Nodi has nothing to say and may hold still. */
+const QUIESCENT: ReadonlySet<NodiState> = new Set<NodiState>(['idle', 'sleeping']);
+
+/**
+ * Whether Nodi may stop animating.
+ *
+ * Nodi's ambient motion is drawn as SVG, and SVG subtrees do not get their own
+ * compositor layer: one animating property repaints the whole figure, filters
+ * (`feTurbulence`, `feGaussianBlur`) included, on every frame. Measured on an idle
+ * app that costs ~50% CPU permanently — with all the animations running or with
+ * only one, it barely differs. The only cheap number of animations is zero, so the
+ * lever that works is *when* rather than *how many*.
+ *
+ * So Nodi animates while something is happening — a real state, an unread
+ * notification, a pointer reaching for it — and holds its pose a few seconds after
+ * the last of those. `animation-play-state: paused` freezes it mid-keyframe and
+ * resumes exactly there, so nothing is lost and no animation is removed.
+ */
+function useAtRest(state: NodiState, raiseArm: boolean, hovered: boolean, reduceMotion: boolean): boolean {
+  const settled = QUIESCENT.has(state) && !raiseArm && !hovered;
+  const [atRest, setAtRest] = useState(false);
+  useEffect(() => {
+    if (!settled) {
+      setAtRest(false);
+      return;
+    }
+    // Someone who asked for less motion gets the still pose immediately.
+    const timer = window.setTimeout(() => setAtRest(true), reduceMotion ? 0 : REST_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [settled, reduceMotion]);
+  return atRest;
+}
+
 /**
  * Nodi, in whichever shape the user chose: the classic character or the orb. Every
  * surface that draws Nodi renders THIS rather than either one directly, so the choice
@@ -53,6 +89,16 @@ export function NodiAvatar({
     return window.nodus.onVaultChanged((vault) => setVaultType(vault?.type ?? null));
   }, []);
 
+  const [hovered, setHovered] = useState(false);
+  const atRest = useAtRest(state, raiseArm, hovered, resolved?.reduceMotion ?? false);
+  // Reaching for Nodi wakes it before the pointer arrives, so it is already moving
+  // by the time it is grabbed rather than starting with a jolt.
+  const wake = {
+    onPointerEnter: () => setHovered(true),
+    onPointerLeave: () => setHovered(false),
+  };
+  const classes = [className, atRest ? 'nodi-at-rest' : ''].filter(Boolean).join(' ') || undefined;
+
   // Until the settings land we can't know which Nodi to draw. Hold the space rather
   // than guessing: drawing the classic one first would flash and swap for orb users.
   if (!resolved) return <span aria-hidden="true" style={{ display: 'block', height, width: height * 0.9 }} />;
@@ -65,10 +111,22 @@ export function NodiAvatar({
         height={height}
         draggable={draggable}
         raiseArm={raiseArm}
-        className={className}
+        className={classes}
         style={style}
+        {...wake}
       />
     );
   }
-  return <Nodi state={state} role={role} height={height} draggable={draggable} raiseArm={raiseArm} className={className} style={style} />;
+  return (
+    <Nodi
+      state={state}
+      role={role}
+      height={height}
+      draggable={draggable}
+      raiseArm={raiseArm}
+      className={classes}
+      style={style}
+      {...wake}
+    />
+  );
 }

--- a/src/components/nodi/NodiOrb.tsx
+++ b/src/components/nodi/NodiOrb.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, type CSSProperties } from 'react';
+import { useId, useMemo, type CSSProperties, type PointerEventHandler } from 'react';
 import { NODI_ORB_DEFAULT_COLOR, hueOfHex } from '@shared/nodiOrb';
 import type { NodiState } from './Nodi';
 import './nodiOrb.css';
@@ -155,6 +155,8 @@ export function NodiOrb({
   raiseArm = false,
   className,
   style,
+  onPointerEnter,
+  onPointerLeave,
 }: {
   state?: NodiState;
   /** Hue (0–359) every cool colour derives from. Defaults to Nodi's own blue. */
@@ -165,6 +167,8 @@ export function NodiOrb({
   raiseArm?: boolean;
   className?: string;
   style?: CSSProperties;
+  onPointerEnter?: PointerEventHandler<SVGSVGElement>;
+  onPointerLeave?: PointerEventHandler<SVGSVGElement>;
 }) {
   const starfield = useMemo(buildStarfield, []);
   const mesh = useMemo(buildMesh, []);
@@ -188,6 +192,8 @@ export function NodiOrb({
       role="img"
       aria-label="Nodi"
       data-state={state}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
     >
       <defs>
         <filter id={u('b1')} x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="1.2" /></filter>

--- a/src/components/nodi/nodi.css
+++ b/src/components/nodi/nodi.css
@@ -236,6 +236,12 @@
 @keyframes nodi-close-halo { 0%,68%{opacity:.7;transform:scale(1)} 84%{opacity:1;transform:scale(1.28)} 100%{opacity:0;transform:scale(1.65)} }
 @keyframes nodi-close-smoke { 0%{opacity:0;transform:translateY(4px) scale(.2)} 32%{opacity:.92} 100%{opacity:0;transform:translateY(-18px) scale(1.8)} }
 
+/* Holds the pose when nothing is happening — paused, not removed, so every keyframe
+   above survives and resumes where it left off. See nodiOrb.css for the measurements
+   that made this necessary; the classic Nodi pays the same per-frame SVG repaint. */
+.nodi-svg.nodi-at-rest,
+.nodi-svg.nodi-at-rest * { animation-play-state: paused; }
+
 @media (prefers-reduced-motion: reduce) {
   .nodi-svg * { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
 }

--- a/src/components/nodi/nodiOrb.css
+++ b/src/components/nodi/nodiOrb.css
@@ -321,6 +321,23 @@
   100% { transform: scale(1.9); opacity: 0; }
 }
 
+/* ── at rest ───────────────────────────────────────────────────────────────────────
+ * Nodi holds its pose when nothing is happening (see NodiAvatar's useAtRest).
+ *
+ * `animation-play-state: paused` and NOT `animation: none`: every keyframe above
+ * stays exactly as authored, the orb freezes wherever in its cycle it happened to
+ * be, and resuming picks up from there instead of snapping back to 0%. Nothing is
+ * removed — flip the class off and the whole thing runs again.
+ *
+ * Why it is worth doing: an SVG subtree has no compositor layer of its own, so any
+ * one animating property repaints the entire orb — turbulence clouds, gaussian
+ * glows, blend modes and all — every frame. Measured idle on this corpus, the orb
+ * cost ~50% CPU with all its animations and still ~23% with only one left running.
+ * Zero is the only cheap number, which is why this is a switch rather than a diet.
+ */
+.nodi-orb.nodi-at-rest,
+.nodi-orb.nodi-at-rest * { animation-play-state: paused; }
+
 @media (prefers-reduced-motion: reduce) {
   .nodi-orb, .nodi-orb * { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
 }

--- a/src/views/ArgumentMapView.tsx
+++ b/src/views/ArgumentMapView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import type { AppSettings, ArgumentBlock, ArgumentMap, ArgumentRouteSuggestion, EdgeDetail, EdgeType, GraphData, IdeaDetail, IdeaType } from '@shared/types';
+import type { AppSettings, ArgumentBlock, ArgumentMap, ArgumentRouteSuggestion, EdgeDetail, EdgeType, IdeaDetail, IdeaPickerItem, IdeaType } from '@shared/types';
 import { EDGE_LABELS, NODE_COLORS, NODE_LABELS, Icon, Spinner } from '../components/ui';
 import { ModelPicker } from '../components/ModelPicker';
 import {
@@ -64,7 +64,7 @@ function maxDepth(block: ArgumentBlock, depth = 0): number {
 }
 
 export function ArgumentMapView({ settings }: { settings: AppSettings }) {
-  const [graph, setGraph] = useState<GraphData>({ nodes: [], edges: [] });
+  const [ideaNodes, setIdeaNodes] = useState<IdeaPickerItem[]>([]);
   const [graphLoaded, setGraphLoaded] = useState(false);
   const [mode, setMode] = useState<'auto' | 'ai'>('auto');
   const [suggestions, setSuggestions] = useState<ArgumentRouteSuggestion[]>([]);
@@ -96,9 +96,13 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
     onDismiss: () => setSeedSearchOpen(false),
   });
 
+  // The seed picker shows at most 60 ideas and searches their label and statement.
+  // It used to get that list by loading the entire ideas graph — 9,721 nodes and
+  // 34,531 edges, none of the edges ever read — which cost ~170 ms of blocked main
+  // process and a multi-megabyte IPC message every time this view opened.
   useEffect(() => {
-    void window.nodus.getGraph('ideas').then((g) => {
-      setGraph(g);
+    void window.nodus.listPickerIdeas().then((ideas) => {
+      setIdeaNodes(ideas);
       setGraphLoaded(true);
     });
   }, []);
@@ -140,12 +144,6 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
   useEffect(() => {
     localStorage.setItem(DETAIL_FONT_KEY, String(detailFontSize));
   }, [detailFontSize]);
-
-  // Idea candidates for the picker (real ideas only, no themes/authors).
-  const ideaNodes = useMemo(
-    () => graph.nodes.filter((n) => n.type !== 'theme' && n.type !== 'author'),
-    [graph]
-  );
 
   const filteredIdeas = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -300,10 +298,10 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
                     )}
                     {filteredIdeas.map((n) => (
                       <button
-                        key={n.id}
+                        key={n.global_id}
                         className="w-full text-left px-3 py-2 hover:bg-neutral-800 border-b border-neutral-800/60 last:border-0"
                         onClick={() => {
-                          setSeedId(n.id);
+                          setSeedId(n.global_id);
                           setSearch(n.label);
                           setSeedSearchOpen(false);
                         }}


### PR DESCRIPTION
Performance audit against a real 465 MB academic vault, and the fixes it produced.

Refs #299 — that issue tracks v3.0.0 performance, CPU and **stability** across the
app; this covers the first two on one vault type, so it stays open. What is left
is listed at the bottom.

## What was wrong

Two independent causes, each measured rather than guessed.

**Read paths block the whole window.** Every one runs to completion on the single
main-process event loop that also answers the renderer, so a slow query is not a
slow section — it is a frozen application. Verified with two synthetic controls
(250 ms spent blocking against 250 ms spent waiting): every read channel froze for
its entire duration.

**Nodi animated forever.** Idle app, mascot on: 50.7% CPU. Mascot off: 0.7%. Mascot
on screen with its animations paused: 0.8% — so the transparent always-on-top
window is free and the animation was the whole bill.

## Measured, before → after

Time the main process could not answer, opening each section in the real window:

| Section | before | after |
|---|---|---|
| Graph | ~2,900 ms | 133 ms |
| Argument map | 417 ms | 142 ms |
| Debates | 350 ms | 114 ms |
| Reading path | 278 ms | 174 ms |
| Author dossier (channel) | 198 ms | 41 ms |
| Idle CPU, whole app | 50.7% | 0.8% |

Causes: a corpus-sized `IN (?,?,…)` making SQLite's cost grow with ideas × works;
the argument map loading 9,721 nodes and 34,531 edges for a sixty-item picker that
never reads an edge; two N+1s in debates; the reading path assembling every gap
statement in the corpus to show three; the author dossier running one theme query
per related author. Plus an unbounded PDF-text cache that had reached a quarter of
the vault file and entered every backup.

## How each fix is proven

Every change dumps its output before and after **from the real code both times** —
`git stash` around the diff, not a reimplementation — and compares byte for byte.
That is what caught the two changes that were faster but wrong:

- a theme aggregate that returned the same labels in a different order, which feeds
  an embedding text hash and would have marked 2,563 ideas as needing re-embedding;
- a batched author query whose shared-theme lists stopped being alphabetical,
  because the old per-author query had been alphabetical by accident of the plan.

Two rewrites were **reverted** after measuring: one gained nothing, the other was
not equivalent.

## Tooling

Six benchmarks under `scripts/bench-*`, all pointed at a copy of a profile and
never the live one: main-process blocking per IPC channel, idle CPU per helper
process, per-section render cost driven through CDP in the real window, SQL
attribution per statement, an `IN`-clause audit, and a renderer V8 profile.

## Not covered

- **Stability — nothing.** No leak, long-session or under-load testing.
- The other seven vault types.
- The what's-new modals' aurora backgrounds: measured at 30–40% CPU while open,
  left alone because the variants could not be told apart above the noise.
- Home's cold start (~1.1 s): diagnosed as I/O on a 465 MB file; a covering index
  made no difference.
- Projects renders in ~658 ms with only 11 ms of IPC — renderer-bound, and the
  profile shows no single hot frame.

Coverage on the academic vault: of the 91 IPC channels its views reach, 36 are
measured and the rest are write/AI actions. No unmeasured read path remains.
