### PR TITLE
Address a running local AI server on its OpenAI-compatible base

### DIFF
--- a/electron/ai/nodusLocalAi.ts
+++ b/electron/ai/nodusLocalAi.ts
@@ -40,7 +40,13 @@ interface ActiveServer {
   key: string;
   modelId: string;
   mode: 'chat' | 'embedding';
+  // llama-server answers /health at the root but serves the OpenAI-compatible
+  // surface under /v1, and the two disagree: /embeddings returns a bare array of
+  // per-token vectors while /v1/embeddings returns the OpenAI envelope callers
+  // parse. Deriving the API URL once, here, is what keeps a caller that reaches a
+  // running server from silently talking to the wrong one.
   baseUrl: string;
+  apiUrl: string;
   child: ChildProcess;
 }
 
@@ -477,7 +483,7 @@ export async function ensureNodusLocalServer(modelId: string, mode: 'chat' | 'em
     throw new Error(`El modelo «${modelId}» no puede ejecutarse como ${mode}.`);
   }
   const key = `${mode}:${modelId}`;
-  if (activeServer?.key === key && activeServer.child.exitCode == null) return `${activeServer.baseUrl}/v1`;
+  if (activeServer?.key === key && activeServer.child.exitCode == null) return activeServer.apiUrl;
   stopNodusLocalServer();
   const executable = await llamaServerPath();
   if (!executable) throw new Error('Instala primero el motor local de Nodus desde Ajustes → Modelos IA.');
@@ -503,12 +509,12 @@ export async function ensureNodusLocalServer(modelId: string, mode: 'chat' | 'em
   const capture = (chunk: unknown) => { output = `${output}${String(chunk)}`.slice(-12_000); };
   child.stdout?.on('data', capture);
   child.stderr?.on('data', capture);
-  const server: ActiveServer = { key, modelId, mode, baseUrl, child };
+  const server: ActiveServer = { key, modelId, mode, baseUrl, apiUrl: `${baseUrl}/v1`, child };
   activeServer = server;
   child.once('exit', () => { if (activeServer === server) activeServer = null; });
   try {
     await waitForServer(baseUrl, child, () => output);
-    return `${baseUrl}/v1`;
+    return server.apiUrl;
   } catch (error) {
     if (activeServer === server) stopNodusLocalServer();
     throw error;

--- a/electron/ai/nodusLocalAi.ts
+++ b/electron/ai/nodusLocalAi.ts
@@ -477,7 +477,7 @@ export async function ensureNodusLocalServer(modelId: string, mode: 'chat' | 'em
     throw new Error(`El modelo «${modelId}» no puede ejecutarse como ${mode}.`);
   }
   const key = `${mode}:${modelId}`;
-  if (activeServer?.key === key && activeServer.child.exitCode == null) return activeServer.baseUrl;
+  if (activeServer?.key === key && activeServer.child.exitCode == null) return `${activeServer.baseUrl}/v1`;
   stopNodusLocalServer();
   const executable = await llamaServerPath();
   if (!executable) throw new Error('Instala primero el motor local de Nodus desde Ajustes → Modelos IA.');

--- a/scripts/test-nodus-local-server-url.mjs
+++ b/scripts/test-nodus-local-server-url.mjs
@@ -1,0 +1,174 @@
+// Guards the URL that ensureNodusLocalServer hands back, because the two exits of
+// that function once disagreed: the exit that spawns llama-server returned the
+// OpenAI-compatible base ({root}/v1) while the exit taken when the model was
+// already running returned the bare root. The first embedding of a session
+// therefore worked and every later one silently produced nothing.
+//
+// Nothing is mocked at the module boundary: the real function spawns a real
+// process and polls it over HTTP. The spawned executable is a stand-in for
+// llama-server that reproduces the one behaviour that makes the divergence
+// destructive rather than cosmetic — measured against llama.cpp b10002 with
+// bge-m3-q8_0 loaded in embedding mode, both endpoints answer HTTP 200 but with
+// different bodies:
+//
+//   POST /v1/embeddings -> { data: [{ embedding: number[1024], index, object }], ... }
+//   POST /embeddings    -> [{ index, embedding: number[][] }]           (bare array)
+//
+// embedWithNodusLocal reads `body.data`, so against the wrong endpoint it returns
+// [] with no exception and no failed status code. Asserting on the returned URL
+// alone would not catch that, so the vectors are exercised too.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, open, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'nodus-local-server-url-'));
+
+// The catalogue is the source of truth for what the manager expects on disk.
+const { getNodusLocalModel } = await import(pathToFileURL(path.join(repoRoot, 'shared/localAiModels.ts')).href)
+  .catch(async () => {
+    const outfile = path.join(tmp, 'catalog.mjs');
+    await build({
+      entryPoints: [path.join(repoRoot, 'shared/localAiModels.ts')],
+      outfile, bundle: true, format: 'esm', platform: 'node', logLevel: 'silent',
+    });
+    return import(pathToFileURL(outfile).href);
+  });
+
+const MODEL_ID = 'bge-m3-q8_0';
+const model = getNodusLocalModel(MODEL_ID);
+assert.ok(model, `the catalogue still ships ${MODEL_ID}`);
+assert.equal(model.runtime, 'llama_cpp', `${MODEL_ID} still runs through the managed server`);
+
+// ── A downloaded model, without downloading 600 MB ───────────────────────────
+// modelStatus only stats each asset and compares its size, so sparse files of the
+// exact expected length are indistinguishable from the real download to it.
+const modelDir = path.join(tmp, 'local-ai', 'models', MODEL_ID);
+await mkdir(modelDir, { recursive: true });
+for (const asset of model.assets) {
+  await mkdir(path.dirname(path.join(modelDir, asset.file)), { recursive: true });
+  const handle = await open(path.join(modelDir, asset.file), 'w');
+  await handle.truncate(asset.bytes);
+  await handle.close();
+}
+
+// ── A stand-in for llama-server ──────────────────────────────────────────────
+// Serves /health at the root and mirrors llama.cpp's split between the bare and
+// the OpenAI-compatible embedding endpoints. It ignores every flag except --port.
+const runtimeDir = path.join(tmp, 'local-ai', 'runtime', 'b10002');
+await mkdir(runtimeDir, { recursive: true });
+const serverScript = path.join(runtimeDir, 'fake-llama-server.mjs');
+await writeFile(
+  serverScript,
+  `import http from 'node:http';
+   const port = Number(process.argv[process.argv.indexOf('--port') + 1]);
+   const vector = Array.from({ length: 8 }, (_, i) => (i + 1) / 10);
+   http.createServer((req, res) => {
+     let body = '';
+     req.on('data', (chunk) => { body += chunk; });
+     req.on('end', () => {
+       const count = (() => {
+         try {
+           const input = JSON.parse(body || '{}').input;
+           return Array.isArray(input) ? input.length : 1;
+         } catch { return 1; }
+       })();
+       const json = (payload) => {
+         res.writeHead(200, { 'content-type': 'application/json' });
+         res.end(JSON.stringify(payload));
+       };
+       if (req.url === '/health') return json({ status: 'ok' });
+       // OpenAI envelope — what embedWithNodusLocal parses.
+       if (req.url === '/v1/embeddings') {
+         return json({
+           model: 'stub', object: 'list', usage: { prompt_tokens: count, total_tokens: count },
+           data: Array.from({ length: count }, (_, index) => ({ object: 'embedding', index, embedding: vector })),
+         });
+       }
+       // llama.cpp's native endpoint: a bare array, vectors nested per token.
+       if (req.url === '/embeddings') {
+         return json(Array.from({ length: count }, (_, index) => ({ index, embedding: [vector] })));
+       }
+       res.writeHead(404, { 'content-type': 'application/json' });
+       res.end(JSON.stringify({ error: { code: 404, message: 'not found' } }));
+     });
+   }).listen(port, '127.0.0.1');\n`
+);
+const executable = path.join(runtimeDir, 'llama-server');
+await writeFile(executable, `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(serverScript)} "$@"\n`);
+await chmod(executable, 0o755);
+
+let manager;
+try {
+  // ── Bundle the real manager, stubbing only Electron's app ──────────────────
+  const electronStub = path.join(tmp, 'electron-stub.mjs');
+  await writeFile(
+    electronStub,
+    `export const app = { getPath: () => ${JSON.stringify(tmp)}, once: () => {} };\nexport default { app };\n`
+  );
+  const outfile = path.join(tmp, 'nodusLocalAi.mjs');
+  await build({
+    entryPoints: [path.join(repoRoot, 'electron/ai/nodusLocalAi.ts')],
+    outfile,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    logLevel: 'silent',
+    tsconfig: path.join(repoRoot, 'electron/tsconfig.json'),
+    // Only the Transformers.js runtime reaches for it, and it ships native .node
+    // binaries esbuild cannot inline. This test drives the llama.cpp path.
+    external: ['@huggingface/transformers'],
+    // adm-zip is CommonJS and requires Node builtins at load time; an ESM bundle
+    // has no require of its own to hand it.
+    banner: { js: "import { createRequire as __createRequire } from 'node:module';\nconst require = __createRequire(import.meta.url);" },
+    plugins: [{
+      name: 'stub-electron',
+      setup(b) { b.onResolve({ filter: /^electron$/ }, () => ({ path: electronStub })); },
+    }],
+  });
+  manager = await import(pathToFileURL(outfile).href);
+
+  // ── The contract: both exits agree ────────────────────────────────────────
+  const cold = await manager.ensureNodusLocalServer(MODEL_ID, 'embedding');
+  const warm = await manager.ensureNodusLocalServer(MODEL_ID, 'embedding');
+
+  assert.match(cold, /^http:\/\/127\.0\.0\.1:\d+\/v1$/, 'a freshly spawned server is addressed on its OpenAI-compatible base');
+  assert.equal(
+    warm,
+    cold,
+    'reaching an already-running server must return the same URL as starting one — a bare root sends callers to llama.cpp native endpoints'
+  );
+
+  // A third call keeps the invariant no matter how many times the cache is hit.
+  assert.equal(await manager.ensureNodusLocalServer(MODEL_ID, 'embedding'), cold, 'the URL is stable across repeated calls');
+
+  // ── The consequence: vectors keep arriving after the first call ───────────
+  const first = await manager.embedWithNodusLocal(MODEL_ID, ['una frase']);
+  const second = await manager.embedWithNodusLocal(MODEL_ID, ['otra frase', 'y una tercera']);
+
+  assert.equal(first.length, 1, 'the first embedding call returns one vector per input');
+  assert.equal(
+    second.length,
+    2,
+    'later calls reuse the running server and must still return one vector per input — the native endpoint answers 200 with no .data, which reads as an empty result'
+  );
+  for (const vectors of [first, second]) {
+    for (const vector of vectors) {
+      assert.ok(Array.isArray(vector) && vector.length > 0, 'every returned vector has components');
+      assert.ok(vector.every(Number.isFinite), 'vectors are flat lists of numbers, not per-token matrices');
+    }
+  }
+
+  // ── The server really was reused ──────────────────────────────────────────
+  const status = await manager.getNodusLocalAiStatus();
+  assert.equal(status.activeModelId, MODEL_ID, 'the manager reports the running model');
+} finally {
+  manager?.stopNodusLocalServer();
+  // The stand-in exits with its parent handle closed; make sure nothing survives.
+  spawnSync('pkill', ['-f', serverScript], { stdio: 'ignore' });
+  await rm(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
Carries @oguzkarayemis's fix from #344 and lands the two things #359 asks for alongside it.

Closes #359.

## The fix (#344, unchanged)

`ensureNodusLocalServer` returned `{root}/v1` when it started `llama-server` and the bare `{root}` when it found one already running. The first embedding request of a session was therefore addressed correctly and every later one was not.

## Why it mattered

`llama-server` answers both endpoints with `HTTP 200` but with different bodies. Measured against the bundled runtime (llama.cpp `b10002`) with `bge-m3-q8_0` in embedding mode:

| Request | Response |
| --- | --- |
| `POST /v1/embeddings` | `{ model, object, usage, data: [{ embedding: number[1024], index, object }] }` |
| `POST /embeddings` | bare array `[{ index, embedding }]`, `embedding` nested `number[][]` |

`embedWithNodusLocal` reads `body.data`, so against the bare root it returned `[]` — no exception, no failed status. `validate()` iterates the vector list and an empty list passes it, `embed()` degraded to `null`, and `null` embeddings are a supported state. The result was that local embeddings quietly stopped being produced after the first call, with nothing surfaced to the user.

Chat was unaffected: `llama-server` routes `/chat/completions` and `/v1/chat/completions` to the same handler.

## What this PR adds

**One source of truth for the suffix.** The two exits spelled `/v1` separately, which is what let them drift. `ActiveServer` now carries the `apiUrl` it was constructed with and both exits read that field, so the divergence is no longer expressible.

**A regression test** — `scripts/test-nodus-local-server-url.mjs`. Nothing asserted the returned URL before, which is why this went unnoticed. It mocks nothing at the module boundary: the real function spawns a real process and polls it over HTTP. The spawned executable stands in for `llama-server` and reproduces the endpoint split measured above, so the test has two independent teeth — it fails on the URL, and it fails again on the empty vectors if only the URL assertion is removed. Both were confirmed against the pre-fix code:

```
AssertionError: reaching an already-running server must return the same URL as starting one
+ 'http://127.0.0.1:59627'
- 'http://127.0.0.1:59627/v1'

AssertionError: the first embedding call returns one vector per input
0 !== 1
```

The 600 MB model asset is faked with a sparse file of the exact expected length, since `modelStatus` only stats sizes.

## Verification

- `npm run typecheck` — clean.
- `eslint` on both changed files — clean.
- `npm test` — 1671/1672. The single failure is `test-prosopography-e2e.mjs`, the one test that launches Electron; it passes standalone and fails identically on this branch with the new test file removed, so it is ambient machine load rather than anything here.
