### PR TITLE
Let a Deep Research report reach the vault it was written for

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.2.0"
+version: "3.2.1"
 date-released: "2026-08-04"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"

--- a/electron/serverSync/replicaService.ts
+++ b/electron/serverSync/replicaService.ts
@@ -315,6 +315,62 @@ async function refreshRole(vault: VaultSummary, token: string): Promise<void> {
 
 // ── Draining the outgoing queue ─────────────────────────────────────────────
 
+/**
+ * What the space at the other end says it will accept.
+ *
+ * Asked once per vault and kept, because it changes only when the server is upgraded. A server
+ * too old to publish these answers `null` for them, and every use below falls back to a
+ * conservative guess rather than to an assumption — see SAFE_BATCH_BYTES.
+ */
+interface RemoteLimits {
+  maxMutationBytes: number | null;
+  maxMutationBatchBytes: number | null;
+  maxMutationBatch: number;
+}
+
+const remoteLimits = new Map<string, { limits: RemoteLimits; at: number }>();
+/**
+ * How long a remembered answer is trusted.
+ *
+ * Not forever, for two reasons that point the same way: the server may be upgraded under a
+ * desktop that stays open for weeks, and the shrunken budget a 413 leaves behind would
+ * otherwise never grow back even once the cause is gone.
+ */
+const LIMITS_TTL_MS = 60 * 60_000;
+
+/**
+ * What to send in one request to a server that has not told us its ceiling.
+ *
+ * Servers before 3.2.1 accepted a 2 MiB body and said so nowhere, so this stays under it. The
+ * cost of guessing low is an extra request; the cost of guessing high was a 413 that marked
+ * nothing, kept everything pending, and re-sent the identical batch every thirty seconds
+ * forever. One of those is a queue that drains slowly and the other is a queue that never
+ * drains at all.
+ */
+const SAFE_BATCH_BYTES = 1_500_000;
+
+async function limitsFor(vault: VaultSummary, token: string): Promise<RemoteLimits> {
+  const cached = remoteLimits.get(vault.id);
+  if (cached && Date.now() - cached.at < LIMITS_TTL_MS) return cached.limits;
+  const fallback: RemoteLimits = { maxMutationBytes: null, maxMutationBatchBytes: null, maxMutationBatch: 100 };
+  try {
+    const response = await request(`${normalizeUrl(vault.remote!.url)}/api/v1/capabilities`, { headers: { authorization: `Bearer ${token}` } });
+    if (!response.ok) return fallback;
+    const value = await response.json() as Partial<Record<keyof RemoteLimits, unknown>>;
+    const positive = (input: unknown): number | null => (typeof input === 'number' && Number.isFinite(input) && input > 0 ? input : null);
+    const limits: RemoteLimits = {
+      maxMutationBytes: positive(value.maxMutationBytes),
+      maxMutationBatchBytes: positive(value.maxMutationBatchBytes),
+      maxMutationBatch: positive(value.maxMutationBatch) ?? 100,
+    };
+    remoteLimits.set(vault.id, { limits, at: Date.now() });
+    return limits;
+  } catch {
+    // Offline. Not cached, so the next tick asks again.
+    return fallback;
+  }
+}
+
 /** Read the live row a queued entry points at, so what is sent is never a stale copy. */
 function readRow(db: Database.Database, table: string, rowKey: string): Record<string, unknown> | null {
   let key: unknown[];
@@ -348,8 +404,12 @@ export async function drainOutbox(vaultId: string): Promise<void> {
   runtime.rejectedMutations = counts.rejected;
   if (pending.length === 0) return;
 
+  const limits = await limitsFor(vault, token);
+  const batchBudget = limits.maxMutationBatchBytes ?? SAFE_BATCH_BYTES;
+
   const mutations = [];
   const sendable: string[] = [];
+  let batchBytes = 0;
   for (const entry of pending) {
     let key: unknown[];
     try { key = JSON.parse(entry.row_key) as unknown[]; } catch { continue; }
@@ -357,7 +417,7 @@ export async function drainOutbox(vaultId: string): Promise<void> {
     // An upsert whose row is gone was deleted after being queued; the delete entry that
     // replaced it carries the truth, so this one is simply dropped.
     if (entry.op === 'upsert' && !row) { markOutboxSent(db, [entry.id]); continue; }
-    mutations.push({
+    const mutation = {
       id: entry.id,
       clientId: clientIdFor(vaultId),
       kind: entry.op,
@@ -366,10 +426,34 @@ export async function drainOutbox(vaultId: string): Promise<void> {
       ...(entry.op === 'upsert' ? { row } : {}),
       schemaVersion: entry.schema_version,
       createdAt: entry.created_at,
-    });
+    };
+
+    // Measured here, where the row is in hand. A Deep Research report is one row carrying its
+    // whole markdown, so a queue of them is megabytes and counting entries says nothing about
+    // the size of the request they make.
+    const size = Buffer.byteLength(JSON.stringify(mutation), 'utf8');
+    if (limits.maxMutationBytes !== null && size > limits.maxMutationBytes) {
+      // Only when the server has actually told us its ceiling. Refusing a row locally against
+      // a guessed limit would throw away work the server would have taken.
+      markOutboxRejected(db, [entry.id], `Este cambio ocupa ${Math.round(size / 1024)} KB y el servidor acepta ${Math.round(limits.maxMutationBytes / 1024)} KB por fila.`);
+      continue;
+    }
+    if (mutations.length >= limits.maxMutationBatch) break;
+    // Always send at least one, so a row larger than a whole batch is still attempted rather
+    // than blocking everything queued behind it.
+    if (mutations.length > 0 && batchBytes + size > batchBudget) break;
+    batchBytes += size;
+    mutations.push(mutation);
     sendable.push(entry.id);
   }
-  if (mutations.length === 0) return;
+  if (mutations.length === 0) {
+    // Everything pending was refused locally for size. The counters still have to move, or
+    // the interface goes on showing changes as queued when nothing is going to be sent.
+    const afterRefusals = countOutbox(db);
+    runtime.pendingMutations = afterRefusals.pending;
+    runtime.rejectedMutations = afterRefusals.rejected;
+    return;
+  }
 
   try {
     const response = await request(
@@ -390,10 +474,28 @@ export async function drainOutbox(vaultId: string): Promise<void> {
       runtime.lastError = 'Faltan imágenes por subir antes de enviar estos cambios.';
       return;
     }
+    if (response.status === 413) {
+      // The batch was too big for this server as a whole. Nothing was stored and nothing is
+      // marked, so the work is safe; what must not happen is re-sending the identical batch
+      // every tick forever, which is exactly what this used to do. Halving the budget makes
+      // the queue converge on a size this server will take.
+      const shrunk = Math.max(64 * 1024, Math.floor(batchBudget / 2));
+      remoteLimits.set(vault.id, { limits: { ...limits, maxMutationBatchBytes: shrunk }, at: Date.now() });
+      runtime.lastError = `El servidor ha rechazado un envío de ${Math.round(batchBytes / 1024)} KB por tamaño. Se reintentará en envíos más pequeños.`;
+      return;
+    }
+    if (response.status === 507) {
+      // The space holds more undelivered changes than it is allowed to. Not a rejection: it
+      // clears when the owner opens Nodus and collects, so the queue is kept whole.
+      runtime.lastError = 'El espacio remoto acumula cambios que su propietario aún no ha recogido. Tus cambios se conservan y se reintentarán.';
+      return;
+    }
     if (!response.ok) throw new Error(`El servidor respondió con HTTP ${response.status}.`);
-    const value = await response.json() as { accepted?: string[]; duplicate?: string[]; rejected?: { id: string; reason: string }[] };
+    const value = await response.json() as { accepted?: string[]; duplicate?: string[]; rejected?: { id: string; reason: string; error_description?: string }[] };
     markOutboxSent(db, [...(value.accepted ?? []), ...(value.duplicate ?? [])]);
-    for (const rejection of value.rejected ?? []) markOutboxRejected(db, [rejection.id], rejection.reason);
+    // The server explains the reasons it can explain; the bare code is the fallback for the
+    // ones it cannot, and for servers that do not send an explanation at all.
+    for (const rejection of value.rejected ?? []) markOutboxRejected(db, [rejection.id], rejection.error_description ?? rejection.reason);
     pruneSentOutbox(db);
     const after = countOutbox(db);
     runtime.pendingMutations = after.pending;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/lib/nodusServerHarness.mjs
+++ b/scripts/lib/nodusServerHarness.mjs
@@ -53,6 +53,7 @@ export function serverEnvironment(overrides = {}) {
     'NODUS_SETUP_TOKEN', 'NODUS_PUBLIC_URL', 'NODUS_DATA_DIR', 'NODUS_HOST', 'NODUS_PORT',
     'NODUS_MAX_SNAPSHOT_BYTES', 'NODUS_MAX_SNAPSHOT_JSON_BYTES',
     'NODUS_MAX_ASSET_BYTES', 'NODUS_MAX_SPACE_ASSET_BYTES', 'NODUS_MAX_VECTOR_BYTES',
+    'NODUS_MAX_MUTATION_BYTES', 'NODUS_MAX_MUTATION_BATCH_BYTES', 'NODUS_MAX_LEDGER_BYTES',
     // NODUS_MAX_CACHED_SNAPSHOTS is refused by the server now, so a developer who still has
     // it exported would fail every boot here rather than see one clear message once.
     'NODUS_MAX_CACHED_SNAPSHOTS', 'NODUS_MAX_SNAPSHOT_CACHE_BYTES', 'NODUS_VECTOR_WORKERS',

--- a/scripts/test-nodus-server-mutations.mjs
+++ b/scripts/test-nodus-server-mutations.mjs
@@ -289,6 +289,12 @@ test('the size limits are published, explained on refusal, and a full ledger is 
     assert.equal(refused.rejected[0].limitBytes, 64 * 1024);
     assert.ok(refused.rejected[0].bytes > 64 * 1024);
     assert.match(refused.rejected[0].error_description, /per row/);
+    // Both numbers, and two different numbers. Rendered in MiB to one decimal, a 187 KiB row
+    // and a 256 KiB ceiling both read "0.2 MiB", and the sentence written to end the guessing
+    // would have printed the same figure twice.
+    const figures = refused.rejected[0].error_description.match(/\d+(?:\.\d+)? [KM]iB/g);
+    assert.equal(figures.length, 2, 'the sentence states the size and the ceiling');
+    assert.notEqual(figures[0], figures[1], 'and they must be distinguishable');
 
     // Filling the ledger is answered "later", not "no": the batch is refused whole and
     // nothing is stored, so the sender keeps work that would otherwise be lost while the

--- a/scripts/test-nodus-server-mutations.mjs
+++ b/scripts/test-nodus-server-mutations.mjs
@@ -11,7 +11,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { MUTABLE_TABLES, rowKey, validateMutation } from '../server/lib/core/mutations.mjs';
+import { DEFAULT_MAX_MUTATION_BYTES, MUTABLE_TABLES, rowKey, validateMutation } from '../server/lib/core/mutations.mjs';
 import * as ledger from '../server/lib/ledger.mjs';
 import { Store } from '../server/lib/store.mjs';
 import { academicSnapshot, publish } from './lib/nodusServerFixtures.mjs';
@@ -98,6 +98,52 @@ test('validation refuses everything the ledger must not carry', () => {
   assert.equal(empty.ok, true);
 });
 
+/** A Deep Research report of `words` words, in the shape the phone and the desktop both send. */
+function reportMutation(words, overrides = {}) {
+  // Accented Spanish on purpose: these are two bytes each once JSON-escaped, and that is half
+  // the reason a report measured far larger than its word count suggested.
+  const markdown = Array.from({ length: words }, (_, index) => (index % 7 === 0 ? 'investigación' : 'análisis')).join(' ');
+  return mutation({
+    id: 'mut-report',
+    table: 'writing_saved_drafts',
+    key: ['dr-2'],
+    row: {
+      id: 'dr-2',
+      title: 'Omisiones en la literatura y fotografía de viaje',
+      brief_json: JSON.stringify({ kind: 'deep_research', objective: 'Omisiones', language: 'es' }),
+      selection_json: '{}',
+      model_json: '{}',
+      draft_json: JSON.stringify({ title: 'Omisiones', draftMarkdown: markdown, bibliography: [] }),
+      created_at: '2026-02-02T00:00:00.000Z',
+      updated_at: '2026-02-02T00:00:00.000Z',
+    },
+    ...overrides,
+  });
+}
+
+test('a Deep Research report fits, and a row that does not says by how much', () => {
+  const { payload } = academicSnapshot();
+  const hasAsset = () => true;
+  const check = (input, maxBytes) => validateMutation(input, { snapshot: payload, hasAsset, ...(maxBytes ? { maxBytes } : {}) });
+
+  // The regression this whole change exists for. Fifteen pages at 450 words a page is what
+  // `targetPages(.exhaustive)` promises, and at 64 KiB it was refused every single time.
+  const exhaustive = reportMutation(15 * 450);
+  assert.ok(check(exhaustive).bytes > 64 * 1024, 'a real report is larger than the old ceiling');
+  assert.equal(check(exhaustive).ok, true, 'and the feature the app ships must fit the limit it ships with');
+
+  // A row past the ceiling reports both numbers, because "too large" alone is a dead end.
+  const refused = check(exhaustive, 32 * 1024);
+  assert.equal(refused.ok, false);
+  assert.equal(refused.reason, 'too_large');
+  assert.equal(refused.limit, 32 * 1024);
+  assert.ok(refused.bytes > refused.limit);
+
+  // The default is not free to raise alone: it is chosen against the worst batch a client
+  // that still counts rows can send. If this product grows, MAX_MUTATION_BATCH_BYTES must too.
+  assert.ok(DEFAULT_MAX_MUTATION_BYTES * 200 <= 64 * 1024 * 1024, 'worst-case batch must stay servable');
+});
+
 test('the ledger is append-only, idempotent, and compacts on acknowledgement', async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-ledger-'));
   try {
@@ -131,6 +177,36 @@ test('the ledger is append-only, idempotent, and compacts on acknowledgement', a
     store.state.spaces.push({ id: spaceId, name: 'Ledger', mutationCursor: 3 });
     const afterCompaction = ledger.append(store, spaceId, [{ id: 'd' }]);
     assert.equal(afterCompaction[0].seq, 4, 'a compacted ledger must not reissue sequence numbers');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('a page of mutations is bounded by bytes, and never by so much that it stalls', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-ledger-bytes-'));
+  try {
+    const store = new Store(root);
+    const spaceId = 'space-bytes';
+    const filler = (size) => ({ id: `e-${size}`, row: { content: 'x'.repeat(size) } });
+    ledger.append(store, spaceId, [filler(4_000), filler(4_001), filler(4_002)]);
+
+    // Counting rows alone could not bound this response, and the response is built as one
+    // string: past 512 MiB Node cannot hold it at all.
+    const page = ledger.since(store, spaceId, 0, 200, 9_000);
+    assert.equal(page.mutations.length, 2, 'the byte budget cuts the page before the count does');
+    assert.equal(page.hasMore, true);
+    assert.equal(page.cursor, 2, 'the cursor follows what was actually handed over');
+    assert.equal(ledger.since(store, spaceId, page.cursor, 200, 9_000).mutations.length, 1);
+
+    // The rule that keeps a big row from becoming a permanently undeliverable one: the owner
+    // acknowledges by cursor, so an entry never handed over can never be acknowledged, and
+    // the ledger would stop draining at that row forever.
+    const alone = ledger.since(store, spaceId, 0, 200, 10);
+    assert.equal(alone.mutations.length, 1, 'an entry larger than the whole budget still ships');
+    assert.equal(alone.hasMore, true);
+
+    assert.equal(ledger.bytes(store, spaceId) > 12_000, true, 'the quota measures the file, not a parse');
+    assert.equal(ledger.bytes(store, 'space-that-never-wrote'), 0);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -183,6 +259,67 @@ test('a writer sends, the owner drains and acknowledges, and a replay changes no
     });
     assert.equal(enormous.status, 413);
     assert.equal((await enormous.json()).limit, 200);
+  });
+});
+
+test('the size limits are published, explained on refusal, and a full ledger is retryable', { timeout: 60_000 }, async () => {
+  await withServer({
+    label: 'mutations-limits',
+    // The floor byteLimit() enforces is 64 KiB, so these are the smallest testable values.
+    env: { NODUS_MAX_MUTATION_BYTES: String(64 * 1024), NODUS_MAX_LEDGER_BYTES: String(64 * 1024) },
+  }, async (server) => {
+    const spaceId = await server.createSpace('Corpus');
+    const owner = await server.deviceToken(server.adminEmail, server.adminPassword, spaceId);
+    await server.createUser('escritor@example.test', 'escritor-account-password', [{ spaceId, role: 'writer' }]);
+    const writer = await server.deviceToken('escritor@example.test', 'escritor-account-password', spaceId);
+    await publish(server.origin, owner.deviceToken, spaceId, academicSnapshot());
+
+    // A client can now learn the limit without being refused by it first.
+    const capabilities = await (await server.api(writer.deviceToken, 'GET', '/api/v1/capabilities')).json();
+    assert.equal(capabilities.maxMutationBytes, 64 * 1024);
+    assert.ok(capabilities.maxMutationBatchBytes > 0);
+    assert.ok(capabilities.maxLedgerBytes > 0);
+
+    // And a refusal says which row, how big it was, and how big it may be.
+    const refused = await (await server.api(writer.deviceToken, 'POST', `/api/v1/spaces/${spaceId}/mutations`, {
+      json: { mutations: [reportMutation(15 * 450)] },
+    })).json();
+    assert.deepEqual(refused.accepted, []);
+    assert.equal(refused.rejected[0].reason, 'too_large');
+    assert.equal(refused.rejected[0].limitBytes, 64 * 1024);
+    assert.ok(refused.rejected[0].bytes > 64 * 1024);
+    assert.match(refused.rejected[0].error_description, /per row/);
+
+    // Filling the ledger is answered "later", not "no": the batch is refused whole and
+    // nothing is stored, so the sender keeps work that would otherwise be lost while the
+    // owner is away. Fifty small notes comfortably pass 64 KiB of ledger.
+    const notes = Array.from({ length: 50 }, (_, index) => mutation({
+      id: `fill-${index}`, key: [`n-fill-${index}`], row: { ...NOTE_ROW, id: `n-fill-${index}`, content: 'x'.repeat(1_200) },
+    }));
+    let full = null;
+    for (let attempt = 0; attempt < 6 && !full; attempt += 1) {
+      const response = await server.api(writer.deviceToken, 'POST', `/api/v1/spaces/${spaceId}/mutations`, {
+        json: { mutations: notes.map((entry) => ({ ...entry, id: `${entry.id}-${attempt}`, key: [`${entry.key[0]}-${attempt}`], row: { ...entry.row, id: `${entry.row.id}-${attempt}` } })) },
+      });
+      if (response.status === 507) full = await response.json();
+      else assert.equal(response.status, 200);
+    }
+    assert.ok(full, 'a ledger nobody drains eventually refuses more');
+    assert.equal(full.error, 'ledger_full');
+    assert.match(full.error_description, /Nothing was lost/);
+
+    // Draining frees it, which is the whole reason this is a 507 and not a rejection.
+    let cursor = 0;
+    for (let page = 0; page < 20; page += 1) {
+      const drained = await (await server.api(owner.deviceToken, 'GET', `/api/v1/spaces/${spaceId}/mutations?since=${cursor}`)).json();
+      cursor = drained.cursor;
+      if (!drained.hasMore) break;
+    }
+    await server.api(owner.deviceToken, 'POST', `/api/v1/spaces/${spaceId}/mutations/ack`, { json: { cursor } });
+    const afterDrain = await server.api(writer.deviceToken, 'POST', `/api/v1/spaces/${spaceId}/mutations`, {
+      json: { mutations: [mutation({ id: 'after-drain', key: ['n-after'], row: { ...NOTE_ROW, id: 'n-after' } })] },
+    });
+    assert.equal(afterDrain.status, 200, 'once the owner has collected, the space accepts again');
   });
 });
 

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,12 +25,12 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.2.0');
+  assert.equal(currentRelease?.version, '3.2.1');
   assert.equal(currentRelease?.date, '2026-08-04');
-  // Opened for whoever runs a Nodus Server: a semantic search no longer stops the server
-  // answering anybody else, and its memory ceiling is stated in memory rather than in a count
-  // of published vaults. A floor rather than an exact count, because more will land here
-  // before 3.2.0 ships.
+  // One bug from both ends: a Deep Research report written on a phone or a colleague's machine
+  // is a single row larger than the server would accept, and nothing about that was visible
+  // from either side. A floor rather than an exact count, in case more lands here before it
+  // ships.
   assert.ok(currentRelease?.highlights.length >= 2, 'the release must describe what changed');
   for (const highlight of currentRelease.highlights) {
     // Written for the person using Nodus: no module names, no internal vocabulary.

--- a/server/README.md
+++ b/server/README.md
@@ -234,6 +234,27 @@ gigabyte for a large academic corpus and a needless eviction for a server with e
 A deployment that still sets it is stopped at boot rather than left believing it had capped
 anything.
 
+### Change size
+
+A publication travels one way. The other way — a collaborator sending changes back — has its own
+three limits, because a single change is no longer necessarily small: a Deep Research report is one
+row whose text column holds the whole report, and fifteen pages of it measure around 190 KiB.
+
+- `NODUS_MAX_MUTATION_BYTES`: largest single row accepted, 256 KiB by default. A row past it is
+  refused with its own size and this limit in the reply, so the sender can say what happened rather
+  than only that something did.
+- `NODUS_MAX_MUTATION_BATCH_BYTES`: largest request full of them, 16 MiB by default. It also bounds
+  the page the owner reads back, which is built as a single JSON string and so can never approach
+  the 512 MiB Node can hold. Raise it whenever you raise the row limit: a client that batches by
+  count can hand over 200 rows at once.
+- `NODUS_MAX_LEDGER_BYTES`: how many undelivered changes one space may hold, 256 MiB by default.
+  The ledger only grows while the owner is away, so a space at its limit answers `507 ledger_full`,
+  which asks the sender to try later and keeps their work, instead of rejecting it.
+
+All three take a whole number of bytes, at least 65536, and refuse to boot on a value the server
+cannot use. `GET /api/v1/capabilities` publishes the three of them, so a client can measure a change
+before making it rather than discovering the limit by being refused.
+
 ## Access levels
 
 A membership grants one of three levels in one space. An account can hold a different level in each

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -46,6 +46,11 @@ services:
       NODUS_MAX_SNAPSHOT_JSON_BYTES: ${NODUS_MAX_SNAPSHOT_JSON_BYTES:-}
       # How much expanded publication stays parsed in memory, 128 MiB by default.
       NODUS_MAX_SNAPSHOT_CACHE_BYTES: ${NODUS_MAX_SNAPSHOT_CACHE_BYTES:-}
+      # What a collaborator may send back: 256 KiB per row, 16 MiB per request, and 256 MiB
+      # of changes held per space while the owner is away. Raise the first two together.
+      NODUS_MAX_MUTATION_BYTES: ${NODUS_MAX_MUTATION_BYTES:-}
+      NODUS_MAX_MUTATION_BATCH_BYTES: ${NODUS_MAX_MUTATION_BATCH_BYTES:-}
+      NODUS_MAX_LEDGER_BYTES: ${NODUS_MAX_LEDGER_BYTES:-}
       # Threads for semantic search. Unset is one, or two where there are cores spare.
       NODUS_VECTOR_WORKERS: ${NODUS_VECTOR_WORKERS:-}
     volumes:

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -29,6 +29,11 @@ services:
       NODUS_MAX_SNAPSHOT_JSON_BYTES: ${NODUS_MAX_SNAPSHOT_JSON_BYTES:-}
       # How much expanded publication stays parsed in memory, 128 MiB by default.
       NODUS_MAX_SNAPSHOT_CACHE_BYTES: ${NODUS_MAX_SNAPSHOT_CACHE_BYTES:-}
+      # What a collaborator may send back: 256 KiB per row, 16 MiB per request, and 256 MiB
+      # of changes held per space while the owner is away. Raise the first two together.
+      NODUS_MAX_MUTATION_BYTES: ${NODUS_MAX_MUTATION_BYTES:-}
+      NODUS_MAX_MUTATION_BATCH_BYTES: ${NODUS_MAX_MUTATION_BATCH_BYTES:-}
+      NODUS_MAX_LEDGER_BYTES: ${NODUS_MAX_LEDGER_BYTES:-}
       # Threads for semantic search. Unset is one, or two where there are cores spare.
       NODUS_VECTOR_WORKERS: ${NODUS_VECTOR_WORKERS:-}
     volumes:

--- a/server/lib/core/mutations.mjs
+++ b/server/lib/core/mutations.mjs
@@ -39,7 +39,22 @@ export const MUTABLE_TABLES = {
 };
 
 export const MUTATION_KINDS = new Set(['upsert', 'delete']);
-export const MAX_MUTATION_BYTES = 64 * 1024;
+/**
+ * How large one row may be, by default.
+ *
+ * It used to be 64 KiB, which predates anything long travelling this channel and turned out to
+ * be below the size of the thing it most needed to carry: a Deep Research report is one row of
+ * `writing_saved_drafts` whose `draft_json` holds the entire markdown. Five pages of Spanish
+ * prose with accented characters escaped into JSON already reach 40-60 KiB, and a real
+ * fifteen-page report measured 187 KiB. The feature and the limit were incompatible by design.
+ *
+ * The number is not free to raise on its own, because until every client batches by bytes the
+ * worst request this server can be handed is MAX_MUTATION_BATCH rows of this size. 256 KiB
+ * therefore buys comfortable headroom over the largest report anybody has produced while
+ * keeping that product at 50 MiB, which is a request a modest machine can still hold.
+ * Raise both together or not at all, and see NODUS_MAX_MUTATION_BATCH_BYTES.
+ */
+export const DEFAULT_MAX_MUTATION_BYTES = 256 * 1024;
 export const MAX_MUTATION_BATCH = 200;
 
 export function isMutableTable(table) {
@@ -59,7 +74,7 @@ export function rowKey(table, key) {
  * looks like, but the snapshot it already holds IS that schema, expressed as data. A
  * column nobody has ever published cannot be written.
  */
-export function validateMutation(mutation, { snapshot, hasAsset }) {
+export function validateMutation(mutation, { snapshot, hasAsset, maxBytes = DEFAULT_MAX_MUTATION_BYTES }) {
   const fail = (reason) => ({ ok: false, reason });
 
   if (!mutation || typeof mutation !== 'object') return fail('malformed');
@@ -106,8 +121,12 @@ export function validateMutation(mutation, { snapshot, hasAsset }) {
     if (!hasAsset(asset.hash)) return { ok: false, reason: 'missing_asset', missing: asset.hash };
   }
 
-  if (Buffer.byteLength(JSON.stringify(mutation)) > MAX_MUTATION_BYTES) return fail('too_large');
-  return { ok: true, table, definition };
+  // Measured and reported, not just compared. A rejection that says only "too large" leaves
+  // the sender with nothing to act on; the phone showed exactly that, and there was no way
+  // from the screen to learn whether the row missed by a kilobyte or by a factor of three.
+  const bytes = Buffer.byteLength(JSON.stringify(mutation));
+  if (bytes > maxBytes) return { ok: false, reason: 'too_large', bytes, limit: maxBytes };
+  return { ok: true, table, definition, bytes };
 }
 
 /**

--- a/server/lib/ledger.mjs
+++ b/server/lib/ledger.mjs
@@ -64,15 +64,48 @@ export function append(store, spaceId, entries) {
   return stamped;
 }
 
-export function since(store, spaceId, cursor, limit) {
+/**
+ * One page of undelivered mutations, bounded by count AND by bytes.
+ *
+ * Counting entries alone was safe only while an entry could not be large. It cannot survive a
+ * bigger row cap: this response is built with JSON.stringify into a single string, and Node
+ * refuses strings past 512 MiB, so 200 entries of a quarter-megabyte each is a response the
+ * process may be unable to hold — in a process that may already be holding a parsed snapshot
+ * of several hundred megabytes. The byte budget is the real bound; the count survives as a
+ * cheap upper limit.
+ *
+ * The first entry is always returned even when it alone blows the budget. Skipping it would
+ * be worse than a large response: the owner acknowledges by cursor, so an entry that is never
+ * handed over is an entry that can never be acknowledged, and the ledger would stop draining
+ * at that row forever. `hasMore` then carries the paging, which both clients already follow.
+ */
+export function since(store, spaceId, cursor, limit, maxBytes = Infinity) {
   const all = readAll(store, spaceId).filter((entry) => Number(entry.seq) > Number(cursor || 0));
   all.sort((a, b) => Number(a.seq) - Number(b.seq));
-  const slice = all.slice(0, limit);
+  const slice = [];
+  let bytes = 0;
+  for (const entry of all) {
+    if (slice.length >= limit) break;
+    bytes += Buffer.byteLength(JSON.stringify(entry));
+    if (slice.length > 0 && bytes > maxBytes) break;
+    slice.push(entry);
+  }
   return {
     mutations: slice,
     cursor: slice.length ? Number(slice.at(-1).seq) : Number(cursor || 0),
     hasMore: all.length > slice.length,
   };
+}
+
+/**
+ * How much undrained ledger this space is holding.
+ *
+ * The file size, not a sum over parsed entries: this is asked on every write to decide whether
+ * to accept more, and re-reading the whole ledger to answer it would make each write cost the
+ * size of every write before it.
+ */
+export function bytes(store, spaceId) {
+  try { return fs.statSync(store.mutationsPath(spaceId)).size; } catch { return 0; }
 }
 
 /**

--- a/server/lib/routes/api.mjs
+++ b/server/lib/routes/api.mjs
@@ -21,7 +21,6 @@ import { NODUS_VERSION } from '../version.mjs';
 
 const AUTH_BODY_BYTES = 32 * 1024;
 const TICKET_TTL_MS = 5 * 60_000;
-const MUTATION_BATCH_BYTES = 2 * 1024 * 1024;
 const VECTOR_QUERY_BYTES = 256 * 1024;
 /** Matches the desktop research assistant's ceiling (electron/ai/researchAssistant.ts). */
 const MAX_CONTEXT_CHARS = 600_000;
@@ -78,6 +77,11 @@ export function createApiRoutes(ctx) {
       maxSnapshotBytes: limits.maxSnapshotBytes,
       maxSnapshotJsonBytes: limits.maxSnapshotJsonBytes,
       maxMutationBatch: MAX_MUTATION_BATCH,
+      // Published so a client can measure a row before spending twenty minutes generating it.
+      // Their absence is why the only way to discover this limit was to be refused by it.
+      maxMutationBytes: limits.maxMutationBytes,
+      maxMutationBatchBytes: limits.maxMutationBatchBytes,
+      maxLedgerBytes: limits.maxLedgerBytes,
     };
   }
 
@@ -400,7 +404,10 @@ export function createApiRoutes(ctx) {
   // ── Mutations ─────────────────────────────────────────────────────────────
 
   async function postMutations(req, res, space) {
-    const input = await jsonBody(req, MUTATION_BATCH_BYTES);
+    // The one write route that had no rate limit, which was tolerable only while a mutation
+    // could not be large. It can now, and the body this accepts is measured in megabytes.
+    if (!rateLimit(req, res, 'mutations', 120, 60_000)) return true;
+    const input = await jsonBody(req, limits.maxMutationBatchBytes);
     const batch = Array.isArray(input.mutations) ? input.mutations : [];
     if (batch.length === 0) {
       json(res, 400, { error: 'empty_batch' });
@@ -422,10 +429,14 @@ export function createApiRoutes(ctx) {
         duplicate.push(mutation.id);
         continue;
       }
-      const verdict = validateMutation(mutation, { snapshot, hasAsset });
+      const verdict = validateMutation(mutation, { snapshot, hasAsset, maxBytes: limits.maxMutationBytes });
       if (!verdict.ok) {
         if (verdict.missing) missingAssets.add(verdict.missing);
-        rejected.push({ id: mutation?.id ?? null, reason: verdict.reason });
+        // Only `too_large` carries numbers, and only because they are the whole difference
+        // between a dead end and an explanation. Every other reason stays a bare code.
+        rejected.push(verdict.reason === 'too_large'
+          ? { id: mutation?.id ?? null, reason: verdict.reason, bytes: verdict.bytes, limitBytes: verdict.limit, error_description: `This row is ${mib(verdict.bytes)} and this server accepts up to ${mib(verdict.limit)} per row (NODUS_MAX_MUTATION_BYTES).` }
+          : { id: mutation?.id ?? null, reason: verdict.reason });
         continue;
       }
       accepted.push({
@@ -447,6 +458,20 @@ export function createApiRoutes(ctx) {
       return true;
     }
 
+    // A full ledger is a temporary condition, not a bad request: it fills because the owner
+    // has not opened Nodus, and it empties when they do. So this refuses the batch whole and
+    // keeps nothing, which leaves the sender's queue intact to retry — deliberately unlike a
+    // rejection, which would throw away a colleague's work over the owner's holiday.
+    const incoming = accepted.reduce((total, entry) => total + Buffer.byteLength(JSON.stringify(entry)) + 1, 0);
+    if (ledger.bytes(store, space.id) + incoming > limits.maxLedgerBytes) {
+      json(res, 507, {
+        error: 'ledger_full',
+        error_description: `This space is holding ${mib(limits.maxLedgerBytes)} of changes that its owner has not collected yet. Nothing was lost. Send again once they have opened Nodus.`,
+        limitBytes: limits.maxLedgerBytes,
+      });
+      return true;
+    }
+
     const stamped = ledger.append(store, space.id, accepted);
     json(res, 200, {
       accepted: stamped.map((entry) => entry.id),
@@ -460,7 +485,10 @@ export function createApiRoutes(ctx) {
   function getMutations(req, res, space, url) {
     const cursor = Number(url.searchParams.get('since') || 0);
     const limit = Math.max(1, Math.min(MAX_MUTATION_BATCH, Number(url.searchParams.get('limit')) || MAX_MUTATION_BATCH));
-    json(res, 200, { ...ledger.since(store, space.id, cursor, limit), spaceSchemaVersion: space.schemaVersion ?? 0 });
+    // Bounded by bytes as well as by count, so a page of large rows cannot become a response
+    // this process is unable to serialize. Callers follow `hasMore`; a short page is normal.
+    const page = ledger.since(store, space.id, cursor, limit, limits.maxMutationBatchBytes);
+    json(res, 200, { ...page, spaceSchemaVersion: space.schemaVersion ?? 0 });
     return true;
   }
 

--- a/server/lib/routes/api.mjs
+++ b/server/lib/routes/api.mjs
@@ -22,6 +22,17 @@ import { NODUS_VERSION } from '../version.mjs';
 const AUTH_BODY_BYTES = 32 * 1024;
 const TICKET_TTL_MS = 5 * 60_000;
 const VECTOR_QUERY_BYTES = 256 * 1024;
+
+/**
+ * A size a person can act on, in the unit that distinguishes it from its neighbours.
+ *
+ * `mib()` is right for an image ceiling of 8 MiB and useless here: a 187 KiB report and a
+ * 256 KiB limit both render as "0.2 MiB", so the sentence meant to end the guessing would have
+ * printed the same number twice.
+ */
+function sizeLabel(bytes) {
+  return bytes < 1024 * 1024 ? `${Math.round(bytes / 1024)} KiB` : `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
 /** Matches the desktop research assistant's ceiling (electron/ai/researchAssistant.ts). */
 const MAX_CONTEXT_CHARS = 600_000;
 
@@ -435,7 +446,7 @@ export function createApiRoutes(ctx) {
         // Only `too_large` carries numbers, and only because they are the whole difference
         // between a dead end and an explanation. Every other reason stays a bare code.
         rejected.push(verdict.reason === 'too_large'
-          ? { id: mutation?.id ?? null, reason: verdict.reason, bytes: verdict.bytes, limitBytes: verdict.limit, error_description: `This row is ${mib(verdict.bytes)} and this server accepts up to ${mib(verdict.limit)} per row (NODUS_MAX_MUTATION_BYTES).` }
+          ? { id: mutation?.id ?? null, reason: verdict.reason, bytes: verdict.bytes, limitBytes: verdict.limit, error_description: `This row is ${sizeLabel(verdict.bytes)} and this server accepts up to ${sizeLabel(verdict.limit)} per row (NODUS_MAX_MUTATION_BYTES).` }
           : { id: mutation?.id ?? null, reason: verdict.reason });
         continue;
       }

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -12,4 +12,4 @@
  * this drifts from the root `package.json`, from `server/package.json`, or from the two iOS
  * targets in `ios/project.yml`.
  */
-export const NODUS_VERSION = '3.2.0';
+export const NODUS_VERSION = '3.2.1';

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -8,6 +8,7 @@ import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
 import { Store, digest, pairingCode, token } from './lib/store.mjs';
+import { DEFAULT_MAX_MUTATION_BYTES } from './lib/core/mutations.mjs';
 import { SnapshotCache } from './lib/snapshotCache.mjs';
 import { body, contentSecurityPolicy, cookies, escapeHtml, form, html, json, jsonBody, redirect } from './lib/http.mjs';
 import { normalizeServerLanguage, serverTranslator } from './lib/i18n.mjs';
@@ -88,6 +89,32 @@ const MAX_ASSET_BYTES = byteLimit('NODUS_MAX_ASSET_BYTES', 8 * 1024 * 1024, buff
 /** Total image budget for one space, so a shared server cannot be filled from one vault. */
 const MAX_SPACE_ASSET_BYTES = byteLimit('NODUS_MAX_SPACE_ASSET_BYTES', 2 * 1024 * 1024 * 1024, bufferLimits.MAX_LENGTH);
 const MAX_VECTOR_BYTES = byteLimit('NODUS_MAX_VECTOR_BYTES', 512 * 1024 * 1024, bufferLimits.MAX_LENGTH);
+/**
+ * One row a collaborator may send. See DEFAULT_MAX_MUTATION_BYTES for why 256 KiB and why it
+ * does not move alone.
+ */
+const MAX_MUTATION_BYTES = byteLimit('NODUS_MAX_MUTATION_BYTES', DEFAULT_MAX_MUTATION_BYTES, bufferLimits.MAX_LENGTH);
+/**
+ * One request full of them, on the wire.
+ *
+ * Deliberately not `MAX_MUTATION_BYTES * MAX_MUTATION_BATCH`: that product is the worst case a
+ * client batching by count can hand over, and honouring it in full would mean accepting 50 MiB
+ * of body, expanded to a string and then to objects — several hundred megabytes of peak for one
+ * request, on a route that anyone with write access can call. 16 MiB accepts around sixty
+ * maximum-size rows at once, which is far past any real queue, and refuses the rest with a
+ * cursor the client keeps rather than losing.
+ */
+const MAX_MUTATION_BATCH_BYTES = byteLimit('NODUS_MAX_MUTATION_BATCH_BYTES', 16 * 1024 * 1024, bufferLimits.MAX_LENGTH);
+/**
+ * How much undrained ledger one space may hold.
+ *
+ * The ledger was the only write channel here with neither a quota nor a rate limit, which was
+ * survivable only because a mutation could not be large. Images have had both for as long as
+ * they have existed; this is the same idea. It fills only while the owner is away, and it is
+ * refused with "come back later" rather than a rejection, because the condition resolves
+ * itself the moment the owner opens Nodus and drains.
+ */
+const MAX_LEDGER_BYTES = byteLimit('NODUS_MAX_LEDGER_BYTES', 256 * 1024 * 1024, bufferLimits.MAX_LENGTH);
 /**
  * How long an unreferenced image survives before the sweeper takes it.
  *
@@ -896,6 +923,9 @@ const apiRoutes = createApiRoutes({
     maxAssetBytes: MAX_ASSET_BYTES,
     maxSpaceAssetBytes: MAX_SPACE_ASSET_BYTES,
     maxVectorBytes: MAX_VECTOR_BYTES,
+    maxMutationBytes: MAX_MUTATION_BYTES,
+    maxMutationBatchBytes: MAX_MUTATION_BATCH_BYTES,
+    maxLedgerBytes: MAX_LEDGER_BYTES,
     assetGraceMs: ASSET_GRACE_MS,
   },
 });

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -100,7 +100,13 @@ const RELEASE_3_2_0_IT: string[] = [
   "Generare un rapporto non blocca più la finestra. Nodus percorre l'intero corpus più volte per ogni rapporto, e ognuna di quelle ricerche lasciava l'applicazione ferma per tutta la sua durata. Ora procedono a tratti e restituiscono il controllo tra l'una e l'altra, così puoi continuare a lavorare mentre il rapporto viene scritto.",
 ];
 
+const RELEASE_3_2_1_IT: string[] = [
+  "Un rapporto di Deep Research scritto sul telefono o su un altro computer ora arriva al vault. Il server accettava soltanto modifiche da 64 KB e un rapporto di quindici pagine occupa quasi il triplo, quindi veniva sempre rifiutato. Il limite sale a 256 KB per modifica e chi amministra un server può regolarlo.",
+  "Una modifica che il server non può accettare ora spiega perché. Prima diceva soltanto che era troppo grande, senza dire quanto occupava né quale fosse il massimo. E una coda di modifiche che non entrava in un invio restava bloccata per sempre. Ora viene divisa in invii più piccoli finché non si svuota.",
+];
+
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.2.1": RELEASE_3_2_1_IT,
   "3.2.0": RELEASE_3_2_0_IT,
   "3.1.0": RELEASE_3_1_0_IT,
   "3.0.4": RELEASE_3_0_4_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -40,7 +40,13 @@ const RELEASE_3_2_0_TR: string[] = [
   "Bir rapor oluşturmak artık pencereyi dondurmuyor. Nodus her rapor için bütün külliyatı birkaç kez tarıyor ve bu aramaların her biri sürdüğü müddetçe uygulamayı durduruyordu. Artık parça parça ilerliyorlar ve aralarında denetimi geri veriyorlar, böylece rapor yazılırken çalışmaya devam edebilirsiniz.",
 ];
 
+const RELEASE_3_2_1_TR: string[] = [
+  "Telefonda veya başka bir bilgisayarda yazılan bir Deep Research raporu artık kasaya ulaşıyor. Sunucu yalnızca 64 KB boyutundaki değişiklikleri kabul ediyordu ve on beş sayfalık bir rapor bunun neredeyse üç katı yer kaplıyor, bu yüzden her seferinde geri çevriliyordu. Sınır değişiklik başına 256 KB'ye çıkıyor ve sunucuyu yöneten kişi bunu ayarlayabilir.",
+  "Sunucunun kabul edemediği bir değişiklik artık nedenini açıklıyor. Önceden yalnızca çok büyük olduğunu söylüyor, ne kadar yer kapladığını da en fazla ne kadar olabileceğini de belirtmiyordu. Ayrıca tek bir gönderime sığmayan bir değişiklik kuyruğu sonsuza kadar takılı kalıyordu. Artık boşalana kadar daha küçük gönderimlere bölünüyor.",
+];
+
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.2.1": RELEASE_3_2_1_TR,
   "3.2.0": RELEASE_3_2_0_TR,
   "3.1.0": RELEASE_3_1_0_TR,
   "3.0.4": RELEASE_3_0_4_TR,

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -709,7 +709,42 @@ const RELEASE_3_2_0_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+/**
+ * 3.2.1 is one bug, told from both ends.
+ *
+ * The Deep Research a phone or a colleague's machine writes is a single row carrying the whole
+ * report, and the server would not take a row that large. Nothing about it was visible from
+ * either side: the limit was not published, the refusal carried no numbers, and a queue that
+ * did not fit gave up quietly and retried forever. The first note is the limit, the second is
+ * everything that made the limit impossible to diagnose.
+ */
+const RELEASE_3_2_1_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'Un informe de Deep Research escrito en el móvil o en otro equipo ya llega a la bóveda. El servidor solo aceptaba cambios de 64 KB y un informe de quince páginas ocupa casi el triple, así que se rechazaba siempre. El límite sube a 256 KB por cambio y quien administre un servidor puede ajustarlo.',
+    en: 'A Deep Research report written on the phone or on another machine now reaches the vault. The server only accepted changes of 64 KB and a fifteen-page report is nearly three times that, so it was refused every time. The limit rises to 256 KB per change and anyone running a server can adjust it.',
+    fr: 'Un rapport Deep Research rédigé sur le téléphone ou sur une autre machine parvient désormais au coffre. Le serveur n’acceptait que des modifications de 64 Ko et un rapport de quinze pages en fait presque le triple, il était donc toujours refusé. La limite passe à 256 Ko par modification et qui administre un serveur peut l’ajuster.',
+    de: 'Ein Deep-Research-Bericht, der auf dem Telefon oder auf einem anderen Rechner entsteht, erreicht jetzt den Tresor. Der Server nahm nur Änderungen von 64 KB an, und ein Bericht über fünfzehn Seiten ist fast dreimal so groß, also wurde er jedes Mal abgewiesen. Die Grenze steigt auf 256 KB pro Änderung und wer einen Server betreibt, kann sie anpassen.',
+    pt: 'Um relatório de Deep Research escrito no telemóvel ou noutro equipamento já chega ao cofre. O servidor só aceitava alterações de 64 KB e um relatório de quinze páginas ocupa quase o triplo, por isso era sempre recusado. O limite sobe para 256 KB por alteração e quem administra um servidor pode ajustá-lo.',
+    'pt-BR': 'Um relatório de Deep Research escrito no celular ou em outro computador agora chega ao cofre. O servidor só aceitava mudanças de 64 KB e um relatório de quinze páginas ocupa quase o triplo, então era sempre recusado. O limite sobe para 256 KB por mudança e quem administra um servidor pode ajustá-lo.',
+  },
+  {
+    scope: 'general',
+    es: 'Un cambio que el servidor no puede aceptar ya explica por qué. Antes solo decía que era demasiado grande, sin decir cuánto ocupaba ni cuál era el máximo. Y una cola de cambios que no cabía en un envío se quedaba atascada para siempre. Ahora se reparte en envíos más pequeños hasta vaciarse.',
+    en: 'A change the server cannot accept now explains why. Before it only said the change was too large, without saying how large it was or what the maximum is. And a queue of changes too big for one delivery used to get stuck forever. It is now split into smaller deliveries until it empties.',
+    fr: 'Une modification que le serveur ne peut pas accepter explique désormais pourquoi. Auparavant, elle indiquait seulement qu’elle était trop volumineuse, sans dire sa taille ni le maximum. Et une file de modifications trop grosse pour un seul envoi restait bloquée pour toujours. Elle se répartit maintenant en envois plus petits jusqu’à se vider.',
+    de: 'Eine Änderung, die der Server nicht annehmen kann, erklärt jetzt warum. Vorher hieß es nur, sie sei zu groß, ohne ihre Größe und ohne das Maximum zu nennen. Und eine Warteschlange, die nicht in eine Sendung passte, blieb für immer stecken. Sie wird jetzt auf kleinere Sendungen verteilt, bis sie leer ist.',
+    pt: 'Uma alteração que o servidor não pode aceitar já explica porquê. Antes apenas dizia que era demasiado grande, sem dizer quanto ocupava nem qual era o máximo. E uma fila de alterações que não cabia num envio ficava encravada para sempre. Agora reparte-se em envios mais pequenos até esvaziar.',
+    'pt-BR': 'Uma mudança que o servidor não pode aceitar agora explica por quê. Antes só dizia que era grande demais, sem dizer quanto ocupava nem qual era o máximo. E uma fila de mudanças que não cabia em um envio ficava travada para sempre. Agora ela é dividida em envios menores até esvaziar.',
+  },
+];
+
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.2.1',
+    date: '2026-08-04',
+    highlights: RELEASE_3_2_1_HIGHLIGHTS,
+  },
   {
     version: '3.2.0',
     date: '2026-08-04',


### PR DESCRIPTION
A Deep Research report written on a phone or on a colleague's machine could not reach the vault it was written for. The report is a single row of `writing_saved_drafts` whose `draft_json` carries the whole markdown, and the server refused any row past 64 KiB. Measured against a real corpus, 17 of 23 saved reports exceed that, the largest at 187 KiB, and even a five-page one lands at 40-60 KiB. The feature and the limit were incompatible by design.

The ceiling was only half of it. Nothing published the limit, so the only way to learn it was to be refused by it. The refusal carried no numbers, so being refused taught nothing either. And the 2 MiB cap on the request body was a second wall that answered 413 for the whole batch, which the desktop turned into an error that marked nothing and re-sent the identical batch every thirty seconds forever.

## Server

- **256 KiB per row, 16 MiB per request**, both configurable (`NODUS_MAX_MUTATION_BYTES`, `NODUS_MAX_MUTATION_BATCH_BYTES`) and both published in `capabilities()`. The row limit deliberately does not move alone: until every client batches by bytes, the worst request is `MAX_MUTATION_BATCH` rows of it, and 256 KiB keeps that product at 50 MiB.
- A `too_large` rejection now carries the row's size and the ceiling.
- **The ledger page is bounded by bytes as well as by count.** The response is built as one JSON string and Node stops at 512 MiB, in a process that may already hold a parsed snapshot of several hundred megabytes. The first entry always ships even when it alone blows the budget, or a row too large could never be acknowledged and the ledger would stop draining there permanently.
- **A per-space ledger quota and a rate limit on `POST /mutations`**, the last write route with neither. A full ledger answers `507 ledger_full` and keeps the sender's work, because it empties by itself when the owner next opens Nodus.

## Desktop

- The outbox reads the server's limits, fills a batch by bytes, and refuses an oversized row locally **only** when the server has actually stated its ceiling. Refusing against a guess would throw away work the server would have taken.
- A 413 halves the batch budget instead of wedging the queue. A 507 is reported as "later", not as a failure.

## Tests

`npm test` is green (1669 tests). New coverage in `scripts/test-nodus-server-mutations.mjs`: a fifteen-page report fits and is asserted larger than the old ceiling, a refusal reports both numbers, the page cuts by bytes and never returns an empty one, and a full ledger answers 507 and accepts again once drained.

The phone side ships alongside in `nodus-mobile`.
