### PR TITLE
Let a Deep Research report be marked as read

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -10,7 +10,7 @@ export interface Migration {
 
 // Versioned, append-only migrations. Never edit an existing migration's SQL once
 // shipped — add a new one. The current schema version is the highest applied.
-export const SCHEMA_VERSION = 123;
+export const SCHEMA_VERSION = 124;
 
 export const migrations: Migration[] = [
   {
@@ -6272,6 +6272,30 @@ export const migrations: Migration[] = [
       );
       CREATE INDEX idx_server_inbox_recent ON server_inbox(arrived_at DESC);
       CREATE INDEX idx_server_inbox_unread ON server_inbox(read, arrived_at DESC);
+    `,
+  },
+  {
+    version: 124,
+    up: /* sql */ `
+      -- Which saved reports have been read. The ROW's existence is what "read" means:
+      -- there is nothing else to store, and a boolean column would need a row for every
+      -- report merely to say "not yet".
+      --
+      -- A table of its own rather than a column on writing_saved_drafts, and that is the
+      -- whole point. That table is in MUTABLE_TABLES: an UPDATE on it fires the outbox
+      -- trigger, so on a connected vault every tick of a checkbox would put the entire
+      -- report back on the wire for the owner to receive again. Reading is not an edit of
+      -- the report.
+      --
+      -- It does travel in a .nodussync package, in the 'writing' group beside the reports
+      -- themselves — that is one person's two machines, and having read something on the
+      -- laptop is still true at the desk. Which is also why 'updated_at' carries the
+      -- moment it was marked rather than a second column repeating it: the merge compares
+      -- that name and no other, and unmarking is a DELETE the tombstones already carry.
+      CREATE TABLE writing_draft_reads (
+        draft_id   TEXT PRIMARY KEY,
+        updated_at TEXT NOT NULL
+      );
     `,
   },
 ];

--- a/electron/db/syncTables.ts
+++ b/electron/db/syncTables.ts
@@ -33,6 +33,10 @@ const SYNC_GROUPS: { key: SyncGroupKey; prefix?: string; tables?: string[] }[] =
     key: 'writing',
     tables: [
       'writing_saved_drafts',
+      // Having read a report is true of the person, not of the machine, so it travels
+      // beside the report it is about. Why it is a table and not a column on the row
+      // above is in the migration that creates it.
+      'writing_draft_reads',
       'projects',
       'project_sections',
       'project_chapters',

--- a/electron/db/writingDraftsRepo.ts
+++ b/electron/db/writingDraftsRepo.ts
@@ -19,7 +19,16 @@ interface SavedWritingDraftRow {
   draft_json: string;
   created_at: string;
   updated_at: string;
+  /** From the LEFT JOIN below: when this report was marked read, or null. */
+  read_at?: string | null;
 }
+
+/** Every list goes through the same join, so a report can never be listed without
+ *  knowing whether it has been read — which is what made the badge and the button in
+ *  the gallery disagree the one time it was fetched separately. */
+const SELECT_DRAFTS =
+  'SELECT d.*, r.updated_at AS read_at FROM writing_saved_drafts d ' +
+  'LEFT JOIN writing_draft_reads r ON r.draft_id = d.id';
 
 function toSavedDraft(row: SavedWritingDraftRow): WritingWorkshopSavedDraft | null {
   try {
@@ -31,6 +40,7 @@ function toSavedDraft(row: SavedWritingDraftRow): WritingWorkshopSavedDraft | nu
       model: row.model_json ? (JSON.parse(row.model_json) as ModelRef) : null,
       draft: JSON.parse(row.draft_json) as WritingWorkshopDraft,
       image: getDecorativeImage('deep_research', row.id),
+      readAt: row.read_at ?? null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -42,7 +52,7 @@ function toSavedDraft(row: SavedWritingDraftRow): WritingWorkshopSavedDraft | nu
 
 export function listWritingWorkshopDrafts(): WritingWorkshopSavedDraft[] {
   const rows = getDb()
-    .prepare('SELECT * FROM writing_saved_drafts ORDER BY updated_at DESC, created_at DESC')
+    .prepare(`${SELECT_DRAFTS} ORDER BY d.updated_at DESC, d.created_at DESC`)
     .all() as SavedWritingDraftRow[];
   return rows.map(toSavedDraft).filter((draft): draft is WritingWorkshopSavedDraft => draft !== null);
 }
@@ -73,11 +83,39 @@ export function saveWritingWorkshopDraft(request: WritingWorkshopSaveDraftReques
 }
 
 export function getWritingWorkshopDraft(id: string): WritingWorkshopSavedDraft | null {
-  const row = getDb().prepare('SELECT * FROM writing_saved_drafts WHERE id = ?').get(id) as SavedWritingDraftRow | undefined;
+  const row = getDb().prepare(`${SELECT_DRAFTS} WHERE d.id = ?`).get(id) as SavedWritingDraftRow | undefined;
   return row ? toSavedDraft(row) : null;
+}
+
+/**
+ * Mark a saved report read, or take the mark back.
+ *
+ * Returns the report as it now stands, or null when there is no such report — the
+ * gallery can have a stale id after a delete on another machine, and inserting a read
+ * mark for a report that is gone would leave a row nothing ever reads.
+ *
+ * There is no foreign key, deliberately: `writing_saved_drafts` rows also arrive by
+ * merge and by the ledger, and a constraint would decide the order those two have to
+ * land in. The delete below is what keeps a mark from outliving its report.
+ */
+export function setWritingWorkshopDraftRead(id: string, read: boolean): WritingWorkshopSavedDraft | null {
+  const db = getDb();
+  const exists = db.prepare('SELECT 1 FROM writing_saved_drafts WHERE id = ?').get(id);
+  if (!exists) return null;
+  if (read) {
+    db.prepare(
+      'INSERT INTO writing_draft_reads (draft_id, updated_at) VALUES (?, ?) ' +
+        'ON CONFLICT(draft_id) DO UPDATE SET updated_at = excluded.updated_at'
+    ).run(id, new Date().toISOString());
+  } else {
+    db.prepare('DELETE FROM writing_draft_reads WHERE draft_id = ?').run(id);
+  }
+  return getWritingWorkshopDraft(id);
 }
 
 export function deleteWritingWorkshopDraft(id: string): boolean {
   deleteDecorativeImageRow('deep_research', id);
+  // Before the report, so a mark can never be left pointing at nothing.
+  getDb().prepare('DELETE FROM writing_draft_reads WHERE draft_id = ?').run(id);
   return getDb().prepare('DELETE FROM writing_saved_drafts WHERE id = ?').run(id).changes > 0;
 }

--- a/electron/ipc/academic.ts
+++ b/electron/ipc/academic.ts
@@ -1217,6 +1217,13 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
     });
     return { ...saved, image };
   });
+  h('writing:saved:read', async (_e, id: string, read: boolean) => {
+    const saved = writingDrafts.setWritingWorkshopDraftRead(id, read);
+    // The same announcement a save makes, so a report marked read while reading it is
+    // already wearing its badge when the gallery comes back.
+    if (saved) announceWritingDrafts();
+    return saved;
+  });
   h('writing:saved:delete', async (_e, id: string) => {
     invalidateDecorativeImageGeneration('deep_research', id);
     translationsRepo.deleteEntityTranslations('deep_research', id);

--- a/electron/preload/academic.ts
+++ b/electron/preload/academic.ts
@@ -483,6 +483,7 @@ export const academicApi: AcademicApi = {
   },
   listWritingWorkshopDrafts: () => ipcRenderer.invoke('writing:saved:list'),
   saveWritingWorkshopDraft: (request) => ipcRenderer.invoke('writing:saved:save', request),
+  setWritingWorkshopDraftRead: (id, read) => ipcRenderer.invoke('writing:saved:read', id, read),
   deleteWritingWorkshopDraft: (id) => ipcRenderer.invoke('writing:saved:delete', id).then(() => undefined),
   onWritingDraftsChanged: (cb) => {
     const listener = () => cb();

--- a/scripts/test-deep-research-read.mjs
+++ b/scripts/test-deep-research-read.mjs
@@ -1,0 +1,148 @@
+// Marking a saved Deep Research report as read, against the REAL schema and the REAL
+// repository. Runs under Electron-as-Node so better-sqlite3 matches the app ABI.
+//
+// Four things are asserted, and each one is a way the feature could be right in the
+// gallery and wrong on disk:
+//
+//   1. The mark is a row in its own table. Not a column on writing_saved_drafts, which
+//      is in MUTABLE_TABLES: an UPDATE there fires the outbox trigger, so on a connected
+//      vault ticking "read" would put the whole report back on the wire. The test proves
+//      the report row is byte-identical before and after.
+//   2. It reaches the list, which is what the gallery draws from.
+//   3. Unmarking removes it, and deleting the report takes its mark with it — a mark
+//      pointing at nothing would be resurrected by the next report that reused the id.
+//   4. It travels in a .nodussync package, in the same group as the reports: having read
+//      something on the laptop is still true at the desk.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+if (!process.argv.includes('--electron-deep-research-read-test')) {
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/electron'),
+    [path.join(repoRoot, 'scripts/test-deep-research-read.mjs'), '--electron-deep-research-read-test'],
+    { cwd: repoRoot, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, stdio: 'inherit' }
+  );
+  process.exit(0);
+}
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-dr-read-'));
+installTsHook();
+
+try {
+  const Database = require('better-sqlite3');
+  const { runMigrations } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
+
+  const db = new Database(path.join(root, 'vault.sqlite'));
+  runMigrations(db);
+  // The repository asks `./database` for its connection; hand it this one before it is
+  // ever loaded, so nothing tries to open the real vault.
+  stubModule('electron/db/database.ts', { getDb: () => db });
+  const repo = require(path.join(repoRoot, 'electron/db/writingDraftsRepo.ts'));
+
+  const brief = { kind: 'deep_research', objective: 'La memoria de la posguerra' };
+  const draft = { title: 'La memoria de la posguerra', brief, selection: {}, draftMarkdown: '# Uno\n\nTexto.' };
+  const saved = repo.saveWritingWorkshopDraft({ draft, title: draft.title, model: null });
+  assert.equal(saved.readAt, null, 'a report is unread when it is written');
+
+  const reportRow = () => db.prepare('SELECT * FROM writing_saved_drafts WHERE id = ?').get(saved.id);
+  const before = JSON.stringify(reportRow());
+
+  // ── 1. Marking read leaves the report itself untouched ──────────────────────
+  const read = repo.setWritingWorkshopDraftRead(saved.id, true);
+  assert.ok(read?.readAt, 'marking read returns the report wearing its mark');
+  assert.equal(
+    JSON.stringify(reportRow()),
+    before,
+    'reading a report must not rewrite the report — that is what puts it back on the wire'
+  );
+  assert.equal(read.updatedAt, saved.updatedAt, 'updatedAt is the report’s, not the reader’s');
+
+  // ── 2. The mark reaches the list the gallery draws ──────────────────────────
+  const listed = repo.listWritingWorkshopDrafts().find((item) => item.id === saved.id);
+  assert.equal(listed?.readAt, read.readAt, 'the list carries the mark');
+  assert.ok(Number.isFinite(Date.parse(read.readAt)), 'the mark is a timestamp');
+
+  // Marking twice is one row with a later stamp, never two.
+  repo.setWritingWorkshopDraftRead(saved.id, true);
+  assert.equal(db.prepare('SELECT COUNT(*) AS n FROM writing_draft_reads').get().n, 1, 'one mark per report');
+
+  // A report that does not exist cannot be marked, and leaves nothing behind.
+  assert.equal(repo.setWritingWorkshopDraftRead('no-such-report', true), null, 'no report, no mark');
+  assert.equal(db.prepare('SELECT COUNT(*) AS n FROM writing_draft_reads').get().n, 1, 'and no stray row');
+
+  // ── 3. Unmarking, and deleting the report ───────────────────────────────────
+  const unread = repo.setWritingWorkshopDraftRead(saved.id, false);
+  assert.equal(unread?.readAt, null, 'the mark can be taken back');
+  assert.equal(db.prepare('SELECT COUNT(*) AS n FROM writing_draft_reads').get().n, 0);
+
+  repo.setWritingWorkshopDraftRead(saved.id, true);
+  repo.deleteWritingWorkshopDraft(saved.id);
+  assert.equal(
+    db.prepare('SELECT COUNT(*) AS n FROM writing_draft_reads').get().n,
+    0,
+    'deleting a report takes its mark with it'
+  );
+
+  // ── 4. It travels between the reader’s own machines ─────────────────────────
+  // `describeSyncCoverage` takes no connection and reads the active vault, so the
+  // classification is checked through the group list, which does.
+  const { syncedTableNames, syncedTablesByGroup } = require(path.join(repoRoot, 'electron/db/syncTables.ts'));
+  assert.ok(syncedTableNames(db).includes('writing_draft_reads'), 'the mark travels in a sync package');
+  const writingGroup = syncedTablesByGroup(db).find((group) => group.key === 'writing');
+  assert.ok(
+    writingGroup?.tables.includes('writing_draft_reads'),
+    'the mark travels in the same group as the reports it is about'
+  );
+
+  db.close();
+  console.log('deep research read marker test passed');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+/** Put an already-built module in the cache so requiring it never runs its source. */
+function stubModule(relative, exports) {
+  const filename = path.join(repoRoot, relative);
+  const Module = require('node:module');
+  const stub = new Module(filename, null);
+  stub.filename = filename;
+  stub.loaded = true;
+  stub.exports = exports;
+  require.cache[filename] = stub;
+}
+
+function installTsHook() {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) {
+      return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    }
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  require.extensions['.ts'] = function loadTs(module, filename) {
+    const source = fs.readFileSync(filename, 'utf8');
+    const output = ts.transpileModule(source, {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}

--- a/shared/api/academic.ts
+++ b/shared/api/academic.ts
@@ -578,6 +578,12 @@ export interface AcademicApi {
   ): Promise<DeepResearchArchiveResult | null>;
   listWritingWorkshopDrafts(): Promise<WritingWorkshopSavedDraft[]>;
   saveWritingWorkshopDraft(request: WritingWorkshopSaveDraftRequest): Promise<WritingWorkshopSavedDraft>;
+  /**
+   * Mark a saved report read, or take the mark back. Resolves to the report as it now
+   * stands, or `null` when it no longer exists — which is the honest answer for a
+   * gallery holding an id another machine has since deleted.
+   */
+  setWritingWorkshopDraftRead(id: string, read: boolean): Promise<WritingWorkshopSavedDraft | null>;
   deleteWritingWorkshopDraft(id: string): Promise<void>;
   /**
    * Push: the saved-drafts table changed under this window's feet.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6044,6 +6044,14 @@ export interface WritingWorkshopSavedDraft {
   model: ModelRef | null;
   draft: WritingWorkshopDraft;
   image: DecorativeImage | null;
+  /**
+   * When the reader marked this report read, or null while they have not.
+   *
+   * Separate from `updatedAt`: reading a report does not change it, and the two would
+   * otherwise fight over the same field — sorting by "most recent" would put whatever
+   * you last opened at the top of the gallery.
+   */
+  readAt: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -7890,4 +7890,7 @@ export const DE: Record<string, string> = {
   "Avanzado · Docker y dominio propio": "Fortgeschritten · Docker und eigene Domain",
   "Un servidor independiente que sigue disponible aunque apagues este ordenador.": "Ein eigenständiger Server, der verfügbar bleibt, auch wenn Sie diesen Computer ausschalten.",
   "Abrir la administración web": "Web-Verwaltung öffnen",
+  "Marcar como leído": "Als gelesen markieren",
+  "Marcar como no leído": "Als ungelesen markieren",
+  "Ya has leído este informe": "Diesen Bericht haben Sie bereits gelesen",
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -8117,4 +8117,7 @@ export const EN: Record<string, string> = {
   "Avanzado · Docker y dominio propio": "Advanced · Docker and your own domain",
   "Un servidor independiente que sigue disponible aunque apagues este ordenador.": "An independent server that stays available even if you switch this computer off.",
   "Abrir la administración web": "Open the web administration",
+  "Marcar como leído": "Mark as read",
+  "Marcar como no leído": "Mark as unread",
+  "Ya has leído este informe": "You have already read this report",
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -7881,4 +7881,7 @@ export const FR: Record<string, string> = {
   "Avanzado · Docker y dominio propio": "Avancé · Docker et domaine propre",
   "Un servidor independiente que sigue disponible aunque apagues este ordenador.": "Un serveur indépendant qui reste disponible même si vous éteignez cet ordinateur.",
   "Abrir la administración web": "Ouvrir l’administration web",
+  "Marcar como leído": "Marquer comme lu",
+  "Marcar como no leído": "Marquer comme non lu",
+  "Ya has leído este informe": "Vous avez déjà lu ce rapport",
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -7293,4 +7293,7 @@ export const IT: Record<string, string> = {
   "Avanzado · Docker y dominio propio": "Avanzato · Docker e dominio proprio",
   "Un servidor independiente que sigue disponible aunque apagues este ordenador.": "Un server indipendente che resta disponibile anche se spegni questo computer.",
   "Abrir la administración web": "Apri l’amministrazione web",
+  "Marcar como leído": "Segna come letto",
+  "Marcar como no leído": "Segna come da leggere",
+  "Ya has leído este informe": "Hai già letto questo report",
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -7840,4 +7840,7 @@ export const PT_BR: Record<string, string> = {
   "Avanzado · Docker y dominio propio": "Avançado · Docker e domínio próprio",
   "Un servidor independiente que sigue disponible aunque apagues este ordenador.": "Um servidor independente que continua disponível mesmo se você desligar este computador.",
   "Abrir la administración web": "Abrir a administração web",
+  "Marcar como leído": "Marcar como lido",
+  "Marcar como no leído": "Marcar como não lido",
+  "Ya has leído este informe": "Você já leu este relatório",
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -7832,4 +7832,7 @@ export const PT: Record<string, string> = {
   "Avanzado · Docker y dominio propio": "Avançado · Docker e domínio próprio",
   "Un servidor independiente que sigue disponible aunque apagues este ordenador.": "Um servidor independente que continua disponível mesmo que desligue este computador.",
   "Abrir la administración web": "Abrir a administração web",
+  "Marcar como leído": "Marcar como lido",
+  "Marcar como no leído": "Marcar como não lido",
+  "Ya has leído este informe": "Já leu este relatório",
 };

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -7640,4 +7640,7 @@ export const TR: Record<string, string> = {
   "Avanzado · Docker y dominio propio": "Gelişmiş · Docker ve kendi alan adınız",
   "Un servidor independiente que sigue disponible aunque apagues este ordenador.": "Bu bilgisayarı kapatsanız bile erişilebilir kalan bağımsız bir sunucu.",
   "Abrir la administración web": "Web yönetimini aç",
+  "Marcar como leído": "Okundu olarak işaretle",
+  "Marcar como no leído": "Okunmadı olarak işaretle",
+  "Ya has leído este informe": "Bu raporu zaten okudunuz",
 };

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -432,6 +432,25 @@ export function DeepResearchView({
     setComposerOpen(true);
   };
 
+  /**
+   * Read, or not read after all.
+   *
+   * The main process announces the change and the gallery re-reads itself, so the two
+   * writes here are only about the wait: the badge flips under the cursor rather than a
+   * round trip later. `openDraft` is separate state and would otherwise keep showing the
+   * old mark until the reader was closed — which is precisely where this is pressed.
+   */
+  const toggleRead = async (saved: WritingWorkshopSavedDraft) => {
+    try {
+      const next = await window.nodus.setWritingWorkshopDraftRead(saved.id, !saved.readAt);
+      if (!next) return;
+      setSavedDrafts((current) => current.map((item) => (item.id === next.id ? next : item)));
+      setOpenDraft((current) => (current?.id === next.id ? next : current));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
   const deleteDraft = async (saved: WritingWorkshopSavedDraft) => {
     const ok = await confirm({
       title: t(copy.deleteTitle),
@@ -663,6 +682,7 @@ export function DeepResearchView({
           onCopy={() => void copyDraft()}
           onCopyReading={() => void copyForListening()}
           onSaveToNotes={() => setSavingToNotes(true)}
+          onToggleRead={() => void toggleRead(openDraft)}
           onTranslate={() => setTranslationOpen(true)}
           onExport={(format) => void exportDraft(format)}
           onCitation={setCitation}
@@ -859,6 +879,7 @@ export function DeepResearchView({
                 onOpen={() => openReader(saved)}
                 onReuse={() => reusePrompt(saved)}
                 onDownload={() => void downloadDraft(saved)}
+                onToggleRead={() => void toggleRead(saved)}
                 onDelete={() => void deleteDraft(saved)}
               />
             ))}
@@ -877,6 +898,7 @@ export function DeepResearchView({
                 onOpen={() => openReader(saved)}
                 onReuse={() => reusePrompt(saved)}
                 onDownload={() => void downloadDraft(saved)}
+                onToggleRead={() => void toggleRead(saved)}
                 onDelete={() => void deleteDraft(saved)}
               />
             ))}
@@ -949,6 +971,40 @@ function SelectCheck({ checked }: { checked: boolean }) {
   );
 }
 
+/**
+ * The mark a report wears once it has been read, over its cover.
+ *
+ * On the illustration rather than beside the title, because the question it answers —
+ * which of these have I already been through? — is asked of the whole gallery at a
+ * glance, and a badge among the metadata has to be read one card at a time.
+ */
+function ReadBadge() {
+  return (
+    <span
+      className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1 rounded-full bg-emerald-950/80 px-2 py-0.5 text-[10px] font-medium text-emerald-200 ring-1 ring-emerald-700/60"
+      title={t('Ya has leído este informe')}
+    >
+      <Icon name="check" size={10} /> {t('Leído')}
+    </span>
+  );
+}
+
+/** The toggle itself, identical wherever a report is listed. */
+function ReadToggle({ read, onToggle }: { read: boolean; onToggle: () => void }) {
+  return (
+    <button
+      className={`btn btn-ghost !py-1 gap-1 border text-xs ${
+        read ? 'border-emerald-700/60 text-emerald-300' : 'border-neutral-700 text-neutral-400'
+      }`}
+      onClick={onToggle}
+      title={read ? t('Marcar como no leído') : t('Marcar como leído')}
+      aria-pressed={read}
+    >
+      <Icon name={read ? 'eyeOff' : 'check'} size={12} />
+    </button>
+  );
+}
+
 function DraftGridCard({
   saved,
   settings,
@@ -959,6 +1015,7 @@ function DraftGridCard({
   onOpen,
   onReuse,
   onDownload,
+  onToggleRead,
   onDelete,
 }: {
   saved: WritingWorkshopSavedDraft;
@@ -970,6 +1027,7 @@ function DraftGridCard({
   onOpen: () => void;
   onReuse: () => void;
   onDownload: () => void;
+  onToggleRead: () => void;
   onDelete: () => void;
 }) {
   const primary = selecting ? onToggle : onOpen;
@@ -1000,10 +1058,18 @@ function DraftGridCard({
             <SelectCheck checked={selected} />
           </span>
         )}
+        {saved.readAt && <ReadBadge />}
       </button>
       <div className="flex flex-1 flex-col p-3">
         <button className="text-left" onClick={primary}>
-          <div className="line-clamp-2 text-sm font-medium text-neutral-200" title={saved.title}>{saved.title}</div>
+          {/* A read report steps back a shade. Not struck through and not hidden: it is
+              still the same report, it is simply no longer one of the ones waiting. */}
+          <div
+            className={`line-clamp-2 text-sm ${saved.readAt ? 'font-normal text-neutral-400' : 'font-medium text-neutral-200'}`}
+            title={saved.title}
+          >
+            {saved.title}
+          </div>
         </button>
         <div className="mt-1 flex items-center gap-1.5 text-[11px] text-neutral-500">
           <Icon name="clock" size={11} /> {formatDate(saved.updatedAt)}
@@ -1025,6 +1091,7 @@ function DraftGridCard({
             >
               <Icon name={downloading ? 'sync' : 'download'} size={12} className={downloading ? 'animate-spin' : ''} />
             </button>
+            <ReadToggle read={!!saved.readAt} onToggle={onToggleRead} />
             <div className="flex-1" />
             <button className="btn btn-ghost !py-1 text-xs text-neutral-500 hover:text-red-400" onClick={onDelete} title={t('Eliminar informe')}>
               <Icon name="trash" size={12} />
@@ -1046,6 +1113,7 @@ function DraftListRow({
   onOpen,
   onReuse,
   onDownload,
+  onToggleRead,
   onDelete,
 }: {
   saved: WritingWorkshopSavedDraft;
@@ -1057,6 +1125,7 @@ function DraftListRow({
   onOpen: () => void;
   onReuse: () => void;
   onDownload: () => void;
+  onToggleRead: () => void;
   onDelete: () => void;
 }) {
   const primary = selecting ? onToggle : onOpen;
@@ -1089,10 +1158,21 @@ function DraftListRow({
         />
       </button>
       <button className="min-w-0 flex-1 text-left" onClick={primary}>
-        <div className="truncate text-sm font-medium text-neutral-200" title={saved.title}>{saved.title}</div>
+        <div
+          className={`truncate text-sm ${saved.readAt ? 'font-normal text-neutral-400' : 'font-medium text-neutral-200'}`}
+          title={saved.title}
+        >
+          {saved.title}
+        </div>
         <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-neutral-500">
           <Icon name="clock" size={11} /> {formatDate(saved.updatedAt)}
           {saved.model && <><span>·</span><span className="truncate">{modelLabel(saved.model)}</span></>}
+          {saved.readAt && (
+            <span className="flex items-center gap-1 text-emerald-400">
+              <span>·</span>
+              <Icon name="check" size={11} /> {t('Leído')}
+            </span>
+          )}
         </div>
       </button>
       {!selecting && (
@@ -1111,6 +1191,7 @@ function DraftListRow({
           >
             <Icon name={downloading ? 'sync' : 'download'} size={12} className={downloading ? 'animate-spin' : ''} />
           </button>
+          <ReadToggle read={!!saved.readAt} onToggle={onToggleRead} />
           <button className="btn btn-ghost !py-1 text-xs text-neutral-500 hover:text-red-400" onClick={onDelete} title={t('Eliminar informe')}>
             <Icon name="trash" size={12} />
           </button>
@@ -1239,6 +1320,7 @@ function ReaderView({
   onCopy,
   onCopyReading,
   onSaveToNotes,
+  onToggleRead,
   onTranslate,
   onExport,
   onCitation,
@@ -1259,6 +1341,7 @@ function ReaderView({
   onCopy: () => void;
   onCopyReading: () => void;
   onSaveToNotes: () => void;
+  onToggleRead: () => void;
   onTranslate: () => void;
   onExport: (format: 'markdown' | 'pdf') => void;
   onCitation: (target: CitationTarget) => void;
@@ -1288,6 +1371,16 @@ function ReaderView({
           onCopyReading={onCopyReading}
           onSaveToNotes={onSaveToNotes}
           onExport={onExport}
+        />
+        {/* Beside the reading actions, where somebody who has just finished the report
+            is already looking, rather than back in the gallery they would have to
+            return to first. */}
+        <HoverLabelButton
+          icon={saved.readAt ? 'eyeOff' : 'check'}
+          label={saved.readAt ? t('Marcar como no leído') : t('Marcar como leído')}
+          onClick={onToggleRead}
+          showLabel={!!saved.readAt}
+          className={`btn-ghost h-9 min-h-9 border ${saved.readAt ? 'border-emerald-700/60 text-emerald-300' : 'border-neutral-700'}`}
         />
         <HoverLabelButton
           icon="languages"


### PR DESCRIPTION
The gallery could say when a report was written and which model wrote it, but not the one thing a reader wants back from a list of twenty: which of these have I already been through. Every card looked identical whether you had read it that morning or never opened it.

## What changed

- A **read toggle** on every card, on every list row, and in the reader's own bar — beside the reading actions, where somebody who has just finished the report is already looking.
- A **badge over the cover** and a lighter title once a report is read, so the question is answered by scanning rather than by opening each one.

## Where the mark lives, and why

A row in a table of its own rather than a column on the report. `writing_saved_drafts` is in `MUTABLE_TABLES`: an UPDATE on it fires the outbox trigger, so on a connected vault ticking "read" would have put the entire report back on the wire for the owner to receive again. Reading a report is not an edit of it.

It **does** travel in a `.nodussync` package, in the same group as the reports — that is one person's two machines, and having read something on the laptop is still true at the desk. Which is also why the stamp is called `updated_at`: the merge compares that name and no other, and unmarking is a DELETE the tombstones already carry.

## Verification

- `npm run typecheck`, `npm run lint` — clean.
- `npm test` — 1670/1671. The one failure, `test-prosopography-e2e.mjs`, fails identically on `main` with the working tree stashed; it is an environment issue with the startup-update modal, not this change.
- New: `scripts/test-deep-research-read.mjs`, against the real schema and the real repository. It asserts the report row is **byte-identical** before and after marking read, that the mark reaches the list, that unmarking and deleting both clear it, and that the table is classified for sync.
- Every new string translated in all seven tables; `test-i18n-coverage.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)