### PR TITLE
Name a search hit by the key its own table declares

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.2.2"
-date-released: "2026-08-04"
+version: "3.2.3"
+date-released: "2026-08-05"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/test-nodus-server-api.mjs
+++ b/scripts/test-nodus-server-api.mjs
@@ -402,6 +402,28 @@ test('the REST API and the MCP tools answer the same questions the same way', { 
       'both surfaces share one lexical search implementation',
     );
 
+    // Every hit must be nameable, on both surfaces. This is not decoration: the mobile
+    // client types `id` as a plain string, so ONE hit without it fails the decode and the
+    // reader gets "Unexpected answer from the server" instead of any of the results. The
+    // interpolation above cannot see the difference — a missing id renders as the string
+    // "undefined" on both sides and the comparison still passes.
+    for (const [surface, results] of [['REST', restSearch.results], ['MCP', mcpSearch.result.structuredContent.results]]) {
+      assert.ok(results.length > 0, `${surface} search found something to check`);
+      for (const hit of results) {
+        assert.ok(Object.hasOwn(hit, 'id'), `${surface}: a ${hit.type} hit was serialised without an id`);
+        assert.equal(typeof hit.id, 'string', `${surface}: the id of a ${hit.type} hit is not a string`);
+        assert.ok(hit.id.length > 0, `${surface}: a ${hit.type} hit carries an empty id`);
+      }
+    }
+
+    // The two tables the guessed fallback chain got wrong. `themes` is keyed on theme_id
+    // and had no id at all; `passages` is keyed on passage_id but also carries the
+    // nodus_id of the work it was cut from, so every passage hit was named after its
+    // source work — an answer that looks right and opens the wrong record.
+    const named = new Map(restSearch.results.map((hit) => [hit.type, hit.id]));
+    assert.equal(named.get('themes'), 't-2', 'a theme hit is named by its theme_id');
+    assert.equal(named.get('passages'), 'p-1', 'a passage hit is named by its passage_id, not by its work');
+
     const mcpSummary = await mcp(server.origin, mcpTokens.access_token, 'tools/call', { name: 'nodus_get_space_summary', arguments: { spaceId } }, 3);
     const restSummary = await readJson(await server.api(owner.deviceToken, 'GET', `/api/v1/spaces/${spaceId}`));
     assert.deepEqual(restSummary.counts, mcpSummary.result.structuredContent.counts);

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,11 +25,10 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.2.2');
-  assert.equal(currentRelease?.date, '2026-08-04');
-  // A sync error that was written on failure and never taken back, so a server that answered
-  // badly for one tick marked the vault for the rest of the session. One highlight, because
-  // that is genuinely all this release is: the floor is one rather than two so a patch does
+  assert.equal(currentRelease?.version, '3.2.3');
+  assert.equal(currentRelease?.date, '2026-08-05');
+  // A search result whose row the server could not name, so the phone discarded the whole
+  // answer rather than one line of it. One highlight: the floor stays at one so a patch does
   // not have to invent a second thing to say.
   assert.ok(currentRelease?.highlights.length >= 1, 'the release must describe what changed');
   for (const highlight of currentRelease.highlights) {

--- a/server/lib/core/search.mjs
+++ b/server/lib/core/search.mjs
@@ -1,48 +1,83 @@
 // Lexical search over a published snapshot.
 //
-// Extracted verbatim from the `nodus_search` MCP tool so the REST surface and the MCP
-// surface cannot answer the same query differently. The field lists are the contract:
-// adding a table here adds it to both at once.
+// Extracted from the `nodus_search` MCP tool so the REST surface and the MCP surface
+// cannot answer the same query differently — and now called by both, which the extraction
+// alone did not achieve: the MCP tool kept its own copy of the loop beside this one until
+// a fix landed here and not there. The table list below is the contract; adding a table
+// adds it to both surfaces at once.
 
 import { rows } from './snapshot.mjs';
 
+/**
+ * Table, the column that names one of its rows, and the text searched in it.
+ *
+ * The key column is declared here because most of these tables do not have one called
+ * `id`: SQLite gives each its own — `theme_id`, `person_id`, `scene_id`. Guessing at
+ * `id ?? nodus_id ?? global_id ?? passage_id` instead produced two failures. A theme, a
+ * character or a scene has none of those, so `id` came out `undefined`, `JSON.stringify`
+ * dropped the key, and the hit reached the client with no id at all — the mobile decoder
+ * refuses the whole response, so one theme label matching the query broke the entire
+ * Search tab. And a passage does have `nodus_id`, but it is the id of the WORK the
+ * passage was cut from: every passage hit was labelled with its source work instead of
+ * itself, which is worse than missing, because it looks like an answer.
+ */
 export const SEARCH_FIELDS = [
-  ['works', ['title', 'abstract', 'citation']],
-  ['ideas', ['label', 'statement']],
-  ['themes', ['label', 'description']],
-  ['gaps', ['text', 'description']],
-  ['notes', ['title', 'content']],
-  ['passages', ['text']],
-  ['persons', ['display_name', 'notes', 'biography']],
-  ['character_profiles', ['species', 'gender', 'pronouns', 'appearance', 'personality', 'backstory']],
-  ['places', ['name', 'kind', 'notes']],
-  ['place_profiles', ['appearance', 'atmosphere', 'history']],
-  ['world_groups', ['name', 'summary', 'description', 'notes']],
-  ['world_scenes', ['title', 'summary', 'notes']],
-  ['world_scene_text', ['text']],
-  ['world_articles', ['title', 'summary', 'body', 'aka', 'notes']],
-  ['world_threads', ['title', 'pitch', 'stakes', 'outcome']],
-  ['world_rules', ['title', 'statement', 'cost', 'limits']],
-  ['world_questions', ['question']],
-  ['world_secrets', ['title', 'content', 'notes']],
+  ['works', 'nodus_id', ['title', 'abstract', 'citation']],
+  ['ideas', 'global_id', ['label', 'statement']],
+  ['themes', 'theme_id', ['label', 'description']],
+  ['gaps', 'id', ['text', 'description']],
+  ['notes', 'id', ['title', 'content']],
+  ['passages', 'passage_id', ['text']],
+  ['persons', 'person_id', ['display_name', 'notes', 'biography']],
+  ['character_profiles', 'person_id', ['species', 'gender', 'pronouns', 'appearance', 'personality', 'backstory']],
+  ['places', 'place_id', ['name', 'kind', 'notes']],
+  ['place_profiles', 'place_id', ['appearance', 'atmosphere', 'history']],
+  ['world_groups', 'group_id', ['name', 'summary', 'description', 'notes']],
+  ['world_scenes', 'scene_id', ['title', 'summary', 'notes']],
+  ['world_scene_text', 'scene_id', ['text']],
+  ['world_articles', 'article_id', ['title', 'summary', 'body', 'aka', 'notes']],
+  ['world_threads', 'thread_id', ['title', 'pitch', 'stakes', 'outcome']],
+  ['world_rules', 'rule_id', ['title', 'statement', 'cost', 'limits']],
+  ['world_questions', 'question_id', ['question']],
+  ['world_secrets', 'secret_id', ['title', 'content', 'notes']],
 ];
 
 const EXCERPT_CHARS = 600;
+
+/**
+ * The id a hit carries: the table's declared key, or one of the generic keys if a
+ * snapshot published by an older desktop is missing it. Always a non-empty string —
+ * clients type this field as a plain string, so a number or a `null` fails to decode
+ * just as loudly as an absent key.
+ */
+function hitId(row, key) {
+  for (const candidate of [key, 'id', 'nodus_id', 'global_id', 'passage_id']) {
+    const value = row[candidate];
+    if (typeof value === 'string' && value !== '') return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+  return null;
+}
 
 export function lexicalSearch(snapshot, query, limit = 20) {
   const needle = String(query ?? '').trim().toLowerCase();
   if (!needle) return [];
   const results = [];
-  for (const [table, fields] of SEARCH_FIELDS) {
+  for (const [table, key, fields] of SEARCH_FIELDS) {
     for (const row of rows(snapshot, table)) {
       const text = fields.map((field) => row[field]).filter((value) => typeof value === 'string').join('\n');
       if (text.toLowerCase().includes(needle)) {
-        results.push({
-          type: table,
-          id: row.id ?? row.nodus_id ?? row.global_id ?? row.passage_id,
-          title: row.title ?? row.label ?? text.slice(0, 120),
-          excerpt: text.slice(0, EXCERPT_CHARS),
-        });
+        // A row nothing can name is dropped rather than served: an unnameable hit is one
+        // the reader cannot open anyway, and emitting it costs them every other hit too.
+        const id = hitId(row, key);
+        if (id !== null) {
+          results.push({
+            type: table,
+            id,
+            title: row.title ?? row.label ?? text.slice(0, 120),
+            excerpt: text.slice(0, EXCERPT_CHARS),
+          });
+        }
       }
       if (results.length >= limit) return results;
     }

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -12,4 +12,4 @@
  * this drifts from the root `package.json`, from `server/package.json`, or from the two iOS
  * targets in `ios/project.yml`.
  */
-export const NODUS_VERSION = '3.2.2';
+export const NODUS_VERSION = '3.2.3';

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -9,6 +9,7 @@ import { gunzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
 import { Store, digest, pairingCode, token } from './lib/store.mjs';
 import { DEFAULT_MAX_MUTATION_BYTES } from './lib/core/mutations.mjs';
+import { lexicalSearch } from './lib/core/search.mjs';
 import { SnapshotCache } from './lib/snapshotCache.mjs';
 import { body, contentSecurityPolicy, cookies, escapeHtml, form, html, json, jsonBody, redirect } from './lib/http.mjs';
 import { normalizeServerLanguage, serverTranslator } from './lib/i18n.mjs';
@@ -582,28 +583,12 @@ function callTool(auth, name, args) {
     return toolResult({ space: { id: space.id, name: space.name, description: space.description, updatedAt: space.updatedAt }, vault: snapshot.vault, generatedAt: snapshot.generatedAt, counts: Object.fromEntries(Object.entries(snapshot.tables ?? {}).map(([key, value]) => [key, Array.isArray(value) ? value.length : 0])) });
   }
   if (name === 'nodus_search') {
-    const query = String(args.query ?? '').trim().toLowerCase();
+    // Shared with GET /api/v1/spaces/:id/search rather than copied beside it. The copy
+    // that used to live here is exactly what lib/core/search.mjs was extracted to
+    // prevent, and it drifted: the fix that gave a theme or a passage hit a usable id
+    // landed in one surface and not the other.
     const limit = Math.max(1, Math.min(50, Number(args.limit) || 20));
-    if (!query) return toolResult({ results: [] });
-    const definitions = [
-      ['works', ['title', 'abstract', 'citation']], ['ideas', ['label', 'statement']], ['themes', ['label', 'description']],
-      ['gaps', ['text', 'description']], ['notes', ['title', 'content']], ['passages', ['text']],
-      ['persons', ['display_name', 'notes', 'biography']], ['character_profiles', ['species', 'gender', 'pronouns', 'appearance', 'personality', 'backstory']],
-      ['places', ['name', 'kind', 'notes']], ['place_profiles', ['appearance', 'atmosphere', 'history']],
-      ['world_groups', ['name', 'summary', 'description', 'notes']], ['world_scenes', ['title', 'summary', 'notes']],
-      ['world_scene_text', ['text']], ['world_articles', ['title', 'summary', 'body', 'aka', 'notes']],
-      ['world_threads', ['title', 'pitch', 'stakes', 'outcome']], ['world_rules', ['title', 'statement', 'cost', 'limits']],
-      ['world_questions', ['question']], ['world_secrets', ['title', 'content', 'notes']],
-    ];
-    const results = [];
-    for (const [table, fields] of definitions) {
-      for (const row of rows(snapshot, table)) {
-        const text = fields.map((field) => row[field]).filter((value) => typeof value === 'string').join('\n');
-        if (text.toLowerCase().includes(query)) results.push({ type: table, id: row.id ?? row.nodus_id ?? row.global_id ?? row.passage_id, title: row.title ?? row.label ?? text.slice(0, 120), excerpt: text.slice(0, 600) });
-        if (results.length >= limit) return toolResult({ results });
-      }
-    }
-    return toolResult({ results });
+    return toolResult({ results: lexicalSearch(snapshot, args.query, limit) });
   }
   if (name === 'nodus_get_work') {
     const work = rows(snapshot, 'works').find((entry) => String(entry.nodus_id ?? entry.id) === String(args.id));

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -109,7 +109,12 @@ const RELEASE_3_2_2_IT: string[] = [
   "Un errore di sincronizzazione già risolto smette di essere mostrato. Il pannello del vault poteva mostrare un guasto del server per tutto il resto della sessione, proprio accanto a una pubblicazione andata a buon fine. L'avviso sparisce appena la sincronizzazione torna a funzionare.",
 ];
 
+const RELEASE_3_2_3_IT: string[] = [
+  "La ricerca sul telefono smette di fallire quando ciò che cerchi compare in un tema, in un personaggio o in una scena. Bastava una sola di quelle schede perché l'app non riuscisse a leggere la risposta e non mostrasse alcun risultato. Ora ogni risultato arriva identificato e l'elenco si apre per intero.",
+];
+
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.2.3": RELEASE_3_2_3_IT,
   "3.2.2": RELEASE_3_2_2_IT,
   "3.2.1": RELEASE_3_2_1_IT,
   "3.2.0": RELEASE_3_2_0_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -49,7 +49,12 @@ const RELEASE_3_2_2_TR: string[] = [
   "Zaten çözülmüş bir eşitleme hatası artık gösterilmiyor. Kasa paneli, başarıyla tamamlanmış bir yayımın hemen yanında, sunucu hatasını oturumun geri kalanı boyunca göstermeye devam edebiliyordu. Uyarı artık eşitleme yeniden çalışır çalışmaz kayboluyor.",
 ];
 
+const RELEASE_3_2_3_TR: string[] = [
+  "Telefondaki arama, aradığınız şey bir temada, bir karakterde ya da bir sahnede geçtiğinde artık başarısız olmuyor. Bu kartlardan yalnızca birinin eşleşmesi, uygulamanın yanıtı okuyamamasına ve hiçbir sonuç göstermemesine yetiyordu. Artık her sonuç kimliğiyle geliyor ve liste eksiksiz açılıyor.",
+];
+
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.2.3": RELEASE_3_2_3_TR,
   "3.2.2": RELEASE_3_2_2_TR,
   "3.2.1": RELEASE_3_2_1_TR,
   "3.2.0": RELEASE_3_2_0_TR,

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -758,7 +758,33 @@ const RELEASE_3_2_2_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+/**
+ * 3.2.3 is search on a connected phone answering at all.
+ *
+ * Each result carries the identifier of the row it found, and for a theme, a character or a
+ * scene the server had none to give: those rows are keyed on a column of their own, and the
+ * generic guess came up empty. The app cannot read a result without one, so it discarded the
+ * whole answer, and a single theme whose name contained the query took every other result down
+ * with it.
+ */
+const RELEASE_3_2_3_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'La búsqueda en el móvil deja de fallar cuando lo que se busca aparece en un tema, un personaje o una escena. Bastaba con que una de esas fichas coincidiera para que la app no pudiera leer la respuesta del servidor y no mostrara ningún resultado. Ahora cada resultado llega identificado y la lista se abre entera.',
+    en: 'Search on the phone stops failing when what you are looking for appears in a theme, a character or a scene. One matching card was enough for the app to be unable to read the answer, so it showed no results at all. Every result now arrives properly identified and the list opens in full.',
+    fr: 'La recherche sur le téléphone cesse d’échouer quand ce que vous cherchez apparaît dans un thème, un personnage ou une scène. Il suffisait d’une seule de ces fiches pour que l’application ne puisse pas lire la réponse et n’affiche aucun résultat. Chaque résultat arrive désormais identifié et la liste s’ouvre en entier.',
+    de: 'Die Suche auf dem Telefon scheitert nicht mehr, wenn das Gesuchte in einem Thema, einer Figur oder einer Szene vorkommt. Eine einzige solche Karte reichte, damit die App die Antwort nicht lesen konnte und gar keine Ergebnisse zeigte. Jedes Ergebnis kommt jetzt eindeutig benannt an und die Liste öffnet sich vollständig.',
+    pt: 'A pesquisa no telemóvel deixa de falhar quando o que procura aparece num tema, numa personagem ou numa cena. Bastava uma dessas fichas coincidir para a aplicação não conseguir ler a resposta e não mostrar resultado nenhum. Agora cada resultado chega identificado e a lista abre por inteiro.',
+    'pt-BR': 'A busca no celular deixa de falhar quando o que você procura aparece em um tema, um personagem ou uma cena. Bastava uma dessas fichas coincidir para o aplicativo não conseguir ler a resposta e não mostrar resultado nenhum. Agora cada resultado chega identificado e a lista abre por inteiro.',
+  },
+];
+
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.2.3',
+    date: '2026-08-05',
+    highlights: RELEASE_3_2_3_HIGHLIGHTS,
+  },
   {
     version: '3.2.2',
     date: '2026-08-04',


### PR DESCRIPTION
A lexical search hit named itself with `row.id ?? row.nodus_id ?? row.global_id ?? row.passage_id`. Of the eighteen tables the search reads, five have a key that chain can reach.

**A theme has none of them.** It is keyed on `theme_id`, so `id` came out `undefined`, `JSON.stringify` dropped the key, and the hit reached the client with no id at all. The mobile client types that field as a plain `String`, so the decode failed and the reader was told the server had answered unexpectedly — instead of getting any of the results. One theme label containing the query took every other hit down with it. `persons`, `places`, `character_profiles`, `place_profiles` and all nine `world_*` tables had the same hole, so a Worldbuilding vault lost its Search tab on almost any query.

**A passage failed the other way.** It does have `nodus_id`, but that is the id of the work the passage was cut from, so every passage hit was named after its source work. That decodes cleanly and opens the wrong record, which is worse than a visible failure. The context package the phone's chat asks for filters passages by `passage_id` against those ids, so it had been returning none of them.

Against the test fixture, the old server answered:

```json
[{"type":"themes"},{"type":"passages","id":"w-1"}]
```

No `id` key at all on the theme, and a work's id on the passage.

## What changed

- Each entry in `SEARCH_FIELDS` now declares the column that names its rows — `['themes', 'theme_id', ['label', 'description']]`. That key is tried first, then the old generic names for snapshots published by an older desktop.
- A row nothing can name is **skipped** rather than served. An unnameable hit cannot be opened anyway, and emitting it costs the reader every other hit in the same response.
- A numeric id is coerced to a string, since a number fails the client's `String` decode exactly as loudly as a missing key.
- The MCP `nodus_search` tool kept its own copy of the loop beside the shared one — precisely what `lib/core/search.mjs` was extracted to prevent, and it had drifted. It calls the shared implementation now, deleting 20 lines. The file's own header claimed a single implementation that did not exist until this change; it now says what is true.

## Tests

The REST/MCP parity test could not have caught either bug: it compared `type:id` interpolated into a string, where a missing id renders as `"undefined"` on both surfaces and matches. It now asserts on both surfaces that the key is present, is a non-empty string, and names the row that matched. The fixture already matched a theme on the existing `archivo` query, so no new fixture data was needed.

Confirmed failing before the fix (`REST: a themes hit was serialised without an id`), then passing. All 57 tests across every suite that boots the server pass. The full suite is green except `test-prosopography-e2e.mjs`, which fails identically on the untouched tree — the known Playwright timeout under machine load.

## Not in this PR

The mobile client could also be made tolerant by making `Hit.id` optional, so that one bad row costs one row instead of the whole response. That lives in the `nodus-mobile` repo and is worth doing as defence in depth, but the server is where the value was lost.
