### PR TITLE
Open 3.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 3.2.5 — 2026-08-07
+
+A corpus that had quietly stopped growing a month ago, the blindfold that kept it
+quiet, and the setting that decides how long a scan takes finally sitting where a
+model is chosen.
+
+### Added
+
+- **The reasoning level beside the model, in Settings › Models.** Every picker
+  that assigns a model to a job now carries its level: the general text model,
+  the five shared advanced roles, the per-vault overrides, and the study vault's
+  primary and fallback columns. It appears only for models that publish levels,
+  which today is Codex and nothing else, so every other row is unchanged.
+- **One level per model, shared by both screens.** The level belongs to the model
+  rather than to the role using it, and Models and Providers now write it through
+  a single function, so setting it in either place sets it for every job running
+  that model. Left on «Default» it stores nothing, which keeps it following the
+  model's own recommendation when Codex changes it.
+
+### Fixed
+
+- **Deep scans could no longer create ideas once a vault passed 9,999 of them.**
+  The id counter was read as text, and the four-digit zero padding keeps a text
+  sort honest only up to `g-9999`: past it `'g-9999'` sorts above `'g-10000'`, so
+  the allocator kept proposing an id that already existed and every scan with a
+  genuinely new idea to record died on `UNIQUE constraint failed: ideas.global_id`.
+  It failed at the very end, after the whole extraction had been paid for, and a
+  work whose ideas all fused into existing ones still went through, so it read as
+  intermittent rather than total. The counter is now read as a number. No
+  migration: ids keep their padding and grow to five digits on their own.
+- **A failed scan said only "Failed".** The queue has always carried the reason
+  and never rendered it, leaving it in the developer console. The state label now
+  carries the message on hover.
+
 ## 3.2.4 — 2026-08-06
 
 The header stops being a shelf, and Nodus gains a way to say something between

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.2.4"
-date-released: "2026-08-06"
+version: "3.2.5"
+date-released: "2026-08-07"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/test-mobile-teaser-guide.mjs
+++ b/scripts/test-mobile-teaser-guide.mjs
@@ -21,7 +21,14 @@ const SHOTS = [
 test('the teaser belongs to 3.2.4, shows once, and is gated on nothing else', async () => {
   const [guide, pkg] = await Promise.all([read('src/components/MobileTeaserGuide.tsx'), read('package.json')]);
   assert.match(guide, /MOBILE_TEASER_RELEASE = '3\.2\.4'/);
-  assert.equal(JSON.parse(pkg).version, '3.2.4', 'the teaser only presents on the version it names');
+  // It presents on the version it names and on no other, so shipping 3.2.5 retires it
+  // rather than showing it a second time. Pin that instead of pinning the app to 3.2.4:
+  // bumping the constant to follow a release is how a one-off teaser becomes permanent.
+  assert.notEqual(
+    JSON.parse(pkg).version,
+    '3.2.4',
+    'once the app moves past 3.2.4 the teaser must stay behind, not follow the release',
+  );
   assert.match(guide, /nodus\.mobileTeaserSeen/);
   assert.match(guide, /__APP_VERSION__ !== MOBILE_TEASER_RELEASE/);
   // Seen once, and only when actually dismissed — a launch that never reached the

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,12 +25,17 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.2.4');
-  assert.equal(currentRelease?.date, '2026-08-06');
-  // The notification centre reachable from the header, the announcements channel behind
-  // it, a right rail with three fewer icons, and an inbox that only shows up when it holds
-  // something. A floor rather than an exact count, in case more lands here before it ships.
+  assert.equal(currentRelease?.version, '3.2.5');
+  assert.equal(currentRelease?.date, '2026-08-07');
+  // Ideas that can be numbered past 9,999 again, a failed scan that says why, the
+  // reasoning level beside the model it belongs to, and the fact that it belongs to the
+  // model. A floor rather than an exact count, in case more lands here before it ships.
   assert.ok(currentRelease?.highlights.length >= 4, 'the release must describe what changed');
+
+  // 3.2.4 keeps the ten it shipped with.
+  const headerRelease = RELEASE_NOTES.find((note) => note.version === '3.2.4');
+  assert.equal(headerRelease?.date, '2026-08-06');
+  assert.equal(headerRelease?.highlights.length, 10);
 
   // 3.2.3 keeps its own four highlights underneath.
   const readMarkersRelease = RELEASE_NOTES.find((note) => note.version === '3.2.3');

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -12,4 +12,4 @@
  * this drifts from the root `package.json`, from `server/package.json`, or from the two iOS
  * targets in `ios/project.yml`.
  */
-export const NODUS_VERSION = '3.2.4';
+export const NODUS_VERSION = '3.2.5';

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -116,6 +116,13 @@ const RELEASE_3_2_3_IT: string[] = [
   "Ogni opera sul telefono ha ora un pulsante che la apre in Zotero per iPhone e iPad. La chiave di Zotero smette di essere una riga morta della scheda e diventa la via di ritorno al PDF, alle note e alle annotazioni che stanno nell'altra applicazione.",
 ];
 
+const RELEASE_3_2_5_IT: string[] = [
+  "Le analisi tornano a creare idee nuove nei corpora grandi. Superate le 9999 idee, Nodus non sapeva più numerare la successiva e l'analisi approfondita di ogni opera falliva proprio alla fine, quando tutto il lavoro dell'IA era già stato speso. Un corpus fermo da settimane torna a crescere.",
+  "La coda di analisi dice perché qualcosa è fallito. Prima mostrava solo «Fallito» e il motivo restava nella console di sviluppo, dove nessuno sarebbe andato a guardare. Lo stato di un'opera fallita porta ora il messaggio al passaggio del mouse, senza uscire dalla barra.",
+  "Il livello di ragionamento si sceglie dove si sceglie il modello. In Impostazioni › Modelli, ogni attività che usa un modello Codex porta il suo livello accanto, da Basso a Massimo. Meno ragionamento risponde prima, e in un'analisi lunga quella differenza si misura in ore.",
+  "Quel livello appartiene al modello, non all'attività. Sceglierlo in Modelli o in Fornitori è la stessa scelta, e tutte le attività che usano quel modello rileggono lo stesso valore. Lasciato su Predefinito, continua a seguire la raccomandazione del modello stesso anche se Codex la cambia.",
+];
+
 const RELEASE_3_2_4_IT: string[] = [
   "Le notifiche hanno ora un pulsante tutto loro nell'intestazione, subito prima di Impostazioni. Apre le stesse due liste che mostra Nodi: gli avvisi pubblicati da Nodus e quello che l'applicazione ha fatto. Funziona anche con la mascotte disattivata, che era proprio il caso in cui non c'era modo di raggiungerle.",
   "Nodus può ora dirti qualcosa tra una versione e l'altra: un sondaggio, un problema noto, una modifica importante. Ogni avviso arriva nella tua lingua, può contenere un link e resta da leggere finché non lo leggi, uno alla volta. Si disattiva nelle Impostazioni, e da quel momento Nodus smette di richiederlo.",
@@ -130,6 +137,7 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.2.5": RELEASE_3_2_5_IT,
   "3.2.4": RELEASE_3_2_4_IT,
   "3.2.3": RELEASE_3_2_3_IT,
   "3.2.2": RELEASE_3_2_2_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -56,6 +56,13 @@ const RELEASE_3_2_3_TR: string[] = [
   "Telefondaki her eser artık onu iPhone ve iPad için Zotero'da açan bir düğme taşıyor. Zotero anahtarı kayıttaki ölü bir satır olmaktan çıkıp diğer uygulamadaki PDF'e, notlara ve işaretlemelere dönüş yolu oluyor.",
 ];
 
+const RELEASE_3_2_5_TR: string[] = [
+  "Taramalar büyük derlemlerde yeniden yeni fikirler oluşturuyor. 9999 fikri aştıktan sonra Nodus bir sonrakini numaralandıramıyor ve her eserin derin analizi, tüm yapay zekâ işi harcandıktan sonra tam sonda başarısız oluyordu. Haftalardır büyümeyen bir derlem yeniden büyüyor.",
+  "Tarama kuyruğu artık bir şeyin neden başarısız olduğunu söylüyor. Önceden yalnızca «Başarısız» yazıyor, gerekçe ise kimsenin bakmayacağı geliştirici konsolunda kalıyordu. Başarısız bir eserin durumu artık mesajı üzerinde taşıyor, çubuktan hiç çıkmadan.",
+  "Akıl yürütme düzeyi, modelin seçildiği yerde seçiliyor. Ayarlar › Modeller içinde Codex modeli çalıştıran her görev düzeyini yanında taşıyor, Düşük'ten Azami'ye. Daha az akıl yürütme daha erken yanıt verir ve uzun bir taramada bu fark saatlerle ölçülür.",
+  "Bu düzey göreve değil modele aittir. Modeller'de ya da Sağlayıcılar'da seçmek aynı seçimdir ve o modeli çalıştıran her görev aynı değeri okur. Varsayılan'da bırakılırsa, Codex önerisini değiştirse bile modelin kendi önerisini izlemeye devam eder.",
+];
+
 const RELEASE_3_2_4_TR: string[] = [
   "Bildirimlerin artık başlıkta kendi düğmesi var, Ayarlar'ın hemen öncesinde. Nodi'nin gösterdiği aynı iki listeyi açıyor: Nodus'un yayımladığı duyurular ve uygulamanın neler yaptığı. Maskot kapalıyken de çalışıyor, ki bunlara ulaşmanın hiçbir yolunun olmadığı durum tam da buydu.",
   "Nodus artık bir sürümle diğeri arasında size bir şey söyleyebiliyor: bir anket, bilinen bir sorun, önemli bir değişiklik. Her duyuru kendi dilinizde geliyor, bir bağlantı taşıyabiliyor ve siz okuyana kadar tek tek okunmamış kalıyor. Ayarlar'dan kapatılabiliyor ve kapatıldığında Nodus onu istemeyi bırakıyor.",
@@ -70,6 +77,7 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.2.5": RELEASE_3_2_5_TR,
   "3.2.4": RELEASE_3_2_4_TR,
   "3.2.3": RELEASE_3_2_3_TR,
   "3.2.2": RELEASE_3_2_2_TR,

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -822,6 +822,54 @@ const RELEASE_3_2_3_HIGHLIGHTS: RawReleaseHighlight[] = [
  * engine addressed on the wrong interface once it was already running, and the buttons
  * that were laying out without their icon.
  */
+/**
+ * v3.2.5 — a corpus that had quietly stopped growing, and the setting that decides
+ * how long a scan takes finally sitting where the model is chosen.
+ *
+ * The first two are one bug and the blindfold that hid it for a month: ideas could not
+ * be numbered past 9,999, and a failed scan only ever said "Failed". The last two are
+ * the reasoning level, which until now lived one tab away from every screen that
+ * assigns a model to a job.
+ */
+const RELEASE_3_2_5_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'academic',
+    es: 'Los escaneos vuelven a crear ideas nuevas en corpus grandes. Al pasar de 9.999 ideas, Nodus ya no sabía numerar la siguiente y el análisis profundo de cada obra fallaba al final, cuando ya se había gastado todo el trabajo de IA. Un corpus que llevaba semanas sin crecer vuelve a crecer.',
+    en: 'Scans can create new ideas again in large corpora. Past 9,999 ideas Nodus could no longer number the next one, and the deep analysis of every work failed at the very end, once all of the AI work had been spent. A corpus that had quietly stopped growing grows again.',
+    fr: 'Les analyses créent de nouveau des idées dans les grands corpus. Au-delà de 9 999 idées, Nodus ne savait plus numéroter la suivante et l’analyse approfondie de chaque œuvre échouait tout à la fin, une fois tout le travail de l’IA dépensé. Un corpus qui avait cessé de grandir grandit à nouveau.',
+    de: 'Scans legen in großen Korpora wieder neue Ideen an. Ab 9.999 Ideen konnte Nodus die nächste nicht mehr nummerieren, und die Tiefenanalyse jedes Werks scheiterte ganz am Ende, wenn die gesamte KI-Arbeit bereits verbraucht war. Ein Korpus, das still stehen geblieben war, wächst wieder.',
+    pt: 'As análises voltam a criar ideias novas em corpora grandes. A partir de 9999 ideias, o Nodus já não sabia numerar a seguinte e a análise profunda de cada obra falhava mesmo no fim, quando já se tinha gasto todo o trabalho de IA. Um corpus que há semanas não crescia volta a crescer.',
+    'pt-BR': 'As análises voltam a criar ideias novas em corpora grandes. A partir de 9999 ideias, o Nodus não sabia mais numerar a seguinte e a análise profunda de cada obra falhava bem no fim, quando já tinha gasto todo o trabalho de IA. Um corpus que havia semanas não crescia volta a crescer.',
+  },
+  {
+    scope: 'academic',
+    es: 'La cola de escaneo dice por qué ha fallado algo. Antes solo ponía «Fallido» y el motivo se quedaba en la consola de desarrollo, donde nadie iba a mirar. Ahora el estado de una obra fallida lleva el mensaje encima, sin salir de la barra.',
+    en: 'The scan queue now says why something failed. It used to say only "Failed", with the reason left in the developer console, where nobody was going to look. The state of a failed work now carries the message on hover, without leaving the bar.',
+    fr: 'La file d’analyse dit pourquoi quelque chose a échoué. Elle n’affichait que «Échec», la raison restant dans la console de développement, où personne n’allait regarder. L’état d’une œuvre en échec porte désormais le message au survol, sans quitter la barre.',
+    de: 'Die Scan-Warteschlange sagt jetzt, warum etwas fehlgeschlagen ist. Vorher stand dort nur «Fehlgeschlagen», und der Grund blieb in der Entwicklerkonsole, wo niemand nachsehen würde. Der Status eines gescheiterten Werks trägt die Meldung nun beim Überfahren, ohne die Leiste zu verlassen.',
+    pt: 'A fila de análise diz porque é que algo falhou. Antes mostrava apenas «Falhou» e o motivo ficava na consola de desenvolvimento, onde ninguém ia ver. O estado de uma obra falhada passa a trazer a mensagem por cima, sem sair da barra.',
+    'pt-BR': 'A fila de análise diz por que algo falhou. Antes mostrava apenas «Falhou» e o motivo ficava no console de desenvolvimento, onde ninguém ia olhar. O estado de uma obra que falhou passa a trazer a mensagem por cima, sem sair da barra.',
+  },
+  {
+    scope: 'general',
+    es: 'El nivel de razonamiento se elige donde se elige el modelo. En Ajustes › Modelos, cada tarea que usa un modelo de Codex lleva su nivel al lado, de Bajo a Máximo. Menos razonamiento contesta antes, y en un escaneo largo esa diferencia se mide en horas.',
+    en: 'The reasoning level is chosen where the model is chosen. In Settings › Models, every job running a Codex model now carries its level beside it, from Low to Max. Less reasoning answers sooner, and across a long scan that difference is measured in hours.',
+    fr: 'Le niveau de raisonnement se choisit là où se choisit le modèle. Dans Paramètres › Modèles, chaque tâche qui utilise un modèle Codex porte son niveau à côté, de Bas à Maximum. Moins de raisonnement répond plus vite, et sur une longue analyse cet écart se compte en heures.',
+    de: 'Die Reasoning-Stufe wird dort gewählt, wo das Modell gewählt wird. Unter Einstellungen › Modelle trägt jede Aufgabe mit einem Codex-Modell ihre Stufe daneben, von Niedrig bis Maximal. Weniger Reasoning antwortet schneller, und über einen langen Scan macht das Stunden aus.',
+    pt: 'O nível de raciocínio escolhe-se onde se escolhe o modelo. Em Definições › Modelos, cada tarefa que usa um modelo Codex passa a ter o seu nível ao lado, de Baixo a Máximo. Menos raciocínio responde mais depressa, e numa análise longa essa diferença mede-se em horas.',
+    'pt-BR': 'O nível de raciocínio é escolhido onde o modelo é escolhido. Em Configurações › Modelos, cada tarefa que usa um modelo Codex passa a ter seu nível ao lado, de Baixo a Máximo. Menos raciocínio responde mais rápido, e numa análise longa essa diferença se mede em horas.',
+  },
+  {
+    scope: 'general',
+    es: 'Ese nivel pertenece al modelo, no a la tarea. Elegirlo en Modelos o en Proveedores es elegir lo mismo, y todas las tareas que usen ese modelo lo leen igual. Si lo dejas en Predeterminado, sigue la recomendación del propio modelo aunque Codex la cambie.',
+    en: 'That level belongs to the model, not to the job. Choosing it in Models or in Providers is the same choice, and every job running that model reads back the same value. Left on Default, it keeps following the model own recommendation even when Codex changes it.',
+    fr: 'Ce niveau appartient au modèle, pas à la tâche. Le choisir dans Modèles ou dans Fournisseurs revient au même, et toutes les tâches qui utilisent ce modèle lisent la même valeur. Laissé sur Par défaut, il suit la recommandation du modèle lui-même, même si Codex la change.',
+    de: 'Diese Stufe gehört zum Modell, nicht zur Aufgabe. Sie in Modelle oder in Anbieter zu wählen ist dieselbe Wahl, und jede Aufgabe mit diesem Modell liest denselben Wert zurück. Auf Standard belassen, folgt sie weiter der Empfehlung des Modells selbst, auch wenn Codex sie ändert.',
+    pt: 'Esse nível pertence ao modelo, não à tarefa. Escolhê-lo em Modelos ou em Fornecedores é a mesma escolha, e todas as tarefas que usem esse modelo leem o mesmo valor. Deixado em Predefinido, continua a seguir a recomendação do próprio modelo mesmo que o Codex a mude.',
+    'pt-BR': 'Esse nível pertence ao modelo, não à tarefa. Escolhê-lo em Modelos ou em Provedores é a mesma escolha, e todas as tarefas que usem esse modelo leem o mesmo valor. Deixado em Padrão, continua seguindo a recomendação do próprio modelo mesmo que o Codex a mude.',
+  },
+];
+
 const RELEASE_3_2_4_HIGHLIGHTS: RawReleaseHighlight[] = [
   {
     scope: 'general',
@@ -916,6 +964,11 @@ const RELEASE_3_2_4_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.2.5',
+    date: '2026-08-07',
+    highlights: RELEASE_3_2_5_HIGHLIGHTS,
+  },
   {
     version: '3.2.4',
     date: '2026-08-06',


### PR DESCRIPTION
Opens 3.2.5 with what this cycle actually changed: the scan bug from #368 and the
reasoning level from #370.

## Version

Moved in the three places `scripts/test-version-agreement.mjs` requires to agree:
`package.json`, `server/package.json` and `server/lib/version.mjs`. `CITATION.cff`
synced from the first with `npm run citation:sync`.

## What's new modal

Four highlights, in the eight languages the modal speaks:

1. Scans can create new ideas again in large corpora.
2. The scan queue says why something failed.
3. The reasoning level is chosen where the model is chosen.
4. That level belongs to the model, so both screens are the same choice.

House style since 3.1.0 holds: short plain sentences, no semicolons, no em dashes.
Italian and Turkish are index-matched to their own arrays rather than falling back
to English.

`CHANGELOG.md` gains the matching 3.2.5 section.

## Two tests updated, deliberately

Both pinned facts this bump changes, and both keep their intent:

- `test-release-notes.mjs` now names 3.2.5 as the current release, and pins 3.2.4
  to the ten highlights it shipped with so it cannot be quietly edited later.
- `test-mobile-teaser-guide.mjs` asserted `package.json` was `3.2.4`, which was how
  it expressed "the teaser presents on the version it names". Moving past 3.2.4
  retires that one-off teaser, which is what "shows once" means, so the assertion is
  inverted: the app must *not* be on 3.2.4, and the constant must not be bumped to
  follow a release. **Worth a look before merging** — it means the mobile-app teaser
  will not be shown again on 3.2.5, only to people who opened 3.2.4.

## Verification

- `npm test` — 1708/1708.
- `npm run typecheck`, `npm run lint`, `npm run build` — clean.