### PR TITLE
Fix argument map collapsing hub ideas into a flat star

### DIFF
--- a/electron/ai/argumentMap.ts
+++ b/electron/ai/argumentMap.ts
@@ -7,11 +7,18 @@ import { completeJson } from './aiClient';
 
 // The argument map is built from the LOCAL subgraph around the seed idea (BFS
 // over real idea↔idea edges), so the model can only reference ideas that
-// actually connect to the seed. We cap the volume so it stays focused and
-// within context limits.
+// actually connect to the seed. We cap the volume so it stays focused.
+//
+// The two paths have very different budgets: the AI path has to fit a model
+// context, while the automatic path is pure local computation and only pays for
+// what it draws. Sharing the AI's cap was what flattened every hub route into a
+// star — an idea with more neighbours than the cap consumed the whole budget at
+// depth 0, so not one neighbour↔neighbour edge survived to branch from.
 const MAX_DEPTH = 3;
-const MAX_IDEAS = 80;
-const MAX_EDGES = 160;
+const AI_MAX_IDEAS = 80;
+const AI_MAX_EDGES = 160;
+const STRUCTURAL_MAX_IDEAS = 400;
+const STRUCTURAL_MAX_EDGES = 1200;
 const STATEMENT_CLIP = 220;
 const MAX_BLOCKS = 90;
 const MAX_TREE_DEPTH = 4;
@@ -80,13 +87,23 @@ function clip(text: string, max = STATEMENT_CLIP): string {
   return clean.length > max ? `${clean.slice(0, max)}…` : clean;
 }
 
-/** BFS the real idea↔idea edges from a seed, returning the focused subgraph. */
-function buildLocalSubgraph(seedId: string): {
+interface LocalSubgraph {
   ideas: IdeaRow[];
   edges: EdgeRow[];
   ideaById: Map<string, IdeaRow>;
   truncated: boolean;
-} {
+  /** Connection counts in the FULL graph, so a capped subgraph can still report
+   *  how many links an idea really has instead of how many survived the cap. */
+  graphDegree: Map<string, number>;
+  graphDebate: Map<string, number>;
+}
+
+function isDebateEdge(type: string): boolean {
+  return type === 'contradicts' || type === 'refutes';
+}
+
+/** BFS the real idea↔idea edges from a seed, returning the focused subgraph. */
+function buildLocalSubgraph(seedId: string, maxIdeas = AI_MAX_IDEAS, maxEdges = AI_MAX_EDGES): LocalSubgraph {
   const allIdeas = getDb()
     .prepare('SELECT global_id, type, label, statement FROM ideas')
     .all() as IdeaRow[];
@@ -95,58 +112,74 @@ function buildLocalSubgraph(seedId: string): {
     throw new Error('La idea indicada no existe en el grafo.');
   }
 
-  const allEdges = getDb()
-    .prepare(
-      `SELECT id, from_id, to_id, type, basis, confidence FROM visible_edges WHERE type != 'contains'`
-    )
-    .all() as EdgeRow[];
+  const allEdges = (
+    getDb()
+      .prepare(
+        `SELECT id, from_id, to_id, type, basis, confidence FROM visible_edges WHERE type != 'contains'`
+      )
+      .all() as EdgeRow[]
+  ).filter((e) => ideaById.has(e.from_id) && ideaById.has(e.to_id));
 
-  // Undirected adjacency over idea↔idea edges.
+  // Undirected adjacency over idea↔idea edges, plus whole-graph counts.
   const adj = new Map<string, { edge: EdgeRow; other: string }[]>();
+  const graphDegree = new Map<string, number>();
+  const graphDebate = new Map<string, number>();
   for (const e of allEdges) {
-    if (!ideaById.has(e.from_id) || !ideaById.has(e.to_id)) continue;
-    (adj.get(e.from_id) ?? adj.set(e.from_id, []).get(e.from_id)!).push({ edge: e, other: e.to_id });
-    (adj.get(e.to_id) ?? adj.set(e.to_id, []).get(e.to_id)!).push({ edge: e, other: e.from_id });
+    for (const [a, b] of [
+      [e.from_id, e.to_id],
+      [e.to_id, e.from_id],
+    ] as const) {
+      (adj.get(a) ?? adj.set(a, []).get(a)!).push({ edge: e, other: b });
+      graphDegree.set(a, (graphDegree.get(a) ?? 0) + 1);
+      if (isDebateEdge(e.type)) graphDebate.set(a, (graphDebate.get(a) ?? 0) + 1);
+    }
   }
 
+  // Expand strongest-link-first (debates lead, see edgePriority). The walk used to
+  // take neighbours in row order, so a capped subgraph kept an arbitrary slice —
+  // for a hub that silently dropped some of the very debates the route promised.
   const visited = new Set<string>([seedId]);
-  const keptEdges = new Map<string, EdgeRow>();
   let frontier: string[] = [seedId];
   let truncated = false;
 
-  for (let depth = 0; depth < MAX_DEPTH && frontier.length > 0; depth++) {
+  for (let depth = 0; depth < MAX_DEPTH && frontier.length > 0 && !truncated; depth++) {
     const next: string[] = [];
     for (const node of frontier) {
-      const neighbors = adj.get(node) ?? [];
-      for (const { edge, other } of neighbors) {
-        if (!keptEdges.has(edge.id)) keptEdges.set(edge.id, edge);
-        if (!visited.has(other)) {
-          visited.add(other);
-          next.push(other);
+      const neighbors = [...(adj.get(node) ?? [])].sort((a, b) => edgePriority(b.edge) - edgePriority(a.edge));
+      for (const { other } of neighbors) {
+        if (visited.has(other)) continue;
+        if (visited.size >= maxIdeas) {
+          truncated = true;
+          break;
         }
+        visited.add(other);
+        next.push(other);
       }
+      if (truncated) break;
     }
     frontier = next;
-    if (visited.size > MAX_IDEAS) {
-      truncated = true;
-      break;
-    }
   }
 
-  // If we capped ideas, keep only the closest ones (BFS order) + their edges.
-  let keptIdeaIds = [...visited];
-  if (keptIdeaIds.length > MAX_IDEAS) {
-    keptIdeaIds = keptIdeaIds.slice(0, MAX_IDEAS);
+  // Keep the INDUCED subgraph: every edge between two kept ideas, not merely the
+  // ones the walk happened to cross. The walk only ever crosses edges out of the
+  // frontier, so collecting them was what left the neighbours with no links of
+  // their own and every branch a leaf.
+  const induced = allEdges.filter((e) => visited.has(e.from_id) && visited.has(e.to_id));
+  let edges = induced;
+  if (induced.length > maxEdges) {
     truncated = true;
+    // The seed's own links are the map's top-level branches: never trade them for
+    // a stronger link buried deeper in the subgraph.
+    const seedEdges = induced.filter((e) => e.from_id === seedId || e.to_id === seedId);
+    const rest = induced
+      .filter((e) => e.from_id !== seedId && e.to_id !== seedId)
+      .sort((a, b) => edgePriority(b) - edgePriority(a))
+      .slice(0, Math.max(0, maxEdges - seedEdges.length));
+    edges = [...seedEdges, ...rest];
   }
-  const keptSet = new Set(keptIdeaIds);
-  const edges = [...keptEdges.values()]
-    .filter((e) => keptSet.has(e.from_id) && keptSet.has(e.to_id))
-    .sort((a, b) => b.confidence - a.confidence)
-    .slice(0, MAX_EDGES);
-  const ideas = keptIdeaIds.map((id) => ideaById.get(id)!).filter(Boolean);
+  const ideas = [...visited].map((id) => ideaById.get(id)!).filter(Boolean);
 
-  return { ideas, edges, ideaById, truncated };
+  return { ideas, edges, ideaById, truncated, graphDegree, graphDebate };
 }
 
 interface RawBlock {
@@ -351,7 +384,11 @@ export async function buildArgumentMap(request: ArgumentMapRequest, model?: Mode
 // ── Automatic mode: structural discovery + tree (no AI) ───────────────────────
 
 const STRUCTURAL_MAX_DEPTH = 3;
-const STRUCTURAL_MAX_CHILDREN = 6;
+/** Branches drawn per level: wide at the seed, narrowing as the map descends.
+ *  1 + 12 + 12·4 + 48·2 = 157 blocks, so a full map always fits the budget below
+ *  and no branch is starved by one that happened to be walked first. */
+const STRUCTURAL_BRANCHES_BY_DEPTH = [12, 4, 2];
+const STRUCTURAL_MAX_BLOCKS = 160;
 
 interface AdjEntry {
   other: string;
@@ -361,9 +398,38 @@ interface AdjEntry {
 /** Sort priority: surface debates (contradicts/refutes) first, then by confidence. */
 function edgePriority(edge: EdgeRow): number {
   let p = edge.confidence;
-  if (edge.type === 'contradicts' || edge.type === 'refutes') p += 1.5;
+  if (isDebateEdge(edge.type)) p += 1.5;
   else if (edge.type === 'supports' || edge.type === 'extends') p += 0.4;
   return p;
+}
+
+/** Which side of the argument a link is on, for the branch quota below. */
+function relationFamily(type: string): 'debate' | 'support' | 'other' {
+  if (isDebateEdge(type)) return 'debate';
+  if (type === 'supports' || type === 'extends' || type === 'precondition_of') return 'support';
+  return 'other';
+}
+
+/**
+ * Choose which connections become branches. Ranking by priority alone hands every
+ * slot to the debates (they carry a +1.5 bonus), which paints a hub as nothing but
+ * contradiction; a map of an argument has to show what backs the idea too. So the
+ * slots are dealt round-robin across the three families, strongest link first
+ * within each, and the result is re-sorted so debates still lead the reading.
+ */
+function pickBranches(candidates: AdjEntry[], cap: number): AdjEntry[] {
+  const buckets: Record<'debate' | 'support' | 'other', AdjEntry[]> = { debate: [], support: [], other: [] };
+  for (const c of [...candidates].sort((a, b) => edgePriority(b.edge) - edgePriority(a.edge))) {
+    buckets[relationFamily(c.edge.type)].push(c);
+  }
+  const families = ['debate', 'support', 'other'] as const;
+  const picked: AdjEntry[] = [];
+  for (let i = 0; picked.length < cap && families.some((f) => buckets[f].length > 0); i++) {
+    const bucket = buckets[families[i % families.length]];
+    const next = bucket.shift();
+    if (next) picked.push(next);
+  }
+  return picked.sort((a, b) => edgePriority(b.edge) - edgePriority(a.edge));
 }
 
 /** Rank idea hubs by weighted connectivity for the automatic route picker. */
@@ -396,7 +462,7 @@ export function discoverArgumentRoutes(): ArgumentRouteSuggestion[] {
       (adj.get(a) ?? adj.set(a, []).get(a)!).push({ other: b, edge: e });
       degree.set(a, (degree.get(a) ?? 0) + 1);
       confSum.set(a, (confSum.get(a) ?? 0) + e.confidence);
-      if (e.type === 'contradicts' || e.type === 'refutes') debate.set(a, (debate.get(a) ?? 0) + 1);
+      if (isDebateEdge(e.type)) debate.set(a, (debate.get(a) ?? 0) + 1);
       const rc = relationCounts.get(a) ?? relationCounts.set(a, new Map()).get(a)!;
       rc.set(e.type, (rc.get(e.type) ?? 0) + 1);
     }
@@ -443,7 +509,11 @@ export function buildStructuralArgumentMap(seedIdeaId: string): ArgumentMap {
   const seed = getIdeaSummary(seedIdeaId);
   if (!seed) throw new Error('La idea indicada no existe en el grafo.');
 
-  const { ideaById, edges, truncated } = buildLocalSubgraph(seedIdeaId);
+  const { ideaById, edges, truncated, graphDegree, graphDebate } = buildLocalSubgraph(
+    seedIdeaId,
+    STRUCTURAL_MAX_IDEAS,
+    STRUCTURAL_MAX_EDGES
+  );
 
   // Adjacency over the kept subgraph.
   const adj = new Map<string, AdjEntry[]>();
@@ -456,59 +526,76 @@ export function buildStructuralArgumentMap(seedIdeaId: string): ArgumentMap {
   const lang: 'es' | 'en' = getSettings().uiLanguage === 'es' ? 'es' : 'en';
   const relLabelOf = (rel: string): string =>
     (lang === 'en' ? EDGE_TYPE_LABELS_EN[rel] : EDGE_TYPE_LABELS[rel]) ?? rel;
-  const seedDegree = adj.get(seed.global_id)?.length ?? 0;
-  const seedDebate =
-    (adj.get(seed.global_id) ?? []).filter((n) => n.edge.type === 'contradicts' || n.edge.type === 'refutes').length;
+  // Counted over the whole graph, not the kept subgraph: the route list promises
+  // the real figure, and a map that quietly reported the post-cap one read as if
+  // connections had gone missing.
+  const seedDegree = graphDegree.get(seed.global_id) ?? 0;
+  const seedDebate = graphDebate.get(seed.global_id) ?? 0;
 
-  let blockCount = 0;
-  const buildNode = (ideaId: string, parentEdge: EdgeRow | null, visited: Set<string>, depth: number): ArgumentBlock => {
-    blockCount++;
-    const idea = ideaById.get(ideaId)!;
-    const relation: ArgumentBlock['relation'] = parentEdge ? (parentEdge.type as ArgumentBlock['relation']) : 'root';
+  const makeBlock = (idea: IdeaRow, parentEdge: EdgeRow | null): ArgumentBlock => ({
+    id: uuid(),
+    ideaId: idea.global_id,
+    label: idea.label,
+    statement: idea.statement,
+    type: idea.type,
+    summary: '',
+    relation: parentEdge ? (parentEdge.type as ArgumentBlock['relation']) : 'root',
+    children: [],
+  });
 
-    const neighbors = (adj.get(ideaId) ?? [])
-      .filter((n) => !visited.has(n.other))
-      .sort((a, b) => edgePriority(b.edge) - edgePriority(a.edge))
-      .slice(0, STRUCTURAL_MAX_CHILDREN);
+  // Grow the tree level by level. A depth-first walk let the first branch it
+  // descended spend the whole block budget, leaving its siblings bare; taking one
+  // level at a time spends the budget evenly across the argument.
+  const root = makeBlock(ideaById.get(seed.global_id)!, null);
+  const placed = new Set<string>([seed.global_id]);
+  const parentEdgeOf = new Map<string, EdgeRow>();
+  let blockCount = 1;
+  let frontier: ArgumentBlock[] = [root];
 
-    const children: ArgumentBlock[] = [];
-    for (const { other, edge } of neighbors) {
-      if (blockCount >= MAX_BLOCKS) break;
-      if (depth >= STRUCTURAL_MAX_DEPTH) break;
-      if (visited.has(other)) continue;
-      visited.add(other);
-      children.push(buildNode(other, edge, visited, depth + 1));
+  for (let depth = 0; depth < STRUCTURAL_MAX_DEPTH && frontier.length > 0 && blockCount < STRUCTURAL_MAX_BLOCKS; depth++) {
+    const cap = STRUCTURAL_BRANCHES_BY_DEPTH[depth] ?? STRUCTURAL_BRANCHES_BY_DEPTH[STRUCTURAL_BRANCHES_BY_DEPTH.length - 1];
+    const next: ArgumentBlock[] = [];
+    for (const block of frontier) {
+      if (blockCount >= STRUCTURAL_MAX_BLOCKS) break;
+      // Ideas already placed elsewhere are skipped: each idea appears once, so the
+      // tree stays a tree and the same card never shows up on two branches.
+      const candidates = (adj.get(block.ideaId!) ?? []).filter((n) => !placed.has(n.other));
+      for (const { other, edge } of pickBranches(candidates, cap)) {
+        if (blockCount >= STRUCTURAL_MAX_BLOCKS) break;
+        if (placed.has(other)) continue;
+        placed.add(other);
+        const child = makeBlock(ideaById.get(other)!, edge);
+        parentEdgeOf.set(child.id, edge);
+        block.children.push(child);
+        blockCount++;
+        next.push(child);
+      }
     }
+    frontier = next;
+  }
 
-    const childCount = children.length;
-    let summary: string;
-    if (relation === 'root') {
-      summary =
+  // Summaries last, so each block can state how many of its connections it drew.
+  const describe = (block: ArgumentBlock): void => {
+    const degree = graphDegree.get(block.ideaId!) ?? 0;
+    const hidden = Math.max(0, degree - block.children.length);
+    if (hidden > 0) block.hiddenChildren = hidden;
+    if (block.relation === 'root') {
+      block.summary =
         lang === 'en'
           ? `${seedDegree} connection(s)${seedDebate ? ` · ${seedDebate} debate(s)` : ''}`
           : `${seedDegree} conexiones${seedDebate ? ` · ${seedDebate} debate(s)` : ''}`;
     } else {
-      const relLabel = relLabelOf(relation);
-      const branches =
-        childCount > 0
-          ? `${relLabel} · ${childCount} ${lang === 'en' ? 'derivation(s)' : 'derivación(es)'}`
-          : `${relLabel} · conf ${parentEdge!.confidence.toFixed(2)}`;
-      summary = branches;
+      const relLabel = relLabelOf(block.relation);
+      const conf = parentEdgeOf.get(block.id)?.confidence ?? 0;
+      block.summary =
+        block.children.length > 0
+          ? `${relLabel} · conf ${conf.toFixed(2)} · ${block.children.length} ${lang === 'en' ? 'derivation(s)' : 'derivación(es)'}`
+          : `${relLabel} · conf ${conf.toFixed(2)}`;
     }
-
-    return {
-      id: uuid(),
-      ideaId,
-      label: idea.label,
-      statement: idea.statement,
-      type: idea.type,
-      summary,
-      relation,
-      children,
-    };
+    for (const child of block.children) describe(child);
   };
+  describe(root);
 
-  const root = buildNode(seed.global_id, null, new Set([seed.global_id]), 0);
   const overview =
     seedDegree === 0
       ? lang === 'en'
@@ -517,10 +604,10 @@ export function buildStructuralArgumentMap(seedIdeaId: string): ArgumentMap {
       : lang === 'en'
         ? `Automatic walkthrough: the central idea links ${seedDegree} connection(s)${
             seedDebate ? `, of which ${seedDebate} are debates (contradictions/refutations)` : ''
-          }. Expand the branches to explore the argument.`
+          }. The map opens its ${root.children.length} strongest branch(es) — debates, support and refinements — and follows each one down the real connections. Expand the branches to explore the argument.`
         : `Recorrido automático: la idea central articula ${seedDegree} conexiones${
             seedDebate ? `, de las cuales ${seedDebate} son debates (contradicciones/refutaciones)` : ''
-          }. Despliega las ramas para explorar la argumentación.`;
+          }. El mapa abre sus ${root.children.length} ramas más fuertes —debates, apoyos y refinamientos— y sigue cada una por las conexiones reales. Despliega las ramas para explorar la argumentación.`;
 
   return {
     seedIdeaId: seed.global_id,

--- a/scripts/test-argument-map-graph.mjs
+++ b/scripts/test-argument-map-graph.mjs
@@ -1,0 +1,228 @@
+// Argument map — the structural (automatic) map of a HUB idea.
+//
+// Reported against a real corpus: a route advertising «119 conexiones · 14
+// debates» opened into 7 blocks — the seed and six leaves — headed «79
+// connection(s) · 9 debate(s)». Three separate faults produced that:
+//
+//   1. the local walk expanded neighbours in row order and only then cut to the
+//      idea budget, so a capped subgraph kept an arbitrary slice and lost 5 of
+//      the 14 debates the route had promised;
+//   2. it kept only the edges the walk itself crossed. For a hub the walk stops
+//      after one level, so not one neighbour↔neighbour edge survived and every
+//      branch was necessarily a leaf, whatever the depth limit said;
+//   3. the header counts were read off that capped subgraph, so the map
+//      contradicted the list it had just been opened from.
+//
+// The fixture reproduces that shape — one hub wired to more neighbours than the
+// budget, those neighbours wired onwards — and runs the REAL
+// buildStructuralArgumentMap over a real SQLite database. Runs under
+// Electron-as-Node so better-sqlite3 matches the app ABI.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+if (!process.argv.includes('--electron-argmap-graph-test')) {
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/electron'),
+    [path.join(repoRoot, 'scripts/test-argument-map-graph.mjs'), '--electron-argmap-graph-test'],
+    { cwd: repoRoot, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, stdio: 'inherit' }
+  );
+  process.exit(0);
+}
+
+const HUB = 'g-hub';
+/** Relation mix of the reported route, neighbour for neighbour. */
+const HUB_LINKS = [
+  ...Array.from({ length: 13 }, (_, i) => ({ type: 'contradicts', confidence: 0.8 - i * 0.01 })),
+  { type: 'refutes', confidence: 0.72 },
+  ...Array.from({ length: 46 }, (_, i) => ({ type: 'supports', confidence: 0.85 - i * 0.005 })),
+  ...Array.from({ length: 45 }, (_, i) => ({ type: 'refines', confidence: 0.9 - i * 0.005 })),
+  ...Array.from({ length: 9 }, (_, i) => ({ type: 'applies_to', confidence: 0.6 - i * 0.01 })),
+  { type: 'variant_of', confidence: 0.55 },
+  { type: 'variant_of', confidence: 0.54 },
+  { type: 'extends', confidence: 0.5 },
+  { type: 'extends', confidence: 0.49 },
+  { type: 'precondition_of', confidence: 0.45 },
+];
+const HUB_DEGREE = HUB_LINKS.length; // 119, as reported
+const HUB_DEBATES = HUB_LINKS.filter((l) => l.type === 'contradicts' || l.type === 'refutes').length; // 14
+/** Neighbours of neighbours, so the subgraph has somewhere to ramify to. */
+const OUTER_PER_NEIGHBOUR = 4;
+
+const SCHEMA = `
+  CREATE TABLE ideas (global_id TEXT PRIMARY KEY, type TEXT, label TEXT, statement TEXT, created_at TEXT);
+  CREATE TABLE edges (id TEXT PRIMARY KEY, from_id TEXT, to_id TEXT, type TEXT, basis TEXT, confidence REAL);
+  CREATE TABLE edge_feedback (from_id TEXT, to_id TEXT, type TEXT, verdict TEXT);
+  CREATE VIEW visible_edges AS
+    SELECT e.* FROM edges e
+    WHERE NOT EXISTS (
+      SELECT 1 FROM edge_feedback f
+      WHERE f.verdict = 'rejected' AND f.type = e.type
+        AND ((f.from_id = e.from_id AND f.to_id = e.to_id)
+          OR (f.from_id = e.to_id AND f.to_id = e.from_id))
+    );
+`;
+
+/** Bundle electron/ai/argumentMap.ts with its Electron-only imports stubbed. */
+async function loadArgumentMap(outDir) {
+  const bundle = path.join(outDir, 'argumentMap.cjs');
+  const stubs = {
+    '../db/database': 'module.exports = { getDb: () => globalThis.__nodusTestDb };',
+    "../db/settingsRepo": "module.exports = { getSettings: () => ({ uiLanguage: 'es' }) };",
+    '../db/ideasRepo': `module.exports = { getIdeaSummary: (id) => globalThis.__nodusTestDb
+      .prepare('SELECT global_id, type, label, statement, created_at FROM ideas WHERE global_id = ?').get(id) ?? null };`,
+    './aiClient': `module.exports = { completeJson: () => { throw new Error('the automatic map must not call the model'); } };`,
+  };
+  await build({
+    entryPoints: [path.join(repoRoot, 'electron/ai/argumentMap.ts')],
+    bundle: true, platform: 'node', format: 'cjs', target: 'es2022', outfile: bundle,
+    alias: { '@shared': path.join(repoRoot, 'shared') },
+    plugins: [{
+      name: 'stub-electron-deps',
+      setup(build) {
+        const names = Object.keys(stubs).map((s) => s.replace(/[./]/g, '\\$&')).join('|');
+        build.onResolve({ filter: new RegExp(`^(${names})$`) }, (args) => ({ path: args.path, namespace: 'stub' }));
+        build.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({ contents: stubs[args.path], loader: 'js' }));
+      },
+    }],
+  });
+  return require(bundle);
+}
+
+function walk(block, depth = 0, acc = []) {
+  acc.push({ block, depth });
+  for (const child of block.children) walk(child, depth + 1, acc);
+  return acc;
+}
+
+const familyOf = (rel) =>
+  rel === 'contradicts' || rel === 'refutes' ? 'debate'
+  : rel === 'supports' || rel === 'extends' || rel === 'precondition_of' ? 'support'
+  : 'other';
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-argmap-graph-'));
+try {
+  const Database = require('better-sqlite3');
+  const db = new Database(path.join(root, 'fixture.sqlite'));
+  db.exec(SCHEMA);
+  const addIdea = db.prepare('INSERT INTO ideas VALUES (?,?,?,?,?)');
+  const addEdge = db.prepare('INSERT INTO edges VALUES (?,?,?,?,?,?)');
+  // Rows go in with the debates LAST, as in the corpus this was reported from.
+  // Trimming in row order therefore drops precisely the links the route was
+  // opened for — the failure mode is invisible if the fixture stores them first.
+  const insertionOrder = HUB_LINKS
+    .map((link, i) => ({ link, i }))
+    .sort((a, b) => Number(familyOf(a.link.type) === 'debate') - Number(familyOf(b.link.type) === 'debate'));
+  db.transaction(() => {
+    addIdea.run(HUB, 'claim', 'idea central', 'La idea semilla del recorrido.', '2026-01-01');
+    insertionOrder.forEach(({ link, i }) => {
+      const id = `g-n${i}`;
+      addIdea.run(id, 'claim', `vecina ${i}`, `Enunciado de la vecina ${i}.`, '2026-01-01');
+      addEdge.run(`e-hub-${i}`, HUB, id, link.type, 'basis', link.confidence);
+      for (let k = 0; k < OUTER_PER_NEIGHBOUR; k++) {
+        const outer = `g-o${i}-${k}`;
+        addIdea.run(outer, 'claim', `derivada ${i}.${k}`, `Enunciado derivado ${i}.${k}.`, '2026-01-01');
+        addEdge.run(`e-out-${i}-${k}`, id, outer, k === 0 ? 'contradicts' : 'refines', 'basis', 0.7 - k * 0.05);
+      }
+      if (i > 0) addEdge.run(`e-sib-${i}`, `g-n${i - 1}`, id, 'supports', 'basis', 0.4);
+    });
+  })();
+
+  globalThis.__nodusTestDb = db;
+  const { buildStructuralArgumentMap, discoverArgumentRoutes } = await loadArgumentMap(root);
+
+  const map = buildStructuralArgumentMap(HUB);
+  const nodes = walk(map.root);
+  const branches = map.root.children;
+
+  // ── The three reported faults ──────────────────────────────────────────────
+
+  const route = discoverArgumentRoutes().find((r) => r.ideaId === HUB);
+  assert.equal(route.degree, HUB_DEGREE, 'the fixture reproduces the reported hub');
+  assert.equal(route.debateCount, HUB_DEBATES);
+  // The header used to quote the post-cap figures (79 / 9 for the real route),
+  // so the map appeared to have lost connections the list had just promised.
+  assert.equal(map.root.summary, `${HUB_DEGREE} conexiones · ${HUB_DEBATES} debate(s)`,
+    'the map header reports the seed\'s real connectivity, matching the route list');
+  assert.match(map.overview, new RegExp(`articula ${HUB_DEGREE} conexiones`), 'and so does the overview');
+  assert.match(map.overview, new RegExp(`${HUB_DEBATES} son debates`));
+
+  const maxDepth = Math.max(...nodes.map((n) => n.depth));
+  assert.ok(maxDepth >= 2, `the map reaches depth ${maxDepth}; it used to stop at 1 for every hub`);
+  const ramifying = branches.filter((c) => c.children.length > 0).length;
+  assert.ok(ramifying >= branches.length - 1,
+    `${ramifying} of ${branches.length} top branches ramify — a hub map is not a list of leaves`);
+
+  // Depth-first, the branch walked first consumed the whole block budget and its
+  // siblings came out bare. Level-order growth keeps them comparable.
+  const sizes = branches.map((c) => walk(c).length);
+  assert.ok(sizes.length > 1);
+  assert.ok(Math.max(...sizes) - Math.min(...sizes) <= 2,
+    `branch sizes ${JSON.stringify(sizes)} must not be lopsided`);
+
+  // The strongest debate, support and refinement of the hub are what a reader
+  // opens the route for; row-order trimming dropped whichever the rows happened
+  // to store late — here, every debate.
+  const drawn = new Set(branches.map((c) => c.label));
+  assert.ok(drawn.has('vecina 0'), 'the strongest contradiction is drawn');
+  assert.ok(drawn.has('vecina 14'), 'the strongest support is drawn');
+  assert.ok(drawn.has('vecina 60'), 'the strongest refinement is drawn');
+  assert.deepEqual(
+    branches.filter((c) => familyOf(c.relation) === 'debate').map((c) => c.label),
+    ['vecina 0', 'vecina 1', 'vecina 2', 'vecina 3'],
+    'and the debate branches are the strongest debates, in order — not an arbitrary slice',
+  );
+
+  // Debates carry a +1.5 ranking bonus, so ranking alone handed every slot to
+  // them: a hub with 46 supports rendered as pure contradiction.
+  assert.deepEqual([...new Set(branches.map((c) => familyOf(c.relation)))].sort(),
+    ['debate', 'other', 'support'], 'the seed shows every side of the argument');
+
+  // ── Invariants the fix must not break ──────────────────────────────────────
+
+  const ids = nodes.map((n) => n.block.ideaId);
+  assert.equal(new Set(ids).size, ids.length, 'the map stays a tree: no idea is drawn twice');
+  assert.equal(map.ideaCount, ids.length, 'and ideaCount counts what is actually drawn');
+
+  assert.ok(nodes.length <= 160, `the map stays paintable: ${nodes.length} blocks`);
+  assert.ok(maxDepth <= 3, 'and no deeper than the walk allows');
+
+  assert.equal(map.root.hiddenChildren, HUB_DEGREE - branches.length,
+    'the seed says how many connections it left undrawn');
+  for (const { block } of nodes) {
+    if (block.hiddenChildren === undefined) continue;
+    assert.ok(Number.isInteger(block.hiddenChildren) && block.hiddenChildren > 0,
+      'undrawn counts are positive integers or absent');
+  }
+
+  console.log(
+    `[argmap] hub ${HUB_DEGREE} conns / ${HUB_DEBATES} debates → ${nodes.length} blocks, ` +
+    `${branches.length} branches (${branches.map((c) => familyOf(c.relation)).join(',')}), depth ${maxDepth}`
+  );
+
+  // A lone idea still yields a readable single-block map.
+  const lone = new Database(path.join(root, 'lone.sqlite'));
+  lone.exec(`${SCHEMA}\nINSERT INTO ideas VALUES ('g-lone','claim','sola','Sin conexiones.','2026-01-01');`);
+  globalThis.__nodusTestDb = lone;
+  const solo = buildStructuralArgumentMap('g-lone');
+  assert.equal(solo.root.children.length, 0);
+  assert.equal(solo.ideaCount, 1);
+  assert.equal(solo.root.hiddenChildren, undefined, 'nothing was left out, so nothing is claimed');
+  assert.match(solo.overview, /no tiene conexiones directas/);
+  assert.throws(() => buildStructuralArgumentMap('g-nope'), /no existe en el grafo/,
+    'an unknown seed is rejected rather than mapped');
+  lone.close();
+  db.close();
+
+  console.log('[argmap] structural hub map OK');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4731,6 +4731,9 @@ export interface ArgumentBlock {
   /** How this block relates to its parent (a real edge type, or 'root'/'framing'). */
   relation: EdgeType | 'root' | 'framing' | 'related';
   children: ArgumentBlock[];
+  /** Connections this idea has in the graph that the map did not draw as branches,
+   *  so a trimmed hub says so instead of passing for a fully explored one. */
+  hiddenChildren?: number;
 }
 
 export interface ArgumentMap {

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -2483,6 +2483,7 @@ export const DE: Record<string, string> = {
   'Trazar el esquema desde esta idea': 'Das Schema von dieser Idee aus zeichnen',
   '{n} debate(s)': '{n} Debatte(n)',
   '{n} conexiones': '{n} Verbindungen',
+  '+{n} conexiones no dibujadas': '+{n} nicht gezeichnete Verbindungen',
   'conf media': 'Ø Konf.',
   'Selecciona una idea y traza su': 'Wählen Sie eine Idee aus und zeichnen Sie ihre',
   'mapa de argumentos': 'Argumentationskarte',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -2540,6 +2540,7 @@ export const EN: Record<string, string> = {
   'Trazar el esquema desde esta idea': 'Trace the scheme from this idea',
   '{n} debate(s)': '{n} debate(s)',
   '{n} conexiones': '{n} connections',
+  '+{n} conexiones no dibujadas': '+{n} connections not drawn',
   'conf media': 'avg conf',
   'Selecciona una idea y traza su': 'Select an idea and trace its',
   'mapa de argumentos': 'argument map',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -2482,6 +2482,7 @@ export const FR: Record<string, string> = {
   'Trazar el esquema desde esta idea': 'Tracer le schéma à partir de cette idée',
   '{n} debate(s)': '{n} débat(s)',
   '{n} conexiones': '{n} connexions',
+  '+{n} conexiones no dibujadas': '+{n} connexions non tracées',
   'conf media': 'conf moyenne',
   'Selecciona una idea y traza su': 'Sélectionnez une idée et tracez sa',
   'mapa de argumentos': 'carte d\'arguments',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -2220,6 +2220,7 @@ export const IT: Record<string, string> = {
   "Trazar el esquema desde esta idea": "Traccia lo schema da questa idea",
   "{n} debate(s)": "{n} dibattito(i)",
   "{n} conexiones": "{n} connessioni",
+  "+{n} conexiones no dibujadas": "+{n} connessioni non tracciate",
   "conf media": "conf. media",
   "Selecciona una idea y traza su": "Seleziona un'idea e tracciala",
   "mapa de argumentos": "mappa degli argomenti",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -2466,6 +2466,7 @@ export const PT_BR: Record<string, string> = {
   'Trazar el esquema desde esta idea': 'Traçar o esquema a partir desta ideia',
   '{n} debate(s)': '{n} debate(s)',
   '{n} conexiones': '{n} conexões',
+  '+{n} conexiones no dibujadas': '+{n} conexões não desenhadas',
   'conf media': 'conf média',
   'Selecciona una idea y traza su': 'Selecione uma ideia e trace seu',
   'mapa de argumentos': 'mapa de argumentos',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -2461,6 +2461,7 @@ export const PT: Record<string, string> = {
   'Trazar el esquema desde esta idea': 'Traçar o esquema a partir desta ideia',
   '{n} debate(s)': '{n} debate(s)',
   '{n} conexiones': '{n} ligações',
+  '+{n} conexiones no dibujadas': '+{n} ligações não desenhadas',
   'conf media': 'conf média',
   'Selecciona una idea y traza su': 'Selecione uma ideia e trace o seu',
   'mapa de argumentos': 'mapa de argumentos',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -2601,6 +2601,7 @@ export const TR: Record<string, string> = {
   "Trazar el esquema desde esta idea": "Bu fikirden şemayı çizin",
   "{n} debate(s)": "{n} tartışma(lar)",
   "{n} conexiones": "{n} bağlantı",
+  "+{n} conexiones no dibujadas": "+{n} çizilmemiş bağlantı",
   "conf media": "yapılandırma ortamı",
   "Selecciona una idea y traza su": "Bir fikir seçin ve onun izini sürün",
   "mapa de argumentos": "argüman haritası",

--- a/src/views/ArgumentMapView.tsx
+++ b/src/views/ArgumentMapView.tsx
@@ -586,6 +586,13 @@ function BlockTree({
               {block.statement && depth === 0 && (
                 <div className="text-xs text-neutral-500 mt-1.5 leading-relaxed">{block.statement}</div>
               )}
+              {/* A hub has far more links than a readable map can draw. Saying how
+                  many were left out keeps the map from reading as the whole story. */}
+              {!!block.hiddenChildren && (
+                <div className="text-[11px] text-neutral-600 mt-1.5">
+                  {tx('+{n} conexiones no dibujadas', { n: block.hiddenChildren })}
+                </div>
+              )}
             </div>
             {hasChildren && (
               <button


### PR DESCRIPTION
Fixes #328.

## Summary

- The local-subgraph walk in `buildLocalSubgraph` expanded neighbours in row order and only capped afterwards, so a well-connected idea could silently lose some of its strongest debates on a capped subgraph.
- It also kept only the edges the BFS itself crossed. For any hub (more neighbours than the idea budget), the walk never leaves depth 0, so no neighbour-to-neighbour edge survived — every branch was forced to be a leaf no matter the configured tree depth.
- The map header quoted connection/debate counts off that capped subgraph, contradicting the route list the map was opened from.
- `buildStructuralArgumentMap` ranked branches by raw priority (debates get a fixed bonus), so a hub with many supports/refinements could render as pure contradiction, and grew the tree depth-first, letting the first-visited branch exhaust the block budget while its siblings stayed bare.

This PR:
- Expands the local subgraph strongest-link-first instead of row order.
- Keeps the full induced subgraph (every edge between retained ideas), not just the ones the walk crossed, so branches can ramify past the first level.
- Gives the automatic (no-AI) path its own larger idea/edge budget, since it's pure local computation and only pays for what it draws — the AI path keeps its original, smaller budget to fit a model context.
- Grows the structural tree level by level, splitting branch slots round-robin across debate/support/other relation families instead of by priority alone.
- Reports real graph-wide connection/debate counts in the header, and how many of an idea's connections were left undrawn (`hiddenChildren`), surfaced in the view as "+N connections not drawn".

## Test plan

- [x] `npm run typecheck`
- [x] `npx eslint` on touched files
- [x] New regression test `scripts/test-argument-map-graph.mjs`, which builds a real SQLite fixture shaped like the reported hub (119 connections / 14 debates, debates inserted last so row-order trimming would drop them) and runs the real `buildStructuralArgumentMap`/`discoverArgumentRoutes` against it under Electron-as-Node. Confirmed it fails against the pre-fix code with the exact reported symptom (`79 conexiones · 9 debate(s)` instead of `119 conexiones · 14 debate(s)`).
- [x] Full suite: `npm test` (1494/1494 passing)
- [x] Verified against a read-only copy of a real corpus (never the user's live vault): header now matches the route list, map reaches depth 3 with branches on every relation family, no branch dropped.
- [x] Drove the packaged app (Playwright + Electron) against an isolated profile pointed at the corpus copy: map renders in ~110ms after click, no animation frame over ~31ms during the 2.5s progressive unfold, ~2650 DOM nodes for 137 blocks, collapse/expand interaction still works, zero console errors.