### PR TITLE
Unfold the argument map one branch at a time

### DIFF
--- a/scripts/test-argument-map-tree.mjs
+++ b/scripts/test-argument-map-tree.mjs
@@ -1,0 +1,123 @@
+// Argument map — progressive unfold and block rendering.
+//
+// Two bugs were reported against this view: branches could not be unfolded one
+// by one, and collapsing one left the card stretched to the height the whole
+// branch used to occupy. The first is logic (asserted by running the unfold),
+// the second is a rendering choice (asserted on the source, the app's
+// convention for UI wiring).
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const outDir = await mkdtemp(path.join(repoRoot, 'node_modules', '.nodus-argmap-'));
+test.after(async () => { await rm(outDir, { recursive: true, force: true }); });
+
+function loadModule(file) {
+  const bundle = path.join(outDir, `${path.basename(file).replace(/\.tsx?$/, '')}.cjs`);
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/esbuild'),
+    [
+      path.join(repoRoot, file),
+      '--bundle',
+      '--platform=node',
+      '--format=cjs',
+      '--target=es2022',
+      `--alias:@shared=${path.join(repoRoot, 'shared')}`,
+      `--outfile=${bundle}`,
+    ],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  return require(bundle);
+}
+
+const { expandableIdsByDepth } = loadModule('src/argumentMapTree.ts');
+const view = fs.readFileSync(path.join(repoRoot, 'src/views/ArgumentMapView.tsx'), 'utf8');
+
+/** A block tree shaped like the structural (automatic) maps: fan-out plus depth. */
+function makeTree() {
+  const leaf = (id) => ({ id, children: [] });
+  return {
+    id: 'root',
+    children: [
+      { id: 'a', children: [{ id: 'a1', children: [leaf('a1x'), leaf('a1y')] }, leaf('a2')] },
+      { id: 'b', children: [leaf('b1')] },
+      leaf('c'),
+    ],
+  };
+}
+
+/** Walk every block, so the assertions can talk about the whole tree. */
+function walk(block, depth = 0, acc = []) {
+  acc.push({ block, depth });
+  for (const child of block.children) walk(child, depth + 1, acc);
+  return acc;
+}
+
+test('the unfold opens one level per tick, root first', () => {
+  const levels = expandableIdsByDepth(makeTree());
+  assert.deepEqual(levels, [['root'], ['a', 'b'], ['a1']]);
+});
+
+test('every expandable block is reached, so the whole map does unfold', () => {
+  const tree = makeTree();
+  const levels = expandableIdsByDepth(tree);
+  const unfolded = new Set(levels.flat());
+  const expandable = walk(tree)
+    .filter(({ block }) => block.children.length > 0)
+    .map(({ block }) => block.id);
+  assert.deepEqual([...unfolded].sort(), [...expandable].sort());
+});
+
+test('a block is never opened before its parent (no orphan levels)', () => {
+  const tree = makeTree();
+  const levels = expandableIdsByDepth(tree);
+  const depthOf = new Map(walk(tree).map(({ block, depth }) => [block.id, depth]));
+  levels.forEach((ids, level) => {
+    assert.ok(ids.length > 0, `level ${level} is populated — the unfold must not stall on a hole`);
+    for (const id of ids) assert.equal(depthOf.get(id), level);
+  });
+});
+
+test('a leaf-only map yields a single level and stops the timer immediately', () => {
+  assert.deepEqual(expandableIdsByDepth({ id: 'root', children: [{ id: 'x', children: [] }] }), [['root']]);
+  assert.deepEqual(expandableIdsByDepth({ id: 'root', children: [] }), []);
+});
+
+test('collapsing a branch cannot distort the block: only the children wrapper animates', () => {
+  assert.ok(
+    !/<motion\.div\s+layout\b/.test(view) && !/\slayout(\s|=)/.test(view.replace(/layout="[^"]*"/g, '')),
+    'no framer-motion `layout` prop: its scale correction stretched the collapsed card and its text',
+  );
+  assert.match(
+    view,
+    /<motion\.div[\s\S]{0,200}key="children"[\s\S]{0,400}animate=\{\{ height: 'auto'/,
+    'the children wrapper animates its own height instead',
+  );
+  assert.doesNotMatch(view, /revealDepth/, 'the depth gate is gone — `expanded` is the only source of truth');
+});
+
+test('a manual toggle takes over from the automatic unfold', () => {
+  assert.match(
+    view,
+    /const toggleExpand = useCallback\(\(id: string\) => \{\s*\n\s*stopReveal\(\);/,
+    'toggling stops the timer, so the unfold cannot reopen a branch the user just collapsed',
+  );
+});
+
+test('the back button sits to the left of the Automatic / AI toggle', () => {
+  const header = view.slice(view.indexOf('{/* Header / setup */}'), view.indexOf('{/* Body */}'));
+  const backButton = header.indexOf("t('Volver al selector')");
+  const modeToggle = header.indexOf("t('Automático')");
+  assert.ok(backButton > -1, 'the back button lives in the header');
+  assert.ok(modeToggle > -1 && backButton < modeToggle, 'and renders before the mode toggle');
+  assert.match(header, /className="btn btn-ghost text-xs gap-1\.5 px-2\.5 py-1\.5 mr-1 border/, 'keeping its own margin');
+  const body = view.slice(view.indexOf('{/* Body */}'));
+  assert.doesNotMatch(body, /t\('Volver al selector'\)/, 'and no longer duplicates inside the map card');
+});

--- a/scripts/test-virtual-card-spacing.mjs
+++ b/scripts/test-virtual-card-spacing.mjs
@@ -1,0 +1,50 @@
+// Virtualised card lists — the row pitch must leave a gap between cards.
+//
+// `VirtualList` gives every row a slot exactly `itemHeight` tall, so a card whose
+// fixed height equals the pitch touches the card above and below it: the reading
+// path shipped that way (246 / 246) and its blocks had no separation at all. The
+// gaps and ideas lists already reserved 12 px, which is the spacing this locks in.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CARD_GAP = 12;
+
+const LISTS = [
+  { view: 'src/views/ReadingPathView.tsx', rowConstant: 'READING_ENTRY_ROW_HEIGHT' },
+  { view: 'src/views/GapsView.tsx', rowConstant: 'GAP_ROW_HEIGHT' },
+  { view: 'src/views/IdeasView.tsx', rowConstant: 'IDEA_ROW_HEIGHT' },
+];
+
+/** Resolve `const NAME = 246;` or `const NAME = A + B;` from the view's own constants. */
+function readRowHeight(source, name) {
+  const numbers = new Map();
+  for (const [, key, value] of source.matchAll(/^const (\w+) = (\d+);$/gm)) numbers.set(key, Number(value));
+  if (numbers.has(name)) return numbers.get(name);
+  const sum = source.match(new RegExp(`^const ${name} = (\\w+) \\+ (\\w+);$`, 'm'));
+  assert.ok(sum, `${name} is a number or a sum of two constants`);
+  const [, left, right] = sum;
+  assert.ok(numbers.has(left) && numbers.has(right), `${name} adds two known constants`);
+  return numbers.get(left) + numbers.get(right);
+}
+
+for (const { view, rowConstant } of LISTS) {
+  test(`${path.basename(view)} separates its cards inside the virtual list`, () => {
+    const source = fs.readFileSync(path.join(repoRoot, view), 'utf8');
+    const rowHeight = readRowHeight(source, rowConstant);
+    const cardHeights = [...source.matchAll(/className=[^\n]*?\bcard\b[^\n]*?h-\[(\d+)px\]/g)].map((m) => Number(m[1]));
+    const alsoBeforeCard = [...source.matchAll(/className=[^\n]*?h-\[(\d+)px\][^\n]*?\bcard\b/g)].map((m) => Number(m[1]));
+    const heights = [...new Set([...cardHeights, ...alsoBeforeCard])];
+    assert.equal(heights.length, 1, `${view} has exactly one fixed card height`);
+
+    assert.ok(
+      rowHeight > heights[0],
+      `${rowConstant} (${rowHeight}) must exceed the ${heights[0]}px card, or the blocks touch`,
+    );
+    assert.equal(rowHeight - heights[0], CARD_GAP, 'and the gap matches the other lists');
+    assert.match(source, new RegExp(`itemHeight=\\{${rowConstant}\\}`), 'the constant is what drives the pitch');
+  });
+}

--- a/src/argumentMapTree.ts
+++ b/src/argumentMapTree.ts
@@ -1,0 +1,16 @@
+import type { ArgumentBlock } from '@shared/types';
+
+/**
+ * Ids of the blocks that have children, grouped by depth: level 0 is the root,
+ * level 1 its expandable children, and so on. The argument map opens one level
+ * per tick, so this is the script of that unfold — and it is contiguous by
+ * construction, because a block only lands at depth d when every ancestor above
+ * it has children too.
+ */
+export function expandableIdsByDepth(block: ArgumentBlock, depth = 0, acc: string[][] = []): string[][] {
+  if (block.children.length === 0) return acc;
+  if (!acc[depth]) acc[depth] = [];
+  acc[depth].push(block.id);
+  for (const child of block.children) expandableIdsByDepth(child, depth + 1, acc);
+  return acc;
+}

--- a/src/views/ArgumentMapView.tsx
+++ b/src/views/ArgumentMapView.tsx
@@ -18,6 +18,7 @@ import {
 } from '../components/NodeDetailPanel';
 import { useDismissableLayer } from '../hooks';
 import { useFeatureModel } from '../hooks/useFeatureModel';
+import { expandableIdsByDepth } from '../argumentMapTree';
 import { t, tx } from '../i18n';
 
 const RELATION_LABELS: Record<string, string> = {
@@ -52,17 +53,6 @@ function typeColor(type: ArgumentBlock['type']): string {
   return type === 'framing' ? '#a78bfa' : NODE_COLORS[type as IdeaType] ?? '#888';
 }
 
-/** Collect every block id that has children — used to default all branches expanded. */
-function collectExpandable(block: ArgumentBlock, acc: Set<string>): void {
-  if (block.children.length > 0) acc.add(block.id);
-  for (const c of block.children) collectExpandable(c, acc);
-}
-
-function maxDepth(block: ArgumentBlock, depth = 0): number {
-  if (block.children.length === 0) return depth;
-  return Math.max(...block.children.map((c) => maxDepth(c, depth + 1)));
-}
-
 export function ArgumentMapView({ settings }: { settings: AppSettings }) {
   const [ideaNodes, setIdeaNodes] = useState<IdeaPickerItem[]>([]);
   const [graphLoaded, setGraphLoaded] = useState(false);
@@ -79,10 +69,10 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
   const [building, setBuilding] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Progressive unfold: the map opens one level per tick after it is built. The
+  // expanded set is the single source of truth, so a manual toggle and the
+  // automatic unfold can never disagree about what is on screen.
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  // Progressive reveal: blocks only render once their depth passes this gate,
-  // which ramps up after the map loads so the scheme "deploys" level by level.
-  const [revealDepth, setRevealDepth] = useState(0);
   const revealTimerRef = useRef<number | null>(null);
 
   const [ideaDetail, setIdeaDetail] = useState<IdeaDetail | null>(null);
@@ -168,21 +158,27 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
     }
   }, []);
 
-  // Drive the progressive reveal once a map is built.
+  // Drive the progressive unfold once a map is built: open the root, then one
+  // deeper level per tick. Stops as soon as the last level is open.
   useEffect(() => {
-    if (!map) return;
-    const depth = maxDepth(map.root);
-    setRevealDepth(0);
     stopReveal();
+    if (!map) {
+      setExpanded(new Set());
+      return;
+    }
+    const levels = expandableIdsByDepth(map.root);
+    setExpanded(new Set(levels[0] ?? []));
+    if (levels.length <= 1) return;
+    let level = 1;
     revealTimerRef.current = window.setInterval(() => {
-      setRevealDepth((d) => {
-        if (d >= depth) {
-          stopReveal();
-          return d;
-        }
-        return d + 1;
+      const ids = levels[level++] ?? [];
+      setExpanded((cur) => {
+        const next = new Set(cur);
+        for (const id of ids) next.add(id);
+        return next;
       });
-    }, 220);
+      if (level >= levels.length) stopReveal();
+    }, 260);
     return stopReveal;
   }, [map, stopReveal]);
 
@@ -197,10 +193,8 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
     setDetailLoading(null);
     try {
       const result = await window.nodus.buildArgumentMap({ seedIdeaId: sid, model, mode });
+      // The unfold effect seeds `expanded` from the new map.
       setMap(result);
-      const ex = new Set<string>();
-      collectExpandable(result.root, ex);
-      setExpanded(ex);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -228,14 +222,17 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
     );
   }, []);
 
-  const toggleExpand = (id: string) => {
+  // A manual toggle hands control to the user: the automatic unfold stops so it
+  // cannot reopen a branch the user just collapsed.
+  const toggleExpand = useCallback((id: string) => {
+    stopReveal();
     setExpanded((cur) => {
       const next = new Set(cur);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
     });
-  };
+  }, [stopReveal]);
 
   const closeDetail = () => {
     detailSeqRef.current++;
@@ -255,6 +252,15 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
     <div className="h-full flex flex-col min-h-0">
       {/* Header / setup */}
       <div className="border-b border-neutral-800 p-3 flex flex-wrap gap-2 items-end text-xs">
+        {map && (
+          <button
+            className="btn btn-ghost text-xs gap-1.5 px-2.5 py-1.5 mr-1 border border-neutral-700"
+            title={t('Volver al selector')}
+            onClick={() => setMap(null)}
+          >
+            <Icon name="chevronLeft" size={12} /> {isAuto ? t('Recorridos') : t('Empezar de nuevo')}
+          </button>
+        )}
         <div className="flex rounded-lg overflow-hidden border border-neutral-700">
           <button
             className={`px-3 py-1.5 ${isAuto ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:bg-neutral-800'}`}
@@ -467,13 +473,6 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
                   <span>· {tx('{n} ideas', { n: map.ideaCount })}</span>
                   {map.truncated && <span className="text-amber-500">· {t('subgrafo recortado')}</span>}
                   <span className="text-neutral-600">· {isAuto ? t('modo automático') : t('modo IA')}</span>
-                  <button
-                    className="ml-auto btn btn-ghost text-xs gap-1 py-0.5 px-2"
-                    title={t('Volver al selector')}
-                    onClick={() => setMap(null)}
-                  >
-                    <Icon name="chevronLeft" size={12} /> {isAuto ? t('Recorridos') : t('Empezar de nuevo')}
-                  </button>
                 </div>
                 {map.overview && <p className="text-sm text-neutral-300 leading-relaxed">{map.overview}</p>}
               </div>
@@ -481,7 +480,6 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
                 block={map.root}
                 depth={0}
                 expanded={expanded}
-                revealDepth={revealDepth}
                 onToggle={toggleExpand}
                 onSelect={selectBlock}
               />
@@ -510,78 +508,78 @@ function BlockTree({
   block,
   depth,
   expanded,
-  revealDepth,
   onToggle,
   onSelect,
 }: {
   block: ArgumentBlock;
   depth: number;
   expanded: Set<string>;
-  revealDepth: number;
   onToggle: (id: string) => void;
   onSelect: (block: ArgumentBlock) => void;
 }) {
   const isExpanded = expanded.has(block.id);
   const hasChildren = block.children.length > 0;
-  const revealed = depth <= revealDepth;
   const accent = RELATION_ACCENT[block.relation] ?? '#737373';
 
   return (
-    <AnimatePresence initial={false}>
-      {revealed && (
-        <motion.div
-          layout
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -6 }}
-          transition={{ duration: 0.28, ease: 'easeOut' }}
-          className="relative"
-        >
-          <div
-            className="group relative rounded-lg border bg-neutral-900/80 hover:bg-neutral-800/80 transition-colors cursor-pointer"
-            style={{ borderLeftColor: accent, borderLeftWidth: 4 }}
-            onClick={() => onSelect(block)}
-          >
-            <div className="p-3">
-              <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2 mb-1 flex-wrap">
-                    <span
-                      className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded"
-                      style={{ backgroundColor: `${typeColor(block.type)}22`, color: typeColor(block.type) }}
-                    >
-                      {t(typeLabel(block.type))}
-                    </span>
-                    {block.relation !== 'root' && (
-                      <span className="text-[10px] text-neutral-500 flex items-center gap-1">
-                        <span style={{ color: accent }}><Icon name="arrowUp" size={10} className="rotate-90" /></span>
-                        {t(RELATION_LABELS[block.relation as EdgeType]) ?? block.relation}
-                      </span>
-                    )}
-                  </div>
-                  <div className="font-medium text-sm text-neutral-100">{block.label}</div>
-                  {block.summary && <div className="text-xs text-neutral-400 mt-1 leading-relaxed">{block.summary}</div>}
-                  {block.statement && depth === 0 && (
-                    <div className="text-xs text-neutral-500 mt-1.5 leading-relaxed">{block.statement}</div>
-                  )}
-                </div>
-                {hasChildren && (
-                  <button
-                    className="shrink-0 p-1 rounded hover:bg-neutral-700 text-neutral-400"
-                    title={isExpanded ? t('Contraer rama') : t('Desplegar rama')}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onToggle(block.id);
-                    }}
-                  >
-                    <Icon name={isExpanded ? 'minus' : 'plus'} size={14} />
-                  </button>
+    <div className="relative">
+      <div
+        className="group relative rounded-lg border bg-neutral-900/80 hover:bg-neutral-800/80 transition-colors cursor-pointer"
+        style={{ borderLeftColor: accent, borderLeftWidth: 4 }}
+        onClick={() => onSelect(block)}
+      >
+        <div className="p-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 mb-1 flex-wrap">
+                <span
+                  className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded"
+                  style={{ backgroundColor: `${typeColor(block.type)}22`, color: typeColor(block.type) }}
+                >
+                  {t(typeLabel(block.type))}
+                </span>
+                {block.relation !== 'root' && (
+                  <span className="text-[10px] text-neutral-500 flex items-center gap-1">
+                    <span style={{ color: accent }}><Icon name="arrowUp" size={10} className="rotate-90" /></span>
+                    {t(RELATION_LABELS[block.relation as EdgeType]) ?? block.relation}
+                  </span>
                 )}
               </div>
+              <div className="font-medium text-sm text-neutral-100">{block.label}</div>
+              {block.summary && <div className="text-xs text-neutral-400 mt-1 leading-relaxed">{block.summary}</div>}
+              {block.statement && depth === 0 && (
+                <div className="text-xs text-neutral-500 mt-1.5 leading-relaxed">{block.statement}</div>
+              )}
             </div>
+            {hasChildren && (
+              <button
+                className="shrink-0 p-1 rounded hover:bg-neutral-700 text-neutral-400"
+                title={isExpanded ? t('Contraer rama') : t('Desplegar rama')}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggle(block.id);
+                }}
+              >
+                <Icon name={isExpanded ? 'minus' : 'plus'} size={14} />
+              </button>
+            )}
           </div>
+        </div>
+      </div>
 
-          {hasChildren && isExpanded && (
+      {/* Only the children wrapper animates. A `layout` animation on the block
+          itself scale-corrects its own text, which left collapsed cards stretched
+          to the height the whole branch used to occupy. */}
+      <AnimatePresence initial={false}>
+        {hasChildren && isExpanded && (
+          <motion.div
+            key="children"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.24, ease: 'easeOut' }}
+            className="overflow-hidden"
+          >
             <div className="ml-3 pl-4 border-l border-neutral-800 mt-1 space-y-1.5">
               {block.children.map((child) => (
                 <BlockTree
@@ -589,15 +587,14 @@ function BlockTree({
                   block={child}
                   depth={depth + 1}
                   expanded={expanded}
-                  revealDepth={revealDepth}
                   onToggle={onToggle}
                   onSelect={onSelect}
                 />
               ))}
             </div>
-          )}
-        </motion.div>
-      )}
-    </AnimatePresence>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/src/views/ReadingPathView.tsx
+++ b/src/views/ReadingPathView.tsx
@@ -27,7 +27,12 @@ const STRATEGY_HELP: Record<ReadingPathStrategy, string> = {
   connected_authors: 'Da peso a autores relacionados por el grafo de ideas.',
   bridges: 'Busca textos que conectan varias líneas temáticas o zonas del grafo.',
 };
-const READING_ENTRY_ROW_HEIGHT = 246;
+// Virtual row pitch = card height + the gap between cards. The card itself stays
+// 246 px (`h-[246px]` below); the extra 12 px is what separates one block from the
+// next, matching the gaps and ideas lists.
+const READING_ENTRY_CARD_HEIGHT = 246;
+const READING_ENTRY_ROW_GAP = 12;
+const READING_ENTRY_ROW_HEIGHT = READING_ENTRY_CARD_HEIGHT + READING_ENTRY_ROW_GAP;
 
 export function ReadingPathView({
   onOpenGraph,


### PR DESCRIPTION
## Argument map

Two bugs were reported against this view: branches could not be unfolded one by one, and collapsing one left the card stretched over the height the whole branch used to occupy.

**The unfold.** Two states disagreed about what was on screen — `expanded`, which opened every branch at once as soon as the map was built, and a `revealDepth` gate that decided what was allowed to render. `expanded` is now the only source of truth: the map opens the root and then one deeper level per tick, so the scheme deploys branch by branch. Any manual toggle stops the timer, so it can no longer reopen a branch the user just collapsed. The level logic moved to `src/argumentMapTree.ts` so it can be exercised directly.

**The distortion.** Each block was wrapped in `<motion.div layout>`. A `layout` animation resolves a box change with scale correction, and the inverse correction only reaches children that are motion components themselves — plain text is left stretched. Collapsing a branch shrank the parent card from the height of the whole subtree to its own, and it stayed deformed, pushing the rest of the map out of view. Only the children wrapper animates now (height `0 → auto`), which never touches the card. framer-motion restores the literal `auto` when that animation completes, so nested branches still grow.

**Back button.** Moved out of the map card and into the header, to the left of the Automatic / AI toggle.

## Reading path

`VirtualList` gives every row a slot exactly `itemHeight` tall, and the card was `h-[246px]` inside a 246 px pitch, so the blocks touched. The pitch is now `246 + 12`; the card keeps its content height and gains the same separation the gaps and ideas lists already had (188/176 and 116/104).

## Tests

- `scripts/test-argument-map-tree.mjs` — runs the unfold (every expandable block is reached, no level opens before its parent) and locks the rendering choices.
- `scripts/test-virtual-card-spacing.mjs` — asserts across the three virtualised card lists that the row pitch exceeds the card height by the shared gap.

Both were checked against the pre-fix sources and fail there, including `READING_ENTRY_ROW_HEIGHT (246) must exceed the 246px card, or the blocks touch`.

`npm run typecheck`, `eslint` and `npm run build` are clean. `npm test` is 1459/1460; the one failure is `test-prosopography-e2e.mjs` timing out on `startup-update-modal`, confirmed pre-existing on this branch point with the changes stashed.
