### PR TITLE
Stop showing a sync error that has already been fixed

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.2.1"
+version: "3.2.2"
 date-released: "2026-08-04"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"

--- a/electron/serverSync/replicaService.ts
+++ b/electron/serverSync/replicaService.ts
@@ -497,6 +497,10 @@ export async function drainOutbox(vaultId: string): Promise<void> {
     // ones it cannot, and for servers that do not send an explanation at all.
     for (const rejection of value.rejected ?? []) markOutboxRejected(db, [rejection.id], rejection.error_description ?? rejection.reason);
     pruneSentOutbox(db);
+    // The batch went out, so whatever the last attempt complained about is over. Without this
+    // the "sending in smaller batches" and "the owner has not collected yet" notices above
+    // would survive the condition that caused them and sit on the panel indefinitely.
+    runtime.lastError = null;
     const after = countOutbox(db);
     runtime.pendingMutations = after.pending;
     runtime.rejectedMutations = after.rejected;

--- a/electron/serverSync/serverSyncService.ts
+++ b/electron/serverSync/serverSyncService.ts
@@ -377,6 +377,12 @@ async function publishVault(vaultId: string): Promise<void> {
     rt.dirtySince = 0;
     rt.pending = false;
     rt.phase = 'ok';
+    // Cleared here and nowhere else it mattered: this was written on failure and never taken
+    // back, so one 502 while the server restarted stayed on the panel for the rest of the
+    // session — beside a publication that had just succeeded and an inbox that had just
+    // applied a change. An error that outlives its cause is worse than no error at all,
+    // because the reader cannot tell it is over.
+    rt.lastError = null;
     rt.lastSyncAt = result.updatedAt || new Date().toISOString();
     rt.lastBytes = compressed.length;
     // After the snapshot, so a client that sees the new revision already has rows for

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/test-inbox-poller.mjs
+++ b/scripts/test-inbox-poller.mjs
@@ -40,7 +40,8 @@ const { updateSettings } = require(path.join(repoRoot, 'electron/db/settingsRepo
 const { setNodusServerToken } = require(path.join(repoRoot, 'electron/secrets/secretStore.ts'));
 const { listServerInbox, unreadServerInboxCount } = require(path.join(repoRoot, 'electron/db/serverInboxRepo.ts'));
 const { drainServerInboxNow } = require(path.join(repoRoot, 'electron/serverSync/inboxPoller.ts'));
-const { getNodusServerOverview } = require(path.join(repoRoot, 'electron/serverSync/serverSyncService.ts'));
+const { getNodusServerOverview, syncNodusServerVaultNow } = require(path.join(repoRoot, 'electron/serverSync/serverSyncService.ts'));
+const { getActiveVault } = require(path.join(repoRoot, 'electron/vaults/vaultRegistry.ts'));
 
 const STAMP = '2026-08-04T09:00:00.000Z';
 
@@ -203,6 +204,38 @@ test('a refused mutation is recorded once, however often it comes back', { timeo
     // It is still in the ledger, because refusing does not acknowledge.
     const remaining = await (await server.api(desktop.accessToken, 'GET', `/api/v1/spaces/${spaceId}/mutations`)).json();
     assert.equal(remaining.mutations.length, 1, 'a refusal must never be acknowledged away');
+  });
+  await rm(userData, { recursive: true, force: true });
+});
+
+test('a sync error goes away when the sync works again', { timeout: 120_000 }, async () => {
+  await withServer({ label: 'stale-error' }, async (server) => {
+    const spaceId = await server.createSpace('Estado');
+    const desktop = await server.pair(await server.pairingCode(spaceId), 'Nodus Desktop');
+    setNodusServerToken(desktop.accessToken);
+    updateSettings({
+      nodusServerUrl: server.origin,
+      nodusServerSpaceId: spaceId,
+      nodusServerSpaceName: 'Estado',
+      nodusServerEnabled: true,
+      nodusServerAutoSync: false,
+    });
+    const vaultId = getActiveVault().id;
+
+    // Whatever went wrong: a server restarting behind its proxy answers 502, and the desktop
+    // reports it. That part was never in doubt.
+    const connection = () => getNodusServerOverview().connections.find((entry) => entry.vaultId === vaultId);
+    updateSettings({ nodusServerUrl: 'http://127.0.0.1:9' });
+    await syncNodusServerVaultNow(vaultId).catch(() => {});
+    assert.ok(connection()?.lastError, 'a failed publication has to say so');
+
+    // What was missing is the other half. The error was written on failure and never taken
+    // back, so one restart left the panel showing a problem for the rest of the session —
+    // next to a publication that had since succeeded and an inbox that had applied a change.
+    updateSettings({ nodusServerUrl: server.origin });
+    await syncNodusServerVaultNow(vaultId);
+    assert.equal(connection()?.phase, 'ok');
+    assert.equal(connection()?.lastError, null, 'an error that outlives its cause cannot be told apart from a live one');
   });
   await rm(userData, { recursive: true, force: true });
 });

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,13 +25,13 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.2.1');
+  assert.equal(currentRelease?.version, '3.2.2');
   assert.equal(currentRelease?.date, '2026-08-04');
-  // One bug from both ends: a Deep Research report written on a phone or a colleague's machine
-  // is a single row larger than the server would accept, and nothing about that was visible
-  // from either side. A floor rather than an exact count, in case more lands here before it
-  // ships.
-  assert.ok(currentRelease?.highlights.length >= 2, 'the release must describe what changed');
+  // A sync error that was written on failure and never taken back, so a server that answered
+  // badly for one tick marked the vault for the rest of the session. One highlight, because
+  // that is genuinely all this release is: the floor is one rather than two so a patch does
+  // not have to invent a second thing to say.
+  assert.ok(currentRelease?.highlights.length >= 1, 'the release must describe what changed');
   for (const highlight of currentRelease.highlights) {
     // Written for the person using Nodus: no module names, no internal vocabulary.
     for (const language of ['es', 'en', 'fr', 'de', 'pt', 'pt-BR']) {

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -12,4 +12,4 @@
  * this drifts from the root `package.json`, from `server/package.json`, or from the two iOS
  * targets in `ios/project.yml`.
  */
-export const NODUS_VERSION = '3.2.1';
+export const NODUS_VERSION = '3.2.2';

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -105,7 +105,12 @@ const RELEASE_3_2_1_IT: string[] = [
   "Una modifica che il server non può accettare ora spiega perché. Prima diceva soltanto che era troppo grande, senza dire quanto occupava né quale fosse il massimo. E una coda di modifiche che non entrava in un invio restava bloccata per sempre. Ora viene divisa in invii più piccoli finché non si svuota.",
 ];
 
+const RELEASE_3_2_2_IT: string[] = [
+  "Un errore di sincronizzazione già risolto smette di essere mostrato. Il pannello del vault poteva mostrare un guasto del server per tutto il resto della sessione, proprio accanto a una pubblicazione andata a buon fine. L'avviso sparisce appena la sincronizzazione torna a funzionare.",
+];
+
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.2.2": RELEASE_3_2_2_IT,
   "3.2.1": RELEASE_3_2_1_IT,
   "3.2.0": RELEASE_3_2_0_IT,
   "3.1.0": RELEASE_3_1_0_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -45,7 +45,12 @@ const RELEASE_3_2_1_TR: string[] = [
   "Sunucunun kabul edemediği bir değişiklik artık nedenini açıklıyor. Önceden yalnızca çok büyük olduğunu söylüyor, ne kadar yer kapladığını da en fazla ne kadar olabileceğini de belirtmiyordu. Ayrıca tek bir gönderime sığmayan bir değişiklik kuyruğu sonsuza kadar takılı kalıyordu. Artık boşalana kadar daha küçük gönderimlere bölünüyor.",
 ];
 
+const RELEASE_3_2_2_TR: string[] = [
+  "Zaten çözülmüş bir eşitleme hatası artık gösterilmiyor. Kasa paneli, başarıyla tamamlanmış bir yayımın hemen yanında, sunucu hatasını oturumun geri kalanı boyunca göstermeye devam edebiliyordu. Uyarı artık eşitleme yeniden çalışır çalışmaz kayboluyor.",
+];
+
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.2.2": RELEASE_3_2_2_TR,
   "3.2.1": RELEASE_3_2_1_TR,
   "3.2.0": RELEASE_3_2_0_TR,
   "3.1.0": RELEASE_3_1_0_TR,

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -739,7 +739,31 @@ const RELEASE_3_2_1_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+/**
+ * 3.2.2 is one line of the interface telling the truth again.
+ *
+ * A server that answers badly for a moment is ordinary and says so; a panel that goes on saying
+ * it long after the server recovered is not, because nothing on screen tells the two apart. The
+ * message was written on failure and never taken back.
+ */
+const RELEASE_3_2_2_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'Un error de sincronización que ya se ha resuelto deja de mostrarse. El panel del vault podía enseñar un fallo del servidor durante el resto de la sesión, justo al lado de una publicación que había ido bien. El aviso se retira en cuanto la sincronización vuelve a funcionar.',
+    en: 'A sync error that has already been resolved stops being shown. The vault panel could display a server failure for the rest of the session, right beside a publication that had gone through. The notice now clears as soon as syncing works again.',
+    fr: 'Une erreur de synchronisation déjà résolue cesse de s’afficher. Le panneau du coffre pouvait montrer une panne du serveur pendant tout le reste de la session, juste à côté d’une publication qui avait réussi. L’avis disparaît dès que la synchronisation refonctionne.',
+    de: 'Ein Synchronisationsfehler, der längst behoben ist, wird nicht mehr angezeigt. Das Panel des Tresors konnte einen Serverfehler für den Rest der Sitzung zeigen, direkt neben einer Veröffentlichung, die gelungen war. Der Hinweis verschwindet jetzt, sobald die Synchronisation wieder funktioniert.',
+    pt: 'Um erro de sincronização já resolvido deixa de ser mostrado. O painel do cofre podia exibir uma falha do servidor durante o resto da sessão, mesmo ao lado de uma publicação que tinha corrido bem. O aviso desaparece assim que a sincronização volta a funcionar.',
+    'pt-BR': 'Um erro de sincronização já resolvido deixa de ser mostrado. O painel do cofre podia exibir uma falha do servidor pelo resto da sessão, bem ao lado de uma publicação que tinha dado certo. O aviso some assim que a sincronização volta a funcionar.',
+  },
+];
+
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.2.2',
+    date: '2026-08-04',
+    highlights: RELEASE_3_2_2_HIGHLIGHTS,
+  },
   {
     version: '3.2.1',
     date: '2026-08-04',


### PR DESCRIPTION
Reported from the connected-vaults panel: a vault showing `Error: El servidor respondió con HTTP 502.` immediately above `Received from other devices: 1 applied, 0 kept, 0 refused`. Both lines were accurate. The server had answered 502 while it restarted behind its proxy, and everything had worked since.

`lastError` was written on failure and never taken back. A successful publication sets `phase`, `lastRevision`, `lastSyncAt` and `lastBytes` and leaves the message exactly where it was, so a single bad tick marks the vault for the rest of the session.

- `serverSyncService.ts` clears it when a publication succeeds. The replica path already did this on a good pull (`replicaService.ts:294`), which is why only the owner's own vault showed the symptom.
- `replicaService.ts` clears it when a batch of mutations goes out, so the two notices added in 3.2.1 — the batch shrinking after a 413, and the owner's ledger being full — stop being displayed once they stop being true.

Regression test in `scripts/test-inbox-poller.mjs`: publish against a dead port, assert the error is reported, publish against the live server, assert it is gone. Verified to fail without the fix.

An error that outlives its cause is worse than no error, because nothing on screen distinguishes it from a live one.