### PR TITLE
Give a pairing code an alphabet somebody can actually read

### DIFF
--- a/scripts/test-nodus-server.mjs
+++ b/scripts/test-nodus-server.mjs
@@ -8,7 +8,31 @@ import { spawn } from 'node:child_process';
 import { gzipSync } from 'node:zlib';
 import test from 'node:test';
 import { missingServerTranslations } from '../server/lib/i18n.mjs';
-import { Store } from '../server/lib/store.mjs';
+import { Store, pairingCode } from '../server/lib/store.mjs';
+
+/**
+ * The code somebody reads off the administration page and types into the desktop.
+ *
+ * It used to be two base64url slices joined by a hyphen and uppercased, which put a `-` or a `_`
+ * *inside* a group in 22% of codes — `HT5--E2FR`, `-HLJ-VF-Y` — beside the group separator, and
+ * folded `a` onto `A` so letters came out twice as likely as digits. The endpoint test caught it
+ * only when it happened to draw a bad one, so it passed four times before failing on main.
+ *
+ * Ten thousand draws is not proof of a distribution; it is enough to fail loudly the moment
+ * anybody puts a variable-alphabet generator back.
+ */
+test('a pairing code can be read aloud and typed back without a second try', () => {
+  const seen = new Set();
+  for (let index = 0; index < 10_000; index += 1) {
+    const code = pairingCode();
+    assert.match(code, /^[A-Z0-9]{4}-[A-Z0-9]{4}$/, `a person has to type this: ${code}`);
+    assert.doesNotMatch(code, /[IO01]/, `I, O, 0 and 1 get transcribed as each other: ${code}`);
+    for (const character of code.replace('-', '')) seen.add(character);
+  }
+  // Every symbol of the intended alphabet, and nothing else: a generator that quietly narrowed
+  // to hexadecimal would still satisfy every assertion above.
+  assert.equal([...seen].sort().join(''), '23456789ABCDEFGHJKLMNPQRSTUVWXYZ');
+});
 
 test('Nodus Server web translations cover every supported app language', () => {
   assert.deepEqual(missingServerTranslations(), {

--- a/server/lib/store.mjs
+++ b/server/lib/store.mjs
@@ -8,6 +8,38 @@ export function token(bytes = 32) {
   return randomBytes(bytes).toString('base64url');
 }
 
+/**
+ * Thirty-two symbols a person can read off a screen and type without a second try.
+ *
+ * No I, O, 0 or 1 — the four that get transcribed as each other — and no lower case, because the
+ * pairing routes uppercase whatever arrives. Exactly 32 so a random byte masked to five bits picks
+ * one uniformly, with no modulo bias and no rejection loop.
+ */
+const PAIRING_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+/**
+ * A pairing code in the shape `XXXX-XXXX`.
+ *
+ * It replaces `` `${token(4).slice(0, 4)}-${token(4).slice(0, 4)}`.toUpperCase() ``, which was
+ * wrong twice. base64url includes `-` and `_`, so 22% of codes carried one *inside* a group,
+ * beside the group separator: `HT5--E2FR` and `-HLJ-VF-Y` are real output, and the administration
+ * page asks somebody to read that off a screen and type it into the desktop. And uppercasing
+ * base64url folds `a` onto `A`, so letters came out twice as likely as digits — an alphabet of 38
+ * symbols that were never worth 38.
+ *
+ * Forty bits, uniform. The code expires in fifteen minutes and the route is rate limited, so the
+ * point of the change is legibility; the entropy simply stopped being a guess.
+ */
+export function pairingCode() {
+  const bytes = randomBytes(8);
+  let code = '';
+  for (let index = 0; index < 8; index += 1) {
+    if (index === 4) code += '-';
+    code += PAIRING_ALPHABET[bytes[index] & 31];
+  }
+  return code;
+}
+
 export function digest(value) {
   return createHash('sha256').update(String(value)).digest('base64url');
 }

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -7,7 +7,7 @@ import { constants as bufferLimits } from 'node:buffer';
 import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import { Store, digest, token } from './lib/store.mjs';
+import { Store, digest, pairingCode, token } from './lib/store.mjs';
 import { body, contentSecurityPolicy, cookies, escapeHtml, form, html, json, jsonBody, redirect } from './lib/http.mjs';
 import { normalizeServerLanguage, serverTranslator } from './lib/i18n.mjs';
 import { helpTip, languagePicker, nodusMark, WEB_STYLES } from './lib/webUi.mjs';
@@ -925,7 +925,7 @@ async function handleLocalProvision(req, res) {
     space.name = vaultName;
   }
 
-  const code = `${token(4).slice(0, 4)}-${token(4).slice(0, 4)}`.toUpperCase();
+  const code = pairingCode();
   store.state.pairingCodes.push({ hash: digest(code), userId: admin.id, spaceId: space.id, expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(), usedAt: null });
   store.save();
   return json(res, 200, { spaceId: space.id, spaceName: space.name, code, publicUrl: publicUrl() });
@@ -1238,7 +1238,7 @@ async function route(req, res) {
     const current = requireSession(req, res, true); if (!current) return;
     const values = await form(req, AUTH_BODY_BYTES); if (!checkCsrf(current, values.csrf)) return html(res, 403, page(tr('error'), `<h1>${tr('sessionExpired')}</h1>`));
     if (!membership(current.user.id, values.spaceId)) return html(res, 403, page(tr('error'), '<h1>No access to that space.</h1>'));
-    const raw = `${token(4).slice(0, 4)}-${token(4).slice(0, 4)}`.toUpperCase();
+    const raw = pairingCode();
     store.state.pairingCodes.push({ hash: digest(raw), userId: current.user.id, spaceId: values.spaceId, expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(), usedAt: null }); store.save();
     return html(res, 200, page(tr('createPairing'), `<div class="page-heading"><div><p class="eyebrow">${tr('publisherDevices')}</p><h1>${tr('connectDesktop')}</h1></div><a class="button-link" href="/">${tr('back')}</a></div><div class="card code-panel"><p>${tr('pairingHelp')}</p><h2><code>${raw}</code></h2><p class="muted">${tr('pairingExpiry')}</p></div>`));
   }


### PR DESCRIPTION
`main` is red. The failing test is `the provisioning secret is written 0600, and guards the endpoint`,
and it is not flaky — the generator behind it is.

## The defect

Both pairing codes were built the same way:

```js
`${token(4).slice(0, 4)}-${token(4).slice(0, 4)}`.toUpperCase()
```

`token()` is `randomBytes(n).toString('base64url')`, and **base64url contains `-` and `_`**. So 22%
of codes carry one *inside* a group, right beside the group separator. Measured over 20 000 draws;
real output:

```
-HLJ-VF-Y   HT5--E2FR   L_SN-GEQE   VBJT--WCE   BOY0-_3OE
```

The administration page prints that and asks somebody to type it into Nodus Desktop. The code is
single-use and expires in fifteen minutes, so a misread is a round trip through the whole flow.

Uppercasing base64url also folds `a` onto `A`: the effective alphabet was 38 symbols distributed
unevenly, a letter twice as likely as a digit.

## The fix

32 symbols — `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` — with no `I`, `O`, `0` or `1`, the four that get
transcribed as each other. Exactly 32, so a random byte masked to five bits picks one uniformly with
no modulo bias and no rejection loop. 40 bits, evenly spread.

**Both** call sites are fixed. The one that broke CI is `/api/v1/local/provision`, which basic mode
pairs through machine-to-machine and would have survived an ugly code. The one that actually matters
is `/admin/pairing`, which a person reads — and that one has been like this all along.

Nothing validates the old format anywhere: both pairing routes uppercase whatever arrives before
hashing it, so no existing code or client is affected.

## Why this got through

The endpoint test only fails when it happens to draw a bad code. It passed on this branch's CI, on
#342's CI, and twice locally, then failed on `main`. A one-in-five failure that looks like flake is
worse than a reliable one, so the generator now has a test of its own: shape, absence of look-alike
characters, and the alphabet genuinely in use, over 10 000 draws. Reinstating the old expression
makes it fail — checked.

## Verification

1603/1603 tests, lint clean, and the endpoint test run five times in a row without a failure.