### PR TITLE
Trim the header rail and give Nodus a way to say something

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.2.3"
-date-released: "2026-08-05"
+version: "3.2.4"
+date-released: "2026-08-06"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -169,6 +169,13 @@ specified operation:
 - **GitHub:** Check and download updates, open incidents and downloads of the project. It also hosts
   the official download of the OpenAI tunnel client, whose integrity checks Nodus before executing
   it. GitHub can receive network data such as IP address.
+- **Nodus announcements:** Nodus downloads a public, static file of announcements published on the
+  project website (GitHub Pages) so it can warn about surveys, known issues or important changes
+  between releases. The request is a plain conditional GET made at most once every four hours, plus
+  one shortly after startup. It sends no identifier, no account, no vault name and no data of any
+  kind about the user's corpus; the server can see only what any web request exposes, such as the IP
+  address. It can be turned off completely in Settings > Updates and news, and when it is off no
+  request is made at all.
 - **Hugging Face or other fixed repositories:** optional download of models, voices and runtimes.
   The repository can receive network data.
 - **OpenAI Secure MCP Tunnel and ChatGPT:** If the user expressly configures this integration, Nodus

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,0 +1,78 @@
+# Publishing an announcement
+
+Announcements are the only channel that reaches installed copies of Nodus between
+releases: a survey worth answering, a provider that broke overnight, a warning about a
+specific build. They appear in the notifications panel, above the activity feed, and
+stay unread until the reader opens them.
+
+Adding a notice is a pull request. Merging it is the deployment.
+
+## Where it lives
+
+| | |
+| --- | --- |
+| Source of truth | [`site/data/announcements.json`](../site/data/announcements.json) |
+| Published at | `https://drakonis96.github.io/nodus/data/announcements.json` |
+| Deployed by | [`.github/workflows/pages.yml`](../.github/workflows/pages.yml), on push to `main` touching `site/**` |
+| Validated by | `scripts/test-announcements.mjs` (part of `npm test`) |
+| Read by | [`electron/announcements.ts`](../electron/announcements.ts) |
+
+## How to add one
+
+Append an object to `notices`. Newest last or first does not matter — the app sorts by
+date, newest first, with warnings ahead of infos published the same day.
+
+```jsonc
+{
+  "id": "2026-09-teaching-survey",   // stable slug, NEVER reused
+  "date": "2026-09-01",              // YYYY-MM-DD
+  "severity": "info",                // "info" | "warning"
+  "url": "https://forms.gle/…",      // optional, https only
+  "expiresAt": "2026-10-15",         // optional; the notice vanishes on its own after this day
+  "minVersion": "3.2.0",             // optional, inclusive
+  "maxVersion": "3.3.1",             // optional, inclusive
+  "copy": {
+    "es": { "title": "…", "body": "…", "linkLabel": "Responder la encuesta" },
+    "en": { "title": "…", "body": "…", "linkLabel": "Answer the survey" },
+    "fr": { … }, "de": { … }, "pt": { … }, "pt-BR": { … }, "it": { … }, "tr": { … }
+  }
+}
+```
+
+**All eight languages are required.** `scripts/test-announcements.mjs` fails the PR if
+one is missing, so a notice cannot reach users half-translated. At runtime the app is
+more forgiving than CI — it needs only `es` and `en`, and falls back English-then-Spanish
+— but that leniency exists for resilience, not as a way around the test.
+
+Caps, enforced both by the test and by the parser: title 120 characters, body 600,
+`linkLabel` 60, URL 300, and at most 50 notices in the file.
+
+## What the app does with it
+
+One conditional `GET` at startup (delayed, so it never competes with boot) and one on
+each tick of the existing four-hour update timer. The response's `ETag` is stored and
+sent back as `If-None-Match`, so the usual answer is a `304` with no body. The last good
+payload is cached in `userData`, so the panel works offline.
+
+Users can turn the whole thing off in **Settings › Updates and news**. When it is off,
+no request is made at all.
+
+## Rules worth keeping
+
+- **Never reuse an `id`.** It is what the read mark hangs off; reusing one silently
+  marks a new notice as already read for everyone who read the old one.
+- **Never edit a notice's meaning in place.** Publish a new one. Editing changes what
+  people who already read it think they read.
+- **Prefer `expiresAt` to deleting.** Deleting an entry makes it vanish mid-read;
+  expiry retires it predictably. Delete only once it has expired for everyone.
+- **Bodies are plain text.** Markup is not rendered — it will show as literal
+  characters.
+- **Links open in the system browser**, and only `https:` ones survive the parser.
+
+## Testing without publishing
+
+Point the app at any URL, including a local file server:
+
+```bash
+NODUS_ANNOUNCEMENTS_URL=http://localhost:8080/announcements.json npm run dev
+```

--- a/electron/announcements.ts
+++ b/electron/announcements.ts
@@ -1,0 +1,180 @@
+import { app, net } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  ANNOUNCEMENTS_URL,
+  isAnnouncementVisible,
+  parseAnnouncements,
+  sortAnnouncements,
+  type Announcement,
+  type AnnouncementEntry,
+} from '@shared/announcements';
+import { getSettings } from './db/settingsRepo';
+
+/**
+ * The published announcements, fetched about as rarely as anything can be and still be
+ * called current.
+ *
+ * The cost of a channel like this is not the transfer, it is the habit: a poll every few
+ * minutes, or a socket held open, would show up as battery on a laptop and as a steady
+ * presence signal on the other end. Neither buys anything — a notice that arrives four
+ * hours late is a notice that arrived. So this rides the update check's existing timer
+ * (see UPDATE_CHECK_INTERVAL_MS in main.ts) rather than starting a second one, and asks
+ * conditionally: the response's ETag comes back as `If-None-Match`, so the ordinary
+ * answer is a 304 with no body at all.
+ *
+ * Main-process only, like the tutorial catalogue and for the same reason: fetching from
+ * the renderer would mean widening the CSP for another remote host.
+ *
+ * State (last good payload, its ETag, and which notices this person has read) is a single
+ * JSON in userData. It is deliberately NOT the Nodi notification store: that one is capped
+ * at 50 and has a "Clear" button, and an announcement must survive both.
+ */
+
+const STATE_FILE = 'announcements.json';
+const FETCH_TIMEOUT_MS = 6_000;
+
+interface AnnouncementsState {
+  /** Validator from the last 200, replayed as If-None-Match. */
+  etag?: string;
+  /** Last successful check, for diagnostics only — the schedule does not read it. */
+  checkedAt?: number;
+  /** The raw payload exactly as served, re-parsed on every read. */
+  payload?: unknown;
+  /** id → when it was read, in ms. Pruned to the ids still being published. */
+  read?: Record<string, number>;
+}
+
+let notify: (() => void) | null = null;
+let checking = false;
+
+/** Register a callback invoked when the list or its read marks change. */
+export function setAnnouncementsNotifier(cb: (() => void) | null): void {
+  notify = cb;
+}
+
+function statePath(): string {
+  return path.join(app.getPath('userData'), STATE_FILE);
+}
+
+function readState(): AnnouncementsState {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath(), 'utf8'));
+    return parsed && typeof parsed === 'object' ? (parsed as AnnouncementsState) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeState(state: AnnouncementsState): void {
+  try {
+    fs.mkdirSync(path.dirname(statePath()), { recursive: true });
+    fs.writeFileSync(statePath(), JSON.stringify(state), 'utf8');
+  } catch (error) {
+    console.warn('[announcements] could not persist state:', error);
+  }
+}
+
+/** Overridable so a verification run can serve a list without publishing one. */
+function announcementsUrl(): string {
+  return process.env.NODUS_ANNOUNCEMENTS_URL || ANNOUNCEMENTS_URL;
+}
+
+/**
+ * Whether the user still wants this channel. A settings read can throw before a vault
+ * is open; that is not consent, so the check is skipped and the next tick tries again.
+ */
+function announcementsAllowed(): boolean {
+  if (process.env.NODUS_DISABLE_ANNOUNCEMENTS === '1') return false;
+  try {
+    return getSettings().announcementsEnabled !== false;
+  } catch {
+    return false;
+  }
+}
+
+/** The notices this build should show today, newest first, with their read marks. */
+export function listAnnouncements(): AnnouncementEntry[] {
+  const state = readState();
+  const { announcements } = parseAnnouncements(state.payload);
+  const read = state.read ?? {};
+  const visible = announcements.filter((announcement) => isAnnouncementVisible(announcement, {
+    now: Date.now(),
+    version: app.getVersion(),
+  }));
+  return sortAnnouncements(visible).map((announcement) => ({
+    ...announcement,
+    read: Boolean(read[announcement.id]),
+  }));
+}
+
+export function unreadAnnouncementCount(): number {
+  return listAnnouncements().reduce((total, entry) => total + (entry.read ? 0 : 1), 0);
+}
+
+/**
+ * Mark one notice read. Per notice on purpose: the point of an announcement is that
+ * somebody actually read it, so opening the panel must not clear the lot the way the
+ * activity feed does.
+ */
+export function markAnnouncementRead(id: string): AnnouncementEntry[] {
+  const state = readState();
+  const read = { ...(state.read ?? {}) };
+  if (!read[id]) {
+    read[id] = Date.now();
+    writeState({ ...state, read });
+    notify?.();
+  }
+  return listAnnouncements();
+}
+
+/** Drop read marks for notices that are no longer published, so the map stays small. */
+function pruneRead(read: Record<string, number>, announcements: readonly Announcement[]): Record<string, number> {
+  const live = new Set(announcements.map((announcement) => announcement.id));
+  const kept: Record<string, number> = {};
+  for (const [id, at] of Object.entries(read)) if (live.has(id)) kept[id] = at;
+  return kept;
+}
+
+/**
+ * Ask for the list. Never throws and never reports failure to the user: an unreachable
+ * file means the app shows the notices it already had, which is the same thing it shows
+ * when there is nothing to announce.
+ */
+export async function refreshAnnouncements(reason: string): Promise<void> {
+  if (checking || !announcementsAllowed()) return;
+  checking = true;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const state = readState();
+    // Electron's net stack, so the app's proxy configuration applies. No cache-buster:
+    // the whole point is to let the CDN answer 304, and a unique URL per check would
+    // force a full transfer every time.
+    const response = await net.fetch(announcementsUrl(), {
+      signal: controller.signal,
+      headers: state.etag ? { 'If-None-Match': state.etag } : {},
+    });
+    if (response.status === 304) {
+      writeState({ ...state, checkedAt: Date.now() });
+      return;
+    }
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+    const { announcements, rejected } = parseAnnouncements(payload);
+    if (rejected > 0) console.warn(`[announcements] ignored ${rejected} malformed entr${rejected === 1 ? 'y' : 'ies'}`);
+    writeState({
+      etag: response.headers.get('etag') ?? undefined,
+      checkedAt: Date.now(),
+      payload,
+      read: pruneRead(state.read ?? {}, announcements),
+    });
+    console.log(`[announcements] ${announcements.length} notice(s) after check (${reason})`);
+    notify?.();
+  } catch (error) {
+    console.log('[announcements] check skipped:', error instanceof Error ? error.message : error);
+  } finally {
+    clearTimeout(timer);
+    checking = false;
+  }
+}

--- a/electron/db/appPrefs.ts
+++ b/electron/db/appPrefs.ts
@@ -30,6 +30,7 @@ export const GLOBAL_PREF_KEYS = [
   'highContrast',
   'reduceMotion',
   'readingFocusMode',
+  'announcementsEnabled',
   'favorites',
   'mascotEnabled',
   'mascotAlwaysOnTop',

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -117,6 +117,7 @@ const DEFAULTS: Omit<AppSettings, 'providerKeys' | 'lockedProviderKeys'> = {
   highContrast: false,
   reduceMotion: false,
   readingFocusMode: false,
+  announcementsEnabled: true,
   mascotEnabled: true,
   mascotAlwaysOnTop: false,
   mascotVaultCostumes: true,

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -58,6 +58,12 @@ import {
   clearNotifications,
   setNotificationsNotifier,
 } from './notifications';
+import {
+  listAnnouncements,
+  markAnnouncementRead,
+  refreshAnnouncements,
+  setAnnouncementsNotifier,
+} from './announcements';
 import { getNodiViewContext, setNodiViewContext, streamNodiChat } from './ai/nodiChat';
 import type { NodiChatRequest } from '@shared/types';
 import { clearNodiConversations, deleteNodiConversation, getNodiConversation, listNodiConversations, saveNodiConversation } from './nodiConversations';
@@ -364,6 +370,9 @@ export function registerIpc(
     if (patch.mascotEnabled !== undefined || patch.mascotAlwaysOnTop !== undefined) {
       applyMascotWindow();
     }
+    // Turning announcements back on asks straight away. The alternative is a panel that
+    // stays empty for up to four hours after the user opted in, which reads as broken.
+    if (patch.announcementsEnabled === true) void refreshAnnouncements('setting enabled');
     // Let other windows (the Nodi overlay) react to setting changes, e.g. costumes.
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) win.webContents.send('settings:changed', next);
@@ -388,6 +397,14 @@ export function registerIpc(
     clearNotifications();
     return listNotifications();
   });
+  setAnnouncementsNotifier(() => {
+    const list = listAnnouncements();
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('announcements:changed', list);
+    }
+  });
+  h('announcements:list', async () => listAnnouncements());
+  h('announcements:markRead', async (_e, id: string) => markAnnouncementRead(String(id)));
   h('nodi:conversations:list', async () => listNodiConversations());
   h('nodi:conversations:get', async (_e, id: string) => getNodiConversation(id));
   h('nodi:conversations:save', async (_e, input) => saveNodiConversation(input));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,6 +25,7 @@ import { setCopilotWindowProvider, startCopilotServer, stopCopilotServer } from 
 import { setZoteroPluginWindowProvider, startZoteroPluginServer, stopZoteroPluginServer } from './zotero-plugin/server';
 import { applyMascotWindow, destroyMascotWindow, setMascotTutorialVisible } from './mascotWindow';
 import { seedWelcomeNotification } from './notifications';
+import { refreshAnnouncements } from './announcements';
 import { startStudyCalendarReminders, stopStudyCalendarReminders } from './studyCalendarReminders';
 import { restorePersistedDockIcon } from './dockIcon';
 import { stopAllWhisperCpp } from './stt/whisperCpp';
@@ -109,10 +110,13 @@ let useUnsignedMacUpdaterFallback = false;
 let autoBackupTimer: NodeJS.Timeout | null = null;
 let autoBackupFirstTimer: NodeJS.Timeout | null = null;
 let autoBackupRunning = false;
+let announcementsFirstTimer: NodeJS.Timeout | null = null;
 /** Set once shutdown starts, so timers that fire mid-quit do not reopen the DB. */
 let quitting = false;
 
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+/** Long enough that the first window has painted and a vault is open. */
+const ANNOUNCEMENTS_STARTUP_DELAY_MS = 45 * 1000;
 
 function macAppBundlePath(): string | null {
   if (process.platform !== 'darwin') return null;
@@ -545,7 +549,16 @@ function setupAutoUpdates(): void {
 
   // The renderer's cinematic startup modal performs the immediate check and
   // presents its result. Keep the long-running scheduled checks here.
-  updateCheckTimer = setInterval(() => void checkForUpdates('scheduled'), UPDATE_CHECK_INTERVAL_MS);
+  //
+  // Announcements ride this timer rather than starting a second one: they change a few
+  // times a year, so a tick of their own would be a wake-up bought for nothing. The
+  // first check is delayed instead of immediate — startup is the one moment the main
+  // process's single event loop is genuinely contended, and nothing here is urgent.
+  updateCheckTimer = setInterval(() => {
+    void checkForUpdates('scheduled');
+    void refreshAnnouncements('scheduled');
+  }, UPDATE_CHECK_INTERVAL_MS);
+  announcementsFirstTimer = setTimeout(() => void refreshAnnouncements('startup'), ANNOUNCEMENTS_STARTUP_DELAY_MS);
 }
 
 // A second copy of this profile tried to start. It has already quit; bring the
@@ -731,6 +744,7 @@ app.on('before-quit', () => {
   stopAllWhisperCpp();
   if (updateCheckTimer) clearInterval(updateCheckTimer);
   if (installUpdateTimer) clearTimeout(installUpdateTimer);
+  if (announcementsFirstTimer) clearTimeout(announcementsFirstTimer);
   // getDb() reopens (and re-migrates) lazily, so a backup tick landing after
   // closeDb() would resurrect the database on a shutting-down process.
   if (autoBackupTimer) clearInterval(autoBackupTimer);
@@ -759,6 +773,7 @@ const updateAwareApp = app as typeof app & { on(event: 'before-quit-for-update',
 updateAwareApp.on('before-quit-for-update', () => {
   quitting = true;
   if (updateCheckTimer) clearInterval(updateCheckTimer);
+  if (announcementsFirstTimer) clearTimeout(announcementsFirstTimer);
   if (autoBackupTimer) clearInterval(autoBackupTimer);
   if (autoBackupFirstTimer) clearTimeout(autoBackupFirstTimer);
   stopRealtimeSync();

--- a/electron/preload/api.ts
+++ b/electron/preload/api.ts
@@ -93,6 +93,14 @@ export const nodusApi: NodusApi = {
     ipcRenderer.on('nodi:notifications:changed', listener);
     return () => ipcRenderer.removeListener('nodi:notifications:changed', listener);
   },
+  // Published announcements
+  listAnnouncements: () => ipcRenderer.invoke('announcements:list'),
+  markAnnouncementRead: (id) => ipcRenderer.invoke('announcements:markRead', id),
+  onAnnouncementsChanged: (cb) => {
+    const listener = (_e: unknown, list: Parameters<typeof cb>[0]) => cb(list);
+    ipcRenderer.on('announcements:changed', listener);
+    return () => ipcRenderer.removeListener('announcements:changed', listener);
+  },
   // Nodi companion: chat (streaming) + overlay-window helpers
   nodiChatStream: async (request, handlers) => {
     const requestId = `nodi-${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",
@@ -28,6 +28,7 @@
     "verify:gallery-virtualization": "node scripts/verify-gallery-virtualization.mjs",
     "verify:debates-payload": "node scripts/verify-debates-payload.mjs",
     "verify:single-instance": "node scripts/verify-single-instance.mjs",
+    "verify:announcements": "npm run build && node scripts/verify-announcements.mjs",
     "verify:api-key-recovery-macos": "node scripts/verify-api-key-recovery-macos.mjs",
     "verify:toolkit-heic": "node scripts/verify-toolkit-heic.mjs",
     "capture:worldbuilding-site": "npm run build && electron-rebuild -f -w better-sqlite3 && node scripts/capture-worldbuilding-site-demo.mjs",

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -454,7 +454,8 @@ try {
 
   // ── Vault wizard: independent, required text + embedding models ───────────
   const originalVaultId = (await page.evaluate(() => window.nodus.getActiveVault())).id;
-  await page.locator('[data-tour="vaults"]').click();
+  // The right-rail Bóvedas button is gone; the centred badge is the way into the panel.
+  await page.locator('[data-testid="header-vault-badge"]').click();
   await page.getByRole('button', { name: 'Añadir', exact: true }).click();
   const vaultDialog = page.getByRole('dialog', { name: 'Añadir bóveda' });
   await vaultDialog.waitFor();
@@ -856,8 +857,21 @@ try {
     assert.fail(`the header badge never settled clear of the rails (${label}): ${safety.why}`);
   };
 
+  const setWindowWidth = async (width) => {
+    await app.evaluate(({ BrowserWindow }, w) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (win) win.setBounds({ width: w, height: Math.max(win.getBounds().height, 900) });
+    }, width).catch(() => {});
+    await page.waitForTimeout(300);
+  };
+  const badgeCentreOffset = async () => {
+    const g = await readHeaderGeometry();
+    if (!g?.visible) return null;
+    return Math.abs((g.badge.left + g.badge.width / 2) - (g.header.left + g.header.width / 2));
+  };
+
   if (headerViewportWidth < 1280) {
-    console.log(`[e2e] header centre badge steps skipped: window is ${headerViewportWidth}px (< xl), where the badge is display:none by design; geometry covered by scripts/test-header-layout.mjs`);
+    console.log(`[e2e] header centre badge steps skipped: the window is ${headerViewportWidth}px and the resize did not take; geometry covered by scripts/test-header-layout.mjs`);
   } else {
     // The model warning is pinned open in this profile (no synthesis model yet at
     // first launch) — the exact state that used to overlap. Force both cases.
@@ -865,8 +879,19 @@ try {
     await page.evaluate(() => window.nodus.updateSettings({ synthesisModel: null }));
     await waitForCondition('aviso de modelo de IA visible', async () =>
       (await page.getByText('Configura un modelo de IA', { exact: true }).count()) > 0);
-    const withAlert = await assertHeaderBadgeSafe('con el aviso de IA abierto');
+    // Since three icons left the rail, the pinned alert alone no longer crowds the badge
+    // at 1440, so the tight case is made by narrowing the window too. That is the state
+    // the clamp exists for: the badge must leave the true centre rather than slide under
+    // a rail. Asserted as an offset from centre, not as an absolute left, because a
+    // narrower window moves the centre as well and would make a raw comparison pass for
+    // the wrong reason.
+    await setWindowWidth(980);
+    const tight = await assertHeaderBadgeSafe('con el aviso de IA abierto y la ventana estrecha');
+    assert.ok(tight.visible, 'the badge stays visible on a tight header');
+    const tightOffset = Math.abs((tight.badge.left + tight.badge.width / 2) - (tight.header.left + tight.header.width / 2));
+    assert.ok(tightOffset > 1, `the tight header must clamp the badge off the true centre (offset ${tightOffset.toFixed(1)}px)`);
 
+    await setWindowWidth(1440);
     await page.evaluate((model) => window.nodus.updateSettings({ synthesisModel: model }), originalSynthesis);
     await waitForCondition('aviso de modelo de IA retirado', async () =>
       (await page.getByText('Configura un modelo de IA', { exact: true }).count()) === 0);
@@ -874,21 +899,12 @@ try {
     // centre — the resting position the design calls for. Waited for rather than
     // sampled: the clamped spot it is leaving is itself "clear of the rails", so a
     // single read could catch it mid-return.
-    const badgeCentreOffset = async () => {
-      const g = await readHeaderGeometry();
-      if (!g?.visible) return null;
-      return Math.abs((g.badge.left + g.badge.width / 2) - (g.header.left + g.header.width / 2));
-    };
     await waitForCondition('el badge vuelve al centro exacto', async () => {
       const offset = await badgeCentreOffset();
       return offset !== null && offset <= 1;
     });
     const roomy = await assertHeaderBadgeSafe('sin el aviso');
     assert.ok(roomy.visible, 'the badge shows on a roomy header');
-    assert.ok(
-      withAlert.badge.left < roomy.badge.left,
-      `the alert pushed the badge off centre (${withAlert.badge.left}) and it came back (${roomy.badge.left})`
-    );
 
     // Hovering a rail button opens its label and widens the rail mid-flight.
     await page.locator('[data-tour="toolkit"]').hover();

--- a/scripts/test-announcements.mjs
+++ b/scripts/test-announcements.mjs
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The gate on the announcements channel.
+ *
+ * site/data/announcements.json is published by merging it: the Pages workflow deploys
+ * on any push to main touching site/**. So this file is the only review step between
+ * writing a notice and every install seeing it, and it enforces the two things that
+ * cannot be fixed after the fact — a notice must be readable in all eight interface
+ * languages, and an id must never be reused, because the id is what a read mark hangs
+ * off and reusing one marks a NEW notice as already read for everyone.
+ *
+ * The runtime parser is deliberately more forgiving (es + en are enough, and it drops
+ * bad entries instead of failing). That is resilience for a file that arrives over the
+ * network; it is not licence to publish an untranslated notice.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const outDir = await mkdtemp(path.join(os.tmpdir(), 'nodus-announcements-'));
+
+function loadModule(file) {
+  const bundle = path.join(outDir, `${path.basename(file, '.ts')}.cjs`);
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/esbuild'),
+    [path.join(repoRoot, file), '--bundle', '--platform=node', '--format=cjs', '--target=es2022', `--outfile=${bundle}`],
+    { cwd: repoRoot, stdio: 'inherit' }
+  );
+  return require(bundle);
+}
+
+const announcements = loadModule('shared/announcements.ts');
+const {
+  ANNOUNCEMENT_LANGUAGES,
+  announcementCopyFor,
+  compareVersions,
+  isAnnouncementVisible,
+  parseAnnouncements,
+  sortAnnouncements,
+} = announcements;
+
+const PUBLISHED_FILE = 'site/data/announcements.json';
+const published = JSON.parse(fs.readFileSync(path.join(repoRoot, PUBLISHED_FILE), 'utf8'));
+
+test.after(() => rm(outDir, { recursive: true, force: true }));
+
+test('the published file has the shape the app expects', () => {
+  assert.equal(typeof published, 'object');
+  assert.ok(Array.isArray(published.notices), `${PUBLISHED_FILE} must hold a "notices" array`);
+  assert.ok(published.notices.length <= 50, 'at most 50 notices may be published at once');
+});
+
+test('every published notice is written in all eight languages', () => {
+  for (const notice of published.notices) {
+    const missing = ANNOUNCEMENT_LANGUAGES.filter((language) => {
+      const copy = notice.copy?.[language];
+      return !copy || typeof copy.title !== 'string' || !copy.title.trim() || typeof copy.body !== 'string' || !copy.body.trim();
+    });
+    assert.deepEqual(missing, [], `notice "${notice.id}" is missing: ${missing.join(', ')}`);
+  }
+});
+
+test('every published notice survives the runtime parser unchanged', () => {
+  // The parser is what users actually get. A notice that it silently drops — a bad id,
+  // an over-long body, a non-https link — would pass a shape check and reach nobody.
+  const { announcements: parsed, rejected } = parseAnnouncements(published);
+  assert.equal(rejected, 0, 'the parser rejected a published notice');
+  assert.equal(parsed.length, published.notices.length);
+});
+
+test('ids are unique, stable slugs and dates are real', () => {
+  const seen = new Set();
+  for (const notice of published.notices) {
+    assert.match(notice.id, /^[a-z0-9][a-z0-9-]{0,63}$/, `"${notice.id}" is not a slug`);
+    assert.ok(!seen.has(notice.id), `"${notice.id}" appears twice`);
+    seen.add(notice.id);
+    assert.match(notice.date, /^\d{4}-\d{2}-\d{2}$/, `"${notice.id}" has no ISO date`);
+    if (notice.expiresAt) {
+      assert.match(notice.expiresAt, /^\d{4}-\d{2}-\d{2}$/, `"${notice.id}" has a malformed expiresAt`);
+      assert.ok(notice.expiresAt >= notice.date, `"${notice.id}" expires before it is published`);
+    }
+    if (notice.url) assert.ok(notice.url.startsWith('https://'), `"${notice.id}" links to a non-https URL`);
+    if (notice.severity) assert.ok(['info', 'warning'].includes(notice.severity), `"${notice.id}" has an unknown severity`);
+  }
+});
+
+// ── the parser, against input nobody controls ─────────────────────────────────
+
+const validCopy = Object.fromEntries(ANNOUNCEMENT_LANGUAGES.map((language) => [language, { title: `T ${language}`, body: `B ${language}` }]));
+const validNotice = { id: 'sample-notice', date: '2026-08-01', severity: 'info', copy: validCopy };
+
+test('the parser accepts a well-formed notice and both container shapes', () => {
+  assert.equal(parseAnnouncements({ notices: [validNotice] }).announcements.length, 1);
+  assert.equal(parseAnnouncements([validNotice]).announcements.length, 1);
+  assert.deepEqual(parseAnnouncements(null), { announcements: [], rejected: 0 });
+  assert.deepEqual(parseAnnouncements('not json'), { announcements: [], rejected: 0 });
+});
+
+test('the parser refuses every link that is not https', () => {
+  for (const url of ['javascript:alert(1)', 'file:///etc/passwd', 'http://example.com', 'example.com', 'data:text/html,x']) {
+    const [parsed] = parseAnnouncements([{ ...validNotice, url }]).announcements;
+    assert.equal(parsed.url, undefined, `${url} must not survive`);
+  }
+  const [ok] = parseAnnouncements([{ ...validNotice, url: 'https://example.com/survey' }]).announcements;
+  assert.equal(ok.url, 'https://example.com/survey');
+});
+
+test('the parser drops notices it cannot trust', () => {
+  const bad = [
+    { ...validNotice, id: 'Not A Slug' },
+    { ...validNotice, id: '' },
+    { ...validNotice, date: '2026-02-31' },
+    { ...validNotice, date: 'yesterday' },
+    { ...validNotice, copy: { es: validCopy.es } },
+    { ...validNotice, copy: { ...validCopy, es: { title: 'x'.repeat(121), body: 'ok' } } },
+    { ...validNotice, copy: { ...validCopy, en: { title: 'ok', body: 'x'.repeat(601) } } },
+    null,
+    'a string',
+  ];
+  for (const notice of bad) {
+    assert.equal(parseAnnouncements([notice]).announcements.length, 0, `${JSON.stringify(notice)?.slice(0, 60)} must be dropped`);
+  }
+});
+
+test('a duplicate id is kept once, and the file is capped', () => {
+  const { announcements: parsed, rejected } = parseAnnouncements([validNotice, { ...validNotice, date: '2026-08-02' }]);
+  assert.equal(parsed.length, 1);
+  assert.equal(rejected, 1);
+  const many = Array.from({ length: 60 }, (_, i) => ({ ...validNotice, id: `notice-${i}` }));
+  assert.equal(parseAnnouncements(many).announcements.length, 50);
+});
+
+test('expiry and version targeting decide what a build shows', () => {
+  const now = Date.parse('2026-08-06T12:00:00Z');
+  const base = { ...validNotice };
+  assert.equal(isAnnouncementVisible({ ...base, expiresAt: '2026-08-06' }, { now, version: '3.2.3' }), true, 'expiry day included');
+  assert.equal(isAnnouncementVisible({ ...base, expiresAt: '2026-08-05' }, { now, version: '3.2.3' }), false);
+  assert.equal(isAnnouncementVisible({ ...base, minVersion: '3.2.3' }, { now, version: '3.2.3' }), true, 'minVersion inclusive');
+  assert.equal(isAnnouncementVisible({ ...base, minVersion: '3.3.0' }, { now, version: '3.2.3' }), false);
+  assert.equal(isAnnouncementVisible({ ...base, maxVersion: '3.2.3' }, { now, version: '3.2.3' }), true, 'maxVersion inclusive');
+  assert.equal(isAnnouncementVisible({ ...base, maxVersion: '3.2.2' }, { now, version: '3.2.3' }), false);
+  // An app version nobody can parse must not hide every targeted notice.
+  assert.equal(isAnnouncementVisible({ ...base, minVersion: '3.3.0' }, { now, version: 'dev' }), true);
+});
+
+test('versions compare by segment, not as strings', () => {
+  assert.ok(compareVersions('3.10.0', '3.9.0') > 0, '10 is above 9');
+  assert.equal(compareVersions('3.2', '3.2.0'), 0, 'missing segments are zero');
+  assert.ok(compareVersions('3.2.3', '3.2.4') < 0);
+});
+
+test('warnings sort above infos published the same day, newest first', () => {
+  const sorted = sortAnnouncements([
+    { ...validNotice, id: 'old', date: '2026-07-01' },
+    { ...validNotice, id: 'info-today', date: '2026-08-01', severity: 'info' },
+    { ...validNotice, id: 'warn-today', date: '2026-08-01', severity: 'warning' },
+  ]);
+  assert.deepEqual(sorted.map((notice) => notice.id), ['warn-today', 'info-today', 'old']);
+});
+
+test('copy falls back English-then-Spanish, never to nothing', () => {
+  const partial = { ...validNotice, copy: { es: { title: 'ES', body: 'ES' }, en: { title: 'EN', body: 'EN' } } };
+  assert.equal(announcementCopyFor(partial, 'de').title, 'EN');
+  assert.equal(announcementCopyFor(partial, 'en').title, 'EN');
+  assert.equal(announcementCopyFor(partial, 'es').title, 'ES');
+  assert.equal(announcementCopyFor({ ...validNotice, copy: { es: { title: 'ES', body: 'ES' } } }, 'fr').title, 'ES');
+});
+
+test('the app fetches announcements conditionally, on the update timer, and can be turned off', () => {
+  const fetcher = fs.readFileSync(path.join(repoRoot, 'electron/announcements.ts'), 'utf8');
+  const main = fs.readFileSync(path.join(repoRoot, 'electron/main.ts'), 'utf8');
+  // A conditional request is the whole cost argument: the usual answer carries no body.
+  assert.match(fetcher, /'If-None-Match'/);
+  assert.match(fetcher, /response\.status === 304/);
+  // The URL is requested verbatim. Appending a cache-buster the way the tutorial
+  // catalogue does would make every check a unique URL, and so a full transfer.
+  assert.match(fetcher, /net\.fetch\(announcementsUrl\(\), \{/);
+  assert.doesNotMatch(fetcher, /\?t=\$\{/);
+  assert.match(fetcher, /announcementsEnabled !== false/);
+  assert.match(fetcher, /NODUS_ANNOUNCEMENTS_URL/);
+  // No timer of its own: it rides the four-hour update check.
+  assert.doesNotMatch(fetcher, /setInterval/);
+  assert.match(main, /refreshAnnouncements\('scheduled'\)/);
+  assert.match(main, /refreshAnnouncements\('startup'\)/);
+  assert.match(main, /UPDATE_CHECK_INTERVAL_MS = 4 \* 60 \* 60 \* 1000/);
+});
+
+test('announcement text is rendered as text, never as markup', () => {
+  for (const file of ['src/components/NotificationsPanel.tsx', 'src/components/nodi/NodiCompanion.tsx']) {
+    const source = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+    assert.doesNotMatch(source, /dangerouslySetInnerHTML/, `${file} must not render remote copy as HTML`);
+  }
+  const panel = fs.readFileSync(path.join(repoRoot, 'src/components/NotificationsPanel.tsx'), 'utf8');
+  assert.doesNotMatch(panel, /<Markdown[^>]*\{copy\./, 'announcement bodies must not go through the Markdown renderer');
+});

--- a/scripts/test-feedback-roadmap-ui.mjs
+++ b/scripts/test-feedback-roadmap-ui.mjs
@@ -52,11 +52,12 @@ test('feedback offers an optional 0–10 product survey in one permanent thread'
   assert.match(styles, /data-score='9'.+data-score='10'/);
 });
 
-test('roadmap follows the requested sequence and is opened from the header', async () => {
-  const [roadmap, roadmapSource, app, english] = await Promise.all([
+test('roadmap follows the requested sequence and is opened from Settings › About', async () => {
+  const [roadmap, roadmapSource, app, settings, english] = await Promise.all([
     read('src/views/RoadmapModal.tsx'),
     read('shared/nodiDocumentation.ts'),
     read('src/App.tsx'),
+    read('src/views/Settings.tsx'),
     read('src/i18n.en.ts'),
   ]);
   const steps = [
@@ -121,8 +122,17 @@ test('roadmap follows the requested sequence and is opened from the header', asy
   }
   assert.match(app, /import \{ RoadmapModal \}/);
   assert.match(app, /roadmapOpen && <RoadmapModal/);
-  const roadmapAction = app.lastIndexOf(`label={t('Roadmap')}`);
+  // The roadmap left the header rail for Settings › About Nodus; the modal still lives
+  // in App, opened through the view context.
+  assert.doesNotMatch(app, /label=\{t\('Roadmap'\)\}/);
+  assert.match(app, /id: 'act:roadmap'/, 'the command palette still opens the roadmap');
+  assert.match(settings, /data-testid="about-roadmap"/);
+  assert.match(settings, /data-testid="open-roadmap"[\s\S]{0,200}onClick=\{onOpenRoadmap\}/);
+
+  // Settings is still the rightmost action, and the notification centre sits just left
+  // of it — the one place a user can always reach announcements, Nodi enabled or not.
+  const notificationsAction = app.lastIndexOf(`label={t('Notificaciones')}`);
   const settingsAction = app.lastIndexOf(`label={t('Ajustes')}`);
-  assert.ok(roadmapAction > 0 && settingsAction > roadmapAction, 'Settings is the rightmost action after Roadmap');
+  assert.ok(notificationsAction > 0 && settingsAction > notificationsAction, 'Settings is the rightmost action, after Notificaciones');
   assert.match(app.slice(settingsAction, settingsAction + 220), /setView\('settings'\)/);
 });

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -43,7 +43,8 @@ test('Nodi context is explicit, bounded and rejects invented product claims', as
   assert.match(backend, /No puedo verificarlo con las fuentes seleccionadas/);
   assert.match(backend, /termina con «Base:»/);
   assert.match(backend, /temperature: 0\.2/);
-  assert.match(documentation, /Roadmap está en la parte superior derecha/);
+  assert.match(documentation, /El roadmap se abre desde Ajustes > Acerca de Nodus/);
+  assert.match(documentation, /Notificaciones está inmediatamente antes de Ajustes/);
   assert.match(documentation, /NODUS_ROADMAP/);
   assert.match(documentation, /Vault de docencia/);
   assert.match(documentation, /Estado resumido del roadmap/);

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,13 +25,17 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.2.3');
-  assert.equal(currentRelease?.date, '2026-08-05');
-  // A search result whose row the server could not name, and then three things about reading
-  // rather than finding: a report marked as read, a passage kept as the place you stopped, and
-  // a work that leads back to its item in Zotero. A floor rather than an exact count, in case
-  // more lands here before it ships.
+  assert.equal(currentRelease?.version, '3.2.4');
+  assert.equal(currentRelease?.date, '2026-08-06');
+  // The notification centre reachable from the header, the announcements channel behind
+  // it, a right rail with three fewer icons, and an inbox that only shows up when it holds
+  // something. A floor rather than an exact count, in case more lands here before it ships.
   assert.ok(currentRelease?.highlights.length >= 4, 'the release must describe what changed');
+
+  // 3.2.3 keeps its own four highlights underneath.
+  const readMarkersRelease = RELEASE_NOTES.find((note) => note.version === '3.2.3');
+  assert.equal(readMarkersRelease?.date, '2026-08-05');
+  assert.equal(readMarkersRelease?.highlights.length, 4);
   for (const highlight of currentRelease.highlights) {
     // Written for the person using Nodus: no module names, no internal vocabulary.
     for (const language of ['es', 'en', 'fr', 'de', 'pt', 'pt-BR']) {

--- a/scripts/test-settings-visual-regressions.mjs
+++ b/scripts/test-settings-visual-regressions.mjs
@@ -30,7 +30,7 @@ assert.ok(latestChangesControl > updatesSection, 'the latest changes control mus
 assert.ok(updatesControl > latestChangesControl, 'latest changes must be presented before the update checker');
 assert.equal(settings.slice(aboutSection, updatesSection).includes('data-testid="about-updates"'), false, 'About Nodus must not render the updates control anymore');
 assert.match(settings, /const ABOUT_ACTION_BUTTON_CLASS = 'btn btn-ghost w-full[^']+sm:w-56'/);
-assert.equal((settings.match(/className=\{ABOUT_ACTION_BUTTON_CLASS\}/g) ?? []).length, 10, 'About actions must use the same responsive button class');
+assert.equal((settings.match(/className=\{ABOUT_ACTION_BUTTON_CLASS\}/g) ?? []).length, 11, 'About actions must use the same responsive button class');
 assert.match(settings, /data-testid="open-latest-changes"[\s\S]*onClick=\{onOpenWhatsNew\}/);
 
 const nodiOverride = settings.match(/<Row label=\{t\('Asistente Nodi'\)\}>(.*?)<\/Row>/s)?.[1] ?? '';

--- a/scripts/test-vault-types.mjs
+++ b/scripts/test-vault-types.mjs
@@ -207,9 +207,15 @@ test('the worldbuilding prompt pack makes the author the source of truth', () =>
   assert.match(pack, /calendario/);
 });
 
-test('the header vault action uses a stable localized label', async () => {
+test('the header vault entry point uses a stable localized label', async () => {
   const app = await Promise.resolve(readSource('@shell'));
-  assert.match(app, /icon="archive"\s+label=\{t\('Bóvedas'\)\}/s);
+  // The right-rail Bóvedas button is gone; the centred badge is the permanent way in,
+  // with the command palette as the last resort when the badge has nowhere to sit.
+  assert.match(app, /data-testid="header-vault-badge"/);
+  assert.match(app, /\{vaultTypeLabel\(activeVault\.type\)\}/);
+  assert.match(app, /id: 'act:vaults', label: t\('Bóvedas'\)/);
+  // The badge must not be hidden below a breakpoint now that nothing else opens the panel.
+  assert.doesNotMatch(app, /header-vault-badge[^"]*\bhidden\b/);
   assert.doesNotMatch(app, /label=\{activeVault\?\.name \?\? t\('Bóveda'\)\}/);
 });
 

--- a/scripts/test-window-preloads.mjs
+++ b/scripts/test-window-preloads.mjs
@@ -54,7 +54,11 @@ test('the Nodi overlay declares every bridge method its code calls', () => {
   const declared = new Set(declaredMethods('NODI_WINDOW_METHODS'));
   // mascot.html loads src/mascot.tsx, whose own tree is the Nodi components. Anything
   // else in the bundle is dead code the overlay never renders.
-  const used = methodsUsedBy((rel) => /nodi|mascot/i.test(rel));
+  //
+  // NotificationsPanel is named for the header, but the overlay imports its
+  // useAnnouncements hook — and a bridge call the overlay makes through a file this
+  // pattern does not name is exactly the failure this test exists to catch.
+  const used = methodsUsedBy((rel) => /nodi|mascot/i.test(rel) || rel === 'src/components/NotificationsPanel.tsx');
   const missing = [...used].filter(([name]) => !declared.has(name)).map(([name, rel]) => `${name} (${rel})`);
   assert.deepEqual(missing, [], 'Nodi calls methods its preload does not expose');
 });

--- a/scripts/verify-announcements.mjs
+++ b/scripts/verify-announcements.mjs
@@ -1,0 +1,181 @@
+// Live verification of the announcements channel, against a real HTTP server and the
+// real app.
+//
+// The unit tests cover the parser, which is where hostile input is handled. What they
+// cannot show is the part the whole design rests on: that the second check sends
+// If-None-Match and is answered with a 304 carrying no body, that a notice reaches the
+// renderer in the reader's language, that reading one is per notice and survives a
+// restart, and — the promise made in Settings and in PRIVACY.md — that switching the
+// setting off means NO request is made at all. Every one of those is a claim about two
+// processes and a socket, so it is checked here with a server that counts what it is
+// asked for.
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const appVersion = require(path.join(repoRoot, 'package.json')).version;
+const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-announcements-'));
+
+if (!existsSync(path.join(repoRoot, 'dist-electron/main.js')) || !existsSync(path.join(repoRoot, 'dist/index.html'))) {
+  throw new Error('Run `npm run build` before this focused verification.');
+}
+
+const LANGUAGES = ['es', 'en', 'fr', 'de', 'pt', 'pt-BR', 'it', 'tr'];
+const copy = (prefix) => Object.fromEntries(LANGUAGES.map((language) => [
+  language,
+  { title: `${prefix} ${language}`, body: `Body for ${language}, long enough to read.`, linkLabel: `Open ${language}` },
+]));
+
+const PAYLOAD = {
+  version: 1,
+  notices: [
+    { id: 'live-notice', date: '2026-08-06', severity: 'warning', url: 'https://example.com/survey', copy: copy('Live') },
+    { id: 'expired-notice', date: '2020-01-01', expiresAt: '2020-02-01', copy: copy('Expired') },
+    { id: 'future-build-notice', date: '2026-08-06', minVersion: '99.0.0', copy: copy('Future') },
+    { id: 'hostile-notice', date: '2026-08-06', url: 'javascript:alert(1)', copy: copy('Hostile') },
+  ],
+};
+
+const ETAG = '"announcements-v1"';
+let requests = [];
+const server = createServer((req, res) => {
+  requests.push({ url: req.url, ifNoneMatch: req.headers['if-none-match'] ?? null });
+  res.setHeader('ETag', ETAG);
+  if (req.headers['if-none-match'] === ETAG) {
+    res.writeHead(304);
+    res.end();
+    return;
+  }
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(PAYLOAD));
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const announcementsUrl = `http://127.0.0.1:${server.address().port}/announcements.json`;
+
+const childEnv = {
+  ...process.env,
+  NODUS_USERDATA: userData,
+  NODUS_DISABLE_AUTO_UPDATE: '1',
+  NODUS_E2E_UPDATE_STATUS: 'not-available',
+  NODUS_ANNOUNCEMENTS_URL: announcementsUrl,
+};
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+async function closeElectronApp(instance) {
+  if (!instance) return;
+  const child = instance.process();
+  let timeout;
+  const closed = instance.close().then(() => true, () => false);
+  const ok = await Promise.race([closed, new Promise((r) => { timeout = setTimeout(() => r(false), 5_000); })]);
+  clearTimeout(timeout);
+  if (!ok && child.exitCode === null && !child.killed) child.kill('SIGKILL');
+}
+
+async function launch() {
+  const app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(60_000);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+  await page.evaluate((version) => {
+    localStorage.setItem('nodus.lastSeenVersion', version);
+    sessionStorage.setItem('nodus.startupUpdateChecked', '1');
+  }, appVersion);
+  await page.evaluate(async () => {
+    await window.nodus.updateSettings({
+      onboardingComplete: true, basicsTutorialVersion: 5, recoverySetupVersion: 1,
+      tourComplete: true, advancedTourComplete: true, mascotEnabled: false, uiLanguage: 'es',
+    });
+  });
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor();
+  return { app, page };
+}
+
+/** The main process schedules its first check 45s out; ask for one now instead. */
+async function refresh(page) {
+  const before = requests.length;
+  await page.evaluate(() => window.nodus.listAnnouncements());
+  // The renderer cannot trigger a fetch, so drive it the way the timer does: the
+  // main process exposes refreshAnnouncements only internally, which is exactly why
+  // this runs through the IPC the app itself uses after a settings change.
+  await page.evaluate(() => window.nodus.updateSettings({ announcementsEnabled: true }));
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline && requests.length === before) {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  return requests.length > before;
+}
+
+let app;
+try {
+  ({ app } = await launch());
+  let page = await app.firstWindow();
+
+  // ── 1. The first check downloads and stores the list ───────────────────────
+  const gotFirst = await refresh(page);
+  assert.ok(gotFirst, 'the app must ask for the announcements file');
+  assert.equal(requests[0].ifNoneMatch, null, 'the first request carries no validator');
+  console.log(`[announcements] first request: ${requests[0].url} (no If-None-Match)`);
+
+  const list = await page.evaluate(() => window.nodus.listAnnouncements());
+  const ids = list.map((entry) => entry.id);
+  assert.deepEqual(ids, ['live-notice', 'hostile-notice'], `only the applicable notices survive, got ${ids.join(', ')}`);
+  console.log(`[announcements] ${ids.length} notices reached the renderer: ${ids.join(', ')}`);
+
+  const live = list.find((entry) => entry.id === 'live-notice');
+  assert.equal(live.read, false, 'a new notice starts unread');
+  assert.equal(live.severity, 'warning');
+  assert.equal(live.url, 'https://example.com/survey');
+  assert.equal(live.copy.es.title, 'Live es', 'the notice carries its Spanish copy');
+  assert.equal(live.copy.tr.title, 'Live tr', 'and every other language');
+
+  const hostile = list.find((entry) => entry.id === 'hostile-notice');
+  assert.equal(hostile.url, undefined, 'a javascript: link must never reach the renderer');
+  console.log('[announcements] expired, version-targeted and javascript: entries filtered as designed');
+
+  // ── 2. The second check is conditional and answered with 304 ───────────────
+  await refresh(page);
+  const second = requests[requests.length - 1];
+  assert.equal(second.ifNoneMatch, ETAG, 'the second request must replay the ETag');
+  console.log(`[announcements] second request sent If-None-Match: ${second.ifNoneMatch} → 304, no body`);
+
+  // ── 3. Reading is per notice, and it persists across a restart ─────────────
+  const afterRead = await page.evaluate(() => window.nodus.markAnnouncementRead('live-notice'));
+  assert.equal(afterRead.find((entry) => entry.id === 'live-notice').read, true);
+  assert.equal(afterRead.find((entry) => entry.id === 'hostile-notice').read, false, 'reading one must not mark the rest');
+
+  await closeElectronApp(app);
+  ({ app } = await launch());
+  page = await app.firstWindow();
+  const afterRestart = await page.evaluate(() => window.nodus.listAnnouncements());
+  assert.equal(afterRestart.find((entry) => entry.id === 'live-notice').read, true, 'the read mark must survive a restart');
+  assert.equal(afterRestart.find((entry) => entry.id === 'hostile-notice').read, false);
+  console.log('[announcements] per-notice read state survived a restart');
+
+  // ── 4. Turned off means no request at all ─────────────────────────────────
+  await page.evaluate(() => window.nodus.updateSettings({ announcementsEnabled: false }));
+  requests = [];
+  await page.evaluate(() => window.nodus.updateSettings({ announcementsEnabled: false }));
+  await new Promise((resolve) => setTimeout(resolve, 4_000));
+  assert.deepEqual(requests, [], `the setting is off, so nothing may be requested (got ${requests.length})`);
+  // And the notices already downloaded stay readable — turning it off stops the asking,
+  // it does not erase what arrived.
+  const offline = await page.evaluate(() => window.nodus.listAnnouncements());
+  assert.equal(offline.length, 2, 'notices already downloaded stay available with the setting off');
+  console.log('[announcements] with the setting off: 0 requests, list still readable');
+
+  console.log('announcements live verification passed');
+} finally {
+  await closeElectronApp(app);
+  await new Promise((resolve) => server.close(resolve));
+  await rm(userData, { recursive: true, force: true });
+}

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -12,4 +12,4 @@
  * this drifts from the root `package.json`, from `server/package.json`, or from the two iOS
  * targets in `ios/project.yml`.
  */
-export const NODUS_VERSION = '3.2.3';
+export const NODUS_VERSION = '3.2.4';

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/shared/announcements.ts
+++ b/shared/announcements.ts
@@ -1,0 +1,232 @@
+/**
+ * Announcements: the one channel that can reach every install between releases.
+ *
+ * A release note explains a version that has already shipped. This is for everything
+ * that cannot wait for one — a survey worth answering, a provider that broke overnight,
+ * a warning about a build. The list is published as a static JSON next to the website
+ * (see {@link ANNOUNCEMENTS_URL}), so adding a notice is a pull request and merging it
+ * is the deployment.
+ *
+ * Everything below treats that file as UNTRUSTED input, because it arrives over the
+ * network and is rendered in the app's own chrome. Ids are slugs, dates have a fixed
+ * shape, links must be https, every string is length-capped, and a notice that fails
+ * any of it is dropped rather than repaired. Bodies are rendered as plain text — never
+ * as markup — which is enforced at the call site, not here.
+ *
+ * Copy is carried per language rather than as t() keys: a notice written after this
+ * build shipped has no key for t() to look up. Spanish and English are required (English
+ * is the fallback every other language already leans on); the remaining six are enforced
+ * by scripts/test-announcements.mjs on the PR that adds the notice, so publishing in one
+ * language alone fails CI rather than reaching users half-translated.
+ */
+
+/** Where the published list lives. Served by GitHub Pages from `site/data/`. */
+export const ANNOUNCEMENTS_URL = 'https://drakonis96.github.io/nodus/data/announcements.json';
+
+/** Every language a notice must be written in before it may be published. */
+export const ANNOUNCEMENT_LANGUAGES = ['es', 'en', 'fr', 'de', 'pt', 'pt-BR', 'it', 'tr'] as const;
+export type AnnouncementLanguage = (typeof ANNOUNCEMENT_LANGUAGES)[number];
+
+/**
+ * The two languages a notice cannot render without. Spanish is the source and English
+ * is the fallback for every other interface language, so a notice carrying both is
+ * readable by everyone even if a translation is missing. CI still demands all eight.
+ */
+export const REQUIRED_ANNOUNCEMENT_LANGUAGES: readonly AnnouncementLanguage[] = ['es', 'en'];
+
+/** 'warning' earns the amber dot and sorts above 'info' on the same day. */
+export type AnnouncementSeverity = 'info' | 'warning';
+
+export interface AnnouncementCopy {
+  title: string;
+  body: string;
+  /** Label for {@link Announcement.url}; falls back to a generic "Open link". */
+  linkLabel?: string;
+}
+
+export interface Announcement {
+  /** Stable, never reused: it is the identity the read mark hangs off. */
+  id: string;
+  /** ISO date (YYYY-MM-DD) the notice was published. */
+  date: string;
+  severity: AnnouncementSeverity;
+  /** An https link — a survey, an issue, a release. Optional. */
+  url?: string;
+  /** ISO date (YYYY-MM-DD) after which the notice disappears on its own. */
+  expiresAt?: string;
+  /** Lowest app version the notice applies to, inclusive. */
+  minVersion?: string;
+  /** Highest app version the notice applies to, inclusive. */
+  maxVersion?: string;
+  copy: Partial<Record<AnnouncementLanguage, AnnouncementCopy>>;
+}
+
+/** An announcement as the renderer needs it: the notice plus this install's read mark. */
+export interface AnnouncementEntry extends Announcement {
+  read: boolean;
+}
+
+const MAX_ANNOUNCEMENTS = 50;
+const MAX_TITLE = 120;
+const MAX_BODY = 600;
+const MAX_LINK_LABEL = 60;
+const MAX_URL = 300;
+const ID_SHAPE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const DATE_SHAPE = /^\d{4}-\d{2}-\d{2}$/;
+const VERSION_SHAPE = /^\d+(\.\d+){0,3}$/;
+
+function cleanText(value: unknown, max: number): string | null {
+  if (typeof value !== 'string') return null;
+  // Collapse whitespace so a stray newline in the JSON cannot fake a paragraph break
+  // or pad a title past its cap after trimming.
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (!trimmed || trimmed.length > max) return null;
+  return trimmed;
+}
+
+function cleanDate(value: unknown): string | null {
+  if (typeof value !== 'string' || !DATE_SHAPE.test(value)) return null;
+  // Shape is not validity: 2026-02-31 matches the pattern and is not a day.
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) return null;
+  return value;
+}
+
+function cleanVersion(value: unknown): string | undefined {
+  return typeof value === 'string' && VERSION_SHAPE.test(value) ? value : undefined;
+}
+
+/**
+ * Only https, and only a URL the platform's parser agrees is one. This is the single
+ * place a published file gets to influence where a click goes, so `javascript:`,
+ * `file:` and a bare hostname all have to fail here.
+ */
+function cleanUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length > MAX_URL) return undefined;
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === 'https:' ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function cleanCopy(value: unknown): AnnouncementCopy | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  const title = cleanText(raw.title, MAX_TITLE);
+  const body = cleanText(raw.body, MAX_BODY);
+  if (!title || !body) return null;
+  const linkLabel = cleanText(raw.linkLabel, MAX_LINK_LABEL);
+  return linkLabel ? { title, body, linkLabel } : { title, body };
+}
+
+function parseAnnouncement(value: unknown): Announcement | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+
+  const id = typeof raw.id === 'string' && ID_SHAPE.test(raw.id) ? raw.id : null;
+  const date = cleanDate(raw.date);
+  if (!id || !date) return null;
+
+  const copy: Partial<Record<AnnouncementLanguage, AnnouncementCopy>> = {};
+  for (const language of ANNOUNCEMENT_LANGUAGES) {
+    const parsed = cleanCopy((raw.copy as Record<string, unknown> | undefined)?.[language]);
+    if (parsed) copy[language] = parsed;
+  }
+  if (REQUIRED_ANNOUNCEMENT_LANGUAGES.some((language) => !copy[language])) return null;
+
+  const expiresAt = cleanDate(raw.expiresAt) ?? undefined;
+  const url = cleanUrl(raw.url);
+  return {
+    id,
+    date,
+    severity: raw.severity === 'warning' ? 'warning' : 'info',
+    ...(url ? { url } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    ...(cleanVersion(raw.minVersion) ? { minVersion: cleanVersion(raw.minVersion) } : {}),
+    ...(cleanVersion(raw.maxVersion) ? { maxVersion: cleanVersion(raw.maxVersion) } : {}),
+    copy,
+  };
+}
+
+export interface AnnouncementsParse {
+  announcements: Announcement[];
+  /** How many entries were dropped, so a malformed file is logged rather than silent. */
+  rejected: number;
+}
+
+/**
+ * Read the published file. Accepts either a bare array or `{ notices: [...] }`, and
+ * never throws: a truncated or hostile file yields an empty list, which the caller
+ * treats the same as "nothing to announce".
+ */
+export function parseAnnouncements(raw: unknown): AnnouncementsParse {
+  const list = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === 'object' && Array.isArray((raw as { notices?: unknown }).notices)
+      ? (raw as { notices: unknown[] }).notices
+      : null;
+  if (!list) return { announcements: [], rejected: 0 };
+
+  const announcements: Announcement[] = [];
+  let rejected = 0;
+  for (const item of list.slice(0, MAX_ANNOUNCEMENTS)) {
+    const parsed = parseAnnouncement(item);
+    if (parsed && !announcements.some((existing) => existing.id === parsed.id)) announcements.push(parsed);
+    else rejected += 1;
+  }
+  return { announcements, rejected };
+}
+
+/** Numeric-segment comparison; both sides have already matched VERSION_SHAPE. */
+export function compareVersions(a: string, b: string): number {
+  const left = a.split('.').map(Number);
+  const right = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Does this notice still apply to this build, on this day? */
+export function isAnnouncementVisible(
+  announcement: Announcement,
+  context: { now: number; version: string },
+): boolean {
+  if (announcement.expiresAt) {
+    const today = new Date(context.now).toISOString().slice(0, 10);
+    if (today > announcement.expiresAt) return false;
+  }
+  // An unparseable app version must not silently hide every targeted notice, so the
+  // version gates only apply when there is a version to compare against.
+  const version = cleanVersion(context.version);
+  if (version) {
+    if (announcement.minVersion && compareVersions(version, announcement.minVersion) < 0) return false;
+    if (announcement.maxVersion && compareVersions(version, announcement.maxVersion) > 0) return false;
+  }
+  return true;
+}
+
+/** Newest first; a warning outranks an info published the same day. */
+export function sortAnnouncements<T extends Announcement>(list: readonly T[]): T[] {
+  const weight = (item: Announcement) => (item.severity === 'warning' ? 0 : 1);
+  return [...list].sort((a, b) => (
+    b.date.localeCompare(a.date)
+    || weight(a) - weight(b)
+    || a.id.localeCompare(b.id)
+  ));
+}
+
+/**
+ * The copy to render, falling back English-then-Spanish. The parser guarantees both
+ * exist, so this never returns undefined for a notice that got this far.
+ */
+export function announcementCopyFor(
+  announcement: Announcement,
+  language: string,
+): AnnouncementCopy {
+  const copy = announcement.copy as Record<string, AnnouncementCopy | undefined>;
+  return copy[language] ?? copy.en ?? copy.es!;
+}

--- a/shared/api/windows.ts
+++ b/shared/api/windows.ts
@@ -21,6 +21,13 @@ export const NODI_WINDOW_METHODS = [
   'markNotificationsRead',
   'clearNotifications',
   'onNotificationsChanged',
+  // published announcements, shown in the same panel
+  'listAnnouncements',
+  'markAnnouncementRead',
+  'onAnnouncementsChanged',
+  // an announcement may carry a link; the main process still refuses any scheme
+  // that is not http/https/mailto (see shell:openExternal)
+  'openExternal',
   // conversations and notes
   'listNodiConversations',
   'saveNodiConversation',

--- a/shared/nodiDocumentation.ts
+++ b/shared/nodiDocumentation.ts
@@ -68,16 +68,18 @@ export const NODUS_DOCUMENTATION = `# Guía interna verificable de Nodus
 - Crear o cargar datos de demostración no abre el tutorial. El tutorial aparece al crear un vault o cuando el usuario lo abre expresamente desde Ajustes > Tutoriales.
 
 ## Cabecera y controles globales
-- En el extremo derecho de la cabecera están, en este orden general: Bóvedas, Comandos, Asistente, Herramientas, controles condicionales del vault, Sugerir / Reportar, Roadmap, selector de tema claro/oscuro y Ajustes.
+- En el extremo derecho de la cabecera están, en este orden general: Comandos, Asistente, Herramientas, controles condicionales del vault, Sugerir / Reportar, selector de tema claro/oscuro, Notificaciones y Ajustes.
 - Herramientas abre el hub Nodus Toolkit; está justo después del botón Asistente.
-- Roadmap está en la parte superior derecha, antes del selector de tema y del icono de Ajustes.
-- El selector de tema claro/oscuro está inmediatamente antes de Ajustes.
-- Bóvedas abre el selector para cambiar, crear, renombrar, duplicar, restablecer o eliminar bóvedas según la acción disponible.
+- Notificaciones está inmediatamente antes de Ajustes y es el último icono antes de él. Abre un panel con dos listas: «Avisos de Nodus» (avisos publicados entre versiones, que se marcan como leídos uno a uno) y «Actividad» (lo que ha hecho la aplicación, que se marca como leído al abrir el panel). Muestra las mismas notificaciones que Nodi, y funciona aunque la mascota esté desactivada.
+- El selector de tema claro/oscuro está justo antes de Notificaciones.
+- La bóveda activa se abre desde la insignia centrada en la cabecera, no desde un icono del extremo derecho: esa insignia abre el selector para cambiar, crear, renombrar, duplicar, restablecer o eliminar bóvedas según la acción disponible. En la paleta de comandos también existe la acción «Bóvedas».
+- Colecciones ya no tiene icono propio en la cabecera; se abre desde la paleta de comandos, en bóvedas académicas.
+- Bandeja solo aparece cuando ha llegado algo desde otro dispositivo; es propia de cada bóveda conectada a Nodus Server.
 - Comandos abre la paleta global; su atajo visible es ⌘K en macOS.
 - El botón Asistente de la cabecera abre el asistente de investigación. Nodi es la mascota independiente situada en la zona inferior derecha cuando está habilitada.
 
 ## Roadmap oficial visible
-El botón Roadmap abre un modal. El orden vigente es:
+El roadmap se abre desde Ajustes > Acerca de Nodus > Ver roadmap de Nodus, y también desde la paleta de comandos. El orden vigente es:
 ${ROADMAP_GUIDE}
 
 ## Ajustes

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -116,7 +116,15 @@ const RELEASE_3_2_3_IT: string[] = [
   "Ogni opera sul telefono ha ora un pulsante che la apre in Zotero per iPhone e iPad. La chiave di Zotero smette di essere una riga morta della scheda e diventa la via di ritorno al PDF, alle note e alle annotazioni che stanno nell'altra applicazione.",
 ];
 
+const RELEASE_3_2_4_IT: string[] = [
+  "Le notifiche hanno ora un pulsante tutto loro nell'intestazione, subito prima di Impostazioni. Apre le stesse due liste che mostra Nodi: gli avvisi pubblicati da Nodus e quello che l'applicazione ha fatto. Funziona anche con la mascotte disattivata, che era proprio il caso in cui non c'era modo di raggiungerle.",
+  "Nodus può ora dirti qualcosa tra una versione e l'altra: un sondaggio, un problema noto, una modifica importante. Ogni avviso arriva nella tua lingua, può contenere un link e resta da leggere finché non lo leggi, uno alla volta. Si disattiva nelle Impostazioni, e da quel momento Nodus smette di richiederlo.",
+  "L'intestazione resta con meno icone. Depositi, Collezioni e Roadmap escono dalla barra di destra. Il deposito attivo si apre dal distintivo al centro, che ora si vede a qualsiasi larghezza di finestra. Collezioni vive nella palette dei comandi e la roadmap si trova nelle Impostazioni, dentro Informazioni su Nodus.",
+  "La casella in arrivo compare solo quando è arrivato qualcosa da un altro dispositivo. Su un computer senza depositi collegati era un'icona perennemente vuota accanto a un'altra che non lo è mai. Anche il pulsante di aggiornamento sparisce dai depositi di fonti primarie, che non si sincronizzano con Zotero.",
+];
+
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.2.4": RELEASE_3_2_4_IT,
   "3.2.3": RELEASE_3_2_3_IT,
   "3.2.2": RELEASE_3_2_2_IT,
   "3.2.1": RELEASE_3_2_1_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -56,7 +56,15 @@ const RELEASE_3_2_3_TR: string[] = [
   "Telefondaki her eser artık onu iPhone ve iPad için Zotero'da açan bir düğme taşıyor. Zotero anahtarı kayıttaki ölü bir satır olmaktan çıkıp diğer uygulamadaki PDF'e, notlara ve işaretlemelere dönüş yolu oluyor.",
 ];
 
+const RELEASE_3_2_4_TR: string[] = [
+  "Bildirimlerin artık başlıkta kendi düğmesi var, Ayarlar'ın hemen öncesinde. Nodi'nin gösterdiği aynı iki listeyi açıyor: Nodus'un yayımladığı duyurular ve uygulamanın neler yaptığı. Maskot kapalıyken de çalışıyor, ki bunlara ulaşmanın hiçbir yolunun olmadığı durum tam da buydu.",
+  "Nodus artık bir sürümle diğeri arasında size bir şey söyleyebiliyor: bir anket, bilinen bir sorun, önemli bir değişiklik. Her duyuru kendi dilinizde geliyor, bir bağlantı taşıyabiliyor ve siz okuyana kadar tek tek okunmamış kalıyor. Ayarlar'dan kapatılabiliyor ve kapatıldığında Nodus onu istemeyi bırakıyor.",
+  "Başlıkta daha az simge kalıyor. Kasalar, Koleksiyonlar ve Yol haritası sağ şeritten çıkıyor. Etkin kasa ortadaki rozetten açılıyor ve bu rozet artık her pencere genişliğinde görünüyor. Koleksiyonlar komut paletinde yaşıyor, yol haritası ise Ayarlar içindeki Nodus Hakkında bölümünde.",
+  "Gelen kutusu yalnızca başka bir cihazdan bir şey geldiğinde görünüyor. Bağlı kasası olmayan bir bilgisayarda, hiç boş kalmayan bir simgenin yanında sürekli boş duran bir simgeydi. Yenileme düğmesi de Zotero ile eşitlenmeyen birincil kaynak kasalarında artık gösterilmiyor.",
+];
+
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.2.4": RELEASE_3_2_4_TR,
   "3.2.3": RELEASE_3_2_3_TR,
   "3.2.2": RELEASE_3_2_2_TR,
   "3.2.1": RELEASE_3_2_1_TR,

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -811,7 +811,58 @@ const RELEASE_3_2_3_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+/**
+ * 3.2.4 — the header stops being a shelf, and Nodus gains a way to say something.
+ *
+ * Four entries because four things change for the reader: a button that always reaches
+ * the notification centre, a channel that can warn about something between releases, a
+ * rail with three fewer icons, and an inbox that only shows up when it holds something.
+ */
+const RELEASE_3_2_4_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'Las notificaciones tienen su propio botón en la cabecera, justo antes de Ajustes. Abre las mismas dos listas que enseña Nodi: los avisos publicados por Nodus y lo que ha estado haciendo la aplicación. Funciona con la mascota desactivada, que era justo cuando no había forma de llegar a ellas.',
+    en: 'Notifications now have their own button in the header, right before Settings. It opens the same two lists Nodi shows: the announcements published by Nodus and what the app has been doing. It works with the mascot turned off, which was exactly when there was no way to reach them.',
+    fr: 'Les notifications ont désormais leur propre bouton dans l’en-tête, juste avant Paramètres. Il ouvre les deux mêmes listes que Nodi affiche: les annonces publiées par Nodus et ce que l’application a fait. Il fonctionne avec la mascotte désactivée, ce qui était justement le cas où rien n’y donnait accès.',
+    de: 'Benachrichtigungen haben jetzt eine eigene Schaltfläche in der Kopfzeile, direkt vor Einstellungen. Sie öffnet dieselben zwei Listen, die Nodi zeigt: die von Nodus veröffentlichten Mitteilungen und das, was die App getan hat. Sie funktioniert auch bei abgeschalteter Maskottchenfigur, und genau dann kam man vorher gar nicht heran.',
+    pt: 'As notificações passam a ter um botão próprio no cabeçalho, mesmo antes de Definições. Abre as mesmas duas listas que o Nodi mostra: os avisos publicados pelo Nodus e o que a aplicação tem andado a fazer. Funciona com a mascote desativada, que era precisamente quando não havia forma de lá chegar.',
+    'pt-BR': 'As notificações agora têm um botão próprio no cabeçalho, logo antes de Configurações. Ele abre as mesmas duas listas que o Nodi mostra: os avisos publicados pelo Nodus e o que o aplicativo andou fazendo. Funciona com o mascote desativado, que era justamente quando não havia como chegar até elas.',
+  },
+  {
+    scope: 'general',
+    es: 'Nodus ya puede avisarte de algo entre una versión y la siguiente: una encuesta, un problema conocido, un cambio importante. Cada aviso llega en tu idioma, puede traer un enlace y sigue sin leer hasta que lo lees, uno a uno. Se desactiva en Ajustes, y al desactivarlo Nodus deja de pedirlo.',
+    en: 'Nodus can now tell you something between one release and the next: a survey, a known problem, an important change. Each notice arrives in your language, may carry a link, and stays unread until you read it, one at a time. You can turn it off in Settings, and once it is off Nodus stops asking for it.',
+    fr: 'Nodus peut désormais vous signaler quelque chose entre deux versions: une enquête, un problème connu, un changement important. Chaque annonce arrive dans votre langue, peut contenir un lien et reste non lue tant que vous ne l’avez pas lue, une par une. Elle se désactive dans les Paramètres, et Nodus cesse alors de la demander.',
+    de: 'Nodus kann dir jetzt zwischen zwei Versionen etwas mitteilen: eine Umfrage, ein bekanntes Problem, eine wichtige Änderung. Jede Mitteilung kommt in deiner Sprache an, kann einen Link enthalten und bleibt ungelesen, bis du sie liest, eine nach der anderen. In den Einstellungen lässt sich das abschalten, und dann fragt Nodus gar nicht mehr danach.',
+    pt: 'O Nodus já pode avisar-te de algo entre uma versão e a seguinte: um inquérito, um problema conhecido, uma alteração importante. Cada aviso chega no teu idioma, pode trazer uma ligação e continua por ler até o leres, um a um. Desativa-se nas Definições, e a partir daí o Nodus deixa de o pedir.',
+    'pt-BR': 'O Nodus já pode avisar você de algo entre uma versão e a seguinte: uma pesquisa, um problema conhecido, uma mudança importante. Cada aviso chega no seu idioma, pode trazer um link e continua não lido até você lê-lo, um a um. Dá para desativar nas Configurações, e aí o Nodus para de pedir.',
+  },
+  {
+    scope: 'general',
+    es: 'La cabecera se queda con menos iconos. Bóvedas, Colecciones y Roadmap salen del extremo derecho. La bóveda activa se abre desde la insignia del centro, que ahora se ve en cualquier anchura de ventana. Colecciones vive en la paleta de comandos y el roadmap está en Ajustes, dentro de Acerca de Nodus.',
+    en: 'The header keeps fewer icons. Vaults, Collections and Roadmap leave the right rail. The active vault opens from the badge in the centre, which is now shown at every window width. Collections lives in the command palette, and the roadmap is in Settings, under About Nodus.',
+    fr: 'L’en-tête garde moins d’icônes. Coffres, Collections et Feuille de route quittent la barre de droite. Le coffre actif s’ouvre depuis le badge central, désormais visible quelle que soit la largeur de la fenêtre. Collections vit dans la palette de commandes et la feuille de route se trouve dans les Paramètres, sous À propos de Nodus.',
+    de: 'Die Kopfzeile behält weniger Symbole. Tresore, Sammlungen und Roadmap verlassen die rechte Leiste. Der aktive Tresor öffnet sich über das Abzeichen in der Mitte, das jetzt bei jeder Fensterbreite sichtbar ist. Sammlungen liegt in der Befehlspalette, und die Roadmap steht in den Einstellungen unter Über Nodus.',
+    pt: 'O cabeçalho fica com menos ícones. Cofres, Coleções e Roadmap saem da barra da direita. O cofre ativo abre a partir do emblema do centro, que passa a ver-se em qualquer largura de janela. Coleções vive na paleta de comandos e o roadmap está nas Definições, dentro de Acerca do Nodus.',
+    'pt-BR': 'O cabeçalho fica com menos ícones. Cofres, Coleções e Roadmap saem da barra da direita. O cofre ativo abre pelo selo do centro, que agora aparece em qualquer largura de janela. Coleções vive na paleta de comandos e o roadmap está nas Configurações, dentro de Sobre o Nodus.',
+  },
+  {
+    scope: 'general',
+    es: 'La bandeja solo aparece cuando ha llegado algo desde otro dispositivo. En un equipo sin bóvedas conectadas era un icono permanentemente vacío al lado de otro que nunca lo está. Además, el botón de actualizar deja de mostrarse en las bóvedas de fuentes primarias, que no sincronizan con Zotero.',
+    en: 'The inbox only appears once something has arrived from another device. On a machine with no connected vaults it was a permanently empty icon sitting next to one that never is. The refresh button also stops showing in primary-sources vaults, which do not sync with Zotero.',
+    fr: 'La boîte de réception n’apparaît que lorsque quelque chose est arrivé d’un autre appareil. Sur une machine sans coffre connecté, c’était une icône vide en permanence à côté d’une autre qui ne l’est jamais. Le bouton d’actualisation disparaît aussi des coffres de sources primaires, qui ne se synchronisent pas avec Zotero.',
+    de: 'Der Posteingang erscheint erst, wenn etwas von einem anderen Gerät angekommen ist. Auf einem Rechner ohne verbundene Tresore war er ein dauerhaft leeres Symbol neben einem, das es nie ist. Auch die Aktualisieren-Schaltfläche verschwindet aus Tresoren für Primärquellen, die sich nicht mit Zotero abgleichen.',
+    pt: 'A caixa de entrada só aparece quando chegou algo de outro dispositivo. Num computador sem cofres ligados era um ícone permanentemente vazio ao lado de outro que nunca está. O botão de atualizar também deixa de aparecer nos cofres de fontes primárias, que não sincronizam com o Zotero.',
+    'pt-BR': 'A caixa de entrada só aparece quando chegou algo de outro dispositivo. Em um computador sem cofres conectados era um ícone permanentemente vazio ao lado de outro que nunca está. O botão de atualizar também deixa de aparecer nos cofres de fontes primárias, que não sincronizam com o Zotero.',
+  },
+];
+
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.2.4',
+    date: '2026-08-06',
+    highlights: RELEASE_3_2_4_HIGHLIGHTS,
+  },
   {
     version: '3.2.3',
     date: '2026-08-05',

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -164,6 +164,7 @@ export type {
 import type { VaultType } from './vaultTypes';
 import type { TutorialVideo } from './tutorialVideos';
 import type { NodiNotificationText } from './nodiNotifications';
+import type { AnnouncementEntry } from './announcements';
 import type {
 } from './toolkitApps';
 import type {
@@ -1331,6 +1332,12 @@ export interface AppSettings {
   reduceMotion: boolean;
   /** Reduces visual noise and gives study reading surfaces a calmer measure. */
   readingFocusMode: boolean;
+  /**
+   * Whether to fetch the published announcements (see shared/announcements.ts). On by
+   * default; when off the app makes no request for them at all, which is the only
+   * promise worth making about a network call.
+   */
+  announcementsEnabled: boolean;
   // Nodi mascot: show the floating companion (visual/animation only for now — no wired
   // behaviour yet). App-wide preference, on by default.
   mascotEnabled: boolean;
@@ -7550,6 +7557,10 @@ export interface NodusApi extends ProsopographyApi, TestimoniesApi, ToolkitApi, 
   markNotificationsRead(): Promise<NodiNotification[]>;
   clearNotifications(): Promise<NodiNotification[]>;
   onNotificationsChanged(cb: (list: NodiNotification[]) => void): () => void;
+  /** Published announcements. Read state is per notice, unlike the activity feed. */
+  listAnnouncements(): Promise<AnnouncementEntry[]>;
+  markAnnouncementRead(id: string): Promise<AnnouncementEntry[]>;
+  onAnnouncementsChanged(cb: (list: AnnouncementEntry[]) => void): () => void;
   listNodiConversations(): Promise<NodiConversation[]>;
   getNodiConversation(id: string): Promise<NodiConversation | null>;
   saveNodiConversation(input: NodiConversationInput): Promise<NodiConversation>;

--- a/site/data/announcements.json
+++ b/site/data/announcements.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "notices": []
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import type { AppSettings, CorpusHealthBucketId, DatabaseSummary, RecoveryStatus, ServerInboxEntry, SyncLogEntry, VaultSummary } from '@shared/types';
+import type { AppSettings, CorpusHealthBucketId, DatabaseSummary, NodiNotification, RecoveryStatus, ServerInboxEntry, SyncLogEntry, VaultSummary } from '@shared/types';
 import type { CsvImportPlanData } from './views/DatabasesView';
 import { FeedbackModal } from './views/FeedbackModal';
 import { RoadmapFeedbackModal, type RoadmapTopicKey } from './views/RoadmapFeedbackModal';
@@ -9,6 +9,7 @@ import { EmbeddingProgressBar } from './components/EmbeddingProgressBar';
 import { PassageProgressBar } from './components/PassageProgressBar';
 import { VaultSwitcher, vaultTypeIcon, vaultTypeLabel } from './components/VaultSwitcher';
 import { ServerInbox } from './components/ServerInbox';
+import { NotificationsPanel, useAnnouncements } from './components/NotificationsPanel';
 import { DatabasesSidebarExplore } from './components/DatabasesSidebarExplore';
 import { StudySidebar, type StudyNavigationTarget } from './components/StudySidebar';
 import { TeachingSidebar } from './components/TeachingSidebar';
@@ -106,6 +107,7 @@ function HeaderAction({
   kbd,
   vaultTrigger = false,
   inboxTrigger = false,
+  notificationsTrigger = false,
 }: {
   icon: string;
   label: string;
@@ -120,12 +122,15 @@ function HeaderAction({
   vaultTrigger?: boolean;
   /** Lets the Inbox panel's outside-click handler ignore its own trigger, so it toggles. */
   inboxTrigger?: boolean;
+  /** Same, for the notifications panel. */
+  notificationsTrigger?: boolean;
 }) {
   return (
     <HoverLabelButton
       data-tour={dataTour}
       data-vault-trigger={vaultTrigger ? '' : undefined}
       data-inbox-trigger={inboxTrigger ? '' : undefined}
+      data-notifications-trigger={notificationsTrigger ? '' : undefined}
       icon={icon}
       label={label}
       title={title}
@@ -204,6 +209,10 @@ export function App() {
   // when nothing has happened — the poller tells the window when something has.
   const [inboxAnchor, setInboxAnchor] = useState<HTMLElement | null>(null);
   const [inbox, setInbox] = useState<ServerInboxEntry[]>([]);
+  // The notification centre. Same two lists Nodi shows, reachable without Nodi.
+  const [notificationsAnchor, setNotificationsAnchor] = useState<HTMLElement | null>(null);
+  const [notifications, setNotifications] = useState<NodiNotification[]>([]);
+  const { announcements, unread: unreadAnnouncements, markRead: markAnnouncementRead } = useAnnouncements();
   // Live placement of the centred vault badge. Both rails around it change width
   // (the logo tracks the sidebar; the action rail grows when a button pins or
   // reveals its label), so the badge is measured rather than pinned at 50% — see
@@ -228,6 +237,17 @@ export function App() {
     (el: HTMLElement) => setInboxAnchor((cur) => (cur === el ? null : el)),
     []
   );
+  // Opening the panel clears the ACTIVITY feed only — "I have seen these" is all that
+  // list ever means. An announcement stays unread until it is read one at a time.
+  const toggleNotifications = useCallback((el: HTMLElement) => {
+    setNotificationsAnchor((cur) => {
+      if (cur === el) return null;
+      if (notifications.some((notification) => !notification.read)) {
+        void window.nodus.markNotificationsRead().then(setNotifications).catch(() => {});
+      }
+      return el;
+    });
+  }, [notifications]);
   const [graphTarget, setGraphTarget] = useState<PendingGraphNavigationTarget & { nonce: number } | null>(null);
   const [ideaTarget, setIdeaTarget] = useState<PendingIdeaNavigationTarget & { nonce: number } | null>(null);
   const [libraryTarget, setLibraryTarget] = useState<PendingLibraryNavigationTarget & { nonce: number } | null>(null);
@@ -306,6 +326,12 @@ export function App() {
   };
 
   const unreadInbox = useMemo(() => inbox.reduce((n, e) => n + (e.read ? 0 : 1), 0), [inbox]);
+  // One count for one button: an unread announcement and an unread activity line both
+  // mean "there is something here you have not seen".
+  const unreadNotifications = useMemo(
+    () => unreadAnnouncements + notifications.reduce((n, x) => n + (x.read ? 0 : 1), 0),
+    [unreadAnnouncements, notifications]
+  );
 
   // Load the inbox once and then let the main process push it. The poller broadcasts after
   // any batch that produced entries, and the mutators return the fresh list themselves, so
@@ -314,6 +340,13 @@ export function App() {
     void window.nodus.listServerInbox().then(setInbox).catch(() => undefined);
     return window.nodus.onServerInboxChanged(setInbox);
   }, [activeVault?.id]);
+
+  // Same pattern for the activity feed, which the main process pushes whenever a job
+  // finishes. Nodi subscribes to the very same channel, so both stay in step.
+  useEffect(() => {
+    void window.nodus.listNotifications().then(setNotifications).catch(() => undefined);
+    return window.nodus.onNotificationsChanged(setNotifications);
+  }, []);
 
   // Sidebar sections grouped for rendering (Explorar · Analizar · Escribir),
   // each group in the user's chosen order, minus any hidden sections. Home is
@@ -966,6 +999,9 @@ export function App() {
       run: () => setView(n.id),
     }));
     const actions: Command[] = [
+      // The last resort for the vault panel: the badge that opens it is placed by
+      // measurement and can, in a window narrow enough, have nowhere to go.
+      { id: 'act:vaults', label: t('Bóvedas'), section: t('Acciones'), icon: 'archive', keywords: 'vaults bovedas boveda cambiar crear renombrar duplicar eliminar', run: () => { const badge = document.querySelector<HTMLElement>('[data-testid="header-vault-badge"]'); if (badge) toggleVaults(badge); } },
       { id: 'act:assistant', label: t(isWorldbuilding ? 'Chat del mundo' : 'Asistente de investigación'), section: t('Acciones'), icon: 'chat', keywords: 'assistant chat', run: () => openAssistant() },
       { id: 'act:presenter', label: 'PDF Presenter', section: t('Acciones'), icon: 'presentation', keywords: 'presentar diapositivas slides pdf presenter proyector herramientas toolkit', run: () => { setToolkitPage('presenter'); setView('toolkit'); } },
       { id: 'act:feedback', label: t('Sugerir función o reportar error'), section: t('Acciones'), icon: 'gitPr', keywords: 'feedback github pr bug feature sugerencia error', run: () => setFeedbackOpen(true) },
@@ -983,7 +1019,7 @@ export function App() {
       );
     }
     return [...navCommands, ...actions];
-  }, [settings?.uiLanguage, settings?.reduceMotion, settings?.readingFocusMode, activeVault?.type, isPrimarySources, isGenealogy, isDatabases, isEstudio, isDocencia, isWorldbuilding, isProsopography, isTestimonios, isDark, onSync, openAssistant, reloadSettings]);
+  }, [settings?.uiLanguage, settings?.reduceMotion, settings?.readingFocusMode, activeVault?.type, isPrimarySources, isGenealogy, isDatabases, isEstudio, isDocencia, isWorldbuilding, isProsopography, isTestimonios, isDark, onSync, openAssistant, reloadSettings, toggleVaults]);
 
   // The startup sequence, as an ordered list of guards rather than a run of early
   // returns. It also sets this render's authoritative language, which is why it is
@@ -1069,6 +1105,7 @@ export function App() {
     setPendingRecordId,
     setCollectionsOpen,
     setManualWhatsNewOpen,
+    setRoadmapOpen,
     createDatabase,
     importCsv,
     loadDemo,
@@ -1126,6 +1163,7 @@ export function App() {
           <button
             ref={setVaultBadgeEl}
             data-vault-trigger
+            data-tour="vault-badge"
             data-testid="header-vault-badge"
             data-badge-fits={vaultBadgePlacement ? String(vaultBadgePlacement.fits) : undefined}
             aria-expanded={Boolean(vaultAnchor)}
@@ -1133,12 +1171,16 @@ export function App() {
               left: vaultBadgePlacement ? `${vaultBadgePlacement.left}px` : '50%',
               visibility: vaultBadgePlacement?.fits ? 'visible' : 'hidden',
             }}
-            className="header-vault-badge absolute top-1/2 hidden -translate-y-1/2 items-center gap-1.5 rounded-full border border-indigo-700/60 bg-indigo-950/30 px-3 py-0.5 text-xs font-semibold uppercase tracking-wide text-indigo-200 transition-colors hover:border-indigo-500 hover:bg-indigo-900/40 xl:inline-flex"
+            className="header-vault-badge absolute top-1/2 inline-flex -translate-y-1/2 items-center gap-1.5 rounded-full border border-indigo-700/60 bg-indigo-950/30 px-3 py-0.5 text-xs font-semibold uppercase tracking-wide text-indigo-200 transition-colors hover:border-indigo-500 hover:bg-indigo-900/40"
             title={t('Bóveda activa')}
             onClick={(e) => toggleVaults(e.currentTarget)}
           >
             <Icon name={vaultTypeIcon(activeVault.type)} size={13} />
-            {vaultTypeLabel(activeVault.type)}
+            {/* The badge is now the only permanent way into the vault panel, so it is
+                shown at every width — the LABEL is what gives way on a narrow window,
+                not the button. Dropping the word leaves an icon-and-chevron chip that
+                fits in a band where the full badge would not. */}
+            <span className="hidden xl:inline">{vaultTypeLabel(activeVault.type)}</span>
             <Icon name="chevronDown" size={12} className={`transition-transform ${vaultAnchor ? 'rotate-180' : ''}`} />
           </button>
         )}
@@ -1149,14 +1191,8 @@ export function App() {
             grows leftwards as labels open, which is why the centre badge measures
             it instead of assuming a fixed clearance. */}
         <div ref={setHeaderActionsEl} data-testid="header-actions" className="flex items-center gap-0.5 pr-4">
-          <HeaderAction
-            dataTour="vaults"
-            vaultTrigger
-            icon="archive"
-            label={t('Bóvedas')}
-            title={t('Bóveda activa')}
-            onClick={(e) => toggleVaults(e.currentTarget)}
-          />
+          {/* No Bóvedas button: the centred badge is the way in, and it is now shown at
+              every width for exactly that reason (see the badge above). */}
           <HeaderAction
             icon="search"
             label={t('Comandos')}
@@ -1188,41 +1224,41 @@ export function App() {
             title={t('Abrir Nodus Toolkit')}
             onClick={() => { setToolkitPage('home'); setView('toolkit'); }}
           />
-          {/* Colecciones y Actualizar dependen de Zotero → solo en bóvedas
-              académicas; genealogía, bases de datos, estudio y docencia no
-              sincronizan con Zotero. */}
-          {!isPrimarySources && !isGenealogy && !isDatabases && !isEstudio && !isDocencia && !isWorldbuilding && !isProsopography && !isTestimonios && (
-            <HeaderAction
-              dataTour="collections"
-              icon="folder"
-              label={t('Colecciones')}
-              onClick={() => setCollectionsOpen(true)}
-            />
-          )}
+          {/* Colecciones ya no vive aquí: sigue a un comando de distancia («Colecciones»
+              en la paleta) y su sitio natural es la configuración de Zotero. */}
           {/* Inside the measured actions box on purpose: the ResizeObserver above feeds
               placeHeaderBadge, which keeps this rail from ever reaching the centred vault
               badge. A badge positioned outside this box is exactly what that geometry
               cannot see. The wrapper is what the count hangs off — HoverLabelButton's
-              `trailing` slot sits inside a label span that is max-w-0 until hover. */}
-          <span className="relative inline-flex">
-            <HeaderAction
-              icon="inbox"
-              label={t('Bandeja')}
-              title={t('Lo que ha llegado de otros dispositivos')}
-              inboxTrigger
-              onClick={(e) => toggleInbox(e.currentTarget)}
-            />
-            {unreadInbox > 0 && (
-              <span className="header-action-badge">{unreadInbox > 9 ? '9+' : unreadInbox}</span>
-            )}
-          </span>
+              `trailing` slot sits inside a label span that is max-w-0 until hover.
+
+              Only shown once something has actually arrived: the inbox is per vault and
+              only means anything for a connected one, so on a local install it was a
+              permanently empty icon sitting next to a bell that is never empty. */}
+          {inbox.length > 0 && (
+            <span className="relative inline-flex">
+              <HeaderAction
+                icon="inbox"
+                label={t('Bandeja')}
+                title={t('Lo que ha llegado de otros dispositivos')}
+                inboxTrigger
+                onClick={(e) => toggleInbox(e.currentTarget)}
+              />
+              {unreadInbox > 0 && (
+                <span className="header-action-badge">{unreadInbox > 9 ? '9+' : unreadInbox}</span>
+              )}
+            </span>
+          )}
           <HeaderAction
             icon="gitPr"
             label={t('Sugerir / Reportar')}
             title={t('Enviar una propuesta o reporte a GitHub')}
             onClick={() => setFeedbackOpen(true)}
           />
-          {!isGenealogy && !isDatabases && !isEstudio && !isDocencia && !isWorldbuilding && !isProsopography && !isTestimonios && (
+          {/* Actualizar depende de Zotero igual que Colecciones dependía, así que la
+              condición es ahora la misma: fuentes primarias no sincroniza con Zotero y
+              antes mostraba este botón por una asimetría entre el comentario y el código. */}
+          {!isPrimarySources && !isGenealogy && !isDatabases && !isEstudio && !isDocencia && !isWorldbuilding && !isProsopography && !isTestimonios && (
             <HeaderAction
               dataTour="sync"
               icon="refresh"
@@ -1234,18 +1270,27 @@ export function App() {
             />
           )}
           <HeaderAction
-            icon="route"
-            label={t('Roadmap')}
-            title={t('Ver roadmap de Nodus')}
-            onClick={() => setRoadmapOpen(true)}
-          />
-          <HeaderAction
             icon={isDark ? 'sun' : 'moon'}
             label={isDark ? t('Usar tema claro') : t('Usar tema oscuro')}
             title={isDark ? t('Cambiar a modo claro') : t('Cambiar a modo oscuro')}
             onClick={() => void toggleTheme()}
             dataTour="theme-toggle"
           />
+          {/* The notification centre, reachable whether or not Nodi is enabled — turning
+              the mascot off used to take the only way to read these with it. */}
+          <span className="relative inline-flex">
+            <HeaderAction
+              dataTour="notifications"
+              icon="bell"
+              label={t('Notificaciones')}
+              title={t('Avisos de Nodus y actividad reciente')}
+              notificationsTrigger
+              onClick={(e) => toggleNotifications(e.currentTarget)}
+            />
+            {unreadNotifications > 0 && (
+              <span className="header-action-badge">{unreadNotifications > 9 ? '9+' : unreadNotifications}</span>
+            )}
+          </span>
           <HeaderAction
             icon="settings"
             label={t('Ajustes')}
@@ -1278,6 +1323,16 @@ export function App() {
               setInboxAnchor(null);
             }
           }}
+        />
+
+        <NotificationsPanel
+          anchorEl={notificationsAnchor}
+          onClose={() => setNotificationsAnchor(null)}
+          notifications={notifications}
+          announcements={announcements}
+          language={settings.uiLanguage}
+          onMarkAnnouncementRead={markAnnouncementRead}
+          onClearActivity={() => void window.nodus.clearNotifications().then(setNotifications).catch(() => {})}
         />
       </header>
 

--- a/src/app/ViewContext.ts
+++ b/src/app/ViewContext.ts
@@ -115,6 +115,7 @@ export interface ViewContext extends VaultFlags {
   // Modals and one-off actions the shell hosts.
   setCollectionsOpen: (open: boolean) => void;
   setManualWhatsNewOpen: (open: boolean) => void;
+  setRoadmapOpen: (open: boolean) => void;
   createDatabase: () => Promise<void>;
   importCsv: () => Promise<void>;
 

--- a/src/app/views/shell.tsx
+++ b/src/app/views/shell.tsx
@@ -7,7 +7,7 @@ const Settings = lazy(() => import('../../views/Settings').then((module) => ({ d
 
 export const shellViews = {
   toolkit: ({ setToolkitPage, settings, toolkitPage }) => <ToolkitView page={toolkitPage} onNavigate={setToolkitPage} settings={settings} />,
-  settings: ({ activeVault, recoveryStatus, reloadSettings, reloadVaults, setManualWhatsNewOpen, settings, vaults }) => (
+  settings: ({ activeVault, recoveryStatus, reloadSettings, reloadVaults, setManualWhatsNewOpen, setRoadmapOpen, settings, vaults }) => (
     <Settings
       settings={settings}
       vaults={vaults}
@@ -16,6 +16,7 @@ export const shellViews = {
       onChange={reloadSettings}
       onVaultsChanged={reloadVaults}
       onOpenWhatsNew={() => setManualWhatsNewOpen(true)}
+      onOpenRoadmap={() => setRoadmapOpen(true)}
     />
   ),
 } satisfies Record<string, ViewRenderer>;

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -1,0 +1,278 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { NodiNotification } from '@shared/types';
+import { announcementCopyFor, type AnnouncementEntry } from '@shared/announcements';
+import { notificationLine, t } from '../i18n';
+import { Icon } from './ui';
+
+/**
+ * The notification centre, in the header.
+ *
+ * Nodi has shown the same two lists since it existed, but Nodi is optional: turn the
+ * mascot off in Settings and the notification centre goes with it, which is how an
+ * announcement could reach an install and never be seen. This panel is the way in that
+ * does not depend on a mascot, anchored under its own header button exactly as
+ * ServerInbox is under the inbox one.
+ *
+ * Two lists, not one, because they are not the same kind of thing:
+ *
+ *  • Avisos — published between releases, kept in their own store, read one at a time.
+ *    A survey link that got buried under fifty "queue finished" lines would be a survey
+ *    nobody answered, so they sit on top and stay until they are read or expire.
+ *  • Actividad — what the app has been doing. Ephemeral, capped at 50, and marked read
+ *    in bulk when the panel opens, because "I have seen these" is all it ever means.
+ */
+
+/** Announcement text arrives over the network; the dot is the only thing it colours. */
+const SEVERITY_DOT: Record<AnnouncementEntry['severity'], string> = {
+  info: 'bg-indigo-600 dark:bg-indigo-400',
+  warning: 'bg-amber-500 dark:bg-amber-400',
+};
+
+/**
+ * Published announcements plus this install's read marks, live.
+ *
+ * Shared by the header panel and by Nodi so the two can never disagree about what is
+ * unread — the count in the header is the count behind the mascot.
+ */
+export function useAnnouncements(): {
+  announcements: AnnouncementEntry[];
+  unread: number;
+  markRead: (id: string) => void;
+} {
+  const [announcements, setAnnouncements] = useState<AnnouncementEntry[]>([]);
+
+  useEffect(() => {
+    window.nodus.listAnnouncements().then(setAnnouncements).catch(() => {});
+    return window.nodus.onAnnouncementsChanged(setAnnouncements);
+  }, []);
+
+  const markRead = useCallback((id: string) => {
+    window.nodus.markAnnouncementRead(id).then(setAnnouncements).catch(() => {});
+  }, []);
+
+  return {
+    announcements,
+    unread: announcements.reduce((total, entry) => total + (entry.read ? 0 : 1), 0),
+    markRead,
+  };
+}
+
+/** A published date, in the reader's locale rather than the ISO the file carries. */
+function announcementDate(date: string): string {
+  const parsed = new Date(`${date}T00:00:00`);
+  return Number.isNaN(parsed.getTime()) ? date : parsed.toLocaleDateString();
+}
+
+export function AnnouncementRow({
+  entry,
+  language,
+  onMarkRead,
+}: {
+  entry: AnnouncementEntry;
+  language: string;
+  onMarkRead: (id: string) => void;
+}) {
+  const copy = announcementCopyFor(entry, language);
+  return (
+    <li className="flex items-start gap-2 border-b border-neutral-900 px-3 py-2.5 last:border-b-0">
+      <span aria-hidden="true" className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${entry.read ? 'bg-transparent' : SEVERITY_DOT[entry.severity]}`} />
+      <div className="min-w-0 flex-1">
+        {/* Plain text on purpose: this string came off the network, and the moment it is
+            rendered as markup the published file becomes a way to inject into the app. */}
+        <p className={`text-xs ${entry.read ? 'text-neutral-400' : 'font-semibold text-neutral-100'}`}>{copy.title}</p>
+        <p className="mt-0.5 text-[11px] leading-4 text-neutral-400">{copy.body}</p>
+        <div className="mt-1.5 flex flex-wrap items-center gap-2">
+          <span className="text-[10px] text-neutral-500">{announcementDate(entry.date)}</span>
+          {entry.url && (
+            <button
+              type="button"
+              className="btn btn-ghost px-1.5 py-0.5 text-[11px] text-indigo-600 dark:text-indigo-300"
+              onClick={() => {
+                // Engaging with the link is reading it; nobody should have to say so twice.
+                onMarkRead(entry.id);
+                void window.nodus.openExternal(entry.url!);
+              }}
+            >
+              <Icon name="external" size={12} /> {copy.linkLabel ?? t('Abrir enlace')}
+            </button>
+          )}
+          {!entry.read && (
+            <button
+              type="button"
+              className="btn btn-ghost px-1.5 py-0.5 text-[11px]"
+              onClick={() => onMarkRead(entry.id)}
+            >
+              <Icon name="check" size={12} /> {t('Marcar como leído')}
+            </button>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+interface NotificationsPanelProps {
+  /** The button the panel hangs from; null when closed. */
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  notifications: NodiNotification[];
+  announcements: AnnouncementEntry[];
+  language: string;
+  onMarkAnnouncementRead: (id: string) => void;
+  onClearActivity: () => void;
+}
+
+export function NotificationsPanel({
+  anchorEl,
+  onClose,
+  notifications,
+  announcements,
+  language,
+  onMarkAnnouncementRead,
+  onClearActivity,
+}: NotificationsPanelProps) {
+  const open = anchorEl != null;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; top: number; width: number; originX: number } | null>(null);
+
+  // Placement, Escape and outside-click are ServerInbox's, deliberately: two panels
+  // hanging off the same header should behave identically, and that one already solved it.
+  useLayoutEffect(() => {
+    if (!open || !anchorEl) {
+      setPos(null);
+      return;
+    }
+    const compute = () => {
+      const r = anchorEl.getBoundingClientRect();
+      const width = Math.min(420, window.innerWidth - 32);
+      const rawLeft = r.left + r.width / 2 - width / 2;
+      const left = Math.max(16, Math.min(rawLeft, window.innerWidth - width - 16));
+      setPos({ left, top: r.bottom + 8, width, originX: r.left + r.width / 2 - left });
+    };
+    compute();
+    window.addEventListener('resize', compute);
+    window.addEventListener('scroll', compute, true);
+    return () => {
+      window.removeEventListener('resize', compute);
+      window.removeEventListener('scroll', compute, true);
+    };
+  }, [open, anchorEl]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (panelRef.current?.contains(target)) return;
+      if (target instanceof Element && target.closest('[data-notifications-trigger]')) return;
+      onClose();
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', onDown, true);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown, true);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open, onClose]);
+
+  const empty = announcements.length === 0 && notifications.length === 0;
+
+  return createPortal(
+    <AnimatePresence>
+      {open && pos && (
+        <motion.div
+          ref={panelRef}
+          key="notifications-panel"
+          data-testid="header-notifications-panel"
+          initial={{ opacity: 0, scaleY: 0.8, y: -8 }}
+          animate={{ opacity: 1, scaleY: 1, y: 0 }}
+          exit={{ opacity: 0, scaleY: 0.85, y: -8 }}
+          transition={{ duration: 0.16, ease: 'easeOut' }}
+          style={{
+            position: 'fixed',
+            left: pos.left,
+            top: pos.top,
+            width: pos.width,
+            transformOrigin: `${pos.originX}px top`,
+            zIndex: 55,
+          }}
+          className="overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950 shadow-2xl"
+          role="dialog"
+          aria-label={t('Notificaciones')}
+        >
+          <div className="flex items-center justify-between gap-2 border-b border-neutral-800 px-3 py-2">
+            <div className="text-sm font-semibold text-neutral-200">{t('Notificaciones')}</div>
+            <button className="btn btn-ghost px-2 py-1" onClick={onClose} title={t('Cerrar')}>
+              <Icon name="x" />
+            </button>
+          </div>
+
+          {empty ? (
+            <p className="px-3 py-6 text-center text-xs text-neutral-500">{t('No hay notificaciones.')}</p>
+          ) : (
+            <div className="max-h-[min(60vh,26rem)] overflow-y-auto">
+              {announcements.length > 0 && (
+                <>
+                  <div className="border-b border-neutral-900 bg-neutral-900/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+                    {t('Avisos de Nodus')}
+                  </div>
+                  <ul>
+                    {announcements.map((entry) => (
+                      <AnnouncementRow key={entry.id} entry={entry} language={language} onMarkRead={onMarkAnnouncementRead} />
+                    ))}
+                  </ul>
+                </>
+              )}
+
+              {notifications.length > 0 && (
+                <>
+                  <div className="flex items-center justify-between gap-2 border-y border-neutral-900 bg-neutral-900/40 px-3 py-1">
+                    <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">{t('Actividad')}</span>
+                    <button className="btn btn-ghost px-1.5 py-0 text-[10px]" onClick={onClearActivity}>{t('Limpiar')}</button>
+                  </div>
+                  <ul>
+                    {notifications.map((notification) => (
+                      <li key={notification.id} className="flex items-start gap-2 border-b border-neutral-900 px-3 py-2 last:border-b-0">
+                        <span
+                          aria-hidden="true"
+                          className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${
+                            notification.read
+                              ? 'bg-transparent'
+                              : notification.kind === 'warning'
+                                ? 'bg-amber-500 dark:bg-amber-400'
+                                : notification.kind === 'success'
+                                  ? 'bg-emerald-600 dark:bg-emerald-400'
+                                  : 'bg-indigo-600 dark:bg-indigo-400'
+                          }`}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className={`text-xs ${notification.read ? 'text-neutral-400' : 'font-semibold text-neutral-100'}`}>
+                            {notificationLine(notification.titleText, notification.title)}
+                          </p>
+                          {(notification.bodyText || notification.body) && (
+                            <p className="mt-0.5 text-[11px] leading-4 text-neutral-400">
+                              {notificationLine(notification.bodyText, notification.body)}
+                            </p>
+                          )}
+                          <p className="mt-1 text-[10px] text-neutral-500">
+                            {new Date(notification.createdAt).toLocaleString()}
+                          </p>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { deriveNodiNoteTitle } from '@shared/nodiNotes';
+import { announcementCopyFor } from '@shared/announcements';
 import type { AppSettings, ModelRef, NodiChatMessage, NodiContextKind, NodiConversation, NodiNote, NodiNotification, NodiOverlayPlacement, VaultType } from '@shared/types';
 import { vaultTypeColor } from '@shared/vaultTypes';
 import { type NodiRole, type NodiState } from './Nodi';
@@ -7,6 +8,7 @@ import { NodiAvatar } from './NodiAvatar';
 import { NodiCitationCard } from './NodiCitationCard';
 import { Markdown, type MarkdownCitation } from '../Markdown';
 import { ModelPicker } from '../ModelPicker';
+import { useAnnouncements } from '../NotificationsPanel';
 import { Icon } from '../ui';
 import { errorText, notificationLine, setActiveLang, t, tx } from '../../i18n';
 import './companion.css';
@@ -139,7 +141,10 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const [panel, setPanel] = useState<'none' | 'notifications' | 'chat' | 'notes'>('none');
   const [helpOpen, setHelpOpen] = useState(false);
   const [ntfs, setNtfs] = useState<NodiNotification[]>([]);
-  const unread = ntfs.reduce((n, x) => n + (x.read ? 0 : 1), 0);
+  // The published announcements, from the same hook the header panel uses, so the two
+  // surfaces can never disagree about what is unread.
+  const { announcements, unread: unreadAnnouncements, markRead: markAnnouncementRead } = useAnnouncements();
+  const unread = unreadAnnouncements + ntfs.reduce((n, x) => n + (x.read ? 0 : 1), 0);
 
   const [messages, setMessages] = useState<NodiChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -664,7 +669,10 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const openNotifications = () => {
     setPanel((p) => (p === 'notifications' ? 'none' : 'notifications'));
     setHelpOpen(false);
-    if (panel !== 'notifications' && unread > 0) window.nodus.markNotificationsRead().then(setNtfs).catch(() => {});
+    // Only the activity feed clears on open. An announcement is read one at a time.
+    if (panel !== 'notifications' && ntfs.some((x) => !x.read)) {
+      window.nodus.markNotificationsRead().then(setNtfs).catch(() => {});
+    }
   };
 
   const nodiState: NodiState = closing ? 'closing' : streaming ? 'thinking' : greet ? 'waving' : celebrate ? 'discovering' : 'idle';
@@ -869,7 +877,41 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
               <button onClick={() => setPanel('none')} aria-label={t('Cerrar')}>✕</button>
             </div>
             <div className="nodi-panel-body">
-              {ntfs.length === 0 ? (
+              {announcements.length > 0 && (
+                <>
+                  <div className="nodi-ntf-section">{t('Avisos de Nodus')}</div>
+                  {announcements.map((entry) => {
+                    const copy = announcementCopyFor(entry, settings?.uiLanguage ?? 'es');
+                    return (
+                      <div key={entry.id} className={`nodi-ntf${entry.read ? '' : ' unread'}`}>
+                        <span className="nodi-ntf-dot" style={{ background: entry.severity === 'warning' ? DOT.warning : DOT.info }} />
+                        <div style={{ minWidth: 0 }}>
+                          {/* Plain text: this came off the network. */}
+                          <div className="nodi-ntf-title">{copy.title}</div>
+                          <div className="nodi-ntf-body">{copy.body}</div>
+                          <div className="nodi-ntf-actions">
+                            {entry.url && (
+                              <button
+                                onClick={() => {
+                                  markAnnouncementRead(entry.id);
+                                  void window.nodus.openExternal(entry.url!);
+                                }}
+                              >
+                                {copy.linkLabel ?? t('Abrir enlace')}
+                              </button>
+                            )}
+                            {!entry.read && (
+                              <button onClick={() => markAnnouncementRead(entry.id)}>{t('Marcar como leído')}</button>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {ntfs.length > 0 && <div className="nodi-ntf-section">{t('Actividad')}</div>}
+                </>
+              )}
+              {ntfs.length === 0 && announcements.length === 0 ? (
                 <div className="nodi-empty">{t('No hay notificaciones.')}</div>
               ) : (
                 ntfs.map((n) => (

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -332,6 +332,25 @@
 .nodi-ntf-title { font-size: 13px; font-weight: 600; }
 .nodi-ntf-body { font-size: 12px; color: #aab4c4; margin-top: 1px; }
 .nodi-ntf-time { font-size: 10px; color: #6b7688; margin-top: 3px; }
+/* Separates the published announcements from the activity feed below them. */
+.nodi-ntf-section {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6b7688;
+  padding: 6px 8px 3px;
+}
+.nodi-ntf-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 5px; }
+.nodi-ntf-actions button {
+  font-size: 11px;
+  color: var(--nodi-vault-accent, #8ea2ff);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.nodi-ntf-actions button:hover { text-decoration: underline; }
 .nodi-empty { padding: 22px 12px; text-align: center; color: #7a8598; font-size: 12px; }
 
 /* Chat */
@@ -806,6 +825,7 @@
 .nodi-theme-light .nodi-ntf.unread { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 9%, transparent); }
 .nodi-theme-light .nodi-ntf-body { color: #64748b; }
 .nodi-theme-light .nodi-ntf-time,
+.nodi-theme-light .nodi-ntf-section,
 .nodi-theme-light .nodi-empty,
 .nodi-theme-light .nodi-chat-status,
 .nodi-theme-light .nodi-typing { color: #94a3b8; }

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -295,6 +295,7 @@ export function HoverLabelButton({
   'data-tour'?: string;
   'data-vault-trigger'?: string;
   'data-inbox-trigger'?: string;
+  'data-notifications-trigger'?: string;
   'data-testid'?: string;
 }) {
   return (

--- a/src/i18n.announcements.ts
+++ b/src/i18n.announcements.ts
@@ -1,0 +1,73 @@
+/**
+ * The notification centre's chrome: the header button, the two section headings and the
+ * announcement controls, plus the two settings cards that moved here.
+ *
+ * Only the chrome. The announcements themselves carry their own copy per language (see
+ * shared/announcements.ts) because they are published after the build that shows them,
+ * so there is no key here for t() to look up.
+ */
+export const ANNOUNCEMENT_TRANSLATIONS = {
+  en: {
+    'Avisos de Nodus y actividad reciente': 'Nodus announcements and recent activity',
+    'Avisos de Nodus': 'Nodus announcements',
+    'Actividad': 'Activity',
+    'Abrir enlace': 'Open link',
+    'Recibir avisos': 'Receive announcements',
+    'Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.': 'Announcements published between releases (surveys, known issues, important changes). A public file is checked every four hours, without sending any identifier or any data from your vault. Turn this off and Nodus stops making that request.',
+    'Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.': 'See what is in development, what is planned and what has already shipped. The roadmap assigns neither dates nor versions.',
+  },
+  fr: {
+    'Avisos de Nodus y actividad reciente': 'Annonces de Nodus et activité récente',
+    'Avisos de Nodus': 'Annonces de Nodus',
+    'Actividad': 'Activité',
+    'Abrir enlace': 'Ouvrir le lien',
+    'Recibir avisos': 'Recevoir les annonces',
+    'Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.': 'Annonces publiées entre deux versions (enquêtes, incidents connus, changements importants). Un fichier public est consulté toutes les quatre heures, sans envoyer d’identifiant ni aucune donnée de votre coffre. Si vous le désactivez, Nodus cesse d’effectuer cette requête.',
+    'Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.': 'Consultez ce qui est en développement, ce qui est prévu et ce qui existe déjà. La feuille de route n’attribue ni dates ni versions.',
+  },
+  de: {
+    'Avisos de Nodus y actividad reciente': 'Nodus-Mitteilungen und letzte Aktivität',
+    'Avisos de Nodus': 'Nodus-Mitteilungen',
+    'Actividad': 'Aktivität',
+    'Abrir enlace': 'Link öffnen',
+    'Recibir avisos': 'Mitteilungen erhalten',
+    'Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.': 'Mitteilungen, die zwischen zwei Versionen veröffentlicht werden (Umfragen, bekannte Probleme, wichtige Änderungen). Alle vier Stunden wird eine öffentliche Datei abgefragt, ohne eine Kennung oder Daten aus deinem Tresor zu senden. Wenn du das ausschaltest, stellt Nodus diese Anfrage nicht mehr.',
+    'Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.': 'Sieh nach, was in Entwicklung ist, was geplant ist und was es schon gibt. Die Roadmap nennt weder Daten noch Versionen.',
+  },
+  pt: {
+    'Avisos de Nodus y actividad reciente': 'Avisos do Nodus e atividade recente',
+    'Avisos de Nodus': 'Avisos do Nodus',
+    'Actividad': 'Atividade',
+    'Abrir enlace': 'Abrir ligação',
+    'Recibir avisos': 'Receber avisos',
+    'Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.': 'Avisos publicados entre versões (inquéritos, incidentes conhecidos, alterações importantes). É consultado um ficheiro público a cada quatro horas, sem enviar qualquer identificador nem dados do teu cofre. Ao desativar, o Nodus deixa de fazer essa consulta.',
+    'Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.': 'Consulta o que está em desenvolvimento, o que está planeado e o que já foi implementado. O roadmap não atribui datas nem versões.',
+  },
+  'pt-BR': {
+    'Avisos de Nodus y actividad reciente': 'Avisos do Nodus e atividade recente',
+    'Avisos de Nodus': 'Avisos do Nodus',
+    'Actividad': 'Atividade',
+    'Abrir enlace': 'Abrir link',
+    'Recibir avisos': 'Receber avisos',
+    'Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.': 'Avisos publicados entre versões (pesquisas, problemas conhecidos, mudanças importantes). Um arquivo público é consultado a cada quatro horas, sem enviar nenhum identificador nem dados do seu cofre. Ao desativar, o Nodus para de fazer essa consulta.',
+    'Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.': 'Veja o que está em desenvolvimento, o que está planejado e o que já foi implementado. O roadmap não atribui datas nem versões.',
+  },
+  it: {
+    'Avisos de Nodus y actividad reciente': 'Avvisi di Nodus e attività recente',
+    'Avisos de Nodus': 'Avvisi di Nodus',
+    'Actividad': 'Attività',
+    'Abrir enlace': 'Apri il link',
+    'Recibir avisos': 'Ricevi gli avvisi',
+    'Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.': 'Avvisi pubblicati tra una versione e l’altra (sondaggi, problemi noti, modifiche importanti). Ogni quattro ore viene consultato un file pubblico, senza inviare alcun identificativo né dati del tuo vault. Se lo disattivi, Nodus smette di fare quella richiesta.',
+    'Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.': 'Scopri cosa è in sviluppo, cosa è pianificato e cosa esiste già. La roadmap non indica date né versioni.',
+  },
+  tr: {
+    'Avisos de Nodus y actividad reciente': 'Nodus duyuruları ve son etkinlikler',
+    'Avisos de Nodus': 'Nodus duyuruları',
+    'Actividad': 'Etkinlik',
+    'Abrir enlace': 'Bağlantıyı aç',
+    'Recibir avisos': 'Duyuruları al',
+    'Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.': 'Sürümler arasında yayımlanan duyurular (anketler, bilinen sorunlar, önemli değişiklikler). Dört saatte bir herkese açık bir dosya kontrol edilir; hiçbir tanımlayıcı ya da kasanızdan veri gönderilmez. Bunu kapattığınızda Nodus bu isteği yapmayı bırakır.',
+    'Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.': 'Neyin geliştirilmekte olduğunu, neyin planlandığını ve neyin hazır olduğunu görün. Yol haritası tarih ya da sürüm belirtmez.',
+  },
+};

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -26,6 +26,7 @@ import { PRIMARY_SOURCES_RELEASE_TRANSLATIONS } from './i18n.primarySourcesRelea
 import { TESTIMONY_TRANSLATIONS } from './i18n.testimonies';
 import { NEW_VAULT_COMPLETION_TRANSLATIONS } from './i18n.newVaultCompletion';
 import { NODI_NOTIFICATION_TRANSLATIONS } from './i18n.nodiNotifications';
+import { ANNOUNCEMENT_TRANSLATIONS } from './i18n.announcements';
 
 export const DE: Record<string, string> = {
   ...DIARIZATION_TRANSLATIONS.de,
@@ -44,6 +45,7 @@ export const DE: Record<string, string> = {
   ...TESTIMONY_TRANSLATIONS.de,
   ...NEW_VAULT_COMPLETION_TRANSLATIONS.de,
   ...NODI_NOTIFICATION_TRANSLATIONS['de'],
+  ...ANNOUNCEMENT_TRANSLATIONS['de'],
   ...WORLD_CHAT_TRANSLATIONS.de,
   "Lo que cuenta el mapa": "Was die Karte erzählt",
   "Ver dónde ocurren las escenas ({n})": "Zeigen, wo die Szenen spielen ({n})",
@@ -1805,8 +1807,8 @@ export const DE: Record<string, string> = {
   '¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.':
     'Ist das Ihr erstes Mal? In weniger als einer Minute zeige ich Ihnen, wie Sie Ihre Zotero-Bibliothek in einen Ideengraphen verwandeln. Sie können es jederzeit überspringen.',
   'Bóvedas independientes': 'Unabhängige Arbeitsbereiche',
-  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
-    'Jeder Arbeitsbereich ist ein eigener Bereich: Bibliothek, Graph, Notizen, Projekte, Chats, Einstellungen, Embeddings und API-Schlüssel können isoliert bleiben. Verwenden Sie diese Auswahl, um einen weiteren zu erstellen, den Arbeitsbereich zu wechseln oder Schlüssel aus einem früheren Arbeitsbereich zu laden.',
+  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
+    'Jeder Arbeitsbereich ist ein eigener Bereich: Bibliothek, Graph, Notizen, Projekte, Chats, Einstellungen, Embeddings und API-Schlüssel können isoliert bleiben. Klicken Sie auf dieses Abzeichen, um einen weiteren zu erstellen, den Arbeitsbereich zu wechseln oder Schlüssel aus einem früheren Arbeitsbereich zu laden.',
   'El grafo de ideas': 'Der Ideengraph',
   'Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.':
     'Er ist das Herzstück von Nodus. Jeder Knoten ist eine Idee aus Ihrer Lektüre, und jede Kante eine Beziehung zwischen ihnen. Er beginnt leer und füllt sich, während Sie Werke gründlich scannen.',
@@ -1814,8 +1816,8 @@ export const DE: Record<string, string> = {
   'Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.':
     'Diese Schaltfläche holt die Werke aus Ihren überwachten Sammlungen. Standardmäßig werden nur Metadaten übernommen; Sie können die automatische Analyse in den Einstellungen aktivieren.',
   'Elegir colecciones': 'Sammlungen auswählen',
-  'Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
-    'Hier entscheiden Sie, welche Zotero-Sammlungen oder -Untersammlungen Nodus überwacht. Beginnen Sie zum Testen mit einer kleinen; ihre Untersammlungen werden automatisch einbezogen.',
+  'Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
+    'Entscheiden Sie, welche Zotero-Sammlungen oder -Untersammlungen Nodus überwacht. Öffnen Sie es über die Befehlspalette (⌘K oder Strg+K), indem Sie nach „Sammlungen“ suchen. Beginnen Sie zum Testen mit einer kleinen; ihre Untersammlungen werden automatisch einbezogen.',
   'Tu biblioteca': 'Ihre Bibliothek',
   'Aquí tienes todas tus obras con su estado de escaneo: ligero (temas) y profundo (ideas). Desde aquí decides qué llevar al grafo.':
     'Hier finden Sie alle Ihre Werke mit ihrem Scan-Status: leicht (Themen) und tief (Ideen). Von hier aus entscheiden Sie, was in den Graphen übernommen wird.',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -20,6 +20,7 @@ import { PRIMARY_SOURCES_RELEASE_TRANSLATIONS } from './i18n.primarySourcesRelea
 import { TESTIMONY_TRANSLATIONS } from './i18n.testimonies';
 import { NEW_VAULT_COMPLETION_TRANSLATIONS } from './i18n.newVaultCompletion';
 import { NODI_NOTIFICATION_TRANSLATIONS } from './i18n.nodiNotifications';
+import { ANNOUNCEMENT_TRANSLATIONS } from './i18n.announcements';
 
 /**
  * English translations keyed by the Spanish source string (see {@link ../i18n}).
@@ -43,6 +44,7 @@ export const EN: Record<string, string> = {
   ...TESTIMONY_TRANSLATIONS.en,
   ...NEW_VAULT_COMPLETION_TRANSLATIONS.en,
   ...NODI_NOTIFICATION_TRANSLATIONS['en'],
+  ...ANNOUNCEMENT_TRANSLATIONS['en'],
   ...WORLD_CHAT_TRANSLATIONS.en,
   "Lo que cuenta el mapa": "What the map tells you",
   "Ver dónde ocurren las escenas ({n})": "See where the scenes happen ({n})",
@@ -1821,8 +1823,8 @@ export const EN: Record<string, string> = {
   '¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.':
     'First time here? In under a minute I’ll show you how to turn your Zotero library into a graph of ideas. You can skip it anytime.',
   'Bóvedas independientes': 'Independent vaults',
-  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
-    'Each vault is a separate space: library, graph, notes, projects, chats, settings, embeddings and API keys can stay isolated. Use this selector to create another vault, switch vaults or load keys from a previous one.',
+  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
+    'Each vault is a separate space: library, graph, notes, projects, chats, settings, embeddings and API keys can stay isolated. Click this badge to create another vault, switch vaults or load keys from a previous one.',
   'El grafo de ideas': 'The idea graph',
   'Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.':
     'It’s the heart of Nodus. Each node is an idea drawn from your reading and each edge a relationship between them. It starts empty and fills up as you deep-scan works.',
@@ -1830,8 +1832,8 @@ export const EN: Record<string, string> = {
   'Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.':
     'This button pulls the works from your monitored collections. By default it only ingests metadata; you can enable automatic analysis in Settings.',
   'Elegir colecciones': 'Choose collections',
-  'Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
-    'Here you decide which Zotero collections or subcollections Nodus watches. Start with a small one to try it out; its subcollections are included automatically.',
+  'Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
+    'Decide which Zotero collections or subcollections Nodus watches. Open it from the command palette (⌘K or Ctrl+K) by searching for “Collections”. Start with a small one to try it out; its subcollections are included automatically.',
   'Tu biblioteca': 'Your library',
   'Aquí tienes todas tus obras con su estado de escaneo: ligero (temas) y profundo (ideas). Desde aquí decides qué llevar al grafo.':
     'Here are all your works with their scan status: light (themes) and deep (ideas). From here you decide what to bring into the graph.',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -26,6 +26,7 @@ import { PRIMARY_SOURCES_RELEASE_TRANSLATIONS } from './i18n.primarySourcesRelea
 import { TESTIMONY_TRANSLATIONS } from './i18n.testimonies';
 import { NEW_VAULT_COMPLETION_TRANSLATIONS } from './i18n.newVaultCompletion';
 import { NODI_NOTIFICATION_TRANSLATIONS } from './i18n.nodiNotifications';
+import { ANNOUNCEMENT_TRANSLATIONS } from './i18n.announcements';
 
 export const FR: Record<string, string> = {
   ...DIARIZATION_TRANSLATIONS.fr,
@@ -44,6 +45,7 @@ export const FR: Record<string, string> = {
   ...TESTIMONY_TRANSLATIONS.fr,
   ...NEW_VAULT_COMPLETION_TRANSLATIONS.fr,
   ...NODI_NOTIFICATION_TRANSLATIONS['fr'],
+  ...ANNOUNCEMENT_TRANSLATIONS['fr'],
   ...WORLD_CHAT_TRANSLATIONS.fr,
   "Lo que cuenta el mapa": "Ce que raconte la carte",
   "Ver dónde ocurren las escenas ({n})": "Voir où se passent les scènes ({n})",
@@ -1804,8 +1806,8 @@ export const FR: Record<string, string> = {
   '¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.':
     'C\'est votre première visite ? En moins d\'une minute, je vous montre comment transformer votre bibliothèque Zotero en un graphe d\'idées. Vous pouvez passer cette étape à tout moment.',
   'Bóvedas independientes': 'Espaces indépendants',
-  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
-    'Chaque espace est un environnement séparé : bibliothèque, graphe, notes, projets, chats, paramètres, embeddings et clés API peuvent rester isolés. Utilisez ce sélecteur pour créer un autre espace, en changer ou charger des clés depuis un espace précédent.',
+  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
+    'Chaque espace est un environnement séparé : bibliothèque, graphe, notes, projets, chats, paramètres, embeddings et clés API peuvent rester isolés. Cliquez sur ce badge pour créer un autre espace, en changer ou charger des clés depuis un espace précédent.',
   'El grafo de ideas': 'Le graphe d\'idées',
   'Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.':
     'C\'est le cœur de Nodus. Chaque nœud est une idée extraite de vos lectures et chaque arête une relation entre elles. Il démarre vide et se remplit au fur et à mesure que vous analysez des œuvres en profondeur.',
@@ -1813,8 +1815,8 @@ export const FR: Record<string, string> = {
   'Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.':
     'Ce bouton récupère les œuvres de vos collections surveillées. Par défaut, seules les métadonnées sont importées ; vous pouvez activer l\'analyse automatique dans les paramètres.',
   'Elegir colecciones': 'Choisir les collections',
-  'Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
-    'Vous décidez ici quelles collections ou sous-collections Zotero Nodus surveille. Commencez par une petite collection pour tester ; ses sous-collections sont incluses automatiquement.',
+  'Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
+    'Décidez quelles collections ou sous-collections Zotero Nodus surveille. Ouvrez-le depuis la palette de commandes (⌘K ou Ctrl+K) en cherchant « Collections ». Commencez par une petite collection pour tester ; ses sous-collections sont incluses automatiquement.',
   'Tu biblioteca': 'Votre bibliothèque',
   'Aquí tienes todas tus obras con su estado de escaneo: ligero (temas) y profundo (ideas). Desde aquí decides qué llevar al grafo.':
     'Voici toutes vos œuvres avec leur état d\'analyse : léger (thèmes) et profond (idées). C\'est ici que vous décidez ce qui rejoint le graphe.',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -20,6 +20,7 @@ import { PRIMARY_SOURCES_RELEASE_TRANSLATIONS } from './i18n.primarySourcesRelea
 import { TESTIMONY_TRANSLATIONS } from './i18n.testimonies';
 import { NEW_VAULT_COMPLETION_TRANSLATIONS } from './i18n.newVaultCompletion';
 import { NODI_NOTIFICATION_TRANSLATIONS } from './i18n.nodiNotifications';
+import { ANNOUNCEMENT_TRANSLATIONS } from './i18n.announcements';
 
 /** Complete static Italian interface table; coverage prohibits runtime fallbacks. */
 export const IT: Record<string, string> = {
@@ -39,6 +40,7 @@ export const IT: Record<string, string> = {
   ...TESTIMONY_TRANSLATIONS.it,
   ...NEW_VAULT_COMPLETION_TRANSLATIONS.it,
   ...NODI_NOTIFICATION_TRANSLATIONS['it'],
+  ...ANNOUNCEMENT_TRANSLATIONS['it'],
   ...WORLD_CHAT_TRANSLATIONS.it,
   "Lo que cuenta el mapa": "Cosa racconta la mappa",
   "Ver dónde ocurren las escenas ({n})": "Vedi dove accadono le scene ({n})",
@@ -1634,13 +1636,13 @@ export const IT: Record<string, string> = {
   "¡Bienvenido a Nodus!": "Benvenuto su Nodus!",
   "¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.": "Prima volta qui? In meno di un minuto ti mostrerò come trasformare la tua libreria Zotero in un grafico di idee. Puoi saltarlo in qualsiasi momento.",
   "Bóvedas independientes": "Volte indipendenti",
-  "Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.": "Ogni deposito è uno spazio separato: libreria, grafico, note, progetti, chat, impostazioni, incorporamenti e chiavi API possono rimanere isolati. Utilizza questo selettore per creare un altro deposito, cambiare deposito o caricare chiavi da uno precedente.",
+  "Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.": "Ogni deposito è uno spazio separato: libreria, grafico, note, progetti, chat, impostazioni, incorporamenti e chiavi API possono rimanere isolati. Fai clic su questo distintivo per creare un altro deposito, cambiare deposito o caricare chiavi da uno precedente.",
   "El grafo de ideas": "Il grafico delle idee",
   "Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.": "È il cuore di Nodus. Ogni nodo è un'idea tratta dalla tua lettura e ogni bordo una relazione tra loro. Inizia vuoto e si riempie man mano che la scansione approfondita funziona.",
   "Actualizar desde Zotero": "Rinfrescati da Zotero",
   "Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.": "Questo pulsante estrae le opere dalle tue collezioni monitorate. Per impostazione predefinita, acquisisce solo metadati; puoi abilitare l'analisi automatica nelle Impostazioni.",
   "Elegir colecciones": "Scegli le collezioni",
-  "Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.": "Qui decidi quali collezioni o sottocollezioni Zotero Nodus orologi. Inizia con uno piccolo per provarlo; le sue sottoraccolte vengono incluse automaticamente.",
+  "Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.": "Decidi quali collezioni o sottocollezioni di Zotero Nodus sorveglia. Aprilo dalla palette dei comandi (⌘K o Ctrl+K) cercando «Collezioni». Inizia con una piccola per provare; le sue sottocollezioni vengono incluse automaticamente.",
   "Tu biblioteca": "La tua biblioteca",
   "Aquí tienes todas tus obras con su estado de escaneo: ligero (temas) y profundo (ideas). Desde aquí decides qué llevar al grafo.": "Ecco tutti i tuoi lavori con il loro stato di scansione: leggeri (temi) e profondi (idee). Da qui decidi cosa portare nel grafico.",
   "Añadir una obra al grafo": "Aggiungi un lavoro al grafico",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -26,6 +26,7 @@ import { PRIMARY_SOURCES_RELEASE_TRANSLATIONS } from './i18n.primarySourcesRelea
 import { TESTIMONY_TRANSLATIONS } from './i18n.testimonies';
 import { NEW_VAULT_COMPLETION_TRANSLATIONS } from './i18n.newVaultCompletion';
 import { NODI_NOTIFICATION_TRANSLATIONS } from './i18n.nodiNotifications';
+import { ANNOUNCEMENT_TRANSLATIONS } from './i18n.announcements';
 
 export const PT_BR: Record<string, string> = {
   ...DIARIZATION_TRANSLATIONS['pt-BR'],
@@ -44,6 +45,7 @@ export const PT_BR: Record<string, string> = {
   ...TESTIMONY_TRANSLATIONS.ptBR,
   ...NEW_VAULT_COMPLETION_TRANSLATIONS['pt-BR'],
   ...NODI_NOTIFICATION_TRANSLATIONS['pt-BR'],
+  ...ANNOUNCEMENT_TRANSLATIONS['pt-BR'],
   ...WORLD_CHAT_TRANSLATIONS.ptBR,
   "Lo que cuenta el mapa": "O que o mapa conta",
   "Ver dónde ocurren las escenas ({n})": "Ver onde acontecem as cenas ({n})",
@@ -1791,8 +1793,8 @@ export const PT_BR: Record<string, string> = {
   '¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.':
     'É a sua primeira vez? Em menos de um minuto eu mostro como transformar sua biblioteca do Zotero em um grafo de ideias. Você pode pular quando quiser.',
   'Bóvedas independientes': 'Espaços independentes',
-  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
-    'Cada espaço é um ambiente separado: biblioteca, grafo, notas, projetos, chats, configurações, embeddings e chaves de API podem ficar isolados. Use este seletor para criar outro, trocar de espaço ou carregar chaves de um espaço anterior.',
+  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
+    'Cada espaço é um ambiente separado: biblioteca, grafo, notas, projetos, chats, configurações, embeddings e chaves de API podem ficar isolados. Clique neste selo para criar outro, trocar de espaço ou carregar chaves de um espaço anterior.',
   'El grafo de ideas': 'O grafo de ideias',
   'Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.':
     'É o coração do Nodus. Cada nó é uma ideia extraída das suas leituras e cada aresta uma relação entre elas. Começa vazio: vai se preenchendo à medida que você escaneia obras a fundo.',
@@ -1800,8 +1802,8 @@ export const PT_BR: Record<string, string> = {
   'Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.':
     'Este botão traz as obras das suas coleções monitoradas. Por padrão, incorpora apenas metadados; você pode ativar a análise automática em Configurações.',
   'Elegir colecciones': 'Escolher coleções',
-  'Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
-    'Aqui você decide quais coleções ou subcoleções do Zotero o Nodus monitora. Comece com uma pequena para testar; suas subcoleções são incluídas automaticamente.',
+  'Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
+    'Decida quais coleções ou subcoleções do Zotero o Nodus monitora. Abra pela paleta de comandos (⌘K ou Ctrl+K) buscando «Coleções». Comece com uma pequena para testar; suas subcoleções são incluídas automaticamente.',
   'Tu biblioteca': 'Sua biblioteca',
   'Aquí tienes todas tus obras con su estado de escaneo: ligero (temas) y profundo (ideas). Desde aquí decides qué llevar al grafo.':
     'Aqui estão todas as suas obras com o status de escaneamento: leve (temas) e profundo (ideias). A partir daqui você decide o que levar para o grafo.',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -26,6 +26,7 @@ import { PRIMARY_SOURCES_RELEASE_TRANSLATIONS } from './i18n.primarySourcesRelea
 import { TESTIMONY_TRANSLATIONS } from './i18n.testimonies';
 import { NEW_VAULT_COMPLETION_TRANSLATIONS } from './i18n.newVaultCompletion';
 import { NODI_NOTIFICATION_TRANSLATIONS } from './i18n.nodiNotifications';
+import { ANNOUNCEMENT_TRANSLATIONS } from './i18n.announcements';
 
 export const PT: Record<string, string> = {
   ...DIARIZATION_TRANSLATIONS.pt,
@@ -44,6 +45,7 @@ export const PT: Record<string, string> = {
   ...TESTIMONY_TRANSLATIONS.pt,
   ...NEW_VAULT_COMPLETION_TRANSLATIONS.pt,
   ...NODI_NOTIFICATION_TRANSLATIONS['pt'],
+  ...ANNOUNCEMENT_TRANSLATIONS['pt'],
   ...WORLD_CHAT_TRANSLATIONS.pt,
   "Lo que cuenta el mapa": "O que conta o mapa",
   "Ver dónde ocurren las escenas ({n})": "Ver onde acontecem as cenas ({n})",
@@ -1789,8 +1791,8 @@ export const PT: Record<string, string> = {
   '¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.':
     'É a primeira vez? Em menos de um minuto mostro-lhe como transformar a sua biblioteca do Zotero num grafo de ideias. Pode saltar isto quando quiser.',
   'Bóvedas independientes': 'Espaços independentes',
-  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
-    'Cada espaço é um ambiente separado: biblioteca, grafo, notas, projetos, chats, definições, embeddings e chaves API podem permanecer isolados. Utilize este seletor para criar outro espaço, mudar de espaço ou carregar chaves de um espaço anterior.',
+  'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.':
+    'Cada espaço é um ambiente separado: biblioteca, grafo, notas, projetos, chats, definições, embeddings e chaves API podem permanecer isolados. Clique neste emblema para criar outro espaço, mudar de espaço ou carregar chaves de um espaço anterior.',
   'El grafo de ideas': 'O grafo de ideias',
   'Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.':
     'É o coração do Nodus. Cada nó é uma ideia extraída das suas leituras e cada aresta uma relação entre elas. Começa vazio: enche-se à medida que analisa obras em profundidade.',
@@ -1798,8 +1800,8 @@ export const PT: Record<string, string> = {
   'Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.':
     'Este botão traz as obras das suas coleções monitorizadas. Por predefinição, incorpora apenas metadados; pode ativar a análise automática nas Definições.',
   'Elegir colecciones': 'Escolher coleções',
-  'Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
-    'Aqui decide que coleções ou subcoleções do Zotero o Nodus vigia. Comece com uma pequena para experimentar; as suas subcoleções são incluídas automaticamente.',
+  'Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.':
+    'Decide que coleções ou subcoleções do Zotero o Nodus vigia. Abre-o a partir da paleta de comandos (⌘K ou Ctrl+K) procurando «Coleções». Comece com uma pequena para experimentar; as suas subcoleções são incluídas automaticamente.',
   'Tu biblioteca': 'A sua biblioteca',
   'Aquí tienes todas tus obras con su estado de escaneo: ligero (temas) y profundo (ideas). Desde aquí decides qué llevar al grafo.':
     'Aqui tem todas as suas obras com o respetivo estado de análise: ligeira (temas) e profunda (ideias). A partir daqui decide o que levar para o grafo.',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -20,6 +20,7 @@ import { PRIMARY_SOURCES_RELEASE_TRANSLATIONS } from './i18n.primarySourcesRelea
 import { TESTIMONY_TRANSLATIONS } from './i18n.testimonies';
 import { NEW_VAULT_COMPLETION_TRANSLATIONS } from './i18n.newVaultCompletion';
 import { NODI_NOTIFICATION_TRANSLATIONS } from './i18n.nodiNotifications';
+import { ANNOUNCEMENT_TRANSLATIONS } from './i18n.announcements';
 
 /** Complete static Turkish interface table; coverage prohibits runtime fallbacks. */
 export const TR: Record<string, string> = {
@@ -39,6 +40,7 @@ export const TR: Record<string, string> = {
   ...TESTIMONY_TRANSLATIONS.tr,
   ...NEW_VAULT_COMPLETION_TRANSLATIONS.tr,
   ...NODI_NOTIFICATION_TRANSLATIONS['tr'],
+  ...ANNOUNCEMENT_TRANSLATIONS['tr'],
   ...WORLD_CHAT_TRANSLATIONS.tr,
   "Lo que cuenta el mapa": "Haritanın anlattıkları",
   "Ver dónde ocurren las escenas ({n})": "Sahnelerin nerede geçtiğini gör ({n})",
@@ -2018,13 +2020,13 @@ export const TR: Record<string, string> = {
   "¡Bienvenido a Nodus!": "Nodus'a hoş geldiniz!",
   "¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.": "İlk seferin mi? Bir dakikadan kısa bir süre içinde size Zotero kitaplığınızı bir fikir grafiğine nasıl dönüştüreceğinizi göstereceğim. İstediğiniz zaman atlayabilirsiniz.",
   "Bóvedas independientes": "Bağımsız kasalar",
-  "Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.": "Her kasa ayrı bir alandır: kitaplık, grafik, notlar, projeler, sohbetler, ayarlar, yerleştirmeler ve API anahtarları ayrı ayrı yaşayabilir. Başka bir kasa oluşturmak, kasaları değiştirmek veya önceki kasanın anahtarlarını yüklemek için bu seçiciyi kullanın.",
+  "Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.": "Her kasa ayrı bir alandır: kitaplık, grafik, notlar, projeler, sohbetler, ayarlar, yerleştirmeler ve API anahtarları ayrı ayrı yaşayabilir. Başka bir kasa oluşturmak, kasaları değiştirmek veya önceki kasanın anahtarlarını yüklemek için bu rozete tıklayın.",
   "El grafo de ideas": "Fikir grafiği",
   "Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.": "Nodus'un kalbidir. Her düğüm, okumalarınızdan çıkarılan bir fikirdir ve her kenar, bunlar arasındaki bir ilişkidir. Boş başlar: Siz taradıkça doldurur, eksiksiz çalışır.",
   "Actualizar desde Zotero": "Zotero'dan güncelleme",
   "Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.": "Bu buton izlenen koleksiyonlarınızdaki çalışmaları getirir. Varsayılan olarak yalnızca meta verileri içerir; Otomatik analizi Ayarlar'dan etkinleştirebilirsiniz.",
   "Elegir colecciones": "Koleksiyonları seçin",
-  "Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.": "Burada Nodus'un hangi Zotero koleksiyonlarını veya alt koleksiyonlarını takip edeceğine karar verirsiniz. Test etmek için küçük bir taneyle başlayın; alt koleksiyonları tek başınadır.",
+  "Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.": "Nodus'un hangi Zotero koleksiyonlarını veya alt koleksiyonlarını takip edeceğine karar verin. Komut paletinden (⌘K veya Ctrl+K) «Koleksiyonlar» arayarak açın. Test etmek için küçük bir taneyle başlayın; alt koleksiyonları otomatik olarak dahil edilir.",
   "Tu biblioteca": "Kitaplığınız",
   "Aquí tienes todas tus obras con su estado de escaneo: ligero (temas) y profundo (ideas). Desde aquí decides qué llevar al grafo.": "Burada tüm çalışmalarınızı tarama durumlarıyla birlikte bulabilirsiniz: hafif (temalar) ve derin (fikirler). Buradan grafiğe ne getireceğinize karar verirsiniz.",
   "Añadir una obra al grafo": "Ağa bir iş ekleme",

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -93,6 +93,7 @@ export function Settings({
   onChange,
   onVaultsChanged: _onVaultsChanged,
   onOpenWhatsNew,
+  onOpenRoadmap,
 }: {
   settings: AppSettings;
   vaults: VaultSummary[];
@@ -102,6 +103,8 @@ export function Settings({
   onChange: () => Promise<unknown>;
   onVaultsChanged: () => Promise<unknown>;
   onOpenWhatsNew: () => void;
+  /** The roadmap left the header rail for this section; the modal still lives in App. */
+  onOpenRoadmap: () => void;
 }) {
   const [saved, setSaved] = useState<string | null>(null);
   const [supersededReloadKey, setSupersededReloadKey] = useState(0);
@@ -626,8 +629,8 @@ export function Settings({
     visibleSettingsSection('models', 'Modelos de IA', 'basico avanzado modelo general extraccion sintesis tutor resumen fusion embeddings transcripcion voz imagen'),
     visibleSettingsSection('extraction', 'Extracción de texto PDFs grandes', 'pdf texto zotero ocr tesseract paginas idiomas'),
     visibleSettingsSection('data', 'Zona de peligro', 'reinicializar grafo borrar ideas temas conexiones autores huecos'),
-    visibleSettingsSection('about', 'Acerca de Nodus', 'proyecto independiente codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado licencia'),
-    visibleSettingsSection('updates', 'Actualizaciones y novedades', 'actualizaciones update version novedades ultimos cambios latest changes changelog buscar instalar reiniciar'),
+    visibleSettingsSection('about', 'Acerca de Nodus', 'proyecto independiente codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado licencia roadmap hoja de ruta futuro'),
+    visibleSettingsSection('updates', 'Actualizaciones y novedades', 'actualizaciones update version novedades ultimos cambios latest changes changelog buscar instalar reiniciar avisos anuncios encuestas noticias'),
   ].filter(Boolean).length;
 
   return (
@@ -1208,7 +1211,7 @@ export function Settings({
           </Section>
       )}
 
-      {visibleSettingsSection('about', 'Acerca de Nodus', 'proyecto independiente codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado licencia terceros legal actualizaciones update version novedades') && (
+      {visibleSettingsSection('about', 'Acerca de Nodus', 'proyecto independiente codigo abierto open source gratuito privacidad privacy rgpd gdpr datos alumnado licencia terceros legal actualizaciones update version novedades roadmap hoja de ruta futuro') && (
         <Section title={t('Acerca de Nodus')}>
           <div className={ABOUT_CARD_CLASS}>
             <div className="flex items-start gap-3">
@@ -1348,6 +1351,29 @@ export function Settings({
             </div>
           </div>
 
+          <div data-testid="about-roadmap" className={ABOUT_CARD_CLASS}>
+            <div className="flex items-start gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300">
+                <Icon name="route" size={19} />
+              </div>
+              <div className="max-w-3xl">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{t('Roadmap')}</h3>
+                <p className="mt-1 text-xs leading-5 text-neutral-600 dark:text-neutral-400">
+                  {t('Consulta qué está en desarrollo, qué está planificado y qué ya se ha implementado. El roadmap no atribuye fechas ni versiones.')}
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+              <button
+                data-testid="open-roadmap"
+                className={ABOUT_ACTION_BUTTON_CLASS}
+                onClick={onOpenRoadmap}
+              >
+                <Icon name="route" /> {t('Ver roadmap de Nodus')}
+              </button>
+            </div>
+          </div>
+
           <div data-testid="about-transparency-security" className={ABOUT_CARD_CLASS}>
             <div className="flex items-start gap-3">
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300">
@@ -1384,7 +1410,7 @@ export function Settings({
         </Section>
       )}
 
-      {visibleSettingsSection('updates', 'Actualizaciones y novedades', 'actualizaciones update version novedades ultimos cambios latest changes changelog buscar instalar reiniciar') && (
+      {visibleSettingsSection('updates', 'Actualizaciones y novedades', 'actualizaciones update version novedades ultimos cambios latest changes changelog buscar instalar reiniciar avisos anuncios encuestas noticias') && (
         <Section title={t('Actualizaciones y novedades')}>
           <div data-testid="about-latest-changes" className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/50 sm:flex-row sm:items-center sm:justify-between">
             <div>
@@ -1398,6 +1424,23 @@ export function Settings({
             >
               <Icon name="star" /> {t('Ver últimos cambios')}
             </button>
+          </div>
+          <div data-testid="about-announcements" className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/50 sm:flex-row sm:items-center sm:justify-between">
+            <div className="max-w-2xl">
+              <label className="text-sm text-neutral-700 dark:text-neutral-300">{t('Avisos de Nodus')}</label>
+              <p className="mt-0.5 text-xs text-neutral-500">
+                {t('Avisos publicados entre versiones (encuestas, incidencias conocidas, cambios importantes). Se consulta un archivo público cada cuatro horas, sin enviar ningún identificador ni dato de tu bóveda. Al desactivarlo, Nodus deja de hacer esa consulta.')}
+              </p>
+            </div>
+            <label className="flex shrink-0 items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+              <input
+                data-testid="toggle-announcements"
+                type="checkbox"
+                checked={settings.announcementsEnabled}
+                onChange={(e) => void patch({ announcementsEnabled: e.target.checked })}
+              />
+              {t('Recibir avisos')}
+            </label>
           </div>
           <div data-testid="about-updates" className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/50 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/src/views/Tour.tsx
+++ b/src/views/Tour.tsx
@@ -13,9 +13,9 @@ const STEPS: TourStep[] = [
     body: '¿Es tu primera vez? En menos de un minuto te enseño cómo convertir tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.',
   },
   {
-    target: 'vaults',
+    target: 'vault-badge',
     title: 'Bóvedas independientes',
-    body: 'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Usa este selector para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.',
+    body: 'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.',
   },
   {
     target: 'nav-graph',
@@ -29,9 +29,10 @@ const STEPS: TourStep[] = [
     body: 'Este botón trae las obras de tus colecciones monitorizadas. Por defecto solo incorpora metadatos; puedes activar análisis automático en Ajustes.',
   },
   {
-    target: 'collections',
+    // Sin ancla: Colecciones ya no tiene icono propio en la cabecera. Se abre desde la
+    // paleta de comandos, que no es un elemento que se pueda señalar en pantalla.
     title: 'Elegir colecciones',
-    body: 'Aquí decides qué colecciones o subcolecciones de Zotero vigila Nodus. Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.',
+    body: 'Decide qué colecciones o subcolecciones de Zotero vigila Nodus. Ábrelo desde la paleta de comandos (⌘K o Ctrl+K) buscando «Colecciones». Empieza con una pequeña para probar; sus subcolecciones se incluyen solas.',
   },
   {
     target: 'nav-library',


### PR DESCRIPTION
Closes #357.

## The rail

Eleven icons become eight on an academic vault, seven elsewhere.

| | Before | After |
| --- | --- | --- |
| Vaults | icon | the centred badge, now shown at every width |
| Collections | icon | command palette (as before) |
| Roadmap | icon | Settings › About Nodus, plus the palette |
| Inbox | always | only when it holds entries |
| Notifications | — | **new**, immediately left of Settings |

**The badge had to be fixed before the button could go.** It was `hidden … xl:inline-flex`, so it vanished below 1280px, and `headerLayout.ts` hides it when it will not fit — its own comment named the Vaults action as the fallback. It now drops its *label* on a narrow window instead of itself, which leaves an icon-and-chevron chip that fits in a band the full badge would not, and `act:vaults` in the palette is the last resort for the remaining extreme.

`Refresh` also stops rendering in primary-sources vaults. The comment above it already said Zotero-only and listed the exclusions; the condition just did not match.

## Notifications

The new button opens the same two lists Nodi shows. This matters because Nodi is optional: with `mascotEnabled: false`, `NodiMascot` returns `null` and the notification centre was unreachable.

Two lists, not one, because the read semantics genuinely differ. **Avisos** are read one at a time and stay until they are. **Actividad** clears in bulk when the panel opens, which is all "I have seen these" ever means. The header and Nodi share `useAnnouncements`, so the two surfaces cannot disagree about the unread count.

The inbox stays a separate button: it is per vault (`serverInboxRepo.ts` is explicit about why), the announcements store is global, and its per-entry read state is a "dealt with this one" marker rather than a "seen it" one. Merging them would have forced one semantic on both.

## Announcements

`site/data/announcements.json` → `https://drakonis96.github.io/nodus/data/announcements.json`. Adding a notice is a PR; merging it is the deployment, since the Pages workflow already deploys on any push to `main` touching `site/**`. Authoring guide in [`docs/announcements.md`](docs/announcements.md).

**Cost.** One conditional `GET` on the update check's existing four-hour timer — no second timer — plus one delayed 45s after startup. The `ETag` comes back as `If-None-Match`, so the ordinary answer is a `304` with no body. Off in Settings means no request at all, and PRIVACY.md now says so.

**A notice** carries a stable id, a date, a severity, all eight languages, and optionally an https link, an `expiresAt` and a `minVersion`/`maxVersion` range. It is treated as untrusted input throughout: ids are slugs, strings are capped, only `https:` links survive the parser, and bodies render as plain text — never markup.

**The gate is CI.** `scripts/test-announcements.mjs` demands all eight languages and refuses a duplicate id, because the id is what a read mark hangs off. The runtime parser needs only `es` + `en` and falls back English-then-Spanish; that leniency is resilience for a file arriving over a network, not a way around the test.

The Nodi overlay now needs four more bridge methods. `openExternal` is among them — the main process already refuses any scheme that is not http/https/mailto. `test-window-preloads.mjs` would not have caught the gap, because its Nodi file pattern does not match `NotificationsPanel.tsx`; that pattern is fixed here too.

## Verification

- `npm run lint`, `npm run typecheck`, `npm run build` — clean.
- `npm test` — 1685 passing, 0 failing.
- `npm run test:e2e` — passing, including the header-badge geometry steps. That assertion needed rewriting: a rail three icons shorter no longer crowds the badge at 1440px, so the tight case is now made by narrowing the window, and the clamp is asserted as an offset from centre rather than as an absolute `left` (a narrower window moves the centre too, which would have made a raw comparison pass for the wrong reason).
- `npm run verify:announcements` — **new**, against a real HTTP server and a real Electron app. Confirms the first request carries no validator, the second sends `If-None-Match` and gets a `304`, expired and version-targeted notices are filtered, a `javascript:` link never reaches the renderer, per-notice read state survives a restart, and the setting turned off produces zero requests while leaving already-downloaded notices readable.

`site/data/announcements.json` ships with an **empty** `notices` array. Merging publishes the endpoint, not a message — the first notice is yours to write.