### PR TITLE
Refresh Ideas count when reopening the view

### DIFF
--- a/scripts/test-vault-query-cache.mjs
+++ b/scripts/test-vault-query-cache.mjs
@@ -41,6 +41,12 @@ try {
     assert.match(source, /getVaultQueryCache/, `${name} must reuse a valid cached query`);
     assert.match(source, /setVaultQueryCache/, `${name} must populate the vault cache`);
   }
+  assert.match(ideas, /const initialListLoad = useRef\(true\)/, 'Ideas must track the first list request of each visit');
+  assert.match(
+    ideas,
+    /const force = initialListLoad\.current;[\s\S]*?initialListLoad\.current = false;[\s\S]*?reload\(force\)/,
+    'entering Ideas must bypass a stale cached list before later requests may reuse it',
+  );
   console.log('Vault query cache tests passed.');
 } finally {
   await rm(temp, { recursive: true, force: true });

--- a/src/views/IdeasView.tsx
+++ b/src/views/IdeasView.tsx
@@ -62,6 +62,11 @@ export function IdeasView({
   const [savingIdea, setSavingIdea] = useState(false);
   const [deletingIdea, setDeletingIdea] = useState(false);
   const [confirmDeleteIdea, setConfirmDeleteIdea] = useState(false);
+  // A cached page is useful while the reader changes pages or returns to a previous
+  // sort during the same visit. It must not survive leaving and re-entering Ideas,
+  // though: deep scans can finish while the view is unmounted, so the queue-idle
+  // transition that normally invalidates query caches may never be observed here.
+  const initialListLoad = useRef(true);
   const [detailWidth, setDetailWidth] = useState(() =>
     loadNumber(IDEAS_DETAIL_WIDTH_KEY, IDEAS_DETAIL_DEFAULT_WIDTH, DETAIL_MIN_WIDTH, DETAIL_MAX_WIDTH)
   );
@@ -136,7 +141,9 @@ export function IdeasView({
   }, [searchQuery, sortKey, typeFilter]);
 
   useEffect(() => {
-    reload(false);
+    const force = initialListLoad.current;
+    initialListLoad.current = false;
+    reload(force);
   }, [reload]);
   useDataRefresh(reload);
   useScanComplete(reload);


### PR DESCRIPTION
## What changed

- Bypass the vault query cache for the first Ideas list request of each mounted visit.
- Keep the existing cache behavior for later pagination and sorting requests during that visit.
- Add a regression assertion to the isolated vault-query-cache test.

## Why

Deep scans may finish while Ideas is unmounted. In that case the view misses the queue active-to-idle transition that normally invalidates cached queries, so reopening Ideas could show an old extracted-ideas count until a previously unused sort forced a database request.

## User impact

Entering Ideas now always reads the current list and total from SQLite, while navigation within the mounted view remains cached.

## Validation

- `node --test scripts/test-vault-query-cache.mjs`
- `npm run typecheck`
- `npx eslint src/views/IdeasView.tsx scripts/test-vault-query-cache.mjs`
- `git diff --check`

All validation ran from the isolated repository worktree without launching Nodus or opening the user's active vault.

Closes #376