### PR TITLE
Stop isolated profiles from deleting the real profile's API keys

### DIFF
--- a/electron/secrets/legacySecretRecovery.ts
+++ b/electron/secrets/legacySecretRecovery.ts
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 import { createDecipheriv, pbkdf2Sync } from 'node:crypto';
 import fs from 'node:fs';
 import type { AiProvider } from '@shared/types';
-import { lockedApiKeyProviders, apiKeyCandidateFiles, getApiKey, setApiKey } from './secretStore';
+import { lockedApiKeyProviders, apiKeyCandidateFiles, archivedApiKeyFiles, getApiKey, setApiKey } from './secretStore';
 
 const KEYCHAIN_TIMEOUT_MS = 120_000;
 const STORAGE_NAMES = ['nodus', 'Nodus'] as const;
@@ -139,7 +139,12 @@ async function performLegacyApiKeyRecovery(
   for (const storageName of STORAGE_NAMES) {
     const pending = lockedApiKeyProviders();
     if (pending.length === 0) break;
-    const candidates = Object.fromEntries(pending.map((provider) => [provider, apiKeyCandidateFiles(provider)])) as Partial<Record<AiProvider, string[]>>;
+    // The emergency archive is included: a blob that only survives there is
+    // exactly the case this recovery exists for.
+    const candidates = Object.fromEntries(pending.map((provider) => [
+      provider,
+      [...apiKeyCandidateFiles(provider), ...archivedApiKeyFiles(provider)],
+    ])) as Partial<Record<AiProvider, string[]>>;
     const keys = await runCredentialRecovery(storageName, candidates);
     for (const provider of pending) {
       const key = keys[provider];

--- a/electron/secrets/secretStore.ts
+++ b/electron/secrets/secretStore.ts
@@ -29,17 +29,29 @@ function legacyRootKeyFile(provider: AiProvider): string {
   return keyFileInDir(app.getPath('userData'), provider);
 }
 
+/** The released userData roots this profile may migrate from.
+ *
+ * app.setName('Nodus') also changed the default userData casing on
+ * case-sensitive systems, so the default profile scans both released spellings;
+ * inode/path deduplication below makes that harmless on Windows and macOS.
+ *
+ * An ISOLATED profile (NODUS_USERDATA — tests, the demo instance, a second copy
+ * opened on purpose) is a different install that merely sits next to the real
+ * one. It must never reach into its neighbour: these paths are not only read,
+ * they are retired and deleted, so scanning the sibling would let a throwaway
+ * profile destroy the user's real API keys. */
+function historicalRoots(currentRoot: string): string[] {
+  if (path.basename(currentRoot).toLowerCase() !== 'nodus') return [currentRoot];
+  const parent = path.dirname(currentRoot);
+  return [currentRoot, path.join(parent, 'nodus'), path.join(parent, 'Nodus')];
+}
+
 /** Every location used by released Nodus versions. The global file remains the
  * canonical target; the others are read-only recovery candidates. */
 export function apiKeyCandidateFiles(provider: AiProvider): string[] {
   const candidates = [keyFile(provider), legacyRootKeyFile(provider)];
   const currentRoot = app.getPath('userData');
-  const parent = path.dirname(currentRoot);
-  // app.setName('Nodus') also changed the default userData casing on
-  // case-sensitive systems. Scan both released roots on every platform;
-  // inode/path deduplication below makes this harmless on Windows and macOS.
-  const roots = [currentRoot, path.join(parent, 'nodus'), path.join(parent, 'Nodus')];
-  for (const root of [...new Set(roots)]) {
+  for (const root of [...new Set(historicalRoots(currentRoot))]) {
     candidates.push(keyFileInDir(path.join(root, 'secrets'), provider), keyFileInDir(root, provider));
     const vaultsRoot = path.join(root, 'vaults');
     try {
@@ -118,6 +130,15 @@ export function getApiKey(provider: AiProvider): string | null {
       return legacy;
     }
   }
+  // Last resort: the emergency archive. Nothing used to read it, so a key that
+  // only survived there was lost in practice.
+  for (const archived of archivedApiKeyFiles(provider)) {
+    const rescued = readKeyFile(archived);
+    if (rescued !== null) {
+      setApiKey(provider, rescued);
+      return rescued;
+    }
+  }
   return null;
 }
 
@@ -127,9 +148,10 @@ export function hasApiKey(provider: AiProvider): boolean {
 
 export function clearApiKey(provider: AiProvider): void {
   if (provider === 'codex' || provider === 'github-copilot') return;
-  // An explicit delete applies to every released storage location; otherwise an
-  // old per-vault copy could silently recreate the key on the next read.
-  for (const file of apiKeyCandidateFiles(provider)) {
+  // An explicit delete applies to every released storage location AND to the
+  // emergency archive; otherwise an old per-vault copy — or the archive getApiKey
+  // now falls back to — would silently recreate the key on the next read.
+  for (const file of [...apiKeyCandidateFiles(provider), ...archivedApiKeyFiles(provider)]) {
     if (fs.existsSync(file)) fs.unlinkSync(file);
   }
 }
@@ -159,10 +181,31 @@ function preserveLockedFile(file: string): void {
   archiveEncryptedFile(file);
 }
 
+function lockedArchiveDir(): string {
+  return path.join(globalSecretsDir(), 'locked-archive');
+}
+
+/** The emergency copies written by preserveLockedFile/retireHistoricalFile,
+ * newest first. Deliberately NOT part of apiKeyCandidateFiles: setApiKey retires
+ * that list, and retiring the rollback would defeat its only purpose. */
+export function archivedApiKeyFiles(provider: AiProvider): string[] {
+  const dir = lockedArchiveDir();
+  const prefix = `ai_key_${provider}-`;
+  try {
+    return fs.readdirSync(dir)
+      .filter((name) => name.startsWith(prefix) && name.endsWith('.bin'))
+      .sort()
+      .reverse()
+      .map((name) => path.join(dir, name));
+  } catch {
+    return []; // nothing was ever archived
+  }
+}
+
 function archiveEncryptedFile(file: string): void {
   const contents = fs.readFileSync(file);
   if (contents.toString('utf8').startsWith('b64:')) return;
-  const archiveDir = path.join(globalSecretsDir(), 'locked-archive');
+  const archiveDir = lockedArchiveDir();
   fs.mkdirSync(archiveDir, { recursive: true });
   const stamp = new Date().toISOString().replace(/[:.]/g, '-');
   const sourceHint = Buffer.from(path.dirname(file)).toString('base64url').slice(-8);
@@ -184,7 +227,8 @@ export type ApiKeyStorageState = 'available' | 'locked' | 'missing';
 
 export function apiKeyStorageState(provider: AiProvider): ApiKeyStorageState {
   if (getApiKey(provider) !== null) return 'available';
-  return apiKeyCandidateFiles(provider).length > 0 ? 'locked' : 'missing';
+  const blobs = [...apiKeyCandidateFiles(provider), ...archivedApiKeyFiles(provider)];
+  return blobs.length > 0 ? 'locked' : 'missing';
 }
 
 export function lockedApiKeyProviders(): AiProvider[] {

--- a/scripts/test-api-key-recovery.mjs
+++ b/scripts/test-api-key-recovery.mjs
@@ -104,6 +104,39 @@ try {
   assert.equal(recovery.decryptChromiumV10Blob(encrypted, password), 'known-legacy-secret', 'Chromium v10 compatibility fixture decrypts');
   assert.equal(recovery.decryptChromiumV10Blob(encrypted, Buffer.from('wrong-password')), null, 'wrong Keychain credential is rejected');
 
+  // A key that survives only in the emergency archive must come back, and an
+  // explicit delete must not be undone by that same archive on the next read.
+  const archiveDir = path.join(globalDir, 'locked-archive');
+  assert.equal(store.apiKeyStorageState('anthropic'), 'missing');
+  fs.writeFileSync(path.join(archiveDir, 'ai_key_anthropic-2026-01-01T00-00-00-000Z-aaaaaaaa.bin'), 'legacy:anthropic-unreadable');
+  assert.equal(store.apiKeyStorageState('anthropic'), 'locked', 'an archive-only blob is reported as recoverable, not missing');
+  fs.writeFileSync(path.join(archiveDir, 'ai_key_anthropic-2026-01-02T00-00-00-000Z-bbbbbbbb.bin'), 'current:anthropic-archived');
+  assert.equal(store.getApiKey('anthropic'), 'anthropic-archived', 'the emergency archive is a recovery source');
+  assert.equal(fs.existsSync(path.join(globalDir, 'ai_key_anthropic.bin')), true, 'the rescued key is promoted to the canonical file');
+  store.clearApiKey('anthropic');
+  assert.equal(store.getApiKey('anthropic'), null, 'an explicit delete purges the archive too');
+  assert.equal(store.apiKeyStorageState('anthropic'), 'missing');
+
+  // An isolated profile sitting beside the real one must not see — let alone
+  // retire — its neighbour's credentials. This is what deleted real API keys.
+  const neighbour = path.join(path.dirname(root), 'nodus');
+  const neighbourSecrets = path.join(neighbour, 'secrets');
+  fs.mkdirSync(neighbourSecrets, { recursive: true });
+  const neighbourKey = path.join(neighbourSecrets, 'ai_key_mistral.bin');
+  fs.writeFileSync(neighbourKey, 'current:neighbour-real-key');
+  try {
+    assert.deepEqual(store.apiKeyCandidateFiles('mistral'), [], 'an isolated profile never scans a sibling profile');
+    store.setApiKey('mistral', 'isolated-profile-key');
+    assert.equal(fs.readFileSync(neighbourKey, 'utf8'), 'current:neighbour-real-key', 'writing a key in an isolated profile leaves the real profile untouched');
+    store.clearApiKey('mistral');
+    assert.equal(fs.existsSync(neighbourKey), true, 'clearing a key in an isolated profile leaves the real profile untouched');
+  } finally {
+    fs.rmSync(neighbour, { recursive: true, force: true });
+  }
+
+  const secretSource = fs.readFileSync(path.join(repoRoot, 'electron/secrets/secretStore.ts'), 'utf8');
+  assert.match(secretSource, /path\.basename\(currentRoot\)\.toLowerCase\(\) !== 'nodus'/, 'sibling-root migration stays gated on the default profile');
+
   const exportSource = fs.readFileSync(path.join(repoRoot, 'electron/export/exportImport.ts'), 'utf8');
   assert.match(exportSource, /lockedApiKeyProviders\(\)/, 'full backup refuses silently locked API keys');
   const restoreBody = exportSource.match(/function restoreApiKeys[\s\S]*?\n}/)?.[0] ?? '';


### PR DESCRIPTION
Fixes #304.

An isolated profile (`NODUS_USERDATA` — tests, the demo instance) is created as a sibling of the real profile inside the platform's app-data directory. `apiKeyCandidateFiles()` scanned those siblings, and that list is not read-only: `setApiKey()` retires every entry (archive + `unlink`) and `clearApiKey()` deletes them. So storing a key in a throwaway profile permanently deleted the real profile's key for that provider.

This was observed, not hypothetical: a test-profile run deleted `ai_key_openrouter.bin`, `ai_key_gemini.bin` and `ai_key_deepseek.bin` from a real profile and left the copies inside the *isolated* profile's `secrets/locked-archive/`, where nobody would look.

## Changes

- `historicalRoots()` gates the sibling scan on the profile actually being the default one (`path.basename(userData).toLowerCase() === 'nodus'`). The 2.3 `nodus` → `Nodus` migration still works for real installs; an isolated profile now sees only its own root and its own vaults.
- `locked-archive` becomes a read-only recovery source in `getApiKey()` and in `legacySecretRecovery`. Nothing ever read it back, so a blob that survived only there was lost in practice — this makes an accident like the one above self-healing on the next launch.
- `clearApiKey()` purges the archive as well, so an explicit delete is not silently undone by the next read.
- It is deliberately *not* added to `apiKeyCandidateFiles()`: `setApiKey()` retires that list, and retiring the rollback would defeat its only purpose.

## Verification

- `scripts/test-api-key-recovery.mjs` gains two cases: an isolated profile leaves a sibling profile's key untouched through `setApiKey`/`clearApiKey`, and an archive-only key is reported as `locked`, rescued by `getApiKey`, promoted to the canonical file, and not resurrected after `clearApiKey`.
- Both were confirmed to fail without the fix (`an isolated profile never scans a sibling profile`) and pass with it.
- `tsc --noEmit` clean; `test-auto-backup`, `test-auto-backup-schedule`, `test-backup-crypto` and `test-backup-vaults` all pass.
