### PR TITLE
Release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 3.0.3 — 2026-07-31
+
+Getting reports out of Deep Research, and a Cancel button that left the job
+running. Both the archive and the cancellation are covered by tests that were
+watched failing before the fix.
+
+### Added
+
+- **Reports leave Deep Research in bulk, and by the card.** Everything the
+  gallery produced left one report at a time through the reader: thirty reports
+  meant thirty save dialogs, and a card could not be downloaded without opening
+  it. A Download button in the header turns the existing selection mode into a
+  bulk export — select-all included, Markdown / PDF / both — and returns one ZIP;
+  every card and list row also gains a download icon. Reports are rendered one at
+  a time because a PDF is printed by a real Chromium window whose deferred
+  teardown only holds if the next print starts after the previous one let go,
+  hence the progress bar: a serial pass can run for a minute, and a silent minute
+  reads as a hang. Two things `scripts/test-deep-research-archive.mjs` pins that
+  a naive archive gets wrong — a zip entry overwrites its namesake, so reports
+  sharing a title get distinct names; and each report's files are staged before
+  being added, so a report whose PDF fails leaves nothing behind instead of an
+  orphan Markdown.
+- **"Suggest with AI" in the image design modal.** It streams a scene description
+  written from the report's own summary into the prompt box — what the generator
+  would have written for itself, which was only ever invisible. Nothing is
+  persisted until the user generates with it. Closes #325.
+
+### Fixed
+
+- **The audio Cancel button did not cancel.** Cancelling only added the job key
+  to a module-level `Set`. That notified no subscriber, so the panel never
+  re-rendered and the click looked like a no-op; and the loop read the flag only
+  between segments, always awaiting the synthesis in flight. A long section takes
+  minutes, a dead TTS worker or a stalled cloud request never settles, and the
+  job then stayed running for the rest of the session with no way to start over.
+  Cancellation is now a record per key: a promise the loop races against the
+  segment in flight, an `AbortSignal` handed to the synthesiser, and an immediate
+  job update so the button acknowledges the click as "Cancelling…". The
+  local-voice synthesiser drops the aborted request and terminates its worker
+  when nothing else is using it, so a cancelled segment stops burning a core to
+  finish a narration nobody will hear. Closes #323.
+
 ## 3.0.2 — 2026-07-31
 
 The Deep Research release. The engine used to overstate itself in ways that
@@ -67,6 +109,22 @@ academic vault, not on fixtures.
   API no longer accepts.
 - **Interviewed characters recited their sheet.** In worldbuilding demo mode they
   answered by reading their own character sheet aloud instead of speaking.
+- **The macOS update never finished installing.** Nodus ships unsigned, so it
+  replaces its own bundle with an external helper rather than handing off to
+  Squirrel.Mac, and the helper waits for the app to exit first. `app.quit()` is
+  cooperative and did not always terminate the process — finishing a download
+  makes electron-updater start a local proxy and register with Squirrel.Mac
+  before it ever consults `autoInstallOnAppQuit` — so the app sat idle in its run
+  loop while the helper waited on a PID that never died. Force Quit then killed
+  the helper too, nothing was installed, and reopening staged another helper
+  doomed the same way. Three layers, because each failed independently: the quit
+  falls back to `app.exit(0)` if the process is still alive shortly after
+  `app.quit()`; the helper ignores TERM/HUP/INT so it survives a force quit, and
+  stops waiting after two minutes instead of forever; and startup reads the
+  helper's state file — written all along, read by nobody — so a stalled install
+  is reported instead of silently re-offered. Covered by
+  `scripts/test-unsigned-mac-update.mjs`, which runs the real generated helper
+  against fake bundles and force-quits it mid-wait.
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.0.2"
+version: "3.0.3"
 date-released: "2026-07-31"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,11 +25,15 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.0.2');
+  assert.equal(currentRelease?.version, '3.0.3');
   assert.equal(currentRelease?.date, '2026-07-31');
-  // The Deep Research release: one highlight per user-visible change, plus the
-  // macOS update install that could never finish.
-  assert.equal(currentRelease?.highlights.length, 6);
+  // Bulk export, the AI-suggested image prompt, and the audio Cancel that did nothing.
+  assert.equal(currentRelease?.highlights.length, 3);
+
+  // 3.0.2 shipped after the macOS update fix merged, so that highlight stays there.
+  const deepResearchRelease = RELEASE_NOTES.find((note) => note.version === '3.0.2');
+  assert.equal(deepResearchRelease?.date, '2026-07-31');
+  assert.equal(deepResearchRelease?.highlights.length, 6);
 
   // 3.0.1 stays reachable from the version picker underneath it.
   const performanceRelease = RELEASE_NOTES.find((note) => note.version === '3.0.1');

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -58,6 +58,12 @@ export const RELEASE_2_7_0_IT: string[] = [
 ];
 
 /** Italian history, indexed by release and highlight order. */
+const RELEASE_3_0_3_IT: string[] = [
+  "I report escono da Deep Research in blocco, e anche dalla loro scheda. Tutto ciò che la galleria produceva usciva uno alla volta, passando dal lettore: una libreria di trenta report significava trenta finestre di salvataggio, e una scheda non si poteva scaricare senza prima aprirla. Ora il pulsante Scarica dell’intestazione riutilizza la modalità di selezione — «seleziona tutto» compreso —, ti lascia scegliere Markdown, PDF o entrambi e consegna un unico ZIP; ogni scheda e ogni riga guadagnano inoltre la propria icona di download. I PDF vengono stampati uno alla volta con una barra di avanzamento, perché quella passata può durare un minuto e un minuto in silenzio sembra un blocco.",
+  "Il design dell’immagine di un report può ora suggerirti la scena. «Suggerisci con l’IA» scrive nel campo del prompt una descrizione visiva ricavata dal riassunto del report stesso — la stessa che il generatore si sarebbe scritto da sé e che finora non vedevi mai. Puoi modificarla, e non viene salvato nulla finché non generi con essa.",
+  "Annullare una narrazione ora la annulla davvero. Il pulsante non produceva nulla di visibile: il lavoro proseguiva fino alla fine della sezione — minuti di attesa, o all’infinito se la voce non rispondeva mai — e restava poi bloccato per tutto il resto della sessione, senza modo di ricominciare. Ora il clic viene riconosciuto subito, il segmento in corso viene scartato e una voce locale smette di consumare un core per finire una narrazione che nessuno ascolterà.",
+];
+
 const RELEASE_3_0_2_IT: string[] = [
   "Deep Research non afferma più di quanto possa sostenere. Ogni citazione viene verificata rispetto a ciò che la fonte dice davvero, e quella che non la sostiene sparisce dal testo e dalla bibliografia. Chi redige riceve ora il contenuto reale di ciò che cita — l’enunciato di ogni idea, ciò che afferma ogni lacuna, chi sostiene ciascuna posizione di un dibattito e il testo letterale di ogni passaggio con la sua pagina —, così i disaccordi fra autori vengono argomentati con nomi anziché citati di sfuggita. La copertura dichiarata è quella realmente citata, non quella assegnata.",
   "Un nuovo pannello indica quali affermazioni conviene verificare prima di citarle. Un terzo delle citazioni che superano la verifica ha un riscontro parziale: la fonte sostiene una versione più debole di quanto la frase affermi. Il report le elenca accanto al testo della loro fonte e all’autore e anno da aprire, così controllare un report passa dal leggere opere intere al confrontare una manciata di coppie.",
@@ -74,6 +80,7 @@ const RELEASE_3_0_1_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.0.3": RELEASE_3_0_3_IT,
   "3.0.2": RELEASE_3_0_2_IT,
   "3.0.1": RELEASE_3_0_1_IT,
   "3.0.0": RELEASE_3_0_0_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -1,3 +1,9 @@
+const RELEASE_3_0_3_TR: string[] = [
+  "Raporlar Deep Research'ten toplu olarak, kendi kartından da çıkabiliyor. Galerinin ürettiği her şey şimdiye dek okuyucudan geçerek teker teker çıkıyordu: otuz raporluk bir kitaplık otuz kaydetme penceresi demekti ve bir kartı önce açmadan indiremiyordunuz. Artık başlıktaki İndir düğmesi seçim kipini —tümünü seç dahil— yeniden kullanıyor, Markdown, PDF ya da her ikisini seçmenize izin veriyor ve tek bir ZIP veriyor; ayrıca her kart ve her satır kendi indirme simgesini kazanıyor. PDF'ler ilerleme çubuğu eşliğinde teker teker yazdırılıyor, çünkü bu geçiş bir dakika sürebiliyor ve sessiz geçen bir dakika donma gibi görünüyor.",
+  "Bir raporun görsel tasarımı artık sahneyi size önerebiliyor. «Yapay zekâ ile öner», raporun kendi özetinden yazılmış görsel bir betimlemeyi istem kutusuna akıtıyor — üreticinin kendisi için yazacağı, şimdiye dek hiç görmediğiniz betimlemenin ta kendisi. Düzenleyebilirsiniz ve onunla üretim yapana kadar hiçbir şey kaydedilmiyor.",
+  "Bir seslendirmeyi iptal etmek artık gerçekten iptal ediyor. Düğme görünür hiçbir şey yapmıyordu: iş bölümün sonuna kadar sürüyor —dakikalarca bekleme, ses hiç yanıt vermezse sonsuza kadar— ve ardından oturumun geri kalanında, baştan başlamanın hiçbir yolu olmadan takılı kalıyordu. Artık tıklama anında karşılık buluyor, işlenmekte olan parça bırakılıyor ve yerel bir ses, kimsenin dinlemeyeceği bir seslendirmeyi bitirmek için bir çekirdeği tüketmeyi bırakıyor.",
+];
+
 const RELEASE_3_0_2_TR: string[] = [
   "Deep Research artık destekleyebileceğinden fazlasını iddia etmiyor. Her kaynak gösterimi, kaynağın gerçekte ne söylediğine karşı denetleniyor; desteklemeyen gösterim metinden de kaynakçadan da siliniyor. Yazan taraf artık aktardığı şeyin gerçek içeriğini alıyor — her fikrin ifadesi, her araştırma boşluğunun iddiası, bir tartışmada hangi tarafı kimin savunduğu ve her pasajın sayfasıyla birlikte birebir metni —, böylece yazarlar arasındaki anlaşmazlıklar geçerken anılmak yerine adlarıyla tartışılıyor. Raporun bildirdiği kapsam, atanan değil gerçekten atıf yapılan kapsamdır.",
   "Yeni bir panel, hangi ifadeleri aktarmadan önce denetlemeniz gerektiğini gösteriyor. Denetimi geçen kaynak gösterimlerinin üçte biri yalnızca kısmen destekleniyor: kaynak, cümlenin iddia ettiğinden daha zayıf bir sürümü destekliyor. Rapor bunları kaynağının metniyle ve açılacak yazar ve yılla birlikte listeliyor; böylece bir raporu denetlemek, eserlerin tamamını okumaktan birkaç çifti karşılaştırmaya iniyor.",
@@ -14,6 +20,7 @@ const RELEASE_3_0_1_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.0.3": RELEASE_3_0_3_TR,
   "3.0.2": RELEASE_3_0_2_TR,
   "3.0.1": RELEASE_3_0_1_TR,
   // Index-matched with RELEASE_3_0_0_HIGHLIGHTS — keep this order.

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -37,6 +37,41 @@ export interface ReleaseNote {
 interface RawReleaseNote extends Omit<ReleaseNote, 'highlights'> { highlights: RawReleaseHighlight[] }
 
 /**
+ * 3.0.3: reports leave Deep Research in bulk, and a button that did nothing now
+ * does what it says. Both bugs behind it were invisible while they happened, so
+ * each highlight says what you saw before, not only what changed.
+ */
+const RELEASE_3_0_3_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'academic',
+    es: 'Los informes salen de Deep Research en bloque, y también desde su tarjeta. Antes todo lo que producía la galería se descargaba de uno en uno y desde el lector: una biblioteca de treinta informes eran treinta diálogos de guardado, y una tarjeta no se podía descargar sin abrirla. Ahora el botón Descargar de la cabecera reutiliza el modo de selección —con seleccionar todo—, te deja elegir Markdown, PDF o ambos y entrega un único ZIP; cada tarjeta y cada fila tienen además su icono de descarga. Los PDF se imprimen de uno en uno con una barra de progreso, porque esa pasada puede durar un minuto y un minuto en silencio parece un cuelgue.',
+    en: 'Reports leave Deep Research in bulk, and from their card too. Everything the gallery produced used to leave one at a time through the reader: a library of thirty reports meant thirty save dialogs, and a card could not be downloaded without opening it first. The header’s Download button now reuses selection mode — select-all included — lets you pick Markdown, PDF or both, and hands back a single ZIP; every card and list row also gains a download icon. PDFs are printed one at a time behind a progress bar, because that pass can run for a minute and a silent minute reads as a hang.',
+    fr: 'Les rapports quittent Deep Research en lot, et depuis leur fiche. Tout ce que produisait la galerie sortait un par un, via le lecteur : une bibliothèque de trente rapports, c’étaient trente boîtes de dialogue d’enregistrement, et une fiche ne pouvait pas être téléchargée sans être ouverte. Le bouton Télécharger de l’en-tête réutilise désormais le mode de sélection — tout sélectionner compris —, vous laisse choisir Markdown, PDF ou les deux, et renvoie une seule archive ZIP ; chaque fiche et chaque ligne gagnent aussi une icône de téléchargement. Les PDF sont imprimés un par un derrière une barre de progression, car ce passage peut durer une minute et une minute silencieuse ressemble à un blocage.',
+    de: 'Berichte verlassen Deep Research jetzt im Bündel — und auch direkt von ihrer Karte. Alles, was die Galerie erzeugte, ging bisher einzeln über den Leser hinaus: eine Bibliothek mit dreißig Berichten bedeutete dreißig Speicherdialoge, und eine Karte ließ sich nicht herunterladen, ohne sie zu öffnen. Die Schaltfläche „Herunterladen“ in der Kopfzeile nutzt nun den Auswahlmodus — samt Alles auswählen —, lässt Markdown, PDF oder beides wählen und liefert ein einziges ZIP; jede Karte und jede Listenzeile erhält zudem ein Download-Symbol. PDFs werden nacheinander hinter einem Fortschrittsbalken gedruckt, denn dieser Durchlauf kann eine Minute dauern, und eine stille Minute wirkt wie ein Absturz.',
+    pt: 'Os relatórios saem do Deep Research em bloco, e também a partir do seu cartão. Tudo o que a galeria produzia saía um de cada vez, pelo leitor: uma biblioteca de trinta relatórios eram trinta caixas de gravação, e um cartão não se podia descarregar sem o abrir. O botão Descarregar do cabeçalho reutiliza agora o modo de seleção — incluindo selecionar tudo —, deixa escolher Markdown, PDF ou ambos e devolve um único ZIP; cada cartão e cada linha ganham também um ícone de descarga. Os PDF são impressos um a um com uma barra de progresso, porque essa passagem pode demorar um minuto e um minuto em silêncio parece um bloqueio.',
+    'pt-BR': 'Os relatórios saem do Deep Research em lote, e também pelo próprio card. Tudo o que a galeria produzia saía um por vez, pelo leitor: uma biblioteca de trinta relatórios eram trinta caixas de salvamento, e um card não dava para baixar sem abrir. O botão Baixar do cabeçalho agora reaproveita o modo de seleção — com selecionar tudo —, deixa escolher Markdown, PDF ou os dois e devolve um único ZIP; cada card e cada linha ganham também um ícone de download. Os PDFs são impressos um a um com barra de progresso, porque essa passagem pode levar um minuto e um minuto em silêncio parece travamento.',
+  },
+  {
+    scope: 'academic',
+    es: 'El diseño de imagen de un informe puede sugerirte la escena. «Sugerir con IA» escribe en el cuadro del prompt una descripción visual a partir del resumen del propio informe, la misma que el generador se habría escrito para sí y que hasta ahora nunca veías. Puedes editarla, y no se guarda nada hasta que generas con ella.',
+    en: 'A report’s image design can now suggest the scene for you. “Suggest with AI” streams a visual description written from the report’s own summary into the prompt box — the same one the generator would have written for itself, which until now you never saw. You can edit it, and nothing is saved until you generate with it.',
+    fr: 'La conception d’image d’un rapport peut désormais vous suggérer la scène. « Suggérer avec l’IA » écrit dans le champ du prompt une description visuelle tirée du résumé du rapport lui-même — celle-là même que le générateur se serait écrite et que vous ne voyiez jamais. Vous pouvez la modifier, et rien n’est enregistré tant que vous ne générez pas avec elle.',
+    de: 'Der Bildentwurf eines Berichts kann die Szene jetzt vorschlagen. „Mit KI vorschlagen“ schreibt eine visuelle Beschreibung aus der Zusammenfassung des Berichts selbst in das Prompt-Feld — genau die, die sich der Generator selbst geschrieben hätte und die bisher unsichtbar blieb. Sie lässt sich bearbeiten, und nichts wird gespeichert, bis Sie damit generieren.',
+    pt: 'O desenho de imagem de um relatório pode agora sugerir-lhe a cena. «Sugerir com IA» escreve na caixa do prompt uma descrição visual feita a partir do resumo do próprio relatório — a mesma que o gerador teria escrito para si e que até agora nunca via. Pode editá-la, e nada é guardado até gerar com ela.',
+    'pt-BR': 'O design de imagem de um relatório pode sugerir a cena para você. “Sugerir com IA” escreve na caixa do prompt uma descrição visual feita a partir do resumo do próprio relatório — a mesma que o gerador teria escrito para si e que até agora você nunca via. Dá para editar, e nada é salvo até você gerar com ela.',
+  },
+  {
+    scope: 'general',
+    es: 'Cancelar una narración ahora la cancela de verdad. El botón no hacía nada visible: el trabajo seguía hasta el final de la sección —minutos de espera, o para siempre si la voz no llegaba a responder— y se quedaba atascado el resto de la sesión sin manera de empezar de nuevo. Ahora el clic se acusa al instante, el fragmento en curso se descarta y una voz local deja de consumir un núcleo para terminar una narración que nadie va a escuchar.',
+    en: 'Cancelling a narration now actually cancels it. The button did nothing visible: the job ran on to the end of the section — minutes of waiting, or forever if the voice never answered — and then stayed stuck for the rest of the session with no way to start over. The click is now acknowledged straight away, the segment in flight is dropped, and a local voice stops burning a core to finish a narration nobody will hear.',
+    fr: 'Annuler une narration l’annule désormais vraiment. Le bouton ne produisait rien de visible : le travail se poursuivait jusqu’à la fin de la section — plusieurs minutes d’attente, ou indéfiniment si la voix ne répondait jamais — puis restait bloqué pour le reste de la session, sans possibilité de recommencer. Le clic est maintenant pris en compte immédiatement, le segment en cours est abandonné, et une voix locale cesse de consommer un cœur pour terminer une narration que personne n’écoutera.',
+    de: 'Das Abbrechen einer Erzählung bricht sie jetzt wirklich ab. Die Schaltfläche bewirkte nichts Sichtbares: Der Auftrag lief bis zum Ende des Abschnitts weiter — minutenlanges Warten, oder endlos, wenn die Stimme nie antwortete — und blieb dann für den Rest der Sitzung hängen, ohne Möglichkeit, neu zu beginnen. Der Klick wird nun sofort bestätigt, das laufende Segment verworfen, und eine lokale Stimme verbraucht keinen Kern mehr, um eine Erzählung zu Ende zu bringen, die niemand hören wird.',
+    pt: 'Cancelar uma narração passa a cancelá-la mesmo. O botão não fazia nada de visível: o trabalho seguia até ao fim da secção — minutos de espera, ou para sempre se a voz nunca chegasse a responder — e depois ficava preso o resto da sessão, sem forma de recomeçar. Agora o clique é reconhecido de imediato, o segmento em curso é descartado e uma voz local deixa de consumir um núcleo para terminar uma narração que ninguém vai ouvir.',
+    'pt-BR': 'Cancelar uma narração agora cancela de verdade. O botão não fazia nada visível: o trabalho seguia até o fim da seção — minutos de espera, ou para sempre se a voz nunca respondesse — e depois ficava travado pelo resto da sessão, sem como recomeçar. Agora o clique é reconhecido na hora, o trecho em andamento é descartado e uma voz local deixa de consumir um núcleo para terminar uma narração que ninguém vai ouvir.',
+  },
+];
+
+/**
  * 3.0.2 is the Deep Research release: the report now proves what it claims,
  * says which claims are worth a second look, and stops freezing the argument
  * views. One highlight per user-visible change, not one per commit.
@@ -530,6 +565,11 @@ const RELEASE_2_7_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.0.3',
+    date: '2026-07-31',
+    highlights: RELEASE_3_0_3_HIGHLIGHTS,
+  },
   {
     version: '3.0.2',
     date: '2026-07-31',


### PR DESCRIPTION
Version bump to 3.0.3, with the what's-new modal written in all seven interface languages.

## What 3.0.3 carries

Everything merged after the `v3.0.2` tag:

- **#326 — Let reports leave Deep Research in bulk, and by the card.** Header Download button reusing selection mode (Markdown / PDF / both → one ZIP), a download icon on every card and list row, and "Suggest with AI" in the image design modal.
- **#324 — Make the audio Cancel button actually cancel.**

## Release notes

Three highlights, each in es / en / fr / de / pt / pt-BR / it / tr: bulk export, the AI-suggested image prompt, and the audio Cancel fix.

## One correction to 3.0.2

The macOS update-install fix (#322) merged *before* the `v3.0.2` tag but *after* the "Release 3.0.2" commit, so it shipped in 3.0.2 with a release-note highlight and no changelog entry. Its changelog entry is added under 3.0.2, where it shipped; the highlight stays where it already was.

## Verification

- `npm test` — 1493/1493 pass.
- `npm run typecheck` — clean.
- `scripts/test-prosopography-e2e.mjs` fails on a stale `dist-electron/`; it passes after `npm run build`.