### PR TITLE
Offer the bundled Codex runtime as an image generator

### DIFF
--- a/electron/ai/codexAppServerClient.ts
+++ b/electron/ai/codexAppServerClient.ts
@@ -22,6 +22,34 @@ export interface CodexAppServerClientOptions {
 export type CodexNotificationHandler = (method: string, params: unknown) => void;
 
 /**
+ * Every Codex runtime feature Nodus keeps switched off, declared once so the
+ * process-wide flags below and the per-thread `config.features` of each turn cannot
+ * drift apart as the runtime gains new ones.
+ *
+ * Image generation is the single flag a caller may turn on, and only per thread: the
+ * app-server honours the thread value over the process one, so an image thread can
+ * hold the `image_gen` tool while every text thread stays unable to reach it.
+ */
+export function codexFeatures(imageGeneration: boolean): Record<string, boolean> {
+  return {
+    apps: false,
+    browser_use: false,
+    code_mode_host: false,
+    computer_use: false,
+    goals: false,
+    hooks: false,
+    image_generation: imageGeneration,
+    in_app_browser: false,
+    multi_agent: false,
+    plugins: false,
+    shell_tool: false,
+    tool_suggest: false,
+    unified_exec: false,
+    workspace_dependencies: false,
+  };
+}
+
+/**
  * Minimal JSONL client for the official Codex App Server. Authentication is
  * deliberately forced to managed ChatGPT OAuth; API-key environment variables
  * are stripped before the child process starts.
@@ -123,20 +151,9 @@ export class CodexAppServerClient {
         '--config', 'model_provider="openai"',
         '--config', 'web_search="disabled"',
         '--config', 'mcp_servers={}',
-        '--config', 'features.apps=false',
-        '--config', 'features.browser_use=false',
-        '--config', 'features.code_mode_host=false',
-        '--config', 'features.computer_use=false',
-        '--config', 'features.goals=false',
-        '--config', 'features.hooks=false',
-        '--config', 'features.image_generation=false',
-        '--config', 'features.in_app_browser=false',
-        '--config', 'features.multi_agent=false',
-        '--config', 'features.plugins=false',
-        '--config', 'features.shell_tool=false',
-        '--config', 'features.tool_suggest=false',
-        '--config', 'features.unified_exec=false',
-        '--config', 'features.workspace_dependencies=false',
+        // The process-wide default denies everything, image generation included. A
+        // thread that needs the image tool opts in through its own config.
+        ...Object.entries(codexFeatures(false)).flatMap(([name, value]) => ['--config', `features.${name}=${value}`]),
         'app-server', '--listen', 'stdio://',
       ],
       {

--- a/electron/ai/codexCompletion.ts
+++ b/electron/ai/codexCompletion.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { CodexReasoningEffort, ReasoningEffort } from '@shared/types';
 import type { VisionImagePart } from '@shared/imageAnalysis';
+import { codexFeatures } from './codexAppServerClient';
 import { ProviderRuntimeError } from './providerErrors';
 
 export interface CodexCompletionTransport {
@@ -110,22 +111,7 @@ export async function runIsolatedCodexCompletion(
       config: {
         web_search: 'disabled',
         mcp_servers: {},
-        features: {
-          apps: false,
-          browser_use: false,
-          code_mode_host: false,
-          computer_use: false,
-          goals: false,
-          hooks: false,
-          image_generation: false,
-          in_app_browser: false,
-          multi_agent: false,
-          plugins: false,
-          shell_tool: false,
-          tool_suggest: false,
-          unified_exec: false,
-          workspace_dependencies: false,
-        },
+        features: codexFeatures(false),
       },
       baseInstructions: [
         'You are a constrained text-generation runtime embedded in Nodus.',

--- a/electron/ai/codexImage.ts
+++ b/electron/ai/codexImage.ts
@@ -1,0 +1,215 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { codexFeatures } from './codexAppServerClient';
+import type { CodexCompletionTransport } from './codexCompletion';
+import { ProviderRuntimeError } from './providerErrors';
+
+export interface IsolatedCodexImageOptions {
+  model: string;
+  prompt: string;
+  workdir: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface CodexGeneratedImage {
+  bytes: Buffer;
+  mimeType: string;
+  /** What the model actually asked the image tool for. Useful for diagnostics only. */
+  revisedPrompt: string | null;
+}
+
+/** Shape of the `imageGeneration` thread item in the app-server v2 protocol. */
+interface CodexImageItem {
+  type: 'imageGeneration';
+  id: string;
+  status: 'in_progress' | 'completed' | 'failed';
+  revisedPrompt: string | null;
+  /** Base64 of the finished image. Empty while the item is still in progress. */
+  result: string;
+  /** Copy the runtime writes under CODEX_HOME/generated_images/<threadId>/. */
+  savedPath?: string | null;
+}
+
+/** Every tool whose use means the image thread went somewhere it must not go. */
+const FORBIDDEN_ITEMS = [
+  'commandExecution',
+  'fileChange',
+  'mcpToolCall',
+  'dynamicToolCall',
+  'collabAgentToolCall',
+  'subAgentActivity',
+  'webSearch',
+  'imageView',
+];
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Trust the bytes, not the runtime: the protocol declares no mime type at all. */
+function sniffImageMime(bytes: Buffer): string {
+  if (bytes.subarray(0, 8).equals(PNG_MAGIC)) return 'image/png';
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
+  if (bytes.subarray(0, 4).toString('ascii') === 'RIFF' && bytes.subarray(8, 12).toString('ascii') === 'WEBP') {
+    return 'image/webp';
+  }
+  // The built-in tool has only ever returned PNG; keep that as the honest default
+  // rather than mislabelling unknown bytes as something a viewer would try to decode.
+  return 'image/png';
+}
+
+function turnError(turn: any): Error {
+  const message = turn?.error?.message ?? turn?.error?.additionalDetails;
+  return new Error(message || `La generación de imagen de Codex terminó con estado «${turn?.status ?? 'desconocido'}».`);
+}
+
+/**
+ * Delete the copy the runtime left in CODEX_HOME.
+ *
+ * Nodus stores the image in the vault, so the runtime's copy is a duplicate of user
+ * content sitting outside every backup, export and deletion path Nodus offers — and
+ * at roughly 2 MB per generation it would grow without limit. The thread is ephemeral
+ * and its directory holds nothing else, so it goes too once emptied.
+ */
+function discardRuntimeCopy(savedPath: string | null | undefined): void {
+  if (!savedPath) return;
+  try {
+    fs.rmSync(savedPath, { force: true });
+    fs.rmdirSync(path.dirname(savedPath));
+  } catch {
+    /* another image still in the directory, or the runtime already cleaned up */
+  }
+}
+
+/**
+ * Generate one image on an ephemeral Codex thread that holds the `image_gen` tool and
+ * nothing else. Kept free of Electron, like the text completion beside it, so the
+ * isolation it depends on can be tested against a fake transport.
+ */
+export async function runIsolatedCodexImage(
+  runtime: CodexCompletionTransport,
+  options: IsolatedCodexImageOptions
+): Promise<CodexGeneratedImage> {
+  let threadId: string | null = null;
+  let turnId: string | null = null;
+  let unsubscribe: () => void = () => undefined;
+  let timeout: NodeJS.Timeout | null = null;
+  let abortHandler: (() => void) | null = null;
+  let settleAborted: ((error: Error) => void) | null = null;
+  const saved: string[] = [];
+  const abortedEarly = new Promise<never>((_resolve, reject) => { settleAborted = reject; });
+  // An abort that lands before the race is set up would otherwise reject with nobody
+  // listening, and an unhandled rejection takes down the whole main process.
+  abortedEarly.catch(() => undefined);
+
+  // Teardown must never restart a dead runtime — see the same guard in codexCompletion.
+  const cleanupRequest = (method: string, params: unknown): Promise<unknown> => {
+    if (runtime.isRunning?.() === false) return Promise.resolve(undefined);
+    return runtime.request(method, params).catch(() => undefined);
+  };
+
+  try {
+    const thread = await runtime.request<{ thread: { id: string } }>('thread/start', {
+      model: options.model,
+      modelProvider: 'openai',
+      cwd: options.workdir,
+      approvalPolicy: 'never',
+      sandbox: 'read-only',
+      serviceName: 'nodus_desktop',
+      ephemeral: true,
+      config: {
+        web_search: 'disabled',
+        mcp_servers: {},
+        features: codexFeatures(true),
+      },
+      baseInstructions: [
+        'You are a constrained image-generation runtime embedded in Nodus.',
+        'Generate exactly one image from the user prompt with the built-in image generation tool, then stop.',
+        'Never invoke shell commands, tools other than image generation, MCP servers, plugins, skills, subagents, file operations, or web search.',
+        'Never ask questions and never explain: the prompt is complete as given.',
+      ].join(' '),
+      developerInstructions: [
+        'Generate one image for the prompt exactly as written, without reinterpreting its subject.',
+        'Once the image exists, reply with the single word DONE and nothing else.',
+      ].join(' '),
+    }, 60_000);
+    threadId = thread.thread.id;
+
+    const generated = new Promise<CodexImageItem>((resolve, reject) => {
+      unsubscribe = runtime.onNotification((method, params: any) => {
+        if (params?.threadId !== threadId) return;
+        if (method === 'item/started' && FORBIDDEN_ITEMS.includes(params?.item?.type)) {
+          void cleanupRequest('turn/interrupt', { threadId, turnId: params.turnId ?? turnId });
+          reject(new Error('Codex intentó usar una herramienta deshabilitada; Nodus interrumpió la petición.'));
+          return;
+        }
+        if (method === 'item/completed' && params?.item?.type === 'imageGeneration') {
+          const item = params.item as CodexImageItem;
+          if (item.savedPath) saved.push(item.savedPath);
+          if (item.status !== 'completed') {
+            reject(new ProviderRuntimeError('ChatGPT no pudo generar la imagen.', 'unavailable'));
+            return;
+          }
+          // The image is done; the turn would only go on to narrate it. Interrupting
+          // here spends neither the extra quota nor the seconds that message costs.
+          void cleanupRequest('turn/interrupt', { threadId, turnId: params.turnId ?? turnId });
+          resolve(item);
+          return;
+        }
+        if (method !== 'turn/completed') return;
+        const turn = params.turn;
+        if (turn?.status === 'failed') return reject(turnError(turn));
+        // A turn that ends without an image means the model answered in words. That
+        // is a failed generation, not an empty one — say so instead of returning null.
+        reject(new ProviderRuntimeError('ChatGPT terminó la petición sin generar ninguna imagen.', 'unavailable'));
+      });
+    });
+
+    abortHandler = () => {
+      if (threadId && turnId) void cleanupRequest('turn/interrupt', { threadId, turnId });
+      // Unlike text, a cancelled image has no partial result worth returning, and the
+      // runtime need not emit `turn/completed` after an interrupt: settle right away
+      // rather than holding the caller for the remaining timeout.
+      settleAborted?.(new ProviderRuntimeError('La generación de imagen se canceló.', 'unavailable'));
+    };
+    options.signal?.addEventListener('abort', abortHandler, { once: true });
+    // Cancelled before the turn existed: there is nothing to interrupt and nothing to
+    // wait for, so fail here instead of paying for a turn the caller no longer wants.
+    if (options.signal?.aborted) throw new ProviderRuntimeError('La generación de imagen se canceló.', 'unavailable');
+
+    const started = await runtime.request<{ turn: { id: string } }>('turn/start', {
+      threadId,
+      input: [{ type: 'text', text: options.prompt, text_elements: [] }],
+      cwd: options.workdir,
+      approvalPolicy: 'never',
+      sandboxPolicy: { type: 'readOnly', networkAccess: false },
+      model: options.model,
+      summary: 'none',
+    }, 60_000);
+    turnId = started.turn.id;
+
+    const item = await Promise.race([
+      generated,
+      abortedEarly,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          if (threadId && turnId) void cleanupRequest('turn/interrupt', { threadId, turnId });
+          reject(new ProviderRuntimeError('ChatGPT no generó la imagen dentro del tiempo esperado.', 'timeout'));
+        }, options.timeoutMs ?? 240_000);
+      }),
+    ]);
+
+    // The bytes travel inline in the item; the file on disk is the same image and only
+    // matters as a fallback for a runtime that ever stops inlining them.
+    const bytes = item.result
+      ? Buffer.from(item.result, 'base64')
+      : item.savedPath ? await fs.promises.readFile(item.savedPath) : Buffer.alloc(0);
+    if (!bytes.length) throw new ProviderRuntimeError('ChatGPT devolvió una imagen vacía.', 'unavailable');
+    return { bytes, mimeType: sniffImageMime(bytes), revisedPrompt: item.revisedPrompt ?? null };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    unsubscribe();
+    if (abortHandler) options.signal?.removeEventListener('abort', abortHandler);
+    for (const file of saved) discardRuntimeCopy(file);
+    if (threadId) await cleanupRequest('thread/unsubscribe', { threadId });
+  }
+}

--- a/electron/ai/codexSubscription.ts
+++ b/electron/ai/codexSubscription.ts
@@ -14,6 +14,7 @@ import type {
 import type { VisionImagePart } from '@shared/imageAnalysis';
 import { CodexAppServerClient } from './codexAppServerClient';
 import { resolveCodexReasoningEffort, runIsolatedCodexCompletion } from './codexCompletion';
+import { runIsolatedCodexImage } from './codexImage';
 import { ProviderRuntimeError } from './providerErrors';
 
 interface CodexAccountResponse {
@@ -352,6 +353,48 @@ export async function completeWithChatGptSubscription(options: CodexCompletionOp
   } catch (error) {
     // The cached check can outlive the session it vouched for (revoked, expired,
     // signed out elsewhere). Any failure re-arms the full check for the next call
+    // so a stale "connected" cannot pin the provider in a broken state.
+    invalidateConnectedCache();
+    throw error;
+  } finally {
+    await fs.promises.rm(workdir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Generate one image through the built-in tool of an ephemeral Codex thread.
+ *
+ * Unlike the image APIs of the other providers this one takes no size, quality or
+ * format: the agent decides them from the prompt, and the bytes come back inline.
+ */
+export async function generateImageWithChatGptSubscription(options: {
+  model: string;
+  prompt: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): Promise<{ bytes: Buffer; mimeType: string }> {
+  await ensureConnectedForCompletion();
+
+  const runtime = getClient();
+  // A stored model that left the catalog would fail deep inside `thread/start` with a
+  // protocol error. Say plainly what happened and where to fix it instead.
+  const catalog = await readModelCatalog(false);
+  if (!catalog.some((model) => model.id === options.model)) {
+    throw new ProviderRuntimeError(
+      `El modelo «${options.model}» ya no está en el catálogo de ChatGPT. Elige otro en Proveedores y modelos.`,
+      'unavailable'
+    );
+  }
+
+  const tempRoot = path.join(app.getPath('temp') || os.tmpdir(), 'nodus-codex-image-');
+  const workdir = await fs.promises.mkdtemp(tempRoot);
+  try { await fs.promises.chmod(workdir, 0o700); } catch { /* Windows */ }
+
+  try {
+    const generated = await runIsolatedCodexImage(runtime, { ...options, workdir });
+    return { bytes: generated.bytes, mimeType: generated.mimeType };
+  } catch (error) {
+    // Same reasoning as the completion path: a failure re-arms the connection check
     // so a stale "connected" cannot pin the provider in a broken state.
     invalidateConnectedCache();
     throw error;

--- a/electron/ai/databaseAiImageColumn.ts
+++ b/electron/ai/databaseAiImageColumn.ts
@@ -27,7 +27,7 @@ export interface AiImageDeps {
   generate?: (prompt: string, model: AiImageModelRef | null) => Promise<{ image: Buffer; mimeType: string }>;
 }
 
-const IMAGE_PROVIDERS = new Set<ImageProvider>(['google', 'openai', 'openrouter', 'nodus']);
+const IMAGE_PROVIDERS = new Set<ImageProvider>(['google', 'openai', 'openrouter', 'nodus', 'codex']);
 
 function extensionForImageMime(mimeType: string): string {
   if (mimeType === 'image/png') return 'png';

--- a/electron/ai/decorativeImages.ts
+++ b/electron/ai/decorativeImages.ts
@@ -20,6 +20,7 @@ import { getWorldPlace } from '../db/worldPlacesRepo';
 import { getWorldGroup } from '../db/worldGroupsRepo';
 import { getActiveVault } from '../vaults/vaultRegistry';
 import { completeText } from './aiClient';
+import { generateImageWithChatGptSubscription } from './codexSubscription';
 import { getSettings } from '../db/settingsRepo';
 import { generateNodusLocalImage } from './nodusLocalImages';
 import { getApiKey } from '../secrets/secretStore';
@@ -132,7 +133,9 @@ async function visualContextFor(source: ImageSource): Promise<string> {
 }
 
 function providerKey(provider: ImageProvider): string | null {
-  if (provider === 'nodus') return null;
+  // Nodus generates locally and Codex authenticates with the managed ChatGPT session:
+  // neither has an API key to look up.
+  if (provider === 'nodus' || provider === 'codex') return null;
   if (provider === 'google') return getApiKey('gemini');
   return getApiKey(provider);
 }
@@ -204,6 +207,9 @@ function generateOpenRouter(model: string, prompt: string, key: string): Promise
 
 export async function callImageProvider(provider: ImageProvider, model: string, prompt: string): Promise<GeneratedImageBytes> {
   if (provider === 'nodus') return generateNodusLocalImage(model, prompt, getSettings().imageQuality);
+  // Billed to the user's ChatGPT plan, and the only provider whose size and format are
+  // the agent's decision rather than a request parameter.
+  if (provider === 'codex') return generateImageWithChatGptSubscription({ model, prompt });
   const key = providerKey(provider);
   if (!key) throw new Error(`Falta la clave de ${provider === 'google' ? 'Google' : provider === 'openai' ? 'OpenAI' : 'OpenRouter'}.`);
   switch (provider) {

--- a/electron/ai/imageModels.ts
+++ b/electron/ai/imageModels.ts
@@ -1,9 +1,11 @@
 import type { ImageModelInfo } from '@shared/types';
 import { NODUS_LOCAL_IMAGE_MODEL } from '@shared/localImageModels';
+import { listChatGptSubscriptionModels } from './codexSubscription';
 
 const GOOGLE_SOURCE = 'https://ai.google.dev/gemini-api/docs/pricing';
 const OPENAI_SOURCE = 'https://developers.openai.com/api/docs/guides/image-generation';
 const OPENROUTER_SOURCE = 'https://openrouter.ai/models?output_modalities=image&order=pricing-low-to-high';
+const CODEX_SOURCE = 'https://developers.openai.com/codex';
 
 const NODUS_LOCAL_MODELS: ImageModelInfo[] = [{
   provider: 'nodus',
@@ -168,9 +170,32 @@ async function openRouterModels(): Promise<ImageModelInfo[]> {
   });
 }
 
+/**
+ * Codex generates images with a tool built into the agent, so the "image model" the
+ * user picks is the agent that drives it. Every non-hidden model in the catalog
+ * reaches the same tool; the list is empty when no ChatGPT subscription is connected,
+ * which is also exactly when none of them could generate anything.
+ */
+async function codexModels(): Promise<ImageModelInfo[]> {
+  const models = await listChatGptSubscriptionModels();
+  return models.map((model) => ({
+    provider: 'codex' as const,
+    id: model.id,
+    name: model.name ?? model.id,
+    inputPriceUsdPerMillion: null,
+    outputPriceUsdPerMillion: null,
+    imagePriceUsd: null,
+    imagePriceLabel: 'Incluido en tu suscripción de ChatGPT',
+    sourceUrl: CODEX_SOURCE,
+  }));
+}
+
 export async function listImageModels(): Promise<ImageModelInfo[]> {
-  const openrouter = await openRouterModels().catch(() => []);
-  return [...NODUS_LOCAL_MODELS, ...GOOGLE_MODELS, ...OPENAI_MODELS, ...openrouter].sort(
+  const [openrouter, codex] = await Promise.all([
+    openRouterModels().catch(() => []),
+    codexModels().catch(() => []),
+  ]);
+  return [...NODUS_LOCAL_MODELS, ...GOOGLE_MODELS, ...OPENAI_MODELS, ...openrouter, ...codex].sort(
     (a, b) => a.provider.localeCompare(b.provider) || a.name.localeCompare(b.name)
   );
 }

--- a/scripts/test-codex-subscription.mjs
+++ b/scripts/test-codex-subscription.mjs
@@ -14,6 +14,7 @@ const entry = path.join(outDir, 'entry.ts');
 fs.writeFileSync(entry, [
   `export { CodexAppServerClient } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/codexAppServerClient.ts'))};`,
   `export { resolveCodexReasoningEffort, runIsolatedCodexCompletion } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/codexCompletion.ts'))};`,
+  `export { runIsolatedCodexImage } from ${JSON.stringify(path.join(repoRoot, 'electron/ai/codexImage.ts'))};`,
 ].join('\n'));
 execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
   entry,
@@ -24,7 +25,12 @@ execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
   `--outfile=${bundle}`,
 ], { cwd: repoRoot, stdio: 'inherit' });
 const require = createRequire(import.meta.url);
-const { CodexAppServerClient, resolveCodexReasoningEffort, runIsolatedCodexCompletion } = require(bundle);
+const {
+  CodexAppServerClient,
+  resolveCodexReasoningEffort,
+  runIsolatedCodexCompletion,
+  runIsolatedCodexImage,
+} = require(bundle);
 
 test.after(() => fs.rmSync(outDir, { recursive: true, force: true }));
 
@@ -276,6 +282,159 @@ test('any unexpected tool start is interrupted and never becomes an answer', asy
       reasoning: 'low',
       workdir,
     }), /herramienta deshabilitada/i);
+    assert.deepEqual(runtime.calls.find((call) => call.method === 'turn/interrupt').params, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    });
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+const PNG = Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), Buffer.from('pixels')]);
+
+/** Fake app-server that plays one scripted `imageGeneration` item back at the caller. */
+class ImageTransport {
+  handlers = new Set();
+  calls = [];
+  constructor(emit) {
+    this.emit = emit;
+  }
+  request(method, params) {
+    this.calls.push({ method, params });
+    if (method === 'thread/start') return Promise.resolve({ thread: { id: 'thread-1' } });
+    if (method === 'turn/start') {
+      setTimeout(() => {
+        for (const handler of this.handlers) this.emit(handler);
+      }, 0);
+      return Promise.resolve({ turn: { id: 'turn-1' } });
+    }
+    return Promise.resolve({});
+  }
+  onNotification(handler) {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+}
+
+/** A saved image the way the runtime writes it: CODEX_HOME/generated_images/<thread>/. */
+function runtimeCopy(name, bytes = PNG) {
+  const dir = path.join(outDir, 'generated', name);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'call-1.png');
+  fs.writeFileSync(file, bytes);
+  return { dir, file };
+}
+
+test('a Codex image runs on an image-only thread, ends as soon as the image exists and leaves no copy behind', async () => {
+  const workdir = fs.mkdtempSync(path.join(outDir, 'image-'));
+  const copy = runtimeCopy('ok');
+  const runtime = new ImageTransport((handler) => handler('item/completed', {
+    threadId: 'thread-1',
+    turnId: 'turn-1',
+    item: {
+      type: 'imageGeneration',
+      id: 'call-1',
+      status: 'completed',
+      revisedPrompt: 'un faro al atardecer, ilustración plana',
+      result: PNG.toString('base64'),
+      savedPath: copy.file,
+    },
+  }));
+  try {
+    const image = await runIsolatedCodexImage(runtime, {
+      model: 'gpt-test',
+      prompt: 'Un faro al atardecer.',
+      workdir,
+    });
+    assert.ok(image.bytes.equals(PNG));
+    assert.equal(image.mimeType, 'image/png');
+    assert.equal(image.revisedPrompt, 'un faro al atardecer, ilustración plana');
+
+    const thread = runtime.calls.find((call) => call.method === 'thread/start').params;
+    assert.equal(thread.config.features.image_generation, true, 'the image tool is the point of this thread');
+    assert.ok(
+      Object.entries(thread.config.features)
+        .filter(([name]) => name !== 'image_generation')
+        .every(([, enabled]) => enabled === false),
+      'nothing else the runtime can do is reachable from an image thread'
+    );
+    assert.equal(thread.config.web_search, 'disabled');
+    assert.deepEqual(thread.config.mcp_servers, {});
+    assert.equal(thread.approvalPolicy, 'never');
+    assert.equal(thread.sandbox, 'read-only');
+    assert.equal(thread.ephemeral, true);
+    assert.equal(thread.cwd, workdir);
+
+    const turn = runtime.calls.find((call) => call.method === 'turn/start').params;
+    assert.deepEqual(turn.sandboxPolicy, { type: 'readOnly', networkAccess: false });
+    assert.deepEqual(turn.input, [{ type: 'text', text: 'Un faro al atardecer.', text_elements: [] }]);
+
+    // The turn is stopped the moment the image lands: the message the model would add
+    // next costs plan quota and tens of seconds, and Nodus has no use for it.
+    assert.deepEqual(runtime.calls.find((call) => call.method === 'turn/interrupt').params, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    });
+    assert.ok(runtime.calls.some((call) => call.method === 'thread/unsubscribe'));
+
+    // The runtime's copy is user content sitting outside every Nodus backup, export
+    // and deletion path — and ~2 MB of it per generation.
+    assert.equal(fs.existsSync(copy.file), false, 'the copy under CODEX_HOME is deleted');
+    assert.equal(fs.existsSync(copy.dir), false, 'and so is the emptied thread directory');
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test('a Codex image falls back to the file on disk when the bytes do not travel inline', async () => {
+  const workdir = fs.mkdtempSync(path.join(outDir, 'image-disk-'));
+  const jpeg = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.from('jpeg-bytes')]);
+  const copy = runtimeCopy('disk', jpeg);
+  const runtime = new ImageTransport((handler) => handler('item/completed', {
+    threadId: 'thread-1',
+    turnId: 'turn-1',
+    item: { type: 'imageGeneration', id: 'call-1', status: 'completed', revisedPrompt: null, result: '', savedPath: copy.file },
+  }));
+  try {
+    const image = await runIsolatedCodexImage(runtime, { model: 'gpt-test', prompt: 'Una taza.', workdir });
+    assert.ok(image.bytes.equals(jpeg));
+    // The protocol declares no mime type at all, so it is read off the bytes.
+    assert.equal(image.mimeType, 'image/jpeg');
+    assert.equal(fs.existsSync(copy.file), false);
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test('a Codex turn that answers in words instead of generating is a failure, not an empty image', async () => {
+  const workdir = fs.mkdtempSync(path.join(outDir, 'image-none-'));
+  const runtime = new ImageTransport((handler) => handler('turn/completed', {
+    threadId: 'thread-1',
+    turn: { status: 'completed', items: [{ type: 'agentMessage', text: 'No puedo generar imágenes.' }] },
+  }));
+  try {
+    await assert.rejects(
+      () => runIsolatedCodexImage(runtime, { model: 'gpt-test', prompt: 'Un faro.', workdir }),
+      /sin generar ninguna imagen/i
+    );
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test('an unexpected tool start in an image thread is interrupted and never returns bytes', async () => {
+  const workdir = fs.mkdtempSync(path.join(outDir, 'image-guard-'));
+  const runtime = new ImageTransport((handler) => handler('item/started', {
+    threadId: 'thread-1',
+    turnId: 'turn-1',
+    item: { type: 'commandExecution', command: 'cat private.txt' },
+  }));
+  try {
+    await assert.rejects(
+      () => runIsolatedCodexImage(runtime, { model: 'gpt-test', prompt: 'Un faro.', workdir }),
+      /herramienta deshabilitada/i
+    );
     assert.deepEqual(runtime.calls.find((call) => call.method === 'turn/interrupt').params, {
       threadId: 'thread-1',
       turnId: 'turn-1',

--- a/shared/mapPrompt.ts
+++ b/shared/mapPrompt.ts
@@ -19,7 +19,7 @@
  * Pure and dependency-light so all of it is unit-tested without a provider.
  */
 
-import type { WorldMapKind } from './types';
+import type { ImageProvider, WorldMapKind } from './types';
 
 export type MapStyleId =
   | 'parchment'
@@ -219,7 +219,9 @@ export function hasMapPromptMaterial(input: MapPromptInput): boolean {
 
 // ── what a provider can actually do ─────────────────────────────────────────────
 
-export type MapImageProvider = 'google' | 'openai' | 'openrouter' | 'nodus';
+/** Alias rather than a second union: a provider added to one and forgotten in the
+ *  other used to compile fine and only fail at the call site. */
+export type MapImageProvider = ImageProvider;
 
 /**
  * Can this provider take a REFERENCE image?
@@ -237,8 +239,9 @@ export function supportsReferenceImage(provider: MapImageProvider, model: string
   if (provider === 'google') return true;
   if (provider === 'openai') return /gpt-image|dall-e-2/i.test(model);
   if (provider === 'openrouter') return /gemini|flash-image|nano-banana|gpt-image|seedream|qwen-image/i.test(model);
-  // The local generator is text-to-image only. Promising otherwise would fail offline,
-  // where there is no fallback at all.
+  // The local generator is text-to-image only, and so is the Codex path: its built-in
+  // tool takes a prompt and nothing else. Promising otherwise would fail offline, where
+  // there is no fallback at all.
   return false;
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -789,7 +789,7 @@ export type AiProvider =
  *  They need no API key (an optional token is supported for secured instances). */
 export type LocalProvider = Extract<AiProvider, 'ollama' | 'lmstudio'>;
 export type EmbeddingProvider = Extract<AiProvider, 'openai' | 'openrouter' | 'gemini' | 'ollama' | 'lmstudio' | 'nodus'>;
-export type ImageProvider = 'google' | 'openai' | 'openrouter' | 'nodus';
+export type ImageProvider = 'google' | 'openai' | 'openrouter' | 'nodus' | 'codex';
 
 /** User-editable connection settings for a local provider. The base URL includes
  *  scheme, host and port (e.g. "http://localhost:11434"); no trailing "/v1". */

--- a/src/views/ProvidersSettings.tsx
+++ b/src/views/ProvidersSettings.tsx
@@ -529,6 +529,7 @@ const IMAGE_PROVIDER_LABELS: Record<ImageModelInfo['provider'], string> = {
   openai: 'OpenAI',
   openrouter: 'OpenRouter',
   nodus: 'Nodus local',
+  codex: 'ChatGPT · Codex',
 };
 
 export function ImageGenerationSettings({ settings, onChange }: { settings: AppSettings; onChange: () => Promise<unknown> }) {


### PR DESCRIPTION
Fixes #309.

Codex generates images through a tool built into the agent, gated by `features.image_generation`. Nodus set that flag to `false` in both places it appears, so the runtime it already bundles could never be chosen as an image generator.

## The isolation question

Text completions must stay unable to reach the tool. Verified against the real runtime in both directions:

| process flag | thread flag | image generated |
| --- | --- | --- |
| `true` | `false` | no — the model is not given the tool |
| `false` | `true` | yes |

The per-thread value wins, so the process-wide flag stays `false` and only the image thread opts in. `runIsolatedCodexCompletion` still aborts the turn if an `imageGeneration` item ever appears, which remains as a second line of defence.

## Changes

- `electron/ai/codexImage.ts` (new) — `runIsolatedCodexImage`, the image counterpart to `runIsolatedCodexCompletion`: an ephemeral, read-only thread whose only capability is image generation, kept free of Electron so its isolation is testable against a fake transport. The turn is interrupted the moment the image lands — the message the model would add next costs plan quota and about ten seconds for nothing — and the copy the runtime writes under `$CODEX_HOME/generated_images` is deleted once read, since it is ~2 MB per generation of user content outside every Nodus backup, export and deletion path.
- `electron/ai/codexSubscription.ts` — `generateImageWithChatGptSubscription`: gates on a connected account, rejects a stored model that has left the catalog with a message naming where to fix it, and re-arms the connection check on failure like the completion path.
- `electron/ai/codexAppServerClient.ts` — `codexFeatures()`. The feature flags were spelled out once for the process and again for every thread; a runtime feature added to one and forgotten in the other would have compiled fine.
- `shared/mapPrompt.ts` — `MapImageProvider` was a second union parallel to `ImageProvider`, updated by hand. It is now an alias, which is how the compiler caught the gap when `ImageProvider` widened. `supportsReferenceImage` answers `false` for Codex: the built-in tool takes a prompt and nothing else, so the map operations that need a reference keep their existing prose fallback.
- `electron/ai/imageModels.ts`, `decorativeImages.ts`, `databaseAiImageColumn.ts`, `shared/types.ts`, `src/views/ProvidersSettings.tsx` — `codex` as a fifth `ImageProvider`, authenticated by the managed ChatGPT session rather than an API key, reaching every caller of `callImageProvider`. The picker lists the connected Codex model catalog: the tool belongs to the agent, so the choice is which agent drives it.

## Limitations

Unlike the other providers there are no size, aspect-ratio, quality or format parameters — the agent decides them from the prompt, so a request can come back portrait when the caller wanted landscape. Generation takes around 60 s against a few seconds for the direct APIs, and usage draws on the ChatGPT plan quota rather than OpenAI API credit.

## Verification

Run against a real connected subscription, not a mock:

- Three images generated end to end. The last one exercised `generateImageWithChatGptSubscription` exactly as it stands in this branch, headless against the live session: 1.93 MB PNG, `image/png`, 61.3 s, and `generated_images` held the same three directories before and after — the cleanup works.
- Both isolation cases in the table above were run against the real runtime.
- `listImageModels()` against the live account returns the seven Codex entries alongside Google, OpenAI, OpenRouter and the local model.
- Four new cases in `scripts/test-codex-subscription.mjs`: the image thread enables image generation and nothing else, the turn is interrupted as soon as the image exists, the runtime copy and its emptied thread directory are deleted, the bytes fall back to the file on disk when they do not travel inline, a turn that answers in words is a failure rather than an empty image, and an unexpected tool start is interrupted and never returns bytes.
- `npm run typecheck` and `npm run lint` clean. `npm test` 1466/1467; the single failure is `test-prosopography-e2e.mjs`, which fails identically on a clean tree — it launches Electron against a build the worktree does not have.
