### PR TITLE
Release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## 3.0.2 — 2026-07-31
+
+The Deep Research release. The engine used to overstate itself in ways that
+compounded: it reported coverage it had not achieved, published attributions its
+sources did not support, and printed raw identifiers where a citation should be.
+Every number below was measured on reports generated over a snapshot of a real
+academic vault, not on fixtures.
+
+### Added
+
+- **The writer now sees the evidence it cites.** The citation menu carried
+  placeholders — "an anchored research gap", "a literal passage from the full
+  text" — so a report cited zero passages and argued gaps and debates from a
+  label. It now carries each idea's statement, what a gap claims, what a
+  contradiction opposes and who holds each side, and the literal text of a
+  passage with its page. A passage whose text cannot be read is never offered.
+- **Citations are checked against their sources.** Each claim is paired with the
+  material cited for it and judged for entailment; what a source does not support
+  is removed from the prose and from the bibliography, so a false attribution
+  cannot survive anywhere in the report.
+- **A support-check panel.** A third of the citations that pass verification are
+  only partially supported — the source backs a weaker version of the sentence
+  than the sentence claims. Those are listed beside the text of their source and
+  the author-year to open, turning a manual check from hours into minutes.
+- **Reading order is planned.** The planner declares each section's role and what
+  it presupposes, and a stable topological sort turns that into the sequence. Two
+  runs of the same objective previously produced a genealogy and a flat thematic
+  list; the progression is now a property of the engine.
+- **Self-contradictions are reported.** A read-only pass flags passages of the
+  report that cannot both be right, quoting both sides verbatim and discarding
+  any finding whose quotes are not in the text. It never rewrites: editing
+  assembled prose would put every verified citation at risk.
+
+### Fixed
+
+- **Coverage counted the plan, not the prose.** Every idea is assigned to some
+  section, and assignment counted as coverage, so the statistic read 120/120
+  while 77 ideas were really cited — and the top-up that lifts a short report was
+  unreachable dead code. Reports landed two pages under their minimum with no
+  truncation flag. Coverage is now what the text cites.
+- **Reports landed on the floor of their page range.** Sections were sized at
+  1400 words on the theory that few long sections beat many short ones; measured,
+  a section asked for 1575 words came back with ~1040 and stayed there even after
+  being rewritten. Sizing the plan to what a section really delivers moves a
+  report from 9 pages to 11–12, with 20% more citations and 22% more ideas.
+- **Malformed citations printed raw identifiers.** Models emit references in
+  shapes the citation pattern never matched, and those escaped both the prose and
+  the accounting. References are now repaired where the label can be
+  reconstructed and dropped where it cannot, and a final sweep guarantees no
+  `nodus://` identifier can reach the page.
+- **Gaps and debates read as debug labels.** "(hueco)" and "(contradicción)"
+  appeared 50 times across three reports as visible text in academic prose. A gap
+  is now cited by the work it is anchored to and a debate by whoever holds one of
+  its sides. Sources whose author the corpus never captured are cited by a
+  shortened title instead of "(Author)".
+- **Split headings.** `Title: subtitle` headings are folded into one phrase,
+  keeping the subtitle rather than truncating it.
+- **The abstract and limitations appeared twice.** The reader showed the abstract
+  as a subtitle and again as the first section, and the markdown export added its
+  own copies on top of the ones already in the body.
+- **The argument map and debates froze the window.** They painted tens of
+  thousands of elements at once; they now render in chunks as you scroll, and the
+  map unfolds one branch at a time instead of opening whole.
+- **Image generation with Google.** It was being asked for an image format the
+  API no longer accepts.
+- **Interviewed characters recited their sheet.** In worldbuilding demo mode they
+  answered by reading their own character sheet aloud instead of speaking.
+
+### Changed
+
+- **The Codex runtime bundled with Nodus can generate images**, so a connected
+  ChatGPT subscription needs no extra key for illustrations.
+
+### Measured and rejected
+
+Kept in the code with the measurement beside it, so none is retried blind:
+multi-probe retrieval (tripled unsupported citations without a relevance floor;
+with one, changed 5–10% of the pool while reducing the distinct works behind it),
+longer sections (the expansion pass fires on 10 of 12 sections, is accepted, and
+the section still finishes at ~1040 words), and preferring literal passages over
+derived ideas (verbatim quoting more than tripled, the argument leaned on a third
+fewer distinct works, and unsupported citations doubled).
+
 ## 3.0.1 — 2026-07-30
 
 A performance release, from an audit run against a real 465 MB academic vault.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.0.1"
-date-released: "2026-07-30"
+version: "3.0.2"
+date-released: "2026-07-31"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/electron/ai/deepResearchCore.ts
+++ b/electron/ai/deepResearchCore.ts
@@ -813,7 +813,7 @@ export function normalizePlan(
     gapIds: strList(s.gapIds).filter((id) => gapIds.has(id)),
     contradictionIds: strList(s.contradictionIds).filter((id) => contradictionIds.has(id)),
     passageIds: strList(s.passageIds).filter((id) => passageIds.has(id)),
-    role: s.role === 'intro' || s.role === 'synthesis' ? s.role : 'body',
+    role: (s.role === 'intro' || s.role === 'synthesis' ? s.role : 'body') as DeepResearchPlanSection['role'],
     dependsOn: strList(s.dependsOn),
   }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "2.7.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "2.7.0",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,10 +25,15 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.0.1');
-  assert.equal(currentRelease?.date, '2026-07-30');
-  // A performance release: one highlight per cause, not one per query fixed.
-  assert.equal(currentRelease?.highlights.length, 3);
+  assert.equal(currentRelease?.version, '3.0.2');
+  assert.equal(currentRelease?.date, '2026-07-31');
+  // The Deep Research release: one highlight per user-visible change.
+  assert.equal(currentRelease?.highlights.length, 5);
+
+  // 3.0.1 stays reachable from the version picker underneath it.
+  const performanceRelease = RELEASE_NOTES.find((note) => note.version === '3.0.1');
+  assert.equal(performanceRelease?.date, '2026-07-30');
+  assert.equal(performanceRelease?.highlights.length, 3);
 
   // The vault introductions live in 3.0.0 and must keep their shape as newer
   // releases land on top of them — hence looked up by version, not as `[0]`.

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -58,6 +58,14 @@ export const RELEASE_2_7_0_IT: string[] = [
 ];
 
 /** Italian history, indexed by release and highlight order. */
+const RELEASE_3_0_2_IT: string[] = [
+  "Deep Research non afferma più di quanto possa sostenere. Ogni citazione viene verificata rispetto a ciò che la fonte dice davvero, e quella che non la sostiene sparisce dal testo e dalla bibliografia. Chi redige riceve ora il contenuto reale di ciò che cita — l’enunciato di ogni idea, ciò che afferma ogni lacuna, chi sostiene ciascuna posizione di un dibattito e il testo letterale di ogni passaggio con la sua pagina —, così i disaccordi fra autori vengono argomentati con nomi anziché citati di sfuggita. La copertura dichiarata è quella realmente citata, non quella assegnata.",
+  "Un nuovo pannello indica quali affermazioni conviene verificare prima di citarle. Un terzo delle citazioni che superano la verifica ha un riscontro parziale: la fonte sostiene una versione più debole di quanto la frase affermi. Il report le elenca accanto al testo della loro fonte e all’autore e anno da aprire, così controllare un report passa dal leggere opere intere al confrontare una manciata di coppie.",
+  "La mappa degli argomenti e i dibattiti non congelano più la finestra. Disegnavano in un colpo solo decine di migliaia di elementi e l’intera applicazione restava bloccata per uno o due secondi all’apertura; ora vengono disegnati a tratti mentre scorri. La mappa si dispiega inoltre un ramo alla volta invece di aprirsi tutta, così puoi seguire una linea argomentativa senza perderti.",
+  "I personaggi intervistati parlano invece di recitare. In modalità dimostrativa rispondevano leggendo la propria scheda ad alta voce; ora rispondono con la loro voce, il loro carattere e i loro silenzi, come in un’intervista vera.",
+  "Il runtime di Codex incluso in Nodus genera anche immagini, così puoi creare illustrazioni senza configurare alcuna chiave aggiuntiva se hai già collegato il tuo abbonamento ChatGPT. E la generazione con Google torna a funzionare: le veniva richiesto un formato di immagine che non accetta più.",
+];
+
 const RELEASE_3_0_1_IT: string[] = [
   "Le sezioni che restavano a pensare ora si aprono subito. Il grafo, la mappa degli argomenti, i dibattiti, il percorso di lettura e le schede d'autore si caricavano percorrendo l'intera biblioteca e bloccavano tutta l'applicazione mentre lo facevano; ora chiedono solo ciò che mostrano. In una cassaforte di quasi 10.000 idee il grafo passa da 2,7 secondi di finestra congelata a meno di 0,2.",
   "Nodi resta fermo quando non ha nulla da dire e torna a muoversi appena ce l'ha. La sua animazione non si fermava mai, nemmeno con l'applicazione a riposo: costava in permanenza mezzo core e scaldava la macchina. Ora mantiene la posa qualche secondo dopo l'ultima attività e si sveglia al passaggio del mouse, a un cambio di stato o all'arrivo di una notifica. Nessuna animazione è stata rimossa.",
@@ -65,6 +73,7 @@ const RELEASE_3_0_1_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.0.2": RELEASE_3_0_2_IT,
   "3.0.1": RELEASE_3_0_1_IT,
   "3.0.0": RELEASE_3_0_0_IT,
   "2.7.0": RELEASE_2_7_0_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -1,3 +1,11 @@
+const RELEASE_3_0_2_TR: string[] = [
+  "Deep Research artık destekleyebileceğinden fazlasını iddia etmiyor. Her kaynak gösterimi, kaynağın gerçekte ne söylediğine karşı denetleniyor; desteklemeyen gösterim metinden de kaynakçadan da siliniyor. Yazan taraf artık aktardığı şeyin gerçek içeriğini alıyor — her fikrin ifadesi, her araştırma boşluğunun iddiası, bir tartışmada hangi tarafı kimin savunduğu ve her pasajın sayfasıyla birlikte birebir metni —, böylece yazarlar arasındaki anlaşmazlıklar geçerken anılmak yerine adlarıyla tartışılıyor. Raporun bildirdiği kapsam, atanan değil gerçekten atıf yapılan kapsamdır.",
+  "Yeni bir panel, hangi ifadeleri aktarmadan önce denetlemeniz gerektiğini gösteriyor. Denetimi geçen kaynak gösterimlerinin üçte biri yalnızca kısmen destekleniyor: kaynak, cümlenin iddia ettiğinden daha zayıf bir sürümü destekliyor. Rapor bunları kaynağının metniyle ve açılacak yazar ve yılla birlikte listeliyor; böylece bir raporu denetlemek, eserlerin tamamını okumaktan birkaç çifti karşılaştırmaya iniyor.",
+  "Argüman haritası ve tartışmalar artık pencereyi dondurmuyor. On binlerce ögeyi tek seferde çiziyor ve açtığınızda uygulamanın tamamı bir iki saniye kilitleniyordu; artık siz kaydırdıkça parça parça çiziliyor. Harita ayrıca tümden açılmak yerine dal dal açılıyor; böylece bir argüman hattını yerinizi kaybetmeden izleyebiliyorsunuz.",
+  "Röportaj yapılan karakterler ezber okumak yerine konuşuyor. Tanıtım modunda karakter künyesini yüksek sesle okuyarak yanıt veriyorlardı; artık kendi sesleriyle, kendi mizaçları ve suskunluklarıyla, gerçek bir röportajdaki gibi yanıt veriyorlar.",
+  "Nodus ile gelen Codex çalışma zamanı artık görsel de üretiyor; ChatGPT aboneliğiniz bağlıysa ek bir anahtar ayarlamadan illüstrasyon oluşturabilirsiniz. Google ile üretim de yeniden çalışıyor: artık kabul etmediği bir görsel biçimi isteniyordu.",
+];
+
 const RELEASE_3_0_1_TR: string[] = [
   "Eskiden takılan bölümler artık anında açılıyor. Grafik, argüman haritası, tartışmalar, okuma rotası ve yazar dosyaları tüm kütüphaneyi dolaşarak yükleniyor ve bu sırada uygulamanın tamamını donduruyordu; artık yalnızca gösterdiklerini istiyorlar. Yaklaşık 10.000 fikirlik bir kasada grafik 2,7 saniyelik donmuş pencereden 0,2 saniyenin altına indi.",
   "Nodi söyleyecek bir şeyi yokken duruşunu koruyor, olduğu anda yeniden hareket ediyor. Animasyonu hiç durmuyordu, uygulama boştayken bile: bu sürekli olarak yarım çekirdeğe mal oluyor ve makineyi ısıtıyordu. Artık son etkinlikten birkaç saniye sonra duruluyor; imleç üzerine gelince, durum değişince veya bir bildirim gelince uyanıyor. Hiçbir animasyon kaldırılmadı.",
@@ -5,6 +13,7 @@ const RELEASE_3_0_1_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.0.2": RELEASE_3_0_2_TR,
   "3.0.1": RELEASE_3_0_1_TR,
   // Index-matched with RELEASE_3_0_0_HIGHLIGHTS — keep this order.
   "3.0.0": [

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -37,6 +37,59 @@ export interface ReleaseNote {
 interface RawReleaseNote extends Omit<ReleaseNote, 'highlights'> { highlights: RawReleaseHighlight[] }
 
 /**
+ * 3.0.2 is the Deep Research release: the report now proves what it claims,
+ * says which claims are worth a second look, and stops freezing the argument
+ * views. One highlight per user-visible change, not one per commit.
+ */
+const RELEASE_3_0_2_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'academic',
+    es: 'Deep Research ya no afirma más de lo que puede sostener. Cada cita se comprueba contra lo que su fuente dice de verdad, y la que no lo sostiene desaparece del texto y de la bibliografía. El redactor recibe ahora el contenido real de lo que cita —el enunciado de cada idea, lo que afirma cada hueco, quién sostiene cada lado de un debate y el texto literal de cada pasaje con su página—, de modo que los desacuerdos entre autores se argumentan con nombres en vez de mencionarse de pasada. La cobertura que declara el informe es la que realmente cita, no la que tenía asignada.',
+    en: 'Deep Research no longer claims more than it can support. Every citation is checked against what its source actually says, and one the source does not support disappears from the text and from the bibliography. The writer now receives the real content of what it cites — each idea’s statement, what each gap claims, who holds each side of a debate and the literal text of each passage with its page — so disagreements between authors are argued with names instead of mentioned in passing. The coverage the report declares is what it really cites, not what it was assigned.',
+    fr: 'Deep Research n’affirme plus au-delà de ce qu’il peut étayer. Chaque citation est confrontée à ce que sa source dit réellement, et celle qui n’est pas étayée disparaît du texte et de la bibliographie. Le rédacteur reçoit désormais le contenu réel de ce qu’il cite — l’énoncé de chaque idée, ce qu’affirme chaque lacune, qui défend chaque position d’un débat et le texte littéral de chaque passage avec sa page —, si bien que les désaccords entre auteurs sont argumentés avec des noms au lieu d’être évoqués en passant. La couverture annoncée est celle qui est réellement citée, non celle qui avait été assignée.',
+    de: 'Deep Research behauptet nicht mehr, als es belegen kann. Jede Quellenangabe wird daran geprüft, was ihre Quelle tatsächlich sagt; was sie nicht stützt, verschwindet aus dem Text und aus dem Literaturverzeichnis. Der Schreiber erhält jetzt den echten Inhalt dessen, was er zitiert — die Aussage jeder Idee, was jede Forschungslücke behauptet, wer welche Seite einer Debatte vertritt und den wörtlichen Text jeder Passage mit Seitenangabe —, sodass Meinungsverschiedenheiten zwischen Autoren mit Namen ausgetragen statt nebenbei erwähnt werden. Die angegebene Abdeckung ist die tatsächlich zitierte, nicht die zugewiesene.',
+    pt: 'O Deep Research deixou de afirmar mais do que consegue sustentar. Cada citação é confrontada com o que a fonte realmente diz, e a que não a sustenta desaparece do texto e da bibliografia. O redator recebe agora o conteúdo real do que cita — o enunciado de cada ideia, o que afirma cada lacuna, quem defende cada lado de um debate e o texto literal de cada passagem com a sua página —, pelo que os desacordos entre autores são argumentados com nomes em vez de referidos de passagem. A cobertura declarada é a realmente citada, não a atribuída.',
+    'pt-BR': 'O Deep Research não afirma mais do que consegue sustentar. Cada citação é checada contra o que a fonte realmente diz, e a que não sustenta some do texto e da bibliografia. O redator agora recebe o conteúdo real do que cita — o enunciado de cada ideia, o que afirma cada lacuna, quem defende cada lado de um debate e o texto literal de cada passagem com sua página —, então divergências entre autores são argumentadas com nomes em vez de citadas de passagem. A cobertura declarada é a realmente citada, não a atribuída.',
+  },
+  {
+    scope: 'academic',
+    es: 'Un panel nuevo te dice qué afirmaciones conviene comprobar antes de citarlas. Un tercio de las citas que sobreviven a la verificación tienen respaldo parcial: la fuente sostiene una versión más débil de lo que la frase afirma. El informe las lista junto al texto de su fuente y el autor y año que abrir, así que contrastar un informe pasa de leerse las obras enteras a comparar un puñado de pares.',
+    en: 'A new panel tells you which claims to check before citing them. A third of the citations that survive verification are only partially supported: the source backs a weaker version of the sentence than the sentence claims. The report lists them next to the text of their source and the author and year to open, so checking a report goes from reading whole works to comparing a handful of pairs.',
+    fr: 'Un nouveau panneau indique quelles affirmations vérifier avant de les citer. Un tiers des citations qui passent la vérification ne sont qu’en partie étayées : la source soutient une version plus faible que ce qu’affirme la phrase. Le rapport les liste à côté du texte de leur source et de l’auteur et de l’année à ouvrir ; vérifier un rapport passe donc de la lecture d’ouvrages entiers à la comparaison de quelques paires.',
+    de: 'Ein neues Panel zeigt, welche Aussagen vor dem Zitieren zu prüfen sind. Ein Drittel der Belege, die die Prüfung überstehen, ist nur teilweise gedeckt: Die Quelle stützt eine schwächere Fassung als der Satz behauptet. Der Bericht listet sie neben dem Text ihrer Quelle sowie Autor und Jahr zum Nachschlagen, sodass die Prüfung eines Berichts vom Lesen ganzer Werke zum Vergleich weniger Paare wird.',
+    pt: 'Um novo painel indica que afirmações convém verificar antes de as citar. Um terço das citações que sobrevivem à verificação tem apoio parcial: a fonte sustenta uma versão mais fraca do que a frase afirma. O relatório lista-as junto ao texto da sua fonte e ao autor e ano a abrir, pelo que conferir um relatório passa de ler obras inteiras a comparar um punhado de pares.',
+    'pt-BR': 'Um painel novo mostra quais afirmações conferir antes de citá-las. Um terço das citações que passam na verificação tem apoio parcial: a fonte sustenta uma versão mais fraca do que a frase afirma. O relatório as lista junto ao texto da fonte e ao autor e ano a abrir, então conferir um relatório passa de ler obras inteiras a comparar alguns pares.',
+  },
+  {
+    scope: 'academic',
+    es: 'El mapa de argumentos y los debates ya no congelan la ventana. Pintaban de golpe decenas de miles de elementos y la aplicación entera se quedaba bloqueada uno o dos segundos al abrirlos; ahora se dibujan por tramos a medida que bajas. Además, el mapa se despliega rama a rama en vez de abrirse entero, así que puedes seguir una línea de argumentación sin perderte.',
+    en: 'The argument map and debates no longer freeze the window. They painted tens of thousands of elements at once and the whole app locked up for a second or two when you opened them; now they draw in chunks as you scroll. The map also unfolds one branch at a time instead of opening whole, so you can follow a line of argument without losing your place.',
+    fr: 'La carte d’arguments et les débats ne figent plus la fenêtre. Ils affichaient d’un coup des dizaines de milliers d’éléments et toute l’application se bloquait une ou deux secondes à l’ouverture ; ils se dessinent désormais par tranches au fil du défilement. La carte se déplie aussi branche par branche au lieu de s’ouvrir entièrement, ce qui permet de suivre un fil argumentatif sans se perdre.',
+    de: 'Argumentkarte und Debatten frieren das Fenster nicht mehr ein. Sie zeichneten Zehntausende Elemente auf einmal und die ganze App blockierte beim Öffnen für ein bis zwei Sekunden; jetzt wird beim Scrollen abschnittsweise gezeichnet. Die Karte klappt zudem Zweig für Zweig auf, statt sich vollständig zu öffnen, sodass man einer Argumentationslinie folgen kann, ohne den Faden zu verlieren.',
+    pt: 'O mapa de argumentos e os debates deixaram de bloquear a janela. Desenhavam de uma vez dezenas de milhares de elementos e a aplicação inteira ficava presa um ou dois segundos ao abri-los; agora desenham-se por troços à medida que percorre. O mapa também se desdobra ramo a ramo em vez de abrir por completo, para poder seguir uma linha de argumentação sem se perder.',
+    'pt-BR': 'O mapa de argumentos e os debates não travam mais a janela. Eles desenhavam dezenas de milhares de elementos de uma vez e o aplicativo inteiro ficava travado um ou dois segundos ao abri-los; agora desenham em trechos conforme você rola. O mapa também se abre galho por galho em vez de tudo de uma vez, para você seguir uma linha de argumentação sem se perder.',
+  },
+  {
+    scope: 'worldbuilding',
+    es: 'Los personajes entrevistados hablan en vez de recitar. En el modo demostración respondían con la ficha del personaje leída en voz alta; ahora contestan desde su propia voz, con su carácter y sus silencios, como una entrevista de verdad.',
+    en: 'Interviewed characters speak instead of reciting. In demo mode they answered by reading their character sheet aloud; now they reply in their own voice, with their temperament and their silences, like a real interview.',
+    fr: 'Les personnages interviewés parlent au lieu de réciter. En mode démonstration, ils répondaient en lisant leur fiche à voix haute ; ils répondent désormais avec leur propre voix, leur tempérament et leurs silences, comme dans un véritable entretien.',
+    de: 'Befragte Figuren sprechen, statt zu rezitieren. Im Demomodus antworteten sie, indem sie ihr Datenblatt vorlasen; jetzt antworten sie mit eigener Stimme, mit ihrem Temperament und ihren Pausen, wie in einem echten Interview.',
+    pt: 'As personagens entrevistadas falam em vez de recitar. No modo demonstração respondiam lendo a sua ficha em voz alta; agora respondem com a sua própria voz, com o seu carácter e os seus silêncios, como numa entrevista a sério.',
+    'pt-BR': 'Os personagens entrevistados falam em vez de recitar. No modo demonstração respondiam lendo a ficha em voz alta; agora respondem com a própria voz, com seu temperamento e seus silêncios, como numa entrevista de verdade.',
+  },
+  {
+    scope: 'toolkit',
+    es: 'El runtime de Codex incluido en Nodus también genera imágenes, así que puedes crear ilustraciones sin configurar ninguna clave adicional si ya tienes conectada tu suscripción de ChatGPT. Y la generación con Google vuelve a funcionar: se le pedía un formato de imagen que ya no acepta.',
+    en: 'The Codex runtime bundled with Nodus now generates images too, so you can create illustrations without setting up any extra key if your ChatGPT subscription is already connected. Generation with Google works again as well: it was being asked for an image format it no longer accepts.',
+    fr: 'Le runtime Codex fourni avec Nodus génère aussi des images : vous pouvez créer des illustrations sans configurer de clé supplémentaire si votre abonnement ChatGPT est déjà connecté. La génération avec Google refonctionne également : on lui demandait un format d’image qu’il n’accepte plus.',
+    de: 'Die mit Nodus gelieferte Codex-Laufzeit erzeugt jetzt auch Bilder, sodass Sie Illustrationen ohne zusätzlichen Schlüssel erstellen können, wenn Ihr ChatGPT-Abo bereits verbunden ist. Auch die Erzeugung mit Google funktioniert wieder: Es wurde ein Bildformat angefordert, das nicht mehr akzeptiert wird.',
+    pt: 'O runtime do Codex incluído no Nodus também gera imagens, pelo que pode criar ilustrações sem configurar qualquer chave adicional se já tiver ligada a sua subscrição do ChatGPT. E a geração com o Google volta a funcionar: pedia-se-lhe um formato de imagem que já não aceita.',
+    'pt-BR': 'O runtime do Codex incluído no Nodus também gera imagens, então você pode criar ilustrações sem configurar nenhuma chave extra se sua assinatura do ChatGPT já estiver conectada. E a geração com o Google voltou a funcionar: pedia-se um formato de imagem que ele não aceita mais.',
+  },
+];
+
+/**
  * 3.0.1 is a performance release: no new surface, three things that were making
  * the app feel slow on a large vault. One highlight per cause, not one per query.
  */
@@ -468,6 +521,11 @@ const RELEASE_2_7_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.0.2',
+    date: '2026-07-31',
+    highlights: RELEASE_3_0_2_HIGHLIGHTS,
+  },
   {
     version: '3.0.1',
     date: '2026-07-30',


### PR DESCRIPTION
Version bump, in-app release notes in all eight languages, and the changelog entry for **3.0.2** — the Deep Research release.

### User-visible changes since 3.0.1

- Deep Research verifies every citation against what its source actually says, and removes from the text *and the bibliography* anything a source does not support.
- A support-check panel lists the claims worth a second look next to the source text and the author-year to open.
- The argument map and debates render in chunks instead of freezing the window, and the map unfolds one branch at a time.
- Interviewed worldbuilding characters speak instead of reading their character sheet aloud.
- The bundled Codex runtime generates images, and generation through Google works again.

Left out of the notes as internal: the CI move to Node 24, a roadmap status change, and the Worldbuilding site demo (which ships on the website, not in the app).

### Note on the test suite

`scripts/test-primary-sources-performance.mjs` fails under full-suite load with `medium text search took 1172.2 ms` against a 1000 ms wall-clock budget. It passes standalone at 134 ms — a 10× margin — and no commit since 3.0.1 touches `primarySources`, `researchRepo` or the archive code it exercises. It is a pre-existing load-sensitive budget, not a regression, and the budget was deliberately **not** loosened to make the run green. Worth converting to a work-count assertion separately.

`npm run typecheck`, `npm run lint` and `npm run build` are clean; every other test passes.