### PR TITLE
Improve Deep Research reading status and bookmark controls

### DIFF
--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -95,6 +95,9 @@ test('report selection offers icon-only copy, bookmark and Nodi quote actions', 
   assert.match(actions, /contextmenu/);
   assert.match(actions, /navigator\.clipboard\.writeText\(active\.text\)/);
   assert.match(actions, /localStorage\.setItem\(storageKey\(contextId\)/);
+  assert.match(actions, /localStorage\.removeItem\(storageKey\(contextId\)/);
+  assert.match(actions, /range\.getClientRects\(\)/, 'the painted bookmark is hit-tested so it can be clicked');
+  assert.match(actions, /useImperativeHandle\(ref, \(\) => \(\{ goToMark \}\)/);
   assert.match(actions, /updateSettings\(\{ mascotEnabled: true \}\)/);
   assert.match(actions, /quoteNodiSelection\(text\)/);
   assert.match(css, /::highlight\(nodus-reader-mark\)/);
@@ -109,6 +112,8 @@ test('report selection offers icon-only copy, bookmark and Nodi quote actions', 
   assert.match(ipc, /webContents\.send\('nodi:quoteSelection'/);
   assert.match(windows, /'consumeNodiQuoteSelection'/);
   assert.match(deepResearch, /ReaderSelectionActions[^>]*targetRef=\{mainRef\}/);
+  assert.match(deepResearch, /label=\{t\('Ir al marcador de lectura'\)\}/);
+  assert.match(deepResearch, /markActionsRef\.current\?\.goToMark\(\)/);
   assert.match(immersion, /ReaderSelectionActions[^>]*contextId=\{`immersion:/);
 });
 

--- a/src/components/ReaderSelectionActions.tsx
+++ b/src/components/ReaderSelectionActions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useState, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import { t } from '../i18n';
 import { Icon } from './ui';
@@ -13,6 +13,15 @@ interface ReaderMark {
 interface ActiveSelection extends ReaderMark {
   left: number;
   top: number;
+}
+
+interface ActiveMarkActions {
+  left: number;
+  top: number;
+}
+
+export interface ReaderSelectionActionsHandle {
+  goToMark: () => boolean;
 }
 
 const HIGHLIGHT_NAME = 'nodus-reader-mark';
@@ -108,22 +117,33 @@ function wordAtPoint(event: MouseEvent, root: HTMLElement): Range | null {
   return range;
 }
 
+function markRectAtPoint(range: Range, x: number, y: number): DOMRect | null {
+  for (const rect of Array.from(range.getClientRects())) {
+    // A small tolerance includes the underline painted just outside the text box and
+    // makes a short, one-word bookmark much less fiddly to hit.
+    if (x >= rect.left - 3 && x <= rect.right + 3 && y >= rect.top - 3 && y <= rect.bottom + 3) return rect;
+  }
+  return null;
+}
+
 /** Icon-only copy, reading-bookmark and Nodi-quote actions for document text. */
-export function ReaderSelectionActions({
-  targetRef,
-  contextId,
-}: {
+export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
   targetRef: RefObject<HTMLElement | null>;
   contextId: string;
-}) {
+  onMarkChange?: (hasMark: boolean) => void;
+}>(function ReaderSelectionActions({ targetRef, contextId, onMarkChange }, ref) {
   const [active, setActive] = useState<ActiveSelection | null>(null);
+  const [activeMarkActions, setActiveMarkActions] = useState<ActiveMarkActions | null>(null);
   const [mark, setMark] = useState<ReaderMark | null>(() => loadMark(contextId));
   const markLabel = t(mark ? 'Mover marcador aquí' : 'Añadir marcador de lectura');
 
   useEffect(() => {
+    const next = loadMark(contextId);
     setActive(null);
-    setMark(loadMark(contextId));
-  }, [contextId]);
+    setActiveMarkActions(null);
+    setMark(next);
+    onMarkChange?.(!!next);
+  }, [contextId, onMarkChange]);
 
   const showSelection = useCallback((event?: MouseEvent) => {
     const root = targetRef.current;
@@ -160,14 +180,32 @@ export function ReaderSelectionActions({
     const onContextMenu = (event: MouseEvent) => {
       if (showSelection(event)) event.preventDefault();
     };
+    const onClick = (event: MouseEvent) => {
+      if (!mark) return;
+      const range = markRange(root, mark);
+      if (!range) return;
+      const rect = markRectAtPoint(range, event.clientX, event.clientY);
+      if (!rect) return;
+      event.preventDefault();
+      event.stopPropagation();
+      window.getSelection()?.removeAllRanges();
+      setActive(null);
+      const width = 43;
+      setActiveMarkActions({
+        left: Math.max(8, Math.min(window.innerWidth - width - 8, rect.left + rect.width / 2 - width / 2)),
+        top: Math.max(8, rect.top - 48),
+      });
+    };
     const hide = (event: Event) => {
       const target = event.target;
       if (target instanceof Element && target.closest('[data-reader-selection-actions]')) return;
       setActive(null);
+      setActiveMarkActions(null);
     };
     root.addEventListener('pointerup', onPointerUp);
     root.addEventListener('keyup', onKeyUp);
     root.addEventListener('contextmenu', onContextMenu);
+    root.addEventListener('click', onClick);
     document.addEventListener('pointerdown', hide, true);
     window.addEventListener('resize', hide);
     root.addEventListener('scroll', hide, { passive: true });
@@ -175,11 +213,12 @@ export function ReaderSelectionActions({
       root.removeEventListener('pointerup', onPointerUp);
       root.removeEventListener('keyup', onKeyUp);
       root.removeEventListener('contextmenu', onContextMenu);
+      root.removeEventListener('click', onClick);
       document.removeEventListener('pointerdown', hide, true);
       window.removeEventListener('resize', hide);
       root.removeEventListener('scroll', hide);
     };
-  }, [showSelection, targetRef]);
+  }, [mark, showSelection, targetRef]);
 
   useEffect(() => {
     const root = targetRef.current;
@@ -208,8 +247,32 @@ export function ReaderSelectionActions({
     const next: ReaderMark = { start: active.start, end: active.end, text: active.text };
     localStorage.setItem(storageKey(contextId), JSON.stringify(next));
     setMark(next);
+    onMarkChange?.(true);
     clearSelection();
   };
+
+  const deleteMark = () => {
+    localStorage.removeItem(storageKey(contextId));
+    setMark(null);
+    setActiveMarkActions(null);
+    onMarkChange?.(false);
+  };
+
+  const goToMark = useCallback(() => {
+    const root = targetRef.current;
+    if (!root || !mark) return false;
+    const range = markRange(root, mark);
+    if (!range) return false;
+    const rect = range.getBoundingClientRect();
+    const rootRect = root.getBoundingClientRect();
+    const top = root.scrollTop + rect.top - rootRect.top - root.clientHeight / 2 + rect.height / 2;
+    setActive(null);
+    setActiveMarkActions(null);
+    root.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+    return true;
+  }, [mark, targetRef]);
+
+  useImperativeHandle(ref, () => ({ goToMark }), [goToMark]);
 
   const quoteInNodi = async () => {
     if (!active) return;
@@ -220,26 +283,40 @@ export function ReaderSelectionActions({
     clearSelection();
   };
 
-  if (!active) return null;
+  if (!active && !activeMarkActions) return null;
   return createPortal(
     <div
       className="reader-selection-actions"
       data-reader-selection-actions
       role="toolbar"
-      aria-label={t('Acciones de selección')}
-      style={{ left: active.left, top: active.top }}
+      aria-label={active ? t('Acciones de selección') : t('Eliminar marcador de lectura')}
+      style={{ left: (active ?? activeMarkActions)?.left, top: (active ?? activeMarkActions)?.top }}
       onPointerDown={(event) => event.preventDefault()}
     >
-      <button type="button" onClick={() => void copy()} title={t('Copiar')} aria-label={t('Copiar')}>
-        <Icon name="copy" size={17} />
-      </button>
-      <button type="button" onClick={saveMark} title={markLabel} aria-label={markLabel}>
-        <Icon name={mark ? 'bookmarkFill' : 'bookmark'} size={17} />
-      </button>
-      <button type="button" onClick={() => void quoteInNodi()} title={t('Citar en Nodi')} aria-label={t('Citar en Nodi')}>
-        <Icon name="quote" size={17} />
-      </button>
+      {active ? (
+        <>
+          <button type="button" onClick={() => void copy()} title={t('Copiar')} aria-label={t('Copiar')}>
+            <Icon name="copy" size={17} />
+          </button>
+          <button type="button" onClick={saveMark} title={markLabel} aria-label={markLabel}>
+            <Icon name={mark ? 'bookmarkFill' : 'bookmark'} size={17} />
+          </button>
+          <button type="button" onClick={() => void quoteInNodi()} title={t('Citar en Nodi')} aria-label={t('Citar en Nodi')}>
+            <Icon name="quote" size={17} />
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          data-tone="danger"
+          onClick={deleteMark}
+          title={t('Eliminar marcador de lectura')}
+          aria-label={t('Eliminar marcador de lectura')}
+        >
+          <Icon name="trash" size={17} />
+        </button>
+      )}
     </div>,
     document.body,
   );
-}
+});

--- a/src/components/readerSelectionActions.css
+++ b/src/components/readerSelectionActions.css
@@ -30,6 +30,16 @@
   outline: none;
 }
 
+.reader-selection-actions button[data-tone='danger'] {
+  color: #f87171;
+}
+
+.reader-selection-actions button[data-tone='danger']:hover,
+.reader-selection-actions button[data-tone='danger']:focus-visible {
+  background: #7f1d1d;
+  color: #fff;
+}
+
 ::highlight(nodus-reader-mark) {
   background-color: rgb(250 204 21 / 0.42);
   color: inherit;
@@ -42,4 +52,14 @@
   background: rgb(255 255 255 / 0.98);
   box-shadow: 0 12px 30px rgb(24 24 27 / 0.16);
   color: #27272a;
+}
+
+.light .reader-selection-actions button[data-tone='danger'] {
+  color: #dc2626;
+}
+
+.light .reader-selection-actions button[data-tone='danger']:hover,
+.light .reader-selection-actions button[data-tone='danger']:focus-visible {
+  background: #fee2e2;
+  color: #991b1b;
 }

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -7907,6 +7907,8 @@ export const DE: Record<string, string> = {
   "Acciones de selección": "Auswahlaktionen",
   "Añadir marcador de lectura": "Lesemarke hinzufügen",
   "Mover marcador aquí": "Lesezeichen hierher verschieben",
+  "Ir al marcador de lectura": "Zur Lesemarke springen",
+  "Eliminar marcador de lectura": "Lesemarke löschen",
   "Citar en Nodi": "In Nodi zitieren",
   "Quitar cita": "Zitat entfernen",
   "Texto visible de la sección abierta o documento completo en los lectores.": "Sichtbarer Text des geöffneten Bereichs oder das vollständige Dokument in den Leseansichten.",

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -8134,6 +8134,8 @@ export const EN: Record<string, string> = {
   "Acciones de selección": "Selection actions",
   "Añadir marcador de lectura": "Add reading bookmark",
   "Mover marcador aquí": "Move bookmark here",
+  "Ir al marcador de lectura": "Go to reading bookmark",
+  "Eliminar marcador de lectura": "Delete reading bookmark",
   "Citar en Nodi": "Quote in Nodi",
   "Quitar cita": "Remove quote",
   "Texto visible de la sección abierta o documento completo en los lectores.": "Visible text from the open section, or the complete document in readers.",

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -7898,6 +7898,8 @@ export const FR: Record<string, string> = {
   "Acciones de selección": "Actions sur la sélection",
   "Añadir marcador de lectura": "Ajouter un signet de lecture",
   "Mover marcador aquí": "Déplacer le signet ici",
+  "Ir al marcador de lectura": "Aller au signet de lecture",
+  "Eliminar marcador de lectura": "Supprimer le signet de lecture",
   "Citar en Nodi": "Citer dans Nodi",
   "Quitar cita": "Retirer la citation",
   "Texto visible de la sección abierta o documento completo en los lectores.": "Texte visible de la section ouverte, ou document complet dans les lecteurs.",

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -7312,6 +7312,8 @@ export const IT: Record<string, string> = {
   "Acciones de selección": "Azioni sulla selezione",
   "Añadir marcador de lectura": "Aggiungi segnalibro di lettura",
   "Mover marcador aquí": "Sposta qui il segnalibro",
+  "Ir al marcador de lectura": "Vai al segnalibro di lettura",
+  "Eliminar marcador de lectura": "Elimina segnalibro di lettura",
   "Citar en Nodi": "Cita in Nodi",
   "Quitar cita": "Rimuovi citazione",
   "Texto visible de la sección abierta o documento completo en los lectores.": "Testo visibile della sezione aperta o documento completo nei lettori.",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -7857,6 +7857,8 @@ export const PT_BR: Record<string, string> = {
   "Acciones de selección": "Ações da seleção",
   "Añadir marcador de lectura": "Adicionar marcador de leitura",
   "Mover marcador aquí": "Mover marcador para cá",
+  "Ir al marcador de lectura": "Ir para o marcador de leitura",
+  "Eliminar marcador de lectura": "Excluir marcador de leitura",
   "Citar en Nodi": "Citar no Nodi",
   "Quitar cita": "Remover citação",
   "Texto visible de la sección abierta o documento completo en los lectores.": "Texto visível da seção aberta ou documento completo nos leitores.",

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -7849,6 +7849,8 @@ export const PT: Record<string, string> = {
   "Acciones de selección": "Ações da seleção",
   "Añadir marcador de lectura": "Adicionar marcador de leitura",
   "Mover marcador aquí": "Mover marcador para aqui",
+  "Ir al marcador de lectura": "Ir para o marcador de leitura",
+  "Eliminar marcador de lectura": "Eliminar marcador de leitura",
   "Citar en Nodi": "Citar no Nodi",
   "Quitar cita": "Remover citação",
   "Texto visible de la sección abierta o documento completo en los lectores.": "Texto visível da secção aberta ou documento completo nos leitores.",

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -7659,6 +7659,8 @@ export const TR: Record<string, string> = {
   "Acciones de selección": "Seçim eylemleri",
   "Añadir marcador de lectura": "Okuma yer imi ekle",
   "Mover marcador aquí": "Yer imini buraya taşı",
+  "Ir al marcador de lectura": "Okuma yer imine git",
+  "Eliminar marcador de lectura": "Okuma yer imini sil",
   "Citar en Nodi": "Nodi'de alıntıla",
   "Quitar cita": "Alıntıyı kaldır",
   "Texto visible de la sección abierta o documento completo en los lectores.": "Açık bölümün görünen metni veya okuyuculardaki belgenin tamamı.",

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -68,6 +68,7 @@ const DEEP_SECTION_OPTIONS: { value: DeepResearchSectionLimit; label: string }[]
 ];
 
 type SortKey = 'recent' | 'oldest' | 'title';
+type ReadFilter = 'all' | 'read' | 'unread';
 
 /**
  * One surface, four readers. The machinery is identical — queue, gallery, reader,
@@ -278,6 +279,7 @@ export function DeepResearchView({
 
   // Gallery controls.
   const [search, setSearch] = useState('');
+  const [readFilter, setReadFilter] = useState<ReadFilter>('all');
   const [sortKey, setSortKey] = useState<SortKey>('recent');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [showTutorial, setShowTutorial] = useState(false);
@@ -613,17 +615,20 @@ export function DeepResearchView({
 
   const visibleDrafts = useMemo(() => {
     const q = search.trim().toLowerCase();
-    const filtered = q
-      ? savedDrafts.filter(
-          (d) => d.title.toLowerCase().includes(q) || d.brief.objective.toLowerCase().includes(q)
-        )
-      : savedDrafts;
+    const filtered = savedDrafts.filter((draft) => {
+      const matchesSearch = !q
+        || draft.title.toLowerCase().includes(q)
+        || draft.brief.objective.toLowerCase().includes(q);
+      const matchesReadState = readFilter === 'all'
+        || (readFilter === 'read' ? !!draft.readAt : !draft.readAt);
+      return matchesSearch && matchesReadState;
+    });
     const sorted = [...filtered];
     if (sortKey === 'title') sorted.sort((a, b) => a.title.localeCompare(b.title));
     else if (sortKey === 'oldest') sorted.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
     else sorted.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
     return sorted;
-  }, [savedDrafts, search, sortKey]);
+  }, [savedDrafts, search, readFilter, sortKey]);
 
   // The strip shows one lane, not two. Reports queued from this window come from the
   // renderer store; reports queued by an MCP client live in the main process and arrive
@@ -786,6 +791,17 @@ export function DeepResearchView({
             placeholder={t(copy.searchPlaceholder)}
           />
         </div>
+        <select
+          className="input !py-1.5 text-xs"
+          value={readFilter}
+          onChange={(e) => setReadFilter(e.target.value as ReadFilter)}
+          aria-label={t('Filtrar por estado')}
+          title={t('Filtrar por estado')}
+        >
+          <option value="all">{t('Leído + no leído')}</option>
+          <option value="read">{t('Solo leído')}</option>
+          <option value="unread">{t('Solo no leído')}</option>
+        </select>
         <select className="input !py-1.5 text-xs" value={sortKey} onChange={(e) => setSortKey(e.target.value as SortKey)}>
           <option value="recent">{t('Más recientes')}</option>
           <option value="oldest">{t('Más antiguos')}</option>
@@ -857,11 +873,13 @@ export function DeepResearchView({
             <div className="max-w-md text-sm text-neutral-500">
               {loadingSavedDrafts
                 ? t(copy.loading)
-                : search.trim()
+                : readFilter !== 'all'
+                  ? t('No hay elementos con estos filtros.')
+                  : search.trim()
                   ? t(copy.noMatch)
                   : t(copy.empty)}
             </div>
-            {!search.trim() && !loadingSavedDrafts && (
+            {!search.trim() && readFilter === 'all' && !loadingSavedDrafts && (
               <button className="btn btn-primary gap-1.5" onClick={() => setComposerOpen(true)}>
                 <Icon name="plus" /> {t(copy.newAction)}
               </button>

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -35,7 +35,7 @@ import { DecorativeImageCard } from '../components/DecorativeImageCard';
 import { AudioPanel } from '../components/AudioPanel';
 import { FindInPage } from '../components/FindInPage';
 import { NodiViewContextSource } from '../components/NodiViewContextSource';
-import { ReaderSelectionActions } from '../components/ReaderSelectionActions';
+import { ReaderSelectionActions, type ReaderSelectionActionsHandle } from '../components/ReaderSelectionActions';
 import { t, tx, getActiveLang } from '../i18n';
 import {
   DEEP_RESEARCH_MAIN_JOB_KEY,
@@ -1371,6 +1371,8 @@ function ReaderView({
   onOpenStudyRecording?: (id: string, timestamp?: number | null) => void;
 }) {
   const mainRef = useRef<HTMLElement | null>(null);
+  const markActionsRef = useRef<ReaderSelectionActionsHandle | null>(null);
+  const [hasReaderMark, setHasReaderMark] = useState(false);
   const contextTitle = appliedTranslation?.title ?? saved.draft.title;
   const contextMarkdown = appliedTranslation?.markdown
     ?? `# ${saved.draft.title}\n\n${saved.draft.abstract ? `${saved.draft.abstract}\n\n` : ''}${stripLeadingAbstract(saved.draft.draftMarkdown, saved.draft.abstract)}`;
@@ -1395,6 +1397,13 @@ function ReaderView({
           onCopyReading={onCopyReading}
           onSaveToNotes={onSaveToNotes}
           onExport={onExport}
+        />
+        <HoverLabelButton
+          icon={hasReaderMark ? 'bookmarkFill' : 'bookmark'}
+          label={t('Ir al marcador de lectura')}
+          onClick={() => markActionsRef.current?.goToMark()}
+          disabled={!hasReaderMark}
+          className={`btn-ghost h-9 min-h-9 border ${hasReaderMark ? 'border-amber-300 text-amber-700 dark:border-amber-700/60 dark:text-amber-300' : 'border-neutral-700 text-neutral-500'}`}
         />
         {/* Beside the reading actions, where somebody who has just finished the report
             is already looking, rather than back in the gallery they would have to
@@ -1456,7 +1465,13 @@ function ReaderView({
             />}
           </div>
         </main>
-        <ReaderSelectionActions key={appliedTranslation?.id ?? 'source'} targetRef={mainRef} contextId={`deep-research:${saved.id}`} />
+        <ReaderSelectionActions
+          key={appliedTranslation?.id ?? 'source'}
+          ref={markActionsRef}
+          targetRef={mainRef}
+          contextId={`deep-research:${saved.id}`}
+          onMarkChange={setHasReaderMark}
+        />
         {showMatrix && (
           <aside className="w-80 shrink-0 overflow-y-auto border-l border-neutral-800 p-4 max-lg:hidden">
             <SupportMatrix draft={saved.draft} onCitation={onCitation} />

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -983,7 +983,7 @@ function SelectCheck({ checked }: { checked: boolean }) {
 function ReadBadge() {
   return (
     <span
-      className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1 rounded-full bg-emerald-950/80 px-2 py-0.5 text-[10px] font-medium text-emerald-200 ring-1 ring-emerald-700/60"
+      className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1 rounded-full bg-emerald-100/90 px-2 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-emerald-300/80 dark:bg-emerald-950/80 dark:text-emerald-200 dark:ring-emerald-700/60"
       title={t('Ya has leído este informe')}
     >
       <Icon name="check" size={10} /> {t('Leído')}


### PR DESCRIPTION
## Summary

- fix the Deep Research **Read** badge so it uses a light emerald surface in light mode while preserving the existing dark-mode treatment
- add an all/read/unread gallery filter that composes with search and sorting
- make painted reading bookmarks clickable and expose an inline trash action
- add a bookmark button to the reader toolbar that scrolls to the saved location and disables itself when no bookmark exists
- localize the new bookmark actions across all supported UI languages

## Root cause

The badge used dark-only Tailwind utilities without light-mode variants. Reading state was available on saved reports but was not part of the gallery filter pipeline. Bookmarks were painted with the CSS Custom Highlight API, which does not create an interactive DOM element, so the reader had no click target for deletion or toolbar navigation.

## User impact

Readers can now distinguish read reports correctly in both themes, narrow the gallery by reading status, jump back to a saved reading position, and remove a yellow bookmark directly from the highlighted text.

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- `node --test scripts/test-i18n-coverage.mjs scripts/test-reading-copy.mjs`
- `node --test scripts/test-nodi-assistant.mjs scripts/test-i18n-coverage.mjs`
- `node scripts/test-deep-research-read.mjs`

Closes #388