### PR TITLE
Say what 3.2.3 is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 3.2.3 — 2026-08-05
+
+Reading, rather than finding. A report can be marked as read, a passage on the
+phone can be kept as the place you stopped, and a work on the phone leads back to
+its item in Zotero. Search on a connected phone also answers at all again.
+
+### Added
+
+- **A Deep Research report can be marked as read**, on the desktop and on the
+  phone. The gallery says so at a glance — a badge over the cover, a lighter
+  title — so the question a list of twenty reports raises is answered by
+  scanning rather than by opening each one. On the desktop the mark travels
+  between your own machines in a sync package; it is deliberately not an edit of
+  the report, so it never goes back on the wire to a connected vault.
+- **A reading bookmark on the phone.** Select a passage in a report and keep it.
+  There is one per report, it is marked in the text itself, reopening the report
+  goes straight to it, and tapping the marked words offers to remove it.
+- **A work on the phone opens in Zotero.** The Zotero key stops being a dead line
+  of the record and becomes the way back to the PDF, the notes and the
+  annotations that live in the other app.
+
+### Fixed
+
+- **Search on a connected phone answers again** when what you are looking for
+  appears in a theme, a character or a scene. One such match was enough for the
+  app to be unable to read the answer, so it showed no results at all.
+
 ## 3.2.0 — 2026-08-04
 
 Work that arrives from another device has somewhere to land, and the two places

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -27,10 +27,11 @@ try {
   const currentRelease = RELEASE_NOTES[0];
   assert.equal(currentRelease?.version, '3.2.3');
   assert.equal(currentRelease?.date, '2026-08-05');
-  // A search result whose row the server could not name, so the phone discarded the whole
-  // answer rather than one line of it. One highlight: the floor stays at one so a patch does
-  // not have to invent a second thing to say.
-  assert.ok(currentRelease?.highlights.length >= 1, 'the release must describe what changed');
+  // A search result whose row the server could not name, and then three things about reading
+  // rather than finding: a report marked as read, a passage kept as the place you stopped, and
+  // a work that leads back to its item in Zotero. A floor rather than an exact count, in case
+  // more lands here before it ships.
+  assert.ok(currentRelease?.highlights.length >= 4, 'the release must describe what changed');
   for (const highlight of currentRelease.highlights) {
     // Written for the person using Nodus: no module names, no internal vocabulary.
     for (const language of ['es', 'en', 'fr', 'de', 'pt', 'pt-BR']) {

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -111,6 +111,9 @@ const RELEASE_3_2_2_IT: string[] = [
 
 const RELEASE_3_2_3_IT: string[] = [
   "La ricerca sul telefono smette di fallire quando ciò che cerchi compare in un tema, in un personaggio o in una scena. Bastava una sola di quelle schede perché l'app non riuscisse a leggere la risposta e non mostrasse alcun risultato. Ora ogni risultato arriva identificato e l'elenco si apre per intero.",
+  "Un rapporto di Deep Research si può contrassegnare come letto, sul computer e sul telefono. La galleria lo dice a colpo d'occhio, con un contrassegno sulla copertina e il titolo più leggero, così non serve più aprire venti rapporti per capire quale resta da leggere.",
+  "Sul telefono, seleziona un passaggio di un rapporto e conservalo come segnalibro di lettura. Ce n'è uno solo per rapporto, resta segnato nel testo stesso e riaprendo il rapporto si arriva proprio lì. Toccando il passaggio segnato lo puoi togliere.",
+  "Ogni opera sul telefono ha ora un pulsante che la apre in Zotero per iPhone e iPad. La chiave di Zotero smette di essere una riga morta della scheda e diventa la via di ritorno al PDF, alle note e alle annotazioni che stanno nell'altra applicazione.",
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -51,6 +51,9 @@ const RELEASE_3_2_2_TR: string[] = [
 
 const RELEASE_3_2_3_TR: string[] = [
   "Telefondaki arama, aradığınız şey bir temada, bir karakterde ya da bir sahnede geçtiğinde artık başarısız olmuyor. Bu kartlardan yalnızca birinin eşleşmesi, uygulamanın yanıtı okuyamamasına ve hiçbir sonuç göstermemesine yetiyordu. Artık her sonuç kimliğiyle geliyor ve liste eksiksiz açılıyor.",
+  "Bir Deep Research raporu artık okundu olarak işaretlenebiliyor, hem masaüstünde hem telefonda. Galeri bunu bir bakışta söylüyor, kapağın üzerindeki bir rozetle ve daha hafif bir başlıkla. Böylece hangisinin beklediğini anlamak için yirmi raporu açmak gerekmiyor.",
+  "Telefonda, bir rapordaki pasajı seçip okuma yer imi olarak saklayabilirsiniz. Her rapor için yalnızca bir tane var, metnin kendisinde işaretli duruyor ve raporu yeniden açtığınızda tam oraya geliyorsunuz. İşaretli pasaja dokunmak onu kaldırmayı öneriyor.",
+  "Telefondaki her eser artık onu iPhone ve iPad için Zotero'da açan bir düğme taşıyor. Zotero anahtarı kayıttaki ölü bir satır olmaktan çıkıp diğer uygulamadaki PDF'e, notlara ve işaretlemelere dönüş yolu oluyor.",
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -759,13 +759,18 @@ const RELEASE_3_2_2_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 /**
- * 3.2.3 is search on a connected phone answering at all.
+ * 3.2.3 is search on a connected phone answering at all, and three things a reader can now do
+ * with what they are reading.
  *
- * Each result carries the identifier of the row it found, and for a theme, a character or a
- * scene the server had none to give: those rows are keyed on a column of their own, and the
- * generic guess came up empty. The app cannot read a result without one, so it discarded the
- * whole answer, and a single theme whose name contained the query took every other result down
- * with it.
+ * The search: each result carries the identifier of the row it found, and for a theme, a
+ * character or a scene the server had none to give — those rows are keyed on a column of their
+ * own, and the generic guess came up empty. The app cannot read a result without one, so it
+ * discarded the whole answer, and a single theme whose name contained the query took every other
+ * result down with it.
+ *
+ * The other three are about reading rather than finding: a report can be marked as read, a
+ * passage on the phone can be kept as the place you stopped, and a work on the phone leads back
+ * to its item in Zotero.
  */
 const RELEASE_3_2_3_HIGHLIGHTS: RawReleaseHighlight[] = [
   {
@@ -776,6 +781,33 @@ const RELEASE_3_2_3_HIGHLIGHTS: RawReleaseHighlight[] = [
     de: 'Die Suche auf dem Telefon scheitert nicht mehr, wenn das Gesuchte in einem Thema, einer Figur oder einer Szene vorkommt. Eine einzige solche Karte reichte, damit die App die Antwort nicht lesen konnte und gar keine Ergebnisse zeigte. Jedes Ergebnis kommt jetzt eindeutig benannt an und die Liste öffnet sich vollständig.',
     pt: 'A pesquisa no telemóvel deixa de falhar quando o que procura aparece num tema, numa personagem ou numa cena. Bastava uma dessas fichas coincidir para a aplicação não conseguir ler a resposta e não mostrar resultado nenhum. Agora cada resultado chega identificado e a lista abre por inteiro.',
     'pt-BR': 'A busca no celular deixa de falhar quando o que você procura aparece em um tema, um personagem ou uma cena. Bastava uma dessas fichas coincidir para o aplicativo não conseguir ler a resposta e não mostrar resultado nenhum. Agora cada resultado chega identificado e a lista abre por inteiro.',
+  },
+  {
+    scope: 'general',
+    es: 'Un informe de Deep Research se puede marcar como leído, en el escritorio y en el móvil. La galería lo dice de un vistazo, con una insignia sobre la portada y el título un punto más ligero, así que ya no hay que abrir veinte informes para saber cuál queda pendiente.',
+    en: 'A Deep Research report can be marked as read, on the desktop and on the phone. The gallery says so at a glance, with a badge over the cover and a lighter title, so you no longer have to open twenty reports to find out which one is still waiting.',
+    fr: 'Un rapport de Deep Research peut être marqué comme lu, sur l’ordinateur comme sur le téléphone. La galerie le dit d’un coup d’œil, avec une pastille sur la couverture et un titre plus léger, et il n’y a plus besoin d’ouvrir vingt rapports pour savoir lequel attend encore.',
+    de: 'Ein Deep-Research-Bericht lässt sich als gelesen markieren, am Schreibtisch und am Telefon. Die Galerie zeigt es auf einen Blick, mit einer Plakette über dem Titelbild und einem leichteren Titel. So müssen Sie nicht mehr zwanzig Berichte öffnen, um zu sehen, welcher noch wartet.',
+    pt: 'Um relatório de Deep Research pode ser marcado como lido, no computador e no telemóvel. A galeria di-lo num relance, com um selo sobre a capa e o título mais leve, por isso já não é preciso abrir vinte relatórios para saber qual ainda está por ler.',
+    'pt-BR': 'Um relatório de Deep Research pode ser marcado como lido, no computador e no celular. A galeria mostra isso num relance, com um selo sobre a capa e o título mais leve, então não é mais preciso abrir vinte relatórios para saber qual ainda está esperando.',
+  },
+  {
+    scope: 'general',
+    es: 'En el móvil, selecciona un pasaje de un informe y guárdalo como marcador de lectura. Solo hay uno por informe, se ve marcado en el propio texto y, al volver a abrir el informe, se abre justo ahí. Tocando el pasaje marcado puedes quitarlo.',
+    en: 'On the phone, select a passage in a report and keep it as a reading bookmark. There is only one per report, it is marked in the text itself, and reopening the report takes you straight to it. Tapping the marked passage offers to remove it.',
+    fr: 'Sur le téléphone, sélectionnez un passage d’un rapport et gardez-le comme marque-page de lecture. Il n’y en a qu’un par rapport, il est signalé dans le texte, et rouvrir le rapport vous y ramène directement. Toucher le passage marqué propose de l’enlever.',
+    de: 'Wählen Sie am Telefon eine Passage in einem Bericht aus und behalten Sie sie als Lesezeichen. Es gibt nur eines pro Bericht, es ist im Text selbst markiert, und beim erneuten Öffnen landen Sie genau dort. Ein Tippen auf die markierte Stelle bietet an, sie zu entfernen.',
+    pt: 'No telemóvel, selecione uma passagem de um relatório e guarde-a como marcador de leitura. Só existe um por relatório, fica assinalado no próprio texto e, ao reabrir o relatório, este abre precisamente aí. Tocar na passagem marcada permite removê-la.',
+    'pt-BR': 'No celular, selecione um trecho de um relatório e guarde como marcador de leitura. Só existe um por relatório, ele fica marcado no próprio texto e, ao reabrir o relatório, ele abre exatamente ali. Tocar no trecho marcado permite removê-lo.',
+  },
+  {
+    scope: 'general',
+    es: 'Cada obra en el móvil lleva ahora un botón que la abre en Zotero para iPhone y iPad. La clave de Zotero deja de ser un dato muerto de la ficha y pasa a ser el camino de vuelta al PDF, a las notas y a las anotaciones que están en la otra aplicación.',
+    en: 'Every work on the phone now carries a control that opens it in Zotero for iPhone and iPad. The Zotero key stops being a dead line of the record and becomes the way back to the PDF, the notes and the annotations that live in the other app.',
+    fr: 'Chaque œuvre sur le téléphone porte désormais un bouton qui l’ouvre dans Zotero pour iPhone et iPad. La clé Zotero cesse d’être une ligne morte de la fiche et devient le chemin de retour vers le PDF, les notes et les annotations qui vivent dans l’autre application.',
+    de: 'Jedes Werk auf dem Telefon hat jetzt eine Schaltfläche, die es in Zotero für iPhone und iPad öffnet. Der Zotero-Schlüssel ist keine tote Zeile des Datensatzes mehr, sondern der Weg zurück zum PDF, zu den Notizen und zu den Anmerkungen in der anderen App.',
+    pt: 'Cada obra no telemóvel passa a ter um botão que a abre no Zotero para iPhone e iPad. A chave do Zotero deixa de ser uma linha morta da ficha e passa a ser o caminho de volta ao PDF, às notas e às anotações que estão na outra aplicação.',
+    'pt-BR': 'Cada obra no celular agora tem um botão que a abre no Zotero para iPhone e iPad. A chave do Zotero deixa de ser uma linha morta da ficha e vira o caminho de volta ao PDF, às notas e às anotações que estão no outro aplicativo.',
   },
 ];
 


### PR DESCRIPTION
3.2.3 was already open with the search fix in it. This adds the three things that landed since, in all eight languages, and gives the release an entry in the CHANGELOG.

- **A Deep Research report can be marked as read**, desktop and phone.
- **A reading bookmark on the phone**: select a passage, keep it, reopen the report there.
- **A work on the phone opens in Zotero.**

3.2.1 and 3.2.2 went without a CHANGELOG entry because each was a single line of the interface telling the truth again. This one adds three things somebody will look for, and a release with features in it belongs in the file that records them.

## Verification

- `npm run typecheck` — clean.
- `node --test scripts/test-release-notes.mjs scripts/test-version-agreement.mjs` — pass. The highlight floor moves from 1 to 4, every language is over the length floor, none uses a semicolon or an em dash, and `it`/`tr` differ from `en` as the test requires.
- `npm run citation:check` — synchronized for 3.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)