### PR TITLE
Put the reasoning level where the model is chosen

### DIFF
--- a/scripts/test-codex-reasoning.mjs
+++ b/scripts/test-codex-reasoning.mjs
@@ -1,0 +1,102 @@
+// The reasoning level a Codex model runs at, chosen from either the Providers tab (a
+// row per model) or the Models tab (beside the picker of each role). Both screens must
+// land on the same value, which is only true because both go through one writer and
+// key the map by MODEL, never by role. Drives the real shared module.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = await mkdtemp(path.join(os.tmpdir(), 'nodus-codex-reasoning-'));
+const outfile = path.join(outDir, 'codexReasoning.mjs');
+await build({
+  entryPoints: [path.join(repoRoot, 'shared/codexReasoning.ts')],
+  outfile,
+  bundle: true,
+  format: 'esm',
+  platform: 'node',
+});
+const { codexReasoningCatalog, reasoningChoiceFor, withCodexReasoning } = await import(pathToFileURL(outfile).href);
+
+// Shaped like what listModels('codex') actually returns, taken from the live catalogue.
+const MODELS = [
+  {
+    id: 'gpt-5.6-luna',
+    name: 'gpt-5.6-luna',
+    supportedReasoningEfforts: [
+      { reasoningEffort: 'low', description: 'Fast responses with lighter reasoning' },
+      { reasoningEffort: 'medium', description: 'Balances speed and reasoning depth' },
+      { reasoningEffort: 'high', description: 'Greater reasoning depth' },
+    ],
+    defaultReasoningEffort: 'medium',
+  },
+  { id: 'sin-niveles', name: 'sin-niveles', supportedReasoningEfforts: [] },
+  { id: 'sin-campo', name: 'sin-campo' },
+];
+
+test('only models that publish levels enter the catalogue', () => {
+  const catalog = codexReasoningCatalog(MODELS);
+  assert.deepEqual(Object.keys(catalog), ['gpt-5.6-luna'], 'a model without levels must not get an entry');
+  assert.equal(catalog['gpt-5.6-luna'].fallback, 'medium', 'the default level is what «Predeterminado» resolves to');
+  assert.equal(catalog['gpt-5.6-luna'].supported.length, 3);
+});
+
+test('a selector is offered only where a level can actually be chosen', () => {
+  const catalog = codexReasoningCatalog(MODELS);
+  assert.ok(reasoningChoiceFor(catalog, { provider: 'codex', model: 'gpt-5.6-luna' }));
+  assert.equal(reasoningChoiceFor(catalog, { provider: 'codex', model: 'sin-niveles' }), null);
+  assert.equal(reasoningChoiceFor(catalog, { provider: 'codex', model: 'desconocido' }), null);
+  assert.equal(reasoningChoiceFor(catalog, { provider: 'gemini', model: 'gemini-3.1-flash-lite' }), null,
+    'no other provider publishes reasoning levels, so no other provider gets a selector');
+  assert.equal(reasoningChoiceFor(catalog, null), null);
+  assert.equal(reasoningChoiceFor(null, { provider: 'codex', model: 'gpt-5.6-luna' }), null,
+    'before the catalogue loads there is nothing to offer');
+});
+
+test('the level belongs to the model, so both screens agree', () => {
+  // Providers writes it from the model row; Models writes it from a role's picker.
+  const fromProviders = withCodexReasoning({}, 'gpt-5.6-luna', 'low');
+  const fromModels = withCodexReasoning({}, 'gpt-5.6-luna', 'low');
+  assert.deepEqual(fromProviders, fromModels, 'the same choice must produce the same stored map');
+  assert.deepEqual(fromProviders, { 'gpt-5.6-luna': 'low' });
+
+  // Two roles on the same model share one entry: changing it in one changes it in both.
+  const shared = withCodexReasoning(fromModels, 'gpt-5.6-luna', 'high');
+  assert.deepEqual(shared, { 'gpt-5.6-luna': 'high' }, 'the map is keyed by model, never by role');
+
+  // Back to «Predeterminado» clears the entry instead of storing a sentinel, so the
+  // model keeps following its own recommendation when Codex changes it.
+  assert.deepEqual(withCodexReasoning(shared, 'gpt-5.6-luna', null), {});
+  assert.deepEqual(withCodexReasoning(undefined, 'otro', 'max'), { otro: 'max' }, 'an unset map is not a crash');
+
+  const before = { a: 'low' };
+  withCodexReasoning(before, 'b', 'high');
+  assert.deepEqual(before, { a: 'low' }, 'the stored settings object is never mutated in place');
+});
+
+test('every model picker that drives a role carries its reasoning level', async () => {
+  const [settings, providers, picker] = await Promise.all([
+    readFile(path.join(repoRoot, 'src/views/Settings.tsx'), 'utf8'),
+    readFile(path.join(repoRoot, 'src/views/ProvidersSettings.tsx'), 'utf8'),
+    readFile(path.join(repoRoot, 'src/components/ModelPicker.tsx'), 'utf8'),
+  ]);
+
+  for (const role of ['synthesisModel', 'extractionModel', 'visionModel', 'summaryModel', 'fusionModel', 'nodiModel']) {
+    const row = settings.match(new RegExp(`<ModelWithReasoning[^>]*settings\\.${role}[^>]*>`));
+    assert.ok(row, `the ${role} picker must offer the reasoning level next to it`);
+  }
+  assert.match(settings, /<ModelWithReasoning[^>]*settings\[key\]/, 'per-vault overrides carry it too');
+  assert.match(settings, /<ModelWithReasoning[^>]*settings\[item\.key\]/, 'the study vault overrides carry it too');
+
+  // One writer, or the two screens drift apart the first time one of them is edited.
+  assert.match(providers, /withCodexReasoning\(settings\.codexReasoningEfforts, model, effort\)/);
+  assert.equal(/function codexReasoningLabel/.test(providers), false,
+    'the level labels must come from the shared component, not a second private copy');
+  assert.match(picker, /withCodexReasoning\(\s*settings\.codexReasoningEfforts/);
+});
+
+await rm(outDir, { recursive: true, force: true });

--- a/scripts/test-settings-visual-regressions.mjs
+++ b/scripts/test-settings-visual-regressions.mjs
@@ -34,7 +34,9 @@ assert.equal((settings.match(/className=\{ABOUT_ACTION_BUTTON_CLASS\}/g) ?? []).
 assert.match(settings, /data-testid="open-latest-changes"[\s\S]*onClick=\{onOpenWhatsNew\}/);
 
 const nodiOverride = settings.match(/<Row label=\{t\('Asistente Nodi'\)\}>(.*?)<\/Row>/s)?.[1] ?? '';
-assert.match(nodiOverride, /<ModelPicker/);
+// ModelWithReasoning is the native picker plus its reasoning level; every adjacent
+// advanced field uses it, so naming it here still pins Nodi to the same control.
+assert.match(nodiOverride, /<ModelWithReasoning/);
 assert.equal(/\bmenu\b/.test(nodiOverride), false, 'the Nodi override must use the same native-size picker as adjacent advanced fields');
 
 console.log('settings visual regression checks passed');

--- a/shared/codexReasoning.ts
+++ b/shared/codexReasoning.ts
@@ -1,0 +1,56 @@
+import type { CodexReasoningEffort, ModelInfo, ModelRef } from './types';
+
+/** The reasoning levels one model publishes, plus the level it falls back to when the
+ *  user leaves it on «Predeterminado». */
+export interface CodexReasoningChoice {
+  supported: NonNullable<ModelInfo['supportedReasoningEfforts']>;
+  fallback: CodexReasoningEffort | null;
+}
+
+export type CodexReasoningCatalog = Record<string, CodexReasoningChoice>;
+
+/**
+ * Index a provider's model list by the reasoning levels each model advertises. Models
+ * that publish none are left out entirely, so «this model has no levels» is a plain
+ * absence and a caller can decide to render no selector without a second condition.
+ */
+export function codexReasoningCatalog(models: ModelInfo[]): CodexReasoningCatalog {
+  const catalog: CodexReasoningCatalog = {};
+  for (const model of models) {
+    const supported = model.supportedReasoningEfforts ?? [];
+    if (supported.length === 0) continue;
+    catalog[model.id] = { supported, fallback: model.defaultReasoningEffort ?? null };
+  }
+  return catalog;
+}
+
+/** The levels a specific selection can offer, or null when it can offer none — a
+ *  non-Codex provider, a model outside the catalogue, or one with no levels. */
+export function reasoningChoiceFor(
+  catalog: CodexReasoningCatalog | null,
+  model: ModelRef | null | undefined
+): CodexReasoningChoice | null {
+  if (!catalog || model?.provider !== 'codex') return null;
+  return catalog[model.model] ?? null;
+}
+
+/**
+ * The single writer for the per-model reasoning map. Providers and Models both go
+ * through it, which is what makes the two screens agree: the level belongs to the
+ * model, not to the role that happens to be using it, so choosing it once in either
+ * place is choosing it everywhere that model runs.
+ *
+ * Null clears the entry rather than storing a sentinel, so «Predeterminado» stays the
+ * absence of a choice and keeps following the model's own recommendation when Codex
+ * changes it.
+ */
+export function withCodexReasoning(
+  current: Record<string, CodexReasoningEffort> | undefined,
+  model: string,
+  effort: CodexReasoningEffort | null
+): Record<string, CodexReasoningEffort> {
+  const next = { ...(current ?? {}) };
+  if (effort) next[model] = effort;
+  else delete next[model];
+  return next;
+}

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
-import type { AppSettings, ModelRef } from '@shared/types';
+import type { AppSettings, CodexReasoningEffort, ModelRef } from '@shared/types';
 import { isSubscriptionProvider } from '@shared/providers';
 import { modelRefSupportsExtraction } from '@shared/localAiModels';
+import {
+  codexReasoningCatalog,
+  reasoningChoiceFor,
+  withCodexReasoning,
+  type CodexReasoningCatalog,
+} from '@shared/codexReasoning';
 import { modelLabel, sameModel, sortModelRefs } from './ui';
 import { Icon } from './ui';
-import { t } from '../i18n';
+import { t, tx } from '../i18n';
 import './modelPicker.css';
 
 /**
@@ -42,6 +48,148 @@ export function ExtractionCapabilityNotice({ model }: { model: ModelRef | null |
     >
       {t('Este modelo local es de visión y no extrae ideas de forma fiable (tiende a divagar y no cerrar el JSON). Para extracción, elige Gemma 4 E2B u otro modelo mayor.')}
     </p>
+  );
+}
+
+export function codexReasoningLabel(effort: CodexReasoningEffort): string {
+  switch (effort) {
+    case 'none': return t('Ninguno');
+    case 'minimal': return t('Mínimo');
+    case 'low': return t('Bajo');
+    case 'medium': return t('Medio');
+    case 'high': return t('Alto');
+    case 'xhigh': return t('Muy alto');
+    case 'max': return t('Máximo');
+    case 'ultra': return t('Ultra');
+    default: return effort.replace(/[_-]+/g, ' ').replace(/^./, (letter) => letter.toUpperCase());
+  }
+}
+
+/**
+ * One catalogue read per app session, shared by every picker on screen. Codex is the
+ * only provider that publishes reasoning levels, so nothing is fetched until a Codex
+ * model is actually selected somewhere. A failure (no subscription connected) clears
+ * the cache so the next picker to mount can try again instead of being stuck empty.
+ */
+let catalogRequest: Promise<CodexReasoningCatalog> | null = null;
+
+function loadCodexReasoningCatalog(): Promise<CodexReasoningCatalog> {
+  if (!catalogRequest) {
+    catalogRequest = window.nodus
+      .listModels('codex')
+      .then(codexReasoningCatalog)
+      .catch(() => { catalogRequest = null; return {}; });
+  }
+  return catalogRequest;
+}
+
+/** Test seam: hand the catalogue in directly instead of going through the provider. */
+export function primeCodexReasoningCatalog(catalog: CodexReasoningCatalog | null): void {
+  catalogRequest = catalog ? Promise.resolve(catalog) : null;
+}
+
+function useCodexReasoningCatalog(model: ModelRef | null | undefined): CodexReasoningCatalog | null {
+  const [catalog, setCatalog] = useState<CodexReasoningCatalog | null>(null);
+  const isCodex = model?.provider === 'codex';
+  useEffect(() => {
+    if (!isCodex) return;
+    let alive = true;
+    void loadCodexReasoningCatalog().then((loaded) => { if (alive) setCatalog(loaded); });
+    return () => { alive = false; };
+  }, [isCodex]);
+  return catalog;
+}
+
+/**
+ * The reasoning level for the model a role is using, rendered beside its picker so the
+ * choice lives where the model is chosen. It writes the same per-model map the
+ * Providers tab writes, so the two screens are never out of step. Renders nothing when
+ * the selected model publishes no levels, which is every provider except Codex today.
+ */
+export function ReasoningPicker({
+  settings,
+  model,
+  patch,
+  compact,
+}: {
+  settings: AppSettings;
+  model: ModelRef | null | undefined;
+  patch: (value: Partial<AppSettings>) => Promise<void> | void;
+  compact?: boolean;
+}) {
+  const catalog = useCodexReasoningCatalog(model);
+  const choice = reasoningChoiceFor(catalog, model);
+  if (!choice || !model) return null;
+  return (
+    <select
+      // Wide enough for the longest level plus its "(default)" suffix in every
+      // language, and never allowed to shrink: a truncated level reads as a different
+      // level. The picker beside it keeps a floor of its own so neither can vanish.
+      className={`input w-48 shrink-0 ${compact ? 'py-1 text-xs' : 'text-xs'}`}
+      data-testid={`model-reasoning-${model.model}`}
+      aria-label={tx('Razonamiento de {model}', { model: modelLabel(model) })}
+      title={t('Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.')}
+      value={settings.codexReasoningEfforts?.[model.model] ?? ''}
+      onChange={(event) => void patch({
+        codexReasoningEfforts: withCodexReasoning(
+          settings.codexReasoningEfforts,
+          model.model,
+          event.target.value ? (event.target.value as CodexReasoningEffort) : null
+        ),
+      })}
+    >
+      <option value="">
+        {choice.fallback
+          ? tx('{level} (predeterminado)', { level: codexReasoningLabel(choice.fallback) })
+          : t('Predeterminado')}
+      </option>
+      {choice.supported.map((option) => (
+        <option key={option.reasoningEffort} value={option.reasoningEffort} title={option.description}>
+          {codexReasoningLabel(option.reasoningEffort)}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/**
+ * A role's model picker with its reasoning level next to it. The reasoning selector
+ * only takes width when the chosen model actually offers levels, so rows for models
+ * without them look exactly as they did.
+ */
+export function ModelWithReasoning({
+  settings,
+  value,
+  onChange,
+  patch,
+  compact,
+  allowEmpty = true,
+  emptyLabel,
+  requireExtraction = false,
+}: {
+  settings: AppSettings;
+  value: ModelRef | null;
+  onChange: (m: ModelRef | null) => void;
+  patch: (value: Partial<AppSettings>) => Promise<void> | void;
+  compact?: boolean;
+  allowEmpty?: boolean;
+  emptyLabel?: string;
+  requireExtraction?: boolean;
+}) {
+  return (
+    <div className="flex w-full min-w-0 flex-wrap items-center gap-2">
+      <ModelPicker
+        className="min-w-[8rem] flex-1"
+        settings={settings}
+        value={value}
+        onChange={onChange}
+        compact={compact}
+        allowEmpty={allowEmpty}
+        emptyLabel={emptyLabel}
+        requireExtraction={requireExtraction}
+      />
+      <ReasoningPicker settings={settings} model={value} patch={patch} compact={compact} />
+    </div>
   );
 }
 

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -1363,6 +1363,8 @@ export const DE: Record<string, string> = {
   'Cargar modelos de Codex': 'Codex-Modelle laden',
   'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
     'Jedes Modell zeigt nur die von Codex veröffentlichten Reasoning-Stufen. „Standard“ verwendet die vom Modell empfohlene Stufe.',
+  'Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.':
+    'Reasoning-Stufe. Weniger Reasoning antwortet schneller, und die Stufe gehört zum Modell, ändert sich also für jede Aufgabe, die es verwendet.',
   'Razonamiento de {model}': 'Reasoning für {model}',
   '{level} (predeterminado)': '{level} (Standard)',
   Ninguno: 'Keines',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -1372,6 +1372,8 @@ export const EN: Record<string, string> = {
   'Cargar modelos de Codex': 'Load Codex models',
   'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
     'Each model shows only the reasoning levels published by Codex. “Default” uses the model’s recommended level.',
+  'Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.':
+    'Reasoning level. Less reasoning answers sooner, and the level belongs to the model, so it changes for every task that uses it.',
   'Razonamiento de {model}': 'Reasoning for {model}',
   '{level} (predeterminado)': '{level} (default)',
   Ninguno: 'None',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -1363,6 +1363,8 @@ export const FR: Record<string, string> = {
   'Cargar modelos de Codex': 'Charger les modèles Codex',
   'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
     'Chaque modèle affiche uniquement les niveaux de raisonnement publiés par Codex. « Par défaut » utilise le niveau recommandé par le modèle.',
+  'Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.':
+    'Niveau de raisonnement. Moins de raisonnement répond plus vite, et le niveau appartient au modèle, il change donc pour toutes les tâches qui l\'utilisent.',
   'Razonamiento de {model}': 'Raisonnement pour {model}',
   '{level} (predeterminado)': '{level} (par défaut)',
   Ninguno: 'Aucun',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -1252,6 +1252,8 @@ export const IT: Record<string, string> = {
   "Límite secundario": "Limite secondario",
   "Cargar modelos de Codex": "Carica i modelli del Codice",
   "Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.": "Ogni modello mostra solo i livelli di ragionamento pubblicati dal Codex. \"Default\" utilizza il livello consigliato dal modello.",
+  "Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.":
+    "Livello di ragionamento. Meno ragionamento risponde prima e il livello appartiene al modello, quindi cambia in tutte le attività che lo usano.",
   "Razonamiento de {model}": "Ragionamento per {model}",
   "{level} (predeterminado)": "{level} (predefinito)",
   "Ninguno": "Nessuno",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -1353,6 +1353,8 @@ export const PT_BR: Record<string, string> = {
   'Cargar modelos de Codex': 'Carregar modelos do Codex',
   'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
     'Cada modelo mostra apenas os níveis de raciocínio publicados pelo Codex. “Padrão” usa o nível recomendado pelo modelo.',
+  'Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.':
+    'Nível de raciocínio. Menos raciocínio responde mais rápido e o nível pertence ao modelo, então muda em todas as tarefas que o usam.',
   'Razonamiento de {model}': 'Raciocínio para {model}',
   '{level} (predeterminado)': '{level} (padrão)',
   Ninguno: 'Nenhum',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -1351,6 +1351,8 @@ export const PT: Record<string, string> = {
   'Cargar modelos de Codex': 'Carregar modelos Codex',
   'Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.':
     'Cada modelo mostra apenas os níveis de raciocínio publicados pelo Codex. «Predefinido» utiliza o nível recomendado pelo modelo.',
+  'Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.':
+    'Nível de raciocínio. Menos raciocínio responde mais depressa e o nível pertence ao modelo, por isso muda em todas as tarefas que o usem.',
   'Razonamiento de {model}': 'Raciocínio para {model}',
   '{level} (predeterminado)': '{level} (predefinido)',
   Ninguno: 'Nenhum',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -1640,6 +1640,8 @@ export const TR: Record<string, string> = {
   "Límite secundario": "İkincil sınır",
   "Cargar modelos de Codex": "Codex Modellerini Yükle",
   "Cada modelo muestra únicamente los niveles de razonamiento publicados por Codex. «Predeterminado» usa el nivel recomendado por el modelo.": "Her model yalnızca Codex tarafından yayınlanan muhakeme seviyelerini görüntüler. “Varsayılan” model tarafından önerilen düzeyi kullanır.",
+  "Nivel de razonamiento. Menos razonamiento responde antes y el nivel es del modelo, así que cambia en todas las tareas que lo usen.":
+    "Akıl yürütme düzeyi. Daha az akıl yürütme daha hızlı yanıt verir ve düzey modele aittir, bu yüzden onu kullanan tüm görevlerde değişir.",
   "Razonamiento de {model}": "{model} gerekçesi",
   "{level} (predeterminado)": "{level} (varsayılan)",
   "Ninguno": "Yok",

--- a/src/views/ProvidersSettings.tsx
+++ b/src/views/ProvidersSettings.tsx
@@ -19,6 +19,8 @@ import { DEFAULT_LOCAL_BASE_URLS, supportsFreeTierShaping } from '@shared/provid
 import { AI_PROVIDERS, PROVIDER_LABELS, isLocalAiProvider, modelLabel, sameModel } from '../components/ui';
 import { IMAGE_PROVIDER_LABELS } from '@shared/providers';
 import { SettingsModelDot, SettingsModelList, settingsModelRowClass } from '../components/SettingsModelList';
+import { codexReasoningLabel } from '../components/ModelPicker';
+import { withCodexReasoning } from '@shared/codexReasoning';
 import { t, tx } from '../i18n';
 
 export function ProvidersSettings({
@@ -228,10 +230,11 @@ function ChatGptSubscriptionRow({
   };
 
   const setReasoning = async (model: string, effort: CodexReasoningEffort | null) => {
-    const next = { ...(settings.codexReasoningEfforts ?? {}) };
-    if (effort) next[model] = effort;
-    else delete next[model];
-    await window.nodus.updateSettings({ codexReasoningEfforts: next });
+    // Same writer the Models tab uses: the level belongs to the model, so choosing it
+    // in either screen is choosing it for every task that runs that model.
+    await window.nodus.updateSettings({
+      codexReasoningEfforts: withCodexReasoning(settings.codexReasoningEfforts, model, effort),
+    });
     await onChange();
   };
 
@@ -1137,16 +1140,3 @@ function ModelList({
   return <div>{rows}</div>;
 }
 
-function codexReasoningLabel(effort: CodexReasoningEffort): string {
-  switch (effort) {
-    case 'none': return t('Ninguno');
-    case 'minimal': return t('Mínimo');
-    case 'low': return t('Bajo');
-    case 'medium': return t('Medio');
-    case 'high': return t('Alto');
-    case 'xhigh': return t('Muy alto');
-    case 'max': return t('Máximo');
-    case 'ultra': return t('Ultra');
-    default: return effort.replace(/[_-]+/g, ' ').replace(/^./, (letter) => letter.toUpperCase());
-  }
-}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -32,7 +32,7 @@ import { LegalDocModal } from '../components/LegalDocModal';
 import { LEGAL_DOCS, type LegalDocId } from '../legalDocs';
 import { confirm } from '../components/feedback';
 import { Icon, PROVIDER_LABELS } from '../components/ui';
-import { ModelPicker, SubscriptionQuotaNotice, ExtractionCapabilityNotice } from '../components/ModelPicker';
+import { ModelPicker, ModelWithReasoning, SubscriptionQuotaNotice, ExtractionCapabilityNotice } from '../components/ModelPicker';
 import { NodiStylePicker } from '../components/nodi/NodiStylePicker';
 import { TutorialVideoGrid } from '../components/TutorialVideos';
 import { vaultTypeLabel } from '../components/VaultSwitcher';
@@ -2393,7 +2393,7 @@ export function Settings({
             </p>
             {settings.modelSettingsMode === 'basic' && <>
               <Row label={t('Modelo general de texto')} hint={t('Conversación, análisis, resúmenes y demás tareas de texto.')}>
-                <ModelPicker settings={settings} value={settings.synthesisModel} onChange={(m) => patch({ synthesisModel: m })} requireExtraction />
+                <ModelWithReasoning settings={settings} patch={patch} value={settings.synthesisModel} onChange={(m) => patch({ synthesisModel: m })} requireExtraction />
               </Row>
               {/* In basic mode this one model runs the scans too, so it is the single
                   most expensive place to pick a subscription-billed provider — and it must be able
@@ -2427,17 +2427,17 @@ export function Settings({
                 <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-neutral-500">{t('Ajustes avanzados comunes')}</h3>
                 {/* The four selectors below drive the scan pipeline: one run covers a
                     whole corpus, so a subscription plan's quota is the real limit. */}
-                <Row label={t('Extracción de temas, ideas y evidencias')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.extractionModel} onChange={(extractionModel) => void patch({ extractionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
+                <Row label={t('Extracción de temas, ideas y evidencias')}><ModelWithReasoning allowEmpty={false} settings={settings} patch={patch} value={settings.extractionModel} onChange={(extractionModel) => void patch({ extractionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
                 <ExtractionCapabilityNotice model={settings.extractionModel} />
                 <SubscriptionQuotaNotice model={settings.extractionModel} />
-                <Row label={t('Visión y OCR de imágenes')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.visionModel} onChange={(visionModel) => void patch({ visionModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <Row label={t('Visión y OCR de imágenes')}><ModelWithReasoning allowEmpty={false} settings={settings} patch={patch} value={settings.visionModel} onChange={(visionModel) => void patch({ visionModel })} emptyLabel="Seleccionar modelo" /></Row>
                 <SubscriptionQuotaNotice model={settings.visionModel} />
-                <Row label={t('Resúmenes de obras')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.summaryModel} onChange={(summaryModel) => void patch({ summaryModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <Row label={t('Resúmenes de obras')}><ModelWithReasoning allowEmpty={false} settings={settings} patch={patch} value={settings.summaryModel} onChange={(summaryModel) => void patch({ summaryModel })} emptyLabel="Seleccionar modelo" /></Row>
                 <SubscriptionQuotaNotice model={settings.summaryModel} />
-                <Row label={t('Fusión y deduplicación')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.fusionModel} onChange={(fusionModel) => void patch({ fusionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
+                <Row label={t('Fusión y deduplicación')}><ModelWithReasoning allowEmpty={false} settings={settings} patch={patch} value={settings.fusionModel} onChange={(fusionModel) => void patch({ fusionModel })} emptyLabel="Seleccionar modelo" requireExtraction /></Row>
                 <ExtractionCapabilityNotice model={settings.fusionModel} />
                 <SubscriptionQuotaNotice model={settings.fusionModel} />
-                <Row label={t('Asistente Nodi')}><ModelPicker className="w-full" allowEmpty={false} settings={settings} value={settings.nodiModel} onChange={(nodiModel) => void patch({ nodiModel })} emptyLabel="Seleccionar modelo" /></Row>
+                <Row label={t('Asistente Nodi')}><ModelWithReasoning allowEmpty={false} settings={settings} patch={patch} value={settings.nodiModel} onChange={(nodiModel) => void patch({ nodiModel })} emptyLabel="Seleccionar modelo" /></Row>
               </div>
               <VaultModelOverrides settings={settings} vaultType={activeVault?.type ?? 'academic'} vaultName={activeVault?.name ?? t('Vault actual')} patch={patch} />
             </>}
@@ -3105,7 +3105,7 @@ function VaultModelOverrides({ settings, vaultType, vaultName, patch }: {
     <p className="mb-3 mt-1 text-xs text-neutral-600">{t('Estos cambios no modifican los demás vaults.')}</p>
     {vaultType === 'estudio' ? <StudyVaultModelOverrides settings={settings} patch={patch} /> : <div className="space-y-3">
       {keys.map((key) => <Row key={key} label={t(VAULT_MODEL_FIELDS[key])}>
-        <ModelPicker allowEmpty={false} settings={settings} value={settings[key]} onChange={(model) => void patch({ [key]: model })} emptyLabel="Seleccionar modelo" />
+        <ModelWithReasoning allowEmpty={false} settings={settings} patch={patch} value={settings[key]} onChange={(model) => void patch({ [key]: model })} emptyLabel="Seleccionar modelo" />
       </Row>)}
     </div>}
   </div>;
@@ -3128,8 +3128,8 @@ function StudyVaultModelOverrides({ settings, patch }: {
     <b className="text-neutral-600">{t('Alternativo ante error')}</b>
     {STUDY_VAULT_MODEL_FIELDS.map((item) => <div key={item.task} className="contents">
       <span className="self-center text-neutral-300">{t(item.label)}</span>
-      <ModelPicker compact allowEmpty={false} settings={settings} value={settings[item.key]} onChange={(model) => void patch({ [item.key]: model })} emptyLabel="Seleccionar modelo" />
-      <ModelPicker compact settings={settings} value={settings.studyAiFallbackModels[item.task] ?? null} onChange={(model) => void patch({ studyAiFallbackModels: { ...settings.studyAiFallbackModels, [item.task]: model } })} emptyLabel="Sin modelo alternativo" />
+      <ModelWithReasoning compact allowEmpty={false} settings={settings} patch={patch} value={settings[item.key]} onChange={(model) => void patch({ [item.key]: model })} emptyLabel="Seleccionar modelo" />
+      <ModelWithReasoning compact settings={settings} patch={patch} value={settings.studyAiFallbackModels[item.task] ?? null} onChange={(model) => void patch({ studyAiFallbackModels: { ...settings.studyAiFallbackModels, [item.task]: model } })} emptyLabel="Sin modelo alternativo" />
     </div>)}
   </div>;
 }


### PR DESCRIPTION
Closes #370.

Every picker in Settings › Models that assigns a model to a job now carries its
reasoning level beside it, and the two screens that can set it agree by
construction.

## What changed

- **`shared/codexReasoning.ts`** (new) — the pure part: index a model list by the
  levels each model publishes, decide whether a selection can offer any, and one
  writer for the per-model map. Providers and Models both go through that writer,
  which is what keeps them in step. Null clears the entry instead of storing a
  sentinel, so «Predeterminado» stays the absence of a choice and keeps following
  the model's own recommendation when Codex changes it.
- **`src/components/ModelPicker.tsx`** — `ReasoningPicker` and the
  `ModelWithReasoning` pairing. The catalogue is read once per session and shared
  by every picker on screen, and nothing is fetched until a Codex model is
  actually selected somewhere. `codexReasoningLabel` moved here from
  ProvidersSettings so there is one set of level names.
- **`src/views/Settings.tsx`** — the general text model, the five shared advanced
  roles, the per-vault overrides and the study vault's primary and fallback
  columns.
- **`src/views/ProvidersSettings.tsx`** — same writer, private copy of the labels
  deleted.
- **`src/i18n.*.ts`** — one new string in all seven languages. The aria-label
  reuses the key Providers already had.

Models that publish no levels render no second control at all, so every row for
every other provider is untouched.

## Verification

- **New test, and it fails first.** `scripts/test-codex-reasoning.mjs` drives the
  real shared module. Reverting one picker to the plain `ModelPicker` fails the
  wiring assertion, and dropping the clear-on-default branch fails the agreement
  assertion — both were confirmed red before going green.
- **Rendered against the compiled stylesheet** in headless Chrome, light and
  dark, at 980 px and at 700 px (narrower than the settings panel can be, since
  the window has `minWidth: 1024`). Two rounds: the first showed the level
  clipped at `w-32` and the picker able to collapse, so the level went to `w-48`
  with the longest label every language can produce, and the picker gained a
  floor.
- `npm run typecheck`, `npm run lint`, `npm run build` — clean.
- `npm test` — 1708/1708.
- `scripts/test-settings-visual-regressions.mjs` pinned the Nodi row to
  `<ModelPicker` by name. Updated to `<ModelWithReasoning`, which is that same
  native picker plus the level, so the check keeps its intent rather than being
  loosened.