### PR TITLE
Let the 3.2.4 mobile teaser retire without stranding the chain behind it

### DIFF
--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -352,42 +352,23 @@ try {
   await whatsNewForExistingUser.waitFor();
   await whatsNewForExistingUser.getByRole('button', { name: 'Explorar las novedades', exact: true }).click();
 
-  // First behind release notes: the look at the mobile app. Unlike its neighbours it has
-  // no tutorial-version guard — the app it previews is in no tutorial — so every 3.2.4
-  // user meets it once.
-  const teaser = page.getByTestId('mobile-teaser-guide');
-  await teaser.waitFor();
-  await teaser.getByRole('heading', { name: 'Un adelanto de lo que viene', exact: true }).waitFor();
-  const teaserCaption = () => teaser.locator('.mobile-teaser-frame figcaption').innerText();
-  const teaserShot = () => teaser.locator('.mobile-teaser-frame img').getAttribute('src');
-  assert.equal(await teaser.locator('.mobile-teaser-dots button').count(), 9, 'nine App Store shots');
-  const firstCaption = await teaserCaption();
-  const firstShot = await teaserShot();
-  await teaser.getByTestId('mobile-teaser-next').click();
-  // Picture and caption must move together. Held behind an exit animation, the image
-  // lagged its caption by the length of the transition and showed the previous screen.
-  await page.waitForFunction(
-    (previous) => document.querySelector('.mobile-teaser-frame figcaption')?.textContent !== previous,
-    firstCaption,
-  );
-  assert.notEqual(await teaserShot(), firstShot, 'the shot changes with its caption, not after it');
-  assert.notEqual(await teaserCaption(), firstCaption);
-  // The survey is the one outbound link, and it must not be the retired forms.gle
-  // short-link domain: that resolves through Firebase Dynamic Links, which is shut down.
-  const survey = teaser.getByTestId('mobile-teaser-survey');
-  assert.equal(await survey.count(), 1, 'the survey call to action is present');
-  assert.equal(await teaser.locator('a[href*="forms.gle"], [data-href*="forms.gle"]').count(), 0);
-  await teaser.getByTestId('mobile-teaser-complete').click();
-  await teaser.waitFor({ state: 'detached' });
-  assert.equal(
-    await page.evaluate((version) => localStorage.getItem(`nodus.mobileTeaserSeen.${version}`), appVersion),
-    '1',
-    'the teaser is marked seen only when dismissed',
-  );
-  console.log('[e2e] the mobile teaser shows once behind release notes, and its carousel keeps shot and caption in step');
-
+  // First behind release notes sat the look at the mobile app, and it was a 3.2.4
+  // one-off: it presents only on the version it names, and its seen-key carries that
+  // version, so pointing the constant at a later release would show the gallery again to
+  // everyone who already met it. Past 3.2.4 the step must retire WITHOUT stalling the
+  // chain it holds — it sits between release notes and the connected-workflows summary,
+  // so a retired modal that forgets to settle strands everything behind it. Reaching the
+  // summary at all is the proof; the carousel itself is covered by
+  // scripts/test-mobile-teaser-guide.mjs, which still pins all nine shipped screenshots.
   const platformTour = page.getByTestId('platform-highlights-update-tour');
   await platformTour.waitFor();
+  assert.equal(
+    await page.getByTestId('mobile-teaser-guide').count(),
+    0,
+    'the 3.2.4 teaser must not come back on a later release',
+  );
+  console.log('[e2e] the retired mobile teaser hands the chain straight to the summary');
+
   assert.equal(await platformTour.locator('.toolkit-guide-progress button').count(), 3, 'existing-user summary has three ordered chapters');
   await platformTour.getByRole('heading', { name: 'MCP local y Nodus Server', exact: true }).waitFor();
   await platformTour.getByRole('button', { name: 'Siguiente', exact: true }).click();


### PR DESCRIPTION
CI went red on `main` at the 3.2.5 bump. The failure is real but the behaviour is
correct: `scripts/e2e-smoke.mjs` waited for `mobile-teaser-guide` to become
visible, and 3.2.5 retires that modal.

Retiring is right, and bumping its constant to follow the release would be wrong:

```js
export const MOBILE_TEASER_RELEASE = '3.2.4';
const SEEN_KEY = `nodus.mobileTeaserSeen.${MOBILE_TEASER_RELEASE}`;
```

The seen-key carries the version, so re-pointing the constant mints a fresh key
and shows the nine-screen gallery again to everyone who already met it on 3.2.4.

## What changed

The smoke test now asserts the thing that can actually break. The teaser holds the
step between the release-notes modal and the connected-workflows summary, so a
retired modal that forgets to call `onSettled` strands every modal behind it.
Reaching the summary is the proof, plus a check that the teaser did not return.

The carousel assertions it stopped exercising — nine screenshots, caption and
image moving together, the survey link that must not be a `forms.gle` short link —
were already covered by `scripts/test-mobile-teaser-guide.mjs`, which is unchanged.

## Verification

- `npm run test:e2e` locally against the real app boot: passes, and the new line
  `[e2e] the retired mobile teaser hands the chain straight to the summary` is in
  the output, immediately before the summary hand-off it now guards.
- Only `scripts/e2e-smoke.mjs` changes. No application code.