### PR TITLE
Make the audio Cancel button actually cancel

### DIFF
--- a/scripts/test-background-jobs.mjs
+++ b/scripts/test-background-jobs.mjs
@@ -312,6 +312,49 @@ try {
   const cancelledResult = jobs.getBackgroundJob(cancelKey).result;
   assert.equal(cancelledResult.cancelled, true, 'cancellation is reported');
   assert.ok(cancelledResult.count < 3, 'cancelling stops before every segment is synthesised');
+  jobs.clearBackgroundJob(cancelKey, jobs.getBackgroundJob(cancelKey).id);
+
+  // ── Cancelling a segment that is still synthesising ─────────────────────────
+  // The real case behind the bug report: a long section takes minutes on a local
+  // voice (and a dead worker or a stalled cloud request never settles at all).
+  // Cancel must not wait for it — the click has to be acknowledged on screen and
+  // the job has to end, without the segment ever completing.
+  const stuckKey = jobs.audioGenerationJobKey('deep_research', 'report-stuck');
+  let abortedSegments = 0;
+  let stuckSynthCalls = 0;
+  const stuckSynth = (_provider, _voiceId, _text, signal) => {
+    stuckSynthCalls += 1;
+    // Never resolves: only aborting can end it.
+    return new Promise((_resolve, reject) => {
+      signal?.addEventListener('abort', () => { abortedSegments += 1; reject(new Error('Síntesis de audio cancelada.')); }, { once: true });
+    });
+  };
+  const stuckStates = [];
+  const unsubscribeStuck = jobs.subscribeBackgroundJob(stuckKey, (job) => {
+    stuckStates.push({ status: job?.status ?? null, cancelling: job?.progress?.cancelling ?? false });
+  });
+  jobs.startAudioGeneration({ ...audioRequest, entityKind: 'deep_research', entityId: 'report-stuck' }, stuckSynth);
+  await waitFor(() => stuckSynthCalls === 1, 'stuck segment synthesis started');
+
+  const notificationsBeforeCancel = stuckStates.length;
+  jobs.cancelAudioGeneration('deep_research', 'report-stuck');
+  assert.ok(
+    stuckStates.length > notificationsBeforeCancel,
+    'clicking Cancel notifies subscribers at once, so the panel re-renders'
+  );
+  assert.equal(stuckStates.at(-1).cancelling, true, 'the panel is told the cancellation is under way');
+  assert.equal(abortedSegments, 1, 'the synthesiser is aborted so the segment stops instead of finishing');
+
+  await waitFor(() => jobs.getBackgroundJob(stuckKey)?.status === 'completed', 'cancelled audio ends without the segment settling');
+  assert.deepEqual(jobs.getBackgroundJob(stuckKey).result, { count: 0, cancelled: true }, 'nothing is saved and cancellation is reported');
+  assert.equal(stuckSynthCalls, 1, 'no further segment is synthesised after cancelling');
+  unsubscribeStuck();
+  jobs.clearBackgroundJob(stuckKey, jobs.getBackgroundJob(stuckKey).id);
+
+  // Cancelling clears its own state: the panel can start over straight away.
+  jobs.startAudioGeneration({ ...audioRequest, entityKind: 'deep_research', entityId: 'report-stuck' }, fakeSynth);
+  await waitFor(() => jobs.getBackgroundJob(stuckKey)?.status === 'completed', 'a run after a cancellation finishes');
+  assert.deepEqual(jobs.getBackgroundJob(stuckKey).result, { count: 3, cancelled: false }, 'a fresh run is not cancelled by the previous one');
 
   console.log('background generation jobs test passed');
 } finally {

--- a/src/backgroundJobs.ts
+++ b/src/backgroundJobs.ts
@@ -492,6 +492,9 @@ export interface AudioGenerationProgress {
   done: number;
   total: number;
   label: string;
+  /** Set the moment the user asks to cancel, so the panel can acknowledge the click
+   *  instead of looking frozen while the segment in flight is abandoned. */
+  cancelling?: boolean;
 }
 
 export interface AudioGenerationResult {
@@ -505,17 +508,67 @@ export function audioGenerationJobKey(kind: AudioEntityKind, id: string): string
   return `audio:generate:${kind}:${id}`;
 }
 
-// Keys whose in-flight generation the user has asked to cancel. Checked between
-// segments; cleared when the loop observes it (so a later run starts clean).
-const audioCancellations = new Set<string>();
+/**
+ * A pending cancellation for one generation key. It is more than a flag: a segment
+ * can take minutes (a long section on a local voice) or never settle at all (a dead
+ * worker, a stalled cloud request), and the loop used to only look at the flag
+ * *between* segments — so Cancel appeared to do nothing, sometimes forever. The
+ * promise lets the loop stop waiting for the segment in flight, and the abort
+ * controller lets the synthesiser drop the work it is doing.
+ */
+interface AudioCancellation {
+  requested: boolean;
+  signal: Promise<void>;
+  request: () => void;
+  controller: AbortController;
+}
+
+const CANCELLED = Symbol('audio-cancelled');
+
+const audioCancellations = new Map<string, AudioCancellation>();
+
+function audioCancellation(key: string): AudioCancellation {
+  const existing = audioCancellations.get(key);
+  if (existing) return existing;
+  let request!: () => void;
+  const signal = new Promise<void>((resolve) => { request = resolve; });
+  const entry: AudioCancellation = { requested: false, signal, request, controller: new AbortController() };
+  audioCancellations.set(key, entry);
+  return entry;
+}
+
+/** Stop waiting on `promise` as soon as cancellation is requested. */
+function untilCancelled<T>(cancellation: AudioCancellation, promise: Promise<T>): Promise<T | typeof CANCELLED> {
+  const cancelled: Promise<typeof CANCELLED> = cancellation.signal.then(() => CANCELLED);
+  return Promise.race<T | typeof CANCELLED>([promise, cancelled]);
+}
 
 export function cancelAudioGeneration(kind: AudioEntityKind, id: string): void {
-  audioCancellations.add(audioGenerationJobKey(kind, id));
+  const key = audioGenerationJobKey(kind, id);
+  const current = getBackgroundJob<AudioGenerationRequest, AudioGenerationProgress, AudioGenerationResult>(key);
+  if (current?.status !== 'running') return;
+  const cancellation = audioCancellation(key);
+  if (cancellation.requested) return;
+  cancellation.requested = true;
+  cancellation.request();
+  cancellation.controller.abort();
+  // Re-render the panel immediately: without this the click mutated a module-level
+  // flag only, so nothing on screen changed until the current segment finished.
+  replaceJob({
+    ...current,
+    progress: { done: 0, total: 0, label: '', ...(current.progress ?? {}), cancelling: true },
+  } as AnyJob);
 }
 
 /** The synthesis backend, injected by the caller so this module stays free of the
- *  heavy WASM/onnx audio engines (and can be bundled and unit-tested on its own). */
-export type SegmentSynthesizer = (provider: AudioProvider, voiceId: string, text: string) => Promise<Uint8Array>;
+ *  heavy WASM/onnx audio engines (and can be bundled and unit-tested on its own).
+ *  `signal` aborts when the user cancels, so the backend can drop the segment. */
+export type SegmentSynthesizer = (
+  provider: AudioProvider,
+  voiceId: string,
+  text: string,
+  signal?: AbortSignal
+) => Promise<Uint8Array>;
 
 export function startAudioGeneration(request: AudioGenerationRequest, synthesize: SegmentSynthesizer): AudioGenerationJob {
   const key = audioGenerationJobKey(request.entityKind, request.entityId);
@@ -524,32 +577,51 @@ export function startAudioGeneration(request: AudioGenerationRequest, synthesize
   audioCancellations.delete(key);
 
   return startBackgroundJob<AudioGenerationRequest, AudioGenerationProgress, AudioGenerationResult>(key, request, async (req, onProgress) => {
-    const segments = await window.nodus.getAudioSegments(req.entityKind, req.entityId, req.segmentRequest);
-    if (!segments.length) throw new Error(req.labels.noText);
-
-    await window.nodus.clearAudioClips(req.entityKind, req.entityId);
-    onProgress({ done: 0, total: segments.length, label: req.labels.preparing });
-
+    const cancellation = audioCancellation(key);
     let done = 0;
-    let cancelled = false;
-    for (const segment of segments) {
-      if (audioCancellations.has(key)) { cancelled = true; break; }
-      onProgress({ done, total: segments.length, label: segment.label });
-      const bytes = await synthesize(req.provider, req.voiceId, segment.text);
-      if (audioCancellations.has(key)) { cancelled = true; break; }
-      await window.nodus.saveAudioClip(req.entityKind, req.entityId, {
-        segmentIndex: segment.index,
-        segmentLabel: segment.label,
-        provider: req.provider,
-        voice: req.voiceId,
-        language: req.language,
-        bytes,
-      });
-      done += 1;
-      onProgress({ done, total: segments.length, label: segment.label });
-    }
+    try {
+      const segments = await untilCancelled(cancellation, window.nodus.getAudioSegments(req.entityKind, req.entityId, req.segmentRequest));
+      if (segments === CANCELLED) return { count: 0, cancelled: true };
+      if (!segments.length) throw new Error(req.labels.noText);
 
-    audioCancellations.delete(key);
-    return { count: done, cancelled };
+      const report = (label: string) =>
+        onProgress({ done, total: segments.length, label, cancelling: cancellation.requested });
+
+      if (await untilCancelled(cancellation, window.nodus.clearAudioClips(req.entityKind, req.entityId)) === CANCELLED) {
+        return { count: 0, cancelled: true };
+      }
+      report(req.labels.preparing);
+
+      for (const segment of segments) {
+        if (cancellation.requested) return { count: done, cancelled: true };
+        report(segment.label);
+        // Race the synthesis: cancelling must end the job now, even when the segment
+        // in flight would take minutes more (or never resolve at all).
+        const synthesized: Promise<Uint8Array | typeof CANCELLED> = synthesize(req.provider, req.voiceId, segment.text, cancellation.controller.signal)
+          // Aborting the backend rejects the segment; that is the cancellation the
+          // user asked for, not a failure to report to them.
+          .catch((error: unknown) => {
+            if (cancellation.requested) return CANCELLED;
+            throw error;
+          });
+        const bytes = await untilCancelled(cancellation, synthesized);
+        if (bytes === CANCELLED || cancellation.requested) return { count: done, cancelled: true };
+        await window.nodus.saveAudioClip(req.entityKind, req.entityId, {
+          segmentIndex: segment.index,
+          segmentLabel: segment.label,
+          provider: req.provider,
+          voice: req.voiceId,
+          language: req.language,
+          bytes,
+        });
+        done += 1;
+        report(segment.label);
+      }
+
+      return { count: done, cancelled: false };
+    } finally {
+      // Clear on every exit — including the throwing one — so a later run starts clean.
+      audioCancellations.delete(key);
+    }
   });
 }

--- a/src/components/AudioPanel.tsx
+++ b/src/components/AudioPanel.tsx
@@ -35,6 +35,7 @@ interface RunProgress {
   done: number;
   total: number;
   label: string;
+  cancelling?: boolean;
 }
 
 export function AudioPanel({
@@ -244,8 +245,13 @@ export function AudioPanel({
             </>
           )}
           {generating ? (
-            <button className="btn btn-ghost border border-neutral-700 text-xs" onClick={cancel}>
-              {t('Cancelar')}
+            <button
+              data-testid="audio-cancel"
+              className="btn btn-ghost border border-neutral-700 text-xs disabled:opacity-60"
+              onClick={cancel}
+              disabled={run?.cancelling}
+            >
+              {run?.cancelling ? t('Cancelando…') : t('Cancelar')}
             </button>
           ) : (
             <button className="btn btn-primary text-xs" onClick={() => void generate()}>

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -1761,6 +1761,7 @@ export const DE: Record<string, string> = {
   'Esto borrará todo el grafo de forma permanente. Para confirmar, escribe este código:':
     'Dadurch wird der gesamte Graph dauerhaft gelöscht. Geben Sie zur Bestätigung diesen Code ein:',
   'Cancelar': 'Abbrechen',
+  'Cancelando…': 'Wird abgebrochen…',
   'Borrando…': 'Wird gelöscht…',
   'Borrar grafo': 'Graph löschen',
   'Contraseña de la copia': 'Passwort der Sicherung',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -1773,6 +1773,7 @@ export const EN: Record<string, string> = {
   'Esto borrará todo el grafo de forma permanente. Para confirmar, escribe este código:':
     'This will permanently delete the entire graph. To confirm, type this code:',
   Cancelar: 'Cancel',
+  'Cancelando…': 'Cancelling…',
   'Borrando…': 'Deleting…',
   'Borrar grafo': 'Delete graph',
   'Contraseña de la copia': 'Backup password',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -1760,6 +1760,7 @@ export const FR: Record<string, string> = {
   'Esto borrará todo el grafo de forma permanente. Para confirmar, escribe este código:':
     'Cela supprimera définitivement tout le graphe. Pour confirmer, saisissez ce code :',
   'Cancelar': 'Annuler',
+  'Cancelando…': 'Annulation…',
   'Borrando…': 'Suppression…',
   'Borrar grafo': 'Supprimer le graphe',
   'Contraseña de la copia': 'Mot de passe de la sauvegarde',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -1596,6 +1596,7 @@ export const IT: Record<string, string> = {
   "Confirmación final": "Conferma finale",
   "Esto borrará todo el grafo de forma permanente. Para confirmar, escribe este código:": "Ciò eliminerà permanentemente l'intero grafico. Per confermare digita questo codice:",
   "Cancelar": "Annulla",
+  "Cancelando…": "Annullamento…",
   "Borrando…": "Eliminazione…",
   "Borrar grafo": "Elimina il grafico",
   "Contraseña de la copia": "Password di backup",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -1747,6 +1747,7 @@ export const PT_BR: Record<string, string> = {
   'Esto borrará todo el grafo de forma permanente. Para confirmar, escribe este código:':
     'Isso excluirá todo o grafo permanentemente. Para confirmar, digite este código:',
   'Cancelar': 'Cancelar',
+  'Cancelando…': 'Cancelando…',
   'Borrando…': 'Excluindo…',
   'Borrar grafo': 'Excluir grafo',
   'Contraseña de la copia': 'Senha do backup',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -1745,6 +1745,7 @@ export const PT: Record<string, string> = {
   'Esto borrará todo el grafo de forma permanente. Para confirmar, escribe este código:':
     'Isto eliminará todo o grafo de forma permanente. Para confirmar, escreva este código:',
   'Cancelar': 'Cancelar',
+  'Cancelando…': 'A cancelar…',
   'Borrando…': 'A eliminar…',
   'Borrar grafo': 'Eliminar grafo',
   'Contraseña de la copia': 'Palavra-passe da cópia de segurança',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -221,6 +221,7 @@ export const TR: Record<string, string> = {
   "Volver": "Geri dönmek",
   "Cerrar": "Kapalı",
   "Cancelar": "İptal etmek",
+  "Cancelando…": "İptal ediliyor…",
   "Eliminar": "Elemek",
   "Revisar": "Gözden geçirmek",
   "Volver a la biblioteca": "Kütüphaneye dön",

--- a/src/lib/audio/synth.ts
+++ b/src/lib/audio/synth.ts
@@ -14,6 +14,8 @@ interface SynthResponse {
   error?: string;
 }
 
+const CANCELLED_MESSAGE = 'Síntesis de audio cancelada.';
+
 let worker: Worker | null = null;
 let seq = 0;
 const pending = new Map<number, { resolve: (b: Uint8Array) => void; reject: (e: Error) => void }>();
@@ -48,17 +50,39 @@ function getWorker(): Worker {
 /**
  * Synthesise one segment to WAV bytes. Piper/Kokoro run in the worker; Hume runs
  * on the main thread (its synthesis is a non-blocking IPC call to the main process).
+ * `signal` fires when the user cancels the narration: the pending request is dropped
+ * so the caller stops waiting for a segment nobody wants any more.
  */
-export async function synthesizeSegment(
+export function synthesizeSegment(
   provider: AudioProvider,
   voiceId: string,
-  text: string
+  text: string,
+  signal?: AbortSignal
 ): Promise<Uint8Array> {
+  if (signal?.aborted) return Promise.reject(new Error(CANCELLED_MESSAGE));
   if (provider === 'hume') return getEngine('hume').synthesize(text, voiceId);
   const id = ++seq;
   const w = getWorker();
   return new Promise<Uint8Array>((resolve, reject) => {
-    pending.set(id, { resolve, reject });
+    const onAbort = (): void => {
+      pending.delete(id);
+      // onnxruntime's inference inside the worker is synchronous, so nothing can
+      // interrupt the segment from here. When ours was the only request in flight,
+      // terminating is the one way to stop it actually burning a core — and it keeps
+      // the next narration from queueing behind the abandoned segment. If another
+      // narration is still using the worker, leave it alone and just drop ours.
+      if (pending.size === 0) {
+        w.terminate();
+        if (worker === w) worker = null;
+      }
+      reject(new Error(CANCELLED_MESSAGE));
+    };
+    const settle = <T>(fn: (value: T) => void) => (value: T): void => {
+      signal?.removeEventListener('abort', onAbort);
+      fn(value);
+    };
+    pending.set(id, { resolve: settle(resolve), reject: settle(reject) });
+    signal?.addEventListener('abort', onAbort, { once: true });
     w.postMessage({ id, provider, voiceId, text });
   });
 }


### PR DESCRIPTION
Closes #323.

Clicking **Cancel** while a narration is being generated did nothing visible, and in the worst case nothing at all — ever.

### The bug

`cancelAudioGeneration()` added the job key to a module-level `Set`. Nothing else happened:

* **No subscriber was notified**, so the panel never re-rendered. The button stayed on *Cancel*, the progress bar stayed where it was, and the click looked like a no-op.
* **The flag was only read between segments**, and the loop always `await`ed the `synthesize()` call in flight. A long section on a local Piper/Kokoro voice takes minutes; a dead TTS worker or a stalled Hume request never settles at all — and then the job stayed `running` for the rest of the session, with no way to restart it because `startBackgroundJob` returns the running job instead of launching a new one.

Verified against the real store before the fix: with a segment in flight, a `cancelAudioGeneration()` call produced **0** subscriber notifications and left the status at `running`.

### The fix

Cancellation becomes a record per generation key (`src/backgroundJobs.ts`) instead of a bare flag:

* a promise the loop **races against the segment in flight**, so the job ends on the click rather than whenever the segment happens to finish (or never);
* an `AbortSignal` passed down to the synthesiser so the abandoned work is actually dropped;
* an **immediate job update** carrying `progress.cancelling`, so the panel re-renders at once — the button reads *Cancelling…* and is disabled;
* clean-up in a `finally`, so a cancelled or failed run leaves no stale state and the next run starts clean.

In `src/lib/audio/synth.ts`, an aborted segment rejects its pending request and terminates the TTS worker **when nothing else is in flight** — onnxruntime inference inside the worker is synchronous and cannot be interrupted any other way, so this is what stops a cancelled segment from burning a core and keeps the next narration from queueing behind it. If another narration is still using the worker it is left alone and only our request is dropped.

Applies to every narration panel: Deep Research reports, immersions, study documents and transcripts.

### Tests

`scripts/test-background-jobs.mjs` gains the case the old test never covered — the old one released the synthesis gate right after cancelling, so it could not tell "cancels promptly" from "waits for the segment". The new case cancels a segment that **never** resolves and asserts that the click notifies subscribers, marks the job as cancelling, aborts the synthesiser, ends the job with `{count: 0, cancelled: true}`, and that a fresh run afterwards completes normally.

`Cancelando…` added to all seven translation tables (i18n coverage test enforces this).

Verified: `npm run typecheck`, `npm run lint`, `npm test`.
