### PR TITLE
Make Deep Research report only what it can support

### DIFF
--- a/electron/ai/deepResearch.ts
+++ b/electron/ai/deepResearch.ts
@@ -4,12 +4,16 @@ import { getSettings } from '../db/settingsRepo';
 import { getActiveVault } from '../vaults/vaultRegistry';
 import { generateGenealogyDeepResearchReport } from './genealogyDeepResearch';
 import { generateStudyDeepResearchReport } from './studyDeepResearch';
-import { buildWritingWorkshopSnapshot } from './writingWorkshop';
+import { buildWritingWorkshopSnapshot, retrieveSectionMaterial } from './writingWorkshop';
 import {
   orchestrateDeepResearch,
   type DeepResearchDeps,
   type DeepResearchPlan,
   type DeepResearchPlanSection,
+  type CitationClaim,
+  type CitationVerdict,
+  type CoherenceIssue,
+  countWords,
   DEEP_RESEARCH_NARRATIVE_RULES,
   type FinalizeInput,
   type FinalizeResult,
@@ -48,11 +52,217 @@ export async function generateDeepResearchReport(
 
 function realDeps(model: ModelRef | null): DeepResearchDeps {
   return {
+    // Single probe by default. Decomposing the objective into sub-questions was
+    // measured on the real corpus and did NOT pay: without a relevance floor it
+    // tripled unsupported citations (3% → 9%), and with one it changed only 5–10%
+    // of the pool while slightly reducing the distinct works behind it. This corpus
+    // is already concentrated on one domain, so every sub-question lands in the same
+    // neighbourhood. `buildWritingWorkshopSnapshot` still takes extra probes, so a
+    // broader corpus can switch this on by passing them here.
     buildSnapshot: (brief) => buildWritingWorkshopSnapshot(brief),
     planReport: (input) => aiPlanReport(input, model),
     writeSection: (input) => aiWriteSection(input, model),
     finalize: (input) => aiFinalize(input, model),
+    retrieveForSection: (input) => retrieveSectionMaterial(input),
+    expandSection: (input) => aiExpandSection(input, model),
+    verifyCitations: (claims) => aiVerifyCitations(claims, model),
+    checkCoherence: (sections) => aiCheckCoherence(sections, model),
   };
+}
+
+interface AiCoherence {
+  tensiones?: { seccion_a?: string; cita_a?: string; seccion_b?: string; cita_b?: string; problema?: string }[];
+}
+function isAiCoherence(v: unknown): v is AiCoherence {
+  return typeof v === 'object' && v !== null;
+}
+
+/**
+ * Look for places where the report argues against itself.
+ *
+ * Read-only by design. Both sides must be quoted verbatim so the orchestrator can
+ * confirm the sentences exist before believing the finding — a model asked to find
+ * contradictions will happily invent one, and an invented tension printed in the
+ * limitations of an academic report is worse than no check at all.
+ */
+async function aiCheckCoherence(
+  sections: { title: string; text: string }[],
+  model: ModelRef | null
+): Promise<CoherenceIssue[]> {
+  const system = [
+    'Revisas la coherencia interna de un informe académico ya redactado.',
+    'Busca ÚNICAMENTE lugares donde el informe se contradice a sí mismo: dos pasajes que no pueden ser ciertos a la vez, o donde una sección afirma algo que otra niega o matiza hasta el punto de resultar incompatible.',
+    'No señales repeticiones, cambios de énfasis, matices compatibles ni cuestiones de estilo. Un desacuerdo ENTRE AUTORES citados no es una contradicción del informe: eso es un debate y es correcto que aparezca.',
+    'Cita ambos pasajes LITERALMENTE, copiando una frase completa de cada uno tal y como aparece en el texto. Si no puedes copiarlas literalmente, no incluyas la tensión.',
+    'Si el informe es coherente, devuelve una lista vacía. Es la respuesta esperada la mayoría de las veces.',
+    'Devuelve SOLO JSON válido: {"tensiones":[{"seccion_a":"...","cita_a":"...","seccion_b":"...","cita_b":"...","problema":"en una frase, qué es incompatible"}]}',
+  ].join('\n');
+  const user = JSON.stringify(
+    { secciones: sections.map((s) => ({ titulo: s.title, texto: s.text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') })) },
+    null,
+    2
+  );
+  try {
+    const ai = await completeJson<AiCoherence>({ system, user, temperature: 0, maxTokens: 1400 }, isAiCoherence, model);
+    return (ai.tensiones ?? [])
+      .filter((t) => t && typeof t.cita_a === 'string' && typeof t.cita_b === 'string')
+      .slice(0, 5)
+      .map((t) => ({
+        sectionA: String(t.seccion_a ?? ''),
+        quoteA: String(t.cita_a ?? ''),
+        sectionB: String(t.seccion_b ?? ''),
+        quoteB: String(t.cita_b ?? ''),
+        issue: String(t.problema ?? '').trim() || 'Afirmaciones incompatibles entre secciones.',
+      }));
+  } catch {
+    return [];
+  }
+}
+
+interface AiProbes {
+  subpreguntas?: string[];
+}
+function isAiProbes(v: unknown): v is AiProbes {
+  return typeof v === 'object' && v !== null;
+}
+
+/**
+ * Break the objective into the questions a researcher would actually go looking for.
+ *
+ * The corpus is searched by semantic similarity, so a single probe reaches only what
+ * resembles the objective *as a whole sentence*. An objective spanning several axes
+ * retrieves the intersection and misses what each axis would surface on its own —
+ * with ~10,000 ideas indexed, a report was being built on the neighbourhood of one
+ * query. Each sub-question becomes an independent probe. Failure is harmless: the
+ * objective alone still works exactly as before.
+ */
+async function aiDecomposeObjective(objective: string, language: string | undefined, model: ModelRef | null): Promise<string[]> {
+  const system = [
+    'Descompones un objetivo de investigación en las preguntas concretas que habría que buscar por separado en una biblioteca académica.',
+    'Cada subpregunta debe ser autónoma y buscable por sí sola, formulada como una frase con contenido (no una etiqueta de dos palabras).',
+    'Cubre ejes distintos del objetivo: sus conceptos, sus actores, sus periodos, sus métodos y sus controversias. No repitas el objetivo con otras palabras.',
+    'Entre 5 y 7 subpreguntas. Devuelve SOLO JSON válido: {"subpreguntas":["...","..."]}',
+  ].join('\n');
+  try {
+    const ai = await completeJson<AiProbes>(
+      { system, user: JSON.stringify({ objetivo: objective, idioma: language ?? 'es' }), temperature: 0.2, maxTokens: 700 },
+      isAiProbes,
+      model
+    );
+    return (ai.subpreguntas ?? [])
+      .filter((q): q is string => typeof q === 'string' && q.trim().length > 12)
+      .slice(0, 7);
+  } catch {
+    return [];
+  }
+}
+
+/** Exposed for `scripts/measure-retrieval-breadth.mjs`. */
+export const __decomposeObjectiveForTesting = aiDecomposeObjective;
+
+/** How many claims are judged per call. Small enough that the judge reads each one. */
+const VERIFY_BATCH = 12;
+
+/**
+ * Exposed for `scripts/verify-citation-judge.mjs`, which feeds the judge deliberately
+ * false citations to check it rejects them. A verifier nobody audits can quietly
+ * approve everything and still look like it is working.
+ */
+export const __verifyCitationsForTesting = aiVerifyCitations;
+
+interface AiVerdicts {
+  veredictos?: { i?: number; veredicto?: string }[];
+}
+function isAiVerdicts(v: unknown): v is AiVerdicts {
+  return typeof v === 'object' && v !== null && Array.isArray((v as AiVerdicts).veredictos);
+}
+
+/**
+ * Judge whether each cited source really supports the sentence it was attached to.
+ *
+ * The citation policy already proves the source exists in the corpus; this is the
+ * only thing standing between "the report cites something real" and "the report
+ * cites something that says what the report claims it says". A claim whose judgement
+ * cannot be obtained defaults to `supports`, because deleting a citation on the
+ * strength of a failed API call would silently damage a correct report.
+ */
+async function aiVerifyCitations(claims: CitationClaim[], model: ModelRef | null): Promise<CitationVerdict[]> {
+  const verdicts: CitationVerdict[] = new Array(claims.length).fill('supports');
+  const system = [
+    'Eres el verificador de citas del modo Deep Research de Nodus.',
+    'Para cada par recibes UNA afirmación tal como aparece en un informe académico y el CONTENIDO de la fuente que se ha citado para sostenerla.',
+    'Tu única tarea es decidir si esa fuente sostiene esa afirmación. No juzgues si la afirmación es cierta en el mundo, ni si está bien escrita, ni si la fuente es buena.',
+    'Veredictos posibles:',
+    '- "sostiene": el contenido afirma, implica o documenta directamente lo que dice la frase.',
+    '- "parcial": el contenido sostiene una parte de la frase, o una versión más débil o más limitada de lo que afirma.',
+    '- "no_sostiene": el contenido trata de otra cosa, dice algo distinto, o no permite afirmar lo que la frase sostiene.',
+    'Una frase puede citar varias fuentes: juzga SOLO la que se te da en cada par, aunque otra fuente distinta pudiera sostener la frase.',
+    'Ante la duda razonable entre "sostiene" y "parcial", elige "parcial". Reserva "no_sostiene" para cuando la relación sea realmente inexistente.',
+    'Devuelve SOLO JSON válido: {"veredictos":[{"i":0,"veredicto":"sostiene|parcial|no_sostiene"}]} con una entrada por par y el mismo índice que recibiste.',
+  ].join('\n');
+
+  for (let start = 0; start < claims.length; start += VERIFY_BATCH) {
+    const batch = claims.slice(start, start + VERIFY_BATCH);
+    const user = JSON.stringify(
+      {
+        pares: batch.map((claim, offset) => ({
+          i: offset,
+          afirmacion: claim.sentence,
+          tipo_de_fuente: claim.kind,
+          contenido_de_la_fuente: claim.content,
+        })),
+      },
+      null,
+      2
+    );
+    try {
+      const ai = await completeJson<AiVerdicts>({ system, user, temperature: 0, maxTokens: 1400 }, isAiVerdicts, model);
+      for (const entry of ai.veredictos ?? []) {
+        const at = start + (typeof entry.i === 'number' ? entry.i : -1);
+        if (at < start || at >= start + batch.length) continue;
+        const raw = String(entry.veredicto ?? '').toLowerCase();
+        verdicts[at] = raw.includes('no_sostiene') ? 'unsupported' : raw.includes('parcial') ? 'partial' : 'supports';
+      }
+    } catch {
+      /* this batch keeps its optimistic default */
+    }
+  }
+  return verdicts;
+}
+
+/**
+ * Rewrite a section that came back too short. Writers under-deliver against a word
+ * target, and accepting that silently is what kept reports pinned to the floor of
+ * their page range. The model is given its own draft and told to deepen it with the
+ * material it already had, never to pad.
+ */
+async function aiExpandSection(
+  input: SectionInput & { draft: string; missingWords: number },
+  model: ModelRef | null
+): Promise<string> {
+  const system = [
+    'Eres el redactor del modo Deep Research de Nodus. Recibes un borrador PROPIO de una sección que se ha quedado corto y debes desarrollarlo.',
+    'Escribe en español salvo que el idioma indicado pida otra lengua.',
+    `El borrador tiene unas ${countWords(input.draft)} palabras y la sección debía tener ~${input.targetWords}. Faltan del orden de ${input.missingWords} palabras.`,
+    'NO rellenes. Desarrolla: recupera del menú de citas el material que el borrador dejó sin usar, contrasta ideas que quedaron sueltas, desarrolla las contradicciones como debates entre autores y explica los huecos en vez de nombrarlos.',
+    'Conserva íntegro lo que ya estaba bien, incluidas TODAS las citas nodus:// tal cual aparecen. Puedes reordenar y reescribir para integrar lo nuevo, pero no elimines citas existentes.',
+    'Cada afirmación nueva necesita su cita del menú, entre paréntesis y en el formato exacto del menú.',
+    ...DEEP_RESEARCH_NARRATIVE_RULES,
+    'Empieza con el encabezado Markdown "## " y el título dado. Devuelve solo el Markdown completo de la sección ampliada, sin JSON ni vallas de código.',
+  ].join('\n');
+  const user = JSON.stringify(
+    {
+      objetivo: input.objective,
+      idioma: input.language,
+      seccion: { titulo: input.section.title, proposito: input.section.purpose, afirmaciones_clave: input.section.keyClaims },
+      menu_de_citas: input.citationMenu,
+      borrador_actual: input.draft,
+      afirmaciones_ya_desarrolladas_en_otras_secciones: input.alreadyDeveloped,
+    },
+    null,
+    2
+  );
+  return completeText({ system, user, temperature: 0.3, maxTokens: 6500 }, model);
 }
 
 interface AiPlan {
@@ -78,9 +288,13 @@ async function aiPlanReport(input: PlanInput, model: ModelRef | null): Promise<D
     countRule,
     `El cuerpo del informe debe ocupar entre ${input.targetPages.min} y ${input.targetPages.max} páginas repartidas entre esas pocas secciones (introducción, cuerpo por líneas argumentales amplias y síntesis/conclusión). La bibliografía final NO cuenta para esa extensión.`,
     'Agrupa las ideas por afinidad temática o argumental: cada sección reúne un CONJUNTO de ideas relacionadas, no una sola. Reparte TODAS las ideas relevantes entre las secciones. Asigna huecos y contradicciones donde aporten tensión.',
+    // Order is planned, not left to the order the sections happen to be emitted in.
+    'ORDEN DEL ARGUMENTO: el informe debe leerse como un razonamiento que progresa, no como una lista de temas. Marca `role` con "intro" para el planteamiento, "body" para el desarrollo y "synthesis" para el cierre, y usa `dependsOn` para declarar de qué secciones previas depende cada una porque dan por establecido algo que necesita.',
+    'Ordena de modo que ninguna sección presuponga algo que solo se establece más adelante. Si el material tiene una dimensión histórica, respétala: lo que explica el origen va antes que lo que explica su consecuencia.',
+    'Reparte las obras entre secciones: evita que una sección dependa casi entera de una sola obra o de un solo autor cuando el corpus ofrece alternativas.',
     'Usa EXCLUSIVAMENTE los identificadores que se te dan. No inventes ideas, obras ni ids.',
     'Devuelve SOLO JSON válido con la forma:',
-    '{"title":"...","abstract":"...","sections":[{"id":"s1","title":"...","purpose":"...","keyClaims":["..."],"ideaIds":["..."],"workIds":["..."],"gapIds":["..."],"contradictionIds":["..."],"passageIds":["..."]}]}',
+    '{"title":"...","abstract":"...","sections":[{"id":"s1","role":"intro|body|synthesis","dependsOn":["s2"],"title":"...","purpose":"...","keyClaims":["..."],"ideaIds":["..."],"workIds":["..."],"gapIds":["..."],"contradictionIds":["..."],"passageIds":["..."]}]}',
   ].join('\n');
   const user = JSON.stringify(
     {
@@ -114,6 +328,8 @@ async function aiPlanReport(input: PlanInput, model: ModelRef | null): Promise<D
       gapIds: Array.isArray(s.gapIds) ? s.gapIds : [],
       contradictionIds: Array.isArray(s.contradictionIds) ? s.contradictionIds : [],
       passageIds: Array.isArray(s.passageIds) ? s.passageIds : [],
+      role: s.role,
+      dependsOn: Array.isArray(s.dependsOn) ? s.dependsOn : [],
     })),
   };
 }
@@ -124,10 +340,17 @@ async function aiWriteSection(input: SectionInput, model: ModelRef | null): Prom
     'Escribe en español salvo que el idioma indicado pida otra lengua.',
     'Usa SOLO los materiales y las citas del menú proporcionado. No inventes obras, autores, datos ni páginas.',
     'Cada afirmación sustantiva debe ir respaldada por una cita del menú, colocada ENTRE PARÉNTESIS y en formato enlace Markdown nodus:// exactamente como aparece en el menú.',
+    // Every menu entry now carries its real content, so the writer can be held to it.
+    'Cada entrada del menú incluye el contenido real de lo que cita en el campo "note". Apóyate en ese contenido: no cites nada cuyo "note" no sostenga lo que afirmas.',
+    'Los pasajes ("kind":"passage") traen el texto literal de la obra entre comillas angulares. Úsalos como evidencia textual, parafrasea o cita con precisión y no extiendas su sentido más allá de lo que dicen.',
+    'Los huecos ("kind":"gap") y las contradicciones ("kind":"contradiction") traen en "note" lo que realmente afirman. Arguméntalos por su contenido, no los menciones de pasada como etiquetas.',
+    'Cuando el menú traiga una contradicción, conviértela en un debate explícito: nombra las dos posturas y, si el campo "source" dice quién las sostiene, atribúyelas a esos autores. Un desacuerdo entre investigadores es más informativo que una afirmación unánime.',
+    'RIQUEZA DE FUENTES: no sostengas una sección con una sola obra ni con un solo autor. Alterna entre las fuentes del menú y, cuando varias sostengan lo mismo, dilo explícitamente porque la convergencia entre autores independientes es un argumento en sí. Si una afirmación descansa en una única fuente, deja constancia de ello en la prosa.',
+    'Cuando cites un hueco, no te limites a constatar que falta investigación: explica qué impide concluir y qué haría falta para cerrarlo.',
     `Extensión objetivo: ~${input.targetWords} palabras (es una sección de fondo, extensa y desarrollada), en 4-7 párrafos densos. Nada de listas salvo que sean imprescindibles.`,
     'Desarrolla la sección con profundidad real: no te limites a enunciar cada idea; contrástalas, encadénalas y construye un argumento continuo que atraviese todas las ideas asignadas.',
     'Relaciona las ideas entre sí: continuidad, diferencias, niveles de abstracción, consecuencias metodológicas, tensiones y huecos.',
-    'No repitas lo ya dicho en secciones anteriores (se te da un resumen). Aporta desarrollo nuevo.',
+    'No repitas lo ya dicho en secciones anteriores. Se te dan el recorrido de cada sección previa y la lista de afirmaciones ya desarrolladas: puedes apoyarte en ellas y remitir a ellas, pero el desarrollo de esta sección debe ser nuevo.',
     ...DEEP_RESEARCH_NARRATIVE_RULES,
     input.isConclusion
       ? 'Esta es la sección de cierre: integra las líneas del informe, nombra los huecos y perfila la contribución.'
@@ -140,7 +363,8 @@ async function aiWriteSection(input: SectionInput, model: ModelRef | null): Prom
       idioma: input.language,
       seccion: { titulo: input.section.title, proposito: input.section.purpose, afirmaciones_clave: input.section.keyClaims },
       menu_de_citas: input.citationMenu,
-      resumen_secciones_previas: input.priorSummary || '(esta es la primera sección)',
+      recorrido_secciones_previas: input.priorSummary || '(esta es la primera sección)',
+      afirmaciones_ya_desarrolladas: input.alreadyDeveloped,
     },
     null,
     2

--- a/electron/ai/deepResearchClient.ts
+++ b/electron/ai/deepResearchClient.ts
@@ -101,6 +101,7 @@ export async function buildDeepResearchBrief(
       'Prefiere POCAS secciones LARGAS y profundas antes que muchas cortas: cada sección agrupa varias ideas afines y las relaciona (continuidad, tensiones, consecuencias), no una idea por sección.',
       ...DEEP_RESEARCH_NARRATIVE_RULES,
       'Reparte TODAS las ideas relevantes del catálogo entre las secciones. Sitúa los huecos y contradicciones donde aporten tensión argumental. Cierra con una síntesis.',
+      'Cada entrada del catálogo trae en `note` el contenido real de lo que cita. Los pasajes traen el texto literal de la obra entre comillas angulares: úsalos como evidencia textual y no extiendas su sentido. Los huecos y las contradicciones traen lo que afirman, así que arguméntalos por su contenido en vez de nombrarlos de pasada.',
       'Empieza cada sección con un encabezado Markdown "## Título". No incluyas el resumen, las limitaciones ni las referencias en `sectionsMarkdown`: pásalos como campos aparte a la herramienta de ensamblado.',
       `Cuando termines de redactar, llama a \`${'nodus_finalize_deep_research'}\` con tu markdown para validar las citas, construir las referencias y (si quieres) guardar el borrador.`,
     ],

--- a/electron/ai/deepResearchCore.ts
+++ b/electron/ai/deepResearchCore.ts
@@ -11,6 +11,7 @@ import type {
   WritingWorkshopMatrixRow,
   WritingWorkshopSection,
   WritingWorkshopSnapshot,
+  SupportAuditEntry,
 } from '@shared/types';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -68,6 +69,8 @@ const IDEA_NOTE_CHARS = 240;
 const PASSAGE_NOTE_CHARS = 480;
 /** Extra material a per-section retrieval may add on top of what the planner assigned. */
 const SECTION_RETRIEVAL_LIMITS = { ideas: 6, passages: 4 } as const;
+/** How many flagged claims the audit lists. Enough to spot-check, not a second report. */
+const MAX_SUPPORT_AUDIT = 40;
 /** Below this share of its word target a section gets one expansion pass. */
 const MIN_SECTION_FILL = 0.78;
 
@@ -338,6 +341,7 @@ export async function orchestrateDeepResearch(
   let totalWords = 0;
   let stoppedReason: string | null = null;
   const verification = { checked: 0, partial: 0, unsupported: 0 };
+  const supportAudit: SupportAuditEntry[] = [];
   let expansions = 0;
   const sectionFill: { words: number; target: number }[] = [];
 
@@ -434,6 +438,17 @@ export async function orchestrateDeepResearch(
             verification.checked += outcome.checked;
             verification.partial += outcome.partial;
             verification.unsupported += outcome.unsupported;
+            for (const entry of outcome.audit) {
+              if (supportAudit.length >= MAX_SUPPORT_AUDIT) break;
+              supportAudit.push({
+                verdict: entry.verdict,
+                kind: entry.claim.kind,
+                section: section.title,
+                sentence: entry.claim.sentence,
+                source: clip(entry.claim.content, 400),
+                sourceLabel: sourceLabelForClaim(entry.claim, maps),
+              });
+            }
             if (outcome.unsupported > 0) {
               markdown = outcome.markdown;
               ({ cited } = applyCitationPolicy(markdown, maps));
@@ -585,6 +600,7 @@ export async function orchestrateDeepResearch(
     matrix,
     bibliography: references,
     nextSteps: finalize.nextSteps,
+    supportAudit,
     limitations: [...finalize.limitations, ...coherenceIssues.map((issue) => L.coherenceLimitation(issue))],
     stats: {
       selectedIdeas: coveredIdeaIds.size,
@@ -1562,6 +1578,8 @@ export interface VerificationOutcome {
   unsupported: number;
   /** Sentences that lost their only support, for honest reporting. */
   strippedSentences: string[];
+  /** The claims worth a second look, paired with the source to check them against. */
+  audit: { verdict: 'partial' | 'removed'; claim: CitationClaim }[];
 }
 
 /**
@@ -1588,7 +1606,11 @@ export function applyVerification(markdown: string, claims: CitationClaim[], ver
     .replace(/\(\s*[;,]?\s*\)/g, '')
     .replace(/\s+([.,;)])/g, '$1')
     .replace(/[ \t]{2,}/g, ' ');
-  return { markdown: out, checked: claims.length, partial, unsupported: doomed.length, strippedSentences };
+  const audit = claims
+    .map((claim, index) => ({ verdict: verdicts[index], claim }))
+    .filter((entry) => entry.verdict === 'partial' || entry.verdict === 'unsupported')
+    .map((entry) => ({ verdict: entry.verdict === 'partial' ? ('partial' as const) : ('removed' as const), claim: entry.claim }));
+  return { markdown: out, checked: claims.length, partial, unsupported: doomed.length, strippedSentences, audit };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1690,6 +1712,10 @@ function sectionSources(section: DeepResearchPlanSection, maps: SnapshotMaps): s
 
 export function buildCitationMenu(section: DeepResearchPlanSection, maps: SnapshotMaps): CitationMenuItem[] {
   const items: CitationMenuItem[] = [];
+  // Passages are offered last, on purpose. Leading with them was measured and made
+  // the report worse: verbatim quoting more than tripled, the argument leaned on a
+  // third fewer distinct works because each passage belongs to a single one, and
+  // unsupported citations doubled as claims overreached a narrow snippet.
   for (const id of section.ideaIds) {
     const idea = maps.ideaById.get(id);
     if (!idea) continue;
@@ -1747,6 +1773,26 @@ export function buildCitationMenu(section: DeepResearchPlanSection, maps: Snapsh
     });
   }
   return items;
+}
+
+/** Author-year behind a flagged claim, so the reader knows which source to open. */
+function sourceLabelForClaim(claim: CitationClaim, maps: SnapshotMaps): string {
+  switch (claim.kind) {
+    case 'idea':
+      return sourceLabelFromWork(maps.ideaById.get(claim.id)?.works[0]) || '';
+    case 'passage': {
+      const workId = maps.passageWorkId.get(claim.id);
+      const page = maps.passagePage.get(claim.id);
+      const base = sourceLabelFromWork(workId ? maps.workInfoById.get(workId) : undefined);
+      return page ? `${base}, ${page}` : base;
+    }
+    case 'gap':
+      return maps.gapById.get(claim.id)?.source || '';
+    case 'contradiction':
+      return maps.contradictionById.get(claim.id)?.sources[0] || '';
+    default:
+      return '';
+  }
 }
 
 /** Which works back an idea, so the writer can name them in prose. */

--- a/electron/ai/deepResearchCore.ts
+++ b/electron/ai/deepResearchCore.ts
@@ -272,8 +272,8 @@ export interface SnapshotMaps {
   passagePage: Map<string, string | null>;
   /** Literal passage text. A passage with no text here is never offered as citable. */
   passageText: Map<string, string>;
-  /** What each gap actually says, so the writer can argue it instead of naming it. */
-  gapById: Map<string, { label: string; summary: string }>;
+  /** What each gap actually says, plus the author-year it is anchored to. */
+  gapById: Map<string, { label: string; summary: string; source: string }>;
   /** What each contradiction actually opposes, and who holds each side. */
   contradictionById: Map<string, { label: string; summary: string; sources: string[] }>;
   validIds: Set<string>;
@@ -481,6 +481,10 @@ export async function orchestrateDeepResearch(
       stoppedReason = L.stoppedPages(targetPages.max);
       break;
     }
+    // The page range is a target, not a cap. A stronger model writes longer sections
+    // than the plan assumed and overshoots by a page or two; cutting a section to
+    // claw that back would cost an argument to save a page, which is a bad trade in
+    // a research report. Only the hard budget check above stops the loop.
     const isConclusion = i === plan.sections.length - 1;
     await runSection(plan.sections[i], isConclusion);
   }
@@ -1117,7 +1121,7 @@ export function buildSnapshotMaps(snapshot: WritingWorkshopSnapshot): SnapshotMa
   const passageWorkId = new Map<string, string>();
   const passagePage = new Map<string, string | null>();
   const passageText = new Map<string, string>();
-  const gapById = new Map<string, { label: string; summary: string }>();
+  const gapById = new Map<string, { label: string; summary: string; source: string }>();
   const contradictionById = new Map<string, { label: string; summary: string; sources: string[] }>();
 
   for (const idea of snapshot.ideas) {
@@ -1144,7 +1148,8 @@ export function buildSnapshotMaps(snapshot: WritingWorkshopSnapshot): SnapshotMa
       });
     }
   }
-  for (const g of snapshot.gaps) gapById.set(g.id, { label: g.label, summary: g.summary ?? '' });
+  for (const g of snapshot.gaps)
+    gapById.set(g.id, { label: g.label, summary: g.summary ?? '', source: sourceLabelFromWork(g.work) });
   for (const c of snapshot.contradictions)
     contradictionById.set(c.id, { label: c.label, summary: c.summary ?? '', sources: c.sources ?? [] });
   for (const p of snapshot.passages) {
@@ -1402,10 +1407,10 @@ export function applyCitationPolicy(
       // not in the visible citation.
       case 'gap':
         cited.gaps.add(id);
-        return `[hueco](nodus://gap/${encodeURIComponent(id)})`;
+        return `[${maps.gapById.get(id)?.source || 'hueco'}](nodus://gap/${encodeURIComponent(id)})`;
       case 'contradiction':
         cited.contradictions.add(id);
-        return `[contradicción](nodus://contradiction/${encodeURIComponent(id)})`;
+        return `[${maps.contradictionById.get(id)?.sources[0] || 'contradicción'}](nodus://contradiction/${encodeURIComponent(id)})`;
       default:
         return label || '';
     }
@@ -1709,7 +1714,7 @@ export function buildCitationMenu(section: DeepResearchPlanSection, maps: Snapsh
     const gap = maps.gapById.get(id);
     if (!gap) continue;
     items.push({
-      token: `[hueco](nodus://gap/${encodeURIComponent(id)})`,
+      token: `[${gap.source || 'hueco'}](nodus://gap/${encodeURIComponent(id)})`,
       kind: 'gap',
       note: clip(gap.summary || gap.label, IDEA_NOTE_CHARS),
     });
@@ -1720,7 +1725,7 @@ export function buildCitationMenu(section: DeepResearchPlanSection, maps: Snapsh
     const sides = contradiction.label ? `Posturas enfrentadas: ${contradiction.label}. ` : '';
     const who = contradiction.sources.length ? ` Lo sostienen ${contradiction.sources.join('; ')}.` : '';
     items.push({
-      token: `[contradicción](nodus://contradiction/${encodeURIComponent(id)})`,
+      token: `[${contradiction.sources[0] || 'contradicción'}](nodus://contradiction/${encodeURIComponent(id)})`,
       kind: 'contradiction',
       note: `${sides}${clip(contradiction.summary, IDEA_NOTE_CHARS)}${who}`.trim(),
       source: contradiction.sources.join('; ') || undefined,
@@ -1790,11 +1795,11 @@ export function buildCitationCatalog(snapshot: WritingWorkshopSnapshot): Citatio
       note: clip(w.title || w.label, 160),
     })),
     gaps: snapshot.gaps.slice(0, POOL_LIMITS.gaps).map((g) => ({
-      token: `[hueco](nodus://gap/${encodeURIComponent(g.id)})`,
+      token: `[${sourceLabelFromWork(g.work) || 'hueco'}](nodus://gap/${encodeURIComponent(g.id)})`,
       note: clip(g.summary || g.label, 160),
     })),
     contradictions: snapshot.contradictions.slice(0, POOL_LIMITS.contradictions).map((c) => ({
-      token: `[contradicción](nodus://contradiction/${encodeURIComponent(c.id)})`,
+      token: `[${c.sources?.[0] || 'contradicción'}](nodus://contradiction/${encodeURIComponent(c.id)})`,
       note: `Posturas enfrentadas: ${c.label}. ${clip(c.summary, 200)}${c.sources?.length ? ` Lo sostienen ${c.sources.join('; ')}.` : ''}`.trim(),
     })),
     // Only passages whose text is actually present; a page number the writer cannot
@@ -1814,15 +1819,21 @@ export function buildCitationCatalog(snapshot: WritingWorkshopSnapshot): Citatio
   };
 }
 
-function sourceLabelFromWork(work: { authors: string[]; year: number | null } | undefined): string {
+function sourceLabelFromWork(work: { authors: string[]; year: number | null; title?: string } | undefined): string {
   if (!work) return '';
-  return authorYearLabel(work.authors[0], work.year);
+  return authorYearLabel(work.authors[0], work.year, work.title);
 }
 
 /** Turn Nodus's stored `Apellido, I.` name into a readable inline citation. */
-function authorYearLabel(author: string | undefined, year: number | null | undefined): string {
+function authorYearLabel(author: string | undefined, year: number | null | undefined, title?: string): string {
   const raw = author?.replace(/\s+/g, ' ').trim();
-  if (!raw) return year ? `Autor (${year})` : 'Autor';
+  if (!raw) {
+    // "Autor" reads as a placeholder in the middle of academic prose. A shortened
+    // title is a real citation for a source whose author the corpus never captured.
+    const short = clip((title ?? '').replace(/\s+/g, ' ').trim(), 42);
+    if (short) return year ? `${short} (${year})` : short;
+    return year ? `Obra sin autor (${year})` : 'Obra sin autor';
+  }
   const comma = raw.indexOf(',');
   const surname = (comma >= 0 ? raw.slice(0, comma) : raw.split(' ').slice(-1).join(' ')).trim() || raw;
   const given = (comma >= 0 ? raw.slice(comma + 1) : raw.split(' ').slice(0, -1).join(' ')).trim();

--- a/electron/ai/deepResearchCore.ts
+++ b/electron/ai/deepResearchCore.ts
@@ -28,10 +28,19 @@ export const WORDS_PER_PAGE = 450;
 const MIN_TARGET_PAGES = 5;
 const MAX_TARGET_PAGES = 20;
 /**
- * A section aims for roughly this many words. Deliberately high so a report is a few
- * long, well-developed sections rather than many thin ones — depth over fragmentation.
+ * How many words a section actually holds, used to decide how many sections a page
+ * target needs.
+ *
+ * This was 1400, chosen as an aspiration: few long sections, depth over
+ * fragmentation. Measured against real reports the aspiration never happened — a
+ * section asked for 1575 words came back with ~1040, and it stayed at ~1040 even
+ * after the expansion pass rewrote it (10 of 12 sections were expanded and 11 of 12
+ * still finished under target). Every report therefore landed at the floor of its
+ * page range. Sizing the plan to what a section really delivers is what puts a
+ * report in the middle of its range instead: the sections are the same length as
+ * before, there are simply enough of them to reach the target.
  */
-const SECTION_TARGET_WORDS = 1400;
+const SECTION_TARGET_WORDS = 1100;
 /** Never fewer than this many sections (intro · body · synthesis at the very least). */
 export const MIN_SECTIONS = 3;
 /** Absolute safety ceiling on total sections (planned + coverage top-ups) — stops runaway loops. */
@@ -47,6 +56,20 @@ const SECTION_WORDS_RANGE = { min: 800, max: 1800 } as const;
 /** Trim the material pool handed to the planner so the prompt stays within limits. */
 export const POOL_LIMITS = { ideas: 70, themes: 20, gaps: 20, contradictions: 16, works: 40, passages: 20 } as const;
 const MAX_MATRIX_ROWS = 80;
+/**
+ * A section can only develop so much material in one pass. Beyond this the citation
+ * menu turns into a catalogue the writer skims instead of an argument it builds, so
+ * surplus ideas are left for the coverage top-up rather than dumped into a section.
+ */
+const MAX_SECTION_IDEAS = 18;
+/** How much of an idea's statement reaches the writer. */
+const IDEA_NOTE_CHARS = 240;
+/** How much of a literal passage reaches the writer. Never truncate below usefulness. */
+const PASSAGE_NOTE_CHARS = 480;
+/** Extra material a per-section retrieval may add on top of what the planner assigned. */
+const SECTION_RETRIEVAL_LIMITS = { ideas: 6, passages: 4 } as const;
+/** Below this share of its word target a section gets one expansion pass. */
+const MIN_SECTION_FILL = 0.78;
 
 /** Shared prose contract for every Deep Research writer, including genealogy and
  * MCP-client mode. These are writing constraints, not a locale-specific UI copy. */
@@ -69,6 +92,12 @@ export interface DeepResearchPlanSection {
   gapIds: string[];
   contradictionIds: string[];
   passageIds: string[];
+  /** Where the section sits in the report's architecture. */
+  role?: 'intro' | 'body' | 'synthesis';
+  /** Ids of the sections whose ground this one presupposes. The planner states the
+   * dependencies; {@link orderSections} turns them into the reading order, so a
+   * coherent sequence is a property of the engine rather than luck of the draw. */
+  dependsOn?: string[];
 }
 
 export interface DeepResearchPlan {
@@ -95,10 +124,18 @@ export interface PlanInput {
   works: { id: string; label: string; summary: string }[];
 }
 
-/** One citable token the model must copy verbatim, plus the claim it supports. */
+/**
+ * One citable token the model must copy verbatim, plus the material it stands for.
+ * `note` always carries the real content (the idea's statement, what the gap says,
+ * what the contradiction opposes, the literal words of the passage) — never a
+ * placeholder. A writer that cannot read what it is citing can only invent.
+ */
 export interface CitationMenuItem {
   token: string;
   note: string;
+  kind: 'idea' | 'work' | 'gap' | 'contradiction' | 'passage';
+  /** Author/year the token resolves to, so the writer can attribute in prose. */
+  source?: string;
 }
 
 export interface SectionInput {
@@ -110,6 +147,42 @@ export interface SectionInput {
   isConclusion: boolean;
   citationMenu: CitationMenuItem[];
   priorSummary: string;
+  /** Claims already developed earlier, verbatim, so the writer can build on them
+   * instead of restating them. Derived from what was really cited, not from the plan. */
+  alreadyDeveloped: string[];
+}
+
+/**
+ * One claim as it stands in the finished prose, paired with the material cited to
+ * support it. This is the unit the verification pass judges: not "does this id
+ * exist" (the citation policy already guarantees that) but "does what this source
+ * says actually support what this sentence asserts".
+ */
+export interface CitationClaim {
+  /** Position in the section markdown, used to apply the verdict back. */
+  offset: number;
+  /** The full citation link as it appears, so it can be removed verbatim. */
+  link: string;
+  kind: 'idea' | 'passage' | 'gap' | 'contradiction';
+  id: string;
+  /** The sentence the citation sits in, with citation markup removed. */
+  sentence: string;
+  /** What the cited source actually says. */
+  content: string;
+}
+
+export type CitationVerdict = 'supports' | 'partial' | 'unsupported';
+
+/** What a per-section retrieval asks the corpus for. */
+export interface SectionRetrievalInput {
+  objective: string;
+  sectionTitle: string;
+  purpose: string;
+  keyClaims: string[];
+  /** Already on the section's desk; the retriever should return something else. */
+  excludeIdeaIds: string[];
+  excludePassageIds: string[];
+  limits: { ideas: number; passages: number };
 }
 
 export interface FinalizeInput {
@@ -138,6 +211,47 @@ export interface DeepResearchDeps {
   planReport(input: PlanInput): Promise<DeepResearchPlan>;
   writeSection(input: SectionInput): Promise<string>;
   finalize(input: FinalizeInput): Promise<FinalizeResult>;
+  /**
+   * Optional second retrieval pass, run once per section with that section's own
+   * focus as the query. The initial snapshot is ranked against the whole objective,
+   * so a section about a narrow sub-question would otherwise never get to ask the
+   * corpus about it — least of all for literal passages, which the snapshot caps
+   * hard. Omitted (undefined) keeps the single-shot behaviour.
+   */
+  retrieveForSection?(input: SectionRetrievalInput): Promise<{
+    ideas?: WritingWorkshopIdeaCandidate[];
+    passages?: WritingWorkshopSnapshot['passages'];
+  }>;
+  /**
+   * Optional single expansion of a section that came back far shorter than asked.
+   * Writers systematically under-deliver against a word target (measured at ~60% of
+   * it), and the engine used to accept whatever arrived, so reports landed at the
+   * floor of their page range. Omitted keeps the single-pass behaviour.
+   */
+  expandSection?(input: SectionInput & { draft: string; missingWords: number }): Promise<string>;
+  /**
+   * Optional entailment check over the finished prose. The citation policy proves a
+   * source exists and is really in the corpus; only this proves the source supports
+   * the sentence it was attached to. Must return one verdict per claim, in order.
+   * Omitted skips verification entirely.
+   */
+  verifyCitations?(claims: CitationClaim[]): Promise<CitationVerdict[]>;
+  /**
+   * Optional read-only check for sections that contradict each other. Deliberately
+   * cannot rewrite: a pass that edits assembled prose puts every verified citation
+   * at risk, so this only reports. Each finding must quote both sides verbatim so
+   * the orchestrator can confirm the sentences really exist before believing it.
+   */
+  checkCoherence?(sections: { title: string; text: string }[]): Promise<CoherenceIssue[]>;
+}
+
+/** Two passages of the same report that cannot both be right. */
+export interface CoherenceIssue {
+  sectionA: string;
+  quoteA: string;
+  sectionB: string;
+  quoteB: string;
+  issue: string;
 }
 
 interface WorkInfo {
@@ -146,6 +260,9 @@ interface WorkInfo {
   authors: string[];
   year: number | null;
   zotero_key: string;
+  /** The only locator the local schema stores. Publisher and journal live in Zotero,
+   * so a reference entry can be author-year-title-DOI and no more than that. */
+  doi?: string | null;
 }
 
 export interface SnapshotMaps {
@@ -153,8 +270,12 @@ export interface SnapshotMaps {
   workInfoById: Map<string, WorkInfo>;
   passageWorkId: Map<string, string>;
   passagePage: Map<string, string | null>;
-  gapIds: Set<string>;
-  contradictionIds: Set<string>;
+  /** Literal passage text. A passage with no text here is never offered as citable. */
+  passageText: Map<string, string>;
+  /** What each gap actually says, so the writer can argue it instead of naming it. */
+  gapById: Map<string, { label: string; summary: string }>;
+  /** What each contradiction actually opposes, and who holds each side. */
+  contradictionById: Map<string, { label: string; summary: string; sources: string[] }>;
   validIds: Set<string>;
 }
 
@@ -168,6 +289,7 @@ export async function orchestrateDeepResearch(
   onProgress?: (p: DeepResearchProgress) => void
 ): Promise<DeepResearchReport> {
   const language = request.language ?? 'es';
+  const L = labels(language);
   const emit = (p: DeepResearchProgress) => {
     try {
       onProgress?.(p);
@@ -176,7 +298,7 @@ export async function orchestrateDeepResearch(
     }
   };
 
-  emit({ phase: 'snapshot', message: 'Reuniendo materiales del corpus…' });
+  emit({ phase: 'snapshot', message: L.gathering });
   const brief: WritingWorkshopBrief = {
     kind: 'deep_research',
     objective: request.objective,
@@ -192,7 +314,7 @@ export async function orchestrateDeepResearch(
   const sectionCount = sectionPlan.target;
   const sectionHardCap = sectionPlan.hardCap;
 
-  emit({ phase: 'planning', message: `Planificando ~${sectionCount} secciones de fondo (${targetPages.min}–${targetPages.max} páginas)…` });
+  emit({ phase: 'planning', message: L.planning(sectionCount, targetPages) });
   const plan = await planWithFallback(deps, request, language, snapshot, sectionPlan, targetPages);
 
   // Budget is measured over the BODY sections only. The abstract, limitations and
@@ -202,7 +324,10 @@ export async function orchestrateDeepResearch(
   const minWords = targetPages.min * WORDS_PER_PAGE;
 
   const written: { section: DeepResearchPlanSection; markdown: string }[] = [];
+  /** Ideas the prose really cites. */
   const coveredIdeaIds = new Set<string>();
+  /** Ideas a section was told to develop, cited or not — used to report honestly. */
+  const assignedIdeaIds = new Set<string>();
   const citedIds = {
     ideas: new Set<string>(),
     works: new Set<string>(),
@@ -212,6 +337,9 @@ export async function orchestrateDeepResearch(
   };
   let totalWords = 0;
   let stoppedReason: string | null = null;
+  const verification = { checked: 0, partial: 0, unsupported: 0 };
+  let expansions = 0;
+  const sectionFill: { words: number; target: number }[] = [];
 
   const runSection = async (
     section: DeepResearchPlanSection,
@@ -227,28 +355,95 @@ export async function orchestrateDeepResearch(
     );
     emit({
       phase: 'section',
-      message: `Redactando: ${section.title}`,
+      message: `${L.writing}: ${section.title}`,
       sectionIndex: written.length + 1,
       sectionTitle: section.title,
       wordsSoFar: totalWords,
       pagesSoFar: pagesFromWords(totalWords),
     });
 
-    let raw = '';
-    try {
-      raw = await deps.writeSection(sectionInput(request, language, section, targetWords, isConclusion, maps, written));
-    } catch {
-      // One retry, then a graceful degraded section — never fail the whole report.
+    // Ask the corpus again, this time about THIS section. Anything it returns is
+    // folded into the maps first, so it is genuinely citable rather than stripped.
+    if (deps.retrieveForSection) {
       try {
-        raw = await deps.writeSection(sectionInput(request, language, section, targetWords, isConclusion, maps, written));
+        const material = await deps.retrieveForSection({
+          objective: request.objective,
+          sectionTitle: section.title,
+          purpose: section.purpose,
+          keyClaims: section.keyClaims,
+          excludeIdeaIds: section.ideaIds,
+          excludePassageIds: section.passageIds,
+          limits: SECTION_RETRIEVAL_LIMITS,
+        });
+        const merged = mergeRetrievedMaterial(maps, material ?? {});
+        const roomForIdeas = Math.max(0, MAX_SECTION_IDEAS - section.ideaIds.length);
+        section.ideaIds = [...new Set([...section.ideaIds, ...merged.ideaIds.slice(0, roomForIdeas)])];
+        section.passageIds = [...new Set([...section.passageIds, ...merged.passageIds])];
       } catch {
-        raw = degradedSection(section, maps);
-        if (!stoppedReason)
-          stoppedReason = 'Una o más secciones no pudieron generarse con el modelo y se resolvieron de forma degradada.';
+        /* retrieval is an enrichment; the section still writes from the plan */
       }
     }
 
-    const { markdown, cited } = applyCitationPolicy(normalizeNarrativeSection(raw, section.title), maps);
+    let raw = '';
+    try {
+      raw = await deps.writeSection(sectionInput(request, language, section, targetWords, isConclusion, maps, written, coveredIdeaIds));
+    } catch {
+      // One retry, then a graceful degraded section — never fail the whole report.
+      try {
+        raw = await deps.writeSection(sectionInput(request, language, section, targetWords, isConclusion, maps, written, coveredIdeaIds));
+      } catch {
+        raw = degradedSection(section, maps, L);
+        if (!stoppedReason) stoppedReason = L.degraded;
+      }
+    }
+
+    // A section that came back well under its target gets exactly one chance to
+    // develop further. Bounded to a single call so a terse model cannot loop.
+    if (deps.expandSection && raw.trim()) {
+      const draftWords = countWords(raw);
+      if (draftWords < targetWords * MIN_SECTION_FILL) {
+        try {
+          const expanded = await deps.expandSection({
+            ...sectionInput(request, language, section, targetWords, isConclusion, maps, written, coveredIdeaIds),
+            draft: raw,
+            missingWords: Math.max(0, targetWords - draftWords),
+          });
+          // Only accept an expansion that genuinely grew the argument.
+          if (countWords(expanded) > draftWords * 1.1) {
+            raw = expanded;
+            expansions += 1;
+          }
+        } catch {
+          /* the original section stands */
+        }
+      }
+    }
+
+    let { markdown, cited } = applyCitationPolicy(normalizeNarrativeSection(raw, section.title), maps);
+
+    // Entailment pass. Everything downstream — the cited sets, the references, the
+    // matrix — is derived from the VERIFIED text, so a citation the source does not
+    // support cannot survive anywhere in the report, not even in the bibliography.
+    if (deps.verifyCitations) {
+      const claims = extractCitationClaims(markdown, maps);
+      if (claims.length > 0) {
+        try {
+          const verdicts = await deps.verifyCitations(claims);
+          if (Array.isArray(verdicts) && verdicts.length === claims.length) {
+            const outcome = applyVerification(markdown, claims, verdicts);
+            verification.checked += outcome.checked;
+            verification.partial += outcome.partial;
+            verification.unsupported += outcome.unsupported;
+            if (outcome.unsupported > 0) {
+              markdown = outcome.markdown;
+              ({ cited } = applyCitationPolicy(markdown, maps));
+            }
+          }
+        } catch {
+          /* an unavailable judge must not cost the report its section */
+        }
+      }
+    }
     if (mergeIntoIndex != null && written[mergeIntoIndex]) {
       const existing = written[mergeIntoIndex];
       existing.markdown = `${existing.markdown.trim()}\n\n${stripInitialHeading(markdown)}`.trim();
@@ -256,13 +451,14 @@ export async function orchestrateDeepResearch(
     } else {
       written.push({ section, markdown });
     }
+    // Coverage is what the prose actually cites. Counting a section's *mandate* as
+    // covered made the statistic unfalsifiable (every idea is assigned to some
+    // section, so it always read 100%) and silently disabled the top-up below.
     for (const id of cited.ideas) {
       citedIds.ideas.add(id);
       coveredIdeaIds.add(id);
     }
-    // Assigned ideas that resolve to real corpus ideas count as covered even if the
-    // model leaned on a neighbour: they were the section's mandate.
-    for (const id of section.ideaIds) if (maps.ideaById.has(id)) coveredIdeaIds.add(id);
+    for (const id of section.ideaIds) if (maps.ideaById.has(id)) assignedIdeaIds.add(id);
     cited.works.forEach((id) => citedIds.works.add(id));
     cited.gaps.forEach((id) => citedIds.gaps.add(id));
     cited.contradictions.forEach((id) => citedIds.contradictions.add(id));
@@ -271,17 +467,18 @@ export async function orchestrateDeepResearch(
       const workId = maps.passageWorkId.get(id);
       if (workId) citedIds.works.add(workId);
     });
+    sectionFill.push({ words: countWords(markdown), target: targetWords });
     totalWords += countWords(markdown);
   };
 
   // Planned sections.
   for (let i = 0; i < plan.sections.length; i++) {
     if (written.length >= sectionHardCap) {
-      stoppedReason = `Se alcanzó el máximo de ${sectionHardCap} secciones.`;
+      stoppedReason = L.stoppedSections(sectionHardCap);
       break;
     }
     if (totalWords >= maxWords) {
-      stoppedReason = `Se alcanzó el presupuesto máximo de ~${targetPages.max} páginas.`;
+      stoppedReason = L.stoppedPages(targetPages.max);
       break;
     }
     const isConclusion = i === plan.sections.length - 1;
@@ -292,46 +489,66 @@ export async function orchestrateDeepResearch(
   // and relevant ideas remain uncovered — but never past the hard caps.
   let topups = 0;
   while (totalWords < minWords && written.length < sectionHardCap && topups < MAX_TOPUP_SECTIONS && !stoppedReason) {
-    const uncovered = snapshot.ideas.filter((idea) => !coveredIdeaIds.has(idea.id)).slice(0, 6);
+    const uncovered = pendingIdeas(snapshot, coveredIdeaIds, assignedIdeaIds).slice(0, 6);
     if (uncovered.length === 0) break;
     topups += 1;
     emit({
       phase: 'coverage',
-      message: `Ampliando cobertura (${uncovered.length} ideas pendientes)…`,
+      message: L.coverage(uncovered.length),
       wordsSoFar: totalWords,
       pagesSoFar: pagesFromWords(totalWords),
     });
     // Expand the last body section instead of creating a new "development
     // complement" epigraph. Coverage grows the argument, not the outline.
     const mergeIntoIndex = Math.max(0, written.length - (written.length > 1 ? 2 : 1));
-    await runSection(coverageSection(topups, uncovered), false, mergeIntoIndex);
+    const before = totalWords;
+    await runSection(coverageSection(topups, uncovered, L), false, mergeIntoIndex);
+    // A top-up that adds nothing would spin the loop against the same ideas.
+    if (totalWords <= before) break;
   }
 
   emit({
     phase: 'assembling',
-    message: 'Ensamblando informe y referencias…',
+    message: L.assembling,
     wordsSoFar: totalWords,
     pagesSoFar: pagesFromWords(totalWords),
   });
 
-  const uncoveredSamples = snapshot.ideas
-    .filter((idea) => !coveredIdeaIds.has(idea.id))
-    .slice(0, 5)
-    .map((idea) => idea.label);
+  // Does the report contradict itself? Reported, never repaired: rewriting assembled
+  // prose would put every verified citation at risk, and a researcher is better
+  // served by being told where the tension is than by having it quietly smoothed.
+  let coherenceIssues: CoherenceIssue[] = [];
+  if (deps.checkCoherence && written.length > 1) {
+    try {
+      const sections = written.map((w) => ({ title: w.section.title, text: stripInitialHeading(w.markdown) }));
+      coherenceIssues = groundCoherenceIssues(await deps.checkCoherence(sections), sections);
+    } catch {
+      /* a missing coherence check never costs the report */
+    }
+  }
 
-  const finalize = await finalizeWithFallback(deps, {
-    objective: request.objective,
-    language,
-    planTitle: plan.title,
-    sectionTitles: written.map((w) => w.section.title),
-    ideasCovered: coveredIdeaIds.size,
-    ideasConsidered: snapshot.ideas.length,
-    uncoveredSamples,
-  });
+  // Now that coverage means "cited", these samples are real: they name material the
+  // report was handed and did not use, which is exactly what a limitation should say.
+  const pending = pendingIdeas(snapshot, coveredIdeaIds, assignedIdeaIds);
+  const uncoveredSamples = pending.slice(0, 5).map((idea) => idea.label);
+
+  const finalize = await finalizeWithFallback(
+    deps,
+    {
+      objective: request.objective,
+      language,
+      planTitle: plan.title,
+      sectionTitles: written.map((w) => w.section.title),
+      ideasCovered: coveredIdeaIds.size,
+      ideasConsidered: snapshot.ideas.length,
+      uncoveredSamples,
+    },
+    L
+  );
 
   // Works actually referenced = works cited directly + the works behind every cited idea.
   const citedWorkIds = collectCitedWorkIds(citedIds, maps);
-  const references = buildReferences(citedWorkIds, maps);
+  const references = buildReferences(citedWorkIds, maps, language);
   const draftMarkdown = assembleMarkdown(written, references, finalize, language);
   const worksCited = citedWorkIds.size;
 
@@ -343,7 +560,7 @@ export async function orchestrateDeepResearch(
     sources: sectionSources(w.section, maps),
   }));
 
-  const matrix = buildMatrix(coveredIdeaIds, maps);
+  const matrix = buildMatrix(coveredIdeaIds, maps, L);
 
   const draft: WritingWorkshopDraft = {
     generatedAt: new Date().toISOString(),
@@ -364,7 +581,7 @@ export async function orchestrateDeepResearch(
     matrix,
     bibliography: references,
     nextSteps: finalize.nextSteps,
-    limitations: finalize.limitations,
+    limitations: [...finalize.limitations, ...coherenceIssues.map((issue) => L.coherenceLimitation(issue))],
     stats: {
       selectedIdeas: coveredIdeaIds.size,
       selectedThemes: 0,
@@ -387,11 +604,15 @@ export async function orchestrateDeepResearch(
     worksCited,
     targetPages,
     stoppedReason,
+    verification: verification.checked > 0 ? { ...verification } : null,
+    expansions,
+    sectionFill,
+    coherenceIssues: coherenceIssues.length,
   };
 
   emit({
     phase: 'done',
-    message: `Informe listo: ${written.length} secciones · ~${meta.pages} páginas`,
+    message: L.done(written.length, meta.pages),
     wordsSoFar: totalWords,
     pagesSoFar: meta.pages,
   });
@@ -406,7 +627,8 @@ function sectionInput(
   targetWords: number,
   isConclusion: boolean,
   maps: SnapshotMaps,
-  written: { section: DeepResearchPlanSection; markdown: string }[]
+  written: { section: DeepResearchPlanSection; markdown: string }[],
+  covered: Set<string>
 ): SectionInput {
   return {
     objective: request.objective,
@@ -417,7 +639,52 @@ function sectionInput(
     isConclusion,
     citationMenu: buildCitationMenu(section, maps),
     priorSummary: summarizePrior(written),
+    alreadyDeveloped: [...covered]
+      .map((id) => maps.ideaById.get(id))
+      .filter((idea): idea is WritingWorkshopIdeaCandidate => !!idea)
+      .slice(0, 24)
+      .map((idea) => clip(idea.statement || idea.label, 140)),
   };
+}
+
+/** Spanish and English function words that start a subtitle and read better lowercased. */
+const SUBTITLE_LEAD_WORDS = new Set(
+  ('del de la el los las un una unos unas hacia entre desde sobre para por con sin tras ante entre cuando donde como '
+    + 'cómo qué quién cuál hasta the a an of from to towards between within during through under over and or').split(' ')
+);
+
+/**
+ * Fold a `Título: subtítulo` heading into one continuous phrase.
+ *
+ * The prose contract asks the planner to avoid split titles and it complies most of
+ * the time, but not always — measured at 3 of 15 headings, and the rate grew as the
+ * report gained sections. Asking a fourth time was not going to work, so the shape
+ * is enforced here instead of requested. The subtitle is kept, not truncated: the
+ * information in it is usually the half that says what the section actually argues.
+ */
+export function normalizeSectionTitle(title: string): string {
+  const clean = (title ?? '').replace(/\s+/g, ' ').trim();
+  const at = clean.search(/\s*[:;—]\s+/u);
+  if (at < 0) return clean;
+  const head = clean.slice(0, at).trim().replace(/[.,;:—]+$/u, '');
+  const tail = clean.slice(at).replace(/^\s*[:;—]\s+/u, '').trim();
+  if (!head) return tail;
+  if (!tail) return head;
+  const [firstWord, ...rest] = tail.split(' ');
+  const lowered = SUBTITLE_LEAD_WORDS.has(firstWord.toLocaleLowerCase('es-ES'))
+    ? [firstWord.toLocaleLowerCase('es-ES'), ...rest].join(' ')
+    : tail;
+  return `${head}, ${lowered}`;
+}
+
+/** Ideas the report has not cited, unfinished section mandates first. */
+function pendingIdeas(
+  snapshot: WritingWorkshopSnapshot,
+  covered: Set<string>,
+  assigned: Set<string>
+): WritingWorkshopIdeaCandidate[] {
+  const rest = snapshot.ideas.filter((idea) => !covered.has(idea.id));
+  return [...rest.filter((idea) => assigned.has(idea.id)), ...rest.filter((idea) => !assigned.has(idea.id))];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -501,7 +768,7 @@ async function planWithFallback(
   } catch {
     plan = null;
   }
-  if (!plan || plan.sections.length === 0) return fallbackPlan(request, snapshot, sectionPlan.target);
+  if (!plan || plan.sections.length === 0) return fallbackPlan(request, snapshot, sectionPlan.target, labels(language));
   return plan;
 }
 
@@ -518,7 +785,7 @@ export function normalizePlan(
 
   const sections = (plan.sections ?? []).slice(0, maxSections).map((s, index) => ({
     id: cleanStr(s.id, `s${index + 1}`),
-    title: cleanStr(s.title, `Sección ${index + 1}`),
+    title: normalizeSectionTitle(cleanStr(s.title, `Sección ${index + 1}`)),
     purpose: cleanStr(s.purpose, ''),
     keyClaims: strList(s.keyClaims).slice(0, 8),
     ideaIds: strList(s.ideaIds).filter((id) => ideaIds.has(id)),
@@ -526,28 +793,111 @@ export function normalizePlan(
     gapIds: strList(s.gapIds).filter((id) => gapIds.has(id)),
     contradictionIds: strList(s.contradictionIds).filter((id) => contradictionIds.has(id)),
     passageIds: strList(s.passageIds).filter((id) => passageIds.has(id)),
+    role: s.role === 'intro' || s.role === 'synthesis' ? s.role : 'body',
+    dependsOn: strList(s.dependsOn),
   }));
 
   return {
     title: cleanStr(plan.title, ''),
     abstract: cleanStr(plan.abstract, ''),
-    sections: ensureIdeaAssignment(sections, snapshot),
+    sections: ensureIdeaAssignment(orderSections(sections), snapshot),
   };
 }
 
-/** Guarantee every section has some material; spread otherwise-unassigned ideas so nothing is dropped. */
+/**
+ * Put the sections in reading order: the framing first, the closing synthesis last,
+ * and each body section after whatever it presupposes.
+ *
+ * Without this the report's sequence was whatever order the planner happened to emit
+ * — two runs of the same objective produced a genealogy and a flat thematic list. A
+ * stable topological sort makes the good ordering reproducible. Cycles and dangling
+ * references are ignored rather than fatal: a half-stated dependency should degrade
+ * to the planner's own order, never drop a section.
+ */
+export function orderSections(sections: DeepResearchPlanSection[]): DeepResearchPlanSection[] {
+  if (sections.length <= 1) return sections;
+  const rank = (s: DeepResearchPlanSection) => (s.role === 'intro' ? 0 : s.role === 'synthesis' ? 2 : 1);
+  const byId = new Map(sections.map((s) => [s.id, s]));
+  const position = new Map(sections.map((s, i) => [s.id, i]));
+  const emitted = new Set<string>();
+  const out: DeepResearchPlanSection[] = [];
+
+  // Stable order: architectural role first, then the planner's own sequence.
+  const queue = [...sections].sort((a, b) => rank(a) - rank(b) || position.get(a.id)! - position.get(b.id)!);
+
+  const visit = (section: DeepResearchPlanSection, guard: Set<string>): void => {
+    if (emitted.has(section.id) || guard.has(section.id)) return;
+    guard.add(section.id);
+    for (const dependency of section.dependsOn ?? []) {
+      const target = byId.get(dependency);
+      // A body section never waits on the closing synthesis, or nothing could open.
+      if (target && target.id !== section.id && rank(target) <= rank(section)) visit(target, guard);
+    }
+    guard.delete(section.id);
+    if (!emitted.has(section.id)) {
+      emitted.add(section.id);
+      out.push(section);
+    }
+  };
+
+  for (const section of queue) visit(section, new Set());
+  return out;
+}
+
+/**
+ * Give every section a mandate without wrecking its coherence.
+ *
+ * The planner only ever sees the top slice of the idea pool (POOL_LIMITS.ideas),
+ * so the rest arrives here unassigned. Round-robining those by index dropped
+ * thematically unrelated ideas into each section and then asked the writer for a
+ * continuous argument. Instead each leftover goes to the section it actually fits,
+ * and a section only takes as much as it can develop — the surplus is left for the
+ * coverage top-up and, failing that, reported as a limitation.
+ */
 function ensureIdeaAssignment(sections: DeepResearchPlanSection[], snapshot: WritingWorkshopSnapshot): DeepResearchPlanSection[] {
   if (sections.length === 0) return sections;
   const assigned = new Set<string>();
   for (const s of sections) for (const id of s.ideaIds) assigned.add(id);
-  const leftover = snapshot.ideas.filter((i) => !assigned.has(i.id)).map((i) => i.id);
-  let cursor = 0;
-  // Round-robin the leftovers into the body sections (skip a lone final conclusion).
+
+  // Body sections only: a lone closing section synthesises, it does not absorb.
   const bodyCount = Math.max(1, sections.length - 1);
-  for (const id of leftover) {
-    sections[cursor % bodyCount].ideaIds.push(id);
-    cursor += 1;
+  const body = sections.slice(0, bodyCount);
+  const profiles = body.map((s) => sectionProfile(s, snapshot));
+
+  const byId = new Map(snapshot.ideas.map((i) => [i.id, i]));
+  // How many ideas each section already draws from each work, so a section is not
+  // handed a pile of material that all traces back to the same book.
+  const workLoad = body.map((section) => {
+    const load = new Map<string, number>();
+    for (const id of section.ideaIds) {
+      for (const w of byId.get(id)?.works ?? []) load.set(w.nodus_id, (load.get(w.nodus_id) ?? 0) + 1);
+    }
+    return load;
+  });
+
+  for (const idea of snapshot.ideas) {
+    if (assigned.has(idea.id)) continue;
+    const text = ideaText(idea);
+    let bestAt = -1;
+    let bestScore = -Infinity;
+    for (let i = 0; i < body.length; i++) {
+      if (body[i].ideaIds.length >= MAX_SECTION_IDEAS) continue;
+      // Affinity first, minus a penalty for piling more of the same work onto a
+      // section; the emptier section breaks remaining ties so nothing starves.
+      const repeats = Math.max(0, ...(idea.works ?? []).map((w) => workLoad[i].get(w.nodus_id) ?? 0));
+      const score = relevanceScore(profiles[i], text) - repeats * 0.03 - body[i].ideaIds.length * 1e-4;
+      if (score > bestScore) {
+        bestScore = score;
+        bestAt = i;
+      }
+    }
+    // Every body section is full: the remaining ideas stay pending on purpose.
+    if (bestAt < 0) break;
+    body[bestAt].ideaIds.push(idea.id);
+    for (const w of idea.works ?? []) workLoad[bestAt].set(w.nodus_id, (workLoad[bestAt].get(w.nodus_id) ?? 0) + 1);
+    assigned.add(idea.id);
   }
+
   // Any section that is still empty borrows the top ideas so it has a mandate.
   for (const s of sections) {
     if (s.ideaIds.length === 0 && snapshot.ideas.length > 0) {
@@ -557,15 +907,66 @@ function ensureIdeaAssignment(sections: DeepResearchPlanSection[], snapshot: Wri
   return sections;
 }
 
-export function fallbackPlan(request: DeepResearchRequest, snapshot: WritingWorkshopSnapshot, sectionCount: number): DeepResearchPlan {
+/** The words that characterise what a section is about, planner text plus its seed ideas. */
+function sectionProfile(section: DeepResearchPlanSection, snapshot: WritingWorkshopSnapshot): Set<string> {
+  const byId = new Map(snapshot.ideas.map((i) => [i.id, i]));
+  const parts = [section.title, section.purpose, ...section.keyClaims];
+  for (const id of section.ideaIds) {
+    const idea = byId.get(id);
+    if (idea) parts.push(ideaText(idea));
+  }
+  return tokenSet(parts.join(' '));
+}
+
+function ideaText(idea: WritingWorkshopIdeaCandidate): string {
+  return [idea.label, idea.statement, (idea.themes ?? []).join(' ')].join(' ');
+}
+
+/** Share of the candidate's meaningful words that the section already talks about. */
+function relevanceScore(profile: Set<string>, text: string): number {
+  const tokens = tokenSet(text);
+  if (tokens.size === 0 || profile.size === 0) return 0;
+  let hits = 0;
+  for (const token of tokens) if (profile.has(token)) hits += 1;
+  return hits / tokens.size;
+}
+
+/** Accent-insensitive content words. Deliberately dependency-free so the core stays pure. */
+function tokenSet(text: string): Set<string> {
+  const normalized = (text ?? '')
+    .toLocaleLowerCase('es-ES')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, "");
+  const out = new Set<string>();
+  for (const word of normalized.split(/[^\p{L}\p{N}]+/u)) {
+    if (word.length > 3 && !STOPWORDS.has(word)) out.add(word);
+  }
+  return out;
+}
+
+/** Frequent function words in the languages Deep Research writes in. */
+const STOPWORDS = new Set(
+  ('para como este esta estos estas desde entre sobre cuando donde porque pero mas menos muy todo toda todos todas '
+    + 'otro otra otros otras cada tanto tanta cual cuales quien quienes ante bajo cabe contra hacia hasta segun sino '
+    + 'that this these those with from into about which their there where when while have has been were was will '
+    + 'their them they than then such also would could should some more most other than dans pour avec sont leur '
+    + 'sich eine einer eines nicht auch aber oder para como mais quando onde porque').split(/\s+/)
+);
+
+export function fallbackPlan(
+  request: DeepResearchRequest,
+  snapshot: WritingWorkshopSnapshot,
+  sectionCount: number,
+  L: Labels = labels(request.language ?? 'es')
+): DeepResearchPlan {
   const ideas = snapshot.ideas;
   const bodyCount = Math.max(1, sectionCount - 2);
   const perSection = Math.max(1, Math.ceil(ideas.length / bodyCount));
   const sections: DeepResearchPlanSection[] = [];
   sections.push({
     id: 's1',
-    title: 'Introducción y planteamiento',
-    purpose: 'Delimitar el problema y anticipar las líneas del argumento.',
+    title: L.introTitle,
+    purpose: L.introPurpose,
     keyClaims: ideas.slice(0, 3).map((i) => i.label),
     ideaIds: ideas.slice(0, Math.min(3, ideas.length)).map((i) => i.id),
     workIds: [],
@@ -578,8 +979,8 @@ export function fallbackPlan(request: DeepResearchRequest, snapshot: WritingWork
     if (chunk.length === 0) continue;
     sections.push({
       id: `s${sections.length + 1}`,
-      title: `Línea argumental ${b + 1}`,
-      purpose: 'Desarrollar y relacionar un grupo de ideas del corpus.',
+      title: `${L.threadTitle} ${b + 1}`,
+      purpose: L.threadPurpose,
       keyClaims: chunk.slice(0, 4).map((i) => i.label),
       ideaIds: chunk.map((i) => i.id),
       workIds: [],
@@ -590,8 +991,8 @@ export function fallbackPlan(request: DeepResearchRequest, snapshot: WritingWork
   }
   sections.push({
     id: `s${sections.length + 1}`,
-    title: 'Síntesis, huecos y contribución',
-    purpose: 'Integrar las líneas, señalar huecos y perfilar la contribución.',
+    title: L.synthesisTitle,
+    purpose: L.synthesisPurpose,
     keyClaims: snapshot.gaps.slice(0, 3).map((g) => g.label),
     ideaIds: [],
     workIds: [],
@@ -600,30 +1001,35 @@ export function fallbackPlan(request: DeepResearchRequest, snapshot: WritingWork
     passageIds: [],
   });
   return {
-    title: `Informe: ${request.objective}`.slice(0, 140),
+    title: `${L.reportTitlePrefix} ${request.objective}`.slice(0, 140),
     abstract: '',
     sections: ensureIdeaAssignment(sections, snapshot),
   };
 }
 
-async function finalizeWithFallback(deps: DeepResearchDeps, input: FinalizeInput): Promise<FinalizeResult> {
+async function finalizeWithFallback(deps: DeepResearchDeps, input: FinalizeInput, L: Labels): Promise<FinalizeResult> {
+  const uncoveredNote = () =>
+    input.uncoveredSamples.length > 0 ? [L.uncoveredLimitation(input.uncoveredSamples)] : [];
   try {
     const result = await deps.finalize(input);
+    const limitations = strList(result.limitations);
+    // The model is told how much was left out, but it is not the guarantor of that
+    // disclosure. If it omits it, the report states it anyway.
+    const mentionsCoverage = limitations.some((line) =>
+      input.uncoveredSamples.some((sample) => line.toLowerCase().includes(sample.toLowerCase().slice(0, 24)))
+    );
     return {
       title: cleanStr(result.title, input.planTitle || input.objective),
       abstract: cleanStr(result.abstract, ''),
-      limitations: strList(result.limitations),
+      limitations: mentionsCoverage ? limitations : [...limitations, ...uncoveredNote()],
       nextSteps: strList(result.nextSteps),
     };
   } catch {
     return {
       title: input.planTitle || input.objective,
       abstract: '',
-      limitations:
-        input.uncoveredSamples.length > 0
-          ? [`Quedaron ideas del corpus sin desarrollar en profundidad (p. ej.: ${input.uncoveredSamples.join('; ')}).`]
-          : [],
-      nextSteps: ['Revisar cada cita y contrastar el informe con las fuentes originales.'],
+      limitations: uncoveredNote(),
+      nextSteps: [L.reviewStep],
     };
   }
 }
@@ -632,11 +1038,11 @@ async function finalizeWithFallback(deps: DeepResearchDeps, input: FinalizeInput
 // Coverage / degraded fallbacks
 // ─────────────────────────────────────────────────────────────────────────────
 
-function coverageSection(index: number, uncovered: WritingWorkshopIdeaCandidate[]): DeepResearchPlanSection {
+function coverageSection(index: number, uncovered: WritingWorkshopIdeaCandidate[], L: Labels): DeepResearchPlanSection {
   return {
     id: `cov-${index}`,
-    title: `Desarrollo complementario ${index}`,
-    purpose: 'Desarrollar ideas del corpus todavía no tratadas en profundidad.',
+    title: `${L.coverageTitle} ${index}`,
+    purpose: L.coveragePurpose,
     keyClaims: uncovered.slice(0, 4).map((i) => i.label),
     ideaIds: uncovered.map((i) => i.id),
     workIds: [],
@@ -685,7 +1091,7 @@ function sentenceLead(label: string): string {
 }
 
 /** Deterministic, source-anchored prose used when the model fails twice on a section. */
-function degradedSection(section: DeepResearchPlanSection, maps: SnapshotMaps): string {
+function degradedSection(section: DeepResearchPlanSection, maps: SnapshotMaps, L: Labels): string {
   const lines = [`## ${section.title}`, ''];
   if (section.purpose) lines.push(section.purpose, '');
   const bullets = section.ideaIds
@@ -697,7 +1103,7 @@ function degradedSection(section: DeepResearchPlanSection, maps: SnapshotMaps): 
       return `- ${clip(idea.statement || idea.label, 260)} ${token}`;
     });
   if (bullets.length > 0) lines.push(...bullets);
-  else lines.push('_No se pudo desarrollar esta sección con el modelo; revisar los materiales asignados._');
+  else lines.push(`_${L.degradedEmpty}_`);
   return lines.join('\n');
 }
 
@@ -710,18 +1116,21 @@ export function buildSnapshotMaps(snapshot: WritingWorkshopSnapshot): SnapshotMa
   const workInfoById = new Map<string, WorkInfo>();
   const passageWorkId = new Map<string, string>();
   const passagePage = new Map<string, string | null>();
+  const passageText = new Map<string, string>();
+  const gapById = new Map<string, { label: string; summary: string }>();
+  const contradictionById = new Map<string, { label: string; summary: string; sources: string[] }>();
 
   for (const idea of snapshot.ideas) {
     ideaById.set(idea.id, idea);
     for (const w of idea.works) {
       if (!workInfoById.has(w.nodus_id)) {
-        workInfoById.set(w.nodus_id, { nodus_id: w.nodus_id, title: w.title, authors: w.authors, year: w.year, zotero_key: w.zotero_key });
+        workInfoById.set(w.nodus_id, { nodus_id: w.nodus_id, title: w.title, authors: w.authors, year: w.year, zotero_key: w.zotero_key, doi: w.doi ?? null });
       }
     }
   }
   for (const w of snapshot.works) {
     if (!workInfoById.has(w.id)) {
-      workInfoById.set(w.id, { nodus_id: w.id, title: w.title, authors: w.authors, year: w.year, zotero_key: w.zotero_key });
+      workInfoById.set(w.id, { nodus_id: w.id, title: w.title, authors: w.authors, year: w.year, zotero_key: w.zotero_key, doi: w.doi ?? null });
     }
   }
   for (const g of snapshot.gaps) {
@@ -735,9 +1144,14 @@ export function buildSnapshotMaps(snapshot: WritingWorkshopSnapshot): SnapshotMa
       });
     }
   }
+  for (const g of snapshot.gaps) gapById.set(g.id, { label: g.label, summary: g.summary ?? '' });
+  for (const c of snapshot.contradictions)
+    contradictionById.set(c.id, { label: c.label, summary: c.summary ?? '', sources: c.sources ?? [] });
   for (const p of snapshot.passages) {
     passageWorkId.set(p.id, p.nodus_id);
     passagePage.set(p.id, p.pageLabel);
+    // `summary` is the clipped literal text of the passage as stored by the retriever.
+    if (p.summary?.trim()) passageText.set(p.id, p.summary.trim());
     if (!workInfoById.has(p.nodus_id)) {
       workInfoById.set(p.nodus_id, {
         nodus_id: p.nodus_id,
@@ -752,16 +1166,183 @@ export function buildSnapshotMaps(snapshot: WritingWorkshopSnapshot): SnapshotMa
   const validIds = new Set<string>();
   for (const id of ideaById.keys()) validIds.add(`idea:${id}`);
   for (const id of workInfoById.keys()) validIds.add(`work:${id}`);
-  const gapIds = new Set(snapshot.gaps.map((g) => g.id));
-  const contradictionIds = new Set(snapshot.contradictions.map((c) => c.id));
-  for (const id of gapIds) validIds.add(`gap:${id}`);
-  for (const id of contradictionIds) validIds.add(`contradiction:${id}`);
+  for (const id of gapById.keys()) validIds.add(`gap:${id}`);
+  for (const id of contradictionById.keys()) validIds.add(`contradiction:${id}`);
   for (const id of passageWorkId.keys()) validIds.add(`passage:${id}`);
 
-  return { ideaById, workInfoById, passageWorkId, passagePage, gapIds, contradictionIds, validIds };
+  return { ideaById, workInfoById, passageWorkId, passagePage, passageText, gapById, contradictionById, validIds };
+}
+
+/**
+ * Fold material retrieved *during* writing into the maps so it becomes citable.
+ * Without this a per-section retrieval would hand the writer tokens that the
+ * citation policy then strips as hallucinated.
+ */
+export function mergeRetrievedMaterial(
+  maps: SnapshotMaps,
+  material: { ideas?: WritingWorkshopIdeaCandidate[]; passages?: WritingWorkshopSnapshot['passages'] }
+): { ideaIds: string[]; passageIds: string[] } {
+  const ideaIds: string[] = [];
+  const passageIds: string[] = [];
+  for (const idea of material.ideas ?? []) {
+    if (!idea?.id) continue;
+    if (!maps.ideaById.has(idea.id)) {
+      maps.ideaById.set(idea.id, idea);
+      maps.validIds.add(`idea:${idea.id}`);
+    }
+    for (const w of idea.works ?? []) {
+      if (!maps.workInfoById.has(w.nodus_id)) {
+        maps.workInfoById.set(w.nodus_id, {
+          nodus_id: w.nodus_id,
+          title: w.title,
+          authors: w.authors,
+          year: w.year,
+          zotero_key: w.zotero_key,
+          doi: w.doi ?? null,
+        });
+        maps.validIds.add(`work:${w.nodus_id}`);
+      }
+    }
+    ideaIds.push(idea.id);
+  }
+  for (const p of material.passages ?? []) {
+    if (!p?.id || !p.summary?.trim()) continue;
+    if (!maps.passageWorkId.has(p.id)) {
+      maps.passageWorkId.set(p.id, p.nodus_id);
+      maps.passagePage.set(p.id, p.pageLabel);
+      maps.passageText.set(p.id, p.summary.trim());
+      maps.validIds.add(`passage:${p.id}`);
+      if (!maps.workInfoById.has(p.nodus_id)) {
+        maps.workInfoById.set(p.nodus_id, {
+          nodus_id: p.nodus_id,
+          title: p.label.split(' · ')[0] ?? p.label,
+          authors: p.authors,
+          year: p.year,
+          zotero_key: p.zotero_key,
+        });
+        maps.validIds.add(`work:${p.nodus_id}`);
+      }
+    }
+    passageIds.push(p.id);
+  }
+  return { ideaIds, passageIds };
 }
 
 const CITATION_RE = /\[([^\]]*)\]\(nodus:\/\/(idea|work|passage|gap|contradiction)\/([^)]+)\)/g;
+const NODUS_KIND = '(?:idea|work|passage|gap|contradiction)';
+/** `[label (nodus://…)]` — brackets and parentheses swapped round. */
+const WRAPPED_RE = new RegExp(`\\[([^\\]]*?)\\s*\\((nodus://${NODUS_KIND}/[^)\\s]+)\\)\\s*\\]`, 'g');
+/** `[label](nodus://…]` — right link, wrong closing bracket. */
+const WRONG_CLOSER_RE = new RegExp(`\\]\\((nodus://${NODUS_KIND}/[^)\\]\\s]+)\\]`, 'g');
+/** `[nodus://…, nodus://…]` — a bare bracketed list instead of links. */
+const BARE_GROUP_RE = new RegExp(`\\[\\s*(nodus://${NODUS_KIND}/[^\\s,\\]]+(?:\\s*,\\s*nodus://${NODUS_KIND}/[^\\s,\\]]+)*)\\s*\\]`, 'g');
+/** `Autor (2005)](nodus://…)` — the closing half of a link whose `[` never arrived. */
+/** The closing half of a link, used by {@link repairMissingOpeners}. */
+const CLOSING_HALF_RE = new RegExp(`\\]\\(nodus://${NODUS_KIND}/[^)\\s]+\\)`, 'g');
+/** How far back a synthesised citation label may reach. */
+const MAX_SYNTHESISED_LABEL = 90;
+
+/**
+ * Repair `Autor (2005)](nodus://…)` — a link whose opening bracket never arrived,
+ * which happens when a model chains two citations inside one parenthesis.
+ *
+ * This cannot be a regex: commas and semicolons occur *inside* the labels of
+ * perfectly good links, so any prefix pattern loose enough to catch the broken case
+ * also mangles the correct one. Instead each closing half is checked for whether an
+ * unmatched `[` really precedes it on the same line.
+ */
+function repairMissingOpeners(markdown: string): string {
+  let out = '';
+  let cursor = 0;
+  for (const match of markdown.matchAll(CLOSING_HALF_RE)) {
+    const closeAt = match.index ?? 0;
+    const lineStart = markdown.lastIndexOf('\n', closeAt) + 1;
+    const segment = markdown.slice(lineStart, closeAt);
+    // An opener exists when the last `[` on the line comes after the last `]`.
+    if (segment.lastIndexOf('[') > segment.lastIndexOf(']')) continue;
+    // Where the label begins. A `(` only counts when it is still OPEN at this point
+    // — the parenthesis of a year like "Romero, L. (2005)" closes before the link
+    // and belongs inside the label, not before it. A comma is never a boundary for
+    // the same reason: "Romero, L." carries one.
+    const floor = Math.max(lineStart, closeAt - MAX_SYNTHESISED_LABEL);
+    let start = -1;
+    let depth = 0;
+    for (let at = closeAt - 1; at >= floor; at--) {
+      const char = markdown[at];
+      if (char === ')') depth += 1;
+      else if (char === '(') {
+        if (depth === 0) {
+          start = at + 1;
+          break;
+        }
+        depth -= 1;
+      } else if (char === ';') {
+        start = at + 1;
+        break;
+      }
+    }
+    // No delimiter means no way to tell where the label starts. Guessing would pull
+    // real prose into a label that the citation policy then overwrites, deleting the
+    // author's sentence. Leave it: the final sweep drops the bare url and the words
+    // the model wrote stay on the page.
+    if (start < 0) continue;
+    while (start < closeAt && /\s/.test(markdown[start])) start += 1;
+    if (start >= closeAt) continue;
+    out += markdown.slice(cursor, start) + '[';
+    cursor = start;
+  }
+  return out + markdown.slice(cursor);
+}
+
+/**
+ * Delete a closing half whose opener could not be reconstructed. The words the model
+ * wrote stay on the page; only the dangling `](nodus://…)` goes, so the reader never
+ * sees a raw identifier and the accounting never counts a citation nobody can click.
+ */
+function dropOrphanCitations(markdown: string): string {
+  let out = '';
+  let cursor = 0;
+  for (const match of markdown.matchAll(CLOSING_HALF_RE)) {
+    const closeAt = match.index ?? 0;
+    const lineStart = markdown.lastIndexOf('\n', closeAt) + 1;
+    const segment = markdown.slice(lineStart, closeAt);
+    if (segment.lastIndexOf('[') > segment.lastIndexOf(']')) continue;
+    out += markdown.slice(cursor, closeAt);
+    cursor = closeAt + match[0].length;
+  }
+  return out + markdown.slice(cursor);
+}
+/**
+ * A reference with no link syntax around it. The only thing that makes a reference
+ * well-formed is the `](` immediately before it — a bare `(` does not, which is how
+ * `[label (nodus://…)]` slipped through unrepaired and put raw ids on the page.
+ */
+const BARE_REF_RE = new RegExp(`(?<!\\]\\()(nodus://${NODUS_KIND}/[^\\s\\]),;]+)`, 'g');
+/** Belt and braces: any reference still not sitting inside a proper link at the end. */
+const SURVIVING_RAW_RE = new RegExp(`(?<!\\]\\()nodus://\\S*`, 'g');
+/** Any markdown link whose target is a nodus reference, valid or not. */
+const ANY_NODUS_LINK_RE = /\[([^\]\n]*)\]\((nodus:\/\/[^)\s]*)\)/g;
+/** The only shape the app can actually resolve. */
+const VALID_TARGET_RE = new RegExp(`^nodus://${NODUS_KIND}/.+$`);
+
+/**
+ * Models occasionally emit a nodus reference that is not a well-formed Markdown link.
+ * Left alone those leak raw ids into the prose AND slip past the citation accounting,
+ * because the policy below only recognises proper links. Normalising them first means
+ * every reference is either canonicalised or dropped — none survives half-written.
+ * The empty label is deliberate: the policy fills in the canonical one, or, for an
+ * id that does not exist, collapses the whole thing to nothing.
+ */
+export function repairLooseCitations(markdown: string): string {
+  return repairMissingOpeners((markdown ?? '').replace(WRAPPED_RE, '[$1]($2)').replace(WRONG_CLOSER_RE, ']($1)'))
+    .replace(BARE_GROUP_RE, (_full, group: string) =>
+      group
+        .split(',')
+        .map((ref) => `[](${ref.trim()})`)
+        .join(', ')
+    )
+    .replace(BARE_REF_RE, (_full, ref: string) => `[](${ref})`);
+}
 
 /**
  * Enforce the citation contract on one section's markdown:
@@ -784,7 +1365,7 @@ export function applyCitationPolicy(
     contradictions: new Set<string>(),
     passages: new Set<string>(),
   };
-  const out = markdown.replace(CITATION_RE, (_full, label: string, type: string, rawId: string) => {
+  const out = repairLooseCitations(markdown).replace(CITATION_RE, (_full, label: string, type: string, rawId: string) => {
     let id = rawId;
     try {
       id = decodeURIComponent(rawId);
@@ -815,17 +1396,194 @@ export function applyCitationPolicy(
         const withPage = page ? `${base}, ${page}` : base;
         return `[${withPage}](nodus://passage/${encodeURIComponent(id)})`;
       }
+      // Gap and contradiction labels are whole sentences in a real corpus, so they
+      // make a terrible anchor: the reader gets a paragraph-long parenthesis. The
+      // content belongs in the writer's menu (where it now is) and behind the link,
+      // not in the visible citation.
       case 'gap':
         cited.gaps.add(id);
-        return `[${label || 'hueco'}](nodus://gap/${encodeURIComponent(id)})`;
+        return `[hueco](nodus://gap/${encodeURIComponent(id)})`;
       case 'contradiction':
         cited.contradictions.add(id);
-        return `[${label || 'contradicción'}](nodus://contradiction/${encodeURIComponent(id)})`;
+        return `[contradicción](nodus://contradiction/${encodeURIComponent(id)})`;
       default:
         return label || '';
     }
   });
-  return { markdown: out, cited };
+  // Whatever shape a model invents next, a raw `nodus://` must never reach the page.
+  // Repairs above try to keep the citation; anything still loose here is dropped.
+  const swept = dropOrphanCitations(out)
+    // A link whose target Nodus cannot resolve is a link to nowhere. Models invent
+    // these — `nodus://contradicción/…` with the Spanish word as the type, or a bare
+    // `nodus://<uuid>` with no type at all — and because they never matched the
+    // citation pattern they slipped past validation and printed as dead links.
+    // The visible author-year survives as plain text; only the link dies.
+    .replace(ANY_NODUS_LINK_RE, (full, label: string, target: string) =>
+      VALID_TARGET_RE.test(target) ? full : label || ''
+    )
+    .replace(SURVIVING_RAW_RE, '')
+    .replace(/\(\s*[;,]?\s*\)/g, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/\s+([.,;)])/g, '$1');
+  return { markdown: swept, cited };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Citation verification (pure)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Sentence boundaries, kept simple: citations sit inside ordinary prose. */
+const SENTENCE_SPLIT = /(?<=[.!?])\s+(?=[¿¡"«(A-ZÁÉÍÓÚÑ])/u;
+
+/**
+ * Pair every citation in a section with the sentence it supports and with what the
+ * cited source actually says. Bare `work` citations are skipped: a work token only
+ * asserts that the work is relevant, which is not an entailment claim.
+ */
+export function extractCitationClaims(markdown: string, maps: SnapshotMaps): CitationClaim[] {
+  const claims: CitationClaim[] = [];
+  const body = stripInitialHeading(markdown);
+  const bodyStart = Math.max(0, markdown.indexOf(body));
+  // Mask every citation to a same-length run of a neutral character before looking
+  // for sentence boundaries. An author initial inside a label ("Autor, N. (2000)")
+  // otherwise reads as the end of a sentence and cuts the citation in half, which
+  // silently left the whole report unverified.
+  const masked = body.replace(CITATION_RE, (link) => '\u0001'.repeat(link.length));
+  for (const span of sentenceSpans(masked)) {
+    const text = body.slice(span.start, span.end);
+    const plain = stripMarkdown(text);
+    for (const match of text.matchAll(CITATION_RE)) {
+      const type = match[2] as CitationClaim['kind'] | 'work';
+      if (type === 'work') continue;
+      let id = match[3];
+      try {
+        id = decodeURIComponent(id);
+      } catch {
+        /* keep raw */
+      }
+      const content = citedContent(type, id, maps);
+      // Nothing to check against means nothing to verify; leave it alone rather
+      // than let a contentless judgement delete a citation.
+      if (!content) continue;
+      claims.push({
+        offset: bodyStart + span.start + (match.index ?? 0),
+        link: match[0],
+        kind: type,
+        id,
+        sentence: plain,
+        content,
+      });
+    }
+  }
+  return claims;
+}
+
+/** Sentence and paragraph spans over text whose citations have been masked. */
+function sentenceSpans(text: string): { start: number; end: number }[] {
+  const spans: { start: number; end: number }[] = [];
+  const separator = new RegExp(`${SENTENCE_SPLIT.source}|\\n{2,}`, 'gu');
+  let start = 0;
+  for (const match of text.matchAll(separator)) {
+    const at = match.index ?? 0;
+    if (at > start) spans.push({ start, end: at });
+    start = at + match[0].length;
+  }
+  if (start < text.length) spans.push({ start, end: text.length });
+  return spans;
+}
+
+function citedContent(type: string, id: string, maps: SnapshotMaps): string {
+  switch (type) {
+    case 'idea':
+      return maps.ideaById.get(id)?.statement?.trim() || maps.ideaById.get(id)?.label?.trim() || '';
+    case 'passage':
+      return maps.passageText.get(id)?.trim() || '';
+    case 'gap': {
+      const gap = maps.gapById.get(id);
+      return [gap?.label, gap?.summary].filter(Boolean).join('. ').trim();
+    }
+    case 'contradiction': {
+      const c = maps.contradictionById.get(id);
+      return [c?.label, c?.summary].filter(Boolean).join('. ').trim();
+    }
+    default:
+      return '';
+  }
+}
+
+
+/**
+ * Keep only the conflicts whose two quotes really appear in the sections they are
+ * attributed to. A model asked to find contradictions will invent them; requiring it
+ * to quote both sides verbatim turns the claim into something checkable, and this
+ * throws away anything that fails the check.
+ */
+export function groundCoherenceIssues(
+  issues: CoherenceIssue[],
+  sections: { title: string; text: string }[]
+): CoherenceIssue[] {
+  const byTitle = new Map(sections.map((s) => [s.title.trim().toLowerCase(), normalizeForMatch(s.text)]));
+  const appearsIn = (title: string, quote: string) => {
+    const needle = normalizeForMatch(quote);
+    if (needle.length < 24) return false;
+    const haystack = byTitle.get((title ?? '').trim().toLowerCase());
+    // Fall back to the whole report: a model often mislabels which section a
+    // sentence came from while quoting it correctly.
+    if (haystack?.includes(needle)) return true;
+    return [...byTitle.values()].some((text) => text.includes(needle));
+  };
+  return (issues ?? []).filter(
+    (issue) =>
+      issue &&
+      typeof issue.quoteA === 'string' &&
+      typeof issue.quoteB === 'string' &&
+      issue.quoteA.trim() !== issue.quoteB.trim() &&
+      appearsIn(issue.sectionA, issue.quoteA) &&
+      appearsIn(issue.sectionB, issue.quoteB)
+  );
+}
+
+function normalizeForMatch(text: string): string {
+  return stripMarkdown(text ?? '')
+    .toLocaleLowerCase('es-ES')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export interface VerificationOutcome {
+  markdown: string;
+  checked: number;
+  partial: number;
+  unsupported: number;
+  /** Sentences that lost their only support, for honest reporting. */
+  strippedSentences: string[];
+}
+
+/**
+ * Apply the verdicts. A citation the source does not support is a false attribution,
+ * so it is removed outright — leaving the sentence standing but unsupported is bad,
+ * leaving a wrong attribution in an academic report is worse. What was removed is
+ * counted and surfaced instead of being swallowed.
+ */
+export function applyVerification(markdown: string, claims: CitationClaim[], verdicts: CitationVerdict[]): VerificationOutcome {
+  const doomed = claims
+    .map((claim, index) => ({ claim, verdict: verdicts[index] }))
+    .filter((entry) => entry.verdict === 'unsupported');
+  const partial = verdicts.filter((v) => v === 'partial').length;
+
+  // Remove from the end so earlier offsets stay valid.
+  let out = markdown;
+  const strippedSentences: string[] = [];
+  for (const { claim } of [...doomed].sort((a, b) => b.claim.offset - a.claim.offset)) {
+    if (out.slice(claim.offset, claim.offset + claim.link.length) !== claim.link) continue;
+    out = out.slice(0, claim.offset) + out.slice(claim.offset + claim.link.length);
+    strippedSentences.push(claim.sentence);
+  }
+  out = out
+    .replace(/\(\s*[;,]?\s*\)/g, '')
+    .replace(/\s+([.,;)])/g, '$1')
+    .replace(/[ \t]{2,}/g, ' ');
+  return { markdown: out, checked: claims.length, partial, unsupported: doomed.length, strippedSentences };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -842,22 +1600,24 @@ export function collectCitedWorkIds(citedIds: { ideas: Set<string>; works: Set<s
   return workIds;
 }
 
-export function buildReferences(workIds: Set<string>, maps: SnapshotMaps): string[] {
+export function buildReferences(workIds: Set<string>, maps: SnapshotMaps, language: PromptLanguage = 'es'): string[] {
+  const L = labels(language);
   const entries = [...workIds]
     .map((id) => maps.workInfoById.get(id))
     .filter((w): w is WorkInfo => !!w)
-    .map(referenceEntry);
-  return dedupe(entries).sort((a, b) => a.localeCompare(b, 'es'));
+    .map((work) => referenceEntry(work, L));
+  return dedupe(entries).sort((a, b) => a.localeCompare(b, language === 'pt-BR' ? 'pt' : language));
 }
 
-function referenceEntry(work: WorkInfo): string {
-  const authors = work.authors.length ? work.authors.join('; ') : 'Autor desconocido';
-  const year = work.year ? ` (${work.year})` : ' (s.f.)';
+function referenceEntry(work: WorkInfo, L: Labels): string {
+  const authors = work.authors.length ? work.authors.join('; ') : L.unknownAuthor;
+  const year = work.year ? ` (${work.year})` : ` (${L.noDate})`;
   const title = work.title ? `. ${work.title.replace(/\.\s*$/, '')}.` : '.';
-  return `${authors}${year}${title}`;
+  const doi = work.doi?.trim() ? ` https://doi.org/${work.doi.trim().replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')}` : '';
+  return `${authors}${year}${title}${doi}`;
 }
 
-function buildMatrix(coveredIdeaIds: Set<string>, maps: SnapshotMaps): WritingWorkshopMatrixRow[] {
+function buildMatrix(coveredIdeaIds: Set<string>, maps: SnapshotMaps, L: Labels): WritingWorkshopMatrixRow[] {
   const rows: WritingWorkshopMatrixRow[] = [];
   for (const id of coveredIdeaIds) {
     if (rows.length >= MAX_MATRIX_ROWS) break;
@@ -866,10 +1626,10 @@ function buildMatrix(coveredIdeaIds: Set<string>, maps: SnapshotMaps): WritingWo
     rows.push({
       claim: clip(idea.statement || idea.label, 240),
       role: matrixRole(idea.type),
-      sourceLabel: sourceLabelFromWork(idea.works[0]) || 'Fuente del corpus',
+      sourceLabel: sourceLabelFromWork(idea.works[0]) || L.corpusSource,
       citation: `nodus://idea/${encodeURIComponent(id)}`,
-      evidence: idea.evidenceCount > 0 ? `${idea.evidenceCount} evidencia(s) ancladas en el corpus.` : 'Idea derivada del corpus.',
-      notes: idea.workCount > 1 ? `Sostenida por ${idea.workCount} obras.` : 'Una obra de respaldo.',
+      evidence: idea.evidenceCount > 0 ? L.anchoredEvidence(idea.evidenceCount) : L.derivedIdea,
+      notes: idea.workCount > 1 ? L.supportedBy(idea.workCount) : L.singleSupport,
     });
   }
   return rows;
@@ -923,32 +1683,74 @@ function sectionSources(section: DeepResearchPlanSection, maps: SnapshotMaps): s
 // Citation menu / helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-function buildCitationMenu(section: DeepResearchPlanSection, maps: SnapshotMaps): CitationMenuItem[] {
+export function buildCitationMenu(section: DeepResearchPlanSection, maps: SnapshotMaps): CitationMenuItem[] {
   const items: CitationMenuItem[] = [];
   for (const id of section.ideaIds) {
     const idea = maps.ideaById.get(id);
-    if (idea) items.push({ token: ideaCitation(idea), note: clip(idea.statement || idea.label, 180) });
+    if (!idea) continue;
+    items.push({
+      token: ideaCitation(idea),
+      kind: 'idea',
+      note: clip(idea.statement || idea.label, IDEA_NOTE_CHARS),
+      source: ideaSupportLabel(idea),
+    });
   }
   for (const id of section.workIds) {
     const work = maps.workInfoById.get(id);
-    if (work) items.push({ token: `[${sourceLabelFromWork(work)}](nodus://work/${encodeURIComponent(id)})`, note: clip(work.title, 160) });
+    if (!work) continue;
+    items.push({
+      token: `[${sourceLabelFromWork(work)}](nodus://work/${encodeURIComponent(id)})`,
+      kind: 'work',
+      note: clip(work.title, 200),
+      source: sourceLabelFromWork(work),
+    });
   }
   for (const id of section.gapIds) {
-    if (maps.gapIds.has(id)) items.push({ token: `[hueco](nodus://gap/${encodeURIComponent(id)})`, note: 'Hueco de investigación anclado.' });
+    const gap = maps.gapById.get(id);
+    if (!gap) continue;
+    items.push({
+      token: `[hueco](nodus://gap/${encodeURIComponent(id)})`,
+      kind: 'gap',
+      note: clip(gap.summary || gap.label, IDEA_NOTE_CHARS),
+    });
   }
   for (const id of section.contradictionIds) {
-    if (maps.contradictionIds.has(id))
-      items.push({ token: `[contradicción](nodus://contradiction/${encodeURIComponent(id)})`, note: 'Contradicción entre autores.' });
+    const contradiction = maps.contradictionById.get(id);
+    if (!contradiction) continue;
+    const sides = contradiction.label ? `Posturas enfrentadas: ${contradiction.label}. ` : '';
+    const who = contradiction.sources.length ? ` Lo sostienen ${contradiction.sources.join('; ')}.` : '';
+    items.push({
+      token: `[contradicción](nodus://contradiction/${encodeURIComponent(id)})`,
+      kind: 'contradiction',
+      note: `${sides}${clip(contradiction.summary, IDEA_NOTE_CHARS)}${who}`.trim(),
+      source: contradiction.sources.join('; ') || undefined,
+    });
   }
   for (const id of section.passageIds) {
     const workId = maps.passageWorkId.get(id);
-    if (workId) {
-      const page = maps.passagePage.get(id);
-      const label = `${sourceLabelFromWork(maps.workInfoById.get(workId))}${page ? `, ${page}` : ''}`;
-      items.push({ token: `[${label}](nodus://passage/${encodeURIComponent(id)})`, note: 'Pasaje literal del texto completo.' });
-    }
+    const text = maps.passageText.get(id);
+    // A passage with no readable text is NOT offered: citing it would be a page
+    // number attached to words the writer never saw.
+    if (!workId || !text) continue;
+    const page = maps.passagePage.get(id);
+    const label = `${sourceLabelFromWork(maps.workInfoById.get(workId))}${page ? `, ${page}` : ''}`;
+    items.push({
+      token: `[${label}](nodus://passage/${encodeURIComponent(id)})`,
+      kind: 'passage',
+      note: `«${clip(text, PASSAGE_NOTE_CHARS)}»`,
+      source: label,
+    });
   }
   return items;
+}
+
+/** Which works back an idea, so the writer can name them in prose. */
+function ideaSupportLabel(idea: WritingWorkshopIdeaCandidate): string {
+  return idea.works
+    .slice(0, 3)
+    .map((w) => sourceLabelFromWork(w))
+    .filter(Boolean)
+    .join('; ');
 }
 
 function ideaCitation(idea: WritingWorkshopIdeaCandidate): string {
@@ -969,6 +1771,9 @@ export interface CitationCatalog {
   works: { token: string; note: string }[];
   gaps: { token: string; note: string }[];
   contradictions: { token: string; note: string }[];
+  /** Literal text from the sources, with the page it sits on. The strongest evidence
+   * the corpus can offer, and the only kind the writer can quote. */
+  passages: { token: string; note: string; source: string }[];
   themes: { id: string; label: string; summary: string }[];
 }
 
@@ -990,8 +1795,21 @@ export function buildCitationCatalog(snapshot: WritingWorkshopSnapshot): Citatio
     })),
     contradictions: snapshot.contradictions.slice(0, POOL_LIMITS.contradictions).map((c) => ({
       token: `[contradicción](nodus://contradiction/${encodeURIComponent(c.id)})`,
-      note: clip(c.summary || c.label, 160),
+      note: `Posturas enfrentadas: ${c.label}. ${clip(c.summary, 200)}${c.sources?.length ? ` Lo sostienen ${c.sources.join('; ')}.` : ''}`.trim(),
     })),
+    // Only passages whose text is actually present; a page number the writer cannot
+    // read is an invitation to invent what the source says.
+    passages: snapshot.passages
+      .filter((p) => p.summary?.trim())
+      .slice(0, POOL_LIMITS.passages)
+      .map((p) => {
+        const label = `${authorYearLabel(p.authors[0], p.year)}${p.pageLabel ? `, ${p.pageLabel}` : ''}`;
+        return {
+          token: `[${label}](nodus://passage/${encodeURIComponent(p.id)})`,
+          note: `«${clip(p.summary, PASSAGE_NOTE_CHARS)}»`,
+          source: label,
+        };
+      }),
     themes: snapshot.themes.slice(0, POOL_LIMITS.themes).map((t) => ({ id: t.id, label: t.label, summary: clip(t.summary, 160) })),
   };
 }
@@ -1013,11 +1831,28 @@ function authorYearLabel(author: string | undefined, year: number | null | undef
   return year ? `${name} (${year})` : name;
 }
 
+/**
+ * A running synopsis of the report so far. The opening sentence of a section says
+ * almost nothing about where its argument ended up, so each entry carries where the
+ * section *closed* — that is what the next one has to pick up from without repeating.
+ */
 function summarizePrior(written: { section: DeepResearchPlanSection; markdown: string }[]): string {
   if (written.length === 0) return '';
   return written
-    .map((w, i) => `${i + 1}. ${w.section.title}: ${clip(firstSentence(stripMarkdown(w.markdown)), 160)}`)
+    .map((w, i) => {
+      const prose = stripMarkdown(stripInitialHeading(w.markdown));
+      const opening = clip(firstSentence(prose), 200);
+      const closing = clip(closingSentences(prose, 2), 320);
+      return `${i + 1}. ${w.section.title}\n   ${opening}\n   … ${closing}`;
+    })
     .join('\n');
+}
+
+/** The last `count` sentences of a passage of prose. */
+function closingSentences(text: string, count: number): string {
+  const sentences = (text ?? '').match(/[^.!?]+[.!?]+/g);
+  if (!sentences || sentences.length === 0) return text ?? '';
+  return sentences.slice(-count).join(' ').trim();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1089,24 +1924,138 @@ function dedupe(items: string[]): string[] {
   return [...new Set(items.map((i) => i.trim()).filter(Boolean))];
 }
 
-function labels(language: PromptLanguage) {
-  if (language === 'en') {
-    return { abstract: 'Abstract', limitations: 'Limitations', references: 'References', noReferences: 'No sources cited.' };
-  }
-  if (language === 'fr') {
-    return { abstract: 'Résumé', limitations: 'Limites', references: 'Références', noReferences: 'Aucune source citée.' };
-  }
-  if (language === 'tr') {
-    return { abstract: 'Özet', limitations: 'Sınırlılıklar', references: 'Kaynakça', noReferences: 'Kaynak belirtilmedi.' };
-  }
-  if (language === 'de') {
-    return { abstract: 'Zusammenfassung', limitations: 'Einschränkungen', references: 'Literaturverzeichnis', noReferences: 'Keine Quellen angegeben.' };
-  }
-  if (language === 'pt') {
-    return { abstract: 'Resumo', limitations: 'Limitações', references: 'Bibliografia', noReferences: 'Nenhuma fonte citada.' };
-  }
-  if (language === 'pt-BR') {
-    return { abstract: 'Resumo', limitations: 'Limitações', references: 'Referências', noReferences: 'Nenhuma fonte citada.' };
-  }
-  return { abstract: 'Resumen', limitations: 'Limitaciones', references: 'Referencias', noReferences: 'Sin fuentes citadas.' };
+export interface Labels {
+  abstract: string;
+  limitations: string;
+  references: string;
+  noReferences: string;
+  gathering: string;
+  planning: (sections: number, pages: { min: number; max: number }) => string;
+  writing: string;
+  coverage: (pending: number) => string;
+  assembling: string;
+  done: (sections: number, pages: number) => string;
+  stoppedSections: (cap: number) => string;
+  stoppedPages: (pages: number) => string;
+  degraded: string;
+  degradedEmpty: string;
+  coverageTitle: string;
+  coveragePurpose: string;
+  introTitle: string;
+  introPurpose: string;
+  threadTitle: string;
+  threadPurpose: string;
+  synthesisTitle: string;
+  synthesisPurpose: string;
+  reportTitlePrefix: string;
+  uncoveredLimitation: (samples: string[]) => string;
+  coherenceLimitation: (issue: CoherenceIssue) => string;
+  reviewStep: string;
+  corpusSource: string;
+  anchoredEvidence: (count: number) => string;
+  derivedIdea: string;
+  supportedBy: (count: number) => string;
+  singleSupport: string;
+  unknownAuthor: string;
+  noDate: string;
+}
+
+const ES: Labels = {
+  abstract: 'Resumen',
+  limitations: 'Limitaciones',
+  references: 'Referencias',
+  noReferences: 'Sin fuentes citadas.',
+  gathering: 'Reuniendo materiales del corpus…',
+  planning: (s, p) => `Planificando ~${s} secciones de fondo (${p.min}–${p.max} páginas)…`,
+  writing: 'Redactando',
+  coverage: (n) => `Ampliando cobertura (${n} ideas pendientes)…`,
+  assembling: 'Ensamblando informe y referencias…',
+  done: (s, p) => `Informe listo: ${s} secciones · ~${p} páginas`,
+  stoppedSections: (c) => `Se alcanzó el máximo de ${c} secciones.`,
+  stoppedPages: (p) => `Se alcanzó el presupuesto máximo de ~${p} páginas.`,
+  degraded: 'Una o más secciones no pudieron generarse con el modelo y se resolvieron de forma degradada.',
+  degradedEmpty: 'No se pudo desarrollar esta sección con el modelo; revisar los materiales asignados.',
+  coverageTitle: 'Desarrollo complementario',
+  coveragePurpose: 'Desarrollar ideas del corpus todavía no tratadas en profundidad.',
+  introTitle: 'Introducción y planteamiento',
+  introPurpose: 'Delimitar el problema y anticipar las líneas del argumento.',
+  threadTitle: 'Línea argumental',
+  threadPurpose: 'Desarrollar y relacionar un grupo de ideas del corpus.',
+  synthesisTitle: 'Síntesis, huecos y contribución',
+  synthesisPurpose: 'Integrar las líneas, señalar huecos y perfilar la contribución.',
+  reportTitlePrefix: 'Informe:',
+  uncoveredLimitation: (s) => `Quedaron ideas del corpus sin desarrollar en profundidad (p. ej.: ${s.join('; ')}).`,
+  coherenceLimitation: (i) =>
+    i.sectionA.trim() === i.sectionB.trim()
+      ? `Tensión interna dentro de «${i.sectionA}». ${i.issue}`
+      : `Tensión interna entre «${i.sectionA}» y «${i.sectionB}». ${i.issue}`,
+  reviewStep: 'Revisar cada cita y contrastar el informe con las fuentes originales.',
+  corpusSource: 'Fuente del corpus',
+  anchoredEvidence: (n) => `${n} evidencia(s) ancladas en el corpus.`,
+  derivedIdea: 'Idea derivada del corpus.',
+  supportedBy: (n) => `Sostenida por ${n} obras.`,
+  singleSupport: 'Una obra de respaldo.',
+  unknownAuthor: 'Autor desconocido',
+  noDate: 's.f.',
+};
+
+const EN: Labels = {
+  abstract: 'Abstract',
+  limitations: 'Limitations',
+  references: 'References',
+  noReferences: 'No sources cited.',
+  gathering: 'Gathering corpus material…',
+  planning: (s, p) => `Planning ~${s} substantial sections (${p.min}–${p.max} pages)…`,
+  writing: 'Writing',
+  coverage: (n) => `Widening coverage (${n} ideas still untouched)…`,
+  assembling: 'Assembling report and references…',
+  done: (s, p) => `Report ready: ${s} sections · ~${p} pages`,
+  stoppedSections: (c) => `Reached the ceiling of ${c} sections.`,
+  stoppedPages: (p) => `Reached the maximum budget of ~${p} pages.`,
+  degraded: 'One or more sections could not be generated by the model and were resolved in a degraded form.',
+  degradedEmpty: 'The model could not develop this section; review the assigned material.',
+  coverageTitle: 'Further development',
+  coveragePurpose: 'Develop corpus ideas not yet treated in depth.',
+  introTitle: 'Introduction and framing',
+  introPurpose: 'Delimit the problem and anticipate the lines of argument.',
+  threadTitle: 'Line of argument',
+  threadPurpose: 'Develop and relate a group of ideas from the corpus.',
+  synthesisTitle: 'Synthesis, gaps and contribution',
+  synthesisPurpose: 'Integrate the lines, name the gaps and outline the contribution.',
+  reportTitlePrefix: 'Report:',
+  uncoveredLimitation: (s) => `Some corpus ideas were left undeveloped (for example: ${s.join('; ')}).`,
+  coherenceLimitation: (i) =>
+    i.sectionA.trim() === i.sectionB.trim()
+      ? `Internal tension within "${i.sectionA}". ${i.issue}`
+      : `Internal tension between "${i.sectionA}" and "${i.sectionB}". ${i.issue}`,
+  reviewStep: 'Check every citation against the original sources.',
+  corpusSource: 'Corpus source',
+  anchoredEvidence: (n) => `${n} piece(s) of evidence anchored in the corpus.`,
+  derivedIdea: 'Idea derived from the corpus.',
+  supportedBy: (n) => `Supported by ${n} works.`,
+  singleSupport: 'One supporting work.',
+  unknownAuthor: 'Unknown author',
+  noDate: 'n.d.',
+};
+
+/** Headings the report itself carries, per language. Progress copy and fallback
+ * prose fall back to English rather than leaking Spanish into a foreign report. */
+const HEADINGS: Partial<Record<PromptLanguage, Pick<Labels, 'abstract' | 'limitations' | 'references' | 'noReferences'>>> = {
+  fr: { abstract: 'Résumé', limitations: 'Limites', references: 'Références', noReferences: 'Aucune source citée.' },
+  tr: { abstract: 'Özet', limitations: 'Sınırlılıklar', references: 'Kaynakça', noReferences: 'Kaynak belirtilmedi.' },
+  de: {
+    abstract: 'Zusammenfassung',
+    limitations: 'Einschränkungen',
+    references: 'Literaturverzeichnis',
+    noReferences: 'Keine Quellen angegeben.',
+  },
+  pt: { abstract: 'Resumo', limitations: 'Limitações', references: 'Bibliografia', noReferences: 'Nenhuma fonte citada.' },
+  'pt-BR': { abstract: 'Resumo', limitations: 'Limitações', references: 'Referências', noReferences: 'Nenhuma fonte citada.' },
+};
+
+export function labels(language: PromptLanguage): Labels {
+  if (language === 'es') return ES;
+  if (language === 'en') return EN;
+  const headings = HEADINGS[language];
+  return headings ? { ...EN, ...headings } : ES;
 }

--- a/electron/ai/writingWorkshop.ts
+++ b/electron/ai/writingWorkshop.ts
@@ -3,6 +3,7 @@ import type {
   IdeaType,
   WritingWorkshopBrief,
   WritingWorkshopCandidateBase,
+  EdgeDetail,
   WritingWorkshopContradictionCandidate,
   WritingWorkshopDraft,
   WritingWorkshopDraftRequest,
@@ -21,7 +22,7 @@ import { getDb } from '../db/database';
 import { getContradictions } from '../graph/graphService';
 import { listTutorRoutes } from '../db/tutorRepo';
 import { completeJson } from './aiClient';
-import { embed } from './aiClient';
+import { embed, embedMany } from './aiClient';
 import { findSimilarIdeas } from '../db/ideasRepo';
 import { findSimilarWorks } from '../db/workSummariesRepo';
 import { findSimilarPassages, type SimilarPassage } from '../db/passagesRepo';
@@ -32,6 +33,10 @@ const MAX_GAPS = 36;
 const MAX_CONTRADICTIONS = 30;
 const MAX_WORKS = 80;
 const MAX_PASSAGES = 24;
+/** How many semantic probes a single snapshot may run. */
+const MAX_PROBES = 8;
+/** Share of the pool reserved for the objective itself; the rest is split between sub-questions. */
+const OBJECTIVE_SHARE = 0.4;
 const MAX_ROUTES = 12;
 const MAX_CONTEXT_CHARS = 420_000;
 const MAX_PASSAGE_CONTEXT_CHARS = 30_000;
@@ -59,6 +64,7 @@ interface WorkLinkRow {
   authors_json: string;
   year: number | null;
   zotero_key: string;
+  doi: string | null;
 }
 
 interface ThemeRow {
@@ -103,6 +109,7 @@ interface WorkRow {
   authors_json: string;
   year: number | null;
   deep_status: WritingWorkshopWorkCandidate['deepStatus'];
+  doi: string | null;
   orientation_summary: string | null;
   themes: string | null;
   idea_count: number;
@@ -139,9 +146,13 @@ function isAiWorkshopResult(value: unknown): value is AiWorkshopResult {
   return typeof v.title === 'string' && typeof v.draftMarkdown === 'string' && Array.isArray(v.outline);
 }
 
-export async function buildWritingWorkshopSnapshot(brief: WritingWorkshopBrief): Promise<WritingWorkshopSnapshot> {
+export async function buildWritingWorkshopSnapshot(
+  brief: WritingWorkshopBrief,
+  /** Extra sub-questions to probe the corpus with, on top of the objective itself. */
+  extraProbes: string[] = []
+): Promise<WritingWorkshopSnapshot> {
   const tokens = tokenize(`${brief.objective} ${kindLabel(brief.kind)}`);
-  const semantic = await buildSemanticRanking(brief.objective);
+  const semantic = await buildSemanticRanking([brief.objective, ...extraProbes]);
   const ideas = rankedIdeas(tokens, semantic);
   const themes = rankedThemes(tokens, semantic);
   const gaps = rankedGaps(tokens, brief.kind, semantic);
@@ -247,24 +258,115 @@ function countTable(table: string): number {
  * idea/work vectors for broad ranking and the fine passage index for direct
  * evidence candidates; lexical matching remains only as an offline fallback.
  */
-async function buildSemanticRanking(objective: string): Promise<WorkshopSemanticRanking> {
+async function buildSemanticRanking(queries: string[]): Promise<WorkshopSemanticRanking> {
   const empty: WorkshopSemanticRanking = { active: false, ideaScores: new Map(), workScores: new Map(), passages: [] };
-  if (!objective.trim()) return empty;
+  // One probe reaches only the corpus neighbourhood of the objective *as a whole*.
+  // A question spanning several axes ("turismo, género y mirada colonial") retrieves
+  // what resembles that whole sentence and misses what each axis would find alone,
+  // so several probes are merged by best score per item.
+  const probes = [...new Set(queries.map((q) => q.trim()).filter(Boolean))].slice(0, MAX_PROBES);
+  if (probes.length === 0) return empty;
   try {
-    const query = await embed(objective.trim());
-    if (!query) return empty;
-    const ideaScores = new Map(findSimilarIdeas(query, -1, MAX_IDEAS).map((hit) => [hit.global_id, semanticStrength(hit.similarity)]));
-    const workScores = new Map(findSimilarWorks(query, -1, MAX_WORKS).map((hit) => [hit.nodus_id, semanticStrength(hit.similarity)]));
-    const passageHits = findSimilarPassages(query, -1, MAX_PASSAGES);
-    for (const hit of passageHits) {
-      const current = workScores.get(hit.nodus_id) ?? 0;
-      workScores.set(hit.nodus_id, Math.max(current, semanticStrength(hit.similarity)));
+    const vectors = (await embedMany(probes)).filter((v): v is number[] => Array.isArray(v) && v.length > 0);
+    if (vectors.length === 0) return empty;
+
+    // Merging by score and then trimming to the cap is NOT enough: the objective's
+    // own neighbourhood scores highest across the board, so the trim throws away
+    // exactly what the sub-questions were meant to add and the pool collapses back
+    // to the single-probe one. Each probe therefore gets a guaranteed quota of
+    // slots, and only what is left over is filled by global score.
+    const ideaScores = new Map<string, number>();
+    const workScores = new Map<string, number>();
+    const passages = new Map<string, SimilarPassage>();
+    const passageScore = new Map<string, number>();
+    const reserve = <T>(chosen: Map<string, T>, limit: number) => chosen.size < limit;
+
+    const quotaFor = (limit: number, index: number) => {
+      // A lone probe is the whole search: quotas must never shrink it below what a
+      // single-probe snapshot used to retrieve.
+      if (vectors.length === 1) return limit;
+      return index === 0
+        ? Math.max(1, Math.round(limit * OBJECTIVE_SHARE))
+        : Math.max(1, Math.floor((limit * (1 - OBJECTIVE_SHARE)) / (vectors.length - 1)));
+    };
+
+    // A quota with no quality floor is how breadth turns into noise: a sub-question
+    // with few good matches still spends its slots on weak material, the writer
+    // argues from it, and the claims it produces are not supported by the sources
+    // they cite. Measured: unsupported citations tripled. So a sub-question may only
+    // contribute material at least as relevant as the WEAKEST hit the objective
+    // itself accepted — breadth, never at the cost of relevance.
+    // The bar is what the single-probe pool would itself have accepted: the weakest
+    // item in the objective's own full-size result set. A sub-question may add
+    // anything that clears it and nothing that does not, so the pool gains breadth
+    // without ever lowering its standard of relevance.
+    const objectiveIdeas = findSimilarIdeas(vectors[0], -1, MAX_IDEAS);
+    const objectiveWorks = findSimilarWorks(vectors[0], -1, MAX_WORKS);
+    const objectivePassages = findSimilarPassages(vectors[0], -1, MAX_PASSAGES * 2);
+    const weakest = <T extends { similarity: number }>(hits: T[]) => (hits.length ? hits[hits.length - 1].similarity : -1);
+    const floors = {
+      ideas: weakest(objectiveIdeas),
+      works: weakest(objectiveWorks),
+      passages: weakest(objectivePassages),
+    };
+
+    vectors.forEach((vector, index) => {
+      const isObjective = index === 0;
+      const ideaHits = isObjective
+        ? objectiveIdeas.slice(0, quotaFor(MAX_IDEAS, index))
+        : findSimilarIdeas(vector, floors.ideas, quotaFor(MAX_IDEAS, index));
+      const workHits = isObjective
+        ? objectiveWorks.slice(0, quotaFor(MAX_WORKS, index))
+        : findSimilarWorks(vector, floors.works, quotaFor(MAX_WORKS, index));
+      const passageHits = isObjective
+        ? objectivePassages.slice(0, quotaFor(MAX_PASSAGES * 2, index))
+        : findSimilarPassages(vector, floors.passages, quotaFor(MAX_PASSAGES * 2, index));
+      for (const hit of ideaHits) {
+        if (reserve(ideaScores, MAX_IDEAS) || ideaScores.has(hit.global_id)) {
+          ideaScores.set(hit.global_id, Math.max(ideaScores.get(hit.global_id) ?? 0, semanticStrength(hit.similarity)));
+        }
+      }
+      for (const hit of workHits) {
+        if (reserve(workScores, MAX_WORKS) || workScores.has(hit.nodus_id)) {
+          workScores.set(hit.nodus_id, Math.max(workScores.get(hit.nodus_id) ?? 0, semanticStrength(hit.similarity)));
+        }
+      }
+      for (const hit of passageHits) {
+        const strength = semanticStrength(hit.similarity);
+        workScores.set(hit.nodus_id, Math.max(workScores.get(hit.nodus_id) ?? 0, strength));
+        if (!passages.has(hit.passage_id) && !reserve(passages, MAX_PASSAGES * 2)) continue;
+        if ((passageScore.get(hit.passage_id) ?? -1) < strength) {
+          passageScore.set(hit.passage_id, strength);
+          passages.set(hit.passage_id, hit);
+        }
+      }
+    });
+
+    // Pass two: the objective fills any slots the quotas left unused.
+    for (const hit of objectiveIdeas) {
+      if (ideaScores.size >= MAX_IDEAS) break;
+      if (!ideaScores.has(hit.global_id)) ideaScores.set(hit.global_id, semanticStrength(hit.similarity));
     }
+    for (const hit of objectiveWorks) {
+      if (workScores.size >= MAX_WORKS) break;
+      if (!workScores.has(hit.nodus_id)) workScores.set(hit.nodus_id, semanticStrength(hit.similarity));
+    }
+    for (const hit of objectivePassages) {
+      if (passages.size >= MAX_PASSAGES * 2) break;
+      if (passages.has(hit.passage_id)) continue;
+      passageScore.set(hit.passage_id, semanticStrength(hit.similarity));
+      passages.set(hit.passage_id, hit);
+    }
+
+    const rankedPassages = [...passages.values()].sort(
+      (a, b) => (passageScore.get(b.passage_id) ?? 0) - (passageScore.get(a.passage_id) ?? 0)
+    );
+
     return {
-      active: ideaScores.size > 0 || workScores.size > 0 || passageHits.length > 0,
+      active: ideaScores.size > 0 || workScores.size > 0 || rankedPassages.length > 0,
       ideaScores,
       workScores,
-      passages: passageHits.map(toPassageCandidate),
+      passages: rankedPassages.map(toPassageCandidate),
     };
   } catch (error) {
     console.warn('[writingWorkshop] semantic ranking unavailable:', error instanceof Error ? error.message : String(error));
@@ -307,6 +409,73 @@ function toPassageCandidate(hit: SimilarPassage): WritingWorkshopPassageCandidat
     year: hit.year,
     zotero_key: hit.zotero_key,
     citation: `nodus://passage/${encodeURIComponent(hit.passage_id)}`,
+  };
+}
+
+/**
+ * Second-pass retrieval for one Deep Research section.
+ *
+ * The workshop snapshot is ranked once against the whole objective, which caps how
+ * much any single sub-question can bring back — passages worst of all. This asks the
+ * same indexes again using the section's own focus as the query, so a section about
+ * a narrow theme can reach material the objective-level ranking never surfaced.
+ * Returns candidates in the same shape the snapshot uses so they merge cleanly.
+ */
+export async function retrieveSectionMaterial(input: {
+  objective: string;
+  sectionTitle: string;
+  purpose: string;
+  keyClaims: string[];
+  excludeIdeaIds: string[];
+  excludePassageIds: string[];
+  limits: { ideas: number; passages: number };
+}): Promise<{ ideas: WritingWorkshopIdeaCandidate[]; passages: WritingWorkshopPassageCandidate[] }> {
+  const query = [input.sectionTitle, input.purpose, ...input.keyClaims].filter(Boolean).join('. ').trim();
+  if (!query) return { ideas: [], passages: [] };
+  const vector = await embed(`${input.objective}\n${query}`);
+  if (!vector) return { ideas: [], passages: [] };
+
+  const skipIdeas = new Set(input.excludeIdeaIds);
+  const skipPassages = new Set(input.excludePassageIds);
+  const ideaHits = findSimilarIdeas(vector, -1, input.limits.ideas * 4).filter((hit) => !skipIdeas.has(hit.global_id));
+  const passageHits = findSimilarPassages(vector, -1, input.limits.passages * 4).filter((hit) => !skipPassages.has(hit.passage_id));
+
+  return {
+    ideas: ideaHits.slice(0, input.limits.ideas).map((hit) => ideaCandidateById(hit.global_id, semanticStrength(hit.similarity))).filter((idea): idea is WritingWorkshopIdeaCandidate => !!idea),
+    passages: passageHits.slice(0, input.limits.passages).map(toPassageCandidate),
+  };
+}
+
+/** Load one idea in snapshot shape. Used by the per-section retrieval. */
+function ideaCandidateById(globalId: string, score: number): WritingWorkshopIdeaCandidate | null {
+  const row = getDb()
+    .prepare(
+      `SELECT i.global_id, i.type, i.label, i.statement,
+              COALESCE(GROUP_CONCAT(DISTINCT t.label), '') AS themes,
+              COUNT(DISTINCT io.nodus_id) AS work_count,
+              COUNT(DISTINCT e.id) AS evidence_count
+         FROM ideas i
+         LEFT JOIN idea_occurrences io ON io.global_id = i.global_id
+         LEFT JOIN evidence e ON e.global_id = i.global_id
+         LEFT JOIN idea_theme_links itl ON itl.global_id = i.global_id
+         LEFT JOIN themes t ON t.theme_id = itl.theme_id
+        WHERE i.global_id = ?
+        GROUP BY i.global_id`
+    )
+    .get(globalId) as Omit<IdeaRow, 'work_ids'> | undefined;
+  if (!row) return null;
+  return {
+    id: row.global_id,
+    label: row.label,
+    summary: clip(row.statement, 240),
+    score,
+    reason: 'Recuperado por similitud semántica con esta sección.',
+    type: row.type,
+    statement: row.statement,
+    themes: splitList(row.themes),
+    workCount: row.work_count,
+    evidenceCount: row.evidence_count,
+    works: ideaWorks(row.global_id),
   };
 }
 
@@ -362,7 +531,7 @@ function rankedIdeas(tokens: Set<string>, semanticIndex: WorkshopSemanticRanking
 function ideaWorks(globalId: string): WritingWorkshopIdeaCandidate['works'] {
   const rows = getDb()
     .prepare(
-      `SELECT w.nodus_id, w.title, w.authors_json, w.year, w.zotero_key
+      `SELECT w.nodus_id, w.title, w.authors_json, w.year, w.zotero_key, w.doi
          FROM idea_occurrences io
          JOIN works w ON w.nodus_id = io.nodus_id
         WHERE io.global_id = ?
@@ -376,6 +545,7 @@ function ideaWorks(globalId: string): WritingWorkshopIdeaCandidate['works'] {
     authors: parseAuthors(row.authors_json),
     year: row.year,
     zotero_key: row.zotero_key,
+    doi: row.doi,
   }));
 }
 
@@ -471,6 +641,21 @@ function rankedGaps(tokens: Set<string>, kind: WritingWorkshopBrief['kind'], sem
     .map(({ item, score, reason }) => ({ ...item, score, reason }));
 }
 
+/** Author-year labels of the works standing behind a dispute, so the writer can say
+ * who holds each side instead of reporting a nameless tension. */
+function debateSources(detail: EdgeDetail): string[] {
+  const ids = [...new Set(detail.evidence.map((e) => e.nodus_id).filter(Boolean))].slice(0, 6);
+  if (ids.length === 0) return [];
+  const rows = getDb()
+    .prepare(`SELECT authors_json, year FROM works WHERE nodus_id IN (${ids.map(() => '?').join(',')})`)
+    .all(...ids) as { authors_json: string; year: number | null }[];
+  const labels = rows.map((row) => {
+    const author = parseAuthors(row.authors_json)[0];
+    return author ? `${author.split(',')[0].trim()}${row.year ? ` (${row.year})` : ''}` : '';
+  });
+  return [...new Set(labels.filter(Boolean))];
+}
+
 function rankedContradictions(tokens: Set<string>, semanticIndex: WorkshopSemanticRanking): WritingWorkshopContradictionCandidate[] {
   return getContradictions()
     .map((detail): Scored<WritingWorkshopContradictionCandidate> => {
@@ -497,6 +682,7 @@ function rankedContradictions(tokens: Set<string>, semanticIndex: WorkshopSemant
           type: detail.edge.type,
           basis: detail.edge.basis,
           confidence: detail.edge.confidence,
+          sources: debateSources(detail),
         },
       };
     })
@@ -508,7 +694,7 @@ function rankedContradictions(tokens: Set<string>, semanticIndex: WorkshopSemant
 function rankedWorks(tokens: Set<string>, semanticIndex: WorkshopSemanticRanking): WritingWorkshopWorkCandidate[] {
   const rows = getDb()
     .prepare(
-      `SELECT w.nodus_id, w.zotero_key, w.title, w.authors_json, w.year, w.deep_status,
+      `SELECT w.nodus_id, w.zotero_key, w.title, w.authors_json, w.year, w.deep_status, w.doi,
               CASE WHEN w.summary_status = 'done' THEN ws.summary ELSE NULL END AS orientation_summary,
               COALESCE(GROUP_CONCAT(DISTINCT t.label), '') AS themes,
               COUNT(DISTINCT io.global_id) AS idea_count,
@@ -545,6 +731,7 @@ function rankedWorks(tokens: Set<string>, semanticIndex: WorkshopSemanticRanking
           authors: parseAuthors(row.authors_json),
           year: row.year,
           zotero_key: row.zotero_key,
+          doi: row.doi,
           themes,
           deepStatus: row.deep_status,
           orientationSummary: row.orientation_summary,

--- a/electron/export/writingWorkshopExport.ts
+++ b/electron/export/writingWorkshopExport.ts
@@ -9,6 +9,7 @@ import type {
   WritingWorkshopExportRequest,
   WritingWorkshopMatrixRow,
 } from '@shared/types';
+import { stripLeadingAbstract } from '@shared/writingDocument';
 import { markdownToPdf } from './markdownRender';
 import { getDecorativeImage, getDecorativeImageData } from '../db/decorativeImagesRepo';
 import {
@@ -215,18 +216,6 @@ function localizedDate(iso: string, language: PromptLanguage): string {
   }
 }
 
-function stripLeadingAbstract(markdown: string, abstract: string): string {
-  const lines = markdown.replace(/\r\n?/g, '\n').split('\n');
-  const first = lines.findIndex((line) => line.trim().length > 0);
-  if (first < 0 || !/^#{1,3}\s+/.test(lines[first])) return markdown;
-  let next = first + 1;
-  while (next < lines.length && !/^#{1,3}\s+/.test(lines[next])) next++;
-  const block = lines.slice(first + 1, next).join(' ').replace(/\s+/g, ' ').trim();
-  const expected = abstract.replace(/\s+/g, ' ').trim();
-  if (!expected || !block || !block.includes(expected.slice(0, Math.min(80, expected.length)))) return markdown;
-  return lines.slice(next).join('\n').trim();
-}
-
 function matrixHtml(rows: WritingWorkshopMatrixRow[], labels: DeepReportLabels): string {
   if (!rows.length) return '';
   const head = `<colgroup><col style="width:20mm" /><col /><col style="width:26mm" /><col /><col style="width:26mm" /></colgroup>
@@ -354,19 +343,15 @@ function renderDraftMarkdown(draft: WritingWorkshopDraft): string {
       '',
     ]),
     '## Borrador',
-    draft.draftMarkdown,
+    // The body already opens with the abstract and closes with its limitations and
+    // references, so those are rendered once — here from the body, not twice.
+    stripLeadingAbstract(draft.draftMarkdown, draft.abstract),
     '',
     '## Matriz de apoyo',
     matrixTable(draft.matrix),
     '',
-    '## Bibliografia sugerida',
-    ...(draft.bibliography.length ? draft.bibliography.map((item) => `- ${item}`) : ['- Sin bibliografia generada.']),
-    '',
     '## Siguientes pasos',
     ...(draft.nextSteps.length ? draft.nextSteps.map((item) => `- ${item}`) : ['- Revisar el borrador.']),
-    '',
-    '## Limitaciones',
-    ...(draft.limitations.length ? draft.limitations.map((item) => `- ${item}`) : ['- Sin limitaciones declaradas.']),
     '',
   ];
   return parts.join('\n');

--- a/scripts/analyze-deep-research-structure.mjs
+++ b/scripts/analyze-deep-research-structure.mjs
@@ -1,0 +1,98 @@
+// Structural analysis of a generated Deep Research report.
+//
+// Answers the questions a page count cannot: does each section develop NEW material
+// or re-tread the previous one, do the ideas inside a section share a theme, and how
+// close does the writer get to the length it was asked for. Reads saved runs only —
+// no model calls, no writes.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const [dir, dbPath] = process.argv.slice(2);
+if (!dir || !dbPath) throw new Error('Usage: analyze-deep-research-structure.mjs <ab-dir> <vault.sqlite>');
+
+const db = new (require('better-sqlite3'))(dbPath, { readonly: true });
+const themesOf = db.prepare(
+  `SELECT COALESCE(GROUP_CONCAT(DISTINCT t.label), '') AS themes
+     FROM idea_theme_links itl JOIN themes t ON t.theme_id = itl.theme_id
+    WHERE itl.global_id = ?`
+);
+
+const CITATION = /\[[^\]]*\]\(nodus:\/\/(idea|passage|gap|contradiction|work)\/([^)]+)\)/g;
+
+function analyze(label) {
+  const { report } = JSON.parse(readFileSync(path.join(dir, `${label}.json`), 'utf8'));
+  const md = report.draft.draftMarkdown;
+  // Body sections only: drop the abstract, limitations and references blocks.
+  const blocks = md
+    .split(/^##\s+/mu)
+    .slice(1)
+    .map((block) => {
+      const nl = block.indexOf('\n');
+      return { title: block.slice(0, nl).trim(), text: block.slice(nl + 1) };
+    })
+    .filter((b) => !/^(Resumen|Abstract|Limitaciones|Limitations|Referencias|References)$/i.test(b.title));
+
+  const seen = new Set();
+  const rows = blocks.map((block) => {
+    const ideas = new Set();
+    const kinds = { passage: 0, gap: 0, contradiction: 0 };
+    for (const m of block.text.matchAll(CITATION)) {
+      const id = decodeURIComponent(m[2]);
+      if (m[1] === 'idea') ideas.add(id);
+      else if (m[1] in kinds) kinds[m[1]] += 1;
+    }
+    const fresh = [...ideas].filter((id) => !seen.has(id));
+    ideas.forEach((id) => seen.add(id));
+
+    // Theme concentration: share of the section's ideas that sit under its single
+    // most common theme. High = the section is about one thing.
+    const counts = new Map();
+    for (const id of ideas) {
+      for (const theme of (themesOf.get(id)?.themes ?? '').split(',').filter(Boolean)) {
+        counts.set(theme, (counts.get(theme) ?? 0) + 1);
+      }
+    }
+    const top = [...counts.entries()].sort((a, b) => b[1] - a[1])[0];
+    const words = block.text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/[#*_`>|-]/g, ' ')
+      .split(/\s+/)
+      .filter(Boolean).length;
+
+    return {
+      title: block.title.slice(0, 46),
+      words,
+      ideas: ideas.size,
+      freshShare: ideas.size ? Number((fresh.length / ideas.size).toFixed(2)) : 0,
+      topTheme: top ? `${top[0].slice(0, 22)} ${Math.round((top[1] / ideas.size) * 100)}%` : '—',
+      passages: kinds.passage,
+      gapsAndTensions: kinds.gap + kinds.contradiction,
+    };
+  });
+
+  return { label, rows, meta: report.meta };
+}
+
+for (const label of ['before', 'after']) {
+  const { rows, meta } = analyze(label);
+  const target = Math.min(1800, Math.max(800, Math.round((meta.targetPages.max * 450) / rows.length)));
+  console.log(`\n═══ ${label.toUpperCase()} — objetivo por sección ≈ ${target} palabras`);
+  console.log('sección'.padEnd(48) + 'palab'.padEnd(8) + '%obj'.padEnd(7) + 'ideas'.padEnd(7) + 'nuevas'.padEnd(8) + 'tema dominante'.padEnd(28) + 'pasajes  tensiones');
+  for (const r of rows) {
+    console.log(
+      r.title.padEnd(48) +
+        String(r.words).padEnd(8) +
+        `${Math.round((r.words / target) * 100)}%`.padEnd(7) +
+        String(r.ideas).padEnd(7) +
+        `${Math.round(r.freshShare * 100)}%`.padEnd(8) +
+        r.topTheme.padEnd(28) +
+        String(r.passages).padEnd(9) +
+        r.gapsAndTensions
+    );
+  }
+  const totalWords = rows.reduce((n, r) => n + r.words, 0);
+  console.log(`→ ${rows.length} secciones · ${totalWords} palabras · ${Math.round((totalWords / (target * rows.length)) * 100)}% de la extensión pedida`);
+}
+db.close();

--- a/scripts/batch-deep-research.mjs
+++ b/scripts/batch-deep-research.mjs
@@ -90,12 +90,27 @@ try {
   delete process.env.GEMINI_API_KEY;
   delete process.env.OPENROUTER_API_KEY;
 
-  const wanted = argOf('--model', 'gemini-3.1-flash-lite');
-  const available = await providers.listModels('gemini', secrets.getApiKey('gemini'));
-  const modelName = available.some((m) => m.id === wanted) ? wanted : available.find((m) => /flash-lite/.test(m.id))?.id;
-  assert.ok(modelName, 'no flash-lite model available');
-  settingsRepo.updateSettings({ deepResearchModel: { provider: 'gemini', model: modelName }, promptLanguage: 'es' });
-  console.log(`[model] ${modelName} · ${TOPICS.length} temas × ${RUNS} ejecuciones = ${TOPICS.length * RUNS} informes\n`);
+  // Codex is a managed subscription: its models come from the CLI runtime, not from
+  // a keyed /models endpoint, and its credentials are bound to this profile's
+  // codexHome — a copied profile reports itself disconnected.
+  const provider = argOf('--provider', 'gemini');
+  let modelName;
+  if (provider === 'codex') {
+    const codex = require(path.join(repoRoot, 'electron/ai/codexSubscription.ts'));
+    const status = await codex.getChatGptSubscriptionStatus(true);
+    assert.ok(status?.connected, 'Connect a ChatGPT subscription in this profile before running with --provider codex');
+    const wanted = argOf('--model', 'gpt-5.6-luna');
+    const available = await codex.listChatGptSubscriptionModels();
+    modelName = available.some((m) => (m.id ?? m) === wanted) ? wanted : (available[0]?.id ?? available[0]);
+    assert.ok(modelName, 'no Codex model available');
+  } else {
+    const wanted = argOf('--model', 'gemini-3.1-flash-lite');
+    const available = await providers.listModels('gemini', secrets.getApiKey('gemini'));
+    modelName = available.some((m) => m.id === wanted) ? wanted : available.find((m) => /flash-lite/.test(m.id))?.id;
+    assert.ok(modelName, 'no flash-lite model available');
+  }
+  settingsRepo.updateSettings({ deepResearchModel: { provider, model: modelName }, promptLanguage: 'es' });
+  console.log(`[model] ${provider}/${modelName} · ${TOPICS.length} temas × ${RUNS} ejecuciones = ${TOPICS.length * RUNS} informes\n`);
 
   const workshop = require(path.join(repoRoot, 'electron/ai/writingWorkshop.ts'));
   const { generateDeepResearchReport } = require(path.join(repoRoot, 'electron/ai/deepResearch.ts'));

--- a/scripts/batch-deep-research.mjs
+++ b/scripts/batch-deep-research.mjs
@@ -1,0 +1,211 @@
+// Generates N Deep Research reports across several objectives against one frozen
+// corpus snapshot, so the engine's behaviour can be judged on its distribution
+// rather than on a single lucky run.
+//
+//   electron scripts/with-nodus-keys.cjs --providers gemini,openrouter -- \
+//     node scripts/batch-deep-research.mjs --runs 5 --out DIR --snapshot DIR
+//
+// Each report is written as <topic>-<n>.json/.md. Failures are recorded and the
+// batch continues: one bad run must not cost the other fourteen.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const FLAG = '--electron-batch-deep-research';
+const argOf = (name, fallback) => {
+  const at = process.argv.indexOf(name);
+  return at >= 0 && process.argv[at + 1] ? process.argv[at + 1] : fallback;
+};
+
+const RUNS = Number(argOf('--runs', '5'));
+const outDir = path.resolve(argOf('--out', path.join(os.tmpdir(), 'nodus-dr-batch')));
+const snapshotDir = path.resolve(argOf('--snapshot', path.join(os.tmpdir(), 'nodus-dr-userdata')));
+const sourceDb = argOf('--source-db', path.join(os.homedir(), 'Library/Application Support/nodus/nodus.sqlite'));
+
+// Three objectives that stress different parts of the corpus: a broad synthesis,
+// a narrow visual-culture question, and one aimed squarely at disagreement.
+const TOPICS = [
+  {
+    key: 'identidad',
+    objective:
+      'Analiza cómo el turismo y la literatura de viajes contribuyeron a construir la identidad nacional y regional española durante el franquismo, atendiendo a la cultura visual, la fotografía y los usos propagandísticos del patrimonio.',
+  },
+  {
+    key: 'fotografia',
+    objective:
+      'Examina el papel de la fotografía y la cultura visual en la representación del paisaje y el patrimonio españoles, discutiendo qué convierte una imagen en documento histórico y qué la convierte en propaganda.',
+  },
+  {
+    key: 'genero',
+    objective:
+      'Discute cómo se han estudiado el género y la mirada colonial en el turismo y la literatura de viajes sobre España, contrastando las posiciones historiográficas en disputa y señalando qué preguntas siguen abiertas.',
+  },
+];
+
+if (!process.argv.includes(FLAG)) {
+  if (!process.env.GEMINI_API_KEY?.trim()) throw new Error('Set GEMINI_API_KEY for this isolated run.');
+  execFileSync(path.join(repoRoot, 'node_modules/.bin/electron'), [...process.argv.slice(1), FLAG], {
+    cwd: repoRoot,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  process.exit(0);
+}
+
+const apiKey = process.env.GEMINI_API_KEY?.trim();
+const openRouterKey = process.env.OPENROUTER_API_KEY?.trim() || null;
+assert.ok(apiKey, 'Gemini key reaches only the isolated child process.');
+
+fs.mkdirSync(snapshotDir, { recursive: true });
+fs.mkdirSync(outDir, { recursive: true });
+const snapshotDb = path.join(snapshotDir, 'nodus.sqlite');
+if (!fs.existsSync(snapshotDb)) {
+  const Database = require('better-sqlite3');
+  const source = new Database(sourceDb, { readonly: true, fileMustExist: true });
+  source.prepare('VACUUM INTO ?').run(snapshotDb);
+  source.close();
+  console.log(`[snapshot] built → ${snapshotDb}`);
+}
+
+installRuntimeHooks(snapshotDir);
+
+let closeDb = () => undefined;
+try {
+  const vaults = require(path.join(repoRoot, 'electron/vaults/vaultRegistry.ts'));
+  assert.equal(vaults.getActiveVault().type, 'academic', 'the batch must run the academic pipeline');
+  const secrets = require(path.join(repoRoot, 'electron/secrets/secretStore.ts'));
+  const settingsRepo = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
+  const providers = require(path.join(repoRoot, 'electron/ai/providers.ts'));
+  ({ closeDb } = require(path.join(repoRoot, 'electron/db/database.ts')));
+
+  secrets.setApiKey('gemini', apiKey);
+  if (openRouterKey) secrets.setApiKey('openrouter', openRouterKey);
+  delete process.env.GEMINI_API_KEY;
+  delete process.env.OPENROUTER_API_KEY;
+
+  const wanted = argOf('--model', 'gemini-3.1-flash-lite');
+  const available = await providers.listModels('gemini', secrets.getApiKey('gemini'));
+  const modelName = available.some((m) => m.id === wanted) ? wanted : available.find((m) => /flash-lite/.test(m.id))?.id;
+  assert.ok(modelName, 'no flash-lite model available');
+  settingsRepo.updateSettings({ deepResearchModel: { provider: 'gemini', model: modelName }, promptLanguage: 'es' });
+  console.log(`[model] ${modelName} · ${TOPICS.length} temas × ${RUNS} ejecuciones = ${TOPICS.length * RUNS} informes\n`);
+
+  const workshop = require(path.join(repoRoot, 'electron/ai/writingWorkshop.ts'));
+  const { generateDeepResearchReport } = require(path.join(repoRoot, 'electron/ai/deepResearch.ts'));
+
+  const failures = [];
+  for (const topic of TOPICS) {
+    for (let run = 1; run <= RUNS; run++) {
+      const label = `${topic.key}-${run}`;
+      const target = path.join(outDir, `${label}.json`);
+      if (fs.existsSync(target)) {
+        console.log(`· ${label} ya existe, se omite`);
+        continue;
+      }
+      // Instrument from outside: the product code never knows it is measured.
+      const probe = { retrievals: 0, expansions: 0 };
+      const originalRetrieve = workshop.retrieveSectionMaterial;
+      workshop.retrieveSectionMaterial = async (input) => {
+        probe.retrievals += 1;
+        return originalRetrieve(input);
+      };
+      const startedAt = Date.now();
+      const phases = [];
+      try {
+        const report = await generateDeepResearchReport(
+          { objective: topic.objective, language: 'es', targetLength: 'standard', audience: 'comunidad académica' },
+          (p) => phases.push(p.phase)
+        );
+        fs.writeFileSync(
+          target,
+          JSON.stringify(
+            {
+              metrics: {
+                label,
+                topic: topic.key,
+                run,
+                model: modelName,
+                objective: topic.objective,
+                elapsedSeconds: Math.round((Date.now() - startedAt) / 1000),
+                phases,
+                probe,
+              },
+              report,
+            },
+            null,
+            2
+          )
+        );
+        fs.writeFileSync(path.join(outDir, `${label}.md`), `# ${report.draft.title}\n\n${report.draft.draftMarkdown}\n`);
+        console.log(
+          `✓ ${label.padEnd(14)} ${String(report.meta.pages).padStart(2)} pág · ${String(report.meta.words).padStart(5)} pal · ` +
+            `${String(report.meta.ideasCovered).padStart(3)} ideas · ${String(report.meta.worksCited).padStart(3)} obras · ` +
+            `${Math.round((Date.now() - startedAt) / 1000)}s`
+        );
+      } catch (error) {
+        failures.push({ label, message: error instanceof Error ? error.message : String(error) });
+        console.log(`✗ ${label}: ${error instanceof Error ? error.message : error}`);
+      } finally {
+        workshop.retrieveSectionMaterial = originalRetrieve;
+      }
+    }
+  }
+  console.log(`\n[batch] fallos: ${failures.length}`);
+  for (const f of failures) console.log(`  ${f.label}: ${f.message}`);
+} finally {
+  try {
+    closeDb();
+  } catch {
+    /* best effort */
+  }
+}
+
+function installRuntimeHooks(userDataPath) {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  const originalLoad = Module._load;
+  const electronStub = {
+    app: { getPath: () => userDataPath, getVersion: () => '0.0.0-dr-batch', getAppPath: () => repoRoot, isPackaged: false, getName: () => 'Nodus' },
+    safeStorage: {
+      isEncryptionAvailable: () => false,
+      encryptString: (v) => Buffer.from(String(v)),
+      decryptString: (v) => Buffer.from(v).toString(),
+    },
+    dialog: { showMessageBoxSync: () => 1 },
+    shell: {},
+    BrowserWindow: class {},
+    ipcMain: { handle: () => undefined, on: () => undefined },
+    net: {},
+  };
+  Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') return electronStub;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  require.extensions['.ts'] = function (module, filename) {
+    const output = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}

--- a/scripts/compare-deep-research-ab.mjs
+++ b/scripts/compare-deep-research-ab.mjs
@@ -1,0 +1,111 @@
+// Re-measures two saved Deep Research runs with one identical yardstick.
+//
+// The per-run metrics are written by the harness at generation time; this reads the
+// stored reports back and derives the comparison numbers offline, so the two sides
+// are always measured by the same code even when they were generated hours apart.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const dir = process.argv[2];
+if (!dir) throw new Error('Usage: node scripts/compare-deep-research-ab.mjs <dir-with-before.json-and-after.json>');
+
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'nodus-dr-compare-'));
+try {
+  const outfile = path.join(tmp, 'writingDocument.mjs');
+  await build({
+    entryPoints: [path.join(repoRoot, 'shared/writingDocument.ts')],
+    outfile,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    logLevel: 'silent',
+  });
+  const { documentBodyForPanels } = await import(pathToFileURL(outfile).href);
+
+  const CITATION = /\[([^\]]*)\]\(nodus:\/\/(idea|work|passage|gap|contradiction)\/([^)]+)\)/g;
+  const HEADING = /^##\s+(.+)$/gmu;
+
+  const measure = (file) => {
+    const { metrics, report } = JSON.parse(readFileSync(file, 'utf8'));
+    const md = report.draft.draftMarkdown ?? '';
+    // Prose = what the reader actually reads: body only, no reference list, no
+    // limitation bullets. Counting the bibliography made a longer report look shorter.
+    const body = documentBodyForPanels(md, report.draft.abstract ?? '')
+      .split(/^##\s+(?:Referencias|References|Références|Literaturverzeichnis|Kaynakça|Bibliografia|Referências)\s*$/mu)[0];
+    const words = body
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/[#*_`>|-]/g, ' ')
+      .split(/\s+/)
+      .filter(Boolean).length;
+
+    const cited = { idea: new Set(), work: new Set(), passage: new Set(), gap: new Set(), contradiction: new Set() };
+    let total = 0;
+    for (const m of md.matchAll(CITATION)) {
+      cited[m[2]].add(decodeURIComponent(m[3]));
+      total += 1;
+    }
+    const abstract = (report.draft.abstract ?? '').trim();
+    return {
+      label: metrics.label,
+      sections: report.meta.sections,
+      bodyWords: report.meta.words,
+      bodyPages: report.meta.pages,
+      targetPages: `${report.meta.targetPages.min}–${report.meta.targetPages.max}`,
+      insideTarget: report.meta.pages >= report.meta.targetPages.min && report.meta.pages <= report.meta.targetPages.max,
+      readerWords: words,
+      headings: [...body.matchAll(HEADING)].map((m) => m[1]),
+      citationsTotal: total,
+      wordsPerCitation: total > 0 ? Math.round(words / total) : null,
+      ideasClaimed: report.meta.ideasCovered,
+      ideasCited: cited.idea.size,
+      coverageHonesty: report.meta.ideasCovered > 0 ? Number((cited.idea.size / report.meta.ideasCovered).toFixed(3)) : null,
+      passagesCited: cited.passage.size,
+      gapsCited: cited.gap.size,
+      contradictionsCited: cited.contradiction.size,
+      worksCited: report.meta.worksCited,
+      topUpRan: metrics.coverageTopUpRan,
+      sectionRetrieval: metrics.sectionRetrieval ?? { available: false },
+      limitations: report.draft.limitations.length,
+      // What the reader sees once the surfaces stop repeating the structured fields.
+      abstractRepeatedInReaderBody: abstract.length > 0 && documentBodyForPanels(md, abstract).includes(abstract),
+      limitationsRepeatedInReaderBody: /^##\s+(Limitaciones|Limitations)/mu.test(documentBodyForPanels(md, abstract)),
+    };
+  };
+
+  const before = measure(path.join(dir, 'before.json'));
+  const after = measure(path.join(dir, 'after.json'));
+  const rows = [
+    ['secciones', before.sections, after.sections],
+    ['palabras del cuerpo', before.bodyWords, after.bodyWords],
+    ['páginas del cuerpo', `${before.bodyPages} (objetivo ${before.targetPages})`, `${after.bodyPages} (objetivo ${after.targetPages})`],
+    ['dentro del objetivo', before.insideTarget, after.insideTarget],
+    ['citas totales', before.citationsTotal, after.citationsTotal],
+    ['palabras por cita', before.wordsPerCitation, after.wordsPerCitation],
+    ['ideas declaradas cubiertas', before.ideasClaimed, after.ideasClaimed],
+    ['ideas realmente citadas', before.ideasCited, after.ideasCited],
+    ['honestidad de la cobertura', before.coverageHonesty, after.coverageHonesty],
+    ['pasajes literales citados', before.passagesCited, after.passagesCited],
+    ['huecos citados', before.gapsCited, after.gapsCited],
+    ['contradicciones citadas', before.contradictionsCited, after.contradictionsCited],
+    ['obras en la bibliografía', before.worksCited, after.worksCited],
+    ['rescate de cobertura', before.topUpRan, after.topUpRan],
+    ['consultas por sección', before.sectionRetrieval.calls ?? 0, after.sectionRetrieval.calls ?? 0],
+    ['pasajes recuperados al redactar', before.sectionRetrieval.passages ?? 0, after.sectionRetrieval.passages ?? 0],
+    ['limitaciones declaradas', before.limitations, after.limitations],
+    ['resumen repetido en el lector', before.abstractRepeatedInReaderBody, after.abstractRepeatedInReaderBody],
+    ['limitaciones repetidas en el lector', before.limitationsRepeatedInReaderBody, after.limitationsRepeatedInReaderBody],
+  ];
+  const pad = (v, n) => String(v).padEnd(n);
+  console.log(`${pad('métrica', 36)}${pad('antes', 22)}después`);
+  console.log('-'.repeat(78));
+  for (const [name, b, a] of rows) console.log(`${pad(name, 36)}${pad(b, 22)}${a}`);
+  console.log('\nEpígrafes antes:  ', before.headings.join(' · '));
+  console.log('Epígrafes después:', after.headings.join(' · '));
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/scripts/judge-deep-research.mjs
+++ b/scripts/judge-deep-research.mjs
@@ -1,0 +1,221 @@
+// Blind pairwise comparison of two Deep Research variants.
+//
+// Without this, every claim that a change "improved the argument" is my opinion.
+// Reports are stripped of anything identifying their variant, shown to a judge as
+// "Informe 1" and "Informe 2", and every pair is judged TWICE with the order
+// swapped. A win counts only when both orderings agree; disagreement is a tie, which
+// is the honest reading of a judge that just prefers whichever came first.
+//
+//   electron scripts/with-nodus-keys.cjs --providers gemini -- \
+//     node scripts/judge-deep-research.mjs --a DIR_A --b DIR_B [--label-a antes --label-b después]
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const FLAG = '--electron-judge-dr';
+const argOf = (name, fallback) => {
+  const at = process.argv.indexOf(name);
+  return at >= 0 && process.argv[at + 1] ? process.argv[at + 1] : fallback;
+};
+const dirA = path.resolve(argOf('--a', ''));
+const dirB = path.resolve(argOf('--b', ''));
+const labelA = argOf('--label-a', 'A');
+const labelB = argOf('--label-b', 'B');
+const snapshotDir = path.resolve(argOf('--snapshot', path.join(os.tmpdir(), 'nodus-dr-userdata')));
+const MAX_WORDS = Number(argOf('--max-words', '5200'));
+
+const DIMENSIONS = [
+  { key: 'continuidad', question: 'Continuidad argumental: ¿cuál se lee como un razonamiento que progresa, donde cada sección se apoya en la anterior, en lugar de como una lista de temas yuxtapuestos?' },
+  { key: 'respaldo', question: 'Respaldo de las afirmaciones: ¿en cuál las afirmaciones sustantivas van acompañadas de una fuente concreta y pertinente, en lugar de afirmarse sin apoyo o con apoyo genérico?' },
+  { key: 'riqueza', question: 'Riqueza de fuentes: ¿cuál se apoya en una variedad real de autores y obras, en lugar de descansar una y otra vez en los mismos?' },
+  { key: 'debate', question: 'Tratamiento del desacuerdo: ¿cuál expone debates y huecos de investigación explicando su contenido, en lugar de mencionarlos de pasada o ignorarlos?' },
+  { key: 'utilidad', question: 'Utilidad para un investigador: ¿cuál usarías antes como punto de partida para escribir un capítulo académico?' },
+];
+
+if (!process.argv.includes(FLAG)) {
+  if (!process.env.GEMINI_API_KEY?.trim()) throw new Error('Set GEMINI_API_KEY for this isolated run.');
+  execFileSync(path.join(repoRoot, 'node_modules/.bin/electron'), [...process.argv.slice(1), FLAG], {
+    cwd: repoRoot,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  process.exit(0);
+}
+
+assert.ok(dirA && dirB, 'Usage: --a DIR_A --b DIR_B');
+const apiKey = process.env.GEMINI_API_KEY?.trim();
+assert.ok(apiKey, 'Gemini key reaches only the isolated child process.');
+installRuntimeHooks(snapshotDir);
+
+let closeDb = () => undefined;
+try {
+  const secrets = require(path.join(repoRoot, 'electron/secrets/secretStore.ts'));
+  const settingsRepo = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
+  const { completeJson } = require(path.join(repoRoot, 'electron/ai/aiClient.ts'));
+  ({ closeDb } = require(path.join(repoRoot, 'electron/db/database.ts')));
+  secrets.setApiKey('gemini', apiKey);
+  delete process.env.GEMINI_API_KEY;
+  const modelName = argOf('--model', 'gemini-3.1-flash-lite');
+  settingsRepo.updateSettings({ deepResearchModel: { provider: 'gemini', model: modelName }, promptLanguage: 'es' });
+  const model = { provider: 'gemini', model: modelName };
+
+  const pairs = buildPairs(dirA, dirB);
+  assert.ok(pairs.length > 0, 'no comparable reports (topics must match between the two directories)');
+  console.log(`[juez] ${pairs.length} pares comparables · ${DIMENSIONS.length} dimensiones · 2 órdenes cada uno\n`);
+
+  const system = [
+    'Eres un investigador académico experimentado que compara dos informes sobre el mismo tema.',
+    'No sabes quién los ha escrito ni con qué herramienta. Júzgalos solo por lo que dicen.',
+    'Para cada criterio elige 1 o 2. Si de verdad son equivalentes puedes responder 0, pero evita el empate cómodo: si uno es mejor, dilo.',
+    'Ignora la longitud como mérito en sí: un informe más largo no es mejor por serlo.',
+    'Devuelve SOLO JSON válido: {"criterios":[{"clave":"continuidad","ganador":1,"motivo":"..."}]} con una entrada por criterio.',
+  ].join('\n');
+
+  const tally = new Map(DIMENSIONS.map((d) => [d.key, { a: 0, b: 0, tie: 0 }]));
+  const notes = [];
+
+  for (const pair of pairs) {
+    // Same pair, both orders. Only an agreement between the two counts as a win.
+    const forward = await ask(completeJson, system, model, pair.textA, pair.textB);
+    const reverse = await ask(completeJson, system, model, pair.textB, pair.textA);
+    for (const dimension of DIMENSIONS) {
+      const first = forward.get(dimension.key);
+      const second = reverse.get(dimension.key);
+      const row = tally.get(dimension.key);
+      // In the reverse run, "1" means B.
+      const winnerForward = first === 1 ? 'a' : first === 2 ? 'b' : null;
+      const winnerReverse = second === 1 ? 'b' : second === 2 ? 'a' : null;
+      if (winnerForward && winnerForward === winnerReverse) row[winnerForward] += 1;
+      else row.tie += 1;
+    }
+    const reason = forward.reasons.get('utilidad');
+    if (reason) notes.push(`${pair.topic}: ${reason}`);
+    console.log(`· ${pair.topic} juzgado`);
+  }
+
+  console.log(`\n═══ Juicio ciego · ${labelA} vs ${labelB} ═══`);
+  console.log('criterio'.padEnd(16) + labelA.padEnd(10) + labelB.padEnd(10) + 'empate');
+  console.log('─'.repeat(46));
+  for (const dimension of DIMENSIONS) {
+    const row = tally.get(dimension.key);
+    console.log(dimension.key.padEnd(16) + String(row.a).padEnd(10) + String(row.b).padEnd(10) + row.tie);
+  }
+  console.log(`\n(un criterio solo se anota cuando el juez coincide en los dos órdenes; si no, cuenta como empate)`);
+  if (notes.length) {
+    console.log('\nMotivos citados en "utilidad":');
+    for (const note of notes.slice(0, 5)) console.log(`  · ${note.slice(0, 220)}`);
+  }
+} finally {
+  try {
+    closeDb();
+  } catch {
+    /* best effort */
+  }
+}
+
+async function ask(completeJson, system, model, first, second) {
+  const user = [
+    '### Informe 1', first, '', '### Informe 2', second, '',
+    'Criterios:',
+    ...DIMENSIONS.map((d) => `- ${d.key}: ${d.question}`),
+  ].join('\n');
+  const chosen = new Map();
+  const reasons = new Map();
+  try {
+    const ai = await completeJson(
+      { system, user, temperature: 0, maxTokens: 1600 },
+      (v) => typeof v === 'object' && v !== null && Array.isArray(v.criterios),
+      model
+    );
+    for (const entry of ai.criterios ?? []) {
+      if (typeof entry?.clave !== 'string') continue;
+      chosen.set(entry.clave, Number(entry.ganador));
+      if (typeof entry.motivo === 'string') reasons.set(entry.clave, entry.motivo);
+    }
+  } catch {
+    /* an unreadable judgement counts as a tie */
+  }
+  chosen.reasons = reasons;
+  return Object.assign(chosen, { reasons });
+}
+
+/** Pair reports by topic, anonymised and trimmed so neither side is identifiable. */
+function buildPairs(a, b) {
+  const load = (dir) => {
+    const map = new Map();
+    for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.json'))) {
+      const { metrics, report } = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+      const topic = metrics.topic ?? metrics.label;
+      if (!map.has(topic)) map.set(topic, anonymise(report));
+    }
+    return map;
+  };
+  const left = load(a);
+  const right = load(b);
+  const pairs = [];
+  for (const [topic, textA] of left) {
+    const textB = right.get(topic);
+    if (textB) pairs.push({ topic, textA, textB });
+  }
+  return pairs;
+}
+
+/**
+ * Strip everything that could identify which engine wrote a report: the `nodus://`
+ * link syntax (kept as plain author-year so the judge can still see whether a claim
+ * is sourced), the limitations block, and any trailing reference list.
+ */
+function anonymise(report) {
+  const body = (report.draft.draftMarkdown ?? '')
+    .split(/^##\s+(?:Referencias|References)\s*$/mu)[0]
+    .replace(/^##\s+(?:Limitaciones|Limitations)[\s\S]*$/mu, '')
+    .replace(/\[([^\]]*)\]\(nodus:\/\/[^)]*\)/g, '$1');
+  const words = body.split(/\s+/);
+  return words.length > MAX_WORDS ? `${words.slice(0, MAX_WORDS).join(' ')}\n\n[…]` : body;
+}
+
+function installRuntimeHooks(userDataPath) {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  const originalLoad = Module._load;
+  const electronStub = {
+    app: { getPath: () => userDataPath, getVersion: () => '0.0.0-dr-judge', getAppPath: () => repoRoot, isPackaged: false, getName: () => 'Nodus' },
+    safeStorage: { isEncryptionAvailable: () => false, encryptString: (v) => Buffer.from(String(v)), decryptString: (v) => Buffer.from(v).toString() },
+    dialog: { showMessageBoxSync: () => 1 },
+    shell: {},
+    BrowserWindow: class {},
+    ipcMain: { handle: () => undefined, on: () => undefined },
+    net: {},
+  };
+  Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') return electronStub;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  require.extensions['.ts'] = function (module, filename) {
+    const output = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}

--- a/scripts/measure-retrieval-breadth.mjs
+++ b/scripts/measure-retrieval-breadth.mjs
@@ -1,0 +1,102 @@
+// Measures what a multi-probe snapshot reaches that a single probe does not.
+//
+// The report is built from whatever the semantic search returns, so the width of
+// that search is a hard ceiling on the report. This compares the pool obtained from
+// the objective alone against the pool obtained by also probing each sub-question,
+// over the real corpus.
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const FLAG = '--electron-breadth';
+const argOf = (n, d) => { const at = process.argv.indexOf(n); return at >= 0 && process.argv[at + 1] ? process.argv[at + 1] : d; };
+const snapshotDir = path.resolve(argOf('--snapshot', path.join(os.tmpdir(), 'nodus-dr-userdata')));
+
+const OBJECTIVES = [
+  'Analiza cómo el turismo y la literatura de viajes contribuyeron a construir la identidad nacional y regional española durante el franquismo, atendiendo a la cultura visual, la fotografía y los usos propagandísticos del patrimonio.',
+  'Examina el papel de la fotografía y la cultura visual en la representación del paisaje y el patrimonio españoles, discutiendo qué convierte una imagen en documento histórico y qué la convierte en propaganda.',
+  'Discute cómo se han estudiado el género y la mirada colonial en el turismo y la literatura de viajes sobre España, contrastando las posiciones historiográficas en disputa y señalando qué preguntas siguen abiertas.',
+];
+
+if (!process.argv.includes(FLAG)) {
+  if (!process.env.GEMINI_API_KEY?.trim()) throw new Error('Set GEMINI_API_KEY for this isolated run.');
+  execFileSync(path.join(repoRoot, 'node_modules/.bin/electron'), [...process.argv.slice(1), FLAG], {
+    cwd: repoRoot, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, stdio: 'inherit', maxBuffer: 64 * 1024 * 1024,
+  });
+  process.exit(0);
+}
+
+const apiKey = process.env.GEMINI_API_KEY?.trim();
+const openRouterKey = process.env.OPENROUTER_API_KEY?.trim() || null;
+installRuntimeHooks(snapshotDir);
+let closeDb = () => undefined;
+try {
+  const secrets = require(path.join(repoRoot, 'electron/secrets/secretStore.ts'));
+  const settingsRepo = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
+  const workshop = require(path.join(repoRoot, 'electron/ai/writingWorkshop.ts'));
+  const deepResearch = require(path.join(repoRoot, 'electron/ai/deepResearch.ts'));
+  ({ closeDb } = require(path.join(repoRoot, 'electron/db/database.ts')));
+  secrets.setApiKey('gemini', apiKey);
+  if (openRouterKey) secrets.setApiKey('openrouter', openRouterKey);
+  delete process.env.GEMINI_API_KEY;
+  const modelName = argOf('--model', 'gemini-3.1-flash-lite');
+  settingsRepo.updateSettings({ deepResearchModel: { provider: 'gemini', model: modelName }, promptLanguage: 'es' });
+  const model = { provider: 'gemini', model: modelName };
+
+  const worksOf = (snapshot) => {
+    const set = new Set();
+    for (const idea of snapshot.ideas) for (const w of idea.works ?? []) set.add(w.nodus_id);
+    return set;
+  };
+
+  const pad = (v, n) => String(v).padEnd(n);
+  console.log(pad('objetivo', 14) + pad('sondas', 8) + pad('ideas 1', 9) + pad('ideas N', 9) + pad('nuevas', 8) + pad('obras 1', 9) + pad('obras N', 9) + pad('pasajes 1', 11) + 'pasajes N');
+  console.log('─'.repeat(92));
+  for (const [index, objective] of OBJECTIVES.entries()) {
+    const brief = { kind: 'deep_research', objective, tone: 'academic', language: 'es' };
+    const single = await workshop.buildWritingWorkshopSnapshot(brief);
+    const probes = await deepResearch.__decomposeObjectiveForTesting(objective, 'es', model);
+    const multi = await workshop.buildWritingWorkshopSnapshot(brief, probes);
+
+    const singleIdeas = new Set(single.ideas.map((i) => i.id));
+    const fresh = multi.ideas.filter((i) => !singleIdeas.has(i.id)).length;
+    console.log(
+      pad(`obj-${index + 1}`, 14) + pad(probes.length, 8) + pad(single.ideas.length, 9) + pad(multi.ideas.length, 9) +
+        pad(`${fresh} (${Math.round((fresh / Math.max(1, multi.ideas.length)) * 100)}%)`, 8) +
+        pad(worksOf(single).size, 9) + pad(worksOf(multi).size, 9) +
+        pad(single.passages.length, 11) + multi.passages.length
+    );
+    if (index === 0) for (const p of probes) console.log(`      · ${p.slice(0, 110)}`);
+  }
+} finally {
+  try { closeDb(); } catch { /* best effort */ }
+}
+
+function installRuntimeHooks(userDataPath) {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  const originalLoad = Module._load;
+  const electronStub = {
+    app: { getPath: () => userDataPath, getVersion: () => '0.0.0-breadth', getAppPath: () => repoRoot, isPackaged: false, getName: () => 'Nodus' },
+    safeStorage: { isEncryptionAvailable: () => false, encryptString: (v) => Buffer.from(String(v)), decryptString: (v) => Buffer.from(v).toString() },
+    dialog: { showMessageBoxSync: () => 1 }, shell: {}, BrowserWindow: class {}, ipcMain: { handle: () => undefined, on: () => undefined }, net: {},
+  };
+  Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  Module._load = function (request, parent, isMain) { if (request === 'electron') return electronStub; return originalLoad.call(this, request, parent, isMain); };
+  require.extensions['.ts'] = function (module, filename) {
+    const output = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+      fileName: filename,
+      compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS, moduleResolution: ts.ModuleResolutionKind.NodeJs, esModuleInterop: true, jsx: ts.JsxEmit.ReactJSX, resolveJsonModule: true, skipLibCheck: true },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}

--- a/scripts/report-deep-research-batch.mjs
+++ b/scripts/report-deep-research-batch.mjs
@@ -1,0 +1,175 @@
+// Aggregates a batch of Deep Research reports into the numbers that decide whether
+// the engine is reliably good, not luckily good once.
+//
+//   electron -e … / ELECTRON_RUN_AS_NODE=1 electron scripts/report-deep-research-batch.mjs <batch-dir> <vault.sqlite>
+//
+// Every figure is derived from the saved reports; no model is asked anything.
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const [dir, dbPath] = process.argv.slice(2);
+if (!dir) throw new Error('Usage: report-deep-research-batch.mjs <batch-dir> [vault.sqlite]');
+const db = dbPath ? new (require('better-sqlite3'))(dbPath, { readonly: true }) : null;
+const workOfIdea = db
+  ? db.prepare('SELECT nodus_id FROM idea_occurrences WHERE global_id = ? ORDER BY confidence DESC LIMIT 1')
+  : null;
+
+const LINK = /\[[^\]\n]*\]\(nodus:\/\/(idea|work|passage|gap|contradiction)\/([^)\s]+)\)/g;
+const ANY_REF = /nodus:\/\//g;
+
+function analyze(file) {
+  const { metrics, report } = JSON.parse(readFileSync(file, 'utf8'));
+  const md = report.draft.draftMarkdown ?? '';
+
+  const cited = { idea: new Set(), work: new Set(), passage: new Set(), gap: new Set(), contradiction: new Set() };
+  let total = 0;
+  for (const m of md.matchAll(LINK)) {
+    cited[m[1]].add(decodeURIComponent(m[2]));
+    total += 1;
+  }
+  // Anything matching nodus:// that is NOT inside a well-formed link leaked raw.
+  const broken = (md.match(ANY_REF) ?? []).length - total;
+
+  // Source concentration: the share of idea citations that trace to the single most
+  // used work. High means the report is propped up on one book.
+  const perWork = new Map();
+  if (workOfIdea) {
+    for (const id of cited.idea) {
+      const row = workOfIdea.get(id);
+      if (row?.nodus_id) perWork.set(row.nodus_id, (perWork.get(row.nodus_id) ?? 0) + 1);
+    }
+  }
+  const topWorkShare = perWork.size
+    ? Math.max(...perWork.values()) / [...perWork.values()].reduce((a, b) => a + b, 0)
+    : null;
+
+  const body = md
+    .split(/^##\s+/mu)
+    .slice(1)
+    .map((b) => ({ title: b.slice(0, b.indexOf('\n')).trim(), text: b.slice(b.indexOf('\n') + 1) }))
+    .filter((b) => !/^(Resumen|Abstract|Limitaciones|Limitations|Referencias|References)$/i.test(b.title));
+
+  // A section is "thin" when it carries almost no sourcing of its own.
+  const thinSections = body.filter((b) => (b.text.match(LINK) ?? []).length < 3).length;
+  const colonTitles = body.filter((b) => /[:;—]/.test(b.title)).length;
+
+  return {
+    label: metrics.label,
+    topic: metrics.topic,
+    pages: report.meta.pages,
+    words: report.meta.words,
+    fill: report.meta.words / (report.meta.targetPages.max * 450),
+    inTarget: report.meta.pages >= report.meta.targetPages.min && report.meta.pages <= report.meta.targetPages.max,
+    sections: body.length,
+    thinSections,
+    colonTitles,
+    citations: total,
+    ideas: cited.idea.size,
+    passages: cited.passage.size,
+    gaps: cited.gap.size,
+    debates: cited.contradiction.size,
+    works: report.meta.worksCited,
+    distinctWorksBehindIdeas: perWork.size,
+    topWorkShare,
+    broken,
+    verification: report.meta.verification ?? null,
+    expansions: report.meta.expansions ?? 0,
+    sectionFill: report.meta.sectionFill ?? [],
+    retrievals: metrics.probe?.retrievals ?? 0,
+    seconds: metrics.elapsedSeconds,
+    titles: body.map((b) => b.title),
+  };
+}
+
+const files = readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
+const rows = files.map((f) => analyze(path.join(dir, f)));
+if (rows.length === 0) throw new Error(`No reports in ${dir}`);
+
+const pad = (v, n) => String(v).padEnd(n);
+const pct = (v) => (v == null ? '—' : `${Math.round(v * 100)}%`);
+console.log(
+  pad('informe', 15) + pad('pág', 5) + pad('%obj', 6) + pad('sec', 5) + pad('flojas', 8) +
+    pad('citas', 7) + pad('ideas', 7) + pad('pasajes', 9) + pad('huecos', 8) + pad('debates', 9) +
+    pad('obras', 7) + pad('conc.', 7) + 'rotas'
+);
+console.log('─'.repeat(105));
+for (const r of rows) {
+  console.log(
+    pad(r.label, 15) + pad(r.pages, 5) + pad(pct(r.fill), 6) + pad(r.sections, 5) + pad(r.thinSections, 8) +
+      pad(r.citations, 7) + pad(r.ideas, 7) + pad(r.passages, 9) + pad(r.gaps, 8) + pad(r.debates, 9) +
+      pad(r.works, 7) + pad(pct(r.topWorkShare), 7) + r.broken
+  );
+}
+
+const stat = (pick) => {
+  const values = rows.map(pick).filter((v) => v != null && Number.isFinite(v));
+  if (!values.length) return { mean: 0, min: 0, max: 0 };
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  return { mean, min: Math.min(...values), max: Math.max(...values) };
+};
+const show = (name, s, fmt = (v) => v.toFixed(1)) =>
+  console.log(`${pad(name, 34)}media ${pad(fmt(s.mean), 10)}rango ${fmt(s.min)} – ${fmt(s.max)}`);
+
+console.log(`\n═══ ${rows.length} informes ═══`);
+show('páginas del cuerpo', stat((r) => r.pages));
+show('extensión sobre el objetivo', stat((r) => r.fill), (v) => `${Math.round(v * 100)}%`);
+show('citas por informe', stat((r) => r.citations));
+show('obras distintas citadas', stat((r) => r.works));
+show('concentración en una obra', stat((r) => r.topWorkShare), (v) => `${Math.round(v * 100)}%`);
+show('pasajes literales', stat((r) => r.passages));
+show('debates citados', stat((r) => r.debates));
+show('huecos citados', stat((r) => r.gaps));
+show('secciones flojas (<3 citas)', stat((r) => r.thinSections));
+show('referencias rotas', stat((r) => r.broken));
+show('segundos por informe', stat((r) => r.seconds), (v) => v.toFixed(0));
+
+const filled = rows.filter((r) => Array.isArray(r.sectionFill) && r.sectionFill.length);
+if (filled.length) {
+  const all = filled.flatMap((r) => r.sectionFill);
+  const ratios = all.map((s) => s.words / Math.max(1, s.target));
+  const mean = ratios.reduce((a, b) => a + b, 0) / ratios.length;
+  const under = ratios.filter((r) => r < 0.78).length;
+  const expansions = filled.reduce((n, r) => n + (r.expansions ?? 0), 0);
+  console.log(`\n═══ Extensión por sección (${all.length} secciones) ═══`);
+  console.log(`Cumplimiento medio del objetivo  ${Math.round(mean * 100)}%`);
+  console.log(`Rango                            ${Math.round(Math.min(...ratios) * 100)}% – ${Math.round(Math.max(...ratios) * 100)}%`);
+  console.log(`Secciones aún bajo el umbral     ${under}/${all.length}`);
+  console.log(`Ampliaciones aceptadas           ${expansions}`);
+  console.log(`Objetivo por sección             ${all[0].target} palabras`);
+}
+
+const verified = rows.filter((r) => r.verification);
+if (verified.length) {
+  const checked = verified.reduce((n, r) => n + r.verification.checked, 0);
+  const partial = verified.reduce((n, r) => n + r.verification.partial, 0);
+  const unsupported = verified.reduce((n, r) => n + r.verification.unsupported, 0);
+  console.log(`\n═══ Verificación de respaldo (${verified.length}/${rows.length} informes) ═══`);
+  console.log(`Afirmaciones comprobadas      ${checked}`);
+  console.log(`Respaldo parcial              ${partial} (${Math.round((partial / Math.max(1, checked)) * 100)}%)`);
+  console.log(`Citas retiradas por infundadas ${unsupported} (${Math.round((unsupported / Math.max(1, checked)) * 100)}%)`);
+  console.log(`Tasa de respaldo verificado   ${Math.round(((checked - unsupported) / Math.max(1, checked)) * 100)}%`);
+}
+
+const inTarget = rows.filter((r) => r.inTarget).length;
+const clean = rows.filter((r) => r.broken === 0).length;
+const noThin = rows.filter((r) => r.thinSections === 0).length;
+const withDebate = rows.filter((r) => r.debates > 0).length;
+const withGap = rows.filter((r) => r.gaps > 0).length;
+const withPassage = rows.filter((r) => r.passages > 0).length;
+console.log(`\nDentro del rango de páginas   ${inTarget}/${rows.length}`);
+console.log(`Sin referencias rotas         ${clean}/${rows.length}`);
+console.log(`Sin secciones flojas          ${noThin}/${rows.length}`);
+console.log(`Con al menos un debate        ${withDebate}/${rows.length}`);
+console.log(`Con al menos un hueco         ${withGap}/${rows.length}`);
+console.log(`Con evidencia textual         ${withPassage}/${rows.length}`);
+
+console.log('\n═══ Orden de las secciones por tema ═══');
+for (const topic of [...new Set(rows.map((r) => r.topic))]) {
+  console.log(`\n▸ ${topic}`);
+  for (const r of rows.filter((x) => x.topic === topic)) {
+    console.log(`   ${r.label}: ${r.titles.map((t) => t.split(/[:;—]/)[0].trim().slice(0, 34)).join(' → ')}`);
+  }
+}
+db?.close();

--- a/scripts/test-deep-research-client.mjs
+++ b/scripts/test-deep-research-client.mjs
@@ -99,7 +99,7 @@ try {
     assert.equal(brief.materials.ideas.length, 70, 'pool trimmed to POOL_LIMITS.ideas');
     assert.ok(brief.materials.ideas.every((i) => /\]\(nodus:\/\/idea\/g-\d+\)$/.test(i.token)), 'idea tokens are real nodus citations');
     assert.ok(brief.sections.target >= 3 && brief.sections.hardCap >= brief.sections.target, 'section scope resolved');
-    assert.equal(brief.sections.target, 4, 'standard client brief defaults to four deep sections');
+    assert.equal(brief.sections.target, 5, 'the client brief is sized like the in-app plan, to what a section really delivers');
     assert.deepEqual(brief.targetPages, { min: 9, max: 14 }, 'standard length → 9–14 pp');
     assert.equal(brief.finalizeWith, 'nodus_finalize_deep_research', 'points the writer at the finalize tool');
     assert.ok(brief.citationPolicy.length > 0 && brief.method.length > 0, 'ships a citation policy + method');

--- a/scripts/test-deep-research.mjs
+++ b/scripts/test-deep-research.mjs
@@ -37,6 +37,10 @@ try {
     applyCitationPolicy,
     buildSnapshotMaps,
     buildCitationCatalog,
+    buildCitationMenu,
+    normalizePlan,
+    orderSections,
+    normalizeSectionTitle,
     resolveTargetPages,
     resolveSectionPlan,
     countWords,
@@ -273,10 +277,16 @@ try {
     };
     const report = await orchestrateDeepResearch({ objective: 'X', targetLength: 'standard' }, deps);
     // Standard auto plan stays small (few, deep sections) and bounded by the +1 grace.
-    assert.ok(report.meta.sections >= 4 && report.meta.sections <= 6, `bounded section count (got ${report.meta.sections})`);
-    assert.ok(report.meta.ideasCovered >= 40, `keeps full corpus coverage (got ${report.meta.ideasCovered}/50)`);
+    assert.ok(report.meta.sections >= 4 && report.meta.sections <= 7, `bounded section count (got ${report.meta.sections})`);
+    // A writer that names one source per section HAS covered almost nothing, and the
+    // report must say so instead of counting every assigned idea as developed.
+    assert.ok(
+      report.meta.ideasCovered < 20,
+      `coverage reflects what was cited, not what was assigned (got ${report.meta.ideasCovered}/50)`
+    );
+    assert.ok(report.draft.limitations.length > 0, 'a thin report declares what it left out');
     assert.ok(!report.draft.draftMarkdown.includes('HALLUCINATED'), 'thin sections also citation-clean');
-    assert.equal(report.meta.sections, 4, 'standard auto mode stays at four broad epigraphs');
+    assert.equal(report.meta.sections, 5, 'standard auto mode plans five sections, sized to what a section really delivers');
     assert.ok(!report.draft.draftMarkdown.includes('### '), 'model-added microheadings are flattened');
     assert.ok(report.draft.draftMarkdown.includes('Matiz adicional. Continuación breve.'), 'microheading content remains as prose');
   }
@@ -330,7 +340,7 @@ try {
     const auto = resolveSectionPlan({ min: 15, max: 20 }, 'auto');
     assert.equal(auto.mode, 'auto', 'auto mode reported');
     assert.ok(auto.target >= 3 && auto.target <= 7, `auto target stays small (got ${auto.target})`);
-    assert.equal(resolveSectionPlan({ min: 9, max: 14 }, 'auto').target, 4, 'standard report defaults to four deep sections');
+    assert.equal(resolveSectionPlan({ min: 9, max: 14 }, 'auto').target, 5, 'a 9-14 page target needs five sections at the measured ~1100 words each');
     assert.ok(auto.hardCap <= MAX_SECTIONS, 'auto hard cap respects the absolute ceiling');
     assert.ok(auto.hardCap === Math.min(MAX_SECTIONS, auto.target + 1), 'auto hard cap = target + 1 grace');
 
@@ -367,6 +377,455 @@ try {
     );
     assert.ok(report.meta.sections <= MAX_SECTIONS, 'never exceeds the absolute section ceiling');
     assert.ok(report.meta.sections <= 7, `auto mode favours few, deep sections (got ${report.meta.sections})`);
+  }
+
+  // ── 11b. The writer is never handed a token whose content it cannot read ────
+  {
+    const snapshot = makeSnapshot(4);
+    snapshot.passages = [
+      {
+        id: 'p-1',
+        label: 'Obra 0 · p. 47',
+        summary: 'El tiempo se hace tiempo humano en la medida en que se articula de modo narrativo.',
+        score: 1,
+        reason: 'test',
+        nodus_id: 'w-0',
+        pageLabel: 'p. 47',
+        authors: ['Autor0, Nombre'],
+        year: 2000,
+        zotero_key: 'Z0',
+        citation: 'nodus://passage/p-1',
+      },
+      // No readable text: this one must never become citable.
+      {
+        id: 'p-empty',
+        label: 'Obra 1',
+        summary: '   ',
+        score: 1,
+        reason: 'test',
+        nodus_id: 'w-1',
+        pageLabel: null,
+        authors: ['Autor1, Nombre'],
+        year: 2001,
+        zotero_key: 'Z1',
+        citation: 'nodus://passage/p-empty',
+      },
+    ];
+    const maps = buildSnapshotMaps(snapshot);
+    const menu = buildCitationMenu(
+      {
+        id: 's1',
+        title: 't',
+        purpose: 'p',
+        keyClaims: [],
+        ideaIds: ['g-0'],
+        workIds: [],
+        gapIds: ['gap-1'],
+        contradictionIds: ['edge-1'],
+        passageIds: ['p-1', 'p-empty'],
+      },
+      maps
+    );
+    const byKind = (kind) => menu.filter((item) => item.kind === kind);
+    assert.equal(byKind('gap').length, 1, 'the gap is offered');
+    assert.ok(
+      byKind('gap')[0].note.includes(snapshot.gaps[0].summary.slice(0, 20)),
+      'the gap carries what it actually says, not a placeholder'
+    );
+    assert.ok(
+      byKind('contradiction')[0].note.includes(snapshot.contradictions[0].summary.slice(0, 20)),
+      'the contradiction carries what it actually opposes'
+    );
+    assert.equal(byKind('passage').length, 1, 'the textless passage is not offered at all');
+    assert.ok(byKind('passage')[0].note.includes('tiempo humano'), 'the passage carries its literal text');
+    assert.ok(byKind('idea')[0].note.includes('Enunciado'), 'the idea carries its statement');
+    // No menu entry may be a generic label.
+    for (const item of menu) {
+      assert.ok(item.note.trim().length > 12, `menu note is substantive for ${item.kind}`);
+    }
+  }
+
+  // ── 11b2. Half-written references are repaired or dropped, never leaked ────
+  {
+    const snapshot = makeSnapshot(3);
+    const maps = buildSnapshotMaps(snapshot);
+    const md = [
+      'Uno [Autor](nodus://idea/g-0].', // right link, wrong closing bracket
+      'Dos [nodus://idea/g-1, nodus://idea/g-2].', // bare bracketed list
+      'Tres nodus://work/w-0 sin enlace.', // bare reference in the prose
+      'Cuatro nodus://idea/NO-EXISTE fantasma.', // bare reference to nothing
+      'Cinco [Autor0, N. (2000) (nodus://idea/g-2)].', // brackets and parentheses swapped
+      'Seis ([x](nodus://idea/g-0); Autor1, N. (2001)](nodus://idea/g-1)).', // second link lost its opening bracket
+      'Siete y la autarquía Autor2, N. (2002)](nodus://idea/g-2) seguía siendo dura.', // orphan with no delimiter to anchor a label
+      'Ocho [Fuentes Vega (2017)](nodus://contradicción/abc) con el tipo en español.', // invented target type
+      'Nueve [hueco](nodus://280a3b7b-5404-4ab8) sin tipo ninguno.', // target with no type segment
+    ].join('\n');
+    const { markdown, cited } = applyCitationPolicy(md, maps);
+    assert.ok(!/nodus:\/\/[^)]*\]/.test(markdown), 'no mismatched bracket survives');
+    // Every surviving reference is a well-formed link, so nothing leaks a raw id.
+    for (const match of markdown.matchAll(/nodus:\/\/[^\s)]+/g)) {
+      const at = markdown.indexOf(match[0]);
+      assert.equal(markdown[at - 1], '(', `reference ${match[0]} sits inside a real link`);
+    }
+    assert.ok(cited.ideas.has('g-0'), 'the mismatched bracket is still counted as a citation');
+    assert.ok(cited.ideas.has('g-1') && cited.ideas.has('g-2'), 'the bare list is counted');
+    assert.ok(cited.works.has('w-0'), 'the bare prose reference is counted');
+    assert.ok(!markdown.includes('NO-EXISTE'), 'a bare reference to nothing is dropped entirely');
+    // Repairing a broken neighbour must not damage a link that was already correct.
+    assert.ok(!/\[\[/.test(markdown), 'no stray bracket is introduced next to a well-formed link');
+    assert.equal((markdown.match(/\]\(nodus:\/\//g) ?? []).length, (markdown.match(/nodus:\/\//g) ?? []).length, 'every surviving reference sits in a link');
+    // When the label cannot be reconstructed the reference goes, but the sentence stays.
+    assert.ok(markdown.includes('y la autarquía Autor2, N. (2002) seguía siendo dura'), 'prose is never eaten to salvage a citation');
+    // A link Nodus cannot resolve loses the link and keeps the visible text.
+    assert.ok(!markdown.includes('contradicción/abc'), 'an invented target type is not printed');
+    assert.ok(markdown.includes('Fuentes Vega (2017)'), 'its author-year survives as plain text');
+    assert.ok(!markdown.includes('280a3b7b'), 'a target with no type segment is not printed');
+  }
+
+  // ── 11c. Coverage counts citations, and a short report is topped up ─────────
+  {
+    const snapshot = makeSnapshot(40);
+    const phases = [];
+    // A writer that produces prose but cites nothing at all.
+    const deps = { ...baseDeps(snapshot), writeSection: async () => `## S\n\n${'palabra '.repeat(300)}` };
+    const report = await orchestrateDeepResearch(
+      { objective: 'X', language: 'es', targetLength: 'standard' },
+      deps,
+      (p) => phases.push(p.phase)
+    );
+    assert.equal(report.meta.ideasCovered, 0, 'citing nothing covers nothing');
+    assert.ok(phases.includes('coverage'), 'a report under its minimum length triggers the coverage top-up');
+    assert.ok(report.draft.limitations.length > 0, 'the report discloses the ideas it never developed');
+    assert.equal(report.draft.stats.selectedIdeas, 0, 'the saved selection matches the honest coverage');
+  }
+
+  // ── 11d. Leftover ideas land where they fit, not by index arithmetic ────────
+  {
+    const snapshot = makeSnapshot(6);
+    // Two clearly separate topics; the planner only claims one idea per section.
+    snapshot.ideas[0].statement = 'La fotografía turística compone el paisaje nacional.';
+    snapshot.ideas[1].statement = 'La legislación agraria reordena la propiedad rural.';
+    snapshot.ideas[2].statement = 'La fotografía de prensa fija el paisaje como emblema.';
+    snapshot.ideas[3].statement = 'La reforma de la propiedad rural altera el catastro agrario.';
+    const plan = {
+      title: 'T',
+      abstract: '',
+      sections: [
+        { id: 's1', title: 'Fotografía y paisaje', purpose: 'La fotografía y el paisaje nacional.', keyClaims: [], ideaIds: ['g-0'], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+        { id: 's2', title: 'Propiedad rural', purpose: 'La legislación agraria y la propiedad rural.', keyClaims: [], ideaIds: ['g-1'], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+        { id: 's3', title: 'Cierre', purpose: 'síntesis', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+      ],
+    };
+    const normalized = normalizePlan(plan, snapshot);
+    const photography = normalized.sections.find((s) => s.id === 's1').ideaIds;
+    const land = normalized.sections.find((s) => s.id === 's2').ideaIds;
+    assert.ok(photography.includes('g-2'), 'the second photography idea joins the photography section');
+    assert.ok(land.includes('g-3'), 'the second land idea joins the land section');
+    assert.ok(!photography.includes('g-3') && !land.includes('g-2'), 'topics are not interleaved by index');
+  }
+
+  // ── 11e. Per-section retrieval reaches material the snapshot never held ─────
+  {
+    const snapshot = makeSnapshot(6);
+    const extraIdea = {
+      id: 'g-late',
+      label: 'Idea tardía',
+      summary: 'Recuperada durante la redacción.',
+      score: 0.9,
+      reason: 'test',
+      type: 'claim',
+      statement: 'Enunciado recuperado por la segunda pasada de recuperación.',
+      themes: [],
+      workCount: 1,
+      evidenceCount: 1,
+      works: [{ nodus_id: 'w-late', title: 'Obra tardía', authors: ['Tardío, Ana'], year: 2010, zotero_key: 'ZL' }],
+    };
+    const extraPassage = {
+      id: 'p-late',
+      label: 'Obra tardía · p. 12',
+      summary: 'Texto literal recuperado para esta sección concreta.',
+      score: 0.9,
+      reason: 'test',
+      nodus_id: 'w-late',
+      pageLabel: 'p. 12',
+      authors: ['Tardío, Ana'],
+      year: 2010,
+      zotero_key: 'ZL',
+      citation: 'nodus://passage/p-late',
+    };
+    let asked = 0;
+    const deps = {
+      ...baseDeps(snapshot),
+      retrieveForSection: async (input) => {
+        asked += 1;
+        assert.ok(input.sectionTitle, 'the retrieval is scoped to a section');
+        return { ideas: [extraIdea], passages: [extraPassage] };
+      },
+    };
+    const report = await orchestrateDeepResearch({ objective: 'X', language: 'es', targetLength: 'concise' }, deps);
+    assert.ok(asked >= 2, 'the corpus is queried once per section, not only once per report');
+    // Retrieved material survives the citation policy instead of being stripped.
+    assert.ok(report.draft.draftMarkdown.includes('nodus://idea/g-late'), 'a retrieved idea is really citable');
+    assert.ok(report.draft.draftMarkdown.includes('nodus://passage/p-late'), 'a retrieved passage is really citable');
+    assert.ok(report.draft.bibliography.some((entry) => entry.includes('Tardío')), 'its work reaches the bibliography');
+  }
+
+  // ── 11f. Report language drives the document, not the developer's locale ────
+  {
+    const snapshot = makeSnapshot(8);
+    const messages = [];
+    const report = await orchestrateDeepResearch(
+      { objective: 'X', language: 'en', targetLength: 'concise' },
+      baseDeps(snapshot),
+      (p) => messages.push(p.message)
+    );
+    assert.ok(report.draft.draftMarkdown.includes('## References'), 'an English report closes in English');
+    assert.ok(!report.draft.draftMarkdown.includes('## Referencias'), 'no Spanish heading leaks in');
+    assert.ok(messages.some((m) => /Gathering|Writing|Assembling/.test(m)), 'progress speaks the report language');
+    assert.ok(!messages.some((m) => /Reuniendo|Redactando|Ensamblando/.test(m)), 'no Spanish progress copy leaks in');
+  }
+
+  // ── 11g. Reading order follows the declared dependencies, not the emission order ─
+  {
+    // The planner emits the consequence before its cause and the framing last.
+    const emitted = [
+      { id: 'consecuencia', role: 'body', dependsOn: ['origen'], title: 'Consecuencia', purpose: '', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+      { id: 'cierre', role: 'synthesis', dependsOn: ['consecuencia'], title: 'Síntesis', purpose: '', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+      { id: 'origen', role: 'body', dependsOn: [], title: 'Origen', purpose: '', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+      { id: 'marco', role: 'intro', dependsOn: [], title: 'Planteamiento', purpose: '', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+    ];
+    const ordered = orderSections(emitted).map((s) => s.id);
+    assert.deepEqual(ordered, ['marco', 'origen', 'consecuencia', 'cierre'], 'framing first, cause before consequence, synthesis last');
+
+    // A dependency cycle must degrade to an order, never hang or drop a section.
+    const cyclic = [
+      { id: 'a', role: 'body', dependsOn: ['b'], title: 'A', purpose: '', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+      { id: 'b', role: 'body', dependsOn: ['a'], title: 'B', purpose: '', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] },
+    ];
+    assert.equal(orderSections(cyclic).length, 2, 'a cycle still yields every section');
+    // An unknown dependency id is ignored rather than fatal.
+    const dangling = [{ id: 'a', role: 'body', dependsOn: ['ghost'], title: 'A', purpose: '', keyClaims: [], ideaIds: [], workIds: [], gapIds: [], contradictionIds: [], passageIds: [] }];
+    assert.equal(orderSections(dangling).length, 1, 'a dangling dependency is ignored');
+  }
+
+  // ── 11h. A short section is expanded once, and only if it really grew ───────
+  {
+    const snapshot = makeSnapshot(20);
+    let expansions = 0;
+    const deps = {
+      ...baseDeps(snapshot),
+      writeSection: async (input) => `## ${input.section.title}\n\nCorto (${input.citationMenu[0]?.token ?? ''}).`,
+      expandSection: async (input) => {
+        expansions += 1;
+        assert.ok(input.draft.includes('Corto'), 'the expander sees its own draft');
+        assert.ok(input.missingWords > 0, 'the expander is told how much is missing');
+        return `## ${input.section.title}\n\n${input.draft} ${'desarrollo '.repeat(600)}`;
+      },
+    };
+    const report = await orchestrateDeepResearch({ objective: 'X', language: 'es', targetLength: 'standard' }, deps);
+    assert.ok(expansions > 0, 'a section far under target is expanded');
+    assert.ok(report.meta.words > 1000, `the expansion reaches the report (got ${report.meta.words} words)`);
+
+    // An expansion that does not actually grow the section is discarded, so a model
+    // that merely reshuffles the same words cannot replace the original draft.
+    let refused = 0;
+    const stingy = {
+      ...baseDeps(snapshot),
+      writeSection: async (input) => `## ${input.section.title}\n\nBORRADOR original breve.`,
+      expandSection: async (input) => {
+        refused += 1;
+        return `## ${input.section.title}\n\nEXPANSION igual.`;
+      },
+    };
+    const weak = await orchestrateDeepResearch({ objective: 'X', language: 'es', targetLength: 'concise' }, stingy);
+    assert.ok(refused > 0, 'the expansion was attempted');
+    assert.ok(!weak.draft.draftMarkdown.includes('EXPANSION'), 'a non-growing expansion is discarded');
+    assert.ok(weak.draft.draftMarkdown.includes('BORRADOR'), 'the original draft survives instead');
+  }
+
+  // ── 11i. Verification: a source that does not support the claim is removed ──
+  {
+    const snapshot = makeSnapshot(10);
+    snapshot.passages = [
+      {
+        id: 'p-1',
+        label: 'Obra 0 · p. 9',
+        summary: 'El turismo interior creció durante la posguerra.',
+        score: 1,
+        reason: 'test',
+        nodus_id: 'w-0',
+        pageLabel: 'p. 9',
+        authors: ['Autor0, N.'],
+        year: 2000,
+        zotero_key: 'zk-0',
+        citation: 'nodus://passage/p-1',
+      },
+    ];
+    // The writer cites two ideas per sentence; the judge rejects everything backed by
+    // the work behind idea g-1, and accepts the rest.
+    const rejected = new Set(['g-1']);
+    let seenClaims = [];
+    const deps = {
+      ...baseDeps(snapshot),
+      writeSection: async (input) => {
+        const tokens = input.citationMenu.filter((c) => c.kind === 'idea').slice(0, 3);
+        const sentences = tokens.map((c, i) => `Afirmación número ${i} sobre el asunto (${c.token}).`);
+        return `## ${input.section.title}\n\n${sentences.join(' ')} ${'texto '.repeat(400)}`;
+      },
+      verifyCitations: async (claims) => {
+        seenClaims = seenClaims.concat(claims);
+        return claims.map((claim) => (rejected.has(claim.id) ? 'unsupported' : 'supports'));
+      },
+    };
+    const report = await orchestrateDeepResearch({ objective: 'X', language: 'es', targetLength: 'concise' }, deps);
+
+    // The judge must receive the real sentence and the real source content.
+    assert.ok(seenClaims.length > 0, 'claims reached the verifier');
+    assert.ok(seenClaims.every((c) => c.sentence.includes('Afirmación número')), 'each claim carries its own sentence');
+    assert.ok(seenClaims.every((c) => c.content.length > 0), 'each claim carries what the source says');
+    assert.ok(seenClaims.some((c) => c.content.includes('Enunciado sustantivo')), 'an idea claim carries its statement');
+
+    // The rejected citation is gone from the prose …
+    assert.ok(!report.draft.draftMarkdown.includes('nodus://idea/g-1'), 'an unsupported citation is removed from the body');
+    // … and therefore from the accounting and the bibliography too.
+    assert.ok(!report.draft.selection.ideaIds.includes('g-1'), 'it stops counting as covered');
+    assert.ok(
+      !report.draft.bibliography.some((entry) => entry.includes('Autor1')),
+      'the work behind it leaves the bibliography unless something else cites it'
+    );
+    assert.ok(report.meta.verification, 'verification is reported');
+    assert.ok(report.meta.verification.checked > 0, 'the number of checked claims is reported');
+    assert.ok(report.meta.verification.unsupported > 0, 'the number of removed citations is reported');
+    // Supported citations survive untouched.
+    assert.ok(report.draft.draftMarkdown.includes('nodus://idea/g-0'), 'a supported citation is kept');
+  }
+
+  // ── 11j. A judge that fails or answers nonsense never damages the report ────
+  {
+    const snapshot = makeSnapshot(10);
+    const base = await orchestrateDeepResearch({ objective: 'X', language: 'es', targetLength: 'concise' }, baseDeps(snapshot));
+    for (const broken of [
+      async () => {
+        throw new Error('judge down');
+      },
+      async () => [],
+      async () => ['sí', 'no'],
+      async () => null,
+    ]) {
+      const report = await orchestrateDeepResearch(
+        { objective: 'X', language: 'es', targetLength: 'concise' },
+        { ...baseDeps(snapshot), verifyCitations: broken }
+      );
+      assert.equal(
+        (report.draft.draftMarkdown.match(/nodus:\/\/idea\//g) ?? []).length,
+        (base.draftMarkdown ?? base.draft.draftMarkdown).match(/nodus:\/\/idea\//g).length,
+        'a broken judge leaves every citation in place'
+      );
+    }
+  }
+
+  // ── 11k. Split headings are folded into one phrase, keeping both halves ────
+  {
+    assert.equal(
+      normalizeSectionTitle('La genealogía de la mirada: del mito romántico a la gestión institucional'),
+      'La genealogía de la mirada, del mito romántico a la gestión institucional',
+      'a colon becomes a comma and the subtitle survives'
+    );
+    assert.equal(
+      normalizeSectionTitle('La construcción del imaginario: Fotografía, patrimonio y folclore'),
+      'La construcción del imaginario, Fotografía, patrimonio y folclore',
+      'a subtitle starting with a content word keeps its capital'
+    );
+    assert.equal(
+      normalizeSectionTitle('Nacionalismo banal: Hacia una síntesis'),
+      'Nacionalismo banal, hacia una síntesis',
+      'a subtitle starting with a function word is lowercased'
+    );
+    assert.equal(normalizeSectionTitle('Un título limpio'), 'Un título limpio', 'a clean title is untouched');
+    assert.equal(normalizeSectionTitle('Ratio 3:1 sin espacio'), 'Ratio 3:1 sin espacio', 'a colon without a following space is not a subtitle');
+
+    // And it reaches the report, not just the helper.
+    const snapshot = makeSnapshot(12);
+    const deps = {
+      ...baseDeps(snapshot),
+      planReport: async (input) => {
+        const plan = fakePlan(input);
+        plan.sections[0].title = 'Genealogías del imaginario: del romanticismo a la propaganda';
+        return plan;
+      },
+    };
+    const report = await orchestrateDeepResearch({ objective: 'X', language: 'es', targetLength: 'concise' }, deps);
+    assert.ok(
+      report.draft.draftMarkdown.includes('## Genealogías del imaginario, del romanticismo a la propaganda'),
+      'the assembled report carries the folded heading'
+    );
+    assert.ok(!/^##\s+[^\n]*:\s/mu.test(report.draft.draftMarkdown), 'no split heading survives into the document');
+  }
+
+  // ── 11l. Self-contradictions are reported only when both quotes are real ───
+  {
+    const snapshot = makeSnapshot(12);
+    let seenSections = [];
+    const run = (issues) =>
+      orchestrateDeepResearch(
+        { objective: 'X', language: 'es', targetLength: 'concise' },
+        {
+          ...baseDeps(snapshot),
+          writeSection: async (input) =>
+            `## ${input.section.title}\n\nEl turismo creció de forma sostenida durante el periodo (${input.citationMenu[0]?.token ?? ''}). ${'texto '.repeat(400)}`,
+          checkCoherence: async (sections) => {
+            seenSections = sections;
+            return issues(sections);
+          },
+        }
+      );
+
+    // A tension whose quotes really appear is reported to the reader.
+    const real = await run((sections) => [
+      {
+        sectionA: sections[0].title,
+        quoteA: 'El turismo creció de forma sostenida durante el periodo',
+        sectionB: sections[1].title,
+        quoteB: 'El turismo creció de forma sostenida durante el periodo',
+        issue: 'Una sección afirma crecimiento sostenido y la otra lo niega.',
+      },
+    ]);
+    // Identical quotes are not a contradiction: the grounding must reject that too.
+    assert.equal(real.meta.coherenceIssues, 0, 'two identical quotes are not a tension');
+
+    // An invented quote is discarded rather than printed in the limitations.
+    const invented = await run(() => [
+      {
+        sectionA: 'Sección 1',
+        quoteA: 'El régimen prohibió por completo el turismo extranjero hasta 1975',
+        sectionB: 'Sección 2',
+        quoteB: 'La apertura turística comenzó en los años cuarenta con plena libertad',
+        issue: 'Fechas incompatibles.',
+      },
+    ]);
+    assert.equal(invented.meta.coherenceIssues, 0, 'an invented tension never reaches the report');
+    assert.ok(
+      !invented.draft.limitations.some((l) => l.includes('Fechas incompatibles')),
+      'and never reaches the limitations either'
+    );
+
+    // The checker sees real section text, stripped of its heading.
+    assert.ok(seenSections.length > 1, 'every section is offered to the coherence check');
+    assert.ok(seenSections.every((s) => !s.text.startsWith('## ')), 'sections arrive without their heading');
+    assert.ok(seenSections.some((s) => s.text.includes('El turismo creció')), 'sections arrive with their prose');
+
+    // A failing checker must not cost the report anything.
+    const broken = await orchestrateDeepResearch(
+      { objective: 'X', language: 'es', targetLength: 'concise' },
+      {
+        ...baseDeps(snapshot),
+        checkCoherence: async () => {
+          throw new Error('coherence down');
+        },
+      }
+    );
+    assert.equal(broken.meta.coherenceIssues, 0, 'a broken coherence check degrades to zero findings');
+    assert.ok(broken.draft.draftMarkdown.includes('## Referencias'), 'and the report still assembles');
   }
 
   // ── 12. All writer routes inherit the same narrative contract ──────────────

--- a/scripts/test-deep-research.mjs
+++ b/scripts/test-deep-research.mjs
@@ -828,6 +828,31 @@ try {
     assert.ok(broken.draft.draftMarkdown.includes('## Referencias'), 'and the report still assembles');
   }
 
+  // ── 11m. Every visible citation reads like a citation ──────────────────────
+  {
+    const snapshot = makeSnapshot(6);
+    // A gap anchored to a work, a debate with a named side, and a work whose author
+    // the corpus never captured.
+    snapshot.gaps[0].work = { nodus_id: 'w-0', title: 'Obra 0', authors: ['Fuentes Vega, Ana'], year: 2017, zotero_key: 'zk-0' };
+    snapshot.contradictions[0].sources = ['Brandis García (2015)', 'Otro (2011)'];
+    snapshot.ideas[1].works = [{ nodus_id: 'w-x', title: 'Bibliografía de viajeros por España y Portugal', authors: [], year: 2004, zotero_key: 'zk-x' }];
+    const maps = buildSnapshotMaps(snapshot);
+    const menu = buildCitationMenu(
+      { id: 's1', title: 't', purpose: '', keyClaims: [], ideaIds: ['g-1'], workIds: [], gapIds: ['gap-1'], contradictionIds: ['edge-1'], passageIds: [] },
+      maps
+    );
+    const anchorOf = (kind) => menu.find((i) => i.kind === kind).token.match(/^\[([^\]]*)\]/)[1];
+    assert.equal(anchorOf('gap'), 'Fuentes Vega, A. (2017)', 'a gap is cited by the work it is anchored to');
+    assert.equal(anchorOf('contradiction'), 'Brandis García (2015)', 'a debate is cited by whoever holds a side');
+    assert.ok(!/^Autor$|^Autor \(/.test(anchorOf('idea')), 'no bare "Autor" placeholder reaches the prose');
+    assert.ok(anchorOf('idea').includes('Bibliografía de viajeros'), 'an authorless work is cited by its shortened title');
+
+    // And the anchors survive the citation policy unchanged.
+    const { markdown } = applyCitationPolicy(`Frase (${menu.find((i) => i.kind === 'gap').token}).`, maps);
+    assert.ok(markdown.includes('[Fuentes Vega, A. (2017)]'), 'the policy keeps the readable anchor');
+    assert.ok(!markdown.includes('[hueco]'), 'the debug-looking label is gone');
+  }
+
   // ── 12. All writer routes inherit the same narrative contract ──────────────
   {
     const sources = await Promise.all([

--- a/scripts/verify-citation-judge.mjs
+++ b/scripts/verify-citation-judge.mjs
@@ -1,0 +1,205 @@
+// Measures whether the citation judge actually judges.
+//
+// A verifier that answers "supports" to everything looks perfect from the outside:
+// nothing is removed, no report is damaged, and the pass appears to work. So this
+// takes REAL claims from generated reports and poisons half of them by swapping in
+// the content of an unrelated source. A useful judge rejects the poisoned pairs and
+// keeps the genuine ones; a lazy one keeps everything and is caught here.
+//
+//   electron scripts/with-nodus-keys.cjs --providers gemini -- \
+//     node scripts/verify-citation-judge.mjs --batch DIR --snapshot DIR [--sample 40]
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const FLAG = '--electron-verify-judge';
+const argOf = (name, fallback) => {
+  const at = process.argv.indexOf(name);
+  return at >= 0 && process.argv[at + 1] ? process.argv[at + 1] : fallback;
+};
+const batchDir = path.resolve(argOf('--batch', path.join(os.tmpdir(), 'nodus-dr-batch')));
+const snapshotDir = path.resolve(argOf('--snapshot', path.join(os.tmpdir(), 'nodus-dr-userdata')));
+const SAMPLE = Number(argOf('--sample', '40'));
+
+if (!process.argv.includes(FLAG)) {
+  if (!process.env.GEMINI_API_KEY?.trim()) throw new Error('Set GEMINI_API_KEY for this isolated run.');
+  execFileSync(path.join(repoRoot, 'node_modules/.bin/electron'), [...process.argv.slice(1), FLAG], {
+    cwd: repoRoot,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  process.exit(0);
+}
+
+const apiKey = process.env.GEMINI_API_KEY?.trim();
+assert.ok(apiKey, 'Gemini key reaches only the isolated child process.');
+installRuntimeHooks(snapshotDir);
+
+let closeDb = () => undefined;
+try {
+  const secrets = require(path.join(repoRoot, 'electron/secrets/secretStore.ts'));
+  const settingsRepo = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
+  const workshop = require(path.join(repoRoot, 'electron/ai/writingWorkshop.ts'));
+  const core = require(path.join(repoRoot, 'electron/ai/deepResearchCore.ts'));
+  ({ closeDb } = require(path.join(repoRoot, 'electron/db/database.ts')));
+  secrets.setApiKey('gemini', apiKey);
+  delete process.env.GEMINI_API_KEY;
+
+  const modelName = argOf('--model', 'gemini-3.1-flash-lite');
+  settingsRepo.updateSettings({ deepResearchModel: { provider: 'gemini', model: modelName }, promptLanguage: 'es' });
+  // The judge is not exported; reach it through the module that owns it.
+  const deepResearch = require(path.join(repoRoot, 'electron/ai/deepResearch.ts'));
+  const verify = deepResearch.__verifyCitationsForTesting;
+  assert.ok(typeof verify === 'function', 'deepResearch must expose the judge for this control');
+
+  // Rebuild claims from the saved reports against a fresh snapshot of the corpus.
+  const files = fs.readdirSync(batchDir).filter((f) => f.endsWith('.json')).sort();
+  assert.ok(files.length > 0, `no reports in ${batchDir}`);
+  const genuine = [];
+  for (const file of files) {
+    const { report } = JSON.parse(fs.readFileSync(path.join(batchDir, file), 'utf8'));
+    const snapshot = await workshop.buildWritingWorkshopSnapshot(report.draft.brief);
+    const maps = core.buildSnapshotMaps(snapshot);
+    for (const claim of core.extractCitationClaims(report.draft.draftMarkdown, maps)) genuine.push(claim);
+    if (genuine.length >= SAMPLE * 3) break;
+  }
+  assert.ok(genuine.length >= 4, `not enough claims to sample (${genuine.length})`);
+  console.log(`[control] ${genuine.length} afirmaciones reales disponibles en ${files.length} informes`);
+
+  // Audit mode: judge only GENUINE claims and break the verdicts down by source kind.
+  // A pass that rejects one kind far more than the others is not detecting bad
+  // citations, it is misreading that kind of source.
+  if (process.argv.includes('--audit')) {
+    const step = Math.max(1, Math.floor(genuine.length / SAMPLE));
+    const sample = [];
+    for (let i = 0; i < genuine.length && sample.length < SAMPLE; i += step) sample.push(genuine[i]);
+    const verdicts = await verify(sample, { provider: 'gemini', model: modelName });
+    const byKind = new Map();
+    sample.forEach((claim, index) => {
+      const row = byKind.get(claim.kind) ?? { supports: 0, partial: 0, unsupported: 0 };
+      row[verdicts[index]] += 1;
+      byKind.set(claim.kind, row);
+    });
+    console.log(`\n═══ Veredictos sobre citas REALES, por tipo de fuente (${sample.length}) ═══`);
+    console.log('tipo'.padEnd(16) + 'sostiene'.padEnd(11) + 'parcial'.padEnd(10) + 'no sostiene');
+    for (const [kind, row] of byKind) {
+      const total = row.supports + row.partial + row.unsupported;
+      console.log(
+        kind.padEnd(16) + String(row.supports).padEnd(11) + String(row.partial).padEnd(10) +
+          `${row.unsupported} (${Math.round((row.unsupported / total) * 100)}%)`
+      );
+    }
+    for (const [kind, row] of byKind) {
+      const total = row.supports + row.partial + row.unsupported;
+      if (total >= 5 && row.unsupported / total > 0.15) {
+        console.log(`\n⚠ "${kind}" se rechaza en el ${Math.round((row.unsupported / total) * 100)}% de los casos reales: el rubro no encaja con ese tipo de fuente.`);
+      }
+    }
+    closeDb();
+    process.exit(0);
+  }
+
+  // Deterministic spread over the pool without Math.random, so the control is repeatable.
+  const step = Math.max(1, Math.floor(genuine.length / SAMPLE));
+  const picked = [];
+  for (let i = 0; i < genuine.length && picked.length < SAMPLE; i += step) picked.push(genuine[i]);
+
+  // Poison every other one: keep the sentence, swap in content from a claim far away
+  // in the pool, which is about something else entirely.
+  const cases = picked.map((claim, index) => {
+    const poisoned = index % 2 === 1;
+    const donor = genuine[(index * 7 + Math.floor(genuine.length / 2)) % genuine.length];
+    return {
+      poisoned,
+      claim: poisoned && donor.content !== claim.content ? { ...claim, content: donor.content } : claim,
+      real: poisoned && donor.content === claim.content ? false : poisoned,
+    };
+  });
+
+  const verdicts = await verify(cases.map((c) => c.claim), { provider: 'gemini', model: modelName });
+  assert.equal(verdicts.length, cases.length, 'one verdict per case');
+
+  let caught = 0;
+  let poisonedTotal = 0;
+  let falseAlarms = 0;
+  let genuineTotal = 0;
+  const misses = [];
+  cases.forEach((entry, index) => {
+    const rejected = verdicts[index] === 'unsupported';
+    if (entry.real) {
+      poisonedTotal += 1;
+      if (rejected) caught += 1;
+      else misses.push(entry.claim);
+    } else {
+      genuineTotal += 1;
+      if (rejected) falseAlarms += 1;
+    }
+  });
+
+  const pct = (a, b) => (b === 0 ? '—' : `${Math.round((a / b) * 100)}%`);
+  console.log(`\n═══ Control del juez de citas (${modelName}) ═══`);
+  console.log(`Citas envenenadas detectadas   ${caught}/${poisonedTotal}  (${pct(caught, poisonedTotal)})  ← recall`);
+  console.log(`Citas buenas rechazadas        ${falseAlarms}/${genuineTotal}  (${pct(falseAlarms, genuineTotal)})  ← falsos positivos`);
+  console.log(`Veredictos: ${verdicts.filter((v) => v === 'supports').length} sostiene · ${verdicts.filter((v) => v === 'partial').length} parcial · ${verdicts.filter((v) => v === 'unsupported').length} no sostiene`);
+  if (misses.length) {
+    console.log('\nEjemplos que se le escaparon:');
+    for (const miss of misses.slice(0, 3)) {
+      console.log(`  frase : ${miss.sentence.slice(0, 130)}`);
+      console.log(`  fuente: ${miss.content.slice(0, 130)}\n`);
+    }
+  }
+  // A judge that keeps everything is worse than useless: it certifies false claims.
+  console.log(caught / Math.max(1, poisonedTotal) >= 0.7 ? '\nVEREDICTO: el juez discrimina.' : '\nVEREDICTO: el juez NO discrimina lo suficiente.');
+} finally {
+  try {
+    closeDb();
+  } catch {
+    /* best effort */
+  }
+}
+
+function installRuntimeHooks(userDataPath) {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  const originalLoad = Module._load;
+  const electronStub = {
+    app: { getPath: () => userDataPath, getVersion: () => '0.0.0-judge-control', getAppPath: () => repoRoot, isPackaged: false, getName: () => 'Nodus' },
+    safeStorage: { isEncryptionAvailable: () => false, encryptString: (v) => Buffer.from(String(v)), decryptString: (v) => Buffer.from(v).toString() },
+    dialog: { showMessageBoxSync: () => 1 },
+    shell: {},
+    BrowserWindow: class {},
+    ipcMain: { handle: () => undefined, on: () => undefined },
+    net: {},
+  };
+  Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') return electronStub;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  require.extensions['.ts'] = function (module, filename) {
+    const output = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}

--- a/scripts/verify-deep-research-live-gemini.mjs
+++ b/scripts/verify-deep-research-live-gemini.mjs
@@ -1,0 +1,252 @@
+// A/B harness for Deep Research against the REAL academic corpus.
+//
+// Runs `generateDeepResearchReport` headlessly over a consistent read-only
+// snapshot of the live vault (VACUUM INTO, so the running app is never touched)
+// and dumps the report plus the metrics that matter for report quality:
+// how many ideas were *actually cited* versus how many the engine claims to have
+// covered, whether the coverage top-up ever fired, and how much evidence
+// (passages, gaps, contradictions) reached the prose.
+//
+// Usage:
+//   GEMINI_API_KEY=… node scripts/verify-deep-research-live-gemini.mjs --label before
+//
+// The snapshot is built once and reused across labels so both sides of the A/B
+// see byte-identical corpus state.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+const FLAG = '--electron-deep-research-live';
+const argOf = (name, fallback) => {
+  const at = process.argv.indexOf(name);
+  return at >= 0 && process.argv[at + 1] ? process.argv[at + 1] : fallback;
+};
+
+const label = argOf('--label', 'run');
+const outDir = path.resolve(argOf('--out', path.join(os.tmpdir(), 'nodus-dr-ab')));
+const snapshotDir = path.resolve(argOf('--snapshot', path.join(os.tmpdir(), 'nodus-dr-userdata')));
+const sourceDb = argOf('--source-db', path.join(os.homedir(), 'Library/Application Support/nodus/nodus.sqlite'));
+
+const OBJECTIVE =
+  argOf(
+    '--objective',
+    'Analiza cómo el turismo y la literatura de viajes contribuyeron a construir la identidad nacional y regional española durante el franquismo, atendiendo a la cultura visual, la fotografía y los usos propagandísticos del patrimonio.'
+  );
+
+// ── Re-exec under Electron's node so better-sqlite3's native ABI matches ──────
+if (!process.argv.includes(FLAG)) {
+  if (!process.env.GEMINI_API_KEY?.trim()) throw new Error('Set GEMINI_API_KEY for this isolated run.');
+  execFileSync(path.join(repoRoot, 'node_modules/.bin/electron'), [...process.argv.slice(1), FLAG], {
+    cwd: repoRoot,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  process.exit(0);
+}
+
+const apiKey = process.env.GEMINI_API_KEY?.trim();
+const openRouterKey = process.env.OPENROUTER_API_KEY?.trim() || null;
+assert.ok(apiKey, 'Gemini key reaches only the isolated child process.');
+
+// ── 1. Consistent snapshot of the live corpus (never touches the original) ────
+fs.mkdirSync(snapshotDir, { recursive: true });
+fs.mkdirSync(outDir, { recursive: true });
+const snapshotDb = path.join(snapshotDir, 'nodus.sqlite');
+if (!fs.existsSync(snapshotDb)) {
+  assert.ok(fs.existsSync(sourceDb), `Source vault not found: ${sourceDb}`);
+  const Database = require('better-sqlite3');
+  const source = new Database(sourceDb, { readonly: true, fileMustExist: true });
+  const started = Date.now();
+  source.prepare('VACUUM INTO ?').run(snapshotDb);
+  source.close();
+  console.log(`[snapshot] built in ${Math.round((Date.now() - started) / 1000)}s → ${snapshotDb}`);
+} else {
+  console.log(`[snapshot] reusing ${snapshotDb}`);
+}
+
+installRuntimeHooks(snapshotDir);
+
+let closeDb = () => undefined;
+const phases = [];
+const startedAt = Date.now();
+
+try {
+  const vaults = require(path.join(repoRoot, 'electron/vaults/vaultRegistry.ts'));
+  const active = vaults.getActiveVault();
+  console.log(`[vault] ${active.name} · type=${active.type} · legacy=${active.legacy}`);
+  assert.equal(active.type, 'academic', 'The A/B must run through the academic Deep Research pipeline.');
+
+  const secrets = require(path.join(repoRoot, 'electron/secrets/secretStore.ts'));
+  const settingsRepo = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
+  const providers = require(path.join(repoRoot, 'electron/ai/providers.ts'));
+  ({ closeDb } = require(path.join(repoRoot, 'electron/db/database.ts')));
+
+  secrets.setApiKey('gemini', apiKey);
+  if (openRouterKey) secrets.setApiKey('openrouter', openRouterKey);
+  delete process.env.GEMINI_API_KEY;
+  delete process.env.OPENROUTER_API_KEY;
+
+  const wanted = argOf('--model', 'gemini-3.1-flash-lite');
+  const available = await providers.listModels('gemini', secrets.getApiKey('gemini'));
+  const modelName = available.some((m) => m.id === wanted)
+    ? wanted
+    : available.find((m) => /flash-lite/.test(m.id))?.id;
+  assert.ok(modelName, 'No flash-lite model available on this key.');
+  console.log(`[model] ${modelName}${modelName === wanted ? '' : ` (fallback; "${wanted}" not offered)`}`);
+
+  // Only the Deep Research model is forced. Embedding provider/model stay exactly
+  // as the vault has them, or the stored idea/passage vectors stop matching.
+  const before = settingsRepo.getSettings();
+  settingsRepo.updateSettings({ deepResearchModel: { provider: 'gemini', model: modelName }, promptLanguage: 'es' });
+  console.log(`[embeddings] ${before.embeddingProvider} · ${before.embeddingModel}`);
+
+  // Instrument the per-section retrieval from the outside, so the A/B can show
+  // whether it actually fired without the product code knowing it is measured.
+  const workshop = require(path.join(repoRoot, 'electron/ai/writingWorkshop.ts'));
+  const retrieval = { calls: 0, ideas: 0, passages: 0, available: typeof workshop.retrieveSectionMaterial === 'function' };
+  if (retrieval.available) {
+    const original = workshop.retrieveSectionMaterial;
+    workshop.retrieveSectionMaterial = async (input) => {
+      retrieval.calls += 1;
+      const out = await original(input);
+      retrieval.ideas += out?.ideas?.length ?? 0;
+      retrieval.passages += out?.passages?.length ?? 0;
+      return out;
+    };
+  }
+
+  const { generateDeepResearchReport } = require(path.join(repoRoot, 'electron/ai/deepResearch.ts'));
+  const report = await generateDeepResearchReport(
+    { objective: OBJECTIVE, language: 'es', targetLength: 'standard', audience: 'comunidad académica' },
+    (p) => {
+      phases.push({ phase: p.phase, message: p.message, words: p.wordsSoFar ?? null });
+      console.log(`  · ${p.phase}: ${p.message}`);
+    }
+  );
+
+  const metrics = measure(report, phases, Date.now() - startedAt, modelName, OBJECTIVE);
+  metrics.sectionRetrieval = retrieval;
+  metrics.embeddings = { provider: before.embeddingProvider, model: before.embeddingModel };
+  fs.writeFileSync(path.join(outDir, `${label}.json`), JSON.stringify({ metrics, report }, null, 2));
+  fs.writeFileSync(
+    path.join(outDir, `${label}.md`),
+    `# ${report.draft.title}\n\n${report.draft.draftMarkdown}\n`
+  );
+  console.log(`\n=== METRICS (${label}) ===`);
+  console.log(JSON.stringify(metrics, null, 2));
+} finally {
+  try {
+    closeDb();
+  } catch {
+    /* best effort */
+  }
+}
+
+// ── Metrics ──────────────────────────────────────────────────────────────────
+function measure(report, phases, elapsedMs, model, objective) {
+  const md = report.draft.draftMarkdown ?? '';
+  const re = /\[([^\]]*)\]\(nodus:\/\/(idea|work|passage|gap|contradiction)\/([^)]+)\)/g;
+  const cited = { idea: new Set(), work: new Set(), passage: new Set(), gap: new Set(), contradiction: new Set() };
+  let total = 0;
+  for (const m of md.matchAll(re)) {
+    cited[m[2]].add(decodeURIComponent(m[3]));
+    total += 1;
+  }
+  // Count the prose only. Including the reference list makes a report with a longer
+  // bibliography look longer than one with more argument in it.
+  const words = md
+    .split(/^##\s+(?:Referencias|References|Références|Literaturverzeichnis|Kaynakça|Bibliografia|Referências)\s*$/mu)[0]
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[#*_`>|-]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean).length;
+  const claimed = report.meta.ideasCovered;
+  const abstract = (report.draft.abstract ?? '').trim();
+  return {
+    label,
+    model,
+    objective,
+    elapsedSeconds: Math.round(elapsedMs / 1000),
+    meta: report.meta,
+    prose: { words, pagesAt450: Math.round(words / 450) },
+    citations: {
+      total,
+      ideas: cited.idea.size,
+      works: cited.work.size,
+      passages: cited.passage.size,
+      gaps: cited.gap.size,
+      contradictions: cited.contradiction.size,
+    },
+    // The headline honesty check: how much of the claimed coverage is real.
+    coverageHonesty: {
+      ideasClaimedCovered: claimed,
+      ideasActuallyCited: cited.idea.size,
+      ratio: claimed > 0 ? Number((cited.idea.size / claimed).toFixed(3)) : null,
+    },
+    coverageTopUpRan: phases.some((p) => p.phase === 'coverage'),
+    sectionsWritten: report.meta.sections,
+    limitations: report.draft.limitations,
+    nextSteps: report.draft.nextSteps,
+    abstractDuplicatedInBody: abstract.length > 0 && md.includes(abstract),
+    bibliographyEntries: (report.draft.bibliography ?? []).length,
+    phases: phases.map((p) => p.phase),
+  };
+}
+
+// ── Electron/TS runtime hooks (same pattern as the other shadow runners) ──────
+function installRuntimeHooks(userDataPath) {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  const originalLoad = Module._load;
+  const electronStub = {
+    app: {
+      getPath: () => userDataPath,
+      getVersion: () => '0.0.0-deep-research-ab',
+      getAppPath: () => repoRoot,
+      isPackaged: false,
+      getName: () => 'Nodus',
+    },
+    safeStorage: {
+      isEncryptionAvailable: () => false,
+      encryptString: (value) => Buffer.from(String(value)),
+      decryptString: (value) => Buffer.from(value).toString(),
+    },
+    dialog: { showMessageBoxSync: () => 1 },
+    shell: {},
+    BrowserWindow: class {},
+    ipcMain: { handle: () => undefined, on: () => undefined },
+    net: {},
+  };
+  Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') return electronStub;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  require.extensions['.ts'] = function (module, filename) {
+    const output = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}

--- a/scripts/with-nodus-keys.cjs
+++ b/scripts/with-nodus-keys.cjs
@@ -1,0 +1,94 @@
+// Runs a command with the installed Nodus app's provider keys injected as env vars.
+//
+// safeStorage only decrypts under a real Electron main process, so this runs as one,
+// reads the encrypted key files from the released profile READ-ONLY, and hands the
+// plaintext to a child process through the environment. Keys are never printed,
+// never written to disk and never reach the parent shell.
+//
+//   ./node_modules/.bin/electron scripts/with-nodus-keys.cjs --providers gemini,openrouter -- node script.mjs …
+const { app, safeStorage } = require('electron');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+app.disableHardwareAcceleration();
+app.setName('Nodus');
+
+const argv = process.argv.slice(2);
+const split = argv.indexOf('--');
+if (split < 0) {
+  console.error('Usage: electron scripts/with-nodus-keys.cjs [--providers a,b] [--profile DIR] -- <command> [args…]');
+  process.exit(2);
+}
+const optionOf = (name, fallback) => {
+  const at = argv.indexOf(name);
+  return at >= 0 && at < split && argv[at + 1] ? argv[at + 1] : fallback;
+};
+const providers = optionOf('--providers', 'gemini').split(',').map((p) => p.trim()).filter(Boolean);
+const profile = optionOf('--profile', path.join(app.getPath('home'), 'Library/Application Support/nodus'));
+const [command, ...commandArgs] = argv.slice(split + 1);
+
+const ENV_NAME = {
+  gemini: 'GEMINI_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+  mistral: 'MISTRAL_API_KEY',
+  groq: 'GROQ_API_KEY',
+};
+
+/** Mirrors electron/secrets/secretStore.ts#readKeyFile, read-only. */
+function readKey(provider) {
+  const candidates = [
+    path.join(profile, 'secrets', `ai_key_${provider}.bin`),
+    path.join(profile, `ai_key_${provider}.bin`),
+  ];
+  try {
+    const vaults = path.join(profile, 'vaults');
+    for (const name of fs.readdirSync(vaults)) candidates.push(path.join(vaults, name, `ai_key_${provider}.bin`));
+  } catch {
+    /* no vault directory */
+  }
+  for (const file of candidates) {
+    if (!fs.existsSync(file)) continue;
+    const buf = fs.readFileSync(file);
+    const asStr = buf.toString('utf8');
+    if (asStr.startsWith('b64:')) return Buffer.from(asStr.slice(4), 'base64').toString('utf8');
+    if (!safeStorage.isEncryptionAvailable()) continue;
+    try {
+      return safeStorage.decryptString(buf);
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return null;
+}
+
+app.whenReady().then(() => {
+  const env = { ...process.env };
+  const found = [];
+  for (const provider of providers) {
+    const name = ENV_NAME[provider];
+    if (!name) {
+      console.error(`[keys] unknown provider "${provider}"`);
+      continue;
+    }
+    const key = readKey(provider);
+    if (key) {
+      env[name] = key;
+      found.push(provider);
+    } else {
+      console.error(`[keys] no usable key for ${provider}`);
+    }
+  }
+  console.error(`[keys] injected: ${found.join(', ') || 'none'}`);
+  // ELECTRON_RUN_AS_NODE leaks into the child otherwise and breaks a real-Electron child.
+  delete env.ELECTRON_RUN_AS_NODE;
+  const child = spawn(command, commandArgs, { stdio: 'inherit', env });
+  child.on('exit', (code, signal) => app.exit(signal ? 1 : (code ?? 0)));
+  child.on('error', (error) => {
+    console.error(`[keys] ${error.message}`);
+    app.exit(1);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5621,7 +5621,7 @@ export interface WritingWorkshopIdeaCandidate extends WritingWorkshopCandidateBa
   themes: string[];
   workCount: number;
   evidenceCount: number;
-  works: { nodus_id: string; title: string; authors: string[]; year: number | null; zotero_key: string }[];
+  works: { nodus_id: string; title: string; authors: string[]; year: number | null; zotero_key: string; doi?: string | null }[];
 }
 
 export interface WritingWorkshopThemeCandidate extends WritingWorkshopCandidateBase {
@@ -5643,6 +5643,10 @@ export interface WritingWorkshopContradictionCandidate extends WritingWorkshopCa
   type: EdgeType | string;
   basis: EdgeBasis;
   confidence: number;
+  /** Author-year labels of the works behind the dispute, so a writer can attribute
+   * the debate to whoever actually holds each position instead of describing a
+   * nameless tension. */
+  sources?: string[];
 }
 
 export interface WritingWorkshopWorkCandidate extends WritingWorkshopCandidateBase {
@@ -5650,6 +5654,8 @@ export interface WritingWorkshopWorkCandidate extends WritingWorkshopCandidateBa
   authors: string[];
   year: number | null;
   zotero_key: string;
+  /** Present when the source carries one; the only locator the local schema stores. */
+  doi?: string | null;
   themes: string[];
   deepStatus: DeepStatus;
   /** Orientation only; never evidence or a citation target. */
@@ -5874,6 +5880,18 @@ export interface DeepResearchMeta {
   targetPages: { min: number; max: number };
   /** Non-null when the loop stopped before covering everything (budget cap, cap on sections, etc.). */
   stoppedReason: string | null;
+  /**
+   * Result of checking that each citation's source really supports the sentence it
+   * was attached to. Null when no verification pass ran. `unsupported` citations were
+   * removed from the prose, so this is a record of what the report stopped claiming.
+   */
+  verification?: { checked: number; partial: number; unsupported: number } | null;
+  /** How many sections came back under their word target and were developed further. */
+  expansions?: number;
+  /** Words each section ended up with, against the target it was given. */
+  sectionFill?: { words: number; target: number }[];
+  /** Passages of the report that contradict each other, reported rather than repaired. */
+  coherenceIssues?: number;
 }
 
 /**

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5721,6 +5721,20 @@ export interface WritingWorkshopMatrixRow {
   notes: string;
 }
 
+/** One claim the verification pass flagged, with the source text to check it against. */
+export interface SupportAuditEntry {
+  verdict: 'partial' | 'removed';
+  kind: 'idea' | 'passage' | 'gap' | 'contradiction';
+  /** The section the claim sits in. */
+  section: string;
+  /** The sentence as it appears in the report. */
+  sentence: string;
+  /** What the cited source actually says. */
+  source: string;
+  /** Author-year of the work behind it, when there is one. */
+  sourceLabel: string;
+}
+
 export interface WritingWorkshopDraft {
   generatedAt: string;
   brief: WritingWorkshopBrief;
@@ -5733,6 +5747,13 @@ export interface WritingWorkshopDraft {
   bibliography: string[];
   nextSteps: string[];
   limitations: string[];
+  /**
+   * What the entailment pass concluded about individual claims, so a researcher can
+   * spot-check the weakest ones instead of re-reading every source. Only claims that
+   * are worth a second look are listed: those whose source supports a weaker version
+   * of the sentence, and those whose citation was removed for not supporting it.
+   */
+  supportAudit?: SupportAuditEntry[];
   stats: {
     selectedIdeas: number;
     selectedThemes: number;

--- a/shared/writingDocument.ts
+++ b/shared/writingDocument.ts
@@ -1,0 +1,65 @@
+// Shared shaping rules for an assembled writing/Deep Research document.
+//
+// `draftMarkdown` is a self-contained document: it opens with the abstract and
+// closes with limitations and references. Every surface that ALSO renders those
+// from the structured fields (the reader's subtitle and side panels, the PDF's
+// abstract box) must drop them from the body first, or the reader sees each one
+// twice. Keeping that rule in one pure module is what stops the two from drifting.
+
+/** Section headings the body carries in each supported language. */
+const SECTION_ALIASES: Record<'abstract' | 'limitations', string[]> = {
+  abstract: ['resumen', 'abstract', 'résumé', 'resume', 'zusammenfassung', 'özet', 'ozet', 'resumo'],
+  limitations: ['limitaciones', 'limitations', 'limites', 'limitações', 'limitacoes', 'einschränkungen', 'einschrankungen', 'sınırlılıklar', 'sinirliliklar'],
+};
+
+function normalizeHeading(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+/, '')
+    .trim()
+    .toLocaleLowerCase('es-ES')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[.:;]+$/, '')
+    .trim();
+}
+
+/**
+ * Remove the document's leading abstract block when it merely repeats `abstract`.
+ * Left untouched when the body does not open with it, so drafts that never carried
+ * one (and anything saved by an older build) render exactly as before.
+ */
+export function stripLeadingAbstract(markdown: string, abstract: string): string {
+  const lines = (markdown ?? '').replace(/\r\n?/g, '\n').split('\n');
+  const first = lines.findIndex((line) => line.trim().length > 0);
+  if (first < 0 || !/^#{1,3}\s+/.test(lines[first])) return markdown;
+  let next = first + 1;
+  while (next < lines.length && !/^#{1,3}\s+/.test(lines[next])) next++;
+  const block = lines.slice(first + 1, next).join(' ').replace(/\s+/g, ' ').trim();
+  const expected = (abstract ?? '').replace(/\s+/g, ' ').trim();
+  if (!expected || !block || !block.includes(expected.slice(0, Math.min(80, expected.length)))) return markdown;
+  return lines.slice(next).join('\n').trim();
+}
+
+/** Drop a whole `## <heading>` block from the body, headings matched by language alias. */
+export function stripSection(markdown: string, kind: 'abstract' | 'limitations'): string {
+  const aliases = new Set(SECTION_ALIASES[kind]);
+  const lines = (markdown ?? '').replace(/\r\n?/g, '\n').split('\n');
+  const out: string[] = [];
+  let skipping = false;
+  for (const line of lines) {
+    if (/^#{1,3}\s+/.test(line)) {
+      skipping = aliases.has(normalizeHeading(line));
+      if (skipping) continue;
+    }
+    if (!skipping) out.push(line);
+  }
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+/**
+ * The body to show next to a subtitle abstract and limitation/next-step panels.
+ * Everything those surfaces render themselves is removed exactly once.
+ */
+export function documentBodyForPanels(markdown: string, abstract: string): string {
+  return stripSection(stripLeadingAbstract(markdown, abstract), 'limitations');
+}

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -7741,4 +7741,8 @@ export const DE: Record<string, string> = {
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Schreibe das Thema und Nodus verfasst die ganze Einheit aus deinen Materialien und zitiert jedes davon. Du kannst die KI die Teile vorschlagen lassen oder sie selbst festlegen: wie viele es sind, wie sie heißen und worauf sich jeder konzentrieren soll.',
   'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Gib das Thema der Lernunterlagen ein. Der Inhalt erklärt es anhand deiner Materialien Schritt für Schritt mit Beispielen und Selbstkontrolle.',
   'La diarización detecta cambios de hablante y etiqueta cada segmento automáticamente. Revisa siempre las etiquetas antes de usar la transcripción.': 'Die Diarisierung erkennt Sprecherwechsel und kennzeichnet jedes Segment automatisch. Prüfe die Kennzeichnungen immer, bevor du das Transkript verwendest.',
+  'Comprobación del respaldo': 'Belegprüfung',
+  '{partial} afirmaciones con respaldo parcial · {removed} citas retiradas': '{partial} Aussagen mit teilweisem Beleg · {removed} Zitate entfernt',
+  'parcial': 'teilweise',
+  'retirada': 'entfernt',
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -7968,4 +7968,8 @@ export const EN: Record<string, string> = {
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Write the topic and Nodus drafts the whole unit from your materials, citing each one. You can let the AI propose the parts or fix them yourself: how many there are, what they are called and what each one should concentrate on.',
   'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Enter the topic for the notes. The content will explain it step by step with examples and self-assessment drawn from your materials.',
   'La diarización detecta cambios de hablante y etiqueta cada segmento automáticamente. Revisa siempre las etiquetas antes de usar la transcripción.': 'Diarization detects speaker changes and labels every segment automatically. Always review the labels before using the transcript.',
+  'Comprobación del respaldo': 'Support check',
+  '{partial} afirmaciones con respaldo parcial · {removed} citas retiradas': '{partial} claims with partial support · {removed} citations removed',
+  'parcial': 'partial',
+  'retirada': 'removed',
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -7732,4 +7732,8 @@ export const FR: Record<string, string> = {
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Écris le sujet et Nodus rédige l’unité complète à partir de tes supports, en citant chacun d’eux. Tu peux laisser l’IA proposer les parties ou les fixer toi-même: combien il y en a, comment elles s’intitulent et sur quoi chacune doit se concentrer.',
   'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Écris le sujet des notes. Le contenu l’expliquera pas à pas avec des exemples et une autoévaluation à partir de tes supports.',
   'La diarización detecta cambios de hablante y etiqueta cada segmento automáticamente. Revisa siempre las etiquetas antes de usar la transcripción.': 'La diarisation détecte les changements de locuteur et étiquette automatiquement chaque segment. Vérifie toujours les étiquettes avant d’utiliser la transcription.',
+  'Comprobación del respaldo': 'Vérification des appuis',
+  '{partial} afirmaciones con respaldo parcial · {removed} citas retiradas': '{partial} affirmations à l\'appui partiel · {removed} citations retirées',
+  'parcial': 'partiel',
+  'retirada': 'retirée',
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -7143,4 +7143,8 @@ export const IT: Record<string, string> = {
   "Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.": "Scrivi il tema e Nodus redige l’intera unità a partire dai tuoi materiali, citandoli uno per uno. Puoi lasciare che l’IA proponga le parti oppure fissarle tu: quante sono, come si intitolano e su che cosa deve concentrarsi ciascuna.",
   "Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.": "Scrivi l’argomento delle dispense. Il contenuto lo spiegherà passo dopo passo con esempi e autovalutazione a partire dai tuoi materiali.",
   "La diarización detecta cambios de hablante y etiqueta cada segmento automáticamente. Revisa siempre las etiquetas antes de usar la transcripción.": "La diarizzazione rileva i cambi di parlante ed etichetta automaticamente ogni segmento. Verifica sempre le etichette prima di usare la trascrizione.",
+  'Comprobación del respaldo': 'Verifica dei riscontri',
+  '{partial} afirmaciones con respaldo parcial · {removed} citas retiradas': '{partial} affermazioni con riscontro parziale · {removed} citazioni rimosse',
+  'parcial': 'parziale',
+  'retirada': 'rimossa',
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -7691,4 +7691,8 @@ export const PT_BR: Record<string, string> = {
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Escreva o tema e o Nodus redige a unidade completa a partir dos seus materiais, citando cada um. Você pode deixar a IA propor as partes ou defini-las: quantas são, como se chamam e no que cada uma deve se concentrar.',
   'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Escreva o tema do material. O conteúdo explicará passo a passo com exemplos e autoavaliação a partir dos seus materiais.',
   'La diarización detecta cambios de hablante y etiqueta cada segmento automáticamente. Revisa siempre las etiquetas antes de usar la transcripción.': 'A diarização detecta mudanças de falante e identifica automaticamente cada segmento. Sempre revise os rótulos antes de usar a transcrição.',
+  'Comprobación del respaldo': 'Verificação do apoio',
+  '{partial} afirmaciones con respaldo parcial · {removed} citas retiradas': '{partial} afirmações com apoio parcial · {removed} citações removidas',
+  'parcial': 'parcial',
+  'retirada': 'removida',
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -7683,4 +7683,8 @@ export const PT: Record<string, string> = {
   'Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.': 'Escreve o tema e o Nodus redige a unidade completa a partir dos teus materiais, citando cada um. Podes deixar a IA propor as partes ou fixá-las tu: quantas são, como se intitulam e em que se deve centrar cada uma.',
   'Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.': 'Escreve o tema dos apontamentos. O conteúdo explica-o passo a passo com exemplos e autoavaliação a partir dos teus materiais.',
   'La diarización detecta cambios de hablante y etiqueta cada segmento automáticamente. Revisa siempre las etiquetas antes de usar la transcripción.': 'A diarização deteta mudanças de orador e etiqueta automaticamente cada segmento. Revê sempre as etiquetas antes de usar a transcrição.',
+  'Comprobación del respaldo': 'Verificação do apoio',
+  '{partial} afirmaciones con respaldo parcial · {removed} citas retiradas': '{partial} afirmações com apoio parcial · {removed} citações retiradas',
+  'parcial': 'parcial',
+  'retirada': 'retirada',
 };

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -7490,4 +7490,8 @@ export const TR: Record<string, string> = {
   "Escribe el tema y Nodus redacta la unidad completa con tus materiales, citando cada uno. Puedes dejar que la IA proponga las partes o fijarlas tú: cuántas son, cómo se titulan y en qué debe centrarse cada una.": "Konuyu yaz; Nodus üniteyi materyallerinden baştan sona yazar ve her birine atıf yapar. Bölümleri yapay zekâya önerttirebilir ya da kendin belirleyebilirsin: kaç tane olacağı, nasıl adlandırılacağı ve her birinin neye odaklanacağı.",
   "Escribe el tema de los apuntes. El contenido lo explicará paso a paso con ejemplos y autoevaluación usando tus materiales.": "Ders notlarının konusunu yaz. İçerik, materyallerini kullanarak örnekler ve öz değerlendirmeyle adım adım açıklayacak.",
   "La diarización detecta cambios de hablante y etiqueta cada segmento automáticamente. Revisa siempre las etiquetas antes de usar la transcripción.": "Konuşmacı ayrıştırma, konuşmacı değişikliklerini algılar ve her bölümü otomatik olarak etiketler. Dökümü kullanmadan önce etiketleri her zaman kontrol et.",
+  'Comprobación del respaldo': 'Dayanak denetimi',
+  '{partial} afirmaciones con respaldo parcial · {removed} citas retiradas': '{partial} kısmi dayanaklı ifade · {removed} kaynak kaldırıldı',
+  'parcial': 'kısmi',
+  'retirada': 'kaldırıldı',
 };

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -19,6 +19,7 @@ import type {
 import type { StudyDeepResearchAudience } from '@shared/studyDeepResearchAudience';
 import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
 import { toReadingCopy } from '@shared/readingCopy';
+import { stripLeadingAbstract } from '@shared/writingDocument';
 import type { PendingGraphNavigationTarget } from '../navigation';
 import { Icon, modelLabel } from '../components/ui';
 import { ModelPicker } from '../components/ModelPicker';
@@ -530,7 +531,7 @@ export function DeepResearchView({
             entityKind="deep_research"
             entityId={openDraft.id}
             sourceTitle={openDraft.draft.title}
-            sourceMarkdown={`# ${openDraft.draft.title}\n\n${openDraft.draft.abstract ? `${openDraft.draft.abstract}\n\n` : ''}${openDraft.draft.draftMarkdown}`}
+            sourceMarkdown={`# ${openDraft.draft.title}\n\n${openDraft.draft.abstract ? `${openDraft.draft.abstract}\n\n` : ''}${stripLeadingAbstract(openDraft.draft.draftMarkdown, openDraft.draft.abstract)}`}
             model={openDraft.model}
             activeTranslationId={appliedTranslation?.id ?? null}
             onApply={setAppliedTranslation}
@@ -549,7 +550,7 @@ export function DeepResearchView({
         )}
         {savingToNotes && (
           <SaveToNotesModal
-            content={`# ${openDraft.draft.title}\n\n${openDraft.draft.abstract ? `${openDraft.draft.abstract}\n\n` : ''}${openDraft.draft.draftMarkdown}`}
+            content={`# ${openDraft.draft.title}\n\n${openDraft.draft.abstract ? `${openDraft.draft.abstract}\n\n` : ''}${stripLeadingAbstract(openDraft.draft.draftMarkdown, openDraft.draft.abstract)}`}
             defaultTitle={openDraft.draft.title}
             kind="writing"
             source={{ origin: 'writing', model: openDraft.model, ref: 'deep_research' }}

--- a/src/views/writingShared.tsx
+++ b/src/views/writingShared.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { DecorativeImageStyle, WritingWorkshopBrief, WritingWorkshopDraft, WritingWorkshopSavedDraft } from '@shared/types';
+import type { DecorativeImageStyle, SupportAuditEntry, WritingWorkshopBrief, WritingWorkshopDraft, WritingWorkshopSavedDraft } from '@shared/types';
 import { documentBodyForPanels } from '@shared/writingDocument';
 import { Badge, Icon } from '../components/ui';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
@@ -214,6 +214,7 @@ export function SupportMatrix({
               </div>
             </div>
           ))}
+          <SupportAudit entries={draft.supportAudit ?? []} />
           <PanelList title={t('Siguientes pasos')} items={draft.nextSteps} />
           <PanelList title={t('Limitaciones')} items={draft.limitations} />
           <PanelList title={t('Bibliografía')} items={draft.bibliography} />
@@ -321,6 +322,51 @@ export function Metric({ label, value }: { label: string; value: string | number
       <div className="text-[11px] text-neutral-500">{label}</div>
       <div className="text-sm font-semibold">{value}</div>
     </div>
+  );
+}
+
+/**
+ * The claims worth checking before citing the report, each next to the source text
+ * it rests on. The engine already removed the citations no source supported; what is
+ * left here is the grey zone — a source that backs a weaker version of the sentence
+ * than the sentence claims — which no automatic check can settle for the reader.
+ */
+export function SupportAudit({ entries }: { entries: SupportAuditEntry[] }) {
+  const [open, setOpen] = useState(false);
+  if (entries.length === 0) return null;
+  const partial = entries.filter((entry) => entry.verdict === 'partial').length;
+  const removed = entries.length - partial;
+  return (
+    <section className="pt-3 border-t border-neutral-800">
+      <button className="flex items-center gap-2 w-full text-left" onClick={() => setOpen((v) => !v)}>
+        <Icon name={open ? 'chevronDown' : 'chevronRight'} size={14} className="text-neutral-500" />
+        <h3 className="font-semibold text-sm">{t('Comprobación del respaldo')}</h3>
+        <Badge color={partial > 0 ? 'amber' : 'neutral'}>{String(entries.length)}</Badge>
+      </button>
+      <p className="text-xs text-neutral-500 mt-1">
+        {tx('{partial} afirmaciones con respaldo parcial · {removed} citas retiradas', {
+          partial: String(partial),
+          removed: String(removed),
+        })}
+      </p>
+      {open && (
+        <ul className="space-y-3 mt-3">
+          {entries.map((entry, index) => (
+            <li key={index} className="text-xs">
+              <div className="flex items-center gap-2 mb-1">
+                <Badge color={entry.verdict === 'partial' ? 'amber' : 'red'}>
+                  {entry.verdict === 'partial' ? t('parcial') : t('retirada')}
+                </Badge>
+                {entry.sourceLabel && <span className="text-neutral-500">{entry.sourceLabel}</span>}
+                <span className="text-neutral-600 truncate">{entry.section}</span>
+              </div>
+              <p className="text-neutral-300">{entry.sentence}</p>
+              <p className="text-neutral-500 mt-1 border-l-2 border-neutral-700 pl-2">{entry.source}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }
 

--- a/src/views/writingShared.tsx
+++ b/src/views/writingShared.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { DecorativeImageStyle, WritingWorkshopBrief, WritingWorkshopDraft, WritingWorkshopSavedDraft } from '@shared/types';
+import { documentBodyForPanels } from '@shared/writingDocument';
 import { Badge, Icon } from '../components/ui';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
 import type { CitationTarget } from '../components/SourceCitationModal';
@@ -139,7 +140,9 @@ export function DraftResultMain({
         </div>
       </section>
       <section className={`card p-4 ${justify ? 'text-justify hyphens-auto' : ''}`}>
-        <Markdown content={draft.draftMarkdown} onCitation={onCitation} onStudyDocument={onStudyDocument} onStudyMaterial={onStudyMaterial} onStudyRecording={onStudyRecording} />
+        {/* The abstract is the subtitle above and the limitations have their own
+            panel below, so the body drops both rather than repeating them. */}
+        <Markdown content={documentBodyForPanels(draft.draftMarkdown, draft.abstract)} onCitation={onCitation} onStudyDocument={onStudyDocument} onStudyMaterial={onStudyMaterial} onStudyRecording={onStudyRecording} />
       </section>
     </div>
   );


### PR DESCRIPTION
Closes #318

Every number below comes from reports generated over a snapshot of the real academic corpus (9,959 ideas, 1,214 works, 33,016 passages), not from fakes.

## What changed

**The writer now sees its evidence.** The citation menu carries the idea's statement, what a gap claims, what a contradiction opposes *and who holds each side*, and the passage's literal text. A passage with no readable text is never offered: a page number attached to words nobody read is an invitation to invent.

**Coverage is what the prose cites**, not what the plan assigned. That makes the statistic falsifiable, revives the coverage top-up that had been unreachable dead code, and makes the limitations honest about what was left out.

**Sections are sized to what a section really delivers.** Measured at ~1040 words rather than the 1400 the plan assumed, which is why every report used to land on the floor of its page range.

**Citations are verified.** Each claim is paired with the source cited for it and checked for entailment; what the source does not support is removed from the prose *and* from the bibliography. Claims with only partial support are surfaced in a new reader panel next to the source text, so spot-checking a report takes minutes instead of hours.

**Reading order is planned.** The planner declares each section's role and dependencies and a stable topological sort turns them into the sequence, so a coherent progression is a property of the engine rather than luck of the draw — two runs of the same objective previously produced a genealogy and a flat thematic list.

Plus: leftover ideas assigned by affinity and source diversity instead of round-robin; per-section retrieval; a read-only coherence check that reports self-contradictions and discards any it cannot quote verbatim; split headings folded into one phrase; gaps and debates cited by their source instead of by the words "hueco" and "contradicción"; and a citation repair that guarantees no raw `nodus://` identifier can reach the page whatever shape the model invents.

## Measured effect

Same corpus, same objectives, `gemini-3.1-flash-lite`:

| | before | after |
|---|---|---|
| body pages (target 9–14) | 7 | 11–12 |
| citations per report | 87 | 108–116 |
| ideas *claimed* covered | 120 | 73 |
| ideas *really* cited | 77 | 73 |
| coverage honesty | 0.64 | **1.00** |
| literal passages cited | 0 | 10–13 |
| attributed debates | 1 | 7–10 |
| broken references | 6 | **0** |
| false attributions published | ~5% | **0** (removed) |

A blind judge, each pair scored in both orders, prefers the reports written by a stronger model on all five dimensions (14 of 15, no wins for the weaker one) — including "which would you use to start writing a chapter".

## What was tried and rejected

Kept in the code with the measurement written beside it, so none of it is retried blind:

- **Multi-probe retrieval.** Decomposing the objective into sub-questions tripled unsupported citations (3% → 9%) with no relevance floor; with one it changed 5–10% of the pool while slightly reducing the distinct works behind it. This corpus is concentrated on one domain, so every sub-question lands in the same neighbourhood.
- **Longer sections.** The expansion pass fires on 10 of 12 sections, is accepted, and the section still finishes at ~1040 words. The ceiling is the model, not the prompt.
- **Preferring literal passages over derived ideas.** Verbatim quoting more than tripled, the argument leaned on a third fewer distinct works, and unsupported citations doubled as claims overreached a narrow snippet.

## Verification

`npm test` 1485/1485, `npm run typecheck` and `npm run lint` clean. The measurement harness ships in `scripts/`: batch generation, scoring, a poisoned-citation control for the verifier (85% recall, 5% false positives), and the blind judge.