### PR TITLE
Keep minting idea ids once the corpus outgrows four digits

### DIFF
--- a/electron/db/ideasRepo.ts
+++ b/electron/db/ideasRepo.ts
@@ -152,14 +152,16 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 
 export function nextGlobalId(): string {
   const db = getDb();
-  const row = db.prepare("SELECT global_id FROM ideas WHERE global_id LIKE 'g-%' ORDER BY global_id DESC LIMIT 1").get() as
-    | { global_id: string }
-    | undefined;
-  let n = 1;
-  if (row) {
-    const parsed = parseInt(row.global_id.slice(2), 10);
-    if (!Number.isNaN(parsed)) n = parsed + 1;
-  }
+  // The counter has to be read as a NUMBER, not as text. Ids are padded to four
+  // digits, which keeps a text sort honest only up to g-9999: past that ceiling
+  // 'g-9999' > 'g-10000' character by character, so ORDER BY global_id DESC kept
+  // answering g-9999 forever and every new idea collided with the existing
+  // g-10000 ("UNIQUE constraint failed: ideas.global_id"), failing every deep
+  // scan that had a genuinely new idea to record.
+  const row = db
+    .prepare("SELECT MAX(CAST(substr(global_id, 3) AS INTEGER)) AS n FROM ideas WHERE global_id GLOB 'g-[0-9]*'")
+    .get() as { n: number | null } | undefined;
+  const n = (row?.n ?? 0) + 1;
   return `g-${String(n).padStart(4, '0')}`;
 }
 

--- a/scripts/test-idea-identity.mjs
+++ b/scripts/test-idea-identity.mjs
@@ -158,6 +158,18 @@ try {
     assert.equal(db.prepare(`SELECT COUNT(*) n FROM ${table} WHERE ${where}`).get(...parameters).n, 0, `${table} no longer references the deleted idea`);
   }
 
+  // ── 7. Allocation keeps counting past the four-digit ceiling ───────────────
+  // Ids are padded to four digits, so ordering them as TEXT is only honest up to
+  // g-9999: past it 'g-9999' > 'g-10000'. A corpus that crossed 9,999 ideas then
+  // got g-10000 proposed on every call, and every deep scan with a genuinely new
+  // idea to record died on UNIQUE constraint failed: ideas.global_id.
+  db.prepare("INSERT INTO ideas (global_id, type, label, statement, created_at) VALUES ('g-9999', 'claim', 'Techo', 'x', ?)")
+    .run(new Date().toISOString());
+  const crossing = repo.createIdea({ type: 'claim', label: 'Cruza el techo', statement: 'x', embedding: null });
+  assert.equal(crossing.global_id, 'g-10000', 'the id after g-9999 is g-10000');
+  const beyond = repo.createIdea({ type: 'claim', label: 'Y sigue', statement: 'x', embedding: null });
+  assert.equal(beyond.global_id, 'g-10001', 'allocation keeps counting once ids outgrow four digits');
+
   db.close();
   console.log('idea identity (dormancy + revival) test passed');
 } finally {

--- a/src/components/QueueBar.tsx
+++ b/src/components/QueueBar.tsx
@@ -151,11 +151,15 @@ export function QueueBar() {
                   <span className="truncate flex-1">{queueTitle(it)}</span>
                   <span className="uppercase text-[10px] text-neutral-500 mx-2">{t(KIND_LABELS[it.kind]) ?? it.kind}</span>
                   <span
+                    // The queue has always carried why an item failed and never shown it,
+                    // so a failure read as a bare "Fallido" and the reason lived only in
+                    // the DevTools console. Hover the state to read it.
+                    title={it.error ?? undefined}
                     className={
                       it.state === 'done'
                         ? 'text-emerald-400'
                         : it.state === 'failed'
-                          ? 'text-red-400'
+                          ? 'cursor-help text-red-400 underline decoration-dotted underline-offset-2'
                           : it.state === 'running'
                             ? 'text-indigo-400'
                             : 'text-neutral-500'


### PR DESCRIPTION
Closes #368.

`nextGlobalId()` read the idea counter as text. Ids are padded to four digits,
which keeps a text sort honest only up to `g-9999`: past that ceiling
`'g-9999'` sorts above `'g-10000'` character by character, so
`ORDER BY global_id DESC` kept answering `g-9999` and the allocator proposed
`g-10000` on every call. `global_id` is the primary key, so the first idea
minted after the ceiling was fine and every one after it died on
`UNIQUE constraint failed: ideas.global_id`.

## What changed

- **`electron/db/ideasRepo.ts`** — read the counter as a number
  (`MAX(CAST(substr(global_id, 3) AS INTEGER))`). Ids keep their four-digit
  padding and grow to five digits on their own. Nothing already stored has to
  change and there is no migration: `g-10000` is a legitimate idea.
- **`src/components/QueueBar.tsx`** — the queue has always carried the reason an
  item failed and never rendered it, which is why this read as a bare "Failed"
  for a month. The state label now carries the message as a tooltip.
- **`scripts/test-idea-identity.mjs`** — the identity test crosses the ceiling
  for real: it seeds `g-9999`, mints the `g-10000` that used to be the last id
  ever allocated, and asserts the next one is `g-10001`.

## Verification

- **The test fails first.** Against the old allocator the new section dies with
  `SqliteError: UNIQUE constraint failed: ideas.global_id` — the exact error
  from the field. With the fix, the file passes.
- **Against a copy of a real affected vault** (9,959 ideas, highest by text
  `g-9999`, highest by number `10000`), the real `createIdea` mints
  `g-10001`, `g-10002`, `g-10003` and all three rows land — no collision.
  Run on a snapshot, never on the live vault.
- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm test` — 1703/1704. The one failure is `test-prosopography-e2e.mjs`
  waiting on `startup-update-modal`, which reproduces identically on a clean
  tree with these changes stashed: a stale build in this worktree, unrelated
  to this work.