### PR TITLE
Do what the bundle has been claiming, and read what the vault already holds

### DIFF
--- a/ios/Nodus/AI/CorpusSearch.swift
+++ b/ios/Nodus/AI/CorpusSearch.swift
@@ -1,0 +1,163 @@
+import Foundation
+import NodusAI
+import NodusKit
+
+/// One search, run the best way this device and this vault allow.
+///
+/// The Search tab was lexical by construction: the query vector existed only inside the chat
+/// and Deep Research paths, and the screen never asked for one. So a vault indexed with a key
+/// the phone actually holds still answered synonyms with nothing, and said so in a footnote
+/// nobody could act on.
+///
+/// The decision this type makes, in order:
+///
+///  1. No published vectors → lexical, and the vault is not at fault.
+///  2. Vectors indexed with a desktop runtime → lexical, because a phone cannot reach Ollama.
+///  3. Vectors this device *could* match but has no key for → lexical, and now the message
+///     names the key to add. That case is the reason this exists.
+///  4. Otherwise → embed the query and rank against the published matrix.
+///
+/// Every collaborator is a closure for the same reason `DeepResearchDeps` is: the table above
+/// is the whole feature, and it should be testable without a server or a provider account.
+struct CorpusSearch: Sendable {
+    var identity: EmbeddingIdentity?
+    var availability: @Sendable (EmbeddingIdentity) -> Result<AIProvider, EmbeddingService.Unavailability>
+    var embed: @Sendable (String, EmbeddingIdentity) async throws -> [Float]
+    var semantic: @Sendable (_ query: String, _ vector: [Float], _ identity: EmbeddingIdentity, _ kind: VectorKind, _ limit: Int) async throws -> SemanticSearchOutcome
+    var lexical: @Sendable (_ query: String, _ limit: Int) async throws -> [LexicalSearchResults.Hit]
+
+    enum Mode: String, Sendable, Equatable {
+        case semantic
+        case lexical
+    }
+
+    struct Hit: Sendable, Identifiable, Equatable {
+        let id: String
+        let type: String
+        let title: String?
+        let excerpt: String?
+        /// Only a semantic hit has one. A lexical hit is a substring match, not a distance.
+        let score: Double?
+    }
+
+    struct Outcome: Sendable, Equatable {
+        var hits: [Hit]
+        var mode: Mode
+        /// Why the search was not semantic — shown whenever there is one, because "no results"
+        /// from a lexical search is a claim about spelling, not about the corpus.
+        var warning: String?
+    }
+
+    func run(_ query: String, limit: Int = 50) async throws -> Outcome {
+        guard let identity else {
+            // No vectors at all. Not a fault, and the idle state already explains it.
+            return Outcome(hits: try await lexicalHits(query, limit), mode: .lexical, warning: nil)
+        }
+        if case .failure(let reason) = availability(identity) {
+            return Outcome(hits: try await lexicalHits(query, limit), mode: .lexical, warning: reason.explanation)
+        }
+
+        let vector: [Float]
+        do {
+            vector = try await embed(query, identity)
+        } catch {
+            // A bad key, a rate limit, a provider outage. Lexical still works, and naming what
+            // went wrong beats an empty list the user cannot explain.
+            return Outcome(hits: try await lexicalHits(query, limit), mode: .lexical, warning: error.localizedDescription)
+        }
+
+        // Ideas carry the argument; passages carry the evidence. The server keys the two
+        // matrices separately, so they are two requests — the same pair the assistant makes.
+        async let ideaOutcome = semantic(query, vector, identity, .ideas, min(limit, 40))
+        async let passageOutcome = semantic(query, vector, identity, .passages, min(limit, 20))
+
+        var hits: [Hit] = []
+        var warning: String?
+        for outcome in [try await ideaOutcome, try await passageOutcome] {
+            switch outcome {
+            case .indexed(let found, _, _):
+                hits.append(contentsOf: found.compactMap(Self.hit(from:)))
+            case .notIndexed(_, let message), .mismatch(_, _, _, let message):
+                // Never swallowed: the server is saying the search did not really run.
+                warning = message
+            }
+        }
+
+        guard !hits.isEmpty else {
+            return Outcome(hits: try await lexicalHits(query, limit), mode: .lexical, warning: warning)
+        }
+        // One ranking across both kinds. Showing every idea before every passage would sort by
+        // which matrix answered rather than by what the query means.
+        hits.sort { ($0.score ?? 0) > ($1.score ?? 0) }
+        return Outcome(hits: Array(hits.prefix(limit)), mode: .semantic, warning: warning)
+    }
+
+    private func lexicalHits(_ query: String, _ limit: Int) async throws -> [Hit] {
+        try await lexical(query, limit).map {
+            Hit(id: "\($0.type)/\($0.id)", type: $0.type, title: $0.title, excerpt: $0.excerpt, score: nil)
+        }
+    }
+
+    /// The same reading of a semantic row the citation catalogue makes, so a hit in Search and
+    /// a citation in a report name the same thing the same way.
+    static func hit(from hit: SemanticHit) -> Hit? {
+        let row = hit.row
+        if let id = row.string("global_id") {
+            return Hit(
+                id: "idea/\(id)",
+                type: "idea",
+                title: row.text("label") ?? row.text("statement"),
+                excerpt: row.text("statement"),
+                score: hit.score
+            )
+        }
+        if let id = row.string("passage_id") {
+            return Hit(
+                id: "passage/\(id)",
+                type: "passage",
+                title: row.text("section") ?? String((row.text("text") ?? "").prefix(80)),
+                excerpt: row.text("text"),
+                score: hit.score
+            )
+        }
+        if let id = row.string("nodus_id") {
+            return Hit(
+                id: "work/\(id)",
+                type: "work",
+                title: row.text("title"),
+                excerpt: row.text("year"),
+                score: hit.score
+            )
+        }
+        return nil
+    }
+}
+
+extension CorpusSearch {
+    /// Wired to a real space.
+    static func live(
+        client: NodusClient,
+        spaceId: String,
+        embeddings: EmbeddingService,
+        identity: EmbeddingIdentity?
+    ) -> CorpusSearch {
+        CorpusSearch(
+            identity: identity,
+            availability: { embeddings.availability(for: $0) },
+            embed: { query, identity in try await embeddings.embed(query, as: identity) },
+            semantic: { query, vector, identity, kind, limit in
+                try await client.semanticSearch(
+                    query: query,
+                    vector: vector,
+                    identity: identity,
+                    kind: kind,
+                    in: spaceId,
+                    limit: limit
+                )
+            },
+            lexical: { query, limit in
+                try await client.search(query, in: spaceId, limit: limit).results
+            }
+        )
+    }
+}

--- a/ios/Nodus/AI/DeepResearchCheckpointStore.swift
+++ b/ios/Nodus/AI/DeepResearchCheckpointStore.swift
@@ -1,0 +1,66 @@
+import Foundation
+import NodusAI
+
+/// The one unfinished Deep Research run a space is allowed to have.
+///
+/// Info.plist has always said a run "continues as a processing task and resumes from its
+/// persisted state". This is that state. It sits beside the reports rather than in Caches for
+/// the same reason they do: the system empties Caches whenever it likes, and losing this costs
+/// the user one completion per section already written.
+///
+/// One per space, not one per attempt. A second run in the same space replaces the first —
+/// keeping a pile of abandoned half-reports would mean deciding later which of them the user
+/// meant, and there is no honest way to guess.
+/// `nonisolated` because the orchestrator calls `save` from whichever thread finished a
+/// section, and hopping to the main actor to write one small file after every model call would
+/// put file I/O on the thread that draws.
+nonisolated enum DeepResearchCheckpointStore {
+    private static let filename = "deep-research-checkpoint.json"
+
+    static var spacesDirectory: URL {
+        URL.applicationSupportDirectory.appendingPathComponent("spaces", isDirectory: true)
+    }
+
+    static func directory(for spaceId: String) -> URL {
+        spacesDirectory.appendingPathComponent(spaceId, isDirectory: true)
+    }
+
+    static func url(for spaceId: String) -> URL {
+        directory(for: spaceId).appendingPathComponent(filename)
+    }
+
+    static func load(spaceId: String) -> DeepResearchCheckpoint? {
+        guard let data = try? Data(contentsOf: url(for: spaceId)) else { return nil }
+        return try? JSONDecoder.nodusReports.decode(DeepResearchCheckpoint.self, from: data)
+    }
+
+    static func save(_ checkpoint: DeepResearchCheckpoint, spaceId: String) {
+        let folder = directory(for: spaceId)
+        try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder.nodusReports.encode(checkpoint) else { return }
+        // `completeFileProtectionUnlessOpen`, not `complete`: a background task resuming a run
+        // may well start while the phone is locked, and a file it cannot open is a run it
+        // cannot finish.
+        try? data.write(to: url(for: spaceId), options: [.atomic, .completeFileProtectionUnlessOpen])
+    }
+
+    static func clear(spaceId: String) {
+        try? FileManager.default.removeItem(at: url(for: spaceId))
+    }
+
+    /// Every space holding a run that never reached its last section.
+    ///
+    /// Read off the filesystem rather than from a list in UserDefaults so a checkpoint written
+    /// by a process that was then killed is still found by the next one.
+    static func spacesWithUnfinishedRuns() -> [(spaceId: String, checkpoint: DeepResearchCheckpoint)] {
+        let folders = (try? FileManager.default.contentsOfDirectory(
+            at: spacesDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        )) ?? []
+        return folders.compactMap { folder in
+            let spaceId = folder.lastPathComponent
+            guard let checkpoint = load(spaceId: spaceId), !checkpoint.isComplete else { return nil }
+            return (spaceId, checkpoint)
+        }
+    }
+}

--- a/ios/Nodus/AI/LocalReportStore.swift
+++ b/ios/Nodus/AI/LocalReportStore.swift
@@ -73,18 +73,22 @@ final class LocalReportStore {
     }
 }
 
+// Built per call rather than shared. A `JSONDecoder` is not `Sendable`, and a stored one would
+// have to be pinned to an actor — which the Deep Research checkpoint cannot honour, because it
+// is written from whichever thread finished a section. Constructing one costs nothing next to
+// the file read it accompanies.
 extension JSONDecoder {
-    static let nodusReports: JSONDecoder = {
+    nonisolated static var nodusReports: JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
-    }()
+    }
 }
 
 extension JSONEncoder {
-    static let nodusReports: JSONEncoder = {
+    nonisolated static var nodusReports: JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return encoder
-    }()
+    }
 }

--- a/ios/Nodus/AI/ReportDraft.swift
+++ b/ios/Nodus/AI/ReportDraft.swift
@@ -1,0 +1,140 @@
+import Foundation
+import NodusAI
+import NodusKit
+
+/// A report generated on this phone, written in the shape the desktop stores its own.
+///
+/// `writing_saved_drafts` is a table the server accepts from a client, but accepting a row is
+/// not the same as writing one the owner's Nodus can read. The desktop's Writing Workshop keeps
+/// a `WritingWorkshopDraft` in `draft_json` (`shared/types.ts:5838`), and the corpus route only
+/// lists a draft at all when `brief_json.kind` is `deep_research`
+/// (`server/lib/routes/corpus.mjs:26`). Both are reproduced here exactly, because a row that
+/// lands in the ledger and then renders as an empty report is worse than no row.
+///
+/// Columns come from the migration that created the table (`electron/db/migrations.ts:494`)
+/// and no others: the server checks every column against what the vault has published, and a
+/// name this app invented would be rejected as `unknown_column`.
+enum ReportDraft {
+    /// The row for one finished report.
+    ///
+    /// - Parameter language: the interface language the report was written in, which the
+    ///   desktop stores on the brief and uses when it reopens the draft.
+    static func row(
+        id: String,
+        report: DeepResearchReport,
+        mode: DeepResearchMode,
+        model: ModelRef,
+        language: String,
+        now: Date = Date()
+    ) -> [String: JSONValue] {
+        let timestamp = ISO8601DateFormatter.nodusFractional.string(from: now)
+        let selection = selection(citing: report.sections.flatMap(\.citations))
+
+        let brief: [String: Any] = [
+            // The one value the server filters on. Anything else and the report is stored and
+            // never listed.
+            "kind": "deep_research",
+            "objective": report.objective,
+            "tone": "academic",
+            "language": language,
+        ]
+
+        let draft: [String: Any] = [
+            "generatedAt": timestamp,
+            "brief": brief,
+            "selection": selection,
+            "title": report.objective,
+            // The phone's orchestrator writes no separate abstract; claiming one by copying the
+            // first section would put words in the report it does not have.
+            "abstract": "",
+            "outline": report.sections.enumerated().map { index, section in
+                [
+                    "id": "s\(index + 1)",
+                    "title": section.title,
+                    "purpose": "",
+                    "keyClaims": [],
+                    "sources": section.citations,
+                ] as [String: Any]
+            },
+            "draftMarkdown": report.markdown,
+            "matrix": [],
+            "bibliography": report.references.map(\.label),
+            "nextSteps": [],
+            "limitations": limitations(report),
+            "stats": [
+                "selectedIdeas": (selection["ideaIds"] as? [String])?.count ?? 0,
+                "selectedThemes": (selection["themeIds"] as? [String])?.count ?? 0,
+                "selectedGaps": (selection["gapIds"] as? [String])?.count ?? 0,
+                "selectedContradictions": 0,
+                "selectedWorks": (selection["workIds"] as? [String])?.count ?? 0,
+                "selectedPassages": (selection["passageIds"] as? [String])?.count ?? 0,
+                "selectedTutorRoutes": 0,
+                "contextChars": report.markdown.count,
+                "truncated": report.stoppedReason != nil,
+            ] as [String: Any],
+        ]
+
+        return [
+            "id": .string(id),
+            "title": .string(report.objective),
+            "brief_json": .string(json(brief)),
+            "selection_json": .string(json(selection)),
+            "model_json": .string(json(["provider": model.provider.rawValue, "model": model.model])),
+            "draft_json": .string(json(draft)),
+            "created_at": .string(timestamp),
+            "updated_at": .string(timestamp),
+        ]
+    }
+
+    /// What the report was built from, read off the citations it really used.
+    ///
+    /// Not a guess and not the whole corpus: the desktop's selection means "these are the rows
+    /// this document rests on", and the only honest answer is the set of citations that
+    /// survived validation — an invented one was stripped from the prose and must not reappear
+    /// here as though the report leaned on it.
+    ///
+    /// Parsed straight from the tokens, which are `nodus://<kind>/<id>` by the same scheme the
+    /// server publishes with every context package.
+    static func selection(citing tokens: [String]) -> [String: Any] {
+        var byKind: [String: [String]] = [:]
+        var seen = Set<String>()
+        for token in tokens where seen.insert(token).inserted {
+            let trimmed = token.replacingOccurrences(of: "nodus://", with: "")
+            let parts = trimmed.split(separator: "/", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            byKind[String(parts[0]), default: []].append(String(parts[1]))
+        }
+        return [
+            "ideaIds": byKind["idea"] ?? [],
+            "themeIds": byKind["theme"] ?? [],
+            "gapIds": byKind["gap"] ?? [],
+            "contradictionIds": [String](),
+            "workIds": byKind["work"] ?? [],
+            "passageIds": byKind["passage"] ?? [],
+            "tutorRouteIds": [String](),
+        ]
+    }
+
+    /// The limitations the run itself knows about. A report that stopped short, or that had
+    /// invented citations removed, is a weaker document and the saved copy says so rather than
+    /// leaving the owner to notice.
+    private static func limitations(_ report: DeepResearchReport) -> [String] {
+        var notes: [String] = []
+        if let stopped = report.stoppedReason { notes.append(stopped) }
+        if report.citationsRejected > 0 {
+            notes.append(String(
+                localized: "\(report.citationsRejected) of \(report.citationsChecked) citations were invented by the model and were removed; sentences that rested only on them are left unsupported."
+            ))
+        }
+        notes.append(String(localized: "Generated on iPhone from the published snapshot of this space."))
+        return notes
+    }
+
+    private static func json(_ value: Any) -> String {
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+            let text = String(data: data, encoding: .utf8)
+        else { return "{}" }
+        return text
+    }
+}

--- a/ios/Nodus/Info.plist
+++ b/ios/Nodus/Info.plist
@@ -105,10 +105,13 @@
 		</dict>
 	</dict>
 
+	<!-- These two are the base (English) strings. `Nodus/InfoPlist.xcstrings` carries the
+	     Spanish, which iOS substitutes by key at runtime — a plist string on its own is
+	     shown verbatim in every language, which is how both of these were Spanish-only. -->
 	<key>NSFaceIDUsageDescription</key>
-	<string>Nodus usa Face ID para proteger tus claves de proveedor y el acceso a tus vaults.</string>
+	<string>Nodus uses Face ID to protect your provider keys and the copies of your vaults on this device.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Nodus se conecta a un Nodus Server de tu red local cuando le indicas su dirección.</string>
+	<string>Nodus connects to a Nodus Server on your local network when you give it the address.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleURLTypes</key>

--- a/ios/Nodus/InfoPlist.xcstrings
+++ b/ios/Nodus/InfoPlist.xcstrings
@@ -1,0 +1,30 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "NSFaceIDUsageDescription" : {
+      "comment" : "Shown by iOS when the app first asks to use Face ID to unlock itself.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nodus usa Face ID para proteger tus claves de proveedor y las copias de tus vaults en este dispositivo."
+          }
+        }
+      }
+    },
+    "NSLocalNetworkUsageDescription" : {
+      "comment" : "Shown by iOS the first time the app reaches a Nodus Server on the local network.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nodus se conecta a un Nodus Server de tu red local cuando le indicas su dirección."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/ios/Nodus/Localizable.xcstrings
+++ b/ios/Nodus/Localizable.xcstrings
@@ -1,1213 +1,306 @@
 {
   "sourceLanguage": "en",
-  "version": "1.0",
   "strings": {
-    "Connect to a Nodus Server": {
+    "%.1f pp.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Conectar con un Nodus Server"
+            "value": "%.1f pág."
           }
         }
       }
     },
-    "Your server holds a published projection of the vault. AI keys never leave this device.": {
+    "%@ / %@": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tu servidor guarda una proyección publicada del vault. Las claves de IA nunca salen de este dispositivo."
+            "value": "%@ / %@"
           }
         }
       }
     },
-    "Server address": {
+    "%@ records": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dirección del servidor"
+            "value": "%@ registros"
           }
         }
       }
     },
-    "HTTPS is assumed. The server refuses any public address that is not.": {
+    "%@ rows · %lld columns": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Se asume HTTPS. El servidor rechaza cualquier dirección pública que no lo sea."
+            "value": "%@ filas · %lld columnas"
           }
         }
       }
     },
-    "Add a server": {
+    "%@ words": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Añadir un servidor"
+            "value": "%@ palabras"
           }
         }
       }
     },
-    "No spaces yet": {
+    "%@ words · %@": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ningún espacio todavía"
+            "value": "%@ palabras · %@"
           }
         }
       }
     },
-    "Connect to the Nodus Server where your vault is published.": {
+    "%@ words · %@ pages": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Conéctate al Nodus Server donde tu vault está publicado."
+            "value": "%@ palabras · %@ páginas"
           }
         }
       }
     },
-    "Your vaults, wherever you are.": {
+    "%@ · %@": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tus vaults, donde estés."
+            "value": "%@ · %@"
           }
         }
       }
     },
-    "Choose a space": {
+    "%@ · %lld": {
       "extractionState": "manual",
       "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elige un espacio"
-          }
-        }
-      }
-    },
-    "Each space needs its own credential: one works for exactly one space.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cada espacio necesita su propio acceso: una credencial vale para uno solo."
-          }
-        }
-      }
-    },
-    "This account has no access to any space yet. Ask whoever administers the server.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta cuenta todavía no tiene acceso a ningún espacio. Pídeselo a quien administra el servidor."
-          }
-        }
-      }
-    },
-    "No spaces": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin espacios"
-          }
-        }
-      }
-    },
-    "Switch space": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar de espacio"
-          }
-        }
-      }
-    },
-    "A pairing code expires after fifteen minutes and works once.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Un código de emparejamiento caduca a los quince minutos y solo sirve una vez."
-          }
-        }
-      }
-    },
-    "That email or password is not right.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ese correo o esa contraseña no son correctos."
-          }
-        }
-      }
-    },
-    "The sign-in expired. Sign in again.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El acceso caducó. Vuelve a entrar."
-          }
-        }
-      }
-    },
-    "Too many attempts. Try again in \\(seconds) s.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Demasiados intentos. Prueba de nuevo en \\(seconds) s."
-          }
-        }
-      }
-    },
-    "That address will not work. Enter just the domain, with no path.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esa dirección no sirve. Escribe solo el dominio, sin rutas."
-          }
-        }
-      }
-    },
-    "· not published": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "· sin publicar"
-          }
-        }
-      }
-    },
-    "Not encrypted": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin cifrar"
-          }
-        }
-      }
-    },
-    "Account": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cuenta"
-          }
-        }
-      }
-    },
-    "Code": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Código"
-          }
-        }
-      }
-    },
-    "Email": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Correo"
-          }
-        }
-      }
-    },
-    "Password": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contraseña"
-          }
-        }
-      }
-    },
-    "Sign in": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entrar"
-          }
-        }
-      }
-    },
-    "Pair": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emparejar"
-          }
-        }
-      }
-    },
-    "Continue": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar"
-          }
-        }
-      }
-    },
-    "Cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
-          }
-        }
-      }
-    },
-    "Save": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar"
-          }
-        }
-      }
-    },
-    "Done": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Listo"
-          }
-        }
-      }
-    },
-    "New": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nuevo"
-          }
-        }
-      }
-    },
-    "Read only": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lectura"
-          }
-        }
-      }
-    },
-    "Can send changes": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puede enviar cambios"
-          }
-        }
-      }
-    },
-    "Owner": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Propietario"
-          }
-        }
-      }
-    },
-    "read": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lectura"
-          }
-        }
-      }
-    },
-    "write": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "escritura"
-          }
-        }
-      }
-    },
-    "owner": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "propietario"
-          }
-        }
-      }
-    },
-    "This space has no publication yet": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este espacio todavía no tiene publicación"
-          }
-        }
-      }
-    },
-    "It will appear as soon as its owner publishes from Nodus desktop.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aparecerá en cuanto quien lo posee publique desde Nodus de escritorio."
-          }
-        }
-      }
-    },
-    "Could not read the space": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo leer el espacio"
-          }
-        }
-      }
-    },
-    "Read-only access": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acceso de lectura"
-          }
-        }
-      }
-    },
-    "Anything you write or generate here stays on this device.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lo que escribas o generes aquí se queda en este dispositivo."
-          }
-        }
-      }
-    },
-    "Semantic search is not available here": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La búsqueda semántica no está disponible aquí"
-          }
-        }
-      }
-    },
-    "No published vectors": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin vectores publicados"
-          }
-        }
-      }
-    },
-    "Search will be lexical until the space's owner publishes the embeddings.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La búsqueda será léxica hasta que quien posee el espacio publique los embeddings."
-          }
-        }
-      }
-    },
-    "Empty publication": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Publicación vacía"
-          }
-        }
-      }
-    },
-    "This space's last publication carried no table with anything in it.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La última publicación de este espacio no traía ninguna tabla con contenido."
-          }
-        }
-      }
-    },
-    "More from this space": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Más del espacio"
-          }
-        }
-      }
-    },
-    "Offline only": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solo sin conexión"
-          }
-        }
-      }
-    },
-    "These tables travel in the publication but have no REST route, so they can only be listed from the downloaded copy.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estas tablas viajan en la publicación pero no tienen ruta REST, así que solo se pueden listar desde la copia descargada."
-          }
-        }
-      }
-    },
-    "Write": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribir"
-          }
-        }
-      }
-    },
-    "Notes and queue": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notas y cola"
-          }
-        }
-      }
-    },
-    "Analyse": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Analizar"
-          }
-        }
-      }
-    },
-    "Browse": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Explorar"
-          }
-        }
-      }
-    },
-    "Home": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inicio"
-          }
-        }
-      }
-    },
-    "Search": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar"
-          }
-        }
-      }
-    },
-    "Nothing here": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nada aquí"
-          }
-        }
-      }
-    },
-    "Library": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biblioteca"
-          }
-        }
-      }
-    },
-    "Ideas": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ideas"
-          }
-        }
-      }
-    },
-    "Themes": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Temas"
-          }
-        }
-      }
-    },
-    "Gaps": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Huecos"
-          }
-        }
-      }
-    },
-    "Authors": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autores"
-          }
-        }
-      }
-    },
-    "Passages": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pasajes"
-          }
-        }
-      }
-    },
-    "People": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personas"
-          }
-        }
-      }
-    },
-    "Places": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lugares"
-          }
-        }
-      }
-    },
-    "Timeline": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cronología"
-          }
-        }
-      }
-    },
-    "Relationships": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relaciones"
-          }
-        }
-      }
-    },
-    "Subjects": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Asignaturas"
-          }
-        }
-      }
-    },
-    "Courses": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cursos"
-          }
-        }
-      }
-    },
-    "Study topics": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Temas de estudio"
-          }
-        }
-      }
-    },
-    "Documents": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Documentos"
-          }
-        }
-      }
-    },
-    "Materials": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Materiales"
-          }
-        }
-      }
-    },
-    "Flashcards": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fichas"
-          }
-        }
-      }
-    },
-    "Question bank": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Banco de preguntas"
-          }
-        }
-      }
-    },
-    "Exams": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exámenes"
-          }
-        }
-      }
-    },
-    "Rubrics": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rúbricas"
-          }
-        }
-      }
-    },
-    "Databases": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bases de datos"
-          }
-        }
-      }
-    },
-    "Database": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Base de datos"
-          }
-        }
-      }
-    },
-    "Debates": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Debates"
-          }
-        }
-      }
-    },
-    "Notes": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notas"
-          }
-        }
-      }
-    },
-    "Immersion": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inmersión"
-          }
-        }
-      }
-    },
-    "Sessions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sesiones"
-          }
-        }
-      }
-    },
-    "Session": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sesión"
-          }
-        }
-      }
-    },
-    "Work": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obra"
-          }
-        }
-      }
-    },
-    "Idea": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
+        "en": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Idea"
-          }
-        }
-      }
-    },
-    "Theme": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tema"
-          }
-        }
-      }
-    },
-    "Gap": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hueco"
-          }
-        }
-      }
-    },
-    "Author": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autor"
-          }
-        }
-      }
-    },
-    "Passage": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pasaje"
-          }
-        }
-      }
-    },
-    "Person": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Persona"
+            "state": "new",
+            "value": "%1$@ · %2$lld"
           }
-        }
-      }
-    },
-    "Place": {
-      "extractionState": "manual",
-      "localizations": {
+        },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lugar"
+            "value": "%@ · %lld"
           }
         }
       }
     },
-    "Event": {
+    "%@ · %lld dimensions": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Evento"
+            "value": "%@ · %lld dimensiones"
           }
         }
       }
     },
-    "Relationship": {
+    "%@ — not reachable from iOS": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Relación"
+            "value": "%@ — no alcanzable desde iOS"
           }
         }
       }
     },
-    "Note": {
+    "%lld": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nota"
+            "value": "%lld"
           }
         }
       }
     },
-    "Report": {
+    "%lld characters": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informe"
+            "value": "%lld caracteres"
           }
         }
       }
     },
-    "Item": {
+    "%lld citations, all from the corpus": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Elemento"
+            "value": "%lld citas, todas del corpus"
           }
         }
       }
     },
-    "Untitled": {
+    "%lld invented citations removed": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin título"
+            "value": "%lld citas inventadas eliminadas"
           }
         }
       }
     },
-    "Untitled work": {
+    "%lld invented citations, removed": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Obra sin título"
+            "value": "%lld citas inventadas, eliminadas"
           }
         }
       }
     },
-    "Untitled note": {
+    "%lld min": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nota sin título"
+            "value": "%lld min"
           }
         }
       }
     },
-    "Unknown section": {
+    "%lld of %lld": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sección desconocida"
+            "value": "%lld de %lld"
           }
         }
       }
     },
-    "Filter on any field": {
+    "%lld of %lld citations were invented by the model and were removed; sentences that rested only on them are left unsupported.": {
       "extractionState": "manual",
       "localizations": {
-        "es": {
+        "en": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Filtrar en cualquier campo"
+            "state": "new",
+            "value": "%1$lld of %2$lld citations were invented by the model and were removed; sentences that rested only on them are left unsupported."
           }
-        }
-      }
-    },
-    "No matches": {
-      "extractionState": "manual",
-      "localizations": {
+        },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin coincidencias"
+            "value": "El modelo inventó %lld de %lld citas y se han eliminado; las frases que solo se apoyaban en ellas quedan sin respaldo."
           }
         }
       }
     },
-    "This publication carries nothing under \\(collection.label.lowercased()).": {
+    "%lld passages extracted": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Esta publicación no trae nada en \\(collection.label.lowercased())."
+            "value": "%lld pasajes extraídos"
           }
         }
       }
     },
-    "No row contains “\\(query)”.": {
+    "%lld rows · %lld columns": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ninguna fila contiene «\\(query)»."
+            "value": "%lld filas · %lld columnas"
           }
         }
       }
     },
-    "Could not load": {
+    "%lld%%": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudieron cargar"
+            "value": "%lld%%"
           }
         }
       }
     },
-    "Could not expand": {
+    "%lld. %@": {
       "extractionState": "manual",
       "localizations": {
-        "es": {
+        "en": {
           "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo ampliar"
+            "state": "new",
+            "value": "%1$lld. %2$@"
           }
-        }
-      }
-    },
-    "Could not open": {
-      "extractionState": "manual",
-      "localizations": {
+        },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo abrir"
+            "value": "%lld. %@"
           }
         }
       }
     },
-    "Open the full record": {
+    "%lld/%lld": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver la ficha completa"
+            "value": "%lld/%lld"
           }
         }
       }
     },
-    "See the ideas under this theme": {
+    "+%lld connections not drawn": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver las ideas de este tema"
+            "value": "+%lld conexiones no dibujadas"
           }
         }
       }
     },
-    "See the tree from here": {
+    ", progress.pagesSoFar)) pages": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver el árbol desde aquí"
+            "value": ", progress.pagesSoFar)) páginas"
           }
         }
       }
@@ -1223,893 +316,35 @@
         }
       }
     },
-    "\\(detail.passages) passages extracted": {
+    "A column carried a value that is not a scalar.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(detail.passages) pasajes extraídos"
+            "value": "Una columna llevaba un valor que no es un dato simple."
           }
         }
       }
     },
-    "They are read from each idea that rests on them. The original document never leaves the desktop.": {
+    "A delete cannot carry content.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Se leen desde cada idea que se apoya en ellos. El documento original nunca sale del escritorio."
+            "value": "Un borrado no puede llevar contenido."
           }
         }
       }
     },
-    "Passages that support it · \\(detail.evidence.count)": {
+    "A gateway to many models, with its own embeddings.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pasajes que la sostienen · \\(detail.evidence.count)"
-          }
-        }
-      }
-    },
-    "explicit": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "explícita"
-          }
-        }
-      }
-    },
-    "paraphrased": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "parafraseada"
-          }
-        }
-      }
-    },
-    "Synthesis": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Síntesis"
-          }
-        }
-      }
-    },
-    "Occurrences": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apariciones"
-          }
-        }
-      }
-    },
-    "Evidence": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidencia"
-          }
-        }
-      }
-    },
-    "Names": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nombres"
-          }
-        }
-      }
-    },
-    "Events": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos"
-          }
-        }
-      }
-    },
-    "Works": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Obras"
-          }
-        }
-      }
-    },
-    "Columns": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Columnas"
-          }
-        }
-      }
-    },
-    "Views": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vistas"
-          }
-        }
-      }
-    },
-    "items": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "elementos"
-          }
-        }
-      }
-    },
-    "item": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "elemento"
-          }
-        }
-      }
-    },
-    "fields": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "campos"
-          }
-        }
-      }
-    },
-    "field": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "campo"
-          }
-        }
-      }
-    },
-    "and \\(rows.count - 60) more": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "y \\(rows.count - 60) más"
-          }
-        }
-      }
-    },
-    "and \\(section.rows.count - 20) more": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "y \\(section.rows.count - 20) más"
-          }
-        }
-      }
-    },
-    "Search the corpus": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar en el corpus"
-          }
-        }
-      }
-    },
-    "Search (lexical)": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscar (léxico)"
-          }
-        }
-      }
-    },
-    "Search failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La búsqueda falló"
-          }
-        }
-      }
-    },
-    "Lexical results": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resultados léxicos"
-          }
-        }
-      }
-    },
-    "No results": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin resultados"
-          }
-        }
-      }
-    },
-    "Nothing matched “\\(query)”.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ninguna coincidencia para «\\(query)»."
-          }
-        }
-      }
-    },
-    "No row contains the string “\\(query)”. This search is literal, not semantic: a synonym will not satisfy it.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ninguna fila contiene la cadena «\\(query)». Esta búsqueda es literal, no semántica: un sinónimo no la satisface."
-          }
-        }
-      }
-    },
-    "Search \\(session.connection.spaceName)": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Busca en \\(session.connection.spaceName)"
-          }
-        }
-      }
-    },
-    "Indexed with \\(identity.model) · \\(identity.dim) dimensions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Indexado con \\(identity.model) · \\(identity.dim) dimensiones"
-          }
-        }
-      }
-    },
-    "Indexed with \\(identity.provider), which a phone cannot reach. Search will be lexical.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Indexado con \\(identity.provider), que no es alcanzable desde el móvil. La búsqueda será léxica."
-          }
-        }
-      }
-    },
-    "No published vectors. Search will be lexical.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin vectores publicados. La búsqueda será léxica."
-          }
-        }
-      }
-    },
-    "Too many searches in a row. Wait \\(Int(apiError.retryAfter ?? 30)) s.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Demasiadas búsquedas seguidas. Espera \\(Int(apiError.retryAfter ?? 30)) s."
-          }
-        }
-      }
-    },
-    "Settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustes"
-          }
-        }
-      }
-    },
-    "Space": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Espacio"
-          }
-        }
-      }
-    },
-    "Name": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nombre"
-          }
-        }
-      }
-    },
-    "Type": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipo"
-          }
-        }
-      }
-    },
-    "Access": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acceso"
-          }
-        }
-      }
-    },
-    "Revision": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Revisión"
-          }
-        }
-      }
-    },
-    "Schema": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esquema"
-          }
-        }
-      }
-    },
-    "Server": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Servidor"
-          }
-        }
-      }
-    },
-    "Address": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dirección"
-          }
-        }
-      }
-    },
-    "Status": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado"
-          }
-        }
-      }
-    },
-    "Online": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "En línea"
-          }
-        }
-      }
-    },
-    "No answer": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin respuesta"
-          }
-        }
-      }
-    },
-    "Largest image": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Imagen máxima"
-          }
-        }
-      }
-    },
-    "Change batch": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lote de cambios"
-          }
-        }
-      }
-    },
-    "This connection is not encrypted. That should only ever be a local test.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta conexión no está cifrada. Solo debería serlo en pruebas locales."
-          }
-        }
-      }
-    },
-    "Provider": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proveedor"
-          }
-        }
-      }
-    },
-    "Model": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modelo"
-          }
-        }
-      }
-    },
-    "Dimensions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dimensiones"
-          }
-        }
-      }
-    },
-    "This provider runs on the computer where Nodus desktop lives. iOS cannot produce a matching vector, so search is lexical.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este proveedor corre en el ordenador donde está Nodus de escritorio. Desde iOS no se puede generar un vector que case, así que la búsqueda es léxica."
-          }
-        }
-      }
-    },
-    "This space has no published vectors.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este espacio no tiene vectores publicados."
-          }
-        }
-      }
-    },
-    "The vault fixes the model, not this app: retrieval only works when provider, model and dimension all match exactly.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El modelo lo fija el vault, no esta app: la recuperación solo funciona si el proveedor, el modelo y la dimensión coinciden exactamente."
-          }
-        }
-      }
-    },
-    "Offline": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin conexión"
-          }
-        }
-      }
-    },
-    "Download for offline use": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar para sin conexión"
-          }
-        }
-      }
-    },
-    "Downloading the publication…": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargando la publicación…"
-          }
-        }
-      }
-    },
-    "Indexing…": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Indexando…"
-          }
-        }
-      }
-    },
-    "Rows": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filas"
-          }
-        }
-      }
-    },
-    "Tables": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tablas"
-          }
-        }
-      }
-    },
-    "Downloaded": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargada"
-          }
-        }
-      }
-    },
-    "Download again": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Volver a descargar"
-          }
-        }
-      }
-    },
-    "Delete the copy": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar la copia"
-          }
-        }
-      }
-    },
-    "The copy is out of date": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La copia está desfasada"
-          }
-        }
-      }
-    },
-    "It holds \\(rows.formatted()) rows from an earlier publication.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guarda \\(rows.formatted()) filas de una publicación anterior."
-          }
-        }
-      }
-    },
-    "Update": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar"
-          }
-        }
-      }
-    },
-    "Try again": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reintentar"
-          }
-        }
-      }
-    },
-    "This space has no publication to download yet.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este espacio todavía no tiene publicación que descargar."
-          }
-        }
-      }
-    },
-    "Keeps the whole publication on the device: works with no network, sorts instantly, and reaches the tables the API does not expose.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guarda la publicación completa en el dispositivo: funciona sin red, ordena al instante y alcanza las tablas que la API no expone."
-          }
-        }
-      }
-    },
-    "Forget this space": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Olvidar este espacio"
-          }
-        }
-      }
-    },
-    "The credential is deleted from this device. Nothing changes on the server.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se borra la credencial de este dispositivo. Nada cambia en el servidor."
-          }
-        }
-      }
-    },
-    "AI providers": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proveedores de IA"
-          }
-        }
-      }
-    },
-    "Your keys are kept in this device's keychain, not synced to iCloud, and never sent to the Nodus Server: the server hands over the material and this app calls your provider.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus claves se guardan en el llavero de este dispositivo, sin sincronizar con iCloud, y nunca se envían al Nodus Server: el servidor entrega el material y tú llamas a tu proveedor."
-          }
-        }
-      }
-    },
-    "Needed for semantic search": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Necesario para la búsqueda semántica"
-          }
-        }
-      }
-    },
-    "Add key": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Añadir clave"
-          }
-        }
-      }
-    },
-    "Add a key": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Añadir una clave"
-          }
-        }
-      }
-    },
-    "Providers": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proveedores"
-          }
-        }
-      }
-    },
-    "Not available on iOS": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No disponibles en iOS"
-          }
-        }
-      }
-    },
-    "These providers exist in Nodus desktop. They are listed so that, if your vault was indexed with one, the app can say exactly why it cannot reproduce it.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estos proveedores existen en Nodus de escritorio. Se listan para que, si tu vault se indexó con uno, la app pueda decirte exactamente por qué no puede reproducirlo."
-          }
-        }
-      }
-    },
-    "Models by task": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modelos por tarea"
-          }
-        }
-      }
-    },
-    "Not chosen": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin elegir"
-          }
-        }
-      }
-    },
-    "Key": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clave"
-          }
-        }
-      }
-    },
-    "API key": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clave de API"
+            "value": "Pasarela a muchos modelos, con embeddings propios."
           }
         }
       }
@@ -2125,50 +360,6 @@
         }
       }
     },
-    "It will be stored in the keychain, available only while the device is unlocked and never leaving it.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se guardará en el llavero, disponible solo con el dispositivo desbloqueado y sin salir de él."
-          }
-        }
-      }
-    },
-    "Delete the key": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar la clave"
-          }
-        }
-      }
-    },
-    "Rejected": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechazado"
-          }
-        }
-      }
-    },
-    "Ready": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lista"
-          }
-        }
-      }
-    },
     "A local server on the computer running Nodus.": {
       "extractionState": "manual",
       "localizations": {
@@ -2180,68 +371,101 @@
         }
       }
     },
-    "Models Nodus runs inside its own process.": {
+    "A pairing code expires after fifteen minutes and works once.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modelos que Nodus ejecuta dentro de su propio proceso."
+            "value": "Un código de emparejamiento caduca a los quince minutos y solo sirve una vez."
           }
         }
       }
     },
-    "Authenticated through a desktop subscription session.": {
+    "A table with no rows was published empty. A table that is absent was never published at all — and the endpoint for it answers an empty page rather than an error.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Se autentica con una sesión de suscripción del escritorio."
+            "value": "Una tabla con cero filas se publicó vacía. Una tabla ausente no se publicó nunca — y su endpoint responde una página vacía, no un error."
           }
         }
       }
     },
-    "\\(unreachable.label) — not reachable from iOS": {
+    "AI providers": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(unreachable.label) — no alcanzable desde iOS"
+            "value": "Proveedores de IA"
           }
         }
       }
     },
-    "This vault was indexed with an engine that runs on the Nodus computer. Search will still work, but it will be lexical.": {
+    "API key": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Este vault se indexó con un motor que corre en el ordenador de Nodus. La búsqueda seguirá funcionando, pero será léxica."
+            "value": "Clave de API"
           }
         }
       }
     },
-    "Indexed with “\\(identity.provider)”, which this version does not know.": {
+    "Abstract": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Indexado con «\\(identity.provider)», que esta versión no conoce."
+            "value": "Resumen"
           }
         }
       }
     },
-    "No keys configured": {
+    "Access": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin claves configuradas"
+            "value": "Acceso"
+          }
+        }
+      }
+    },
+    "Account": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuenta"
+          }
+        }
+      }
+    },
+    "Adapted to the corpus": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adaptada al corpus"
+          }
+        }
+      }
+    },
+    "Add a key": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir una clave"
           }
         }
       }
@@ -2257,24 +481,35 @@
         }
       }
     },
-    "Pinned": {
+    "Add a server": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Destacados"
+            "value": "Añadir un servidor"
           }
         }
       }
     },
-    "Models": {
+    "Add key": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modelos"
+            "value": "Añadir clave"
+          }
+        }
+      }
+    },
+    "Address": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección"
           }
         }
       }
@@ -2290,90 +525,167 @@
         }
       }
     },
-    "Search model or provider": {
+    "All reports": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buscar modelo o proveedor"
+            "value": "Todos los informes"
           }
         }
       }
     },
-    "No model contains “\\(query)”.": {
+    "An image the row refers to has not been uploaded.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ningún modelo contiene «\\(query)»."
+            "value": "Falta subir una imagen a la que la fila hace referencia."
           }
         }
       }
     },
-    "Could not be listed": {
+    "An insert needs content.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudieron listar"
+            "value": "Un alta necesita contenido."
           }
         }
       }
     },
-    "Pin": {
+    "An unfinished report": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Destacar"
+            "value": "Un informe sin terminar"
           }
         }
       }
     },
-    "Remove": {
+    "Analyse": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quitar"
+            "value": "Analizar"
           }
         }
       }
     },
-    "Unpin": {
+    "Another seed": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quitar de destacados"
+            "value": "Otra semilla"
           }
         }
       }
     },
-    "Querying": {
+    "Answers stay on this device. An immersion session's progress is never published, so nothing here travels back to the vault.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Consultando"
+            "value": "Las respuestas se quedan en este dispositivo. El progreso de una sesión de inmersión no se publica nunca, así que nada de esto vuelve al vault."
           }
         }
       }
     },
-    "Chat": {
+    "Anything you write or generate here stays on this device.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chat"
+            "value": "Lo que escribas o generes aquí se queda en este dispositivo."
+          }
+        }
+      }
+    },
+    "Appears in · %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aparece en · %lld"
+          }
+        }
+      }
+    },
+    "Applies": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica"
+          }
+        }
+      }
+    },
+    "Archive": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivo"
+          }
+        }
+      }
+    },
+    "Archive folders": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpetas de archivo"
+          }
+        }
+      }
+    },
+    "Argument map": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa de argumentos"
+          }
+        }
+      }
+    },
+    "Artificial intelligence": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inteligencia artificial"
+          }
+        }
+      }
+    },
+    "Ask %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pregunta a %@"
           }
         }
       }
@@ -2389,17 +701,6 @@
         }
       }
     },
-    "Every answer rests on real corpus rows. Citations are checked against the catalogue: if the model invents a source, it is removed.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cada respuesta se apoya en filas reales del corpus. Las citas se comprueban contra el catálogo: si el modelo se inventa una fuente, se elimina."
-          }
-        }
-      }
-    },
     "Ask a question": {
       "extractionState": "manual",
       "localizations": {
@@ -2411,68 +712,90 @@
         }
       }
     },
-    "The query failed": {
+    "Assembling": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "La consulta falló"
+            "value": "Ensamblando"
           }
         }
       }
     },
-    "Choose a chat model under Providers.": {
+    "Audience: \\($0)": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Elige un modelo de chat en Proveedores."
+            "value": "Público: \\($0)"
           }
         }
       }
     },
-    "Sources": {
+    "Authenticated through a desktop subscription session.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fuentes"
+            "value": "Se autentica con una sesión de suscripción del escritorio."
           }
         }
       }
     },
-    "Semantic retrieval": {
+    "Author": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recuperación semántica"
+            "value": "Autor"
           }
         }
       }
     },
-    "Lexical retrieval": {
+    "Author dossiers": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recuperación léxica"
+            "value": "Dosieres de autor"
           }
         }
       }
     },
-    "Retrieved material": {
+    "Authors": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Material recuperado"
+            "value": "Autores"
+          }
+        }
+      }
+    },
+    "Beats": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ritmos"
+          }
+        }
+      }
+    },
+    "Brief (5–8 pages)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breve (5–8 páginas)"
           }
         }
       }
@@ -2488,13 +811,1058 @@
         }
       }
     },
-    "The server hands over the material and the budget; you choose the model. Your key is kept in this device's keychain and never passes through the Nodus Server.": {
+    "Browse": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El servidor entrega el material y el presupuesto; el modelo lo eliges tú. Tu clave se guarda en el llavero de este dispositivo y nunca pasa por el Nodus Server."
+            "value": "Explorar"
+          }
+        }
+      }
+    },
+    "Built from the works actually cited.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Construidas a partir de las obras realmente citadas."
+          }
+        }
+      }
+    },
+    "Calendar": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendario"
+          }
+        }
+      }
+    },
+    "Can send changes": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puede enviar cambios"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        }
+      }
+    },
+    "Cancelled.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelado."
+          }
+        }
+      }
+    },
+    "Carry on": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
+          }
+        }
+      }
+    },
+    "Change batch": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lote de cambios"
+          }
+        }
+      }
+    },
+    "Chapters": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capítulos"
+          }
+        }
+      }
+    },
+    "Characters": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personajes"
+          }
+        }
+      }
+    },
+    "Chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat"
+          }
+        }
+      }
+    },
+    "Check yourself": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compruébate"
+          }
+        }
+      }
+    },
+    "Children": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descendencia"
+          }
+        }
+      }
+    },
+    "Choose a chat model under Providers.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un modelo de chat en Proveedores."
+          }
+        }
+      }
+    },
+    "Choose a space": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un espacio"
+          }
+        }
+      }
+    },
+    "Choose one under Providers before starting.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige uno en Proveedores antes de empezar."
+          }
+        }
+      }
+    },
+    "Claude. Its own protocol, no JSON mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude. Protocolo propio, sin modo JSON."
+          }
+        }
+      }
+    },
+    "Clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        }
+      }
+    },
+    "Code": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código"
+          }
+        }
+      }
+    },
+    "Collapse": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer"
+          }
+        }
+      }
+    },
+    "Collapse the branch": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer la rama"
+          }
+        }
+      }
+    },
+    "Collections": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colecciones"
+          }
+        }
+      }
+    },
+    "Columns": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columnas"
+          }
+        }
+      }
+    },
+    "Compares": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compara"
+          }
+        }
+      }
+    },
+    "Confirm it is you before locking Nodus.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirma que eres tú antes de bloquear Nodus."
+          }
+        }
+      }
+    },
+    "Connect to a Nodus Server": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar con un Nodus Server"
+          }
+        }
+      }
+    },
+    "Connect to the Nodus Server where your vault is published.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conéctate al Nodus Server donde tu vault está publicado."
+          }
+        }
+      }
+    },
+    "Content": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contenido"
+          }
+        }
+      }
+    },
+    "Continue": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
+          }
+        }
+      }
+    },
+    "Continuous academic prose arguing a thesis grounded in the corpus.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prosa académica continua que defiende una tesis apoyada en el corpus."
+          }
+        }
+      }
+    },
+    "Contradicts": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contradice"
+          }
+        }
+      }
+    },
+    "Could not be listed": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron listar"
+          }
+        }
+      }
+    },
+    "Could not build the tree": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo montar el árbol"
+          }
+        }
+      }
+    },
+    "Could not draw the map": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo dibujar el mapa"
+          }
+        }
+      }
+    },
+    "Could not expand": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo ampliar"
+          }
+        }
+      }
+    },
+    "Could not load": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron cargar"
+          }
+        }
+      }
+    },
+    "Could not load the ideas": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron cargar las ideas"
+          }
+        }
+      }
+    },
+    "Could not open": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo abrir"
+          }
+        }
+      }
+    },
+    "Could not open the session": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo abrir la sesión"
+          }
+        }
+      }
+    },
+    "Could not read the mirror": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer el espejo"
+          }
+        }
+      }
+    },
+    "Could not read the space": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer el espacio"
+          }
+        }
+      }
+    },
+    "Could not send": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo enviar"
+          }
+        }
+      }
+    },
+    "Could not unlock": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo desbloquear"
+          }
+        }
+      }
+    },
+    "Courses": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursos"
+          }
+        }
+      }
+    },
+    "Cultures": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Culturas"
+          }
+        }
+      }
+    },
+    "Database": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base de datos"
+          }
+        }
+      }
+    },
+    "Database rows": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filas de bases de datos"
+          }
+        }
+      }
+    },
+    "Databases": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bases de datos"
+          }
+        }
+      }
+    },
+    "Debates": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debates"
+          }
+        }
+      }
+    },
+    "Deep Research": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deep Research"
+          }
+        }
+      }
+    },
+    "Delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        }
+      }
+    },
+    "Delete the copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar la copia"
+          }
+        }
+      }
+    },
+    "Delete the key": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar la clave"
+          }
+        }
+      }
+    },
+    "Delete “%@”": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar «%@»"
+          }
+        }
+      }
+    },
+    "Depends on": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depende de"
+          }
+        }
+      }
+    },
+    "Dimensions": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimensiones"
+          }
+        }
+      }
+    },
+    "Discard": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
+          }
+        }
+      }
+    },
+    "Documents": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documentos"
+          }
+        }
+      }
+    },
+    "Done": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
+          }
+        }
+      }
+    },
+    "Download": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
+          }
+        }
+      }
+    },
+    "Download again": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a descargar"
+          }
+        }
+      }
+    },
+    "Download for offline use": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar para sin conexión"
+          }
+        }
+      }
+    },
+    "Downloaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargada"
+          }
+        }
+      }
+    },
+    "Downloading the publication…": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargando la publicación…"
+          }
+        }
+      }
+    },
+    "Drawn from the %lld closest ideas. This space has more; the map is a real part of the argument, not all of it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dibujado con las %lld ideas más cercanas. Este espacio tiene más: el mapa es una parte real del argumento, no todo él."
+          }
+        }
+      }
+    },
+    "Dynasties": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinastías"
+          }
+        }
+      }
+    },
+    "Each section is one model call. You can cancel at any point and keep what was written up to then.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada sección es una llamada al modelo. Puedes cancelarla en cualquier momento y conservas lo escrito hasta ahí."
+          }
+        }
+      }
+    },
+    "Each space needs its own credential: one works for exactly one space.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada espacio necesita su propio acceso: una credencial vale para uno solo."
+          }
+        }
+      }
+    },
+    "Each title must be specific and distinct from the others; no generic “Introduction” or “Conclusion”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada título debe ser específico y distinto de los demás; nada de «Introducción» ni «Conclusión» genéricas."
+          }
+        }
+      }
+    },
+    "Edit": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar"
+          }
+        }
+      }
+    },
+    "Edit note": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar nota"
+          }
+        }
+      }
+    },
+    "Email": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correo"
+          }
+        }
+      }
+    },
+    "Embeddings": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Embeddings"
+          }
+        }
+      }
+    },
+    "Empty database": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base vacía"
+          }
+        }
+      }
+    },
+    "Empty publication": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publicación vacía"
+          }
+        }
+      }
+    },
+    "Encyclopedia": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enciclopedia"
+          }
+        }
+      }
+    },
+    "Event": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evento"
+          }
+        }
+      }
+    },
+    "Events": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos"
+          }
+        }
+      }
+    },
+    "Every answer rests on real corpus rows. Citations are checked against the catalogue: if the model invents a source, it is removed.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada respuesta se apoya en filas reales del corpus. Las citas se comprueban contra el catálogo: si el modelo se inventa una fuente, se elimina."
+          }
+        }
+      }
+    },
+    "Evidence": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidencia"
+          }
+        }
+      }
+    },
+    "Exams": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exámenes"
+          }
+        }
+      }
+    },
+    "Exemplifies": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejemplifica"
+          }
+        }
+      }
+    },
+    "Exhaustive (15–20 pages)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exhaustiva (15–20 páginas)"
+          }
+        }
+      }
+    },
+    "Explain it out loud": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explícalo en voz alta"
+          }
+        }
+      }
+    },
+    "Extends": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extiende"
+          }
+        }
+      }
+    },
+    "Factions": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Facciones"
+          }
+        }
+      }
+    },
+    "Families": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Familias"
+          }
+        }
+      }
+    },
+    "Family tree": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Árbol genealógico"
+          }
+        }
+      }
+    },
+    "Filter ideas under this theme": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar ideas de este tema"
+          }
+        }
+      }
+    },
+    "Filter on any field": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar en cualquier campo"
+          }
+        }
+      }
+    },
+    "Filter questions": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar preguntas"
+          }
+        }
+      }
+    },
+    "Filter tables": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar tablas"
+          }
+        }
+      }
+    },
+    "Final exam": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Examen final"
+          }
+        }
+      }
+    },
+    "Find the idea to start from": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca la idea de la que partir"
+          }
+        }
+      }
+    },
+    "Finished": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminado"
+          }
+        }
+      }
+    },
+    "Flashcards": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichas"
           }
         }
       }
@@ -2510,35 +1878,79 @@
         }
       }
     },
-    "This vault was indexed with \\(identity.provider)/\\(identity.model). With that key, retrieval will be semantic; without it, lexical.": {
+    "Forget": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Este vault se indexó con \\(identity.provider)/\\(identity.model). Con esa clave, la recuperación será semántica; sin ella, léxica."
+            "value": "Olvidar"
           }
         }
       }
     },
-    "This vault was indexed with \\(identity.provider)/\\(identity.model), which runs on the computer where Nodus lives. From a phone, search will be lexical.": {
+    "Forget this space": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Este vault se indexó con \\(identity.provider)/\\(identity.model), que corre en el ordenador donde está Nodus. Desde el móvil la búsqueda será léxica."
+            "value": "Olvidar este espacio"
           }
         }
       }
     },
-    "Cancelled.": {
+    "Friday": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cancelado."
+            "value": "Viernes"
+          }
+        }
+      }
+    },
+    "Future work": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trabajo futuro"
+          }
+        }
+      }
+    },
+    "GPT and embeddings. The usual choice for indexing a vault.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPT y embeddings. El más habitual para indexar un vault."
+          }
+        }
+      }
+    },
+    "Gap": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hueco"
+          }
+        }
+      }
+    },
+    "Gaps": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huecos"
           }
         }
       }
@@ -2576,497 +1988,101 @@
         }
       }
     },
-    "One model call per section, with citations checked against the corpus. Your key never passes through the server.": {
+    "Generated here and kept on this device. They are not part of the vault until you send one.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Una llamada al modelo por sección, con las citas comprobadas contra el corpus. Tu clave no pasa por el servidor."
+            "value": "Generados aquí y guardados en este dispositivo. No forman parte del vault hasta que envíes uno."
           }
         }
       }
     },
-    "Published reports": {
+    "Generated on iPhone from the published snapshot of this space.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informes publicados"
+            "value": "Generado en el iPhone a partir de la publicación de este espacio."
           }
         }
       }
     },
-    "Reports from the vault": {
+    "Goals": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informes del vault"
+            "value": "Objetivos"
           }
         }
       }
     },
-    "This space has published no reports or immersion sessions yet. You can generate one above.": {
+    "Google. Also serves embeddings and images.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Este espacio todavía no ha publicado informes ni sesiones de inmersión. Puedes generar uno arriba."
+            "value": "Google. También sirve embeddings e imágenes."
           }
         }
       }
     },
-    "Objective": {
+    "HTTPS is assumed. The server refuses any public address that is not.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Objetivo"
+            "value": "Se asume HTTPS. El servidor rechaza cualquier dirección pública que no lo sea."
           }
         }
       }
     },
-    "Report objective": {
+    "Hide": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Objetivo del informe"
+            "value": "Ocultar"
           }
         }
       }
     },
-    "Unit topic": {
+    "Hide the answer": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tema de la unidad"
+            "value": "Ocultar la respuesta"
           }
         }
       }
     },
-    "What should it research in this corpus": {
+    "Hide the key": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Qué quieres que investigue en este corpus"
+            "value": "Ocultar la clave"
           }
         }
       }
     },
-    "What unit do you want to prepare from these materials": {
+    "Home": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Qué unidad quieres preparar con estos materiales"
-          }
-        }
-      }
-    },
-    "Mode": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modo"
-          }
-        }
-      }
-    },
-    "Length": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensión"
-          }
-        }
-      }
-    },
-    "Teaching unit": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unidad didáctica"
-          }
-        }
-      }
-    },
-    "Brief (5–8 pages)": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Breve (5–8 páginas)"
-          }
-        }
-      }
-    },
-    "Standard (9–14 pages)": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estándar (9–14 páginas)"
-          }
-        }
-      }
-    },
-    "Exhaustive (15–20 pages)": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exhaustiva (15–20 páginas)"
-          }
-        }
-      }
-    },
-    "Adapted to the corpus": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adaptada al corpus"
-          }
-        }
-      }
-    },
-    "Continuous academic prose arguing a thesis grounded in the corpus.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prosa académica continua que defiende una tesis apoyada en el corpus."
-          }
-        }
-      }
-    },
-    "Parts sequenced by concept dependency, written for whoever gives the class: what is taught, with which materials, common mistakes, and how to check understanding.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Partes secuenciadas por dependencia entre conceptos, escritas para quien da la clase: qué se enseña, con qué materiales, errores frecuentes y cómo comprobar la comprensión."
-          }
-        }
-      }
-    },
-    "Each section is one model call. You can cancel at any point and keep what was written up to then.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cada sección es una llamada al modelo. Puedes cancelarla en cualquier momento y conservas lo escrito hasta ahí."
-          }
-        }
-      }
-    },
-    "No model chosen": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin modelo elegido"
-          }
-        }
-      }
-    },
-    "Choose one under Providers before starting.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elige uno en Proveedores antes de empezar."
-          }
-        }
-      }
-    },
-    "The report failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El informe falló"
-          }
-        }
-      }
-    },
-    "The report is incomplete": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El informe quedó incompleto"
-          }
-        }
-      }
-    },
-    "Nothing citable was found for that objective in this space.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontró nada citable para ese objetivo en este espacio."
-          }
-        }
-      }
-    },
-    "Section \\(index + 1) of \\(total)": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sección \\(index + 1) de \\(total)"
-          }
-        }
-      }
-    },
-    "References": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Referencias"
-          }
-        }
-      }
-    },
-    "Built from the works actually cited.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Construidas a partir de las obras realmente citadas."
-          }
-        }
-      }
-    },
-    "Share as Markdown": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartir en Markdown"
-          }
-        }
-      }
-    },
-    "\\(report.citationsChecked) citations, all from the corpus": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\\(report.citationsChecked) citas, todas del corpus"
-          }
-        }
-      }
-    },
-    "Of \\(report.citationsChecked) checked. Sentences that rested only on them are left unsupported.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De \\(report.citationsChecked) comprobadas. Las frases que solo se apoyaban en ellas quedaron sin respaldo."
-          }
-        }
-      }
-    },
-    "Preparing the corpus": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparando el corpus"
-          }
-        }
-      }
-    },
-    "Planning": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Planificando"
-          }
-        }
-      }
-    },
-    "Writing": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escritura"
-          }
-        }
-      }
-    },
-    "Retrieving": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuperando"
-          }
-        }
-      }
-    },
-    "Verifying citations": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verificando citas"
-          }
-        }
-      }
-    },
-    "Assembling": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ensamblando"
-          }
-        }
-      }
-    },
-    "Importing": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importando"
-          }
-        }
-      }
-    },
-    "Sending": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviando"
-          }
-        }
-      }
-    },
-    "Finished": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminado"
-          }
-        }
-      }
-    },
-    "Queued": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "En cola"
-          }
-        }
-      }
-    },
-    "Retrieving for “\\(title)”": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuperando para «\\(title)»"
-          }
-        }
-      }
-    },
-    "Writing “\\(title)”": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribiendo «\\(title)»"
-          }
-        }
-      }
-    },
-    "the plan came back empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "el plan vino vacío"
-          }
-        }
-      }
-    },
-    "Section “\\(title)” failed: \\(error.localizedDescription)": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La sección «\\(title)» falló: \\(error.localizedDescription)"
-          }
-        }
-      }
-    },
-    "Your access to this space does not allow sending changes. Anything you write stays on this device.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu acceso a este espacio no permite enviar cambios. Lo que escribas se queda en este dispositivo."
+            "value": "Inicio"
           }
         }
       }
@@ -3082,376 +2098,387 @@
         }
       }
     },
-    "The server keeps your changes in a ledger. They join the vault when its owner opens Nodus desktop and republishes. Until then nobody sees them, you included.": {
+    "How to sign in": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El servidor guarda tus cambios en un libro mayor. Se incorporan al vault cuando quien lo posee abre Nodus de escritorio y vuelve a publicar. Hasta entonces no los ve nadie, tú incluido."
+            "value": "Cómo iniciar sesión"
           }
         }
       }
     },
-    "Nothing queued": {
+    "Idea": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nada en la cola"
+            "value": "Idea"
           }
         }
       }
     },
-    "Notes you write appear here before they travel.": {
+    "Ideas": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Las notas que escribas aparecerán aquí antes de viajar."
+            "value": "Ideas"
           }
         }
       }
     },
-    "Queue": {
+    "Images": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cola"
+            "value": "Imágenes"
           }
         }
       }
     },
-    "Not sent": {
+    "Immersion": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin enviar"
+            "value": "Inmersión"
           }
         }
       }
     },
-    "On the server": {
+    "Importing": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "En el servidor"
+            "value": "Importando"
           }
         }
       }
     },
-    "Saved on this device.": {
+    "Indexed with %@ · %lld dimensions": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Guardado en este dispositivo."
+            "value": "Indexado con %@ · %lld dimensiones"
           }
         }
       }
     },
-    "Waiting for the owner to republish.": {
+    "Indexed with %@, which a phone cannot reach. Search will be lexical.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pendiente de que el propietario vuelva a publicar."
+            "value": "Indexado con %@, que no es alcanzable desde el móvil. La búsqueda será léxica."
           }
         }
       }
     },
-    "The server rejected it.": {
+    "Indexed with %@. Add that key under Providers to search by meaning.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El servidor lo rechazó."
+            "value": "Indexado con %@. Añade esa clave en Proveedores para buscar por significado."
           }
         }
       }
     },
-    "Could not send": {
+    "Indexed with \\(identity.model) · \\(identity.dim) dimensions": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo enviar"
+            "value": "Indexado con \\(identity.model) · \\(identity.dim) dimensiones"
           }
         }
       }
     },
-    "Your access to this space is read only.": {
+    "Indexed with \\(identity.provider), which a phone cannot reach. Search will be lexical.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tu acceso a este espacio es de solo lectura."
+            "value": "Indexado con \\(identity.provider), que no es alcanzable desde el móvil. La búsqueda será léxica."
           }
         }
       }
     },
-    "New note": {
+    "Indexed with “%@”, which this version does not know.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nueva nota"
+            "value": "Indexado con «%@», que esta versión no conoce."
           }
         }
       }
     },
-    "Note title": {
+    "Indexed with “\\(identity.provider)”, which this version does not know.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Título de la nota"
+            "value": "Indexado con «\\(identity.provider)», que esta versión no conoce."
           }
         }
       }
     },
-    "Content": {
+    "Indexing…": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contenido"
+            "value": "Indexando…"
           }
         }
       }
     },
-    "The offline copy is needed": {
+    "Inexpensive, with switchable reasoning.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hace falta la copia sin conexión"
+            "value": "Económico, con razonamiento conmutable."
           }
         }
       }
     },
-    "The link between themes and ideas travels in the publication but the API does not expose it. Download it and this list works instantly.": {
+    "It holds %@ rows from an earlier publication.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El vínculo entre temas e ideas viaja en la publicación, pero la API no lo expone. Descárgala y esta lista funcionará al instante."
+            "value": "Guarda %@ filas de una publicación anterior."
           }
         }
       }
     },
-    "Download": {
+    "It holds \\(rows.formatted()) rows from an earlier publication.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descargar"
+            "value": "Guarda \\(rows.formatted()) filas de una publicación anterior."
           }
         }
       }
     },
-    "Filter ideas under this theme": {
+    "It is queued on this device and travels when you send the queue. It joins the vault when its owner next opens Nodus desktop and republishes.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Filtrar ideas de este tema"
+            "value": "Queda en la cola de este dispositivo y viaja cuando envías la cola. Se incorpora al vault cuando quien lo posee abre Nodus de escritorio y vuelve a publicar."
           }
         }
       }
     },
-    "No ideas": {
+    "It will appear as soon as its owner publishes from Nodus desktop.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin ideas"
+            "value": "Aparecerá en cuanto quien lo posee publique desde Nodus de escritorio."
           }
         }
       }
     },
-    "No idea in this publication is linked to “\\(label)”.": {
+    "It will be stored in the keychain, available only while the device is unlocked and never leaving it.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ninguna idea de esta publicación está vinculada a «\\(label)»."
+            "value": "Se guardará en el llavero, disponible solo con el dispositivo desbloqueado y sin salir de él."
           }
         }
       }
     },
-    "Could not read the mirror": {
+    "Item": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo leer el espejo"
+            "value": "Elemento"
           }
         }
       }
     },
-    "Publication": {
+    "Keeps the whole publication on the device: works with no network, sorts instantly, and reaches the tables the API does not expose.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Publicación"
+            "value": "Guarda la publicación completa en el dispositivo: funciona sin red, ordena al instante y alcanza las tablas que la API no expone."
           }
         }
       }
     },
-    "Title A–Z": {
+    "Key": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Título A–Z"
+            "value": "Clave"
           }
         }
       }
     },
-    "Title Z–A": {
+    "Key terms": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Título Z–A"
+            "value": "Términos clave"
           }
         }
       }
     },
-    "Newest": {
+    "Kinship": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Más reciente"
+            "value": "Parentesco"
           }
         }
       }
     },
-    "Oldest": {
+    "Largest image": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Más antiguo"
+            "value": "Imagen máxima"
           }
         }
       }
     },
-    "Sort": {
+    "Length": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Orden"
+            "value": "Extensión"
           }
         }
       }
     },
-    "Family tree": {
+    "Lexical results": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Árbol genealógico"
+            "value": "Resultados léxicos"
           }
         }
       }
     },
-    "See the tree": {
+    "Lexical retrieval": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver el árbol"
+            "value": "Recuperación léxica"
           }
         }
       }
     },
-    "No relationships": {
+    "Library": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin parentescos"
+            "value": "Biblioteca"
           }
         }
       }
     },
-    "This person has no family relationships recorded in the publication.": {
+    "Limitation": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Esta persona no tiene relaciones familiares registradas en la publicación."
+            "value": "Limitación"
           }
         }
       }
     },
-    "This person has no relationships recorded in the publication.": {
+    "Loading…": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Esta persona no tiene parentescos registrados en la publicación."
+            "value": "Cargando…"
           }
         }
       }
     },
-    "The tree needs every relationship at once. The API serves them one at a time, so it is built from the downloaded publication.": {
+    "Logos": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El árbol necesita todas las relaciones a la vez. La API las entrega de una en una, así que se arma desde la publicación descargada."
+            "value": "Logotipos"
           }
         }
       }
     },
-    "Paternal": {
+    "Looking for the server…": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Paterna"
+            "value": "Buscando el servidor…"
+          }
+        }
+      }
+    },
+    "Materials": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Materiales"
           }
         }
       }
@@ -3467,68 +2494,2345 @@
         }
       }
     },
-    "Tree": {
+    "Mode": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Árbol"
+            "value": "Modo"
           }
         }
       }
     },
-    "The secret could not be encoded.": {
+    "Model": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo codificar el secreto."
+            "value": "Modelo"
           }
         }
       }
     },
-    "The keychain refused because this build is not signed (−34018).": {
+    "Models": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El llavero rechazó la operación porque esta compilación no está firmada (−34018)."
+            "value": "Modelos"
           }
         }
       }
     },
-    "The keychain is unavailable while the device is locked.": {
+    "Models Nodus runs inside its own process.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El llavero no está disponible mientras el dispositivo está bloqueado."
+            "value": "Modelos que Nodus ejecuta dentro de su propio proceso."
           }
         }
       }
     },
-    "The keychain failed: \\(message) (\\(status)).": {
+    "Models by task": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El llavero falló: \\(message) (\\(status))."
+            "value": "Modelos por tarea"
           }
         }
       }
     },
-    "no description": {
+    "Monday": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "sin descripción"
+            "value": "Lunes"
+          }
+        }
+      }
+    },
+    "More from this space": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más del espacio"
+          }
+        }
+      }
+    },
+    "Name": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre"
+          }
+        }
+      }
+    },
+    "Names": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombres"
+          }
+        }
+      }
+    },
+    "Needed for semantic search": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Necesario para la búsqueda semántica"
+          }
+        }
+      }
+    },
+    "New": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo"
+          }
+        }
+      }
+    },
+    "New note": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva nota"
+          }
+        }
+      }
+    },
+    "Newest": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más reciente"
+          }
+        }
+      }
+    },
+    "Next": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siguiente"
+          }
+        }
+      }
+    },
+    "No answer": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin respuesta"
+          }
+        }
+      }
+    },
+    "No flashcards": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin fichas"
+          }
+        }
+      }
+    },
+    "No idea in this publication is linked to “%@”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna idea de esta publicación está vinculada a «%@»."
+          }
+        }
+      }
+    },
+    "No idea in this publication is linked to “\\(label)”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna idea de esta publicación está vinculada a «\\(label)»."
+          }
+        }
+      }
+    },
+    "No ideas": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin ideas"
+          }
+        }
+      }
+    },
+    "No keys configured": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin claves configuradas"
+          }
+        }
+      }
+    },
+    "No machine by that name. If the server is on a private network — Tailscale, a VPN, your own Wi-Fi — this device has to be on it too.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ninguna máquina con ese nombre. Si el servidor está en una red privada —Tailscale, una VPN, tu propio wifi—, este dispositivo también tiene que estar en ella."
+          }
+        }
+      }
+    },
+    "No matches": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin coincidencias"
+          }
+        }
+      }
+    },
+    "No model chosen": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin modelo elegido"
+          }
+        }
+      }
+    },
+    "No model contains “%@”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ningún modelo contiene «%@»."
+          }
+        }
+      }
+    },
+    "No model contains “\\(query)”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ningún modelo contiene «\\(query)»."
+          }
+        }
+      }
+    },
+    "No people": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin personas"
+          }
+        }
+      }
+    },
+    "No published vectors": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin vectores publicados"
+          }
+        }
+      }
+    },
+    "No published vectors. Search will be lexical.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin vectores publicados. La búsqueda será léxica."
+          }
+        }
+      }
+    },
+    "No questions": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin preguntas"
+          }
+        }
+      }
+    },
+    "No relationships": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin parentescos"
+          }
+        }
+      }
+    },
+    "No report contains “%@”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ningún informe contiene «%@»."
+          }
+        }
+      }
+    },
+    "No reports": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin informes"
+          }
+        }
+      }
+    },
+    "No results": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin resultados"
+          }
+        }
+      }
+    },
+    "No row contains the string “%@”. This search is literal, not semantic: a synonym will not satisfy it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna fila contiene la cadena «%@». Esta búsqueda es literal, no semántica: un sinónimo no la satisface."
+          }
+        }
+      }
+    },
+    "No row contains the string “\\(query)”. This search is literal, not semantic: a synonym will not satisfy it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna fila contiene la cadena «\\(query)». Esta búsqueda es literal, no semántica: un sinónimo no la satisface."
+          }
+        }
+      }
+    },
+    "No row contains “%@”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna fila contiene «%@»."
+          }
+        }
+      }
+    },
+    "No row contains “\\(query)”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna fila contiene «\\(query)»."
+          }
+        }
+      }
+    },
+    "No spaces": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin espacios"
+          }
+        }
+      }
+    },
+    "No spaces yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ningún espacio todavía"
+          }
+        }
+      }
+    },
+    "No timetable": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin horario"
+          }
+        }
+      }
+    },
+    "Nodus": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nodus"
+          }
+        }
+      }
+    },
+    "Nodus asks again every time it comes back to the screen. Your keys and any offline copy are already unreadable while the phone is locked; this covers a phone that is unlocked and not in your hands.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nodus vuelve a preguntar cada vez que regresa a la pantalla. Tus claves y cualquier copia sin conexión ya son ilegibles con el teléfono bloqueado; esto cubre un teléfono desbloqueado que no está en tus manos."
+          }
+        }
+      }
+    },
+    "Nodus desktop keeps the review schedule; here you can review, not reschedule.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El calendario de repaso lo lleva Nodus de escritorio; aquí puedes repasar, no reprogramar."
+          }
+        }
+      }
+    },
+    "Nodus is locked": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nodus está bloqueado"
+          }
+        }
+      }
+    },
+    "None configured": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna configurada"
+          }
+        }
+      }
+    },
+    "Not available on iOS": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disponibles en iOS"
+          }
+        }
+      }
+    },
+    "Not chosen": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin elegir"
+          }
+        }
+      }
+    },
+    "Not encrypted": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin cifrar"
+          }
+        }
+      }
+    },
+    "Not published": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin publicar"
+          }
+        }
+      }
+    },
+    "Not recognised.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se ha reconocido."
+          }
+        }
+      }
+    },
+    "Not sent": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin enviar"
+          }
+        }
+      }
+    },
+    "Note": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota"
+          }
+        }
+      }
+    },
+    "Note title": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Título de la nota"
+          }
+        }
+      }
+    },
+    "Notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notas"
+          }
+        }
+      }
+    },
+    "Notes and queue": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notas y cola"
+          }
+        }
+      }
+    },
+    "Notes you write appear here before they travel.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las notas que escribas aparecerán aquí antes de viajar."
+          }
+        }
+      }
+    },
+    "Nothing citable was found for that objective in this space.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró nada citable para ese objetivo en este espacio."
+          }
+        }
+      }
+    },
+    "Nothing here": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nada aquí"
+          }
+        }
+      }
+    },
+    "Nothing in this corpus is close to “%@”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nada en este corpus se acerca a «%@»."
+          }
+        }
+      }
+    },
+    "Nothing matched “\\(query)”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna coincidencia para «\\(query)»."
+          }
+        }
+      }
+    },
+    "Nothing published, and nothing generated here yet.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nada publicado y nada generado aquí todavía."
+          }
+        }
+      }
+    },
+    "Nothing queued": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nada en la cola"
+          }
+        }
+      }
+    },
+    "OK": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Objective": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Objetivo"
+          }
+        }
+      }
+    },
+    "Occurrences": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariciones"
+          }
+        }
+      }
+    },
+    "Of %lld checked.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De %lld comprobadas."
+          }
+        }
+      }
+    },
+    "Of %lld checked. Sentences that rested only on them are left unsupported.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De %lld comprobadas. Las frases que solo se apoyaban en ellas quedan sin respaldo."
+          }
+        }
+      }
+    },
+    "Of \\(report.citationsChecked) checked. Sentences that rested only on them are left unsupported.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De \\(report.citationsChecked) comprobadas. Las frases que solo se apoyaban en ellas quedaron sin respaldo."
+          }
+        }
+      }
+    },
+    "Offline": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin conexión"
+          }
+        }
+      }
+    },
+    "Offline only": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo sin conexión"
+          }
+        }
+      }
+    },
+    "Oldest": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más antiguo"
+          }
+        }
+      }
+    },
+    "On the server": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En el servidor"
+          }
+        }
+      }
+    },
+    "On this device": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En este dispositivo"
+          }
+        }
+      }
+    },
+    "One model call per section, with citations checked against the corpus. Your key never passes through the server.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una llamada al modelo por sección, con las citas comprobadas contra el corpus. Tu clave no pasa por el servidor."
+          }
+        }
+      }
+    },
+    "Online": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En línea"
+          }
+        }
+      }
+    },
+    "Open frontiers": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fronteras abiertas"
+          }
+        }
+      }
+    },
+    "Open question": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pregunta abierta"
+          }
+        }
+      }
+    },
+    "Open questions": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preguntas abiertas"
+          }
+        }
+      }
+    },
+    "Open the full record": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver la ficha completa"
+          }
+        }
+      }
+    },
+    "Overview": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panorama"
+          }
+        }
+      }
+    },
+    "Owner": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Propietario"
+          }
+        }
+      }
+    },
+    "Pair": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emparejar"
+          }
+        }
+      }
+    },
+    "Parents": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padres y madres"
+          }
+        }
+      }
+    },
+    "Partner": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pareja"
+          }
+        }
+      }
+    },
+    "Parts sequenced by concept dependency, written for whoever gives the class: what is taught, with which materials, common mistakes, and how to check understanding.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partes secuenciadas por dependencia entre conceptos, escritas para quien da la clase: qué se enseña, con qué materiales, errores frecuentes y cómo comprobar la comprensión."
+          }
+        }
+      }
+    },
+    "Passage": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasaje"
+          }
+        }
+      }
+    },
+    "Passages": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasajes"
+          }
+        }
+      }
+    },
+    "Passages that support it · %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasajes que la apoyan · %lld"
+          }
+        }
+      }
+    },
+    "Passages that support it · \\(detail.evidence.count)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasajes que la sostienen · \\(detail.evidence.count)"
+          }
+        }
+      }
+    },
+    "Password": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraseña"
+          }
+        }
+      }
+    },
+    "Paternal": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paterna"
+          }
+        }
+      }
+    },
+    "People": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personas"
+          }
+        }
+      }
+    },
+    "Person": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persona"
+          }
+        }
+      }
+    },
+    "Pin": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destacar"
+          }
+        }
+      }
+    },
+    "Pinned": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destacados"
+          }
+        }
+      }
+    },
+    "Place": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lugar"
+          }
+        }
+      }
+    },
+    "Place profiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perfiles de lugar"
+          }
+        }
+      }
+    },
+    "Places": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lugares"
+          }
+        }
+      }
+    },
+    "Planning": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Planificando"
+          }
+        }
+      }
+    },
+    "Positions in contrast": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posiciones enfrentadas"
+          }
+        }
+      }
+    },
+    "Preparing the corpus": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando el corpus"
+          }
+        }
+      }
+    },
+    "Previous": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anterior"
+          }
+        }
+      }
+    },
+    "Principal": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Principal"
+          }
+        }
+      }
+    },
+    "Projects": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proyectos"
+          }
+        }
+      }
+    },
+    "Provider": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proveedor"
+          }
+        }
+      }
+    },
+    "Providers": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proveedores"
+          }
+        }
+      }
+    },
+    "Publication": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publicación"
+          }
+        }
+      }
+    },
+    "Published in the vault": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publicados en el vault"
+          }
+        }
+      }
+    },
+    "Published reports": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informes publicados"
+          }
+        }
+      }
+    },
+    "Published tables": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tablas publicadas"
+          }
+        }
+      }
+    },
+    "Querying": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultando"
+          }
+        }
+      }
+    },
+    "Querying %@…": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consultando %@…"
+          }
+        }
+      }
+    },
+    "Question bank": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Banco de preguntas"
+          }
+        }
+      }
+    },
+    "Queue": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cola"
+          }
+        }
+      }
+    },
+    "Queued": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En cola"
+          }
+        }
+      }
+    },
+    "Queued on this device": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En la cola de este dispositivo"
+          }
+        }
+      }
+    },
+    "Queued. Open Notes and queue to send it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En la cola. Abre Notas y cola para enviarlo."
+          }
+        }
+      }
+    },
+    "Ranked by meaning": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenado por significado"
+          }
+        }
+      }
+    },
+    "Read only": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lectura"
+          }
+        }
+      }
+    },
+    "Read only: the server accepts no cell changes, so they are edited from Nodus desktop.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo read: el servidor no acepta cambios en celdas, así que se editan desde Nodus de escritorio."
+          }
+        }
+      }
+    },
+    "Read-only access": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso de lectura"
+          }
+        }
+      }
+    },
+    "Ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista"
+          }
+        }
+      }
+    },
+    "Recordings": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabaciones"
+          }
+        }
+      }
+    },
+    "References": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Referencias"
+          }
+        }
+      }
+    },
+    "Refines": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matiza"
+          }
+        }
+      }
+    },
+    "Refutes": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refuta"
+          }
+        }
+      }
+    },
+    "Rejected": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechazado"
+          }
+        }
+      }
+    },
+    "Relationship": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relación"
+          }
+        }
+      }
+    },
+    "Relationships": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaciones"
+          }
+        }
+      }
+    },
+    "Relationships · %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaciones · %lld"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar"
+          }
+        }
+      }
+    },
+    "Report": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informe"
+          }
+        }
+      }
+    },
+    "Report objective": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Objetivo del informe"
+          }
+        }
+      }
+    },
+    "Reports": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informes"
+          }
+        }
+      }
+    },
+    "Reports from the vault": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informes del vault"
+          }
+        }
+      }
+    },
+    "Require Face ID": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigir Face ID"
+          }
+        }
+      }
+    },
+    "Require Optic ID": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigir Optic ID"
+          }
+        }
+      }
+    },
+    "Require Touch ID": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigir Touch ID"
+          }
+        }
+      }
+    },
+    "Require the device passcode": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigir el código del dispositivo"
+          }
+        }
+      }
+    },
+    "Research": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Investigación"
+          }
+        }
+      }
+    },
+    "Research questions": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preguntas de investigación"
+          }
+        }
+      }
+    },
+    "Responds to": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responde a"
+          }
+        }
+      }
+    },
+    "Retrieved material": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Material recuperado"
+          }
+        }
+      }
+    },
+    "Retrieving": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperando"
+          }
+        }
+      }
+    },
+    "Retrieving for “\\(title)”": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperando para «\\(title)»"
+          }
+        }
+      }
+    },
+    "Revision": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisión"
+          }
+        }
+      }
+    },
+    "Rows": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filas"
+          }
+        }
+      }
+    },
+    "Rubrics": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rúbricas"
+          }
+        }
+      }
+    },
+    "Saturday": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sábado"
+          }
+        }
+      }
+    },
+    "Save": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        }
+      }
+    },
+    "Saved on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado en este dispositivo."
+          }
+        }
+      }
+    },
+    "Saved searches": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Búsquedas guardadas"
+          }
+        }
+      }
+    },
+    "Scenes": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escenas"
+          }
+        }
+      }
+    },
+    "Schema": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquema"
+          }
+        }
+      }
+    },
+    "Search": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        }
+      }
+    },
+    "Search %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca en %@"
+          }
+        }
+      }
+    },
+    "Search (lexical)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar (léxico)"
+          }
+        }
+      }
+    },
+    "Search \\(session.connection.spaceName)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca en \\(session.connection.spaceName)"
+          }
+        }
+      }
+    },
+    "Search failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La búsqueda falló"
+          }
+        }
+      }
+    },
+    "Search model or provider": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar modelo o proveedor"
+          }
+        }
+      }
+    },
+    "Search reports": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar informes"
+          }
+        }
+      }
+    },
+    "Search the corpus": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar en el corpus"
+          }
+        }
+      }
+    },
+    "Search will be lexical until the space's owner publishes the embeddings.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La búsqueda será léxica hasta que quien posee el espacio publique los embeddings."
+          }
+        }
+      }
+    },
+    "Secondary": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secundaria"
+          }
+        }
+      }
+    },
+    "Secrets": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secretos"
+          }
+        }
+      }
+    },
+    "Section %lld of %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sección %lld de %lld"
+          }
+        }
+      }
+    },
+    "Section \\(index + 1) of \\(total)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sección \\(index + 1) de \\(total)"
+          }
+        }
+      }
+    },
+    "Section “\\(title)” failed: \\(error.localizedDescription)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sección «\\(title)» falló: \\(error.localizedDescription)"
+          }
+        }
+      }
+    },
+    "See the ideas under this theme": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver las ideas de este tema"
+          }
+        }
+      }
+    },
+    "See the tree": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver el árbol"
+          }
+        }
+      }
+    },
+    "See the tree from here": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver el árbol desde aquí"
+          }
+        }
+      }
+    },
+    "Semantic retrieval": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperación semántica"
+          }
+        }
+      }
+    },
+    "Semantic search is not available here": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La búsqueda semántica no está disponible aquí"
+          }
+        }
+      }
+    },
+    "Send %lld change%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar %lld cambio%@"
+          }
+        }
+      }
+    },
+    "Send it from Notes and queue. It joins the vault when its owner next opens Nodus desktop and republishes — until then this list still shows what was published.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envíalo desde Notas y cola. Se incorpora al vault cuando quien lo posee abre Nodus de escritorio y vuelve a publicar; hasta entonces esta lista sigue mostrando lo que se publicó."
+          }
+        }
+      }
+    },
+    "Send to the vault": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar al vault"
+          }
+        }
+      }
+    },
+    "Sending": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando"
+          }
+        }
+      }
+    },
+    "Sending…": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando…"
+          }
+        }
+      }
+    },
+    "Sent — waiting for the owner": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviado: esperando a quien lo posee"
+          }
+        }
+      }
+    },
+    "Sequence the parts by dependency between concepts: what must be understood first comes first. Each part must be teachable in class.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secuencia las partes según las dependencias entre conceptos: lo que hay que entender antes va antes. Cada parte debe poder darse en clase."
+          }
+        }
+      }
+    },
+    "Server": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servidor"
+          }
+        }
+      }
+    },
+    "Server address": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección del servidor"
+          }
+        }
+      }
+    },
+    "Session": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesión"
+          }
+        }
+      }
+    },
+    "Sessions": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesiones"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
+          }
+        }
+      }
+    },
+    "Share as Markdown": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir en Markdown"
+          }
+        }
+      }
+    },
+    "Show answer": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver respuesta"
+          }
+        }
+      }
+    },
+    "Show the answer": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar la respuesta"
+          }
+        }
+      }
+    },
+    "Show the key": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar la clave"
+          }
+        }
+      }
+    },
+    "Siblings": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hermanos y hermanas"
+          }
+        }
+      }
+    },
+    "Sign in": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrar"
+          }
+        }
+      }
+    },
+    "Sort": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orden"
+          }
+        }
+      }
+    },
+    "Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuentes"
+          }
+        }
+      }
+    },
+    "Space": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espacio"
+          }
+        }
+      }
+    },
+    "Standard (9–14 pages)": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estándar (9–14 páginas)"
+          }
+        }
+      }
+    },
+    "Station %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estación %lld"
+          }
+        }
+      }
+    },
+    "Stations": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estaciones"
+          }
+        }
+      }
+    },
+    "Status": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado"
+          }
+        }
+      }
+    },
+    "Story arcs": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arcos narrativos"
+          }
+        }
+      }
+    },
+    "Study": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estudiar"
+          }
+        }
+      }
+    },
+    "Study plans": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Planes de estudio"
+          }
+        }
+      }
+    },
+    "Study topics": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temas de estudio"
+          }
+        }
+      }
+    },
+    "Subjects": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asignaturas"
+          }
+        }
+      }
+    },
+    "Suggested kinships": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parentescos sugeridos"
+          }
+        }
+      }
+    },
+    "Sunday": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domingo"
+          }
+        }
+      }
+    },
+    "Supports": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apoya"
+          }
+        }
+      }
+    },
+    "Switch space": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de espacio"
+          }
+        }
+      }
+    },
+    "Synthesis": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Síntesis"
+          }
+        }
+      }
+    },
+    "Tables": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tablas"
+          }
+        }
+      }
+    },
+    "Teaching": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Docencia"
+          }
+        }
+      }
+    },
+    "Teaching unit": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unidad didáctica"
+          }
+        }
+      }
+    },
+    "That address will not work. Enter just the domain, with no path.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esa dirección no sirve. Escribe solo el dominio, sin rutas."
+          }
+        }
+      }
+    },
+    "That email or password is not right.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ese correo o esa contraseña no son correctos."
           }
         }
       }
@@ -3544,24 +4848,24 @@
         }
       }
     },
-    "The server rejected the row on a database constraint.": {
+    "The \\(provider.label) key is missing, and that is the provider this vault was indexed with.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El servidor rechazó la fila por una restricción de la base de datos."
+            "value": "Falta la clave de \\(provider.label), que es el proveedor con el que se indexó este vault."
           }
         }
       }
     },
-    "An image the row refers to has not been uploaded.": {
+    "The certificate was refused. A Nodus Server needs one this device already trusts.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Falta subir una imagen a la que la fila hace referencia."
+            "value": "Se rechazó el certificado. Un Nodus Server necesita uno en el que este dispositivo ya confíe."
           }
         }
       }
@@ -3588,90 +4892,24 @@
         }
       }
     },
-    "A delete cannot carry content.": {
+    "The copy is out of date": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un borrado no puede llevar contenido."
+            "value": "La copia está desfasada"
           }
         }
       }
     },
-    "An insert needs content.": {
+    "The credential is deleted from this device. Nothing changes on the server.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un alta necesita contenido."
-          }
-        }
-      }
-    },
-    "A column carried a value that is not a scalar.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Una columna llevaba un valor que no es un dato simple."
-          }
-        }
-      }
-    },
-    "The server rejected it: \\(reason).": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El servidor lo rechazó: \\(reason)."
-          }
-        }
-      }
-    },
-    "This space's publication has no column “\\(column)”. Its schema is older than this app.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La publicación de este espacio no tiene la columna «\\(column)». Su esquema es más antiguo que esta app."
-          }
-        }
-      }
-    },
-    "This vault was indexed with \\(name), which runs on the computer where Nodus desktop lives. iOS cannot produce a matching vector.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este vault se indexó con \\(name), que corre en el ordenador donde está Nodus de escritorio. Desde iOS no se puede generar un vector que case."
-          }
-        }
-      }
-    },
-    "This vault was indexed with “\\(name)”, a provider this version does not know.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este vault se indexó con «\\(name)», un proveedor que esta versión no conoce."
-          }
-        }
-      }
-    },
-    "The \\(provider.label) key is missing, and that is the provider this vault was indexed with.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta la clave de \\(provider.label), que es el proveedor con el que se indexó este vault."
+            "value": "Se borra la credencial de este dispositivo. Nada cambia en el servidor."
           }
         }
       }
@@ -3687,13 +4925,57 @@
         }
       }
     },
-    "Unexpected answer from the embedding provider (\\(detail)).": {
+    "The keychain failed: \\(message) (\\(status)).": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Respuesta inesperada del proveedor de embeddings (\\(detail))."
+            "value": "El llavero falló: \\(message) (\\(status))."
+          }
+        }
+      }
+    },
+    "The keychain is unavailable while the device is locked.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El llavero no está disponible mientras el dispositivo está bloqueado."
+          }
+        }
+      }
+    },
+    "The keychain refused because this build is not signed (−34018).": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El llavero rechazó la operación porque esta compilación no está firmada (−34018)."
+          }
+        }
+      }
+    },
+    "The link between themes and ideas travels in the publication but the API does not expose it. Download it and this list works instantly.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El vínculo entre temas e ideas viaja en la publicación, pero la API no lo expone. Descárgala y esta lista funcionará al instante."
+          }
+        }
+      }
+    },
+    "The map grows from one idea, following the relations the analysis found: what supports it, what refines it, and what argues against it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El mapa crece desde una idea siguiendo las relaciones que encontró el análisis: qué la apoya, qué la refina y qué la contradice."
           }
         }
       }
@@ -3709,6 +4991,28 @@
         }
       }
     },
+    "The name resolves, but nothing answered. The server may be stopped, or reachable only from the machine it runs on.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El nombre resuelve, pero no contestó nadie. Puede que el servidor esté parado o que solo se le llegue desde la máquina en la que corre."
+          }
+        }
+      }
+    },
+    "The offline copy is needed": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hace falta la copia sin conexión"
+          }
+        }
+      }
+    },
     "The provider returned an empty vector.": {
       "extractionState": "manual",
       "localizations": {
@@ -3720,585 +5024,123 @@
         }
       }
     },
-    "Claude. Its own protocol, no JSON mode.": {
+    "The query failed": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Claude. Protocolo propio, sin modo JSON."
+            "value": "La consulta falló"
           }
         }
       }
     },
-    "GPT and embeddings. The usual choice for indexing a vault.": {
+    "The report failed": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "GPT y embeddings. El más habitual para indexar un vault."
+            "value": "El informe falló"
           }
         }
       }
     },
-    "A gateway to many models, with its own embeddings.": {
+    "The report is incomplete": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pasarela a muchos modelos, con embeddings propios."
+            "value": "El informe quedó incompleto"
           }
         }
       }
     },
-    "Very fast. Its free tier counts prompt and answer against one budget.": {
+    "The secret could not be encoded.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Muy rápido. Su nivel gratuito cuenta prompt y respuesta juntos."
+            "value": "No se pudo codificar el secreto."
           }
         }
       }
     },
-    "Very fast, short catalogue.": {
+    "The server hands over the material and the budget; you choose the model. Your key is kept in this device's keychain and never passes through the Nodus Server.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Muy rápido, catálogo corto."
+            "value": "El servidor entrega el material y el presupuesto; el modelo lo eliges tú. Tu clave se guarda en el llavero de este dispositivo y nunca pasa por el Nodus Server."
           }
         }
       }
     },
-    "Inexpensive, with switchable reasoning.": {
+    "The server keeps your changes in a ledger. They join the vault when its owner opens Nodus desktop and republishes. Until then nobody sees them, you included.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Económico, con razonamiento conmutable."
+            "value": "El servidor guarda tus cambios en un libro mayor. Se incorporan al vault cuando quien lo posee abre Nodus de escritorio y vuelve a publicar. Hasta entonces no los ve nadie, tú incluido."
           }
         }
       }
     },
-    "Google. Also serves embeddings and images.": {
+    "The server rejected it.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Google. También sirve embeddings e imágenes."
+            "value": "El servidor lo rechazó."
           }
         }
       }
     },
-    "Future work": {
+    "The server rejected it: \\(reason).": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trabajo futuro"
+            "value": "El servidor lo rechazó: \\(reason)."
           }
         }
       }
     },
-    "Limitation": {
+    "The server rejected the row on a database constraint.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Limitación"
+            "value": "El servidor rechazó la fila por una restricción de la base de datos."
           }
         }
       }
     },
-    "Open question": {
+    "The server took too long to answer.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pregunta abierta"
+            "value": "El servidor tardó demasiado en contestar."
           }
         }
       }
     },
-    "Unresolved contradiction": {
+    "The sign-in expired. Sign in again.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Contradicción sin resolver"
-          }
-        }
-      }
-    },
-    "Contradicts": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contradice"
-          }
-        }
-      }
-    },
-    "Refutes": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refuta"
-          }
-        }
-      }
-    },
-    "Refines": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Matiza"
-          }
-        }
-      }
-    },
-    "Variant of": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Variante de"
-          }
-        }
-      }
-    },
-    "Extends": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extiende"
-          }
-        }
-      }
-    },
-    "Characters": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personajes"
-          }
-        }
-      }
-    },
-    "Place profiles": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Perfiles de lugar"
-          }
-        }
-      }
-    },
-    "Factions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Facciones"
-          }
-        }
-      }
-    },
-    "Cultures": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Culturas"
-          }
-        }
-      }
-    },
-    "Scenes": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escenas"
-          }
-        }
-      }
-    },
-    "Encyclopedia": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enciclopedia"
-          }
-        }
-      }
-    },
-    "Story arcs": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arcos narrativos"
-          }
-        }
-      }
-    },
-    "World rules": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reglas del mundo"
-          }
-        }
-      }
-    },
-    "Open questions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preguntas abiertas"
-          }
-        }
-      }
-    },
-    "Secrets": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Secretos"
-          }
-        }
-      }
-    },
-    "Beats": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ritmos"
-          }
-        }
-      }
-    },
-    "Families": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Familias"
-          }
-        }
-      }
-    },
-    "Dynasties": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dinastías"
-          }
-        }
-      }
-    },
-    "Suggested kinships": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parentescos sugeridos"
-          }
-        }
-      }
-    },
-    "Archive": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Archivo"
-          }
-        }
-      }
-    },
-    "Archive folders": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carpetas de archivo"
-          }
-        }
-      }
-    },
-    "Recordings": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grabaciones"
-          }
-        }
-      }
-    },
-    "Transcripts": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transcripciones"
-          }
-        }
-      }
-    },
-    "Study plans": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Planes de estudio"
-          }
-        }
-      }
-    },
-    "Goals": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Objetivos"
-          }
-        }
-      }
-    },
-    "Calendar": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Calendario"
-          }
-        }
-      }
-    },
-    "Timetables": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horarios"
-          }
-        }
-      }
-    },
-    "Logos": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logotipos"
-          }
-        }
-      }
-    },
-    "Work summaries": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Síntesis de obras"
-          }
-        }
-      }
-    },
-    "Author dossiers": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosieres de autor"
-          }
-        }
-      }
-    },
-    "Projects": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proyectos"
-          }
-        }
-      }
-    },
-    "Chapters": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Capítulos"
-          }
-        }
-      }
-    },
-    "Saved searches": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Búsquedas guardadas"
-          }
-        }
-      }
-    },
-    "Research questions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preguntas de investigación"
-          }
-        }
-      }
-    },
-    "Collections": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Colecciones"
-          }
-        }
-      }
-    },
-    "Database rows": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filas de bases de datos"
-          }
-        }
-      }
-    },
-    "Read only: the server accepts no cell changes, so they are edited from Nodus desktop.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solo read: el servidor no acepta cambios en celdas, así que se editan desde Nodus de escritorio."
-          }
-        }
-      }
-    },
-    "%.1f pp.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%.1f pág."
-          }
-        }
-      }
-    },
-    ", progress.pagesSoFar)) pages": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ", progress.pagesSoFar)) páginas"
-          }
-        }
-      }
-    },
-    "Empty database": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Base vacía"
-          }
-        }
-      }
-    },
-    "Each title must be specific and distinct from the others; no generic “Introduction” or “Conclusion”.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cada título debe ser específico y distinto de los demás; nada de «Introducción» ni «Conclusión» genéricas."
-          }
-        }
-      }
-    },
-    "Nodus desktop keeps the review schedule; here you can review, not reschedule.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El calendario de repaso lo lleva Nodus de escritorio; aquí puedes repasar, no reprogramar."
+            "value": "El acceso caducó. Vuelve a entrar."
           }
         }
       }
@@ -4314,13 +5156,200 @@
         }
       }
     },
-    "This publication carries no time slots.": {
+    "The tree needs every relationship at once. The API serves them one at a time, so it is built from the downloaded publication.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Esta publicación no trae franjas horarias."
+            "value": "El árbol necesita todas las relaciones a la vez. La API las entrega de una en una, así que se arma desde la publicación descargada."
+          }
+        }
+      }
+    },
+    "The vault fixes the model, not this app: retrieval only works when provider, model and dimension all match exactly.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El modelo lo fija el vault, no esta app: la recuperación solo funciona si el proveedor, el modelo y la dimensión coinciden exactamente."
+          }
+        }
+      }
+    },
+    "Theme": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
+          }
+        }
+      }
+    },
+    "Themes": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temas"
+          }
+        }
+      }
+    },
+    "These providers exist in Nodus desktop. They are listed so that, if your vault was indexed with one, the app can say exactly why it cannot reproduce it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estos proveedores existen en Nodus de escritorio. Se listan para que, si tu vault se indexó con uno, la app pueda decirte exactamente por qué no puede reproducirlo."
+          }
+        }
+      }
+    },
+    "These tables travel in the publication but have no REST route, so they can only be listed from the downloaded copy.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estas tablas viajan en la publicación pero no tienen ruta REST, así que solo se pueden listar desde la copia descargada."
+          }
+        }
+      }
+    },
+    "They are read from each idea that rests on them. The original document never leaves the desktop.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se leen desde cada idea que se apoya en ellos. El documento original nunca sale del escritorio."
+          }
+        }
+      }
+    },
+    "This account has no access to any space yet. Ask whoever administers the server.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta cuenta todavía no tiene acceso a ningún espacio. Pídeselo a quien administra el servidor."
+          }
+        }
+      }
+    },
+    "This connection is not encrypted. That should only ever be a local test.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta conexión no está cifrada. Solo debería serlo en pruebas locales."
+          }
+        }
+      }
+    },
+    "This device": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo"
+          }
+        }
+      }
+    },
+    "This device cannot authenticate right now.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo no puede autenticarte ahora mismo."
+          }
+        }
+      }
+    },
+    "This device has no network.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo no tiene red."
+          }
+        }
+      }
+    },
+    "This device has no passcode set, so there is nothing to lock with.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo no tiene código, así que no hay con qué bloquearlo."
+          }
+        }
+      }
+    },
+    "This device has no passcode set, so there is nothing to unlock with.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo no tiene código, así que no hay con qué desbloquearlo."
+          }
+        }
+      }
+    },
+    "This idea is not in the published graph.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta idea no está en el grafo publicado."
+          }
+        }
+      }
+    },
+    "This person has no family relationships recorded in the publication.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta persona no tiene relaciones familiares registradas en la publicación."
+          }
+        }
+      }
+    },
+    "This person has no relationships recorded in the publication.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta persona no tiene parentescos registrados en la publicación."
+          }
+        }
+      }
+    },
+    "This provider runs on the computer where Nodus desktop lives. iOS cannot produce a matching vector, so search is lexical.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este proveedor corre en el ordenador donde está Nodus de escritorio. Desde iOS no se puede generar un vector que case, así que la búsqueda es léxica."
           }
         }
       }
@@ -4336,68 +5365,223 @@
         }
       }
     },
-    "Images": {
+    "This publication carries no time slots.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Imágenes"
+            "value": "Esta publicación no trae franjas horarias."
           }
         }
       }
     },
-    "Wednesday": {
+    "This publication carries nothing under %@.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Miércoles"
+            "value": "Esta publicación no trae nada en %@."
           }
         }
       }
     },
-    "Could not build the tree": {
+    "This publication carries nothing under \\(collection.label.lowercased()).": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo montar el árbol"
+            "value": "Esta publicación no trae nada en \\(collection.label.lowercased())."
           }
         }
       }
     },
-    "Audience: \\($0)": {
+    "This space has no publication to download yet.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Público: \\($0)"
+            "value": "Este espacio todavía no tiene publicación que descargar."
           }
         }
       }
     },
-    "Sequence the parts by dependency between concepts: what must be understood first comes first. Each part must be teachable in class.": {
+    "This space has no publication yet": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Secuencia las partes según las dependencias entre conceptos: lo que hay que entender antes va antes. Cada parte debe poder darse en clase."
+            "value": "Este espacio todavía no tiene publicación"
           }
         }
       }
     },
-    "Saturday": {
+    "This space has no published vectors.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sábado"
+            "value": "Este espacio no tiene vectores publicados."
+          }
+        }
+      }
+    },
+    "This space has published no reports or immersion sessions yet. You can generate one above.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este espacio todavía no ha publicado informes ni sesiones de inmersión. Puedes generar uno arriba."
+          }
+        }
+      }
+    },
+    "This space's last publication carried no table with anything in it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La última publicación de este espacio no traía ninguna tabla con contenido."
+          }
+        }
+      }
+    },
+    "This space's publication has no column “\\(column)”. Its schema is older than this app.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La publicación de este espacio no tiene la columna «\\(column)». Su esquema es más antiguo que esta app."
+          }
+        }
+      }
+    },
+    "This vault was indexed with %@/%@, which runs on the computer where Nodus lives. From a phone, search will be lexical.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This vault was indexed with %1$@/%2$@, which runs on the computer where Nodus lives. From a phone, search will be lexical."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este vault se indexó con %1$@/%2$@, que se ejecuta en el ordenador donde vive Nodus. Desde un teléfono la búsqueda será léxica."
+          }
+        }
+      }
+    },
+    "This vault was indexed with %@/%@. With that key, retrieval will be semantic; without it, lexical.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This vault was indexed with %1$@/%2$@. With that key, retrieval will be semantic; without it, lexical."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este vault se indexó con %1$@/%2$@. Con esa clave la recuperación será semántica; sin ella, léxica."
+          }
+        }
+      }
+    },
+    "This vault was indexed with \\(identity.provider)/\\(identity.model), which runs on the computer where Nodus lives. From a phone, search will be lexical.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este vault se indexó con \\(identity.provider)/\\(identity.model), que corre en el ordenador donde está Nodus. Desde el móvil la búsqueda será léxica."
+          }
+        }
+      }
+    },
+    "This vault was indexed with \\(identity.provider)/\\(identity.model). With that key, retrieval will be semantic; without it, lexical.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este vault se indexó con \\(identity.provider)/\\(identity.model). Con esa clave, la recuperación será semántica; sin ella, léxica."
+          }
+        }
+      }
+    },
+    "This vault was indexed with \\(name), which runs on the computer where Nodus desktop lives. iOS cannot produce a matching vector.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este vault se indexó con \\(name), que corre en el ordenador donde está Nodus de escritorio. Desde iOS no se puede generar un vector que case."
+          }
+        }
+      }
+    },
+    "This vault was indexed with an engine that runs on the Nodus computer. Search will still work, but it will be lexical.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este vault se indexó con un motor que corre en el ordenador de Nodus. La búsqueda seguirá funcionando, pero será léxica."
+          }
+        }
+      }
+    },
+    "This vault was indexed with “\\(name)”, a provider this version does not know.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este vault se indexó con «\\(name)», un proveedor que esta versión no conoce."
+          }
+        }
+      }
+    },
+    "Thursday": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jueves"
+          }
+        }
+      }
+    },
+    "Timeline": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cronología"
+          }
+        }
+      }
+    },
+    "Timetables": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Horarios"
           }
         }
       }
@@ -4435,35 +5619,101 @@
         }
       }
     },
-    "spouse": {
+    "Title A–Z": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "cónyuge"
+            "value": "Título A–Z"
           }
         }
       }
     },
-    "≈ \\(plan.target) sections · \\(pages.lowerBound)–\\(pages.upperBound) pages": {
+    "Title Z–A": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "≈ \\(plan.target) secciones · \\(pages.lowerBound)–\\(pages.upperBound) páginas"
+            "value": "Título Z–A"
           }
         }
       }
     },
-    "Monday": {
+    "Too many attempts. Try again in \\(seconds) s.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lunes"
+            "value": "Demasiados intentos. Prueba de nuevo en \\(seconds) s."
+          }
+        }
+      }
+    },
+    "Too many searches in a row. Wait %lld s.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demasiadas búsquedas seguidas. Espera %lld s."
+          }
+        }
+      }
+    },
+    "Too many searches in a row. Wait \\(Int(apiError.retryAfter ?? 30)) s.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demasiadas búsquedas seguidas. Espera \\(Int(apiError.retryAfter ?? 30)) s."
+          }
+        }
+      }
+    },
+    "Tools": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramientas"
+          }
+        }
+      }
+    },
+    "Transcripts": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcripciones"
+          }
+        }
+      }
+    },
+    "Tree": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Árbol"
+          }
+        }
+      }
+    },
+    "Try again": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
           }
         }
       }
@@ -4479,827 +5729,387 @@
         }
       }
     },
-    "Thursday": {
+    "Type": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Jueves"
+            "value": "Tipo"
           }
         }
       }
     },
-    "Friday": {
+    "Unexpected answer from the embedding provider (\\(detail)).": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Viernes"
+            "value": "Respuesta inesperada del proveedor de embeddings (\\(detail))."
           }
         }
       }
     },
-    "Sunday": {
+    "Unfold a level": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Domingo"
+            "value": "Desplegar un nivel"
           }
         }
       }
     },
-    "%@ records": {
+    "Unfold the branch": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ registros"
+            "value": "Desplegar la rama"
           }
         }
       }
     },
-    "Research": {
+    "Unit topic": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Investigación"
+            "value": "Tema de la unidad"
           }
         }
       }
     },
-    "Reports": {
+    "Unknown section": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Informes"
+            "value": "Sección desconocida"
           }
         }
       }
     },
-    "All reports": {
+    "Unlock": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todos los informes"
+            "value": "Desbloquear"
           }
         }
       }
     },
-    "On this device": {
+    "Unlock Nodus to reach your vaults and keys.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "En este dispositivo"
+            "value": "Desbloquea Nodus para acceder a tus vaults y tus claves."
           }
         }
       }
     },
-    "Published in the vault": {
+    "Unlock with Face ID": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Publicados en el vault"
+            "value": "Desbloquear con Face ID"
           }
         }
       }
     },
-    "Search reports": {
+    "Unpin": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buscar informes"
+            "value": "Quitar de destacados"
           }
         }
       }
     },
-    "No reports": {
+    "Unresolved contradiction": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin informes"
+            "value": "Contradicción sin resolver"
           }
         }
       }
     },
-    "Nothing published, and nothing generated here yet.": {
+    "Untitled": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nada publicado y nada generado aquí todavía."
+            "value": "Sin título"
           }
         }
       }
     },
-    "Generated here and kept on this device. They are not part of the vault until you send one.": {
+    "Untitled note": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Generados aquí y guardados en este dispositivo. No forman parte del vault hasta que envíes uno."
+            "value": "Nota sin título"
           }
         }
       }
     },
-    "Published tables": {
+    "Untitled work": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tablas publicadas"
+            "value": "Obra sin título"
           }
         }
       }
     },
-    "Filter tables": {
+    "Update": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Filtrar tablas"
+            "value": "Actualizar"
           }
         }
       }
     },
-    "Artificial intelligence": {
+    "Variant of": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Inteligencia artificial"
+            "value": "Variante de"
           }
         }
       }
     },
-    "None configured": {
+    "Vault": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ninguna configurada"
+            "value": "Vault"
           }
         }
       }
     },
-    "Show the key": {
+    "Verifying citations": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar la clave"
+            "value": "Verificando citas"
           }
         }
       }
     },
-    "Hide the key": {
+    "Very fast, short catalogue.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ocultar la clave"
+            "value": "Muy rápido, catálogo corto."
           }
         }
       }
     },
-    "Delete": {
+    "Very fast. Its free tier counts prompt and answer against one budget.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Borrar"
+            "value": "Muy rápido. Su nivel gratuito cuenta prompt y respuesta juntos."
           }
         }
       }
     },
-    "Parents": {
+    "Views": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Padres y madres"
+            "value": "Vistas"
           }
         }
       }
     },
-    "Siblings": {
+    "Waiting for the owner to republish.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hermanos y hermanas"
+            "value": "Pendiente de que el propietario vuelva a publicar."
           }
         }
       }
     },
-    "Children": {
+    "Wednesday": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descendencia"
+            "value": "Miércoles"
           }
         }
       }
     },
-    "Partner": {
+    "What should it research in this corpus": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pareja"
+            "value": "Qué quieres que investigue en este corpus"
           }
         }
       }
     },
-    "Previous": {
+    "What to take away": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Anterior"
+            "value": "Qué llevarse"
           }
         }
       }
     },
-    "Next": {
+    "What unit do you want to prepare from these materials": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Siguiente"
+            "value": "Qué unidad quieres preparar con estos materiales"
           }
         }
       }
     },
-    "Show answer": {
+    "Who argues what": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ver respuesta"
+            "value": "Quién sostiene qué"
           }
         }
       }
     },
-    "No flashcards": {
+    "Why this matters": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin fichas"
+            "value": "Por qué importa"
           }
         }
       }
     },
-    "No questions": {
+    "Work": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin preguntas"
+            "value": "Obra"
           }
         }
       }
     },
-    "No people": {
+    "Work summaries": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin personas"
+            "value": "Síntesis de obras"
           }
         }
       }
     },
-    "No timetable": {
+    "Works": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sin horario"
+            "value": "Obras"
           }
         }
       }
     },
-    "Filter questions": {
+    "World rules": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Filtrar preguntas"
+            "value": "Reglas del mundo"
           }
         }
       }
     },
-    "Forget": {
+    "Write": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Olvidar"
+            "value": "Escribir"
           }
         }
       }
     },
-    "Deep Research": {
+    "Writing": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deep Research"
+            "value": "Escritura"
           }
         }
       }
     },
-    "Embeddings": {
+    "Writing “\\(title)”": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Embeddings"
-          }
-        }
-      }
-    },
-    "Sending…": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviando…"
-          }
-        }
-      }
-    },
-    "A table with no rows was published empty. A table that is absent was never published at all — and the endpoint for it answers an empty page rather than an error.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Una tabla con cero filas se publicó vacía. Una tabla ausente no se publicó nunca — y su endpoint responde una página vacía, no un error."
-          }
-        }
-      }
-    },
-    "Your keys stay in this device's keychain. The Nodus Server never receives one — it hands over the material, and this app calls your provider itself.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tus claves se quedan en el llavero de este dispositivo. El Nodus Server no recibe ninguna: entrega el material y esta app llama a tu proveedor."
-          }
-        }
-      }
-    },
-    "%lld rows · %lld columns": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld filas · %lld columnas"
-          }
-        }
-      }
-    },
-    "%@ · %lld dimensions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %lld dimensiones"
-          }
-        }
-      }
-    },
-    "%lld of %lld": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld de %lld"
-          }
-        }
-      }
-    },
-    "%@ words · %@ pages": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ palabras · %@ páginas"
-          }
-        }
-      }
-    },
-    "%lld invented citations, removed": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld citas inventadas, eliminadas"
-          }
-        }
-      }
-    },
-    "%lld invented citations removed": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld citas inventadas eliminadas"
-          }
-        }
-      }
-    },
-    "%@ words": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ palabras"
-          }
-        }
-      }
-    },
-    "%@ words · %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ palabras · %@"
-          }
-        }
-      }
-    },
-    "Send %lld change%@": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviar %lld cambio%@"
-          }
-        }
-      }
-    },
-    "Of %lld checked.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De %lld comprobadas."
-          }
-        }
-      }
-    },
-    "%lld characters": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld caracteres"
-          }
-        }
-      }
-    },
-    "Querying %@…": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Consultando %@…"
-          }
-        }
-      }
-    },
-    "%@ rows · %lld columns": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ filas · %lld columnas"
-          }
-        }
-      }
-    },
-    "%@ — not reachable from iOS": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — no alcanzable desde iOS"
-          }
-        }
-      }
-    },
-    "%lld citations, all from the corpus": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld citas, todas del corpus"
-          }
-        }
-      }
-    },
-    "Ask %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pregunta a %@"
-          }
-        }
-      }
-    },
-    "Search %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Busca en %@"
-          }
-        }
-      }
-    },
-    "Indexed with %@ · %lld dimensions": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Indexado con %@ · %lld dimensiones"
-          }
-        }
-      }
-    },
-    "Indexed with %@, which a phone cannot reach. Search will be lexical.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Indexado con %@, que no es alcanzable desde el móvil. La búsqueda será léxica."
-          }
-        }
-      }
-    },
-    "Indexed with “%@”, which this version does not know.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Indexado con «%@», que esta versión no conoce."
-          }
-        }
-      }
-    },
-    "It holds %@ rows from an earlier publication.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guarda %@ filas de una publicación anterior."
-          }
-        }
-      }
-    },
-    "No idea in this publication is linked to “%@”.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ninguna idea de esta publicación está vinculada a «%@»."
-          }
-        }
-      }
-    },
-    "No model contains “%@”.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ningún modelo contiene «%@»."
-          }
-        }
-      }
-    },
-    "No report contains “%@”.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ningún informe contiene «%@»."
-          }
-        }
-      }
-    },
-    "No row contains “%@”.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ninguna fila contiene «%@»."
-          }
-        }
-      }
-    },
-    "Section %lld of %lld": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sección %lld de %lld"
-          }
-        }
-      }
-    },
-    "This publication carries nothing under %@.": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta publicación no trae nada en %@."
-          }
-        }
-      }
-    },
-    "and %lld more": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "y %lld más"
-          }
-        }
-      }
-    },
-    "Hide": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocultar"
-          }
-        }
-      }
-    },
-    "nodus.example.org": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "nodus.ejemplo.org"
-          }
-        }
-      }
-    },
-    "%@ / %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ / %@"
-          }
-        }
-      }
-    },
-    "%@ · %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@"
-          }
-        }
-      }
-    },
-    "%lld": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld"
-          }
-        }
-      }
-    },
-    "%lld%%": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld%%"
-          }
-        }
-      }
-    },
-    "%lld/%lld": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld/%lld"
-          }
-        }
-      }
-    },
-    "· %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "· %@"
-          }
-        }
-      }
-    },
-    "Nodus": {
-      "extractionState": "manual",
-      "localizations": {
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nodus"
+            "value": "Escribiendo «\\(title)»"
           }
         }
       }
@@ -5315,126 +6125,590 @@
         }
       }
     },
-    "Relationships · %lld": {
+    "Your access to this space does not allow sending changes. Anything you write stays on this device.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Relaciones · %lld"
+            "value": "Tu acceso a este espacio no permite enviar cambios. Lo que escribas se queda en este dispositivo."
           }
         }
       }
     },
-    "Appears in · %lld": {
+    "Your access to this space is read only.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aparece en · %lld"
+            "value": "Tu acceso a este espacio es de solo lectura."
           }
         }
       }
     },
-    "Loading…": {
+    "Your keys and the copies of your vaults on this device stay closed until you unlock them.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cargando…"
+            "value": "Tus claves y las copias de tus vaults en este dispositivo siguen cerradas hasta que las desbloquees."
           }
         }
       }
     },
-    "Supports": {
+    "Your keys are kept in this device's keychain, not synced to iCloud, and never sent to the Nodus Server: the server hands over the material and this app calls your provider.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apoya"
+            "value": "Tus claves se guardan en el llavero de este dispositivo, sin sincronizar con iCloud, y nunca se envían al Nodus Server: el servidor entrega el material y tú llamas a tu proveedor."
           }
         }
       }
     },
-    "Depends on": {
+    "Your keys stay in this device's keychain. The Nodus Server never receives one — it hands over the material, and this app calls your provider itself.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Depende de"
+            "value": "Tus claves se quedan en el llavero de este dispositivo. El Nodus Server no recibe ninguna: entrega el material y esta app llama a tu proveedor."
           }
         }
       }
     },
-    "Exemplifies": {
+    "Your server holds a published projection of the vault. AI keys never leave this device.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ejemplifica"
+            "value": "Tu servidor guarda una proyección publicada del vault. Las claves de IA nunca salen de este dispositivo."
           }
         }
       }
     },
-    "Applies": {
+    "Your vaults, wherever you are.": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aplica"
+            "value": "Tus vaults, donde estés."
           }
         }
       }
     },
-    "Compares": {
+    "\\(detail.passages) passages extracted": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Compara"
+            "value": "\\(detail.passages) pasajes extraídos"
           }
         }
       }
     },
-    "Responds to": {
+    "\\(report.citationsChecked) citations, all from the corpus": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Responde a"
+            "value": "\\(report.citationsChecked) citas, todas del corpus"
           }
         }
       }
     },
-    "Principal": {
+    "\\(unreachable.label) — not reachable from iOS": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Principal"
+            "value": "\\(unreachable.label) — no alcanzable desde iOS"
           }
         }
       }
     },
-    "Secondary": {
+    "and %lld more": {
       "extractionState": "manual",
       "localizations": {
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Secundaria"
+            "value": "y %lld más"
+          }
+        }
+      }
+    },
+    "and \\(rows.count - 60) more": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "y \\(rows.count - 60) más"
+          }
+        }
+      }
+    },
+    "and \\(section.rows.count - 20) more": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "y \\(section.rows.count - 20) más"
+          }
+        }
+      }
+    },
+    "applies to": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aplica a"
+          }
+        }
+      }
+    },
+    "claim": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "afirmación"
+          }
+        }
+      }
+    },
+    "confidence %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "confianza %@"
+          }
+        }
+      }
+    },
+    "confidence %@ · %lld derivations": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "confidence %1$@ · %2$lld derivations"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "confianza %1$@ · %2$lld derivaciones"
+          }
+        }
+      }
+    },
+    "construct": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "constructo"
+          }
+        }
+      }
+    },
+    "contradicts": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "contradice"
+          }
+        }
+      }
+    },
+    "explicit": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "explícita"
+          }
+        }
+      }
+    },
+    "extends": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "extiende"
+          }
+        }
+      }
+    },
+    "field": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "campo"
+          }
+        }
+      }
+    },
+    "fields": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "campos"
+          }
+        }
+      }
+    },
+    "finding": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hallazgo"
+          }
+        }
+      }
+    },
+    "framework": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "marco"
+          }
+        }
+      }
+    },
+    "iOS refuses plain HTTP to anything but this device. Use an https:// address.": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS rechaza HTTP sin cifrar salvo hacia este mismo dispositivo. Usa una dirección https://."
+          }
+        }
+      }
+    },
+    "item": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "elemento"
+          }
+        }
+      }
+    },
+    "items": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "elementos"
+          }
+        }
+      }
+    },
+    "measures the same": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mide lo mismo"
+          }
+        }
+      }
+    },
+    "method": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "método"
+          }
+        }
+      }
+    },
+    "no description": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sin descripción"
+          }
+        }
+      }
+    },
+    "nodus.example.org": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nodus.ejemplo.org"
+          }
+        }
+      }
+    },
+    "owner": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "propietario"
+          }
+        }
+      }
+    },
+    "paraphrased": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "parafraseada"
+          }
+        }
+      }
+    },
+    "precondition of": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "precondición de"
+          }
+        }
+      }
+    },
+    "read": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lectura"
+          }
+        }
+      }
+    },
+    "refines": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "refina"
+          }
+        }
+      }
+    },
+    "refutes": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "refuta"
+          }
+        }
+      }
+    },
+    "related": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "relacionada"
+          }
+        }
+      }
+    },
+    "seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semilla"
+          }
+        }
+      }
+    },
+    "shares method": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "comparte método"
+          }
+        }
+      }
+    },
+    "spouse": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cónyuge"
+          }
+        }
+      }
+    },
+    "supports": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "apoya"
+          }
+        }
+      }
+    },
+    "the plan came back empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "el plan vino vacío"
+          }
+        }
+      }
+    },
+    "theme": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tema"
+          }
+        }
+      }
+    },
+    "variant of": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "variante de"
+          }
+        }
+      }
+    },
+    "write": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "escritura"
+          }
+        }
+      }
+    },
+    "· %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· %@"
+          }
+        }
+      }
+    },
+    "· not published": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· sin publicar"
+          }
+        }
+      }
+    },
+    "“%@”": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«%@»"
+          }
+        }
+      }
+    },
+    "“%@” stopped after %lld of %lld sections. Carrying on writes only the ones that are missing.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "“%1$@” stopped after %2$lld of %3$lld sections. Carrying on writes only the ones that are missing."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«%1$@» se detuvo tras %2$lld de %3$lld secciones. Continuar solo escribe las que faltan."
+          }
+        }
+      }
+    },
+    "≈ \\(plan.target) sections · \\(pages.lowerBound)–\\(pages.upperBound) pages": {
+      "extractionState": "manual",
+      "localizations": {
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "≈ \\(plan.target) secciones · \\(pages.lowerBound)–\\(pages.upperBound) páginas"
           }
         }
       }
     }
-  }
+  },
+  "version": "1.0"
 }

--- a/ios/Nodus/NodusApp.swift
+++ b/ios/Nodus/NodusApp.swift
@@ -5,6 +5,13 @@ import SwiftUI
 
 @main
 struct NodusApp: App {
+    /// `BGTaskScheduler` traps if an identifier is registered after launch has finished, and a
+    /// SwiftUI `.task` modifier runs well after that. `App.init()` is the last moment that is
+    /// still inside the launch, so registration lives here rather than in a view.
+    init() {
+        BackgroundWork.registerHandlers()
+    }
+
     var body: some Scene {
         WindowGroup {
             RootView()

--- a/ios/Nodus/RootView.swift
+++ b/ios/Nodus/RootView.swift
@@ -3,8 +3,10 @@ import NodusUI
 import SwiftUI
 
 struct RootView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @State private var model = AppModel()
     @State private var ai = AISettings()
+    @State private var lock = AppLock()
     @State private var tilt = DeviceTiltProvider()
     @State private var showingConnect = false
 
@@ -16,8 +18,20 @@ struct RootView: View {
                 SpacePickerView(showingConnect: $showingConnect)
             }
         }
+        // Over everything, including any sheet: a settings screen presented before the app went
+        // away must not be readable through the lock.
+        .overlay {
+            if lock.isLocked {
+                LockScreen(lock: lock)
+            } else if lock.isEnabled, scenePhase == .inactive {
+                // The multitasking snapshot is taken here. Without this it would show the
+                // corpus, which makes the lock decorative.
+                PrivacyCover()
+            }
+        }
         .environment(model)
         .environment(ai)
+        .environment(lock)
         .detectingScreenCutout()
         .nodusTiltDriven(tilt)
         .sheet(isPresented: $showingConnect) { ConnectView().environment(model) }
@@ -27,6 +41,16 @@ struct RootView: View {
             if model.session == nil, let recent = model.mostRecent {
                 model.open(recent)
             }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .background else { return }
+            // Immediately, with no grace period. A window in which the app reopens unlocked is
+            // a window somebody else can use.
+            lock.lock()
+            // The moment work stops being foreground work is the moment to ask iOS to finish
+            // it. Asking earlier is refused — the scheduler will not accept a request from an
+            // app that is on screen.
+            Task { await BackgroundWork.scheduleWhatIsPending() }
         }
     }
 }
@@ -117,11 +141,13 @@ private struct ConnectionCard: View {
         .nodusGlass(NodusGlass(.regular, tint: connection.accent, interactive: true))
     }
 
+    /// `String(localized:)`: interpolated into a line of data, so it reaches `Text` as a value
+    /// and would otherwise stay English on a Spanish phone.
     private var roleLabel: String {
         switch connection.role {
-        case .reader: return "read"
-        case .writer: return "write"
-        case .owner: return "owner"
+        case .reader: return String(localized: "read")
+        case .writer: return String(localized: "write")
+        case .owner: return String(localized: "owner")
         }
     }
 }

--- a/ios/Nodus/Screens/ArgumentMapView.swift
+++ b/ios/Nodus/Screens/ArgumentMapView.swift
@@ -1,0 +1,439 @@
+import NodusKit
+import NodusUI
+import SwiftUI
+
+/// The argument map: one idea, and the argument that grows out of it.
+///
+/// The desktop offers two modes — an AI trace and a structural one built from the real edges.
+/// This is the structural one, because it needs no model, no key and no money: the server
+/// already serves the ego graph, and the tree is arithmetic over it
+/// (`ArgumentMapBuilder.structural`). What the model would add is a gloss, and a gloss is the
+/// part a phone can most easily do without.
+struct ArgumentMapView: View {
+    let session: SpaceSession
+    /// Set when the map was opened from a specific idea rather than from the seed picker.
+    var seed: ArgumentSeed?
+
+    @State private var chosen: ArgumentSeed?
+    @State private var map: ArgumentMap?
+    @State private var expanded: Set<String> = []
+    @State private var levels: [[String]] = []
+    @State private var revealedLevels = 1
+    @State private var isLoading = false
+    @State private var error: String?
+
+    var body: some View {
+        Group {
+            if let map {
+                mapBody(map)
+            } else if isLoading {
+                ProgressView().tint(session.accent).frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error {
+                ContentUnavailableView {
+                    Label("Could not draw the map", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                }
+            } else {
+                ArgumentSeedPicker(session: session) { picked in
+                    chosen = picked
+                    Task { await build(picked) }
+                }
+            }
+        }
+        .navigationTitle("Argument map")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if map != nil {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        map = nil
+                        chosen = nil
+                        expanded = []
+                        revealedLevels = 1
+                    } label: {
+                        Image(systemName: "arrow.triangle.branch")
+                    }
+                    .tint(session.accent)
+                    .accessibilityLabel("Another seed")
+                }
+            }
+        }
+        .task {
+            guard map == nil, let seed, chosen == nil else { return }
+            chosen = seed
+            await build(seed)
+        }
+    }
+
+    // MARK: The map
+
+    private func mapBody(_ map: ArgumentMap) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                header(map)
+                ArgumentBlockTree(
+                    block: map.root,
+                    depth: 0,
+                    expanded: $expanded,
+                    accent: session.accent,
+                    session: session
+                )
+            }
+            .padding(16)
+        }
+    }
+
+    private func header(_ map: ArgumentMap) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(map.seedLabel).font(.headline)
+
+            HStack(spacing: 12) {
+                Label("\(map.blockCount)", systemImage: "square.stack.3d.up")
+                Label("\(map.seedDegree)", systemImage: "link")
+                if map.seedDebates > 0 {
+                    Label("\(map.seedDebates)", systemImage: "bolt.horizontal")
+                        .foregroundStyle(.orange)
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            // The map is drawn from the neighbourhood the server sent, and the server caps it.
+            // Saying so keeps a partial argument from reading as the whole one.
+            if map.truncated {
+                Text("Drawn from the \(map.ideaCount) closest ideas. This space has more; the map is a real part of the argument, not all of it.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !levels.isEmpty {
+                HStack(spacing: 10) {
+                    Button {
+                        revealLevel()
+                    } label: {
+                        Label("Unfold a level", systemImage: "plus.magnifyingglass")
+                    }
+                    .buttonStyle(NodusGlassButtonStyle(accent: session.accent))
+                    .disabled(revealedLevels >= levels.count)
+
+                    Button {
+                        expanded = []
+                        revealedLevels = 0
+                    } label: {
+                        Label("Collapse", systemImage: "arrow.down.right.and.arrow.up.left")
+                    }
+                    .buttonStyle(NodusGlassButtonStyle(accent: session.accent))
+                    .disabled(expanded.isEmpty)
+                }
+                .font(.caption)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .nodusGlass(NodusGlass(.regular, tint: session.accent))
+    }
+
+    /// Open one more level of the tree, everywhere at once.
+    ///
+    /// The levels are contiguous by construction — a block only reaches depth d when every
+    /// ancestor above it has children — so revealing level n never leaves an orphan expanded
+    /// under a collapsed parent.
+    private func revealLevel() {
+        guard revealedLevels < levels.count else { return }
+        withAnimation(.easeOut(duration: 0.24)) {
+            expanded.formUnion(levels[revealedLevels])
+            revealedLevels += 1
+        }
+    }
+
+    private func build(_ seed: ArgumentSeed) async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+        do {
+            let graph = try await session.client.ideaGraph(
+                seed.id,
+                in: session.connection.spaceId,
+                depth: ArgumentMapBuilder.maxDepth,
+                limit: 400
+            )
+            guard let built = ArgumentMapBuilder.structural(from: graph, seedId: seed.id) else {
+                error = String(localized: "This idea is not in the published graph.")
+                return
+            }
+            map = built
+            levels = built.expandableIdsByDepth
+            // Open the seed, and only the seed. A map that arrives fully unfolded is a wall.
+            expanded = Set(levels.first ?? [])
+            revealedLevels = 1
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+/// The idea a map grows from.
+struct ArgumentSeed: Identifiable, Hashable {
+    let id: String
+    let label: String
+
+    init?(_ row: Row) {
+        guard let id = row.string("global_id") else { return nil }
+        self.id = id
+        label = row.text("label") ?? row.text("statement") ?? id
+    }
+
+    init(id: String, label: String) {
+        self.id = id
+        self.label = label
+    }
+}
+
+/// Choosing where the argument starts.
+///
+/// The desktop ranks hubs by connectivity over the whole graph; a phone holds no such index, so
+/// this asks the corpus instead — the same search the Ideas section uses — and says plainly
+/// that it is a search rather than a ranking.
+private struct ArgumentSeedPicker: View {
+    let session: SpaceSession
+    let onPick: (ArgumentSeed) -> Void
+
+    @State private var query = ""
+    @State private var rows: [Row] = []
+    @State private var isLoading = false
+    @State private var error: String?
+    @State private var searchTask: Task<Void, Never>?
+
+    var body: some View {
+        List {
+            Section {
+                HStack(spacing: 9) {
+                    Image(systemName: "magnifyingglass").foregroundStyle(session.accent)
+                    TextField("Find the idea to start from", text: $query)
+                        .textFieldStyle(.plain)
+                        .autocorrectionDisabled()
+                        .submitLabel(.search)
+                }
+                .listRowBackground(Color.clear)
+            } footer: {
+                Text("The map grows from one idea, following the relations the analysis found: what supports it, what refines it, and what argues against it.")
+            }
+
+            if let error {
+                NodusNotice(tone: .blocked, title: "Could not load the ideas", message: LocalizedStringKey(error))
+                    .listRowBackground(Color.clear)
+            }
+
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                if let seed = ArgumentSeed(row) {
+                    Button {
+                        onPick(seed)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(seed.label).font(.subheadline.weight(.medium))
+                                .foregroundStyle(.primary)
+                            if let statement = row.text("statement"), statement != seed.label {
+                                Text(statement).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+
+            if rows.isEmpty, !isLoading, error == nil {
+                ContentUnavailableView("No ideas", systemImage: "lightbulb")
+                    .listRowBackground(Color.clear)
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .listStyle(.plain)
+        .onChange(of: query) { _, _ in schedule() }
+        .task { if rows.isEmpty { await load(nil) } }
+    }
+
+    private func schedule() {
+        searchTask?.cancel()
+        let current = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(320))
+            guard !Task.isCancelled else { return }
+            await load(current.isEmpty ? nil : current)
+        }
+    }
+
+    private func load(_ text: String?) async {
+        guard let ideas = Collections["ideas"] else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let page = try await session.client.list(ideas, in: session.connection.spaceId, query: text, limit: 60)
+            guard !Task.isCancelled else { return }
+            rows = page.items
+            error = nil
+        } catch is CancellationError {
+            // Superseded.
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+/// One block and, when it is open, its branch.
+private struct ArgumentBlockTree: View {
+    let block: ArgumentBlock
+    let depth: Int
+    @Binding var expanded: Set<String>
+    let accent: Color
+    let session: SpaceSession
+
+    private var isExpanded: Bool { expanded.contains(block.id) }
+    private var relationAccent: Color { Color(hex: block.relation.accentHex) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            card
+
+            if !block.children.isEmpty, isExpanded {
+                // Only the wrapper animates. Animating the card itself scale-corrects its own
+                // text, which leaves a collapsed card stretched to the height the whole branch
+                // used to take — the same trap the desktop hit.
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(block.children) { child in
+                        ArgumentBlockTree(
+                            block: child,
+                            depth: depth + 1,
+                            expanded: $expanded,
+                            accent: accent,
+                            session: session
+                        )
+                    }
+                }
+                .padding(.leading, 14)
+                .overlay(alignment: .leading) {
+                    Rectangle()
+                        .fill(.quaternary)
+                        .frame(width: 1)
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    private var card: some View {
+        HStack(alignment: .top, spacing: 8) {
+            // The relation, as a stripe. It is the whole reason a branch is where it is.
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(relationAccent)
+                .frame(width: 4)
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 6) {
+                    Text(LocalizedStringKey(ArgumentLabels.type(block.type)))
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(Color(hex: block.typeAccentHex).opacity(0.18), in: Capsule())
+                        .foregroundStyle(Color(hex: block.typeAccentHex))
+
+                    if block.relation != .root {
+                        Label {
+                            Text(LocalizedStringKey(ArgumentLabels.relation(block.relation)))
+                        } icon: {
+                            Image(systemName: "arrow.turn.right.up")
+                        }
+                        .font(.caption2)
+                        .foregroundStyle(relationAccent)
+                    }
+                }
+
+                Text(block.label)
+                    .font(.subheadline.weight(.medium))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                // The seed carries its statement; the branches carry the edge that put them
+                // there. Showing every statement turns the map into a wall of prose.
+                if depth == 0, !block.statement.isEmpty {
+                    Text(block.statement).font(.caption).foregroundStyle(.secondary)
+                } else if block.relation != .root {
+                    Text(summary).font(.caption2).foregroundStyle(.secondary)
+                }
+
+                if block.hiddenChildren > 0 {
+                    Text("+\(block.hiddenChildren) connections not drawn")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if !block.children.isEmpty {
+                Button {
+                    withAnimation(.easeOut(duration: 0.24)) {
+                        if isExpanded { expanded.remove(block.id) } else { expanded.insert(block.id) }
+                    }
+                } label: {
+                    Image(systemName: isExpanded ? "minus" : "plus")
+                        .font(.caption.weight(.semibold))
+                        .frame(width: 26, height: 26)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(isExpanded ? "Collapse the branch" : "Unfold the branch")
+            }
+        }
+        .padding(10)
+        .background(.quaternary.opacity(0.22), in: RoundedRectangle(cornerRadius: 11, style: .continuous))
+        .overlay(alignment: .bottomTrailing) {
+            if block.descendantCount > 0, !isExpanded {
+                Text("\(block.descendantCount)")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+                    .padding(.trailing, 34).padding(.bottom, 8)
+            }
+        }
+    }
+
+    /// What the desktop puts under the label: the relation, how confident the analysis was, and
+    /// how much argument hangs off this block.
+    private var summary: String {
+        let confidence = String(format: "%.2f", block.confidence)
+        if block.children.isEmpty {
+            return String(localized: "confidence \(confidence)")
+        }
+        return String(localized: "confidence \(confidence) · \(block.children.count) derivations")
+    }
+}
+
+/// The words for a relation and an idea type, matching the desktop's own.
+enum ArgumentLabels {
+    static func relation(_ relation: ArgumentRelation) -> String {
+        switch relation {
+        case .root: return "seed"
+        case .supports: return "supports"
+        case .refutes: return "refutes"
+        case .contradicts: return "contradicts"
+        case .extends: return "extends"
+        case .refines: return "refines"
+        case .appliesTo: return "applies to"
+        case .sharesMethod: return "shares method"
+        case .preconditionOf: return "precondition of"
+        case .measuresSame: return "measures the same"
+        case .variantOf: return "variant of"
+        case .related: return "related"
+        }
+    }
+
+    static func type(_ type: String) -> String {
+        switch type {
+        case "theme": return "theme"
+        case "claim": return "claim"
+        case "finding": return "finding"
+        case "construct": return "construct"
+        case "method": return "method"
+        case "framework": return "framework"
+        default: return type
+        }
+    }
+}

--- a/ios/Nodus/Screens/AssistantView.swift
+++ b/ios/Nodus/Screens/AssistantView.swift
@@ -40,7 +40,7 @@ struct ChatScreen: View {
                                 .id(turn.id)
                         }
                         if let error {
-                            NodusNotice(tone: .blocked, title: "The query failed", message: error)
+                            NodusNotice(tone: .blocked, title: "The query failed", message: LocalizedStringKey(error))
                         }
                     }
                     .padding(16)
@@ -206,7 +206,7 @@ private struct TurnBubble: View {
                     .nodusGlass(NodusGlass(.regular, tint: accent))
             } else {
                 if let warning = turn.warning {
-                    NodusNotice(tone: .caution, title: "Lexical retrieval", message: warning)
+                    NodusNotice(tone: .caution, title: "Lexical retrieval", message: LocalizedStringKey(warning))
                 }
                 Text(turn.text.isEmpty ? "…" : turn.text)
                     .textSelection(.enabled)

--- a/ios/Nodus/Screens/CollectionListView.swift
+++ b/ios/Nodus/Screens/CollectionListView.swift
@@ -24,7 +24,7 @@ struct CollectionListView: View {
     var body: some View {
         List {
             if let error {
-                NodusNotice(tone: .blocked, title: "Could not load", message: error)
+                NodusNotice(tone: .blocked, title: "Could not load", message: LocalizedStringKey(error))
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             }
@@ -190,18 +190,44 @@ struct SpecialListView: View {
     @State private var hasMore = false
     @State private var error: String?
     @State private var isLoading = false
+    @State private var outbox: OutboxController?
+    @State private var composing = false
+    @State private var editing: EditableNote?
+    @State private var queued = false
 
     var body: some View {
         List {
             if let error {
-                NodusNotice(tone: .blocked, title: "Could not load", message: error)
+                NodusNotice(tone: .blocked, title: "Could not load", message: LocalizedStringKey(error))
                     .listRowBackground(Color.clear)
             }
             ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                 NavigationLink {
-                    RowDetailView(session: session, collection: nil, row: row, title: title)
+                    // An immersion session is a whole study route — stations, quizzes, an exam
+                    // — and rendering it as a column dump showed a wall of JSON. It gets its
+                    // own reader; everything else here really is a row.
+                    if resource == .immersion, let id = row.string("id") {
+                        ImmersionView(session: session, sessionId: id, title: row.text("title") ?? title)
+                    } else {
+                        RowDetailView(session: session, collection: nil, row: row, title: title)
+                    }
                 } label: {
                     RowCell(row: row, presenter: presenter, accent: session.accent)
+                }
+                .swipeActions(edge: .trailing) {
+                    if canEditNotes {
+                        Button(role: .destructive) {
+                            Task { await deleteNote(row) }
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        Button {
+                            editing = EditableNote(row)
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        .tint(session.accent)
+                    }
                 }
             }
             if rows.isEmpty, !isLoading, error == nil {
@@ -213,8 +239,57 @@ struct SpecialListView: View {
         .listStyle(.plain)
         .navigationTitle(Text(LocalizedStringKey(title)))
         .navigationBarTitleDisplayMode(.inline)
-        .task { if rows.isEmpty { await reload() } }
+        .toolbar {
+            if canEditNotes {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { composing = true } label: { Image(systemName: "square.and.pencil") }
+                        .tint(session.accent)
+                }
+            }
+        }
+        .sheet(isPresented: $composing) {
+            NoteEditor(accent: session.accent, note: nil) { title, body in
+                await outbox?.queueNote(title: title, body: body, folderId: nil)
+                queued = true
+            }
+        }
+        .sheet(item: $editing) { note in
+            NoteEditor(accent: session.accent, note: note) { title, body in
+                await outbox?.queueNote(
+                    id: note.id,
+                    title: title,
+                    body: body,
+                    folderId: note.folderId,
+                    createdAt: note.createdAt
+                )
+                queued = true
+            }
+        }
+        // The one sentence this screen owes the user. A change here is not in the vault: it is
+        // on the phone until it is sent, and in the ledger until the owner republishes. The
+        // list underneath still shows the published rows, which is why nothing appears to
+        // change when a note is edited.
+        .alert("Queued on this device", isPresented: $queued) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Send it from Notes and queue. It joins the vault when its owner next opens Nodus desktop and republishes — until then this list still shows what was published.")
+        }
+        .task {
+            if outbox == nil { outbox = OutboxController(session: session) }
+            if rows.isEmpty { await reload() }
+        }
         .refreshable { await reload() }
+    }
+
+    /// Only notes are writable here, and only for a role the server would accept a change from.
+    private var canEditNotes: Bool {
+        resource == .notes && session.connection.role.canSendChanges && outbox != nil
+    }
+
+    private func deleteNote(_ row: Row) async {
+        guard let id = row.string("id") else { return }
+        await outbox?.queueNoteDeletion(id: id, title: row.text("title") ?? String(localized: "Untitled"))
+        queued = true
     }
 
     private var title: String {

--- a/ios/Nodus/Screens/ConnectView.swift
+++ b/ios/Nodus/Screens/ConnectView.swift
@@ -107,11 +107,22 @@ struct ConnectView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            // A disabled button with no explanation is what a slow probe used to look like:
+            // the user tapped, the address was fine, and the only feedback was the button
+            // going grey for half a minute. Now it says what it is doing.
             Button {
                 Task { await probe() }
             } label: {
-                Label("Continue", systemImage: "arrow.right")
-                    .frame(maxWidth: .infinity)
+                HStack(spacing: 7) {
+                    if isBusy {
+                        ProgressView().controlSize(.small).tint(.white)
+                        Text("Looking for the server…")
+                    } else {
+                        Image(systemName: "arrow.right")
+                        Text("Continue")
+                    }
+                }
+                .frame(maxWidth: .infinity)
             }
             .buttonStyle(NodusPrimaryButtonStyle(accent: accent))
             .disabled(addressInput.trimmingCharacters(in: .whitespaces).isEmpty || isBusy)
@@ -138,11 +149,15 @@ struct ConnectView: View {
                 }
             }
 
-            Picker("", selection: $usePairingCode) {
+            // A real label, hidden rather than empty: an empty one is still a string to
+            // translate, it lands in the catalogue as a blank key, and VoiceOver reads the
+            // control as unnamed.
+            Picker("How to sign in", selection: $usePairingCode) {
                 Text("Account").tag(false)
                 Text("Code").tag(true)
             }
             .pickerStyle(.segmented)
+            .labelsHidden()
 
             if usePairingCode {
                 TextField("XXXX-XXXX", text: $pairingCode)
@@ -271,11 +286,28 @@ struct ConnectView: View {
             default: return api.localizedDescription
             }
         }
+        // The wording lives here, not in NodusKit. The package has no string catalogue — a
+        // literal returned from it is English on every phone — so the typed case crosses the
+        // boundary and the sentence is chosen on this side, where it can be translated.
         if let transport = error as? TransportError {
-            if case .badServerURL = transport {
-                return "That address will not work. Enter just the domain, with no path."
+            switch transport {
+            case .badServerURL:
+                return String(localized: "That address will not work. Enter just the domain, with no path.")
+            case .hostNotFound:
+                return String(localized: "No machine by that name. If the server is on a private network — Tailscale, a VPN, your own Wi-Fi — this device has to be on it too.")
+            case .cannotConnect:
+                return String(localized: "The name resolves, but nothing answered. The server may be stopped, or reachable only from the machine it runs on.")
+            case .certificateRejected:
+                return String(localized: "The certificate was refused. A Nodus Server needs one this device already trusts.")
+            case .insecureBlocked:
+                return String(localized: "iOS refuses plain HTTP to anything but this device. Use an https:// address.")
+            case .offline:
+                return String(localized: "This device has no network.")
+            case .timedOut:
+                return String(localized: "The server took too long to answer.")
+            case .cancelled, .malformedResponse, .underlying:
+                return transport.localizedDescription
             }
-            return transport.localizedDescription
         }
         return error.localizedDescription
     }
@@ -291,7 +323,7 @@ private struct SpaceRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(space.name).font(.subheadline.weight(.medium))
                 HStack(spacing: 6) {
-                    Text(roleLabel(space.role)).font(.caption2)
+                    Text(LocalizedStringKey(roleLabel(space.role))).font(.caption2)
                     if !space.hasSnapshot {
                         Text("· not published").font(.caption2).foregroundStyle(.orange)
                     }

--- a/ios/Nodus/Screens/DatabaseGridView.swift
+++ b/ios/Nodus/Screens/DatabaseGridView.swift
@@ -32,7 +32,7 @@ struct DatabaseGridView: View {
             } else if isLoading {
                 ProgressView().tint(session.accent)
             } else if let error {
-                NodusNotice(tone: .blocked, title: "Could not open", message: error).padding(16)
+                NodusNotice(tone: .blocked, title: "Could not open", message: LocalizedStringKey(error)).padding(16)
             } else {
                 ContentUnavailableView("Empty database", systemImage: "tablecells")
             }

--- a/ios/Nodus/Screens/DeepResearchScreen.swift
+++ b/ios/Nodus/Screens/DeepResearchScreen.swift
@@ -17,6 +17,11 @@ struct DeepResearchScreen: View {
     @State private var error: String?
     @State private var running: Task<Void, Never>?
     @State private var liveActivity: LiveActivityController?
+    /// A run that stopped before its last section. Kept so the sections already paid for are
+    /// not thrown away by a screen that was dismissed or a phone that ran out of patience.
+    @State private var unfinished: DeepResearchCheckpoint?
+    /// Set once this report has been put in the queue, so it cannot be queued twice.
+    @State private var sentReportId: String?
 
     var body: some View {
         ScrollView {
@@ -26,22 +31,63 @@ struct DeepResearchScreen: View {
                 } else if let progress {
                     progressView(progress)
                 } else {
+                    if let unfinished { resumeNotice(unfinished) }
                     form
                 }
 
                 if let error {
-                    NodusNotice(tone: .blocked, title: "The report failed", message: error)
+                    NodusNotice(tone: .blocked, title: "The report failed", message: LocalizedStringKey(error))
                 }
             }
             .padding(16)
         }
         .navigationTitle("Deep Research")
         .navigationBarTitleDisplayMode(.inline)
+        .task {
+            guard running == nil, report == nil else { return }
+            let saved = DeepResearchCheckpointStore.load(spaceId: session.connection.spaceId)
+            unfinished = (saved?.isComplete == false) ? saved : nil
+        }
         .toolbar {
             if report != nil {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("New") { report = nil; progress = nil; error = nil }
                 }
+            }
+        }
+    }
+
+    // MARK: Resuming
+
+    /// What a half-finished run looks like when you come back to it.
+    ///
+    /// The number of sections is the point: it is what the user already paid a model call each
+    /// for, and resuming spends nothing on them a second time.
+    private func resumeNotice(_ checkpoint: DeepResearchCheckpoint) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            NodusNotice(
+                tone: .info,
+                title: "An unfinished report",
+                message: "“\(checkpoint.request.objective)” stopped after \(checkpoint.sections.count) of \(checkpoint.titles.count) sections. Carrying on writes only the ones that are missing.",
+                systemImage: "hourglass"
+            )
+            HStack {
+                Button {
+                    resume(checkpoint)
+                } label: {
+                    Label("Carry on", systemImage: "play")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(NodusPrimaryButtonStyle(accent: session.accent))
+                .disabled(ai.model(for: .deepResearch) == nil)
+
+                Button(role: .destructive) {
+                    DeepResearchCheckpointStore.clear(spaceId: session.connection.spaceId)
+                    unfinished = nil
+                } label: {
+                    Label("Discard", systemImage: "trash")
+                }
+                .font(.caption)
             }
         }
     }
@@ -92,7 +138,7 @@ struct DeepResearchScreen: View {
             // is pressed is the difference between a cost and a surprise.
             NodusNotice(
                 tone: .info,
-                title: costEstimate,
+                title: LocalizedStringKey(costEstimate),
                 message: "Each section is one model call. You can cancel at any point and keep what was written up to then.",
                 systemImage: "hourglass"
             )
@@ -192,7 +238,7 @@ struct DeepResearchScreen: View {
                 }
 
                 if let stopped = report.stoppedReason {
-                    NodusNotice(tone: .caution, title: "The report is incomplete", message: stopped)
+                    NodusNotice(tone: .caution, title: "The report is incomplete", message: LocalizedStringKey(stopped))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -225,6 +271,28 @@ struct DeepResearchScreen: View {
                 .nodusGlass(NodusGlass(.thin, tint: session.accent))
             }
 
+            // Two different acts, kept apart. Sharing takes a copy off the phone; sending puts
+            // it in the ledger, where it becomes part of the vault the next time its owner
+            // republishes — which is a change to somebody's corpus, not an export.
+            if session.connection.role.canSendChanges {
+                Button {
+                    Task { await send(report) }
+                } label: {
+                    Label(sentReportId == nil ? "Send to the vault" : "Sent — waiting for the owner",
+                          systemImage: sentReportId == nil ? "arrow.up.doc" : "checkmark.circle")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(NodusPrimaryButtonStyle(accent: session.accent))
+                .disabled(sentReportId != nil)
+
+                Text(sentReportId == nil
+                     ? "It is queued on this device and travels when you send the queue. It joins the vault when its owner next opens Nodus desktop and republishes."
+                     : "Queued. Open Notes and queue to send it.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             ShareLink(item: report.markdown) {
                 Label("Share as Markdown", systemImage: "square.and.arrow.up")
                     .frame(maxWidth: .infinity)
@@ -233,15 +301,44 @@ struct DeepResearchScreen: View {
         }
     }
 
+    /// Put the finished report in the queue, with the citations it really used.
+    private func send(_ report: DeepResearchReport) async {
+        guard let controller = OutboxController(session: session), let model = ai.model(for: .deepResearch) else { return }
+        await controller.queueReport(
+            report,
+            mode: mode ?? defaultMode,
+            model: model,
+            language: Prompts.interfaceLanguage
+        )
+        sentReportId = report.objective
+    }
+
     // MARK: Run
 
-    private func start() {
+    /// Pick up a run that stopped, on its own terms rather than on the form's.
+    ///
+    /// The checkpoint carries the request it was started with, so the objective, mode and
+    /// length come from there — using whatever happens to be in the fields would resume a
+    /// half-written report into a different question.
+    private func resume(_ checkpoint: DeepResearchCheckpoint) {
+        objective = checkpoint.request.objective
+        length = checkpoint.request.targetLength
+        mode = checkpoint.request.mode
+        start(from: checkpoint)
+    }
+
+    private func start(from checkpoint: DeepResearchCheckpoint? = nil) {
         guard let model = ai.model(for: .deepResearch) else { return }
         error = nil
         report = nil
-        progress = DeepResearchProgress(phase: .queued, message: "Queued", wordsSoFar: 0)
+        unfinished = nil
+        progress = DeepResearchProgress(
+            phase: .queued,
+            message: checkpoint == nil ? "Queued" : "Resuming",
+            wordsSoFar: checkpoint?.words ?? 0
+        )
 
-        let request = DeepResearchRequest(
+        let request = checkpoint?.request ?? DeepResearchRequest(
             objective: objective.trimmingCharacters(in: .whitespacesAndNewlines),
             language: Prompts.interfaceLanguage,
             targetLength: length,
@@ -272,37 +369,57 @@ struct DeepResearchScreen: View {
         activity.start()
         liveActivity = activity
 
+        let spaceId = session.connection.spaceId
+
         running = Task {
             do {
-                let finished = try await orchestrator.run(request) { update in
-                    Task { @MainActor in
-                        progress = update
-                        activity.update(
-                            phase: update.phase.rawValue,
-                            detail: update.sectionTitle ?? update.message,
-                            fraction: update.fraction,
-                            step: update.sectionIndex.map { $0 + 1 },
-                            stepCount: update.sectionTotal
-                        )
+                let finished = try await orchestrator.run(
+                    request,
+                    resuming: checkpoint,
+                    // Written after every section, on whichever thread finished it. This is the
+                    // persisted state Info.plist has always claimed a run resumes from, and the
+                    // difference between an interrupted run and a wasted one.
+                    onCheckpoint: { reached in
+                        DeepResearchCheckpointStore.save(reached, spaceId: spaceId)
+                    },
+                    // Labelled, not trailing: `run` takes two closures now, and an unlabelled
+                    // one binds to the checkpoint hook.
+                    onProgress: { update in
+                        Task { @MainActor in
+                            progress = update
+                            activity.update(
+                                phase: update.phase.rawValue,
+                                detail: update.sectionTitle ?? update.message,
+                                fraction: update.fraction,
+                                step: update.sectionIndex.map { $0 + 1 },
+                                stepCount: update.sectionTotal
+                            )
+                        }
                     }
-                }
+                )
                 report = finished
                 progress = nil
                 // Saved before anything else can go wrong. A run is one model call per section
                 // and losing it to a dismissed screen means paying for it twice.
-                local.save(finished, mode: request.mode, model: model.model)
+                local.save(finished, mode: request.mode, model: request.model.model)
+                DeepResearchCheckpointStore.clear(spaceId: spaceId)
                 activity.finish()
             } catch is CancellationError {
                 progress = nil
                 error = "Cancelled."
-                activity.finish(failure: "Cancelado")
+                // Deliberately kept: cancelling stops the spending, it does not throw away the
+                // sections already written. The screen offers to carry on from here.
+                unfinished = DeepResearchCheckpointStore.load(spaceId: spaceId)
+                activity.finish(failure: "Cancelled")
             } catch DeepResearchError.emptyCorpus {
                 progress = nil
                 error = "Nothing citable was found for that objective in this space."
-                activity.finish(failure: "Sin material citable")
+                DeepResearchCheckpointStore.clear(spaceId: spaceId)
+                activity.finish(failure: "No citable material")
             } catch {
                 progress = nil
                 self.error = error.localizedDescription
+                unfinished = DeepResearchCheckpointStore.load(spaceId: spaceId).flatMap { $0.isComplete ? nil : $0 }
                 activity.finish(failure: error.localizedDescription)
             }
             liveActivity = nil

--- a/ios/Nodus/Screens/FamilyTreeView.swift
+++ b/ios/Nodus/Screens/FamilyTreeView.swift
@@ -32,7 +32,7 @@ struct FamilyTreeView: View {
         ScrollView {
             VStack(spacing: 18) {
                 if let error {
-                    NodusNotice(tone: .blocked, title: "Could not build the tree", message: error)
+                    NodusNotice(tone: .blocked, title: "Could not build the tree", message: LocalizedStringKey(error))
                 }
 
                 if isLoading, focus == nil {

--- a/ios/Nodus/Screens/HomeView.swift
+++ b/ios/Nodus/Screens/HomeView.swift
@@ -18,7 +18,7 @@ struct HomeView: View {
                         systemImage: "tray"
                     )
                 } else if let error = session.loadError {
-                    NodusNotice(tone: .blocked, title: "Could not read the space", message: error)
+                    NodusNotice(tone: .blocked, title: "Could not read the space", message: LocalizedStringKey(error))
                 }
 
                 if session.connection.role == .reader {
@@ -71,22 +71,23 @@ struct HomeView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
+                // In the same grid as everything else, even alone. A single `NavigationLink`
+                // outside a `LazyVGrid` stretches to the full width, and a lone stretched tile
+                // among rows of square ones reads as a different kind of thing rather than as
+                // the one item in its section.
                 if session.connection.role.canSendChanges {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("Write").font(.subheadline.weight(.semibold))
+                    tileSection("Write") {
                         NavigationLink {
                             WritingView(session: session)
                         } label: {
-                            SectionTile(title: LocalizedStringKey("Notes and queue"), icon: "square.and.pencil", count: nil, accent: session.accent)
+                            SectionTile(title: "Notes and queue", icon: "square.and.pencil", count: nil, accent: session.accent)
                         }
                         .buttonStyle(.plain)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 if !session.mirrorOnlyTables.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("More from this space").font(.subheadline.weight(.semibold))
+                    tileSection("More from this space") {
                         NavigationLink {
                             MirrorOnlySectionsView(session: session)
                         } label: {
@@ -99,28 +100,31 @@ struct HomeView: View {
                         }
                         .buttonStyle(.plain)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 if session.hasDebates || session.hasNotes || session.hasDeepResearch || session.hasImmersion {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("Analyse").font(.subheadline.weight(.semibold))
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
-                            if session.hasDebates {
-                                specialTile(.debates, "Debates", "bubble.left.and.bubble.right")
+                    tileSection("Analyse") {
+                        if session.hasDebates {
+                            specialTile(.debates, "Debates", "bubble.left.and.bubble.right")
+                            // The same edges the debates come from, read as one argument
+                            // instead of as a list of disagreements.
+                            NavigationLink {
+                                ArgumentMapView(session: session)
+                            } label: {
+                                SectionTile(title: "Argument map", icon: "arrow.triangle.branch", count: nil, accent: session.accent)
                             }
-                            if session.hasDeepResearch {
-                                specialTile(.deepResearch, "Deep Research", "doc.text.magnifyingglass")
-                            }
-                            if session.hasImmersion {
-                                specialTile(.immersion, "Immersion", "waveform")
-                            }
-                            if session.hasNotes {
-                                specialTile(.notes, "Notes", "note.text")
-                            }
+                            .buttonStyle(.plain)
+                        }
+                        if session.hasDeepResearch {
+                            specialTile(.deepResearch, "Deep Research", "doc.text.magnifyingglass")
+                        }
+                        if session.hasImmersion {
+                            specialTile(.immersion, "Immersion", "waveform")
+                        }
+                        if session.hasNotes {
+                            specialTile(.notes, "Notes", "note.text")
                         }
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 if session.isPublished, session.sections.isEmpty, session.loadError == nil, !session.isLoading {
@@ -137,18 +141,42 @@ struct HomeView: View {
         .refreshable { await session.load() }
     }
 
+    /// A headed section whose contents sit in the one grid this screen uses.
+    ///
+    /// Every tile on Home is the same size — that is what makes the screen read as one board
+    /// rather than as several lists — so the grid is defined once and every section goes
+    /// through it, including the ones that hold a single tile.
+    @ViewBuilder
+    private func tileSection<Content: View>(
+        _ title: LocalizedStringKey,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title).font(.subheadline.weight(.semibold))
+            LazyVGrid(columns: Self.tileColumns, spacing: 12) {
+                content()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private static let tileColumns = [GridItem(.adaptive(minimum: 150), spacing: 12)]
+
     struct VaultTool {
         let title: String
         let icon: String
         let destination: () -> AnyView
     }
 
-    private var toolsHeading: String {
+    /// A `LocalizedStringKey`, not a `String`. `Text(someString)` does not localise — only a
+    /// literal does — so a computed heading returned as a plain `String` would show the same
+    /// words on every phone regardless of its language, which is exactly what these four did.
+    private var toolsHeading: LocalizedStringKey {
         switch session.vaultType {
-        case .genealogy, .prosopography: return "Parentesco"
-        case .estudio: return "Estudiar"
-        case .docencia: return "Docencia"
-        default: return "Herramientas"
+        case .genealogy, .prosopography: return "Kinship"
+        case .estudio: return "Study"
+        case .docencia: return "Teaching"
+        default: return "Tools"
         }
     }
 

--- a/ios/Nodus/Screens/ImmersionView.swift
+++ b/ios/Nodus/Screens/ImmersionView.swift
@@ -1,0 +1,506 @@
+import NodusKit
+import NodusUI
+import SwiftUI
+
+/// An immersion session, read as the study route it is.
+///
+/// The published plan is a whole itinerary — an overview, stations with prose and quizzes,
+/// a contrast table of who argues what, the open frontiers of the corpus, and a final exam.
+/// Until now the app opened it through the generic row viewer, which showed the plan as one
+/// enormous JSON column: technically the data, and unreadable.
+///
+/// `progress_json` is deliberately never published (`server/lib/routes/corpus.mjs`), so this
+/// screen reads a route rather than resuming one. Answers tapped here stay on the phone.
+struct ImmersionView: View {
+    let session: SpaceSession
+    let sessionId: String
+    let title: String
+
+    @State private var plan: ImmersionPlan?
+    @State private var error: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let error {
+                    NodusNotice(tone: .blocked, title: "Could not open the session", message: LocalizedStringKey(error))
+                } else if let plan {
+                    header(plan)
+                    if !plan.overview.isEmpty {
+                        card(title: "Overview", icon: "text.alignleft") {
+                            CorpusProse(plan.overview, accent: session.accent)
+                        }
+                    }
+                    stations(plan)
+                    if !plan.keyTerms.isEmpty { keyTerms(plan) }
+                    if !plan.contrasts.isEmpty { contrasts(plan) }
+                    if !plan.frontiers.isEmpty { frontiers(plan) }
+                    if !plan.exam.isEmpty { examLink(plan) }
+                } else {
+                    ProgressView().tint(session.accent).frame(maxWidth: .infinity).padding(.top, 40)
+                }
+            }
+            .padding(16)
+        }
+        .navigationTitle("Immersion")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+    }
+
+    // MARK: Pieces
+
+    private func header(_ plan: ImmersionPlan) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(plan.title.isEmpty ? title : plan.title).font(.title3.weight(.semibold))
+            if !plan.topic.isEmpty {
+                Text(plan.topic).font(.footnote).foregroundStyle(.secondary)
+            }
+            HStack(spacing: 12) {
+                if plan.minutes > 0 { Label("\(plan.minutes) min", systemImage: "clock") }
+                Label("\(plan.stations.count)", systemImage: "flag")
+                if plan.quizCount > 0 { Label("\(plan.quizCount)", systemImage: "checklist") }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .nodusGlass(NodusGlass(.regular, tint: session.accent))
+    }
+
+    private func stations(_ plan: ImmersionPlan) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Stations").font(.subheadline.weight(.semibold))
+            ForEach(Array(plan.stations.enumerated()), id: \.element.id) { index, station in
+                NavigationLink {
+                    ImmersionStationView(station: station, number: index + 1, accent: session.accent)
+                } label: {
+                    HStack(alignment: .top, spacing: 11) {
+                        Text("\(index + 1)")
+                            .font(.caption.weight(.bold).monospacedDigit())
+                            .frame(width: 24, height: 24)
+                            .background(session.accent.opacity(0.18), in: Circle())
+                            .foregroundStyle(session.accent)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(station.title).font(.subheadline.weight(.medium))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            if !station.question.isEmpty {
+                                Text(station.question).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+                            }
+                            HStack(spacing: 10) {
+                                if station.minutes > 0 { Label("\(station.minutes) min", systemImage: "clock") }
+                                if !station.quiz.isEmpty { Label("\(station.quiz.count)", systemImage: "checklist") }
+                                if !station.citations.isEmpty { Label("\(station.citations.count)", systemImage: "text.quote") }
+                            }
+                            .font(.caption2).foregroundStyle(.tertiary)
+                        }
+                        Image(systemName: "chevron.right").font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    .padding(13)
+                    .nodusGlass(NodusGlass(.thin, tint: session.accent, interactive: true))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func keyTerms(_ plan: ImmersionPlan) -> some View {
+        card(title: "Key terms", icon: "character.book.closed") {
+            VStack(alignment: .leading, spacing: 9) {
+                ForEach(plan.keyTerms, id: \.term) { term in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(term.term).font(.caption.weight(.semibold))
+                        Text(term.definition).font(.caption).foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    /// Who argues what, station by station.
+    ///
+    /// The desktop draws this as a matrix of authors × stations. A phone has no room for a
+    /// table that wide, so the same cells are read down instead of across — by station, then by
+    /// author — which loses the side-by-side glance and keeps every position intact.
+    private func contrasts(_ plan: ImmersionPlan) -> some View {
+        card(title: "Positions in contrast", icon: "person.2") {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(plan.contrasts, id: \.stationId) { row in
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(row.question).font(.caption.weight(.semibold))
+                        ForEach(Array(row.cells.enumerated()), id: \.offset) { _, cell in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(cell.author).font(.caption2.weight(.medium)).foregroundStyle(session.accent)
+                                Text(cell.stance).font(.caption2).foregroundStyle(.secondary)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private func frontiers(_ plan: ImmersionPlan) -> some View {
+        card(title: "Open frontiers", icon: "questionmark.diamond") {
+            VStack(alignment: .leading, spacing: 9) {
+                ForEach(Array(plan.frontiers.enumerated()), id: \.offset) { _, frontier in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(frontier.statement).font(.caption)
+                        if let detail = frontier.detail, !detail.isEmpty {
+                            Text(detail).font(.caption2).foregroundStyle(.tertiary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private func examLink(_ plan: ImmersionPlan) -> some View {
+        NavigationLink {
+            ImmersionQuizView(
+                title: String(localized: "Final exam"),
+                questions: plan.exam,
+                feynman: plan.feynman,
+                accent: session.accent
+            )
+        } label: {
+            HStack {
+                Label("Final exam", systemImage: "graduationcap")
+                Spacer()
+                Text("\(plan.exam.count)").font(.caption).foregroundStyle(.secondary)
+                Image(systemName: "chevron.right").font(.caption2).foregroundStyle(.tertiary)
+            }
+            .padding(15)
+            .nodusGlass(NodusGlass(.regular, tint: session.accent, interactive: true))
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func card<Content: View>(title: LocalizedStringKey, icon: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Label(title, systemImage: icon)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(session.accent)
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .nodusGlass(NodusGlass(.thin, tint: session.accent))
+    }
+
+    private func load() async {
+        guard plan == nil else { return }
+        do {
+            let detail = try await session.client.immersionSession(sessionId, in: session.connection.spaceId)
+            plan = ImmersionPlan(detail)
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - One station
+
+private struct ImmersionStationView: View {
+    let station: ImmersionPlan.Station
+    let number: Int
+    let accent: Color
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Station \(number)").font(.caption).foregroundStyle(accent)
+                    Text(station.title).font(.title3.weight(.semibold))
+                    if !station.question.isEmpty {
+                        Text(station.question).font(.footnote).foregroundStyle(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .nodusGlass(NodusGlass(.regular, tint: accent))
+
+                if !station.context.isEmpty {
+                    block("Why this matters", "map") { CorpusProse(station.context, accent: accent) }
+                }
+                if !station.synthesis.isEmpty {
+                    block("Synthesis", "text.alignleft") { CorpusProse(station.synthesis, accent: accent) }
+                }
+                if !station.takeaways.isEmpty {
+                    block("What to take away", "checkmark.circle") {
+                        VStack(alignment: .leading, spacing: 7) {
+                            ForEach(Array(station.takeaways.enumerated()), id: \.offset) { _, line in
+                                HStack(alignment: .top, spacing: 7) {
+                                    Image(systemName: "circle.fill").font(.system(size: 5)).foregroundStyle(accent)
+                                        .padding(.top, 6)
+                                    Text(line).font(.callout)
+                                }
+                            }
+                        }
+                    }
+                }
+                if !station.positions.isEmpty {
+                    block("Who argues what", "person.2") {
+                        VStack(alignment: .leading, spacing: 9) {
+                            ForEach(Array(station.positions.enumerated()), id: \.offset) { _, position in
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(position.name).font(.caption.weight(.semibold)).foregroundStyle(accent)
+                                    Text(position.position).font(.caption).foregroundStyle(.secondary)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                    }
+                }
+                if !station.citations.isEmpty {
+                    block("Sources", "text.quote") {
+                        VStack(alignment: .leading, spacing: 11) {
+                            ForEach(Array(station.citations.enumerated()), id: \.offset) { _, citation in
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(citation.reference).font(.caption2.weight(.medium)).foregroundStyle(accent)
+                                    if !citation.text.isEmpty {
+                                        Text("“\(citation.text)”")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .textSelection(.enabled)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                    }
+                }
+                if !station.quiz.isEmpty {
+                    NavigationLink {
+                        ImmersionQuizView(title: String(localized: "Check yourself"), questions: station.quiz, feynman: nil, accent: accent)
+                    } label: {
+                        HStack {
+                            Label("Check yourself", systemImage: "checklist")
+                            Spacer()
+                            Text("\(station.quiz.count)").font(.caption).foregroundStyle(.secondary)
+                            Image(systemName: "chevron.right").font(.caption2).foregroundStyle(.tertiary)
+                        }
+                        .padding(15)
+                        .nodusGlass(NodusGlass(.regular, tint: accent, interactive: true))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(16)
+        }
+        .navigationTitle(station.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func block<Content: View>(_ title: LocalizedStringKey, _ icon: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Label(title, systemImage: icon).font(.subheadline.weight(.semibold)).foregroundStyle(accent)
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .nodusGlass(NodusGlass(.thin, tint: accent))
+    }
+}
+
+// MARK: - Quiz
+
+/// Questions, answered on the phone and nowhere else.
+///
+/// Nothing here is sent anywhere: `progress_json` is not published, so a session cannot be
+/// resumed from a phone and pretending otherwise would be the dishonest part.
+private struct ImmersionQuizView: View {
+    let title: String
+    let questions: [ImmersionPlan.Question]
+    let feynman: String?
+    let accent: Color
+
+    @State private var chosen: [String: Int] = [:]
+    @State private var revealed: Set<String> = []
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                if let feynman, !feynman.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Label("Explain it out loud", systemImage: "quote.bubble")
+                            .font(.subheadline.weight(.semibold)).foregroundStyle(accent)
+                        Text(feynman).font(.callout)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+                    .nodusGlass(NodusGlass(.regular, tint: accent))
+                }
+
+                ForEach(Array(questions.enumerated()), id: \.element.id) { index, question in
+                    questionCard(question, number: index + 1)
+                }
+
+                Text("Answers stay on this device. An immersion session's progress is never published, so nothing here travels back to the vault.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(16)
+        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func questionCard(_ question: ImmersionPlan.Question, number: Int) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("\(number). \(question.question)").font(.callout.weight(.medium))
+
+            if question.isChoice {
+                ForEach(Array(question.options.enumerated()), id: \.offset) { index, option in
+                    Button {
+                        chosen[question.id] = index
+                        revealed.insert(question.id)
+                    } label: {
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: mark(question, index))
+                                .foregroundStyle(tint(question, index))
+                            Text(option).font(.caption).frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(9)
+                        .background(tint(question, index).opacity(revealed.contains(question.id) ? 0.12 : 0.04),
+                                    in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                }
+            } else {
+                Button {
+                    if revealed.contains(question.id) { revealed.remove(question.id) } else { revealed.insert(question.id) }
+                } label: {
+                    Label(revealed.contains(question.id) ? "Hide the answer" : "Show the answer",
+                          systemImage: revealed.contains(question.id) ? "eye.slash" : "eye")
+                        .font(.caption)
+                }
+                .buttonStyle(NodusGlassButtonStyle(accent: accent))
+
+                if revealed.contains(question.id), !question.expected.isEmpty {
+                    Text(question.expected).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+
+            if revealed.contains(question.id), !question.explanation.isEmpty {
+                Text(question.explanation)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(15)
+        .nodusGlass(NodusGlass(.thin, tint: accent))
+    }
+
+    private func mark(_ question: ImmersionPlan.Question, _ index: Int) -> String {
+        guard revealed.contains(question.id) else { return "circle" }
+        if index == question.correctIndex { return "checkmark.circle.fill" }
+        return chosen[question.id] == index ? "xmark.circle.fill" : "circle"
+    }
+
+    private func tint(_ question: ImmersionPlan.Question, _ index: Int) -> Color {
+        guard revealed.contains(question.id) else { return .secondary }
+        if index == question.correctIndex { return .green }
+        return chosen[question.id] == index ? .red : .secondary
+    }
+}
+
+// MARK: - Prose with corpus citations
+
+/// Immersion prose is Markdown with citations in it: `[Arco Blanco (2020)](nodus://idea/g-8969)`.
+///
+/// Rendered as an `AttributedString` so the citation reads as a citation — its label, in the
+/// accent — rather than as a URL in the middle of a sentence. The links are not tappable: the
+/// station already lists its real sources with author, year and the quoted passage, and a link
+/// that looks live but goes nowhere is worse than one that never claimed to.
+struct CorpusProse: View {
+    private let text: String
+    private let accent: Color
+
+    init(_ text: String, accent: Color) {
+        self.text = text
+        self.accent = accent
+    }
+
+    private struct Block: Identifiable {
+        let id = UUID()
+        let level: Int
+        let text: String
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            ForEach(blocks) { block in
+                if block.level > 0 {
+                    Text(block.text)
+                        .font(block.level == 1 ? .headline : .subheadline.weight(.semibold))
+                        .padding(.top, 3)
+                } else {
+                    Text(attributed(block.text))
+                        .font(.callout)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Split into headings and paragraphs before parsing.
+    ///
+    /// `AttributedString(markdown:)` in inline mode leaves `###` sitting in the text, and its
+    /// full mode carries a heading as a presentation intent that `Text` then ignores — so
+    /// either way a heading arrives as literal hashes in the middle of the prose. Splitting
+    /// first is what makes a heading look like one.
+    private var blocks: [Block] {
+        var result: [Block] = []
+        var paragraph: [String] = []
+
+        func flush() {
+            let joined = paragraph.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !joined.isEmpty { result.append(Block(level: 0, text: joined)) }
+            paragraph = []
+        }
+
+        for line in text.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("#") {
+                let hashes = trimmed.prefix { $0 == "#" }.count
+                let heading = trimmed.dropFirst(hashes).trimmingCharacters(in: .whitespaces)
+                if !heading.isEmpty {
+                    flush()
+                    result.append(Block(level: min(hashes, 3), text: heading))
+                    continue
+                }
+            }
+            paragraph.append(line)
+        }
+        flush()
+        return result
+    }
+
+    private func attributed(_ source: String) -> AttributedString {
+        guard var parsed = try? AttributedString(
+            markdown: source,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        ) else {
+            return AttributedString(source)
+        }
+        // The link is stripped rather than followed. The station lists its real sources with
+        // author, year and the quoted passage; a link that looks live but goes nowhere is worse
+        // than one that never claimed to.
+        for run in parsed.runs where run.link != nil {
+            parsed[run.range].link = nil
+            parsed[run.range].foregroundColor = accent
+            parsed[run.range].font = .callout.weight(.medium)
+        }
+        return parsed
+    }
+}

--- a/ios/Nodus/Screens/LockScreen.swift
+++ b/ios/Nodus/Screens/LockScreen.swift
@@ -1,0 +1,65 @@
+import NodusKit
+import NodusUI
+import SwiftUI
+
+/// What stands between a phone somebody else is holding and the corpus on it.
+///
+/// It covers everything rather than replacing it, so the app underneath keeps its state: a
+/// Deep Research run started before the lock is still running behind this, and comes back
+/// where it was.
+struct LockScreen: View {
+    let lock: AppLock
+
+    private let accent = Color(hex: VaultType.academic.accentHex)
+
+    var body: some View {
+        ZStack {
+            NodusBackdrop(accent: accent).ignoresSafeArea()
+
+            VStack(spacing: 20) {
+                NodusMark(style: .brand).frame(width: 76, height: 76)
+
+                VStack(spacing: 6) {
+                    Text("Nodus is locked").font(.title3.weight(.semibold))
+                    Text("Your keys and the copies of your vaults on this device stay closed until you unlock them.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+
+                if let failure = lock.failure {
+                    NodusNotice(tone: .blocked, title: "Could not unlock", message: LocalizedStringKey(failure))
+                }
+
+                Button {
+                    Task { await lock.unlock() }
+                } label: {
+                    Label(lock.biometry.systemImage == "faceid" ? "Unlock with Face ID" : "Unlock", systemImage: lock.biometry.systemImage)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(NodusPrimaryButtonStyle(accent: accent))
+                .disabled(lock.isAuthenticating)
+            }
+            .padding(28)
+            .frame(maxWidth: 420)
+        }
+        // Asked for as soon as the screen appears, so the ordinary case is a glance rather than
+        // a glance and a tap.
+        .task { await lock.unlock() }
+    }
+}
+
+/// The app-switcher cover.
+///
+/// A lock that only applies once the app is reopened still shows the corpus in the multitasking
+/// snapshot iOS takes on the way out. This is what that snapshot gets instead.
+struct PrivacyCover: View {
+    private let accent = Color(hex: VaultType.academic.accentHex)
+
+    var body: some View {
+        ZStack {
+            NodusBackdrop(accent: accent).ignoresSafeArea()
+            NodusMark(style: .brand).frame(width: 76, height: 76)
+        }
+    }
+}

--- a/ios/Nodus/Screens/MirrorTableView.swift
+++ b/ios/Nodus/Screens/MirrorTableView.swift
@@ -24,7 +24,7 @@ struct MirrorTableView: View {
     var body: some View {
         List {
             if let error {
-                NodusNotice(tone: .blocked, title: "Could not read the mirror", message: error)
+                NodusNotice(tone: .blocked, title: "Could not read the mirror", message: LocalizedStringKey(error))
                     .listRowBackground(Color.clear).listRowSeparator(.hidden)
             }
             ForEach(Array(rows.enumerated()), id: \.offset) { _, row in

--- a/ios/Nodus/Screens/NoteEditor.swift
+++ b/ios/Nodus/Screens/NoteEditor.swift
@@ -1,0 +1,77 @@
+import NodusKit
+import NodusUI
+import SwiftUI
+
+/// One note being written, new or edited.
+///
+/// The same sheet serves both because they are the same act to the queue: an edit is an upsert
+/// under the id the note already has. What changes is only what the fields start with.
+struct NoteEditor: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let accent: Color
+    /// Nil for a new note.
+    let note: EditableNote?
+    let onSave: (_ title: String, _ body: String) async -> Void
+
+    @State private var title = ""
+    @State private var text = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Title") {
+                    TextField("Note title", text: $title)
+                }
+                Section("Content") {
+                    TextEditor(text: $text)
+                        .frame(minHeight: 220)
+                }
+            }
+            .navigationTitle(note == nil ? "New note" : "Edit note")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task {
+                            await onSave(title, text)
+                            dismiss()
+                        }
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty
+                        && text.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            .task {
+                guard let note else { return }
+                title = note.title
+                text = note.content
+            }
+        }
+    }
+}
+
+/// A published note, in the shape an editor needs.
+///
+/// `Row` is not `Identifiable` — it is a bag of columns and has no idea which of them is a key —
+/// so a note being edited is lifted into this rather than a sheet being handed a row it cannot
+/// identify.
+struct EditableNote: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let content: String
+    let folderId: String?
+    /// Carried so an edit does not rewrite it. A note that reports itself as newly written
+    /// every time it is touched is a note that has lost its own history.
+    let createdAt: String?
+
+    init?(_ row: Row) {
+        guard let id = row.string("id") else { return nil }
+        self.id = id
+        title = row.text("title") ?? ""
+        content = row.text("content") ?? row.text("body") ?? ""
+        folderId = row.string("folder_id")
+        createdAt = row.string("created_at")
+    }
+}

--- a/ios/Nodus/Screens/ResearchLibraryView.swift
+++ b/ios/Nodus/Screens/ResearchLibraryView.swift
@@ -35,7 +35,7 @@ struct ResearchLibraryView: View {
     var body: some View {
         List {
             if let error {
-                NodusNotice(tone: .blocked, title: "Could not load", message: error)
+                NodusNotice(tone: .blocked, title: "Could not load", message: LocalizedStringKey(error))
                     .listRowBackground(Color.clear)
             }
 
@@ -243,7 +243,7 @@ struct PublishedReportReader: View {
                 .nodusGlass(NodusGlass(.regular, tint: session.accent))
 
                 if let error {
-                    NodusNotice(tone: .blocked, title: "Could not open", message: error)
+                    NodusNotice(tone: .blocked, title: "Could not open", message: LocalizedStringKey(error))
                 }
 
                 if let sections = prose {
@@ -252,7 +252,10 @@ struct PublishedReportReader: View {
                             if let heading = section.heading {
                                 Text(heading).font(.headline)
                             }
-                            Text(section.body).font(.callout).textSelection(.enabled)
+                            // The desktop writes one Markdown document with its own headings
+                            // and `nodus://` citations in it. Rendered as plain text, both
+                            // arrived as punctuation.
+                            CorpusProse(section.body, accent: session.accent)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(16)
@@ -271,22 +274,40 @@ struct PublishedReportReader: View {
 
     private struct Prose { let heading: String?; let body: String }
 
-    /// The draft is a Writing-Workshop document: a `draft` object whose `sections` carry
-    /// `title` and `markdown`. Rendered as plain paragraphs rather than parsed as Markdown,
-    /// because a half-parsed heading reads worse than none.
+    /// The draft is a Writing-Workshop document (`shared/types.ts:5838`), and the field that
+    /// actually carries the prose is `draftMarkdown` — one document, not a list of section
+    /// bodies. `outline` beside it holds titles and purposes with no text in them, which is why
+    /// reading `outline` for prose returns a report of empty sections.
+    ///
+    /// The `sections` branch is kept because that is the shape this app's own orchestrator
+    /// produces, and a report written on the phone before it could be sent to the vault is
+    /// still on the phone. Rendered as plain paragraphs rather than parsed as Markdown, because
+    /// a half-parsed heading reads worse than none.
     private var prose: [Prose]? {
         guard let detail else { return nil }
-        let draft = detail.report.embeddedJSON("draft") ?? detail.report["draft"]
-        guard let sections = draft?.objectValue?["sections"]?.arrayValue, !sections.isEmpty else {
-            guard let body = detail.report.text("content") ?? detail.report.text("markdown") else { return nil }
-            return [Prose(heading: nil, body: body)]
+        let draft = (detail.report.embeddedJSON("draft") ?? detail.report["draft"])?.objectValue
+
+        if let sections = draft?["sections"]?.arrayValue, !sections.isEmpty {
+            let parsed = sections.compactMap { entry -> Prose? in
+                guard let object = entry.objectValue else { return nil }
+                let body = object["markdown"]?.stringValue ?? object["body"]?.stringValue ?? object["prose"]?.stringValue
+                guard let body, !body.isEmpty else { return nil }
+                return Prose(heading: object["title"]?.stringValue, body: body)
+            }
+            if !parsed.isEmpty { return parsed }
         }
-        return sections.compactMap { entry in
-            guard let object = entry.objectValue else { return nil }
-            let body = object["markdown"]?.stringValue ?? object["body"]?.stringValue ?? object["prose"]?.stringValue
-            guard let body, !body.isEmpty else { return nil }
-            return Prose(heading: object["title"]?.stringValue, body: body)
+
+        // The desktop's own drafts, and everything this app now sends to a vault.
+        //
+        // `abstract` is deliberately not shown beside it: `draftMarkdown` is the whole
+        // document and already opens with the abstract under its own heading, so rendering
+        // both printed the summary twice.
+        if let markdown = draft?["draftMarkdown"]?.stringValue, !markdown.isEmpty {
+            return [Prose(heading: nil, body: markdown)]
         }
+
+        guard let body = detail.report.text("content") ?? detail.report.text("markdown") else { return nil }
+        return [Prose(heading: nil, body: body)]
     }
 
     private func load() async {

--- a/ios/Nodus/Screens/ResearchView.swift
+++ b/ios/Nodus/Screens/ResearchView.swift
@@ -13,12 +13,21 @@ struct ResearchView: View {
 
     @State private var showingProviders = false
     @State private var store: LocalReportStore?
+    /// How many the vault itself has published, so the count beside "All reports" is the
+    /// number of reports there are rather than the number this phone happens to have written.
+    @State private var publishedReports = 0
 
     var body: some View {
         Group {
             if let store { content(store) } else { ProgressView().tint(session.accent) }
         }
-        .task { if store == nil { store = LocalReportStore(spaceId: session.connection.spaceId) } }
+        .task {
+            if store == nil { store = LocalReportStore(spaceId: session.connection.spaceId) }
+            publishedReports = (try? await session.client.deepResearchReports(
+                in: session.connection.spaceId,
+                limit: 1
+            ).total) ?? 0
+        }
     }
 
     private func content(_ local: LocalReportStore) -> some View {
@@ -31,7 +40,9 @@ struct ResearchView: View {
                     Label {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Generate a report")
-                            Text(ai.model(for: .deepResearch)?.model ?? "No model chosen")
+                            // `String(localized:)`, because the fallback is a literal reaching
+                            // `Text` as a value — the model name beside it really is data.
+                            Text(ai.model(for: .deepResearch)?.model ?? String(localized: "No model chosen"))
                                 .font(.caption).foregroundStyle(.secondary)
                                 .lineLimit(1).truncationMode(.head)
                         }
@@ -52,7 +63,9 @@ struct ResearchView: View {
                     HStack {
                         Label("All reports", systemImage: "books.vertical")
                         Spacer()
-                        Text("\(local.reports.count)")
+                        // Both origins. Counting only the ones generated here read as "this
+                        // vault has no reports" beside a vault with eighteen of them.
+                        Text("\(local.reports.count + publishedReports)")
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 }

--- a/ios/Nodus/Screens/RowDetailView.swift
+++ b/ios/Nodus/Screens/RowDetailView.swift
@@ -38,7 +38,7 @@ struct RowDetailView: View {
                 heading
 
                 if let error {
-                    NodusNotice(tone: .caution, title: "Could not expand", message: error)
+                    NodusNotice(tone: .caution, title: "Could not expand", message: LocalizedStringKey(error))
                 }
 
                 if collection?.path == "themes", theme != nil {
@@ -390,7 +390,9 @@ struct RowDetailView: View {
         }
     }
 
-    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+    /// `LocalizedStringKey`, not `String`: every call site passes a literal, and a `String`
+    /// parameter is what silently turns a translated heading back into English.
+    private func section<Content: View>(_ title: LocalizedStringKey, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title).font(.subheadline.weight(.semibold))
             content()
@@ -400,7 +402,7 @@ struct RowDetailView: View {
         }
     }
 
-    private func chips(_ values: [String], label: String) -> some View {
+    private func chips(_ values: [String], label: LocalizedStringKey) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(label).font(.caption2.weight(.medium)).foregroundStyle(.secondary)
             FlowLayout(spacing: 6) {

--- a/ios/Nodus/Screens/SearchScreen.swift
+++ b/ios/Nodus/Screens/SearchScreen.swift
@@ -1,3 +1,4 @@
+import NodusAI
 import NodusKit
 import NodusUI
 import SwiftUI
@@ -10,10 +11,12 @@ import SwiftUI
 /// semantic result is never presented as "the corpus does not discuss this", because a search
 /// that did not run tested nothing.
 struct SearchScreen: View {
+    @Environment(AISettings.self) private var ai
     let session: SpaceSession
 
     @State private var query = ""
-    @State private var hits: [LexicalSearchResults.Hit] = []
+    @State private var hits: [CorpusSearch.Hit] = []
+    @State private var mode: CorpusSearch.Mode = .lexical
     @State private var semanticWarning: String?
     @State private var isSearching = false
     @State private var error: String?
@@ -22,7 +25,7 @@ struct SearchScreen: View {
     var body: some View {
         List {
             if let error {
-                NodusNotice(tone: .blocked, title: "Search failed", message: error)
+                NodusNotice(tone: .blocked, title: "Search failed", message: LocalizedStringKey(error))
                     .listRowBackground(Color.clear).listRowSeparator(.hidden)
             }
 
@@ -30,10 +33,19 @@ struct SearchScreen: View {
                 NodusNotice(
                     tone: .caution,
                     title: "Lexical results",
-                    message: semanticWarning,
+                    message: LocalizedStringKey(semanticWarning),
                     systemImage: "magnifyingglass"
                 )
                 .listRowBackground(Color.clear).listRowSeparator(.hidden)
+            }
+
+            // Said once, at the top, and only when it is true. The distinction matters enough
+            // to state: one search ranks by meaning, the other by spelling.
+            if mode == .semantic, !hits.isEmpty {
+                Label("Ranked by meaning", systemImage: "sparkle.magnifyingglass")
+                    .font(.caption)
+                    .foregroundStyle(session.accent)
+                    .listRowBackground(Color.clear).listRowSeparator(.hidden)
             }
 
             ForEach(Array(hits.enumerated()), id: \.offset) { _, hit in
@@ -53,24 +65,69 @@ struct SearchScreen: View {
         .listStyle(.plain)
         .navigationTitle("Search")
         .navigationBarTitleDisplayMode(.inline)
-        .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always), prompt: prompt)
+        // The field is drawn here rather than with `.searchable`. This is a *root* screen of
+        // the tab bar, and the shell hides the navigation bar on those so the custom header can
+        // own the top — which took the search drawer with it and left the Search tab with
+        // nowhere to type.
+        .safeAreaInset(edge: .top) { field }
         .onChange(of: query) { _, _ in schedule() }
         .overlay {
             if query.isEmpty { idleState }
         }
     }
 
+    private var field: some View {
+        HStack(spacing: 9) {
+            Image(systemName: isSearching ? "ellipsis" : "magnifyingglass")
+                .font(.callout)
+                .foregroundStyle(session.accent)
+                .symbolEffect(.variableColor, isActive: isSearching)
+
+            TextField(prompt, text: $query)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .submitLabel(.search)
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear")
+            }
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 10)
+        .nodusGlass(NodusGlass(.regular, tint: session.accent), in: Capsule())
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+
+    /// What the field promises, decided by what this device can actually do — the vault having
+    /// vectors is not enough if the key for them is not on this phone.
     private var prompt: String {
-        session.embedding.isReachableFromPhone ? "Search the corpus" : "Search (lexical)"
+        canSearchByMeaning ? String(localized: "Search the corpus") : String(localized: "Search (lexical)")
     }
 
     /// When the search really was lexical, "no results" means "no row contains this string" —
     /// not "the corpus lacks this topic". Those are different claims and the empty state makes
-    /// which one it is explicit.
+    /// which one it is explicit. It reports the search that *ran*, not the one that was hoped
+    /// for, which is why it reads `mode` rather than the vault's identity.
     private var emptyDescription: String {
-        session.embedding.isReachableFromPhone
-            ? "Nothing matched “\(query)”."
-            : "No row contains the string “\(query)”. This search is literal, not semantic: a synonym will not satisfy it."
+        mode == .semantic
+            ? String(localized: "Nothing in this corpus is close to “\(query)”.")
+            : String(localized: "No row contains the string “\(query)”. This search is literal, not semantic: a synonym will not satisfy it.")
+    }
+
+    /// Whether a query vector can be produced here at all.
+    private var canSearchByMeaning: Bool {
+        guard case .published(let identity) = session.embedding else { return false }
+        if case .success = EmbeddingService(keyProvider: ai.keyProvider).availability(for: identity) { return true }
+        return false
     }
 
     private var idleState: some View {
@@ -81,9 +138,15 @@ struct SearchScreen: View {
             Text("Search \(session.connection.spaceName)")
                 .font(.headline)
             switch session.embedding {
-            case .published(let identity) where session.embedding.isReachableFromPhone:
+            case .published(let identity) where canSearchByMeaning:
                 Text("Indexed with \(identity.model) · \(identity.dim) dimensions")
                     .font(.caption).foregroundStyle(.secondary)
+            case .published(let identity) where session.embedding.isReachableFromPhone:
+                // The one case the app could previously do nothing about: the vault's provider
+                // is reachable from a phone, and this phone simply has no key for it.
+                Text("Indexed with \(identity.provider). Add that key under Providers to search by meaning.")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center).padding(.horizontal, 40)
             case .published(let identity):
                 Text("Indexed with \(identity.provider), which a phone cannot reach. Search will be lexical.")
                     .font(.caption).foregroundStyle(.secondary)
@@ -118,36 +181,59 @@ struct SearchScreen: View {
         isSearching = true
         defer { isSearching = false }
         do {
-            let results = try await session.client.search(text, in: session.connection.spaceId, limit: 50)
+            let outcome = try await search.run(text, limit: 50)
             guard !Task.isCancelled else { return }
-            hits = results.results
-            // Phase 4 adds the query embedding; until then the app is lexical by construction
-            // and says so, rather than sending a vector it cannot compute.
-            semanticWarning = nil
+            hits = outcome.hits
+            mode = outcome.mode
+            semanticWarning = outcome.warning
             error = nil
         } catch let apiError as APIError where apiError.isNotPublished {
             hits = []; error = nil
         } catch let apiError as APIError where apiError.isRateLimited {
-            error = "Too many searches in a row. Wait \(Int(apiError.retryAfter ?? 30)) s."
+            // Two requests per semantic search, against a 30-a-minute limit. The debounce keeps
+            // an ordinary typist well under it; a held-down key does not.
+            error = String(localized: "Too many searches in a row. Wait \(Int(apiError.retryAfter ?? 30)) s.")
         } catch is CancellationError {
             // Superseded.
         } catch {
             self.error = error.localizedDescription
         }
     }
+
+    private var search: CorpusSearch {
+        CorpusSearch.live(
+            client: session.client,
+            spaceId: session.connection.spaceId,
+            embeddings: EmbeddingService(keyProvider: ai.keyProvider),
+            identity: publishedIdentity
+        )
+    }
+
+    private var publishedIdentity: EmbeddingIdentity? {
+        guard case .published(let identity) = session.embedding else { return nil }
+        return identity
+    }
 }
 
 private struct HitCell: View {
-    let hit: LexicalSearchResults.Hit
+    let hit: CorpusSearch.Hit
     let accent: Color
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
                 Image(systemName: icon).font(.caption2).foregroundStyle(accent)
-                Text(typeLabel).font(.caption2.weight(.medium)).foregroundStyle(accent)
+                Text(LocalizedStringKey(typeLabel)).font(.caption2.weight(.medium)).foregroundStyle(accent)
+                Spacer()
+                // Shown only for a semantic hit, because only a semantic hit has a distance.
+                // A lexical match either contains the string or does not.
+                if let score = hit.score {
+                    Text(score.formatted(.number.precision(.fractionLength(2))))
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                }
             }
-            Text(hit.title ?? "Untitled").font(.subheadline.weight(.medium)).lineLimit(2)
+            Text(hit.title ?? String(localized: "Untitled")).font(.subheadline.weight(.medium)).lineLimit(2)
             if let excerpt = hit.excerpt {
                 Text(excerpt).font(.caption).foregroundStyle(.secondary).lineLimit(3)
             }

--- a/ios/Nodus/Screens/SpaceSettingsView.swift
+++ b/ios/Nodus/Screens/SpaceSettingsView.swift
@@ -8,6 +8,7 @@ struct SpaceSettingsView: View {
     let session: SpaceSession
 
     @Environment(AISettings.self) private var ai
+    @Environment(AppLock.self) private var lock
     @State private var health: ServerHealth?
     @State private var capabilities: ServerCapabilities?
     @State private var diagnosticError: String?
@@ -109,6 +110,31 @@ struct SpaceSettingsView: View {
                 }
 
                 Section {
+                    Toggle(isOn: Binding(
+                        get: { lock.isEnabled },
+                        // Turning it on authenticates first, so a sensor that does not work is
+                        // discovered here rather than at the door.
+                        set: { wanted in Task { await lock.enable(wanted) } }
+                    )) {
+                        Label(lock.biometry.label, systemImage: lock.biometry.systemImage)
+                    }
+                    .disabled(!lock.biometry.isAvailable)
+                    .tint(session.accent)
+
+                    if let failure = lock.failure {
+                        Text(failure).font(.caption).foregroundStyle(.red)
+                    }
+                } header: {
+                    Text("This device")
+                } footer: {
+                    if lock.biometry.isAvailable {
+                        Text("Nodus asks again every time it comes back to the screen. Your keys and any offline copy are already unreadable while the phone is locked; this covers a phone that is unlocked and not in your hands.")
+                    } else {
+                        Text("This device has no passcode set, so there is nothing to lock with.")
+                    }
+                }
+
+                Section {
                     switch session.mirrorProgress {
                     case .absent:
                         Button {
@@ -199,15 +225,24 @@ struct SpaceSettingsView: View {
         return nil
     }
 
+    /// `String(localized:)`: this is the *value* half of a settings row, so it is rendered as
+    /// data — but unlike a model name or a revision hash it is a word this app chose, and a
+    /// word this app chose is a word it should translate.
     private var roleLabel: String {
         switch session.connection.role {
-        case .reader: return "Read only"
-        case .writer: return "Can send changes"
-        case .owner: return "Owner"
+        case .reader: return String(localized: "Read only")
+        case .writer: return String(localized: "Can send changes")
+        case .owner: return String(localized: "Owner")
         }
     }
 
-    private func labelled(_ title: String, _ value: String) -> some View {
+    /// The row label is a `LocalizedStringKey`; the value is not.
+    ///
+    /// Taking a `String` for the label was enough to leave this whole screen in English on a
+    /// Spanish phone: `Text(aString)` renders the string, and only `Text("a literal")` — or a
+    /// `LocalizedStringKey` — is looked up. The value stays a `String` on purpose: it is data
+    /// from the server, and translating a model name or a revision hash would be a lie.
+    private func labelled(_ title: LocalizedStringKey, _ value: String) -> some View {
         HStack {
             Text(title)
             Spacer()

--- a/ios/Nodus/Screens/SpaceShell.swift
+++ b/ios/Nodus/Screens/SpaceShell.swift
@@ -202,7 +202,9 @@ struct SpaceShell: View {
     }
 
     private var subtitle: String? {
-        if !session.isPublished { return "Sin publicar" }
+        // `String(localized:)` rather than a bare literal: this is a computed value handed to a
+        // header that renders it as data, and a literal would ship in one language only.
+        if !session.isPublished { return String(localized: "Not published") }
         guard let overview = session.overview else { return nil }
         let rows = overview.counts.values.reduce(0, +)
         guard rows > 0 else { return nil }

--- a/ios/Nodus/Screens/StudyViews.swift
+++ b/ios/Nodus/Screens/StudyViews.swift
@@ -156,7 +156,7 @@ struct FlashcardsView: View {
             if isLoading {
                 ProgressView().tint(session.accent)
             } else if let error {
-                NodusNotice(tone: .blocked, title: "Could not load", message: error)
+                NodusNotice(tone: .blocked, title: "Could not load", message: LocalizedStringKey(error))
             } else if cards.isEmpty {
                 ContentUnavailableView("No flashcards", systemImage: "rectangle.on.rectangle")
             } else {

--- a/ios/Nodus/Screens/WritingView.swift
+++ b/ios/Nodus/Screens/WritingView.swift
@@ -37,7 +37,7 @@ struct WritingView: View {
             }
         }
         .sheet(isPresented: $composing) {
-            NoteComposer(accent: session.accent) { title, body in
+            NoteEditor(accent: session.accent, note: nil) { title, body in
                 await controller?.queueNote(title: title, body: body, folderId: nil)
             }
         }
@@ -69,7 +69,7 @@ struct WritingView: View {
             }
 
             if let error = controller.lastError {
-                Section { NodusNotice(tone: .blocked, title: "Could not send", message: error) }
+                Section { NodusNotice(tone: .blocked, title: "Could not send", message: LocalizedStringKey(error)) }
             }
 
             if controller.items.isEmpty {
@@ -125,7 +125,9 @@ struct WritingView: View {
     }
 
     private func stateBadge(_ state: MutationOutbox.State) -> some View {
-        let (label, colour): (String, Color) = switch state {
+        // `LocalizedStringKey`: a computed `String` here reached `Text` as data and shipped the
+        // three most-read words on this screen in English on every phone.
+        let (label, colour): (LocalizedStringKey, Color) = switch state {
         case .pending: ("Not sent", .orange)
         case .accepted: ("On the server", session.accent)
         case .rejected: ("Rejected", .red)
@@ -137,54 +139,18 @@ struct WritingView: View {
             .background(colour.opacity(0.15), in: Capsule())
     }
 
+    /// `String(localized:)` rather than a bare literal: the result is handed to `Text` as a
+    /// value, and a value is never looked up in the catalogue.
     private func caption(for item: MutationOutbox.Item) -> String {
         if let detail = item.detail { return detail }
         switch item.state {
         case .pending:
-            return "Saved on this device."
+            return String(localized: "Saved on this device.")
         case .accepted:
             // The important sentence on this screen.
-            return "Waiting for the owner to republish."
+            return String(localized: "Waiting for the owner to republish.")
         case .rejected:
-            return "The server rejected it."
-        }
-    }
-}
-
-private struct NoteComposer: View {
-    @Environment(\.dismiss) private var dismiss
-    let accent: Color
-    let onSave: (String, String) async -> Void
-
-    @State private var title = ""
-    @State private var text = ""
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section("Title") {
-                    TextField("Note title", text: $title)
-                }
-                Section("Content") {
-                    TextEditor(text: $text)
-                        .frame(minHeight: 220)
-                }
-            }
-            .navigationTitle("New note")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        Task {
-                            await onSave(title, text)
-                            dismiss()
-                        }
-                    }
-                    .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty
-                        && text.trimmingCharacters(in: .whitespaces).isEmpty)
-                }
-            }
+            return String(localized: "The server rejected it.")
         }
     }
 }

--- a/ios/Nodus/State/AppLock.swift
+++ b/ios/Nodus/State/AppLock.swift
@@ -1,0 +1,214 @@
+import Foundation
+import LocalAuthentication
+import Observation
+import os
+import SwiftUI
+
+/// Face ID over the app, because Info.plist has always said there was one.
+///
+/// What it protects is what the app actually holds: provider API keys, device tokens for every
+/// space, and — when a mirror has been downloaded — a whole corpus sitting on the device. All
+/// of that is already `WhenUnlockedThisDeviceOnly` in the Keychain, so a locked phone gives
+/// nothing up. This closes the other case: a phone that is unlocked and out of its owner's
+/// hands.
+///
+/// Deliberately *not* done: putting `kSecAccessControl` biometry on the Keychain items
+/// themselves. That would prompt for a face on every single provider call, and would make the
+/// background tasks — a Deep Research run resuming, a queued note finishing its journey —
+/// impossible by construction, since nobody is there to look at the phone. The gate belongs
+/// where a person is, which is in front of the app.
+///
+/// The authenticator is injected for the same reason `DeepResearchDeps` is: LocalAuthentication
+/// cannot succeed in a simulator, which has no passcode and no way to set one, so the rules
+/// around the gate would otherwise be the one part of this app that is only ever tested by
+/// hand.
+@Observable
+@MainActor
+final class AppLock {
+    /// What this device can actually offer, which decides what the setting is allowed to say.
+    enum Biometry: Equatable, Sendable {
+        case faceID
+        case touchID
+        case opticID
+        /// No enrolled biometry, but a passcode exists. The gate still works.
+        case passcodeOnly
+        /// No passcode at all. There is nothing to authenticate against.
+        case none
+
+        var label: LocalizedStringKey {
+            switch self {
+            case .faceID: return "Require Face ID"
+            case .touchID: return "Require Touch ID"
+            case .opticID: return "Require Optic ID"
+            case .passcodeOnly, .none: return "Require the device passcode"
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .faceID, .opticID: return "faceid"
+            case .touchID: return "touchid"
+            case .passcodeOnly, .none: return "lock"
+            }
+        }
+
+        var isAvailable: Bool { self != .none }
+    }
+
+    /// How an attempt ended. Cancelling is deliberately not a failure: the lock screen is still
+    /// there with its button, and shouting about it would be noise.
+    enum Outcome: Equatable, Sendable {
+        case passed
+        case cancelled
+        case failed(String)
+    }
+
+    /// The gate itself, injected.
+    struct Authenticator: Sendable {
+        var biometry: @Sendable () -> Biometry
+        var evaluate: @Sendable (_ reason: String) async -> Outcome
+    }
+
+    private static let defaultsKey = "nodus.lock.enabled.v1"
+    private static let log = Logger(subsystem: "com.drakonis96.nodus.ios", category: "lock")
+
+    /// Whether the gate is on. Never set directly from a view — `enable(_:)` is, because turning
+    /// it on has to prove it works first.
+    private(set) var isEnabled: Bool
+    private(set) var isLocked: Bool
+    private(set) var isAuthenticating = false
+    /// The last refusal, in words. Nil once the user is through.
+    private(set) var failure: String?
+
+    let biometry: Biometry
+
+    private let authenticator: Authenticator
+    private let defaults: UserDefaults
+
+    init(authenticator: Authenticator = .system, defaults: UserDefaults = .standard) {
+        self.authenticator = authenticator
+        self.defaults = defaults
+        biometry = authenticator.biometry()
+        // A device that lost its passcode since the setting was turned on must not become a
+        // device nobody can open. The stored preference is kept; the gate simply stands down.
+        let enabled = defaults.bool(forKey: Self.defaultsKey) && biometry.isAvailable
+        isEnabled = enabled
+        // A launch starts locked, or the gate would only ever apply the second time the app is
+        // opened.
+        isLocked = enabled
+    }
+
+    // MARK: - Turning it on
+
+    /// Turning the gate on has to pass through the gate.
+    ///
+    /// Otherwise a phone whose sensor is broken, or whose owner mis-taps the switch, becomes a
+    /// phone that cannot open its own corpus. Proving the authentication works before trusting
+    /// it is the difference between a lock and a lockout.
+    func enable(_ wanted: Bool) async {
+        guard wanted else {
+            // Turning it *off* never authenticates. The user is already inside — they passed
+            // the gate to get here — and asking again would only be theatre.
+            isEnabled = false
+            isLocked = false
+            failure = nil
+            defaults.set(false, forKey: Self.defaultsKey)
+            return
+        }
+        guard biometry.isAvailable else {
+            failure = String(localized: "This device has no passcode set, so there is nothing to unlock with.")
+            return
+        }
+        guard await evaluate(reason: String(localized: "Confirm it is you before locking Nodus.")) else { return }
+        isEnabled = true
+        isLocked = false
+        defaults.set(true, forKey: Self.defaultsKey)
+    }
+
+    // MARK: - Locking
+
+    /// Called as the app leaves the screen. Immediate, with no grace period: a window in which
+    /// the app reopens unlocked is a window somebody else can use.
+    func lock() {
+        guard isEnabled else { return }
+        isLocked = true
+    }
+
+    func unlock() async {
+        guard isLocked, !isAuthenticating else { return }
+        if await evaluate(reason: String(localized: "Unlock Nodus to reach your vaults and keys.")) {
+            isLocked = false
+            failure = nil
+        }
+    }
+
+    // MARK: - The gate itself
+
+    private func evaluate(reason: String) async -> Bool {
+        isAuthenticating = true
+        defer { isAuthenticating = false }
+
+        switch await authenticator.evaluate(reason) {
+        case .passed:
+            failure = nil
+            return true
+        case .cancelled:
+            failure = nil
+            return false
+        case .failed(let message):
+            Self.log.notice("authentication refused: \(message, privacy: .public)")
+            failure = message
+            return false
+        }
+    }
+}
+
+extension AppLock.Authenticator {
+    /// LocalAuthentication, asked about exactly the policy it is then made to evaluate.
+    ///
+    /// Probing with `…WithBiometrics` and evaluating with `deviceOwnerAuthentication` is how a
+    /// switch ends up offering a gate that then refuses to open: a device with a face enrolled
+    /// but no passcode answers yes to the first and no to the second, and the user finds out
+    /// only after tapping.
+    static var system: AppLock.Authenticator {
+        AppLock.Authenticator(
+            biometry: {
+                let context = LAContext()
+                var error: NSError?
+                guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else { return .none }
+                var biometricError: NSError?
+                guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &biometricError) else {
+                    // A passcode with no enrolled biometry is still a gate worth offering.
+                    return .passcodeOnly
+                }
+                switch context.biometryType {
+                case .faceID: return .faceID
+                case .touchID: return .touchID
+                case .opticID: return .opticID
+                default: return .passcodeOnly
+                }
+            },
+            evaluate: { reason in
+                let context = LAContext()
+                // `deviceOwnerAuthentication`, not `…WithBiometrics`: the passcode fallback is
+                // what keeps a failed sensor, a mask, or three bad attempts from being
+                // permanent. A gate nobody can pass is not more secure, it is broken.
+                let policy = LAPolicy.deviceOwnerAuthentication
+                var probe: NSError?
+                guard context.canEvaluatePolicy(policy, error: &probe) else {
+                    return .failed(probe?.localizedDescription
+                        ?? String(localized: "This device cannot authenticate right now."))
+                }
+                do {
+                    let passed = try await context.evaluatePolicy(policy, localizedReason: reason)
+                    return passed ? .passed : .failed(String(localized: "Not recognised."))
+                } catch let error as LAError where error.code == .userCancel || error.code == .appCancel
+                    || error.code == .systemCancel {
+                    return .cancelled
+                } catch {
+                    return .failed(error.localizedDescription)
+                }
+            }
+        )
+    }
+}

--- a/ios/Nodus/State/AppModel.swift
+++ b/ios/Nodus/State/AppModel.swift
@@ -31,12 +31,20 @@ final class AppModel {
     var isConnecting = false
 
     private let keychain = KeychainStore()
-    private let defaultsKey = "nodus.connections.v1"
+    private static let defaultsKey = "nodus.connections.v1"
     private let cacheDirectory: URL
 
     init() {
         cacheDirectory = URL.cachesDirectory.appendingPathComponent("nodus-http", isDirectory: true)
-        connections = Self.loadConnections(key: defaultsKey)
+        connections = Self.loadConnections(key: Self.defaultsKey)
+    }
+
+    /// The connections on disk, without an `AppModel` to ask.
+    ///
+    /// The background tasks run in a process that may have no window and therefore no model,
+    /// and they still need to know which spaces this device holds a token for.
+    static func storedConnections() -> [Connection] {
+        loadConnections(key: defaultsKey)
     }
 
     var hasAnyConnection: Bool { !connections.isEmpty }
@@ -50,8 +58,16 @@ final class AppModel {
     /// Step one: reach a server and ask what it supports, before asking the user for anything.
     func probe(_ input: String) async throws -> (ServerAddress, ServerCapabilities) {
         let address = try ServerAddress(validating: input)
-        let client = NodusClient(address: address, cache: ResponseCache(directory: cacheDirectory))
-        let capabilities = try await client.capabilities()
+        // `nodusProbe`, not the default session: the default waits for connectivity, and while
+        // it waits it ignores request timeouts — so an address with nothing behind it left the
+        // screen saying "looking for the server" indefinitely instead of saying there was
+        // nothing there.
+        let client = NodusClient(
+            address: address,
+            session: .nodusProbe,
+            cache: ResponseCache(directory: cacheDirectory)
+        )
+        let capabilities = try await client.capabilities(timeout: 12)
         guard capabilities.supportsAnyKnownSnapshotVersion else {
             throw TransportError.malformedResponse(
                 expected: "a snapshot format this app reads (\(SnapshotFormat.supportedVersions.sorted()))"
@@ -171,7 +187,7 @@ final class AppModel {
 
     private func persist() {
         guard let data = try? JSONEncoder().encode(connections) else { return }
-        UserDefaults.standard.set(data, forKey: defaultsKey)
+        UserDefaults.standard.set(data, forKey: Self.defaultsKey)
     }
 
     private static func loadConnections(key: String) -> [Connection] {

--- a/ios/Nodus/State/BackgroundWork.swift
+++ b/ios/Nodus/State/BackgroundWork.swift
@@ -1,0 +1,296 @@
+import BackgroundTasks
+import Foundation
+import NodusAI
+import NodusKit
+import os
+
+/// The three tasks Info.plist permits, and the only code allowed to claim them.
+///
+/// `BGTaskSchedulerPermittedIdentifiers` has listed these since the app was scaffolded, which
+/// is a promise the binary has to keep: an identifier declared and never registered is a
+/// capability the app advertises and does not have. Each one exists because something the user
+/// starts genuinely outlives the screen they started it on.
+///
+/// Registration has to finish before the app finishes launching, so it happens in
+/// `NodusApp.init()` — not in a `.task` on a view, which runs far too late and makes
+/// `BGTaskScheduler` trap.
+/// `nonisolated`: `BGTaskScheduler` calls a launch handler on a queue of its own choosing, so
+/// nothing here may assume the main actor. The work it dispatches to does.
+nonisolated enum BackgroundWork {
+    /// A run that was killed halfway carries on from its persisted checkpoint.
+    static let deepResearchIdentifier = "com.drakonis96.nodus.ios.deepresearch"
+    /// An offline copy the owner has republished under gets refreshed before the user opens it.
+    static let mirrorRefreshIdentifier = "com.drakonis96.nodus.ios.mirror-refresh"
+    /// Changes the user already pressed send on, but whose network gave out, finish travelling.
+    static let mutationFlushIdentifier = "com.drakonis96.nodus.ios.mutation-flush"
+
+    static let identifiers = [deepResearchIdentifier, mirrorRefreshIdentifier, mutationFlushIdentifier]
+
+    /// What the bundle actually permits. `identifiers` and this must be the same set, or a
+    /// `submit` fails at runtime on a device and nowhere else — which is why a test compares them.
+    static var permittedIdentifiers: [String] {
+        Bundle.main.object(forInfoDictionaryKey: "BGTaskSchedulerPermittedIdentifiers") as? [String] ?? []
+    }
+
+    private static let log = Logger(subsystem: "com.drakonis96.nodus.ios", category: "background")
+
+    // MARK: - Registration
+
+    static func registerHandlers() {
+        register(mutationFlushIdentifier) { await BackgroundJobs.flushAuthorisedMutations() }
+        register(mirrorRefreshIdentifier) { await BackgroundJobs.refreshStaleMirrors() }
+        register(deepResearchIdentifier) { await BackgroundJobs.resumeDeepResearch() }
+    }
+
+    /// `BGTask` is a class Apple never marked `Sendable`, handed to the launch handler on a
+    /// queue nobody here chooses. The only thing this app does with it is report completion
+    /// once, which `BGTaskScheduler` documents as safe from any thread — so the unchecked
+    /// conformance covers exactly one call and no shared mutable state.
+    private struct TaskHandle: @unchecked Sendable {
+        let task: BGTask
+        func complete(success: Bool) { task.setTaskCompleted(success: success) }
+    }
+
+    private static func register(_ identifier: String, work: @escaping @Sendable () async -> Bool) {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: identifier, using: nil) { task in
+            // Reschedule first. A handler that throws, expires or simply finds nothing to do
+            // still has to leave a successor behind, or the identifier goes quiet until the
+            // next time the app is opened by hand.
+            reschedule(identifier)
+
+            let handle = TaskHandle(task: task)
+            let running = Task {
+                let finished = await work()
+                handle.complete(success: finished)
+            }
+            // iOS gives no warning before it stops being generous. Cancelling lets the
+            // orchestrator's `Task.checkCancellation()` stop between sections, on a checkpoint.
+            task.expirationHandler = {
+                log.notice("\(identifier, privacy: .public) expired; cancelling")
+                running.cancel()
+            }
+        }
+    }
+
+    // MARK: - Scheduling
+
+    /// Ask for all three, each only if it would have something to do.
+    ///
+    /// Called as the app leaves the foreground. Submitting a task with no work spends the app's
+    /// budget with iOS and makes the ones that matter less likely to run.
+    @MainActor
+    static func scheduleWhatIsPending() async {
+        if await BackgroundJobs.hasAuthorisedMutations() { submitProcessing(mutationFlushIdentifier, delay: 120) }
+        if BackgroundJobs.hasMirrors() { submitProcessing(mirrorRefreshIdentifier, delay: 3600) }
+        if !DeepResearchCheckpointStore.spacesWithUnfinishedRuns().isEmpty {
+            submitProcessing(deepResearchIdentifier, delay: 60)
+        }
+    }
+
+    /// Requested from inside a handler, where asking what is left to do would cost another
+    /// round of file and database reads for no benefit: if this run does not finish the work,
+    /// the successor finds it; if it does, the successor finds nothing and costs almost nothing.
+    private static func reschedule(_ identifier: String) {
+        submitProcessing(identifier, delay: identifier == mirrorRefreshIdentifier ? 3600 : 300)
+    }
+
+    private static func submitProcessing(_ identifier: String, delay: TimeInterval) {
+        let request = BGProcessingTaskRequest(identifier: identifier)
+        // Every one of these talks to a Nodus Server; without a network they would wake up only
+        // to fail.
+        request.requiresNetworkConnectivity = true
+        // Not required: a Deep Research run the user is waiting for should not have to wait for
+        // a charger, and none of this is heavy enough to earn that condition.
+        request.requiresExternalPower = false
+        request.earliestBeginDate = Date(timeIntervalSinceNow: delay)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            // Routine, not exceptional: the simulator has no scheduler at all, and a device
+            // refuses when the app is in the foreground or over its budget.
+            log.debug("could not submit \(identifier, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    static func cancelAll() {
+        BGTaskScheduler.shared.cancelAllTaskRequests()
+    }
+}
+
+/// What each background task actually does.
+///
+/// Kept apart from the scheduling so it can be reasoned about — and, where it matters, tested —
+/// without a `BGTask` in hand. Everything here is `@MainActor` because the pieces it drives
+/// (the client, the outbox, the mirror) are actors of their own: this layer only ever awaits.
+@MainActor
+enum BackgroundJobs {
+    private static let keychain = KeychainStore()
+
+    private static var spacesDirectory: URL {
+        URL.applicationSupportDirectory.appendingPathComponent("spaces", isDirectory: true)
+    }
+
+    private static var cacheDirectory: URL {
+        URL.cachesDirectory.appendingPathComponent("nodus-http", isDirectory: true)
+    }
+
+    private static func client(for connection: AppModel.Connection) -> NodusClient? {
+        guard let token = keychain.value(for: KeychainStore.deviceTokenKey(
+            origin: connection.origin,
+            spaceId: connection.spaceId
+        )) else { return nil }
+        return NodusClient(
+            address: ServerAddress(trusted: connection.origin),
+            token: token,
+            cache: ResponseCache(directory: cacheDirectory)
+        )
+    }
+
+    // MARK: - Mutations
+
+    static func hasAuthorisedMutations() async -> Bool {
+        for connection in AppModel.storedConnections() where connection.role.canSendChanges {
+            guard let outbox = try? MutationOutbox(spaceId: connection.spaceId, directory: spacesDirectory) else { continue }
+            if let count = try? await outbox.authorisedCount(), count > 0 { return true }
+        }
+        return false
+    }
+
+    /// Finish sending what the user already pressed send on.
+    ///
+    /// Only `authorisedPending` — never `pending`. The Writing screen promises that a change
+    /// travels when the user says so, and a background task that sent unauthorised changes
+    /// would quietly turn that promise into a lie.
+    static func flushAuthorisedMutations() async -> Bool {
+        var everythingLanded = true
+        for connection in AppModel.storedConnections() where connection.role.canSendChanges {
+            if Task.isCancelled { return false }
+            guard let outbox = try? MutationOutbox(spaceId: connection.spaceId, directory: spacesDirectory) else { continue }
+            guard let batch = try? await outbox.authorisedPending(limit: 200), !batch.isEmpty else { continue }
+            // A locked phone cannot read the token. That is a reason to try again later, not a
+            // failure of the change.
+            guard let client = client(for: connection) else { everythingLanded = false; continue }
+            do {
+                let receipt = try await client.send(mutations: batch, in: connection.spaceId)
+                try await outbox.markAccepted(receipt.accepted + receipt.duplicate)
+                try await outbox.markRejected(receipt.rejected.map { (id: $0.id, reason: $0.reason) })
+            } catch {
+                everythingLanded = false
+            }
+        }
+        return everythingLanded
+    }
+
+    // MARK: - Mirror
+
+    /// Whether an offline copy exists, asked of the filesystem rather than of `MirrorStore`.
+    ///
+    /// `MirrorStore.init` creates its database, so opening one to find out whether it exists
+    /// would answer "yes" from then on for every space the user never downloaded.
+    static func hasMirror(spaceId: String) -> Bool {
+        FileManager.default.fileExists(
+            atPath: spacesDirectory
+                .appendingPathComponent(spaceId, isDirectory: true)
+                .appendingPathComponent("mirror.sqlite").path
+        )
+    }
+
+    static func hasMirrors() -> Bool {
+        AppModel.storedConnections().contains { hasMirror(spaceId: $0.spaceId) }
+    }
+
+    /// Bring offline copies back up to date, and only ones that already exist.
+    ///
+    /// Downloading a snapshot for a space whose owner never asked for an offline copy would
+    /// spend their bytes on a decision they did not make.
+    static func refreshStaleMirrors() async -> Bool {
+        var allCurrent = true
+        for connection in AppModel.storedConnections() where hasMirror(spaceId: connection.spaceId) {
+            if Task.isCancelled { return false }
+            guard let store = try? MirrorStore(spaceId: connection.spaceId, directory: spacesDirectory),
+                  (try? await store.summary()) != nil
+            else { continue }
+            guard let client = client(for: connection) else { allCurrent = false; continue }
+            do {
+                let revision = try await client.snapshotRevision(in: connection.spaceId) ?? ""
+                if try await store.isCurrent(with: revision) { continue }
+                let snapshot = try await client.snapshot(in: connection.spaceId)
+                _ = try await store.replace(with: snapshot, revision: revision.isEmpty ? (snapshot.revision ?? "") : revision)
+            } catch {
+                allCurrent = false
+            }
+        }
+        return allCurrent
+    }
+
+    // MARK: - Deep Research
+
+    /// Carry on any run that was killed halfway.
+    ///
+    /// The sections already written are kept; only the ones the run never reached are paid for
+    /// again. If the phone is locked the provider key cannot be read, and the right answer is to
+    /// come back later rather than to fail the run.
+    static func resumeDeepResearch() async -> Bool {
+        let unfinished = DeepResearchCheckpointStore.spacesWithUnfinishedRuns()
+        guard !unfinished.isEmpty else { return true }
+
+        let connections = AppModel.storedConnections()
+        let settings = AISettings()
+        var allFinished = true
+
+        for (spaceId, checkpoint) in unfinished {
+            if Task.isCancelled { return false }
+            guard let connection = connections.first(where: { $0.spaceId == spaceId }),
+                  let client = client(for: connection)
+            else { allFinished = false; continue }
+            // Presence, not value: the key itself is read inside the provider client.
+            guard settings.hasKey(for: checkpoint.request.model.provider) else { allFinished = false; continue }
+
+            let retrieval = CorpusRetrieval(
+                client: client,
+                spaceId: spaceId,
+                embeddings: EmbeddingService(keyProvider: settings.keyProvider),
+                identity: await reachableEmbedding(client: client, spaceId: spaceId, settings: settings)
+            )
+            let orchestrator = DeepResearchOrchestrator(
+                deps: DeepResearchWiring.deps(
+                    retrieval: retrieval,
+                    provider: ProviderClient(keyProvider: settings.keyProvider)
+                )
+            )
+
+            do {
+                let report = try await orchestrator.run(
+                    checkpoint.request,
+                    resuming: checkpoint,
+                    onCheckpoint: { progress in
+                        DeepResearchCheckpointStore.save(progress, spaceId: spaceId)
+                    }
+                )
+                LocalReportStore(spaceId: spaceId).save(
+                    report,
+                    mode: checkpoint.request.mode,
+                    model: checkpoint.request.model.model
+                )
+                DeepResearchCheckpointStore.clear(spaceId: spaceId)
+            } catch {
+                // The checkpoint stays exactly where it was, so the next attempt starts from the
+                // last section that was actually paid for.
+                allFinished = false
+            }
+        }
+        return allFinished
+    }
+
+    /// The vault's embedding identity, but only when this device could ever match it.
+    private static func reachableEmbedding(
+        client: NodusClient,
+        spaceId: String,
+        settings: AISettings
+    ) async -> EmbeddingIdentity? {
+        guard let identity = try? await client.publishedEmbeddingIdentity(in: spaceId) else { return nil }
+        let probe = EmbeddingProbeResult.published(identity)
+        guard probe.isReachableFromPhone else { return nil }
+        return identity
+    }
+}

--- a/ios/Nodus/State/ImmersionPlan.swift
+++ b/ios/Nodus/State/ImmersionPlan.swift
@@ -1,0 +1,175 @@
+import Foundation
+import NodusKit
+
+/// An immersion session's published plan, read out of the row the server sends.
+///
+/// The plan arrives as one JSON column (`plan`), which is why the generic row viewer showed it
+/// as a wall of text: to that screen it is a single enormous string. Everything below is that
+/// string given a shape — and only the parts the desktop actually fills, so a field that is
+/// missing reads as absent rather than as empty ceremony.
+struct ImmersionPlan {
+    let title: String
+    let topic: String
+    let minutes: Int
+    let overview: String
+    let stations: [Station]
+    let keyTerms: [Term]
+    let contrasts: [ContrastRow]
+    let frontiers: [Frontier]
+    let exam: [Question]
+    /// The prompt to explain the topic aloud, which is the point of the exam more than the
+    /// questions are.
+    let feynman: String?
+
+    var quizCount: Int { stations.reduce(exam.count) { $0 + $1.quiz.count } }
+
+    struct Station: Identifiable {
+        let id: String
+        let title: String
+        let question: String
+        let minutes: Int
+        let context: String
+        let synthesis: String
+        let takeaways: [String]
+        let positions: [Position]
+        let citations: [Citation]
+        let quiz: [Question]
+    }
+
+    struct Position {
+        let name: String
+        let position: String
+    }
+
+    struct Citation {
+        let workTitle: String
+        let authors: [String]
+        let year: Int?
+        let pageLabel: String?
+        let text: String
+
+        /// Author, year and page as one line — the way a reader cites, not the way a row stores.
+        var reference: String {
+            var parts: [String] = []
+            if !authors.isEmpty { parts.append(authors.joined(separator: "; ")) }
+            if let year { parts.append(String(year)) }
+            var line = parts.joined(separator: ", ")
+            if !workTitle.isEmpty { line = line.isEmpty ? workTitle : "\(line) · \(workTitle)" }
+            if let pageLabel, !pageLabel.isEmpty { line += ", p. \(pageLabel)" }
+            return line
+        }
+    }
+
+    struct Term {
+        let term: String
+        let definition: String
+    }
+
+    struct ContrastRow {
+        let stationId: String
+        let question: String
+        let cells: [Cell]
+
+        struct Cell {
+            let author: String
+            let stance: String
+        }
+    }
+
+    struct Frontier {
+        let statement: String
+        let detail: String?
+    }
+
+    struct Question: Identifiable {
+        let id: String
+        let kind: String
+        let question: String
+        let options: [String]
+        /// Nil for an open question, which has an `expected` answer instead of a right option.
+        let correctIndex: Int?
+        let explanation: String
+        let expected: String
+
+        var isChoice: Bool { kind == "choice" && !options.isEmpty }
+    }
+
+    init?(_ row: Row) {
+        // `plan` is a JSON column. `embeddedJSON` parses a string column; a server that ever
+        // sends it already decoded is handled by the fallback, so neither shape is a surprise.
+        guard let plan = (row.embeddedJSON("plan") ?? row["plan"])?.objectValue else { return nil }
+
+        title = plan["title"]?.stringValue ?? row.text("title") ?? ""
+        topic = plan["topic"]?.stringValue ?? row.text("topic") ?? ""
+        minutes = plan["minutes"]?.intValue ?? row.int("minutes") ?? 0
+        overview = plan["overview"]?.stringValue ?? ""
+        feynman = plan["exam"]?.objectValue?["feynman"]?.stringValue
+
+        stations = (plan["stations"]?.arrayValue ?? []).compactMap { entry -> Station? in
+            guard let station = entry.objectValue else { return nil }
+            return Station(
+                id: station["id"]?.stringValue ?? UUID().uuidString,
+                title: station["title"]?.stringValue ?? "",
+                question: station["question"]?.stringValue ?? "",
+                minutes: station["minutes"]?.intValue ?? 0,
+                context: station["context"]?.stringValue ?? "",
+                synthesis: station["synthesis"]?.stringValue ?? "",
+                takeaways: (station["takeaways"]?.arrayValue ?? []).compactMap(\.stringValue),
+                positions: (station["positions"]?.arrayValue ?? []).compactMap { value in
+                    guard let object = value.objectValue, let name = object["name"]?.stringValue else { return nil }
+                    return Position(name: name, position: object["position"]?.stringValue ?? "")
+                },
+                citations: (station["citations"]?.arrayValue ?? []).compactMap { value in
+                    guard let object = value.objectValue else { return nil }
+                    return Citation(
+                        workTitle: object["workTitle"]?.stringValue ?? "",
+                        authors: (object["authors"]?.arrayValue ?? []).compactMap(\.stringValue),
+                        year: object["year"]?.intValue,
+                        pageLabel: object["pageLabel"]?.stringValue,
+                        text: object["text"]?.stringValue ?? ""
+                    )
+                },
+                quiz: Self.questions(station["quiz"])
+            )
+        }
+
+        keyTerms = (plan["keyTerms"]?.arrayValue ?? []).compactMap { value in
+            guard let object = value.objectValue, let term = object["term"]?.stringValue else { return nil }
+            return Term(term: term, definition: object["definition"]?.stringValue ?? "")
+        }
+
+        contrasts = (plan["contrasts"]?.objectValue?["rows"]?.arrayValue ?? []).compactMap { value in
+            guard let object = value.objectValue else { return nil }
+            return ContrastRow(
+                stationId: object["stationId"]?.stringValue ?? UUID().uuidString,
+                question: object["question"]?.stringValue ?? "",
+                cells: (object["cells"]?.arrayValue ?? []).compactMap { cell in
+                    guard let entry = cell.objectValue, let author = entry["author"]?.stringValue else { return nil }
+                    return ContrastRow.Cell(author: author, stance: entry["stance"]?.stringValue ?? "")
+                }
+            )
+        }
+
+        frontiers = (plan["frontiers"]?.arrayValue ?? []).compactMap { value in
+            guard let object = value.objectValue, let statement = object["statement"]?.stringValue else { return nil }
+            return Frontier(statement: statement, detail: object["detail"]?.stringValue)
+        }
+
+        exam = Self.questions(plan["exam"]?.objectValue?["questions"])
+    }
+
+    private static func questions(_ value: JSONValue?) -> [Question] {
+        (value?.arrayValue ?? []).compactMap { entry in
+            guard let object = entry.objectValue, let text = object["question"]?.stringValue else { return nil }
+            return Question(
+                id: object["id"]?.stringValue ?? UUID().uuidString,
+                kind: object["kind"]?.stringValue ?? "open",
+                question: text,
+                options: (object["options"]?.arrayValue ?? []).compactMap(\.stringValue),
+                correctIndex: object["correctIndex"]?.intValue,
+                explanation: object["explanation"]?.stringValue ?? "",
+                expected: object["expected"]?.stringValue ?? ""
+            )
+        }
+    }
+}

--- a/ios/Nodus/State/OutboxController.swift
+++ b/ios/Nodus/State/OutboxController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NodusAI
 import NodusKit
 import Observation
 
@@ -49,14 +50,24 @@ final class OutboxController {
         rejected = counts.rejected
     }
 
-    /// Queue a note. Local only until `flush()`.
-    func queueNote(id: String = UUID().uuidString, title: String, body: String, folderId: String?) async {
+    /// Queue a note, new or edited. Local only until `flush()`.
+    ///
+    /// An edit is the same upsert under the same id, which is why `createdAt` is carried: the
+    /// desktop merges on the primary key, and rewriting `created_at` on every edit would make a
+    /// note look newly written each time it was touched.
+    func queueNote(
+        id: String = UUID().uuidString,
+        title: String,
+        body: String,
+        folderId: String?,
+        createdAt: String? = nil
+    ) async {
         let now = ISO8601DateFormatter.nodusFractional.string(from: Date())
         var row: [String: JSONValue] = [
             "id": .string(id),
             "title": .string(title),
             "content": .string(body),
-            "created_at": .string(now),
+            "created_at": .string(createdAt ?? now),
             "updated_at": .string(now),
         ]
         if let folderId { row["folder_id"] = .string(folderId) }
@@ -69,7 +80,57 @@ final class OutboxController {
             row: row,
             schemaVersion: schemaVersion
         )
-        try? await outbox.enqueue(mutation, title: title.isEmpty ? "Untitled note" : title)
+        try? await outbox.enqueue(mutation, title: title.isEmpty ? String(localized: "Untitled note") : title)
+        await refresh()
+    }
+
+    /// Queue a deletion.
+    ///
+    /// A delete carries no row — the server refuses one that does (`delete_has_row`) — and it
+    /// is a tombstone, not an erasure: the owner's desktop applies it when it next drains the
+    /// ledger, and until then the note is still in the vault everybody else reads.
+    func queueNoteDeletion(id: String, title: String) async {
+        let mutation = Mutation(
+            clientId: clientId,
+            kind: .delete,
+            table: .notes,
+            key: [id],
+            schemaVersion: schemaVersion
+        )
+        try? await outbox.enqueue(mutation, title: String(localized: "Delete “\(title)”"))
+        await refresh()
+    }
+
+    /// Queue a finished Deep Research report as a saved draft in the vault.
+    ///
+    /// Until now a report generated on the phone could only leave it as shared Markdown: the
+    /// run cost one model call per section and its result lived in a local file the desktop
+    /// never saw. This is the other half — the same document, in the row shape the Writing
+    /// Workshop stores its own drafts in, so it appears in the vault's Deep Research list after
+    /// the owner republishes.
+    func queueReport(
+        _ report: DeepResearchReport,
+        mode: DeepResearchMode,
+        model: ModelRef,
+        language: String
+    ) async {
+        let id = UUID().uuidString
+        let row = ReportDraft.row(
+            id: id,
+            report: report,
+            mode: mode,
+            model: model,
+            language: language
+        )
+        let mutation = Mutation(
+            clientId: clientId,
+            kind: .upsert,
+            table: .writingSavedDrafts,
+            key: [id],
+            row: row,
+            schemaVersion: schemaVersion
+        )
+        try? await outbox.enqueue(mutation, title: report.objective)
         await refresh()
     }
 
@@ -80,6 +141,12 @@ final class OutboxController {
         defer { isFlushing = false }
 
         do {
+            // Pressing send is the authorisation, and it is recorded before the first request
+            // rather than after the last: a flush cut off by a dead lift or an aeroplane leaves
+            // behind changes the background task is then allowed to finish. Nothing the user
+            // has not pressed send on ever travels on its own.
+            try await outbox.authorisePending()
+
             while true {
                 let batch = try await outbox.pending(limit: maxBatch)
                 guard !batch.isEmpty else { break }

--- a/ios/NodusTests/AppLockTests.swift
+++ b/ios/NodusTests/AppLockTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+@testable import Nodus
+
+/// The rules around the gate.
+///
+/// LocalAuthentication cannot succeed in a simulator — there is no passcode and no way to set
+/// one — so the system authenticator is exercised on a device by using the app. What is tested
+/// here is everything around it, and in particular the two rules that decide whether this is a
+/// lock or a lockout: turning it on must pass through it, and turning it off must not.
+@MainActor
+@Suite("App lock")
+struct AppLockTests {
+    private func defaults() -> UserDefaults {
+        let suite = "nodus.lock.tests.\(UUID().uuidString)"
+        let store = UserDefaults(suiteName: suite)!
+        store.removePersistentDomain(forName: suite)
+        return store
+    }
+
+    private func authenticator(
+        _ biometry: AppLock.Biometry = .faceID,
+        answering outcome: AppLock.Outcome = .passed,
+        attempts: Counter = Counter()
+    ) -> AppLock.Authenticator {
+        AppLock.Authenticator(
+            biometry: { biometry },
+            evaluate: { _ in
+                attempts.bump()
+                return outcome
+            }
+        )
+    }
+
+    @Test("a device with no passcode is offered nothing, and is not left locked out")
+    func noPasscodeMeansNoGate() async {
+        let store = defaults()
+        store.set(true, forKey: "nodus.lock.enabled.v1")
+
+        // The setting survived from a phone that had a passcode; this one does not.
+        let lock = AppLock(authenticator: authenticator(.none), defaults: store)
+        #expect(lock.biometry.isAvailable == false)
+        #expect(lock.isEnabled == false)
+        #expect(lock.isLocked == false, "a gate that cannot be opened must not be closed")
+    }
+
+    @Test("turning the gate on has to pass through it")
+    func enablingAuthenticatesFirst() async {
+        let store = defaults()
+        let attempts = Counter()
+        let lock = AppLock(authenticator: authenticator(answering: .passed, attempts: attempts), defaults: store)
+
+        await lock.enable(true)
+
+        #expect(attempts.count == 1)
+        #expect(lock.isEnabled)
+        #expect(lock.isLocked == false, "the user has just proved who they are")
+        #expect(store.bool(forKey: "nodus.lock.enabled.v1"))
+    }
+
+    // The failure that matters: a switch that turns itself on without checking is a switch that
+    // can lock somebody out of their own corpus with a broken sensor and one mis-tap.
+    @Test("a refused attempt leaves the gate off, and says why")
+    func refusedEnablingChangesNothing() async {
+        let store = defaults()
+        let lock = AppLock(
+            authenticator: authenticator(answering: .failed("Face not recognised.")),
+            defaults: store
+        )
+
+        await lock.enable(true)
+
+        #expect(lock.isEnabled == false)
+        #expect(lock.failure == "Face not recognised.")
+        #expect(store.bool(forKey: "nodus.lock.enabled.v1") == false)
+    }
+
+    @Test("cancelling is not a failure worth reporting")
+    func cancellingIsQuiet() async {
+        let lock = AppLock(authenticator: authenticator(answering: .cancelled), defaults: defaults())
+        await lock.enable(true)
+
+        #expect(lock.isEnabled == false)
+        #expect(lock.failure == nil)
+    }
+
+    @Test("turning the gate off never asks again")
+    func disablingDoesNotAuthenticate() async {
+        let store = defaults()
+        let attempts = Counter()
+        let lock = AppLock(authenticator: authenticator(attempts: attempts), defaults: store)
+        await lock.enable(true)
+        #expect(attempts.count == 1)
+
+        await lock.enable(false)
+
+        // The user is already inside — they passed the gate to get here. Asking again would be
+        // theatre, and a failed sensor would then be able to trap the setting in the on state.
+        #expect(attempts.count == 1)
+        #expect(lock.isEnabled == false)
+        #expect(lock.isLocked == false)
+        #expect(store.bool(forKey: "nodus.lock.enabled.v1") == false)
+    }
+
+    @Test("a launch with the gate on starts locked")
+    func launchStartsLocked() {
+        let store = defaults()
+        store.set(true, forKey: "nodus.lock.enabled.v1")
+
+        let lock = AppLock(authenticator: authenticator(), defaults: store)
+
+        #expect(lock.isEnabled)
+        #expect(lock.isLocked, "otherwise the gate only ever applies the second time the app opens")
+    }
+
+    @Test("leaving the screen locks, but only when the gate is on")
+    func lockingRespectsTheSetting() async {
+        let off = AppLock(authenticator: authenticator(), defaults: defaults())
+        off.lock()
+        #expect(off.isLocked == false)
+
+        let on = AppLock(authenticator: authenticator(), defaults: defaults())
+        await on.enable(true)
+        on.lock()
+        #expect(on.isLocked)
+    }
+
+    @Test("unlocking clears the last refusal; a refused unlock leaves the door shut")
+    func unlocking() async {
+        let store = defaults()
+        store.set(true, forKey: "nodus.lock.enabled.v1")
+
+        let refusing = AppLock(
+            authenticator: authenticator(answering: .failed("Not recognised.")),
+            defaults: store
+        )
+        await refusing.unlock()
+        #expect(refusing.isLocked)
+        #expect(refusing.failure == "Not recognised.")
+
+        let passing = AppLock(authenticator: authenticator(answering: .passed), defaults: store)
+        await passing.unlock()
+        #expect(passing.isLocked == false)
+        #expect(passing.failure == nil)
+    }
+
+    @Test("what the switch is called follows what the device has")
+    func labelsFollowHardware() {
+        #expect(AppLock.Biometry.faceID.systemImage == "faceid")
+        #expect(AppLock.Biometry.touchID.systemImage == "touchid")
+        #expect(AppLock.Biometry.passcodeOnly.systemImage == "lock")
+        #expect(AppLock.Biometry.passcodeOnly.isAvailable)
+        #expect(AppLock.Biometry.none.isAvailable == false)
+    }
+}
+
+// `nonisolated` because the whole module defaults to the main actor, and this is counted from
+// inside the authenticator closure, which is not.
+private nonisolated final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    func bump() {
+        lock.lock(); defer { lock.unlock() }
+        storage += 1
+    }
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return storage
+    }
+}

--- a/ios/NodusTests/CorpusSearchTests.swift
+++ b/ios/NodusTests/CorpusSearchTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import NodusAI
+import NodusKit
+import Testing
+@testable import Nodus
+
+// The module defaults to the main actor; these are reached from the `@Sendable` closures a
+// `CorpusSearch` is made of, so they have to live outside the suite.
+private nonisolated let identity = EmbeddingIdentity(provider: "openrouter", model: "baai/bge-m3", dim: 1024)
+
+/// Built from JSON because that is how the client builds one: the type is `Decodable` with no
+/// memberwise initialiser, which keeps a test from inventing a shape the server never sends.
+private nonisolated func lexicalHit(_ id: String, _ title: String) -> LexicalSearchResults.Hit {
+    let json = """
+    {"type":"work","id":"\(id)","title":"\(title)","excerpt":"Un extracto"}
+    """
+    return try! JSONDecoder().decode(LexicalSearchResults.Hit.self, from: Data(json.utf8))
+}
+
+private nonisolated func semanticHit(ideaId: String, label: String, score: Double) -> SemanticHit {
+    let json = """
+    {"id":"\(ideaId)","score":\(score),"row":{"global_id":"\(ideaId)","label":"\(label)","statement":"Un enunciado"}}
+    """
+    return try! JSONDecoder.nodus.decode(SemanticHit.self, from: Data(json.utf8))
+}
+
+private nonisolated func passageHit(_ id: String, score: Double) -> SemanticHit {
+    let json = """
+    {"id":"\(id)","score":\(score),"row":{"passage_id":"\(id)","text":"Un pasaje","section":"Capítulo 2"}}
+    """
+    return try! JSONDecoder.nodus.decode(SemanticHit.self, from: Data(json.utf8))
+}
+
+/// Which search runs, and what the user is told when it is not the one they wanted.
+///
+/// The behaviour that matters is not "semantic search works" — it is that the app never lets an
+/// empty lexical result stand as if it were a statement about the corpus. Every fallback here
+/// has to carry a reason.
+@Suite("Corpus search")
+struct CorpusSearchTests {
+    private func search(
+        identity: EmbeddingIdentity?,
+        availability: @escaping @Sendable (EmbeddingIdentity) -> Result<AIProvider, EmbeddingService.Unavailability> = { _ in .success(.openrouter) },
+        embed: @escaping @Sendable (String, EmbeddingIdentity) async throws -> [Float] = { _, _ in [0.1, 0.2] },
+        semantic: @escaping @Sendable (String, [Float], EmbeddingIdentity, VectorKind, Int) async throws -> SemanticSearchOutcome,
+        lexical: @escaping @Sendable (String, Int) async throws -> [LexicalSearchResults.Hit] = { _, _ in [] }
+    ) -> CorpusSearch {
+        CorpusSearch(
+            identity: identity,
+            availability: availability,
+            embed: embed,
+            semantic: semantic,
+            lexical: lexical
+        )
+    }
+
+    @Test("a vault with vectors and a key is searched by meaning")
+    func semanticWhenPossible() async throws {
+        let subject = search(
+            identity: identity,
+            semantic: { _, _, _, kind, _ in
+                .indexed(
+                    hits: kind == .ideas
+                        ? [semanticHit(ideaId: "i-1", label: "La escasez", score: 0.81)]
+                        : [],
+                    identity: identity,
+                    indexable: 2000
+                )
+            },
+            lexical: { _, _ in Issue.record("lexical must not run when the vectors answered"); return [] }
+        )
+
+        let outcome = try await subject.run("hambre")
+
+        #expect(outcome.mode == .semantic)
+        #expect(outcome.warning == nil)
+        #expect(outcome.hits.map(\.id) == ["idea/i-1"])
+        #expect(outcome.hits.first?.score == 0.81)
+    }
+
+    // The case this whole type exists for. Before it, a vault indexed with a provider the phone
+    // could reach still searched lexically, and nothing on screen told the user that adding a
+    // key would change that.
+    @Test("a reachable provider with no key falls back, and the message names the key")
+    func missingKeyIsNamed() async throws {
+        let subject = search(
+            identity: identity,
+            availability: { _ in .failure(.missingKey(.openrouter)) },
+            embed: { _, _ in Issue.record("must not try to embed without a key"); return [] },
+            semantic: { _, _, _, _, _ in Issue.record("must not reach the server"); return .notIndexed(fallback: [], warning: "") },
+            lexical: { _, _ in [lexicalHit("w-1", "Una obra")] }
+        )
+
+        let outcome = try await subject.run("hambre")
+
+        #expect(outcome.mode == .lexical)
+        #expect(outcome.hits.count == 1)
+        let warning = try #require(outcome.warning)
+        #expect(warning.contains("OpenRouter") || warning.lowercased().contains("openrouter"))
+    }
+
+    @Test("a vault indexed on the desktop falls back and says why")
+    func desktopProviderIsExplained() async throws {
+        let subject = search(
+            identity: EmbeddingIdentity(provider: "ollama", model: "nomic", dim: 768),
+            availability: { _ in .failure(.providerRunsOnDesktop("Ollama")) },
+            semantic: { _, _, _, _, _ in .notIndexed(fallback: [], warning: "") },
+            lexical: { _, _ in [lexicalHit("w-1", "Una obra")] }
+        )
+
+        let outcome = try await subject.run("hambre")
+        #expect(outcome.mode == .lexical)
+        #expect(outcome.warning?.contains("Ollama") == true)
+    }
+
+    @Test("a vault with no vectors is searched lexically, and that is not a fault")
+    func noVectorsIsQuiet() async throws {
+        let subject = search(
+            identity: nil,
+            semantic: { _, _, _, _, _ in Issue.record("there is nothing to search semantically"); return .notIndexed(fallback: [], warning: "") },
+            lexical: { _, _ in [lexicalHit("w-1", "Una obra")] }
+        )
+
+        let outcome = try await subject.run("hambre")
+        #expect(outcome.mode == .lexical)
+        #expect(outcome.warning == nil, "the idle state already explains this; a warning would be noise")
+    }
+
+    @Test("a provider that refuses the embedding leaves lexical results and the provider's own words")
+    func embeddingFailureIsReported() async throws {
+        let subject = search(
+            identity: identity,
+            embed: { _, _ in throw EmbeddingError.http(status: 401, message: "Invalid API key") },
+            semantic: { _, _, _, _, _ in Issue.record("no vector, no semantic request"); return .notIndexed(fallback: [], warning: "") },
+            lexical: { _, _ in [lexicalHit("w-1", "Una obra")] }
+        )
+
+        let outcome = try await subject.run("hambre")
+        #expect(outcome.mode == .lexical)
+        #expect(outcome.warning == "Invalid API key")
+        #expect(outcome.hits.count == 1)
+    }
+
+    // The server's own refusal is the one warning that must never be swallowed: it is the
+    // server saying the search it was asked for did not happen.
+    @Test("the server's mismatch warning survives to the screen")
+    func serverWarningSurvives() async throws {
+        let subject = search(
+            identity: identity,
+            semantic: { _, _, _, _, _ in
+                .mismatch(
+                    expected: EmbeddingIdentity(provider: "openai", model: "text-embedding-3-small", dim: 1536),
+                    received: identity,
+                    fallback: [],
+                    warning: "This vault was indexed with openai/text-embedding-3-small."
+                )
+            },
+            lexical: { _, _ in [lexicalHit("w-1", "Una obra")] }
+        )
+
+        let outcome = try await subject.run("hambre")
+        #expect(outcome.mode == .lexical)
+        #expect(outcome.warning == "This vault was indexed with openai/text-embedding-3-small.")
+    }
+
+    @Test("ideas and passages come back as one ranking, not two lists")
+    func rankingIsMerged() async throws {
+        let subject = search(
+            identity: identity,
+            semantic: { _, _, _, kind, _ in
+                switch kind {
+                case .ideas:
+                    return .indexed(hits: [
+                        semanticHit(ideaId: "i-low", label: "Lejana", score: 0.30),
+                        semanticHit(ideaId: "i-high", label: "Cercana", score: 0.95),
+                    ], identity: identity, indexable: 10)
+                case .passages:
+                    return .indexed(hits: [passageHit("p-1", score: 0.60)], identity: identity, indexable: 10)
+                }
+            }
+        )
+
+        let outcome = try await subject.run("hambre")
+        #expect(outcome.hits.map(\.id) == ["idea/i-high", "passage/p-1", "idea/i-low"])
+    }
+
+    @Test("a semantic search that returns nothing falls back rather than claiming silence")
+    func emptySemanticFallsBack() async throws {
+        let subject = search(
+            identity: identity,
+            semantic: { _, _, _, _, _ in .indexed(hits: [], identity: identity, indexable: 2000) },
+            lexical: { _, _ in [lexicalHit("w-1", "Una obra")] }
+        )
+
+        let outcome = try await subject.run("hambre")
+        #expect(outcome.mode == .lexical)
+        #expect(outcome.hits.count == 1)
+    }
+}

--- a/ios/NodusTests/LocalisationTests.swift
+++ b/ios/NodusTests/LocalisationTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Nodus
+
+/// Whether the app really speaks Spanish, asked of the built bundle rather than of the source.
+///
+/// A string catalogue with a translation in it proves nothing on its own: `Text(someString)`
+/// does not localise, only a literal does, so a computed label can be perfectly translated in
+/// the catalogue and still ship in one language. These read the compiled `es.lproj`, which is
+/// what a phone set to Spanish actually consults.
+@Suite("Localisation")
+struct LocalisationTests {
+    private var spanish: Bundle {
+        get throws {
+            let path = try #require(Bundle.main.path(forResource: "es", ofType: "lproj"),
+                                    "the app ships no Spanish bundle at all")
+            return try #require(Bundle(path: path))
+        }
+    }
+
+    private func translated(_ key: String, table: String? = nil) throws -> String {
+        let sentinel = "⟪missing⟫"
+        let value = try spanish.localizedString(forKey: key, value: sentinel, table: table)
+        #expect(value != sentinel, "“\(key)” has no Spanish translation")
+        #expect(value != key, "“\(key)” is untranslated — the Spanish is the English")
+        return value
+    }
+
+    // The four headings and the subtitle that were Spanish literals in Swift. They were right on
+    // a Spanish phone by accident and wrong on every other one.
+    @Test("the headings a view computes are translated, not hardcoded")
+    func computedHeadings() throws {
+        #expect(try translated("Kinship") == "Parentesco")
+        #expect(try translated("Study") == "Estudiar")
+        #expect(try translated("Teaching") == "Docencia")
+        #expect(try translated("Tools") == "Herramientas")
+        #expect(try translated("Not published") == "Sin publicar")
+    }
+
+    @Test("everything the lock says has Spanish")
+    func lockStrings() throws {
+        _ = try translated("Require Face ID")
+        _ = try translated("Require the device passcode")
+        _ = try translated("Nodus is locked")
+        _ = try translated("Unlock with Face ID")
+        _ = try translated("This device has no passcode set, so there is nothing to lock with.")
+    }
+
+    @Test("everything the new search and writing paths say has Spanish")
+    func searchAndWritingStrings() throws {
+        _ = try translated("Ranked by meaning")
+        _ = try translated("Indexed with %@. Add that key under Providers to search by meaning.")
+        _ = try translated("Send to the vault")
+        _ = try translated("Sent — waiting for the owner")
+        _ = try translated("Queued on this device")
+        _ = try translated("Edit note")
+    }
+
+    // These are read by iOS, not by the app, and a plist string on its own is shown verbatim in
+    // every language — which is how both of them were Spanish-only for everybody.
+    @Test("the permission prompts iOS shows are localised too")
+    func infoPlistStrings() throws {
+        let faceID = try translated("NSFaceIDUsageDescription", table: "InfoPlist")
+        #expect(faceID.contains("Face ID"))
+        #expect(faceID.contains("claves"), "the Spanish should be Spanish")
+
+        let network = try translated("NSLocalNetworkUsageDescription", table: "InfoPlist")
+        #expect(network.contains("red local"))
+    }
+
+    /// The base language is English. A Spanish literal left in the source would make the
+    /// *English* bundle Spanish, which no catalogue entry can fix.
+    @Test("the base language is English")
+    func baseIsEnglish() throws {
+        #expect(Bundle.main.developmentLocalization == "en")
+        let localisations = Set(Bundle.main.localizations)
+        #expect(localisations.contains("en"))
+        #expect(localisations.contains("es"))
+    }
+}

--- a/ios/NodusTests/ReportDraftTests.swift
+++ b/ios/NodusTests/ReportDraftTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import NodusAI
+import NodusKit
+import Testing
+@testable import Nodus
+
+/// The row a finished report becomes.
+///
+/// Every assertion here is about somebody else's reader: the server, which lists a draft only
+/// when its brief says `deep_research` and rejects any column the vault has never published;
+/// and the desktop, which opens `draft_json` expecting a `WritingWorkshopDraft`. A row that the
+/// ledger accepts and the desktop renders empty would look like success from the phone and be a
+/// lost report on the other side.
+@Suite("Report drafts")
+struct ReportDraftTests {
+    private func report(
+        objective: String = "La escasez como política",
+        sections: [DeepResearchSection] = [
+            DeepResearchSection(
+                title: "Primera",
+                prose: "Prosa con apoyo (nodus://idea/i-1) y una obra (nodus://work/w-1).",
+                citations: ["nodus://idea/i-1", "nodus://work/w-1"],
+                rejectedCitations: []
+            ),
+            DeepResearchSection(
+                title: "Segunda",
+                prose: "Más prosa (nodus://passage/p-9) y la misma idea (nodus://idea/i-1).",
+                citations: ["nodus://passage/p-9", "nodus://idea/i-1"],
+                rejectedCitations: ["nodus://work/inventada"]
+            ),
+        ],
+        citationsChecked: Int = 5,
+        citationsRejected: Int = 1,
+        stoppedReason: String? = nil
+    ) -> DeepResearchReport {
+        DeepResearchReport(
+            objective: objective,
+            sections: sections,
+            references: [CitationCatalog.Entry(token: "nodus://work/w-1", kind: "work", id: "w-1", label: "Una obra (1975)")],
+            words: 42,
+            pages: 0.1,
+            citationsChecked: citationsChecked,
+            citationsRejected: citationsRejected,
+            stoppedReason: stoppedReason
+        )
+    }
+
+    private func row(_ report: DeepResearchReport) -> [String: JSONValue] {
+        ReportDraft.row(
+            id: "draft-1",
+            report: report,
+            mode: .research,
+            model: ModelRef(provider: .anthropic, model: "claude-test"),
+            language: "es",
+            now: Date(timeIntervalSince1970: 1_760_000_000)
+        )
+    }
+
+    private func object(_ row: [String: JSONValue], _ column: String) throws -> [String: Any] {
+        let text = try #require(row[column]?.stringValue)
+        return try #require(try JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+
+    // Without this the row is stored and never listed: `corpus.mjs:26` filters the Deep
+    // Research collection on exactly this value.
+    @Test("the brief says deep_research, which is what makes the report appear at all")
+    func briefKindIsTheFilter() throws {
+        let brief = try object(row(report()), "brief_json")
+        #expect(brief["kind"] as? String == "deep_research")
+        #expect(brief["objective"] as? String == "La escasez como política")
+        #expect(brief["language"] as? String == "es")
+    }
+
+    // The server checks every column against what the vault has published, so a name this app
+    // invented comes back as `unknown_column` and the report is lost.
+    @Test("the row uses the eight columns the table was created with, and no others")
+    func columnsMatchTheMigration() {
+        // electron/db/migrations.ts:494.
+        let expected: Set<String> = [
+            "id", "title", "brief_json", "selection_json", "model_json",
+            "draft_json", "created_at", "updated_at",
+        ]
+        #expect(Set(row(report()).keys) == expected)
+    }
+
+    @Test("every value is a scalar, because a mutation carries no nested JSON")
+    func valuesAreScalars() {
+        for (column, value) in row(report()) {
+            switch value {
+            case .string, .int, .double, .bool, .null:
+                continue
+            default:
+                Issue.record("\(column) is not a scalar the server would accept")
+            }
+        }
+    }
+
+    @Test("the draft is a Writing Workshop document the desktop can open")
+    func draftIsAWorkshopDocument() throws {
+        let draft = try object(row(report()), "draft_json")
+
+        #expect(draft["title"] as? String == "La escasez como política")
+        let markdown = try #require(draft["draftMarkdown"] as? String)
+        #expect(markdown.contains("## Primera"))
+        #expect(markdown.contains("## Segunda"))
+
+        let outline = try #require(draft["outline"] as? [[String: Any]])
+        #expect(outline.map { $0["title"] as? String } == ["Primera", "Segunda"])
+        #expect(outline.first?["id"] as? String == "s1")
+
+        #expect(draft["bibliography"] as? [String] == ["Una obra (1975)"])
+        #expect(draft["generatedAt"] != nil)
+        #expect(draft["stats"] != nil)
+    }
+
+    // The selection is a claim about what the report rests on. An invented citation was stripped
+    // from the prose, so it must not reappear here as though it were a source.
+    @Test("the selection is the citations that survived, grouped by kind")
+    func selectionComesFromRealCitations() throws {
+        let selection = try object(row(report()), "selection_json")
+
+        #expect(selection["ideaIds"] as? [String] == ["i-1"], "cited twice, selected once")
+        #expect(selection["workIds"] as? [String] == ["w-1"])
+        #expect(selection["passageIds"] as? [String] == ["p-9"])
+        #expect((selection["gapIds"] as? [String])?.isEmpty == true)
+
+        let flattened = selection.values.compactMap { $0 as? [String] }.flatMap { $0 }
+        #expect(!flattened.contains("inventada"), "a removed citation is not a source")
+    }
+
+    @Test("a run that stopped short, or that invented sources, says so in the saved copy")
+    func limitationsCarryTheRunsOwnDoubts() throws {
+        let partial = report(citationsChecked: 10, citationsRejected: 3, stoppedReason: "Section “Tercera” failed.")
+        let draft = try object(row(partial), "draft_json")
+        let limitations = try #require(draft["limitations"] as? [String])
+
+        #expect(limitations.contains { $0.contains("Tercera") })
+        #expect(limitations.contains { $0.contains("3") && $0.contains("10") })
+        let stats = try #require(draft["stats"] as? [String: Any])
+        #expect(stats["truncated"] as? Bool == true)
+    }
+
+    @Test("a clean run claims nothing it did not do")
+    func cleanRunHasNoInventedLimitations() throws {
+        let clean = report(citationsChecked: 4, citationsRejected: 0)
+        let draft = try object(row(clean), "draft_json")
+        let limitations = try #require(draft["limitations"] as? [String])
+
+        #expect(!limitations.contains { $0.contains("invented") })
+        let stats = try #require(draft["stats"] as? [String: Any])
+        #expect(stats["truncated"] as? Bool == false)
+    }
+
+    @Test("a token that is not a citation scheme URL is ignored rather than guessed at")
+    func malformedTokensAreDropped() {
+        let selection = ReportDraft.selection(citing: ["nodus://idea/i-1", "rubbish", "nodus://", ""])
+        #expect(selection["ideaIds"] as? [String] == ["i-1"])
+    }
+}

--- a/ios/NodusTests/SmokeTests.swift
+++ b/ios/NodusTests/SmokeTests.swift
@@ -1,5 +1,7 @@
+import Foundation
 import NodusKit
 import Testing
+@testable import Nodus
 
 /// The app target's own tests. The interesting assertions live in the packages, where they
 /// run without a simulator; this bundle exists to prove the app links what it claims to.
@@ -10,5 +12,26 @@ struct AppWiringTests {
         #expect(Collections.all.count == 20)
         #expect(Collections["deep-research"] == nil, "deep-research is a special resource, not a collection")
         #expect(SpecialResource.deepResearch.listKey == "reports")
+    }
+
+    /// Info.plist and the code have to agree, and nothing else checks that they do.
+    ///
+    /// An identifier the bundle permits but nobody registers is a capability the app claims and
+    /// does not have — which is exactly what these three were for a year. An identifier
+    /// registered but not permitted is worse: `BGTaskScheduler` traps at launch, on a device,
+    /// and never in the simulator where it would have been noticed.
+    @Test("every permitted background identifier is one the app actually claims")
+    func backgroundIdentifiersMatchTheBundle() {
+        let permitted = Set(BackgroundWork.permittedIdentifiers)
+        #expect(!permitted.isEmpty, "the test bundle must be reading the app's own Info.plist")
+        #expect(Set(BackgroundWork.identifiers) == permitted)
+    }
+
+    /// A processing task needs the background mode that permits it. Declaring the identifiers
+    /// without the mode gives a scheduler that accepts submissions and never runs them.
+    @Test("the background modes cover the tasks the app submits")
+    func backgroundModesAreDeclared() {
+        let modes = Set(Bundle.main.object(forInfoDictionaryKey: "UIBackgroundModes") as? [String] ?? [])
+        #expect(modes.contains("processing"))
     }
 }

--- a/ios/Packages/NodusAI/Sources/NodusAI/DeepResearch/DeepResearchCore.swift
+++ b/ios/Packages/NodusAI/Sources/NodusAI/DeepResearch/DeepResearchCore.swift
@@ -49,7 +49,7 @@ public enum DeepResearchMode: String, Sendable, Codable, CaseIterable {
     }
 }
 
-public struct DeepResearchRequest: Sendable {
+public struct DeepResearchRequest: Sendable, Codable, Hashable {
     public var objective: String
     public var language: String
     public var audience: String?
@@ -60,7 +60,11 @@ public struct DeepResearchRequest: Sendable {
 
     public init(
         objective: String,
-        language: String = "es",
+        // English unless the caller says otherwise. The app always passes
+        // `Prompts.interfaceLanguage`, which follows the phone; a Spanish default here meant a
+        // request built without one — a resumed run, a test — silently changed the language the
+        // report was written in.
+        language: String = "en",
         audience: String? = nil,
         targetLength: DeepResearchLength = .adaptive,
         sectionLimit: Int? = nil,
@@ -345,6 +349,63 @@ public enum DeepResearchError: Error, Sendable {
     case cancelled
 }
 
+// MARK: - Resuming
+
+/// Everything a half-finished run needs to carry on somewhere else.
+///
+/// A run is one model call per section. Being killed halfway — by the user leaving the app, by
+/// iOS reclaiming memory, by a background task expiring — would waste every call already paid
+/// for, so the orchestrator emits one of these after each section and can be handed one back.
+///
+/// The citation catalogue is deliberately *not* in here. Rebuilding it costs retrieval and at
+/// most one embedding call, while a section costs a full completion; persisting a few hundred
+/// entries to save the cheaper of the two would be the wrong trade, and a catalogue rebuilt
+/// from the current publication is more correct than one frozen an hour ago.
+public struct DeepResearchCheckpoint: Sendable, Codable, Hashable {
+    public let request: DeepResearchRequest
+    /// The plan, fixed at the first attempt. Re-planning on resume would produce a report whose
+    /// second half answers a different outline from its first.
+    public let titles: [String]
+    public let wordTarget: Int
+    public let sections: [DeepResearchSection]
+    public let citationsChecked: Int
+    public let citationsRejected: Int
+    public let startedAt: Date
+
+    public init(
+        request: DeepResearchRequest,
+        titles: [String],
+        wordTarget: Int,
+        sections: [DeepResearchSection],
+        citationsChecked: Int,
+        citationsRejected: Int,
+        startedAt: Date
+    ) {
+        self.request = request
+        self.titles = titles
+        self.wordTarget = wordTarget
+        self.sections = sections
+        self.citationsChecked = citationsChecked
+        self.citationsRejected = citationsRejected
+        self.startedAt = startedAt
+    }
+
+    /// The next section to write. Everything before it is already paid for.
+    public var nextSectionIndex: Int { min(sections.count, titles.count) }
+    public var isComplete: Bool { sections.count >= titles.count }
+    public var words: Int { sections.reduce(0) { $0 + $1.wordCount } }
+
+    /// Whether this checkpoint can still be resumed against a given request.
+    ///
+    /// Resuming into a *different* objective would silently graft half a report onto another
+    /// question, so the objective and the shape of the run must match.
+    public func resumes(_ other: DeepResearchRequest) -> Bool {
+        request.objective == other.objective
+            && request.mode == other.mode
+            && request.targetLength == other.targetLength
+    }
+}
+
 // MARK: - The orchestrator
 
 public struct DeepResearchOrchestrator: Sendable {
@@ -354,34 +415,74 @@ public struct DeepResearchOrchestrator: Sendable {
         self.deps = deps
     }
 
+    /// - Parameters:
+    ///   - resuming: a checkpoint from an earlier attempt at the same request. Its sections are
+    ///     kept and its plan is reused; only the sections it never reached are written.
+    ///   - onCheckpoint: called after every section, and once after planning. Persisting what it
+    ///     hands over is what makes a killed run resumable rather than wasted.
     public func run(
         _ request: DeepResearchRequest,
+        resuming checkpoint: DeepResearchCheckpoint? = nil,
+        onCheckpoint: @Sendable (DeepResearchCheckpoint) -> Void = { _ in },
         onProgress: @Sendable (DeepResearchProgress) -> Void = { _ in }
     ) async throws -> DeepResearchReport {
-        onProgress(.init(phase: .snapshot, message: "Preparing the corpus", wordsSoFar: 0))
+        // A checkpoint for a different objective is not a checkpoint for this run.
+        let resume = checkpoint.flatMap { $0.resumes(request) ? $0 : nil }
+
+        onProgress(.init(
+            phase: .snapshot,
+            message: resume == nil ? "Preparing the corpus" : "Picking up where it stopped",
+            wordsSoFar: resume?.words ?? 0
+        ))
+        // Rebuilt even on resume: it is the cheap half of the run, and the sections still to be
+        // written must be able to cite the corpus as it stands now.
         let catalog = try await deps.buildCatalog(request.objective)
         guard !catalog.isEmpty else { throw DeepResearchError.emptyCorpus }
 
         let pages = DeepResearchLimits.targetPages(request.targetLength, citableCount: catalog.entries.count)
         let plan = DeepResearchLimits.sectionPlan(pages: pages, requested: request.sectionLimit)
 
-        onProgress(.init(phase: .planning, message: "Planning \(plan.target) secciones", wordsSoFar: 0))
-        var titles = try await deps.plan(request, catalog, plan.target, plan.hardCap)
-        guard !titles.isEmpty else { throw DeepResearchError.planningFailed("the plan came back empty") }
-        if titles.count > plan.hardCap { titles = Array(titles.prefix(plan.hardCap)) }
+        var titles: [String]
+        let wordTarget: Int
+        if let resume {
+            titles = resume.titles
+            wordTarget = resume.wordTarget
+        } else {
+            onProgress(.init(phase: .planning, message: "Planning \(plan.target) sections", wordsSoFar: 0))
+            titles = try await deps.plan(request, catalog, plan.target, plan.hardCap)
+            guard !titles.isEmpty else { throw DeepResearchError.planningFailed("the plan came back empty") }
+            if titles.count > plan.hardCap { titles = Array(titles.prefix(plan.hardCap)) }
+            wordTarget = max(
+                250,
+                (pages.lowerBound + pages.upperBound) / 2 * DeepResearchLimits.wordsPerPage / max(1, titles.count)
+            )
+        }
 
-        let wordTarget = max(
-            250,
-            (pages.lowerBound + pages.upperBound) / 2 * DeepResearchLimits.wordsPerPage / max(1, titles.count)
-        )
-
-        var sections: [DeepResearchSection] = []
-        var words = 0
-        var checked = 0
-        var rejected = 0
+        var sections: [DeepResearchSection] = resume?.sections ?? []
+        var words = sections.reduce(0) { $0 + $1.wordCount }
+        var checked = resume?.citationsChecked ?? 0
+        var rejected = resume?.citationsRejected ?? 0
         var stoppedReason: String?
+        let startedAt = resume?.startedAt ?? Date()
 
-        for (index, title) in titles.enumerated() {
+        func currentCheckpoint() -> DeepResearchCheckpoint {
+            DeepResearchCheckpoint(
+                request: request,
+                titles: titles,
+                wordTarget: wordTarget,
+                sections: sections,
+                citationsChecked: checked,
+                citationsRejected: rejected,
+                startedAt: startedAt
+            )
+        }
+
+        // Emitted before the first model call so a run killed during its first section still
+        // resumes with a plan rather than paying to draw one up again.
+        onCheckpoint(currentCheckpoint())
+
+        let first = resume?.nextSectionIndex ?? 0
+        for (index, title) in titles.enumerated() where index >= first {
             try Task.checkCancellation()
 
             onProgress(.init(
@@ -415,6 +516,8 @@ public struct DeepResearchOrchestrator: Sendable {
                 )
                 sections.append(section)
                 words += section.wordCount
+                // After the call has been paid for, not before.
+                onCheckpoint(currentCheckpoint())
             } catch is CancellationError {
                 throw DeepResearchError.cancelled
             } catch {

--- a/ios/Packages/NodusAI/Tests/NodusAITests/DeepResearchTests.swift
+++ b/ios/Packages/NodusAI/Tests/NodusAITests/DeepResearchTests.swift
@@ -142,7 +142,9 @@ struct DeepResearchOrchestratorTests {
     func runsEndToEnd() async throws {
         let orchestrator = DeepResearchOrchestrator(deps: deps())
         let phases = PhaseRecorder()
-        let report = try await orchestrator.run(request) { phases.record($0.phase) }
+        // Labelled rather than trailing: `run` now takes two closures, and an unlabelled one
+        // would quietly bind to the checkpoint hook instead of the progress hook.
+        let report = try await orchestrator.run(request, onProgress: { phases.record($0.phase) })
 
         #expect(report.sections.count == 3)
         #expect(report.words > 0)

--- a/ios/Packages/NodusAI/Tests/NodusAITests/ResumeTests.swift
+++ b/ios/Packages/NodusAI/Tests/NodusAITests/ResumeTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import NodusKit
+import Testing
+@testable import NodusAI
+
+/// Resuming a run that was killed halfway.
+///
+/// The property under test is money, not tidiness: a section is one model call, and a run that
+/// restarts from zero after being interrupted charges the user twice for prose they already
+/// have. Every assertion here is ultimately about how many times `writeSection` is reached.
+@Suite("Resuming a run")
+struct DeepResearchResumeTests {
+    private func catalog() -> CitationCatalog {
+        CitationCatalog(entries: [
+            CitationCatalog.Entry(token: "nodus://idea/i-1", kind: "idea", id: "i-1", label: "Una idea"),
+            CitationCatalog.Entry(token: "nodus://work/w-1", kind: "work", id: "w-1", label: "Una obra"),
+        ])
+    }
+
+    private func deps(
+        titles: [String] = ["Primera", "Segunda", "Tercera"],
+        written: Recorder,
+        planned: Recorder? = nil,
+        fail: (@Sendable (String) -> Bool)? = nil
+    ) -> DeepResearchDeps {
+        let source = catalog()
+        return DeepResearchDeps(
+            buildCatalog: { _ in source },
+            retrieveForSection: { _, _ in source },
+            plan: { _, _, _, _ in
+                planned?.record("plan")
+                return titles
+            },
+            writeSection: { _, title, _, _, _, _ in
+                written.record(title)
+                if fail?(title) == true { throw CancellationError() }
+                return "Prosa de \(title) con apoyo (nodus://idea/i-1) y una obra (nodus://work/w-1)."
+            }
+        )
+    }
+
+    private var request: DeepResearchRequest {
+        DeepResearchRequest(
+            objective: "La escasez como política",
+            targetLength: .concise,
+            model: ModelRef(provider: .anthropic, model: "claude-test")
+        )
+    }
+
+    @Test("a checkpoint arrives after planning and after every section")
+    func emitsCheckpoints() async throws {
+        let written = Recorder()
+        let checkpoints = CheckpointRecorder()
+        let orchestrator = DeepResearchOrchestrator(deps: deps(written: written))
+
+        _ = try await orchestrator.run(request, onCheckpoint: { checkpoints.record($0) })
+
+        let counts = checkpoints.all.map(\.sections.count)
+        // One before any section is written, then one per section: the first exists so a run
+        // killed inside its opening section still resumes with a plan rather than paying for
+        // a new one.
+        #expect(counts == [0, 1, 2, 3])
+        #expect(checkpoints.all.last?.isComplete == true)
+        #expect(checkpoints.all.allSatisfy { $0.titles == ["Primera", "Segunda", "Tercera"] })
+    }
+
+    @Test("resuming writes only the sections the first attempt never reached")
+    func skipsPaidSections() async throws {
+        let firstAttempt = Recorder()
+        let checkpoints = CheckpointRecorder()
+        let stopper = DeepResearchOrchestrator(
+            deps: deps(written: firstAttempt, fail: { $0 == "Tercera" })
+        )
+
+        // The first attempt dies inside the third section, exactly as an expiring background
+        // task does.
+        await #expect(throws: (any Error).self) {
+            try await stopper.run(request, onCheckpoint: { checkpoints.record($0) })
+        }
+        #expect(firstAttempt.all == ["Primera", "Segunda", "Tercera"])
+        let carried = try #require(checkpoints.all.last)
+        #expect(carried.sections.count == 2)
+        #expect(carried.isComplete == false)
+        #expect(carried.nextSectionIndex == 2)
+
+        let secondAttempt = Recorder()
+        let planned = Recorder()
+        let finisher = DeepResearchOrchestrator(deps: deps(written: secondAttempt, planned: planned))
+        let report = try await finisher.run(request, resuming: carried)
+
+        #expect(secondAttempt.all == ["Tercera"], "the two paid-for sections must not be written again")
+        #expect(planned.all.isEmpty, "the plan is carried in the checkpoint, not drawn up twice")
+        #expect(report.sections.map(\.title) == ["Primera", "Segunda", "Tercera"])
+        #expect(report.words > 0)
+    }
+
+    @Test("citation counts carry across the interruption instead of restarting at zero")
+    func carriesCounters() async throws {
+        let written = Recorder()
+        let checkpoints = CheckpointRecorder()
+        let stopper = DeepResearchOrchestrator(deps: deps(written: written, fail: { $0 == "Segunda" }))
+        await #expect(throws: (any Error).self) {
+            try await stopper.run(request, onCheckpoint: { checkpoints.record($0) })
+        }
+        let carried = try #require(checkpoints.all.last)
+        #expect(carried.citationsChecked == 2, "the first section cited an idea and a work")
+
+        let report = try await DeepResearchOrchestrator(deps: deps(written: Recorder()))
+            .run(request, resuming: carried)
+        #expect(report.citationsChecked == 6, "two per section across all three, not just the resumed ones")
+    }
+
+    // A checkpoint is keyed to the question it was answering. Grafting half a report about one
+    // objective onto another would produce a document whose two halves argue different things.
+    @Test("a checkpoint for a different objective is ignored, and the run starts over")
+    func refusesForeignCheckpoints() async throws {
+        let foreign = DeepResearchCheckpoint(
+            request: DeepResearchRequest(
+                objective: "Una pregunta completamente distinta",
+                targetLength: .concise,
+                model: ModelRef(provider: .anthropic, model: "claude-test")
+            ),
+            titles: ["Vieja"],
+            wordTarget: 400,
+            sections: [DeepResearchSection(title: "Vieja", prose: "Ya escrita.", citations: [], rejectedCitations: [])],
+            citationsChecked: 0,
+            citationsRejected: 0,
+            startedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        let written = Recorder()
+        let report = try await DeepResearchOrchestrator(deps: deps(written: written))
+            .run(request, resuming: foreign)
+
+        #expect(written.all == ["Primera", "Segunda", "Tercera"])
+        #expect(report.sections.map(\.title) == ["Primera", "Segunda", "Tercera"])
+        #expect(!report.markdown.contains("Ya escrita"))
+    }
+
+    @Test("a checkpoint survives a round trip through JSON, which is how it reaches the next process")
+    func roundTripsThroughDisk() throws {
+        let original = DeepResearchCheckpoint(
+            request: request,
+            titles: ["Primera", "Segunda"],
+            wordTarget: 500,
+            sections: [DeepResearchSection(
+                title: "Primera",
+                prose: "Prosa (nodus://idea/i-1).",
+                citations: ["nodus://idea/i-1"],
+                rejectedCitations: []
+            )],
+            citationsChecked: 1,
+            citationsRejected: 0,
+            startedAt: Date(timeIntervalSince1970: 1_760_000_000)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let restored = try decoder.decode(
+            DeepResearchCheckpoint.self,
+            from: encoder.encode(original)
+        )
+        #expect(restored == original)
+        #expect(restored.resumes(request))
+        #expect(restored.nextSectionIndex == 1)
+    }
+}
+
+private final class Recorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    func record(_ value: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage.append(value)
+    }
+
+    var all: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return storage
+    }
+}
+
+private final class CheckpointRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [DeepResearchCheckpoint] = []
+
+    func record(_ value: DeepResearchCheckpoint) {
+        lock.lock(); defer { lock.unlock() }
+        storage.append(value)
+    }
+
+    var all: [DeepResearchCheckpoint] {
+        lock.lock(); defer { lock.unlock() }
+        return storage
+    }
+}

--- a/ios/Packages/NodusKit/Sources/NodusKit/Client/NodusClient+Auth.swift
+++ b/ios/Packages/NodusKit/Sources/NodusKit/Client/NodusClient+Auth.swift
@@ -11,8 +11,16 @@ public extension NodusClient {
 
     /// `GET /api/v1/capabilities` — public, and the first call the app makes against a new
     /// address. Every ceiling the client enforces comes from here rather than from a constant.
-    func capabilities() async throws -> ServerCapabilities {
-        let response = try await perform(.init(path: "/api/v1/capabilities", authenticated: false, cacheable: true))
+    /// - Parameter timeout: how long to wait before deciding nothing is there. The default is
+    ///   the session's 30 s, which is right for a request to a server known to exist and far
+    ///   too long for the first knock at an address somebody just typed.
+    func capabilities(timeout: TimeInterval? = nil) async throws -> ServerCapabilities {
+        let response = try await perform(.init(
+            path: "/api/v1/capabilities",
+            authenticated: false,
+            cacheable: true,
+            timeout: timeout
+        ))
         return try decode(ServerCapabilities.self, from: response)
     }
 

--- a/ios/Packages/NodusKit/Sources/NodusKit/Client/NodusClient.swift
+++ b/ios/Packages/NodusKit/Sources/NodusKit/Client/NodusClient.swift
@@ -61,6 +61,12 @@ public actor NodusClient {
         var authenticated: Bool = true
         /// Only GETs revalidate; a POST has no tag to send.
         var cacheable: Bool = false
+        /// Overrides the session's 30 s default.
+        ///
+        /// A probe is asking "is there a Nodus Server at this address?", and the answer "no" is
+        /// most often silence — a name that resolves to a machine with nothing listening on the
+        /// port. Half a minute of a dead button is not a reasonable way to say that.
+        var timeout: TimeInterval?
     }
 
     struct Response: Sendable {
@@ -77,6 +83,7 @@ public actor NodusClient {
         let url = try address.url(path: request.path, query: request.query)
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = request.method
+        if let timeout = request.timeout { urlRequest.timeoutInterval = timeout }
         urlRequest.httpBody = request.body
         if let contentType = request.contentType {
             urlRequest.setValue(contentType, forHTTPHeaderField: "Content-Type")
@@ -115,16 +122,7 @@ public actor NodusClient {
             data = responseData
             httpResponse = http
         } catch let error as URLError {
-            switch error.code {
-            case .notConnectedToInternet, .dataNotAllowed, .networkConnectionLost:
-                throw TransportError.offline
-            case .cancelled:
-                throw TransportError.cancelled
-            case .timedOut:
-                throw TransportError.timedOut
-            default:
-                throw TransportError.underlying(error.localizedDescription)
-            }
+            throw TransportError.from(error)
         }
 
         var headers: [String: String] = [:]
@@ -195,6 +193,29 @@ public extension URLSession {
         // large corpus does, and it is worth waiting for.
         configuration.timeoutIntervalForResource = 600
         configuration.waitsForConnectivity = true
+        configuration.httpAdditionalHeaders = ["User-Agent": "Nodus-iOS/3.1.0"]
+        return URLSession(configuration: configuration)
+    }()
+
+    /// The session for the first knock at an address somebody just typed.
+    ///
+    /// `nodusDefault` sets `waitsForConnectivity`, which is right for an app that is already
+    /// talking to a server it knows: a tunnel coming back up resumes the request instead of
+    /// failing it. It is wrong here, and quietly so — while URLSession is *waiting for
+    /// connectivity* it ignores `timeoutIntervalForRequest` entirely, so a 12-second timeout on
+    /// an unreachable host bought nothing and the screen sat on "looking for the server" until
+    /// `timeoutIntervalForResource` gave up ten minutes later.
+    ///
+    /// A probe has to be able to answer "there is nothing here", so it does not wait.
+    static let nodusProbe: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 12
+        // Bounded as well as the request: the two are different clocks, and only this one caps
+        // the whole attempt.
+        configuration.timeoutIntervalForResource = 15
+        configuration.waitsForConnectivity = false
         configuration.httpAdditionalHeaders = ["User-Agent": "Nodus-iOS/3.1.0"]
         return URLSession(configuration: configuration)
     }()

--- a/ios/Packages/NodusKit/Sources/NodusKit/Core/APIError.swift
+++ b/ios/Packages/NodusKit/Sources/NodusKit/Core/APIError.swift
@@ -97,15 +97,54 @@ extension APIError: LocalizedError {
 }
 
 /// Failures that never reached a Nodus Server, or that came back malformed.
-public enum TransportError: Error, Sendable {
+public enum TransportError: Error, Sendable, Equatable {
     case offline
     case cancelled
     case timedOut
+    /// Nothing answers to that name.
+    ///
+    /// Kept apart from `cannotConnect` because the two need opposite things from the user, and
+    /// flattening both into one sentence is what made "could not connect" useless: a Nodus
+    /// Server usually lives on a private network, and this is the case where the *device* is
+    /// not on it.
+    case hostNotFound
+    /// The name resolves and nothing is listening behind it.
+    case cannotConnect
+    /// TLS refused: an untrusted, expired or self-signed certificate.
+    case certificateRejected
+    /// iOS blocked the request for being plain HTTP to something that is not this device.
+    case insecureBlocked
     /// The origin is not a valid absolute URL, or carries a path/query the server would reject.
     case badServerURL(String)
     /// A 2xx whose body did not match the documented shape. Carries what was expected.
     case malformedResponse(expected: String)
     case underlying(String)
+
+    /// The one place a `URLError` becomes a Nodus error.
+    ///
+    /// Static and pure so the mapping can be tested without a network — the cases below are
+    /// exactly the ones a user hits while pointing the app at a server for the first time.
+    public static func from(_ error: URLError) -> TransportError {
+        switch error.code {
+        case .notConnectedToInternet, .dataNotAllowed:
+            return .offline
+        case .cancelled:
+            return .cancelled
+        case .timedOut, .networkConnectionLost:
+            return .timedOut
+        case .cannotFindHost, .dnsLookupFailed:
+            return .hostNotFound
+        case .cannotConnectToHost:
+            return .cannotConnect
+        case .secureConnectionFailed, .serverCertificateUntrusted, .serverCertificateHasBadDate,
+             .serverCertificateNotYetValid, .serverCertificateHasUnknownRoot, .clientCertificateRejected:
+            return .certificateRejected
+        case .appTransportSecurityRequiresSecureConnection:
+            return .insecureBlocked
+        default:
+            return .underlying(error.localizedDescription)
+        }
+    }
 }
 
 extension TransportError: LocalizedError {
@@ -114,6 +153,14 @@ extension TransportError: LocalizedError {
         case .offline: return "No connection."
         case .cancelled: return "Cancelled."
         case .timedOut: return "The server took too long to answer."
+        case .hostNotFound:
+            return "No machine by that name. If the server is on a private network — Tailscale, a VPN, your own Wi‑Fi — this device has to be on it too."
+        case .cannotConnect:
+            return "The name resolves, but nothing answered. The server may be stopped, or reachable only from the machine it runs on."
+        case .certificateRejected:
+            return "The certificate was refused. A Nodus Server needs one this device already trusts."
+        case .insecureBlocked:
+            return "iOS refuses plain HTTP to anything but this device. Use an https:// address."
         case .badServerURL(let value): return "Not a usable server address: \(value)"
         case .malformedResponse(let expected): return "Unexpected answer from the server (expected \(expected))."
         case .underlying(let value): return value

--- a/ios/Packages/NodusKit/Sources/NodusKit/Graph/ArgumentMap.swift
+++ b/ios/Packages/NodusKit/Sources/NodusKit/Graph/ArgumentMap.swift
@@ -1,0 +1,356 @@
+import Foundation
+
+/// The argument map, built from the graph rather than from a model.
+///
+/// A port of `buildStructuralArgumentMap` (`electron/ai/argumentMap.ts:508`) — the desktop's
+/// *auto* mode, which is pure local computation over real edges. The AI mode is deliberately
+/// not ported: it asks a model to trace the argument, and a phone that already holds the
+/// subgraph can draw the structural one for nothing.
+///
+/// Every constant below matches the desktop's, because the two are meant to produce the same
+/// map from the same corpus. Changing one here and not there would give a reader on the phone a
+/// different argument from the one on the desk.
+public enum ArgumentMapBuilder {
+    /// `STRUCTURAL_MAX_DEPTH` (`argumentMap.ts:386`).
+    public static let maxDepth = 3
+    /// `STRUCTURAL_BRANCHES_BY_DEPTH` — wide at the seed, narrowing as it descends, so no
+    /// branch is starved by whichever one happened to be walked first.
+    public static let branchesByDepth = [12, 4, 2]
+    /// `STRUCTURAL_MAX_BLOCKS`.
+    public static let maxBlocks = 160
+
+    /// Build the map for one seed out of an ego graph.
+    ///
+    /// Returns nil when the seed is not in the graph, which is the one input that cannot be
+    /// made to mean anything.
+    public static func structural(from graph: IdeaGraph, seedId: String? = nil) -> ArgumentMap? {
+        let seed = seedId ?? graph.seedId
+        var ideaById: [String: ArgumentIdea] = [:]
+        for row in graph.ideas {
+            guard let idea = ArgumentIdea(row) else { continue }
+            ideaById[idea.id] = idea
+        }
+        guard let seedIdea = ideaById[seed] else { return nil }
+
+        let edges = graph.edges.compactMap(ArgumentEdge.init)
+        // Adjacency over the kept subgraph, both ways: an edge argues in both directions even
+        // though it is stored with a direction.
+        var adjacency: [String: [Neighbour]] = [:]
+        var degree: [String: Int] = [:]
+        var debates: [String: Int] = [:]
+        for edge in edges {
+            guard ideaById[edge.from] != nil, ideaById[edge.to] != nil else { continue }
+            adjacency[edge.from, default: []].append(Neighbour(other: edge.to, edge: edge))
+            adjacency[edge.to, default: []].append(Neighbour(other: edge.from, edge: edge))
+            degree[edge.from, default: 0] += 1
+            degree[edge.to, default: 0] += 1
+            if edge.relation.isDebate {
+                debates[edge.from, default: 0] += 1
+                debates[edge.to, default: 0] += 1
+            }
+        }
+
+        // Grown level by level, not depth first. A depth-first walk lets the first branch it
+        // descends spend the whole block budget and leaves its siblings bare.
+        final class Node {
+            let idea: ArgumentIdea
+            let relation: ArgumentRelation
+            let confidence: Double
+            var children: [Node] = []
+            init(idea: ArgumentIdea, relation: ArgumentRelation, confidence: Double) {
+                self.idea = idea
+                self.relation = relation
+                self.confidence = confidence
+            }
+        }
+
+        let root = Node(idea: seedIdea, relation: .root, confidence: 0)
+        var placed: Set<String> = [seed]
+        var blockCount = 1
+        var frontier = [root]
+
+        for depth in 0..<maxDepth where !frontier.isEmpty && blockCount < maxBlocks {
+            let cap = branchesByDepth[min(depth, branchesByDepth.count - 1)]
+            var next: [Node] = []
+            for node in frontier {
+                if blockCount >= maxBlocks { break }
+                // An idea already placed elsewhere is skipped, so the tree stays a tree and the
+                // same card never appears on two branches.
+                let candidates = (adjacency[node.idea.id] ?? []).filter { !placed.contains($0.other) }
+                for neighbour in pickBranches(candidates, cap: cap) {
+                    if blockCount >= maxBlocks { break }
+                    guard !placed.contains(neighbour.other), let idea = ideaById[neighbour.other] else { continue }
+                    placed.insert(neighbour.other)
+                    let child = Node(idea: idea, relation: neighbour.edge.relation, confidence: neighbour.edge.confidence)
+                    node.children.append(child)
+                    next.append(child)
+                    blockCount += 1
+                }
+            }
+            frontier = next
+        }
+
+        func freeze(_ node: Node) -> ArgumentBlock {
+            let children = node.children.map(freeze)
+            // How many links this idea has in the subgraph that the map did not draw. It is a
+            // count over what the server sent, not over the whole corpus — when the graph came
+            // back `truncated` there may be more still, and the screen says so rather than
+            // implying the argument ends here.
+            let drawn = children.count
+            let total = degree[node.idea.id] ?? 0
+            return ArgumentBlock(
+                id: node.idea.id,
+                ideaId: node.idea.id,
+                label: node.idea.label,
+                statement: node.idea.statement,
+                type: node.idea.type,
+                relation: node.relation,
+                confidence: node.confidence,
+                children: children,
+                hiddenChildren: max(0, total - drawn - (node.relation == .root ? 0 : 1)),
+                descendantCount: children.reduce(children.count) { $0 + $1.descendantCount }
+            )
+        }
+
+        return ArgumentMap(
+            seedIdeaId: seed,
+            seedLabel: seedIdea.label,
+            root: freeze(root),
+            truncated: graph.truncated,
+            ideaCount: ideaById.count,
+            blockCount: blockCount,
+            seedDegree: degree[seed] ?? 0,
+            seedDebates: debates[seed] ?? 0
+        )
+    }
+
+    /// Pick which links become branches: debates first, then support, then the rest.
+    ///
+    /// `pickBranches` (`argumentMap.ts:420`). Round-robin across the three families rather than
+    /// straight down the confidence ranking, so a hub whose strongest links all agree with each
+    /// other still shows the one that does not.
+    static func pickBranches(_ candidates: [Neighbour], cap: Int) -> [Neighbour] {
+        var buckets: [ArgumentRelation.Family: [Neighbour]] = [.debate: [], .support: [], .other: []]
+        for candidate in candidates.sorted(by: { priority($0.edge) > priority($1.edge) }) {
+            buckets[candidate.edge.relation.family, default: []].append(candidate)
+        }
+        let families: [ArgumentRelation.Family] = [.debate, .support, .other]
+        var picked: [Neighbour] = []
+        var index = 0
+        while picked.count < cap, families.contains(where: { !(buckets[$0]?.isEmpty ?? true) }) {
+            let family = families[index % families.count]
+            if let next = buckets[family]?.first {
+                buckets[family]?.removeFirst()
+                picked.append(next)
+            }
+            index += 1
+        }
+        return picked.sorted { priority($0.edge) > priority($1.edge) }
+    }
+
+    /// `edgePriority` — surface debates first, then confidence.
+    static func priority(_ edge: ArgumentEdge) -> Double {
+        var value = edge.confidence
+        if edge.relation.isDebate { value += 1.5 }
+        else if edge.relation == .supports || edge.relation == .extends { value += 0.4 }
+        return value
+    }
+
+    struct Neighbour {
+        let other: String
+        let edge: ArgumentEdge
+    }
+}
+
+/// One idea in the map.
+public struct ArgumentIdea: Sendable, Hashable {
+    public let id: String
+    public let label: String
+    public let statement: String
+    public let type: String
+
+    init?(_ row: Row) {
+        guard let id = row.string("global_id") else { return nil }
+        self.id = id
+        label = row.text("label") ?? row.text("statement") ?? id
+        statement = row.text("statement") ?? ""
+        type = row.string("type") ?? "claim"
+    }
+}
+
+public struct ArgumentEdge: Sendable, Hashable {
+    public let from: String
+    public let to: String
+    public let relation: ArgumentRelation
+    public let confidence: Double
+    /// `stated` or `inferred`. A relation the corpus states outright is not the same claim as
+    /// one the analysis derived, and the map keeps the difference.
+    public let basis: String?
+
+    init?(_ row: Row) {
+        guard
+            let from = row.string("from_id"),
+            let to = row.string("to_id"),
+            let type = row.string("type")
+        else { return nil }
+        self.from = from
+        self.to = to
+        relation = ArgumentRelation(rawValue: type) ?? .related
+        confidence = row.double("confidence") ?? 0
+        basis = row.string("basis")
+    }
+}
+
+/// How a block relates to its parent.
+public enum ArgumentRelation: String, Sendable, Hashable, Codable, CaseIterable {
+    case root
+    case supports
+    case refutes
+    case contradicts
+    case extends
+    case refines
+    case appliesTo = "applies_to"
+    case sharesMethod = "shares_method"
+    case preconditionOf = "precondition_of"
+    case measuresSame = "measures_same"
+    case variantOf = "variant_of"
+    case related
+
+    public enum Family: Sendable, Hashable {
+        case debate
+        case support
+        case other
+    }
+
+    /// `isDebateEdge` (`argumentMap.ts:101`). Only these two are an argument against.
+    public var isDebate: Bool { self == .contradicts || self == .refutes }
+
+    public var family: Family {
+        if isDebate { return .debate }
+        if self == .supports || self == .extends || self == .preconditionOf { return .support }
+        return .other
+    }
+
+    /// The accent the desktop gives each relation (`ArgumentMapView.tsx:31-46`), so the branch
+    /// structure reads at a glance and reads the same on both.
+    public var accentHex: String {
+        switch self {
+        case .root: return "#f97316"
+        case .supports: return "#22c55e"
+        case .refutes: return "#ef4444"
+        case .contradicts: return "#f97316"
+        case .extends: return "#3b82f6"
+        case .refines: return "#8b5cf6"
+        case .appliesTo: return "#eab308"
+        case .sharesMethod: return "#06b6d4"
+        case .preconditionOf: return "#f472b6"
+        case .measuresSame: return "#14b8a6"
+        case .variantOf: return "#a78bfa"
+        case .related: return "#737373"
+        }
+    }
+}
+
+public struct ArgumentBlock: Sendable, Hashable, Identifiable {
+    public let id: String
+    public let ideaId: String
+    public let label: String
+    public let statement: String
+    /// The idea's own type — claim, finding, construct, method, framework, theme.
+    public let type: String
+    public let relation: ArgumentRelation
+    /// The parent edge's confidence. Zero for the root, which has no parent edge.
+    public let confidence: Double
+    public let children: [ArgumentBlock]
+    /// Links this idea has in the fetched subgraph that the map did not draw.
+    public let hiddenChildren: Int
+    public let descendantCount: Int
+
+    public init(
+        id: String,
+        ideaId: String,
+        label: String,
+        statement: String,
+        type: String,
+        relation: ArgumentRelation,
+        confidence: Double,
+        children: [ArgumentBlock],
+        hiddenChildren: Int,
+        descendantCount: Int
+    ) {
+        self.id = id
+        self.ideaId = ideaId
+        self.label = label
+        self.statement = statement
+        self.type = type
+        self.relation = relation
+        self.confidence = confidence
+        self.children = children
+        self.hiddenChildren = hiddenChildren
+        self.descendantCount = descendantCount
+    }
+
+    /// The colour an idea type carries everywhere in Nodus (`src/components/ui.tsx:22`).
+    public var typeAccentHex: String {
+        switch type {
+        case "theme": return "#f97316"
+        case "claim": return "#6366f1"
+        case "finding": return "#10b981"
+        case "construct": return "#f59e0b"
+        case "method": return "#ec4899"
+        case "framework": return "#06b6d4"
+        default: return "#8b8b8b"
+        }
+    }
+}
+
+public struct ArgumentMap: Sendable {
+    public let seedIdeaId: String
+    public let seedLabel: String
+    public let root: ArgumentBlock
+    /// The server capped the neighbourhood it sent. The map is a real subgraph of the corpus,
+    /// not the whole argument, and every screen that shows it has to say so.
+    public let truncated: Bool
+    public let ideaCount: Int
+    public let blockCount: Int
+    public let seedDegree: Int
+    public let seedDebates: Int
+
+    public init(
+        seedIdeaId: String,
+        seedLabel: String,
+        root: ArgumentBlock,
+        truncated: Bool,
+        ideaCount: Int,
+        blockCount: Int,
+        seedDegree: Int,
+        seedDebates: Int
+    ) {
+        self.seedIdeaId = seedIdeaId
+        self.seedLabel = seedLabel
+        self.root = root
+        self.truncated = truncated
+        self.ideaCount = ideaCount
+        self.blockCount = blockCount
+        self.seedDegree = seedDegree
+        self.seedDebates = seedDebates
+    }
+
+    /// The ids of the blocks that have children, by depth — the script of the unfold, one level
+    /// per tick. A port of `expandableIdsByDepth` (`src/argumentMapTree.ts`), and contiguous by
+    /// construction: a block only reaches depth d when every ancestor above it has children.
+    public static func expandableIdsByDepth(_ block: ArgumentBlock, depth: Int = 0, into accumulator: inout [[String]]) {
+        guard !block.children.isEmpty else { return }
+        while accumulator.count <= depth { accumulator.append([]) }
+        accumulator[depth].append(block.id)
+        for child in block.children {
+            expandableIdsByDepth(child, depth: depth + 1, into: &accumulator)
+        }
+    }
+
+    public var expandableIdsByDepth: [[String]] {
+        var accumulator: [[String]] = []
+        Self.expandableIdsByDepth(root, into: &accumulator)
+        return accumulator
+    }
+}

--- a/ios/Packages/NodusKit/Sources/NodusKit/Store/MutationOutbox.swift
+++ b/ios/Packages/NodusKit/Sources/NodusKit/Store/MutationOutbox.swift
@@ -60,6 +60,13 @@ public actor MutationOutbox {
                 );
                 CREATE INDEX IF NOT EXISTS outbox_state ON outbox (state, created_at);
                 """)
+            // Added after the queue already existed on devices, so it is an ALTER guarded by a
+            // column check rather than a change to the CREATE above — which would never run
+            // again on a database that already has the table.
+            let columns = try db.columns(in: "outbox").map(\.name)
+            if !columns.contains("authorised") {
+                try db.execute(sql: "ALTER TABLE outbox ADD COLUMN authorised INTEGER NOT NULL DEFAULT 0")
+            }
         }
     }
 
@@ -68,9 +75,12 @@ public actor MutationOutbox {
     public func enqueue(_ mutation: Mutation, title: String) throws {
         let payload = try JSONEncoder.nodus.encode(mutation)
         try dbQueue.write { db in
+            // `authorised` is written as 0 rather than left to its default because this is an
+            // INSERT OR REPLACE: editing a change that was already authorised puts it back
+            // behind the send button, which is the honest reading of "this is a new change".
             try db.execute(sql: """
-                INSERT OR REPLACE INTO outbox (id, tbl, title, state, detail, payload, created_at, sent_at)
-                VALUES (?, ?, ?, ?, NULL, ?, ?, NULL)
+                INSERT OR REPLACE INTO outbox (id, tbl, title, state, detail, payload, created_at, sent_at, authorised)
+                VALUES (?, ?, ?, ?, NULL, ?, ?, NULL, 0)
                 """, arguments: [
                     mutation.id, mutation.table, title, State.pending.rawValue,
                     String(data: payload, encoding: .utf8) ?? "{}",
@@ -80,12 +90,53 @@ public actor MutationOutbox {
     }
 
     public func pending(limit: Int) throws -> [Mutation] {
+        try mutations(sql: "SELECT payload FROM outbox WHERE state = ? ORDER BY created_at LIMIT ?",
+                      arguments: [State.pending.rawValue, limit])
+    }
+
+    /// Pending changes the user has already asked to send.
+    ///
+    /// The background flush reads this and never `pending(limit:)`, which is the whole
+    /// difference between finishing a journey the user started and starting one for them. A
+    /// note written on a plane and never sent stays on the device until they press the button,
+    /// exactly as the Writing screen promises.
+    public func authorisedPending(limit: Int) throws -> [Mutation] {
+        try mutations(sql: """
+            SELECT payload FROM outbox
+            WHERE state = ? AND authorised = 1
+            ORDER BY created_at LIMIT ?
+            """, arguments: [State.pending.rawValue, limit])
+    }
+
+    /// Record that the user pressed send. Returns how many changes that covered.
+    ///
+    /// Called at the start of a foreground flush, before the first request, so a flush cut off
+    /// by a dead network leaves behind changes the background task is allowed to finish.
+    @discardableResult
+    public func authorisePending() throws -> Int {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE outbox SET authorised = 1 WHERE state = ? AND authorised = 0",
+                arguments: [State.pending.rawValue]
+            )
+            return db.changesCount
+        }
+    }
+
+    /// How many changes the background flush would be allowed to send right now.
+    public func authorisedCount() throws -> Int {
         try dbQueue.read { db in
-            try GRDB.Row.fetchAll(
+            try Int.fetchOne(
                 db,
-                sql: "SELECT payload FROM outbox WHERE state = ? ORDER BY created_at LIMIT ?",
-                arguments: [State.pending.rawValue, limit]
-            ).compactMap { row in
+                sql: "SELECT COUNT(*) FROM outbox WHERE state = ? AND authorised = 1",
+                arguments: [State.pending.rawValue]
+            ) ?? 0
+        }
+    }
+
+    private func mutations(sql: String, arguments: StatementArguments) throws -> [Mutation] {
+        try dbQueue.read { db in
+            try GRDB.Row.fetchAll(db, sql: sql, arguments: arguments).compactMap { row in
                 guard
                     let payload: String = row["payload"],
                     let data = payload.data(using: .utf8)

--- a/ios/Packages/NodusKit/Tests/NodusKitTests/ArgumentMapTests.swift
+++ b/ios/Packages/NodusKit/Tests/NodusKitTests/ArgumentMapTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+@testable import NodusKit
+
+/// The argument map, which is arithmetic over real edges rather than anything a model said.
+///
+/// The properties that matter are the ones that make the map an argument instead of a star: it
+/// grows evenly rather than pouring the whole budget into the first branch, an idea appears
+/// once, and a link that disagrees is never crowded out by the many that agree.
+@Suite("Argument map")
+struct ArgumentMapTests {
+    private func graph(ideas: [String], edges: [(String, String, String, Double)], truncated: Bool = false) -> IdeaGraph {
+        let ideaRows = ideas.map { id in
+            JSONValue.object([
+                "global_id": .string(id),
+                "label": .string("Idea \(id)"),
+                "statement": .string("Enunciado de \(id)"),
+                "type": .string("claim"),
+            ])
+        }
+        let edgeRows = edges.enumerated().map { index, edge in
+            JSONValue.object([
+                "id": .string("e\(index)"),
+                "from_id": .string(edge.0),
+                "to_id": .string(edge.1),
+                "type": .string(edge.2),
+                "confidence": .double(edge.3),
+                "basis": .string("inferred"),
+            ])
+        }
+        let payload = JSONValue.object([
+            "seedId": .string(ideas.first ?? ""),
+            "depth": .int(3),
+            "ideas": .array(ideaRows),
+            "edges": .array(edgeRows),
+            "truncated": .bool(truncated),
+        ])
+        let data = try! JSONEncoder.nodus.encode(payload)
+        return try! JSONDecoder.nodus.decode(IdeaGraph.self, from: data)
+    }
+
+    @Test("a seed with no edges is still a map, of one block")
+    func lonelySeed() throws {
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(ideas: ["a"], edges: [])))
+        #expect(map.root.ideaId == "a")
+        #expect(map.root.children.isEmpty)
+        #expect(map.blockCount == 1)
+        #expect(map.seedDegree == 0)
+    }
+
+    @Test("a seed outside the graph produces no map rather than an empty one")
+    func unknownSeed() {
+        #expect(ArgumentMapBuilder.structural(from: graph(ideas: ["a"], edges: []), seedId: "zzz") == nil)
+    }
+
+    // Each idea is placed once, so the tree stays a tree: the same card appearing on two
+    // branches would make one argument look like two.
+    @Test("an idea reachable by two paths is placed once")
+    func noDuplicates() throws {
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(
+            ideas: ["a", "b", "c", "d"],
+            edges: [("a", "b", "supports", 0.9), ("a", "c", "supports", 0.8), ("b", "d", "refines", 0.7), ("c", "d", "refines", 0.7)]
+        )))
+
+        var seen: [String] = []
+        func walk(_ block: ArgumentBlock) {
+            seen.append(block.ideaId)
+            block.children.forEach(walk)
+        }
+        walk(map.root)
+        #expect(seen.count == Set(seen).count, "\(seen) repeats an idea")
+        #expect(Set(seen) == ["a", "b", "c", "d"])
+    }
+
+    // The reason the desktop grows the tree level by level. Depth-first let the first branch
+    // spend the whole budget and left its siblings bare.
+    @Test("the tree grows level by level, so no branch starves another")
+    func growsByLevel() throws {
+        // One seed with three neighbours, each of which has its own chain.
+        var edges: [(String, String, String, Double)] = []
+        var ideas = ["seed"]
+        for branch in ["x", "y", "z"] {
+            ideas.append("\(branch)1")
+            edges.append(("seed", "\(branch)1", "supports", 0.9))
+            for step in 2...4 {
+                ideas.append("\(branch)\(step)")
+                edges.append(("\(branch)\(step - 1)", "\(branch)\(step)", "refines", 0.8))
+            }
+        }
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(ideas: ideas, edges: edges), seedId: "seed"))
+
+        #expect(map.root.children.count == 3, "every first-level branch is drawn")
+        for child in map.root.children {
+            #expect(!child.children.isEmpty, "\(child.ideaId) was left bare")
+        }
+    }
+
+    // Debates are the point of an argument map. A hub whose strongest links all agree with each
+    // other must still show the one that does not.
+    @Test("a disagreement is drawn even when every stronger link agrees")
+    func debatesSurviveTheCap() throws {
+        var ideas = ["seed", "against"]
+        var edges: [(String, String, String, Double)] = [("seed", "against", "contradicts", 0.10)]
+        for index in 1...30 {
+            ideas.append("for\(index)")
+            edges.append(("seed", "for\(index)", "supports", 0.99))
+        }
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(ideas: ideas, edges: edges), seedId: "seed"))
+
+        let drawn = map.root.children.map(\.ideaId)
+        #expect(drawn.contains("against"), "the only contradiction was crowded out by agreement")
+        #expect(drawn.first == "against", "a debate outranks a stronger agreement")
+        #expect(map.root.children.count == ArgumentMapBuilder.branchesByDepth[0])
+    }
+
+    @Test("a hub says how many of its links it did not draw")
+    func hiddenChildrenAreCounted() throws {
+        var ideas = ["seed"]
+        var edges: [(String, String, String, Double)] = []
+        for index in 1...30 {
+            ideas.append("n\(index)")
+            edges.append(("seed", "n\(index)", "supports", 0.5))
+        }
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(ideas: ideas, edges: edges), seedId: "seed"))
+
+        #expect(map.root.children.count == 12)
+        #expect(map.root.hiddenChildren == 18, "30 links, 12 drawn")
+        #expect(map.seedDegree == 30)
+    }
+
+    @Test("the map never grows past its budget however dense the corpus")
+    func respectsTheBudget() throws {
+        // A dense mesh: every idea linked to every other.
+        let ideas = (0..<60).map { "i\($0)" }
+        var edges: [(String, String, String, Double)] = []
+        for (index, from) in ideas.enumerated() {
+            for to in ideas[(index + 1)...] {
+                edges.append((from, to, "supports", 0.5))
+            }
+        }
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(ideas: ideas, edges: edges), seedId: "i0"))
+
+        #expect(map.blockCount <= ArgumentMapBuilder.maxBlocks)
+        var depth = 0
+        func measure(_ block: ArgumentBlock, _ level: Int) {
+            depth = max(depth, level)
+            block.children.forEach { measure($0, level + 1) }
+        }
+        measure(map.root, 0)
+        #expect(depth <= ArgumentMapBuilder.maxDepth)
+    }
+
+    @Test("the unfold script is contiguous, so no branch opens under a closed parent")
+    func unfoldScriptIsContiguous() throws {
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(
+            ideas: ["a", "b", "c", "d", "e"],
+            edges: [("a", "b", "supports", 0.9), ("b", "c", "refines", 0.8), ("c", "d", "refines", 0.7), ("a", "e", "contradicts", 0.6)]
+        ), seedId: "a"))
+
+        let levels = map.expandableIdsByDepth
+        #expect(levels.first == ["a"], "the seed is the first thing to unfold")
+        // Every id at level n+1 hangs off one that is expandable at level n.
+        for (index, level) in levels.enumerated() where index > 0 {
+            #expect(!level.isEmpty, "level \(index) is empty, so the script has a hole")
+        }
+    }
+
+    @Test("a truncated neighbourhood is carried through, not quietly dropped")
+    func truncationSurvives() throws {
+        let map = try #require(ArgumentMapBuilder.structural(
+            from: graph(ideas: ["a", "b"], edges: [("a", "b", "supports", 0.9)], truncated: true),
+            seedId: "a"
+        ))
+        #expect(map.truncated)
+        #expect(map.ideaCount == 2)
+    }
+
+    @Test("an unknown relation is 'related' rather than a crash or a guess")
+    func unknownRelations() throws {
+        let map = try #require(ArgumentMapBuilder.structural(from: graph(
+            ideas: ["a", "b"],
+            edges: [("a", "b", "invented_by_a_future_schema", 0.5)]
+        ), seedId: "a"))
+        #expect(map.root.children.first?.relation == .related)
+    }
+
+    @Test("the relation accents match the desktop's, because the two draw the same map")
+    func accentsMatchTheDesktop() {
+        // ArgumentMapView.tsx:31-46.
+        #expect(ArgumentRelation.supports.accentHex == "#22c55e")
+        #expect(ArgumentRelation.refutes.accentHex == "#ef4444")
+        #expect(ArgumentRelation.contradicts.accentHex == "#f97316")
+        #expect(ArgumentRelation.refines.accentHex == "#8b5cf6")
+        #expect(ArgumentRelation.contradicts.isDebate)
+        #expect(ArgumentRelation.refutes.isDebate)
+        #expect(!ArgumentRelation.supports.isDebate)
+        #expect(ArgumentRelation.supports.family == .support)
+        #expect(ArgumentRelation.variantOf.family == .other)
+    }
+}

--- a/ios/Packages/NodusKit/Tests/NodusKitTests/EnvelopeTests.swift
+++ b/ios/Packages/NodusKit/Tests/NodusKitTests/EnvelopeTests.swift
@@ -226,3 +226,63 @@ struct VaultTypeTests {
         #expect(vault.type == nil)
     }
 }
+
+/// What a failed connection is allowed to say.
+///
+/// A Nodus Server usually lives on a private network, so the two ordinary failures — "this
+/// device is not on that network" and "nothing is listening" — are the ones a user actually
+/// hits, and they need opposite things done about them. Collapsing both into "could not
+/// connect" is what left a real user staring at a screen with nothing to act on.
+@Suite("Transport errors")
+struct TransportErrorTests {
+    @Test("a name that resolves to nothing is told apart from a port with nothing behind it")
+    func namingTheTwoFailures() {
+        #expect(TransportError.from(URLError(.cannotFindHost)) == .hostNotFound)
+        #expect(TransportError.from(URLError(.dnsLookupFailed)) == .hostNotFound)
+        #expect(TransportError.from(URLError(.cannotConnectToHost)) == .cannotConnect)
+
+        let notFound = TransportError.hostNotFound.errorDescription ?? ""
+        let refused = TransportError.cannotConnect.errorDescription ?? ""
+        #expect(notFound != refused)
+        #expect(notFound.contains("private network"), "the fix is to join the network, and it should say so")
+        #expect(refused.contains("stopped") || refused.contains("reachable"))
+    }
+
+    @Test("a refused certificate is not reported as a missing server")
+    func certificatesAreTheirOwnFailure() {
+        for code: URLError.Code in [.secureConnectionFailed, .serverCertificateUntrusted,
+                                    .serverCertificateHasBadDate, .serverCertificateHasUnknownRoot] {
+            #expect(TransportError.from(URLError(code)) == .certificateRejected)
+        }
+        #expect(TransportError.certificateRejected.errorDescription?.contains("certificate") == true)
+    }
+
+    @Test("ATS blocking cleartext says what to type instead")
+    func cleartextIsExplained() {
+        #expect(TransportError.from(URLError(.appTransportSecurityRequiresSecureConnection)) == .insecureBlocked)
+        #expect(TransportError.insecureBlocked.errorDescription?.contains("https://") == true)
+    }
+
+    @Test("the ordinary three keep their meaning")
+    func theUsualSuspects() {
+        #expect(TransportError.from(URLError(.notConnectedToInternet)) == .offline)
+        #expect(TransportError.from(URLError(.cancelled)) == .cancelled)
+        #expect(TransportError.from(URLError(.timedOut)) == .timedOut)
+        // A code with no case of its own keeps the system's own words rather than being
+        // flattened into a wrong one.
+        #expect(TransportError.from(URLError(.badServerResponse)) != .hostNotFound)
+    }
+
+    @Test("every case says something, because a blank error is worse than a wrong one")
+    func nothingIsSilent() {
+        let cases: [TransportError] = [
+            .offline, .cancelled, .timedOut, .hostNotFound, .cannotConnect,
+            .certificateRejected, .insecureBlocked, .badServerURL("x"),
+            .malformedResponse(expected: "y"), .underlying("z"),
+        ]
+        for value in cases {
+            let text = value.errorDescription ?? ""
+            #expect(!text.isEmpty, "\(value) has no description")
+        }
+    }
+}

--- a/ios/Packages/NodusKit/Tests/NodusKitTests/OutboxTests.swift
+++ b/ios/Packages/NodusKit/Tests/NodusKitTests/OutboxTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import NodusKit
+
+/// The queue, and the one distinction the background flush rests on.
+///
+/// The Writing screen promises that a change travels when the user presses send. A background
+/// task exists to finish a send the network cut short — not to start one. That difference is
+/// the `authorised` flag, and everything here tests it, because getting it wrong would mean a
+/// note written on a plane leaving the device without anybody asking.
+@Suite("Mutation outbox authorisation")
+struct MutationOutboxAuthorisationTests {
+    private func makeOutbox(directory: URL? = nil) throws -> (MutationOutbox, URL) {
+        let folder = directory ?? FileManager.default.temporaryDirectory
+            .appendingPathComponent("nodus-outbox-\(UUID().uuidString)")
+        return (try MutationOutbox(spaceId: "space-under-test", directory: folder), folder)
+    }
+
+    private func note(_ id: String, title: String = "Una nota") -> Mutation {
+        Mutation(
+            id: id,
+            clientId: "client-1",
+            kind: .upsert,
+            table: .notes,
+            key: [id],
+            row: ["id": .string(id), "title": .string(title), "content": .string("Cuerpo")],
+            schemaVersion: 245
+        )
+    }
+
+    @Test("a queued change waits behind the send button")
+    func queuedChangesAreNotAuthorised() async throws {
+        let (outbox, _) = try makeOutbox()
+        try await outbox.enqueue(note("n-1"), title: "Una nota")
+        try await outbox.enqueue(note("n-2"), title: "Otra nota")
+
+        #expect(try await outbox.pending(limit: 10).count == 2)
+        #expect(try await outbox.authorisedCount() == 0)
+        #expect(try await outbox.authorisedPending(limit: 10).isEmpty,
+                "nothing may travel on its own before the user has pressed send")
+    }
+
+    @Test("pressing send authorises what is pending, and nothing else")
+    func authorisingCoversPendingOnly() async throws {
+        let (outbox, _) = try makeOutbox()
+        try await outbox.enqueue(note("n-1"), title: "Primera")
+        try await outbox.enqueue(note("n-2"), title: "Segunda")
+        try await outbox.enqueue(note("n-3"), title: "Tercera")
+        try await outbox.markAccepted(["n-3"])
+
+        let covered = try await outbox.authorisePending()
+        #expect(covered == 2, "the accepted change is already gone; authorising it would mean nothing")
+        #expect(try await outbox.authorisedCount() == 2)
+        #expect(Set(try await outbox.authorisedPending(limit: 10).map(\.id)) == ["n-1", "n-2"])
+    }
+
+    @Test("editing an authorised change puts it back behind the button")
+    func reEnqueueingRevokesAuthorisation() async throws {
+        let (outbox, _) = try makeOutbox()
+        try await outbox.enqueue(note("n-1", title: "Primer intento"), title: "Primer intento")
+        try await outbox.authorisePending()
+        #expect(try await outbox.authorisedCount() == 1)
+
+        // Same id, new content: this is the user changing their mind, not the queue retrying.
+        try await outbox.enqueue(note("n-1", title: "Segundo intento"), title: "Segundo intento")
+        #expect(try await outbox.authorisedCount() == 0)
+        #expect(try await outbox.pending(limit: 10).count == 1)
+    }
+
+    @Test("accepting a change takes it out of what the background flush would send")
+    func acceptedChangesLeaveTheQueue() async throws {
+        let (outbox, _) = try makeOutbox()
+        try await outbox.enqueue(note("n-1"), title: "Una nota")
+        try await outbox.authorisePending()
+        try await outbox.markAccepted(["n-1"])
+
+        #expect(try await outbox.authorisedCount() == 0)
+        #expect(try await outbox.authorisedPending(limit: 10).isEmpty)
+        let counts = try await outbox.counts()
+        #expect(counts.accepted == 1)
+        #expect(counts.pending == 0)
+    }
+
+    // The column was added after the queue already existed on devices, so the migration is an
+    // ALTER guarded by a column check. Reopening the same database is what would break if the
+    // guard were wrong, and it is the exact thing every launch does.
+    @Test("reopening a queue that already exists runs the migration again without complaint")
+    func migrationIsIdempotent() async throws {
+        let (first, folder) = try makeOutbox()
+        try await first.enqueue(note("n-1"), title: "Una nota")
+        try await first.authorisePending()
+
+        let (second, _) = try makeOutbox(directory: folder)
+        #expect(try await second.authorisedCount() == 1)
+        #expect(try await second.authorisedPending(limit: 10).map(\.id) == ["n-1"])
+    }
+
+}

--- a/ios/Packages/NodusUI/Sources/NodusUI/Components/Components.swift
+++ b/ios/Packages/NodusUI/Sources/NodusUI/Components/Components.swift
@@ -131,11 +131,17 @@ public struct NodusNotice: View {
     public enum Tone: Sendable { case info, caution, blocked }
 
     public var tone: Tone
-    public var title: String
-    public var message: String?
+    /// `LocalizedStringKey`, not `String`. Every notice in the app passes a literal here, and a
+    /// `String` parameter meant `Text` received a value rather than a key — so not one notice
+    /// was ever translated, however complete the catalogue was.
+    public var title: LocalizedStringKey
+    /// Also a key, so a literal is translated. A runtime value — a server's warning, an error's
+    /// description — is wrapped by the caller as `LocalizedStringKey(text)`, which finds no
+    /// entry and renders the text as it is.
+    public var message: LocalizedStringKey?
     public var systemImage: String?
 
-    public init(tone: Tone = .info, title: String, message: String? = nil, systemImage: String? = nil) {
+    public init(tone: Tone = .info, title: LocalizedStringKey, message: LocalizedStringKey? = nil, systemImage: String? = nil) {
         self.tone = tone
         self.title = title
         self.message = message


### PR DESCRIPTION
## What this is

Everything the iOS app declared and did not have, plus three readers for work the vault already publishes.

## Capabilities that were declared and absent

| | Before | Now |
|---|---|---|
| **Background tasks** | Three identifiers in `BGTaskSchedulerPermittedIdentifiers`, no registration | Registered. A Deep Research run checkpoints per section and resumes; the mirror refreshes; the outbox finishes a send |
| **Face ID** | `NSFaceIDUsageDescription` with no `LocalAuthentication` anywhere | A real gate over the app, opt-in, which authenticates before it will turn on |
| **Semantic search** | The Search tab never embedded its query | Ranks by meaning when it can, and names the missing key when it cannot |
| **Writing** | 1 of 11 mutable tables, create-only | Notes edited and deleted; a report generated here can be sent to the vault |
| **Localisation** | 5 hardcoded Spanish literals — and, underneath, every notice in the app | 606 entries, none untranslated, plus an `InfoPlist.xcstrings` |

## New

- **Immersion reader** — the published plan as a study route: overview, stations with their question, context, synthesis, takeaways, positions and cited sources, key terms, contrasts, frontiers and a final exam. It was previously opened through the generic row viewer, which showed the plan as one enormous JSON column.
- **Argument map** — a port of the desktop's structural mode (`electron/ai/argumentMap.ts:508`) with its constants intact: depth 3, branches 12/4/2, 160 blocks, and the round-robin that keeps a single contradiction from being crowded out by thirty stronger agreements. No model and no key: it is arithmetic over the ego graph the server already serves.
- **Deep Research reports** render their headings and citations. The reader looked for `draft.sections[].markdown`; the desktop writes `draftMarkdown`, so every report published from the desktop had been rendering blank.

## Defects found while verifying

- `NodusNotice` took `String`, and `Text` of a value is never looked up — so not one notice in 35 call sites was ever translated. Same for half of Settings, the queue's three states, and every heading a view computed.
- The Search tab had no visible field: `.searchable` lives in a navigation bar the shell hides on root screens.
- The connect probe could hang for ten minutes. The session sets `waitsForConnectivity`, and while URLSession waits for connectivity it ignores request timeouts entirely. The probe now has its own session that does not wait, and `TransportError` tells *no machine by that name* apart from *nothing answered* — the two need opposite things from the reader.
- `MirrorStore.init` creates its database, so asking it whether a mirror exists would have answered yes forever after.

## Verification

- **173 tests**, up from 114 — 33 app, 90 NodusKit (including the live ones), 45 NodusAI, 5 NodusUI.
- Driven against a Nodus Server holding copies of nine real vaults, including a 135,533-row academic corpus with 18 published reports and an immersion session.
- The four mutation shapes were put through the real server's validator: 4 accepted, 0 rejected, and a note written in the app was read back out of the ledger.
- Face ID reaches `evaluatePolicy` on a simulator that cannot present the panel, which is as far as a simulator goes; the prompt itself needs hardware.

## Not done

Signing. This machine still has no valid identity and no provisioning profile, so the build is archived unsigned and sideloaded.
