### PR TITLE
Stop the argument map and debates from freezing the window

### DIFF
--- a/scripts/test-incremental-list.mjs
+++ b/scripts/test-incremental-list.mjs
@@ -1,0 +1,141 @@
+// Paging budget for the long, unbounded lists (debates, argument routes).
+//
+// Opening those sections used to paint every card in one render — measured on a
+// real corpus, 128k DOM nodes for the argument routes and 90k for the debates —
+// which blocked the renderer for one to two seconds. A click on another sidebar
+// section was not even processed until the paint finished, so the section could
+// not be left again while it loaded. The views now render one page at a time.
+//
+// Two rules carry that fix and both are asserted here, plus the wiring in the
+// views themselves, which is where the first attempt went wrong: paging by
+// debate *cluster* still let one connected component paint every contradiction
+// inside it.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const outDir = await mkdtemp(path.join(repoRoot, 'node_modules', '.nodus-inclist-'));
+test.after(async () => { await rm(outDir, { recursive: true, force: true }); });
+
+function loadModule(file) {
+  const bundle = path.join(outDir, `${path.basename(file).replace(/\.tsx?$/, '')}.cjs`);
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/esbuild'),
+    [
+      path.join(repoRoot, file),
+      '--bundle',
+      '--platform=node',
+      '--format=cjs',
+      '--target=es2022',
+      `--alias:@shared=${path.join(repoRoot, 'shared')}`,
+      `--outfile=${bundle}`,
+    ],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  return require(bundle);
+}
+
+const { incrementalSliceLength } = loadModule('src/incrementalList.ts');
+const read = (file) => fs.readFileSync(path.join(repoRoot, file), 'utf8');
+
+test('an unweighted list is cut at the budget, never above the list itself', () => {
+  const routes = Array.from({ length: 8_498 }, (_, i) => i);
+  assert.equal(incrementalSliceLength(routes, 40), 40);
+  assert.equal(incrementalSliceLength(routes, 80), 80);
+  assert.equal(incrementalSliceLength(routes.slice(0, 12), 40), 12);
+  assert.equal(incrementalSliceLength([], 40), 0);
+});
+
+test('weight counts what an item actually paints, not how many items there are', () => {
+  // 30 debates spread over clusters of three: six blocks fill a 25-card page,
+  // not twenty-five blocks (which would have painted 75 cards).
+  const blocks = Array.from({ length: 10 }, () => ({ debates: [1, 2, 3] }));
+  const weight = (block) => block.debates.length;
+  const taken = incrementalSliceLength(blocks, 25, weight);
+  assert.equal(taken, 9, `expected the budget to stop at nine blocks, got ${taken}`);
+  const painted = blocks.slice(0, taken).reduce((sum, b) => sum + b.debates.length, 0);
+  assert.ok(painted <= 25 + 3, `a page must not overshoot by more than one block, painted ${painted}`);
+});
+
+test('the first item always renders, however heavy it is', () => {
+  // The pathological corpus: one connected component holding every contradiction.
+  const blocks = [{ debates: Array.from({ length: 900 }, (_, i) => i) }, { debates: [1] }];
+  const taken = incrementalSliceLength(blocks, 25, (b) => b.debates.length);
+  assert.equal(taken, 1, 'a single over-budget block must still render, and alone');
+});
+
+test('a zero or negative weight cannot stall the page', () => {
+  const blocks = Array.from({ length: 500 }, () => ({ debates: [] }));
+  const taken = incrementalSliceLength(blocks, 25, (b) => b.debates.length);
+  assert.equal(taken, 25, `an empty-weight item must still cost one, got ${taken}`);
+});
+
+test('the debates view pages by cards, not by cluster', () => {
+  const source = read('src/views/DebateView.tsx');
+  assert.match(
+    source,
+    /useIncrementalList\(blocks, DEBATES_PAGE_SIZE, blockWeight\)/,
+    'DebateView must page the render blocks with a weight, or one big cluster paints every card in it'
+  );
+  assert.match(source, /shownBlocks\.map/, 'DebateView must render the paged slice, not the full list');
+  assert.doesNotMatch(
+    source,
+    /\{clusters\.map|\{filtered\.map|\{debates\.map/,
+    'DebateView must not map the unpaged list anywhere in its JSX'
+  );
+});
+
+test('the argument route picker pages its suggestions', () => {
+  const source = read('src/views/ArgumentMapView.tsx');
+  assert.match(source, /useIncrementalList<ArgumentRouteSuggestion>\(filteredSuggestions, ROUTES_PAGE_SIZE\)/);
+  assert.match(source, /\{shownSuggestions\.map/, 'the picker must render the paged slice');
+  assert.doesNotMatch(
+    source,
+    /\{filteredSuggestions\.map/,
+    'the picker must not map the full filtered list'
+  );
+});
+
+test('only a manual click spins the refresh button', () => {
+  // Entering the section discovers routes automatically and shows its own
+  // indicator. Wiring the button icon to the same flag spun both at once, which
+  // read as if the app were refreshing on its own.
+  const source = read('src/views/ArgumentMapView.tsx');
+  assert.match(
+    source,
+    /className=\{refreshing \? 'animate-spin' : ''\}/,
+    'the refresh icon must spin on the manual-refresh flag'
+  );
+  assert.match(source, /onClick=\{\(\) => discoverRoutes\(true\)\}/, 'the button must ask for a manual refresh');
+  // The app header carries its own icon-only «Actualizar» (Zotero sync), so this
+  // button needs an identity of its own for anything driving the real window.
+  assert.match(source, /data-testid="argument-routes-refresh"/, 'the refresh button must be addressable');
+  assert.match(
+    source,
+    /if \(manual\) setRefreshing\(true\)/,
+    'discoverRoutes must only raise the manual flag when asked to'
+  );
+  assert.doesNotMatch(
+    source,
+    /name="sync" className=\{suggestionsLoading \? 'animate-spin' : ''\}/,
+    'the refresh icon must no longer follow the automatic discovery flag'
+  );
+});
+
+test('the seed picker query waits for the mode that uses it', () => {
+  // The section opens in automatic mode, where there is no seed picker. Loading
+  // it on mount cost a second blocking main-process round trip on entry.
+  const source = read('src/views/ArgumentMapView.tsx');
+  assert.match(
+    source,
+    /if \(mode !== 'ai' \|\| pickerRequested\.current\) return;/,
+    'listPickerIdeas must be deferred until the IA mode is selected, and asked for once'
+  );
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RefObject } from 'react';
+import { incrementalSliceLength } from './incrementalList';
 import { invalidateVaultQueryCache } from './vaultQueryCache';
 
 /** Track whether the light theme is active (App stamps `.light` on <html>). */
@@ -66,6 +67,61 @@ export function useScanComplete(onComplete: () => void): void {
       prevActive = active;
     });
   }, []);
+}
+
+/**
+ * Reveal a long list one page at a time, growing as the sentinel scrolls near.
+ *
+ * The debates list and the argument-route picker are unbounded: a real corpus
+ * produces ~1.100 debates and ~8.500 ranked routes. Painting them all in the
+ * single render that opens the section blocked the renderer's main thread for
+ * one to two seconds — long enough that a click on another sidebar section was
+ * not processed at all until the paint finished, which is exactly what the
+ * section felt like from the outside. One page keeps that first paint cheap
+ * without taking the "scroll through everything" behaviour away.
+ *
+ * `items` must be referentially stable across renders that do not change it
+ * (a `useMemo`'d filter result), because a new array means a new list and
+ * collapses back to the first page.
+ *
+ * `weight` counts an item as more than one towards the page — a debate cluster
+ * holds several cards, and paging by clusters alone let one big cluster paint
+ * hundreds of them. It must be stable for the same reason `items` is.
+ */
+export function useIncrementalList<T, E extends HTMLElement = HTMLDivElement>(
+  items: T[],
+  pageSize: number,
+  weight?: (item: T) => number
+): { visible: T[]; hasMore: boolean; sentinelRef: RefObject<E>; showMore: () => void } {
+  const [count, setCount] = useState(pageSize);
+  const sentinelRef = useRef<E>(null);
+
+  useEffect(() => {
+    setCount(pageSize);
+  }, [items, pageSize]);
+
+  const shown = useMemo(() => incrementalSliceLength(items, count, weight), [items, count, weight]);
+
+  const hasMore = shown < items.length;
+  const showMore = useCallback(() => setCount((n) => n + pageSize), [pageSize]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasMore) return;
+    // Ancestor scroll containers clip the intersection rectangle, so the viewport
+    // root is right even though the sentinel lives inside the section's scroller.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setCount((n) => n + pageSize);
+      },
+      { rootMargin: '600px' }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, pageSize]);
+
+  const visible = useMemo(() => (shown >= items.length ? items : items.slice(0, shown)), [items, shown]);
+  return { visible, hasMore, sentinelRef, showMore };
 }
 
 /**

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -2477,6 +2477,7 @@ export const DE: Record<string, string> = {
   'El modelo está trazando el esquema de argumentos…': 'Das Modell zeichnet das Argumentationsschema…',
   'No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.':
     'Es gibt noch keine verbundenen Ideen. Analysieren Sie Ihre Werke (tiefer Scan), damit der Graph Verbindungen zwischen Ideen erzeugt.',
+  'Mostrar más': 'Mehr anzeigen',
   'Ningún recorrido coincide con los filtros actuales.': 'Keine Route entspricht den aktuellen Filtern.',
   'Trazar el esquema desde esta idea': 'Das Schema von dieser Idee aus zeichnen',
   '{n} debate(s)': '{n} Debatte(n)',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -2534,6 +2534,7 @@ export const EN: Record<string, string> = {
   'El modelo está trazando el esquema de argumentos…': 'The model is tracing the argument scheme…',
   'No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.':
     'No connected ideas yet. Analyze your works (deep scan) so the graph generates connections between ideas.',
+  'Mostrar más': 'Show more',
   'Ningún recorrido coincide con los filtros actuales.': 'No route matches the current filters.',
   'Trazar el esquema desde esta idea': 'Trace the scheme from this idea',
   '{n} debate(s)': '{n} debate(s)',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -2476,6 +2476,7 @@ export const FR: Record<string, string> = {
   'El modelo está trazando el esquema de argumentos…': 'Le modèle trace le schéma d\'arguments…',
   'No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.':
     'Il n\'y a pas encore d\'idées connectées. Analysez vos œuvres (analyse approfondie) pour que le graphe génère des connexions entre les idées.',
+  'Mostrar más': 'Afficher plus',
   'Ningún recorrido coincide con los filtros actuales.': 'Aucun parcours ne correspond aux filtres actuels.',
   'Trazar el esquema desde esta idea': 'Tracer le schéma à partir de cette idée',
   '{n} debate(s)': '{n} débat(s)',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -2214,6 +2214,7 @@ export const IT: Record<string, string> = {
   "Construyendo el esquema…": "Costruire lo schema…",
   "El modelo está trazando el esquema de argumentos…": "Il modello sta tracciando lo schema argomentativo...",
   "No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.": "Nessuna idea collegata ancora. Analizza i tuoi lavori (scansione profonda) in modo che il grafico generi connessioni tra le idee.",
+  "Mostrar más": "Mostra altri",
   "Ningún recorrido coincide con los filtros actuales.": "Nessun percorso corrisponde ai filtri attuali.",
   "Trazar el esquema desde esta idea": "Traccia lo schema da questa idea",
   "{n} debate(s)": "{n} dibattito(i)",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -2460,6 +2460,7 @@ export const PT_BR: Record<string, string> = {
   'El modelo está trazando el esquema de argumentos…': 'O modelo está traçando o esquema de argumentos…',
   'No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.':
     'Ainda não há ideias conectadas. Analise suas obras (varredura profunda) para que o grafo gere conexões entre ideias.',
+  'Mostrar más': 'Mostrar mais',
   'Ningún recorrido coincide con los filtros actuales.': 'Nenhum percurso corresponde aos filtros atuais.',
   'Trazar el esquema desde esta idea': 'Traçar o esquema a partir desta ideia',
   '{n} debate(s)': '{n} debate(s)',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -2455,6 +2455,7 @@ export const PT: Record<string, string> = {
   'El modelo está trazando el esquema de argumentos…': 'O modelo está a traçar o esquema de argumentos…',
   'No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.':
     'Ainda não há ideias ligadas. Analise as suas obras (análise profunda) para que o grafo gere ligações entre ideias.',
+  'Mostrar más': 'Mostrar mais',
   'Ningún recorrido coincide con los filtros actuales.': 'Nenhum percurso corresponde aos filtros atuais.',
   'Trazar el esquema desde esta idea': 'Traçar o esquema a partir desta ideia',
   '{n} debate(s)': '{n} debate(s)',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -2595,6 +2595,7 @@ export const TR: Record<string, string> = {
   "Construyendo el esquema…": "Plan oluşturuluyor…",
   "El modelo está trazando el esquema de argumentos…": "Model argümanların şemasını çiziyor…",
   "No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.": "Henüz bağlantılı fikir yok. Grafiğin fikirler arasında bağlantılar oluşturması için çalışmalarınızı analiz edin (derin tarama).",
+  "Mostrar más": "Daha fazla göster",
   "Ningún recorrido coincide con los filtros actuales.": "Mevcut filtrelerle eşleşen tur yok.",
   "Trazar el esquema desde esta idea": "Bu fikirden şemayı çizin",
   "{n} debate(s)": "{n} tartışma(lar)",

--- a/src/incrementalList.ts
+++ b/src/incrementalList.ts
@@ -1,0 +1,28 @@
+/**
+ * How many items of a long list a page budget covers.
+ *
+ * Split out from `useIncrementalList` so the rule can be asserted without a
+ * renderer. The rule has two edges that matter, and both were real bugs:
+ *
+ *  - An item can weigh more than one card. Debates are grouped into clusters,
+ *    and paging by clusters alone let a single connected component paint every
+ *    contradiction it contained — the exact freeze the paging was added to fix.
+ *  - The first item always renders, even when it alone blows the budget, so a
+ *    heavy first item shows something instead of an empty list with a
+ *    "show more" button under it.
+ */
+export function incrementalSliceLength<T>(
+  items: readonly T[],
+  budget: number,
+  weight?: (item: T) => number
+): number {
+  if (items.length === 0) return 0;
+  if (!weight) return Math.min(Math.max(1, budget), items.length);
+  let used = 0;
+  let index = 0;
+  while (index < items.length && (index === 0 || used < budget)) {
+    used += Math.max(1, weight(items[index]));
+    index += 1;
+  }
+  return index;
+}

--- a/src/views/ArgumentMapView.tsx
+++ b/src/views/ArgumentMapView.tsx
@@ -16,7 +16,7 @@ import {
   DETAIL_DEFAULT_FONT,
   type DetailLoading,
 } from '../components/NodeDetailPanel';
-import { useDismissableLayer } from '../hooks';
+import { useDismissableLayer, useIncrementalList } from '../hooks';
 import { useFeatureModel } from '../hooks/useFeatureModel';
 import { expandableIdsByDepth } from '../argumentMapTree';
 import { t, tx } from '../i18n';
@@ -53,12 +53,20 @@ function typeColor(type: ArgumentBlock['type']): string {
   return type === 'framing' ? '#a78bfa' : NODE_COLORS[type as IdeaType] ?? '#888';
 }
 
+// A well-connected corpus ranks thousands of routes. Painting them all at once is
+// what froze the section; one screenful at a time is enough to scroll from.
+const ROUTES_PAGE_SIZE = 40;
+
 export function ArgumentMapView({ settings }: { settings: AppSettings }) {
   const [ideaNodes, setIdeaNodes] = useState<IdeaPickerItem[]>([]);
   const [graphLoaded, setGraphLoaded] = useState(false);
   const [mode, setMode] = useState<'auto' | 'ai'>('auto');
   const [suggestions, setSuggestions] = useState<ArgumentRouteSuggestion[]>([]);
   const [suggestionsLoading, setSuggestionsLoading] = useState(false);
+  // Only a click on «Actualizar» spins that button's icon. The automatic discovery
+  // on entering the section has its own indicator, and spinning both at once read
+  // as if the app were refreshing on its own.
+  const [refreshing, setRefreshing] = useState(false);
   const [seedId, setSeedId] = useState('');
   const [search, setSearch] = useState('');
   const [seedSearchOpen, setSeedSearchOpen] = useState(false);
@@ -90,17 +98,25 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
   // It used to get that list by loading the entire ideas graph — 9,721 nodes and
   // 34,531 edges, none of the edges ever read — which cost ~170 ms of blocked main
   // process and a multi-megabyte IPC message every time this view opened.
+  //
+  // Only the IA mode has a seed picker, and the section opens in automatic mode, so
+  // the query waits until the user actually switches: entering the section then
+  // costs one blocking main-process round trip instead of two.
+  const pickerRequested = useRef(false);
   useEffect(() => {
+    if (mode !== 'ai' || pickerRequested.current) return;
+    pickerRequested.current = true;
     void window.nodus.listPickerIdeas().then((ideas) => {
       setIdeaNodes(ideas);
       setGraphLoaded(true);
     });
-  }, []);
+  }, [mode]);
 
   // Discover ranked idea hubs for the automatic mode. Cheap (local DB, no AI),
   // so we run it on mount and whenever the user (re)enters automatic mode.
-  const discoverRoutes = useCallback(async () => {
+  const discoverRoutes = useCallback(async (manual = false) => {
     setSuggestionsLoading(true);
+    if (manual) setRefreshing(true);
     setError(null);
     try {
       const raw = await window.nodus.discoverArgumentRoutes();
@@ -109,6 +125,7 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSuggestionsLoading(false);
+      setRefreshing(false);
     }
   }, []);
 
@@ -150,6 +167,13 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
     if (minConnections > 1) base = base.filter((s) => s.degree >= minConnections);
     return base;
   }, [suggestions, suggestionSearch, minConnections]);
+
+  const {
+    visible: shownSuggestions,
+    hasMore: hasMoreSuggestions,
+    sentinelRef: suggestionsSentinelRef,
+    showMore: showMoreSuggestions,
+  } = useIncrementalList<ArgumentRouteSuggestion>(filteredSuggestions, ROUTES_PAGE_SIZE);
 
   const stopReveal = useCallback(() => {
     if (revealTimerRef.current != null) {
@@ -367,8 +391,13 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
                 onChange={(e) => setMinConnections(Math.max(0, Number(e.target.value)))}
               />
             </label>
-            <button className="btn btn-ghost gap-1.5" onClick={() => discoverRoutes()} disabled={suggestionsLoading}>
-              <Icon name="sync" className={suggestionsLoading ? 'animate-spin' : ''} /> {t('Actualizar')}
+            <button
+              data-testid="argument-routes-refresh"
+              className="btn btn-ghost gap-1.5"
+              onClick={() => discoverRoutes(true)}
+              disabled={suggestionsLoading}
+            >
+              <Icon name="sync" className={refreshing ? 'animate-spin' : ''} /> {t('Actualizar')}
             </button>
           </div>
         )}
@@ -415,7 +444,7 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
                     {t('Ningún recorrido coincide con los filtros actuales.')}
                   </div>
                 )}
-                {filteredSuggestions.map((s, i) => (
+                {shownSuggestions.map((s, i) => (
                   <button
                     key={s.ideaId}
                     className="w-full text-left card p-3 hover:bg-neutral-800/80 transition-colors group"
@@ -453,6 +482,13 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
                     </div>
                   </button>
                 ))}
+                {hasMoreSuggestions && (
+                  <div ref={suggestionsSentinelRef} className="pt-2 pb-6 text-center">
+                    <button className="btn btn-ghost border border-neutral-700 text-xs" onClick={showMoreSuggestions}>
+                      {t('Mostrar más')} ({filteredSuggestions.length - shownSuggestions.length})
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/src/views/DebateView.tsx
+++ b/src/views/DebateView.tsx
@@ -4,7 +4,7 @@ import { Badge, EDGE_LABELS, Icon, Spinner } from '../components/ui';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
 import { SaveToNotesModal } from '../components/SaveToNotesModal';
-import { useDataRefresh, useScanComplete } from '../hooks';
+import { useDataRefresh, useIncrementalList, useScanComplete } from '../hooks';
 import {
   ASSISTANT_CONTEXTS,
   type PendingAssistantNavigationTarget,
@@ -18,6 +18,12 @@ type StatusFilter = 'all' | 'open' | 'leaning';
 // Above this many distinct ideas, a connected component is no longer a meaningful
 // single "debate" — render its face-offs as standalone cards instead of one cluster.
 const MAX_CLUSTER_POSITIONS = 6;
+
+// A real corpus surfaces over a thousand contradictions. Every card carries two
+// evidence columns and a timeline, so painting the whole list in the render that
+// opens the section blocked the window for over a second — the section could not
+// even be left again until it finished.
+const DEBATES_PAGE_SIZE = 25;
 
 interface AnalysisState {
   text: string;
@@ -65,15 +71,44 @@ export function DebateView({
     });
   }, [debates, search, basis, status]);
 
-  // Group by cluster so multi-sided debates render together (already cluster-sorted).
-  const clusters = useMemo(() => {
-    const map = new Map<string, Debate[]>();
+  // Group by cluster so multi-sided debates render together (already cluster-sorted),
+  // then settle here — rather than in the JSX — which groups earn the cluster box.
+  // A huge connected component already rendered as loose cards, so splitting it
+  // across pages is invisible; only the boxed clusters have to stay whole.
+  const blocks = useMemo(() => {
+    const byCluster = new Map<string, Debate[]>();
     for (const d of filtered) {
-      if (!map.has(d.clusterId)) map.set(d.clusterId, []);
-      map.get(d.clusterId)!.push(d);
+      if (!byCluster.has(d.clusterId)) byCluster.set(d.clusterId, []);
+      byCluster.get(d.clusterId)!.push(d);
     }
-    return Array.from(map.values());
+    const out: { key: string; debates: Debate[]; positions: number; themes: string[] }[] = [];
+    for (const group of byCluster.values()) {
+      const positions = new Set(group.flatMap((d) => [d.sideA.ideaId, d.sideB.ideaId])).size;
+      if (group.length > 1 && positions <= MAX_CLUSTER_POSITIONS) {
+        out.push({
+          key: group[0].clusterId,
+          debates: group,
+          positions,
+          themes: Array.from(new Set(group.flatMap((d) => d.sharedThemes))),
+        });
+        continue;
+      }
+      for (const d of group) out.push({ key: d.id, debates: [d], positions: 0, themes: [] });
+    }
+    return out;
   }, [filtered]);
+
+  const blockWeight = useCallback((block: (typeof blocks)[number]) => block.debates.length, []);
+  const {
+    visible: shownBlocks,
+    hasMore: hasMoreBlocks,
+    sentinelRef: blocksSentinelRef,
+    showMore: showMoreBlocks,
+  } = useIncrementalList(blocks, DEBATES_PAGE_SIZE, blockWeight);
+  const shownDebates = useMemo(
+    () => shownBlocks.reduce((sum, block) => sum + block.debates.length, 0),
+    [shownBlocks]
+  );
 
   const analyze = useCallback((debate: Debate) => {
     setAnalyses((prev) => ({ ...prev, [debate.id]: { text: '', loading: true } }));
@@ -167,13 +202,8 @@ export function DebateView({
           </div>
         )}
 
-        {clusters.map((group) => {
-          const positions = new Set(group.flatMap((d) => [d.sideA.ideaId, d.sideB.ideaId])).size;
-          // Only wrap genuinely small multi-sided debates; a huge connected component
-          // (e.g. most contradictions chaining together) renders as standalone cards.
-          const isCluster = group.length > 1 && positions <= MAX_CLUSTER_POSITIONS;
-          const clusterThemes = Array.from(new Set(group.flatMap((d) => d.sharedThemes)));
-          const cards = group.map((d) => (
+        {shownBlocks.map((block) => {
+          const cards = block.debates.map((d) => (
             <DebateCard
               key={d.id}
               debate={d}
@@ -190,13 +220,13 @@ export function DebateView({
               }
             />
           ));
-          if (!isCluster) return <Fragment key={group[0].clusterId}>{cards}</Fragment>;
+          if (block.positions === 0) return <Fragment key={block.key}>{cards}</Fragment>;
           return (
-            <div key={group[0].clusterId} className="rounded-lg border border-neutral-800 p-3 bg-neutral-900/40">
+            <div key={block.key} className="rounded-lg border border-neutral-800 p-3 bg-neutral-900/40">
               <div className="flex flex-wrap items-center gap-2 mb-3 px-1">
                 <Icon name="network" size={15} className="text-rose-300" />
-                <span className="text-sm font-medium">{tx('Debate de {n} posiciones', { n: positions })}</span>
-                {clusterThemes.slice(0, 4).map((th) => (
+                <span className="text-sm font-medium">{tx('Debate de {n} posiciones', { n: block.positions })}</span>
+                {block.themes.slice(0, 4).map((th) => (
                   <Badge key={th} color="neutral">
                     {th}
                   </Badge>
@@ -206,6 +236,14 @@ export function DebateView({
             </div>
           );
         })}
+
+        {hasMoreBlocks && (
+          <div ref={blocksSentinelRef} className="pt-1 pb-6 text-center">
+            <button className="btn btn-ghost border border-neutral-700 text-xs" onClick={showMoreBlocks}>
+              {t('Mostrar más')} ({filtered.length - shownDebates})
+            </button>
+          </div>
+        )}
       </div>
 
       {citation && (


### PR DESCRIPTION
Closes #312.

## The freeze

Not the main process — an earlier audit already brought both IPC channels down to ~150 ms. Both views painted their **entire list** in the single render that opens the section, so the renderer's main thread went one to two seconds without yielding and the click on another sidebar section was never processed until the paint finished.

Measured against a copy of a real corpus (9,959 ideas, 19,934 edges), driving the real window over CDP:

| Section | Items | DOM nodes before → after | Escape click accepted before → after |
|---|---|---|---|
| Argument map | 8,498 routes | 128,676 → **958** | 2,023 ms → **105 ms** |
| Debates | 1,147 contradictions | 90,037 → **2,354** | 1,316 ms → **109 ms** |

New `useIncrementalList` hook (`src/hooks.ts`): one page (40 routes / 25 debates), growing as an `IntersectionObserver` sentinel scrolls near, plus a «Mostrar más» button for the same thing by hand. Nothing becomes unreachable — the whole list is still scrollable.

**Debates has to page by cards, not by cluster.** A huge connected component already renders as loose cards (`MAX_CLUSTER_POSITIONS = 6`), so twenty-five clusters still painted about a thousand of them — 64k nodes, most of the freeze still there. Which groups earn the cluster box is now settled in the memo, before paging, and the page budget counts the cards a block holds.

## The two spinning arrows

The Argument map's refresh icon followed `suggestionsLoading`, the same flag that lights the "Detecting routes…" indicator, so both arrows spun on entering the section and it read as if the app were refreshing on its own. It now follows a `refreshing` flag that only the manual click raises.

While in there: `listPickerIdeas()` is deferred until the user switches to IA mode. The section opens in automatic mode, which has no seed picker, so entering it now costs one blocking main-process round trip instead of two.

## Verification

- Measured on the real window over CDP, before and after, with the numbers above.
- Functionally checked in the running app: on entry the refresh button does **not** spin (only the discovery indicator does); clicking it **does** spin it; the route list opens at 40 and grows 40 per scroll; debates open at 25 and grow 25 per scroll, and «Mostrar más» works.
- `scripts/test-incremental-list.mjs` — 8 tests fixing the paging arithmetic (weights, the always-render-the-first-item edge, a zero weight not stalling the page) and the wiring in both views.
- `npm run typecheck`, `npm run lint` and `test-i18n-coverage` pass; the one new string is translated into all seven languages.

## Note

The refresh button gained `data-testid="argument-routes-refresh"`. The app header has its own icon-only «Actualizar» (Zotero sync), and matching on text alone clicked that one instead.
