### PR TITLE
Ask Google for the only image format it accepts

### DIFF
--- a/electron/ai/decorativeImages.ts
+++ b/electron/ai/decorativeImages.ts
@@ -144,13 +144,16 @@ async function generateGoogle(model: string, prompt: string, key: string): Promi
       model,
       input: prompt,
       store: false,
-      response_format: { type: 'image', mime_type: 'image/png', aspect_ratio: '16:9', image_size: '1K' },
+      // JPEG is the ONLY mime the Interactions API accepts here — PNG is rejected with a
+      // 400 before the model runs. The declared type is a fallback anyway: the stored mime
+      // comes from sniffing the returned bytes.
+      response_format: { type: 'image', mime_type: 'image/jpeg', aspect_ratio: '16:9', image_size: '1K' },
     },
     { timeout: IMAGE_TIMEOUT_MS, maxRetries: 0 }
   );
   const data = response.output_image?.data;
   if (!data) throw new Error('Google no devolvió datos de imagen.');
-  return { bytes: Buffer.from(data, 'base64'), mimeType: 'image/png' };
+  return { bytes: Buffer.from(data, 'base64'), mimeType: response.output_image?.mime_type ?? 'image/jpeg' };
 }
 
 async function postBase64Image(url: string, body: Record<string, unknown>, key: string): Promise<GeneratedImageBytes> {

--- a/electron/ai/genealogyDemoPortraits.ts
+++ b/electron/ai/genealogyDemoPortraits.ts
@@ -46,7 +46,8 @@ async function googlePortraitGenerator(prompt: string): Promise<Buffer | null> {
       model: DEMO_PORTRAIT_MODEL,
       input: prompt,
       store: false,
-      response_format: { type: 'image', mime_type: 'image/png', aspect_ratio: '1:1', image_size: '1K' },
+      // JPEG is the only mime the Interactions API accepts; PNG returns a 400.
+      response_format: { type: 'image', mime_type: 'image/jpeg', aspect_ratio: '1:1', image_size: '1K' },
     },
     { timeout: PORTRAIT_TIMEOUT_MS, maxRetries: 0 }
   );
@@ -86,7 +87,7 @@ export async function generateDemoPortraits(opts: {
     try {
       const bytes = await generate(buildDaguerreotypePrompt(targets[i]));
       if (bytes && bytes.length) {
-        setPersonPortrait(targets[i].personId, bytes, 'image/png', { focusX: 0.5, focusY: 0.42, scale: 1 });
+        setPersonPortrait(targets[i].personId, bytes, 'image/jpeg', { focusX: 0.5, focusY: 0.42, scale: 1 });
         generated++;
       } else {
         skipped++;

--- a/electron/maps/mapGeneration.ts
+++ b/electron/maps/mapGeneration.ts
@@ -111,13 +111,14 @@ async function generateWithReference(
         { type: 'input_image', image_url: `data:${reference.mimeType};base64,${reference.bytes.toString('base64')}` },
       ] as never,
       store: false,
-      response_format: { type: 'image', mime_type: 'image/png', image_size: '2K' },
+      // JPEG is the only mime the Interactions API accepts; PNG returns a 400.
+      response_format: { type: 'image', mime_type: 'image/jpeg', image_size: '2K' },
     },
     { timeout: IMAGE_TIMEOUT_MS, maxRetries: 0 },
   );
   const data = response.output_image?.data;
   if (!data) throw new Error('Google no devolvió datos de imagen.');
-  return { bytes: Buffer.from(data, 'base64'), mimeType: 'image/png' };
+  return { bytes: Buffer.from(data, 'base64'), mimeType: response.output_image?.mime_type ?? 'image/jpeg' };
 }
 
 /**


### PR DESCRIPTION
Regenerating the decorative image of a deep research report failed with a 400 from Google before the model ever ran:

```
400 The value 'image/png' is not supported for 'response_format.mime_type'. Supported values: 'image/jpeg'.
```

The Interactions API takes JPEG and nothing else — the SDK declares `ImageResponseFormatMimeType = "image/jpeg"`. The typechecker could not catch the PNG we were sending because the SDK's response-format union ends in a `{ [k: string]: any }` catch-all, so any literal is assignable and the mismatch only ever appears as a runtime 400.

Three call sites sent the invalid value, all of them Google-only (the OpenAI and OpenRouter paths use different request shapes and were unaffected):

- `electron/ai/decorativeImages.ts` — decorative images for reports and immersions, and every caller of `callImageProvider`: genealogy reference portraits, worldbuilding portraits and gallery images.
- `electron/maps/mapGeneration.ts` — worldbuilding maps generated from a reference crop.
- `electron/ai/genealogyDemoPortraits.ts` — demo genealogy portraits.

Each now requests `image/jpeg` and takes the mime from `response.output_image.mime_type` rather than hardcoding it. Nothing downstream shifts: `prepareImageStorage` derives the stored mime by sniffing the magic bytes, so it was already correcting the wrong label, and thumbnails were JPEG all along. For a decorative illustration the format change is not visible.

Verified with `tsc --noEmit` on both projects, `eslint` on the three files, and the `test-decorative-images`, `test-genealogy-demo` and `test-map-generation-ui` suites.

Fixes #306
