### PR TITLE
Move every workflow action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -66,13 +66,13 @@ jobs:
           exit 1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -94,7 +94,7 @@ jobs:
             app.nodus.stability=experimental
 
       - name: Publish experimental multi-platform image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./server
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -30,10 +30,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,13 +29,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'schedule' && 'main' || github.ref }}
 
       - name: Set up Node
         if: github.event_name == 'schedule'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -105,10 +105,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Refs #316.

Moves **every** action in the four workflows off the deprecated Node 20 runtime. Fifteen `uses:` lines, no other change.

## What the warning actually was

It is about the runtime the **action itself** runs on (`runs.using: node20` in the action's metadata), not about `node-version: 22` — that is the Node the *steps* use and was already current.

| Action | Was | Now | Runtime before → after |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | node20 → node24 |
| `actions/setup-node` | v4 | **v7** | node20 → node24 |
| `docker/setup-qemu-action` | v3 | **v4** | node20 → node24 |
| `docker/setup-buildx-action` | v3 | **v4** | node20 → node24 |
| `docker/login-action` | v3 | **v4** | node20 → node24 |
| `docker/metadata-action` | v5 | **v6** | node20 → node24 |
| `docker/build-push-action` | v6 | **v7** | node20 → node24 |

Untouched because they were already fine: `actions/configure-pages@v6` and `actions/deploy-pages@v5` are node24, `actions/upload-pages-artifact@v5` is composite. Audited by reading `runs.using` from each action's own `action.yml` at the pinned ref — nothing node20 is left.

## Why v7 for checkout and setup-node, not the minimum v5

v5 is where `setup-node` made caching automatic whenever `package.json` carries a `packageManager` field; v6 narrowed that back to npm only. Landing on v6 or later avoids adopting that behaviour just to leave it behind again, and v7 adds nothing breaking.

## Every breaking change, checked against this repo

| Major | What it removes or changes | Applies here? |
|---|---|---|
| `setup-node` v5 | Auto-cache when `packageManager` is present | **No** — `package.json` has no such field |
| `checkout` v7 | Blocks fork-PR checkout for `pull_request_target` / `workflow_run` | **No** — neither trigger is used |
| `setup-buildx` v4 | Drops the `config`, `config-inline` and `install` inputs | **No** — the step passes no inputs at all |
| `build-push` v7 | Drops `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` | **No** — neither appears anywhere in `.github/` |
| `metadata` v6 | Changes how a `#` inside a list value is read | **No** — no `#` in the `tags` or `labels` here |
| All | Require runner ≥ v2.327.1 | **No risk** — every runner is GitHub-hosted |

## What is actually verified

Only `ci.yml` runs on a pull request, so it is the only one this PR can prove green. The other three are **review-only**, and I did not trigger any of them, because each does something outward-facing:

- `release.yml` — fires on `v*` tags; dispatching it cuts a real release
- `pages.yml` — redeploys the live site
- `nodus-server-image.yml` — publishes the image to GHCR

All four files were parsed to confirm the YAML is still valid and the step lists are unchanged apart from the version strings.
