### PR TITLE
Curate the academic Analyse sidebar: gaps move inside Coverage, two labs wait for a corpus

### DIFF
--- a/scripts/test-vault-types.mjs
+++ b/scripts/test-vault-types.mjs
@@ -281,8 +281,14 @@ test('primary_sources uses a dedicated documentary shell and keeps optional auth
   assert.match(vt.vaultTypePromptPack('primary_sources'), /propuesta pendiente de revisión/i);
 });
 
-test('academic shows the full sidebar; estudio uses its dedicated learning workspace', () => {
-  assert.deepEqual(vt.defaultHiddenViewsForType('academic'), []);
+test('academic hides only what an immature corpus cannot feed; estudio uses its dedicated learning workspace', () => {
+  // The Hypothesis lab and the Reading path answer with noise until the corpus has
+  // been analysed in depth, which reads as broken rather than empty. Everything else
+  // an academic vault owns stays visible.
+  assert.deepEqual(vt.defaultHiddenViewsForType('academic'), ['hypothesis', 'reading']);
+  for (const kept of ['search', 'library', 'graph', 'argument', 'ideas', 'authors', 'immersion', 'debate', 'research', 'deepResearch', 'writing', 'projects', 'notes', 'toolkit']) {
+    assert.ok(!vt.defaultHiddenViewsForType('academic').includes(kept), `${kept} stays visible in academic`);
+  }
   const estudioHidden = vt.defaultHiddenViewsForType('estudio');
   for (const hidden of ['search', 'library', 'graph', 'debate', 'deepResearch', 'writing', 'notes']) {
     assert.ok(estudioHidden.includes(hidden), `${hidden} replaced by a study-specific surface`);
@@ -401,7 +407,7 @@ test('viewsDisallowedForType lists the scoped views not applicable to a type', (
 test('effectiveSidebarHidden: preset when untouched, user choice once customised', () => {
   // Untouched → the type preset drives visibility.
   assert.deepEqual(vt.effectiveSidebarHidden([], false, 'estudio'), vt.defaultHiddenViewsForType('estudio'));
-  assert.deepEqual(vt.effectiveSidebarHidden([], false, 'academic'), []);
+  assert.deepEqual(vt.effectiveSidebarHidden([], false, 'academic'), ['hypothesis', 'reading']);
   // Customised → the user's explicit set wins, regardless of type.
   assert.deepEqual(vt.effectiveSidebarHidden(['graph'], true, 'estudio'), ['graph']);
   assert.deepEqual(vt.effectiveSidebarHidden([], true, 'estudio'), []);

--- a/scripts/test-view-registry.mjs
+++ b/scripts/test-view-registry.mjs
@@ -66,3 +66,42 @@ test('the registry adds the render and nothing else: labels and gating stay put'
   assert.match(readSource('src/navigation.ts'), /export const NAV_ITEMS: NavItem\[\]/);
   assert.match(readSource('shared/vaultTypes.ts'), /VAULT_TYPE_SCOPED_VIEWS/);
 });
+
+// Gaps is the one view deliberately reachable without a sidebar entry of its own:
+// it is a tab inside Coverage. What makes that safe is that it stays a routable
+// view — Home, Search and the advanced tour all navigate to it — so the guard has
+// to hold BOTH halves at once. Losing the renderer would 404 those callers; growing
+// a NAV_ITEM back would put a second, full-screen Huecos beside the tab.
+test('gaps is routable without a sidebar section, and lands on the Coverage tab', () => {
+  const navigation = readSource('src/navigation.ts');
+  assert.ok(viewUnion().includes('gaps'), 'gaps must stay in the View union');
+  assert.ok(
+    !/\{ id: 'gaps',/.test(navigation),
+    'gaps must NOT have a NAV_ITEM: it is a tab inside Coverage, not a section'
+  );
+
+  // Both ids render the same workspace, each entering by its own tab.
+  const corpus = readSource('src/app/views/corpus.tsx');
+  assert.match(corpus, /gaps: \([^)]*\) => \(\s*<CoverageWorkspace\s+vaultId=\{[^}]*\}\s+initialTab="gaps"/);
+  assert.match(corpus, /research: \([^)]*\) => \(\s*<CoverageWorkspace\s+vaultId=\{[^}]*\}\s+initialTab="map"/);
+  assert.equal(registeredViews().get('gaps'), 'corpus.tsx');
+
+  // The callers that still navigate to it must keep working.
+  assert.match(readSource('src/app/views/corpus.tsx'), /onOpenGaps=\{\(\) => setView\('gaps'\)\}/);
+  assert.match(readSource('src/views/AdvancedTour.tsx'), /view: 'gaps'/);
+});
+
+// The two labs that need a deeply analysed corpus are hidden by default, but hiding
+// is a SIDEBAR preset — it must never make them unroutable, or the advanced tour
+// walks into a section that cannot render.
+test('the views academic hides by default are still routable', () => {
+  const registered = registeredViews();
+  for (const view of ['hypothesis', 'reading']) {
+    assert.ok(registered.has(view), `${view} is hidden from the sidebar, not removed`);
+    assert.ok(/\{ id: '(hypothesis|reading)',/.test(readSource('src/navigation.ts')));
+  }
+  // The tour still walks through both, so a preset that blocked navigation would break it.
+  const tour = readSource('src/views/AdvancedTour.tsx');
+  assert.match(tour, /view: 'hypothesis'/);
+  assert.match(tour, /view: 'reading'/);
+});

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -122,6 +122,7 @@ const RELEASE_3_2_4_IT: string[] = [
   "L'intestazione resta con meno icone. Depositi, Collezioni e Roadmap escono dalla barra di destra. Il deposito attivo si apre dal distintivo al centro, che ora si vede a qualsiasi larghezza di finestra. Collezioni vive nella palette dei comandi e la roadmap si trova nelle Impostazioni, dentro Informazioni su Nodus.",
   "La casella in arrivo compare solo quando è arrivato qualcosa da un altro dispositivo. Su un computer senza depositi collegati era un'icona perennemente vuota accanto a un'altra che non lo è mai. Anche il pulsante di aggiornamento sparisce dai depositi di fonti primarie, che non si sincronizzano con Zotero.",
   "Nodus dice finalmente dove trovarlo fuori dall'applicazione. La finestra delle novità e le Impostazioni, in Informazioni su Nodus, portano a Reddit, YouTube e X con l'icona di ogni rete. I collegamenti si aprono nel tuo browser e l'applicazione non invia nulla a quelle reti.",
+  "Un deposito accademico si apre con meno sezioni. Lacune diventa una scheda dentro Copertura, perché una lacuna significa qualcosa solo guardando che cosa manca alla tua domanda. Ipotesi e Percorso di lettura restano nascosti all'inizio, dato che su un corpus appena sincronizzato rispondevano con rumore. Entrambi tornano dalle Impostazioni.",
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -62,6 +62,7 @@ const RELEASE_3_2_4_TR: string[] = [
   "Başlıkta daha az simge kalıyor. Kasalar, Koleksiyonlar ve Yol haritası sağ şeritten çıkıyor. Etkin kasa ortadaki rozetten açılıyor ve bu rozet artık her pencere genişliğinde görünüyor. Koleksiyonlar komut paletinde yaşıyor, yol haritası ise Ayarlar içindeki Nodus Hakkında bölümünde.",
   "Gelen kutusu yalnızca başka bir cihazdan bir şey geldiğinde görünüyor. Bağlı kasası olmayan bir bilgisayarda, hiç boş kalmayan bir simgenin yanında sürekli boş duran bir simgeydi. Yenileme düğmesi de Zotero ile eşitlenmeyen birincil kaynak kasalarında artık gösterilmiyor.",
   "Nodus artık uygulamanın dışında nerede bulunacağını da söylüyor. Yenilikler penceresi ve Ayarlar içindeki Nodus Hakkında bölümü, her birinin kendi simgesiyle Reddit, YouTube ve X hesaplarına götürüyor. Bağlantılar tarayıcınızda açılır ve uygulama bu ağlara hiçbir şey göndermez.",
+  "Akademik bir kasa daha az bölümle açılıyor. Boşluklar, Kapsam içinde bir sekmeye dönüşüyor, çünkü bir boşluk ancak kendi sorunuza neyin eksik olduğuna bakarken anlam taşır. Hipotez ve Okuma yolu başlangıçta gizli geliyor, çünkü yeni eşitlenmiş bir külliyatta gürültüyle yanıt veriyorlardı. İkisi de Ayarlar üzerinden geri gelir.",
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -864,6 +864,15 @@ const RELEASE_3_2_4_HIGHLIGHTS: RawReleaseHighlight[] = [
     pt: 'O Nodus passa a dizer onde encontrá-lo fora da aplicação. O modal de novidades e as Definições, em Acerca do Nodus, levam ao Reddit, ao YouTube e ao X com o ícone de cada rede. As ligações abrem no seu navegador e a aplicação não envia nada para essas redes.',
     'pt-BR': 'O Nodus agora diz onde encontrá-lo fora do aplicativo. O modal de novidades e as Configurações, em Sobre o Nodus, levam ao Reddit, ao YouTube e ao X com o ícone de cada rede. Os links abrem no seu navegador e o aplicativo não envia nada para essas redes.',
   },
+  {
+    scope: 'academic',
+    es: 'Un vault académico abre con menos secciones. Huecos pasa a ser una pestaña dentro de Cobertura, porque un hueco solo significa algo mirando qué le falta a tu pregunta. Hipótesis y Ruta de lectura quedan ocultas de entrada, ya que con un corpus recién sincronizado respondían con ruido. Las dos vuelven desde Ajustes.',
+    en: 'An academic vault opens with fewer sections. Gaps becomes a tab inside Coverage, because a gap only means something when you are looking at what your own question is missing. Hypotheses and Reading path start hidden, since on a freshly synced corpus they answered with noise. Both come back from Settings.',
+    fr: 'Un coffre académique s’ouvre avec moins de sections. Lacunes devient un onglet dans Couverture, car une lacune n’a de sens que face à ce qui manque à votre propre question. Hypothèses et Parcours de lecture sont masqués au départ, car sur un corpus fraîchement synchronisé ils répondaient par du bruit. Les deux reviennent depuis les Paramètres.',
+    de: 'Ein akademischer Tresor öffnet mit weniger Abschnitten. Lücken wird zu einem Reiter innerhalb von Abdeckung, denn eine Lücke bedeutet nur etwas im Blick darauf, was der eigenen Frage fehlt. Hypothesen und Lesepfad sind anfangs ausgeblendet, da sie bei einem frisch synchronisierten Korpus mit Rauschen antworteten. Beide kommen über die Einstellungen zurück.',
+    pt: 'Um cofre académico abre com menos secções. Lacunas passa a ser um separador dentro de Cobertura, porque uma lacuna só significa algo olhando para o que falta à sua pergunta. Hipóteses e Percurso de leitura ficam ocultos à partida, já que num corpus acabado de sincronizar respondiam com ruído. Ambos voltam a partir das Definições.',
+    'pt-BR': 'Um cofre acadêmico abre com menos seções. Lacunas passa a ser uma aba dentro de Cobertura, porque uma lacuna só significa algo olhando para o que falta à sua pergunta. Hipóteses e Caminho de leitura começam ocultos, já que em um corpus recém-sincronizado respondiam com ruído. Os dois voltam pelas Configurações.',
+  },
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [

--- a/shared/vaultTypes.ts
+++ b/shared/vaultTypes.ts
@@ -67,7 +67,14 @@ export const VAULT_TYPES: VaultTypeDef[] = [
   {
     id: 'academic',
     available: true,
-    defaultHiddenViews: [],
+    // The Hypothesis lab and the Reading path both need a corpus that has already
+    // been analysed in depth: on a freshly synced library they answer with noise,
+    // which reads as a broken section rather than an empty one. They are hidden by
+    // default and stay one click away in the sidebar configurator — and, as with
+    // every preset, the moment the user customises the sidebar this no longer
+    // applies (see effectiveSidebarHidden). Gaps is absent from here because it is
+    // no longer a section at all: it is a tab inside Coverage.
+    defaultHiddenViews: ['hypothesis', 'reading'],
     promptPack: '',
   },
   {

--- a/src/app/views/corpus.tsx
+++ b/src/app/views/corpus.tsx
@@ -8,9 +8,8 @@ const GraphView = lazy(() => import('../../views/GraphView').then((module) => ({
 const ArgumentMapView = lazy(() => import('../../views/ArgumentMapView').then((module) => ({ default: module.ArgumentMapView })));
 const IdeasView = lazy(() => import('../../views/IdeasView').then((module) => ({ default: module.IdeasView })));
 const AuthorsView = lazy(() => import('../../views/AuthorsView').then((module) => ({ default: module.AuthorsView })));
-const GapsView = lazy(() => import('../../views/GapsView').then((module) => ({ default: module.GapsView })));
+const CoverageWorkspace = lazy(() => import('../../views/CoverageWorkspace').then((module) => ({ default: module.CoverageWorkspace })));
 const DebateView = lazy(() => import('../../views/DebateView').then((module) => ({ default: module.DebateView })));
-const ResearchMapView = lazy(() => import('../../views/ResearchMapView').then((module) => ({ default: module.ResearchMapView })));
 const HypothesisLabView = lazy(() => import('../../views/HypothesisLabView').then((module) => ({ default: module.HypothesisLabView })));
 const ReadingPathView = lazy(() => import('../../views/ReadingPathView').then((module) => ({ default: module.ReadingPathView })));
 const WritingWorkshopView = lazy(() => import('../../views/WritingWorkshopView').then((module) => ({ default: module.WritingWorkshopView })));
@@ -53,9 +52,13 @@ export const corpusViews = {
     />
   ),
   immersion: ({ navigate, settings }) => <ImmersionView settings={settings} onOpenGraph={(target) => navigate('graph', target)} />,
+  // Cobertura y Huecos son el mismo espacio con dos pestañas. 'gaps' ya no tiene
+  // entrada en la barra lateral, pero sigue siendo una vista enrutable —Inicio,
+  // Buscar y el tour avanzado navegan a ella— y entra por la pestaña de huecos.
   gaps: ({ activeVault, navigate, openAssistant, setView }) => (
-    <GapsView
+    <CoverageWorkspace
       vaultId={activeVault?.id ?? null}
+      initialTab="gaps"
       onOpenGraph={(target) => navigate('graph', target)}
       onOpenAssistant={openAssistant}
       onOpenDebates={() => setView('debate')}
@@ -64,8 +67,10 @@ export const corpusViews = {
   debate: ({ navigate, openAssistant }) => (
     <DebateView onOpenGraph={(target) => navigate('graph', target)} onOpenAssistant={openAssistant} />
   ),
-  research: ({ navigate, openAssistant, setView }) => (
-    <ResearchMapView
+  research: ({ activeVault, navigate, openAssistant, setView }) => (
+    <CoverageWorkspace
+      vaultId={activeVault?.id ?? null}
+      initialTab="map"
       onOpenGraph={(target) => navigate('graph', target)}
       onOpenAssistant={openAssistant}
       onOpenDebates={() => setView('debate')}

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -909,6 +909,7 @@ export const DE: Record<string, string> = {
   'import': 'import',
   'command': 'command',
   'Huecos': 'Lücken',
+  'Cobertura y huecos': 'Abdeckung und Lücken',
   'Ruta de lectura': 'Lesepfad',
   'Escritura': 'Schreiben',
   'Debates': 'Debatten',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -890,6 +890,7 @@ export const EN: Record<string, string> = {
   import: 'import',
   command: 'command',
   Huecos: 'Gaps',
+  'Cobertura y huecos': 'Coverage and gaps',
   'Ruta de lectura': 'Reading path',
   Escritura: 'Writing',
   Debates: 'Debates',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -908,6 +908,7 @@ export const FR: Record<string, string> = {
   'import': 'import',
   'command': 'command',
   'Huecos': 'Lacunes',
+  'Cobertura y huecos': 'Couverture et lacunes',
   'Ruta de lectura': 'Parcours de lecture',
   'Escritura': 'Écriture',
   'Debates': 'Débats',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -851,6 +851,7 @@ export const IT: Record<string, string> = {
   "import": "importare",
   "command": "comando",
   "Huecos": "Lacune",
+  "Cobertura y huecos": "Copertura e lacune",
   "Ruta de lectura": "Percorso di lettura",
   "Escritura": "Scrivere",
   "Debates": "Dibattiti",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -904,6 +904,7 @@ export const PT_BR: Record<string, string> = {
   'import': 'import',
   'command': 'command',
   'Huecos': 'Lacunas',
+  'Cobertura y huecos': 'Cobertura e lacunas',
   'Ruta de lectura': 'Caminho de leitura',
   'Escritura': 'Escrita',
   'Debates': 'Debates',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -904,6 +904,7 @@ export const PT: Record<string, string> = {
   'import': 'import',
   'command': 'command',
   'Huecos': 'Lacunas',
+  'Cobertura y huecos': 'Cobertura e lacunas',
   'Ruta de lectura': 'Percurso de leitura',
   'Escritura': 'Escrita',
   'Debates': 'Debates',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -1242,6 +1242,7 @@ export const TR: Record<string, string> = {
   "import": "ithalat",
   "command": "komut",
   "Huecos": "Boşluklar",
+  "Cobertura y huecos": "Kapsam ve boşluklar",
   "Escritura": "Yazma",
   "Debates": "Tartışmalar",
   "Ajustes": "Ayarlar",

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -109,7 +109,10 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'teachingUnits', label: 'Diseño de unidades', icon: 'compass', group: 'create' },
   // Analizar — superficies derivadas del grafo y síntesis.
   { id: 'immersion', label: 'Inmersión', icon: 'target', group: 'analyze' },
-  { id: 'gaps', label: 'Huecos', icon: 'gap', group: 'analyze' },
+  // 'gaps' NO tiene entrada propia: los huecos son una pestaña dentro de Cobertura,
+  // porque solo significan algo mirando qué le falta a una pregunta concreta. Sigue
+  // siendo una vista enrutable —Inicio, Buscar y el tour navegan a ella— y aterriza
+  // en esa pestaña; ver src/app/views/corpus.tsx.
   { id: 'debate', label: 'Debates', icon: 'scale', group: 'analyze' },
   { id: 'research', label: 'Cobertura', icon: 'help', group: 'analyze' },
   { id: 'hypothesis', label: 'Hipótesis', icon: 'flask', group: 'analyze' },

--- a/src/views/CoverageWorkspace.tsx
+++ b/src/views/CoverageWorkspace.tsx
@@ -1,0 +1,105 @@
+// Cobertura y Huecos responden la misma pregunta —¿qué le falta a mi corpus?— desde
+// los dos extremos: el mapa de cobertura mide la biblioteca contra la pregunta que
+// escribe el investigador, y los huecos son lo que las propias obras declaran que
+// queda pendiente. Sueltos en el menú parecían alternativas; aquí son dos pestañas
+// del mismo sitio.
+//
+// Los dos hijos se montan tal cual, cada uno con su encabezado: la pestaña dice en
+// qué sección estás y el encabezado explica qué hace. Solo vive una a la vez, así
+// que cambiar de pestaña no paga el coste de la otra.
+import { useState } from 'react';
+import { Icon } from '../components/ui';
+import type {
+  PendingAssistantNavigationTarget,
+  PendingGraphNavigationTarget,
+} from '../navigation';
+import { t } from '../i18n';
+import { GapsView } from './GapsView';
+import { ResearchMapView } from './ResearchMapView';
+
+export type CoverageTab = 'map' | 'gaps';
+
+const TABS: readonly (readonly [CoverageTab, string, string])[] = [
+  ['map', 'Cobertura', 'compass'],
+  ['gaps', 'Huecos', 'gap'],
+] as const;
+
+export function CoverageWorkspace({
+  vaultId,
+  initialTab,
+  onOpenGraph,
+  onOpenAssistant,
+  onOpenDebates,
+}: {
+  vaultId: string | null;
+  /** Qué pestaña abre. Navegar a 'gaps' entra directamente por los huecos. */
+  initialTab: CoverageTab;
+  onOpenGraph: (target: PendingGraphNavigationTarget) => void;
+  onOpenAssistant: (target?: PendingAssistantNavigationTarget) => void;
+  onOpenDebates: () => void;
+}) {
+  const [tab, setTab] = useState<CoverageTab>(initialTab);
+
+  return (
+    <div className="h-full flex flex-col min-h-0">
+      <nav
+        className="shrink-0 flex border-b border-neutral-800 px-3"
+        role="tablist"
+        aria-label={t('Cobertura y huecos')}
+      >
+        {TABS.map(([value, label, icon], index) => (
+          <button
+            key={value}
+            id={`coverage-tab-${value}`}
+            role="tab"
+            data-testid={`coverage-tab-${value}`}
+            aria-selected={tab === value}
+            aria-controls="coverage-tabpanel"
+            tabIndex={tab === value ? 0 : -1}
+            // border-current sigue al color del texto, que sí tiene remap en modo
+            // claro; una tinta indigo fija en el borde se quedaría sin traducir.
+            className={`flex items-center gap-1.5 border-b-2 px-3 py-2 text-xs font-medium ${
+              tab === value
+                ? 'border-current text-indigo-300'
+                : 'border-transparent text-neutral-500 hover:text-neutral-200'
+            }`}
+            onClick={() => setTab(value)}
+            onKeyDown={(event) => {
+              const delta = event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
+              if (!delta) return;
+              event.preventDefault();
+              const next = (index + delta + TABS.length) % TABS.length;
+              setTab(TABS[next][0]);
+              const buttons = event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+              buttons?.[next]?.focus();
+            }}
+          >
+            <Icon name={icon} size={13} /> {t(label)}
+          </button>
+        ))}
+      </nav>
+
+      <div
+        id="coverage-tabpanel"
+        role="tabpanel"
+        aria-labelledby={`coverage-tab-${tab}`}
+        className="flex-1 min-h-0"
+      >
+        {tab === 'map' ? (
+          <ResearchMapView
+            onOpenGraph={onOpenGraph}
+            onOpenAssistant={onOpenAssistant}
+            onOpenDebates={onOpenDebates}
+          />
+        ) : (
+          <GapsView
+            vaultId={vaultId}
+            onOpenGraph={onOpenGraph}
+            onOpenAssistant={onOpenAssistant}
+            onOpenDebates={onOpenDebates}
+          />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #361

The `academic` vault type was the only one that never got a curated sidebar. Its **Analyse** group offered seven entries that all read as "use AI on my corpus", and two of them answer with noise until the corpus has been analysed in depth. This makes Analyse four entries and turns three siblings into steps.

Immersion · ~~Gaps~~ · Debates · Coverage · ~~Hypotheses~~ · ~~Reading path~~ · Deep Research
→ Immersion · Debates · Coverage *(Gaps inside)* · Deep Research

## What changed

**Gaps becomes a tab inside Coverage.** A new `CoverageWorkspace` renders a two-tab strip over the two existing views, which mount unchanged and one at a time. `gaps` loses its `NAV_ITEM` but stays a routable view — Home, Search and the advanced tour all navigate to it — and now enters through that tab.

The two views are not the same engine, which is why they are tabs and not a merge. Gaps are written into the `gaps` table during each work's analysis and cost zero AI to read; Coverage is a user-authored question decomposed into subquestions and mapped against the corpus, editable and re-mappable. Neither belongs inside Deep Research, which produces a frozen document.

**Hypotheses and Reading path are hidden by default for academic vaults.** Hiding is a sidebar preset: both stay routable, the advanced tour still walks through them, and the sidebar configurator brings them back. Per `effectiveSidebarHidden`, the preset stops applying the moment a user customises their sidebar, so anyone who has already touched it sees no change.

**The active tab underlines with `border-current`**, so the rule follows the text colour that light mode remaps. A fixed indigo border would have stayed dark on white — `border-indigo-*` has no `.light` override in `src/index.css`.

## Verification

- `npm run typecheck`, `eslint` on the touched files — clean
- `npm test` — 1696/1696
- `npm run build` and `npm run test:e2e` — pass, schema v124
- The new `gaps is routable without a sidebar section` test was mutation-checked: restoring the `gaps` NAV_ITEM makes it fail
- Tab strip rendered headless against the compiled CSS in both themes. Active `rgb(165,180,252)` on dark and `rgb(79,70,229)` on light, underline tracking the text colour in both

## Notes

- Adds one new i18n key (`'Cobertura y huecos'`) across all seven translated languages, and a sixth What's New highlight to the open 3.2.4 with `scope: 'academic'`.
- The `CHANGELOG.md` section for 3.2.4 is not written here — this repo writes it when the version is closed, and seven other commits are already waiting for it.
- The overlap between Deep Research and Coverage/Gaps is deliberately left alone: it is a product decision, not a layout one.