### PR TITLE
Use Zotero-style typing indicators in Nodus chats

### DIFF
--- a/scripts/test-chat-typing-indicator.mjs
+++ b/scripts/test-chat-typing-indicator.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (file) => readFile(path.join(root, file), 'utf8');
+
+test('Nodi and the research assistant share the Zotero-style waiting indicator', async () => {
+  const [indicator, styles, nodi, assistant] = await Promise.all([
+    read('src/components/ChatTypingIndicator.tsx'),
+    read('src/components/chatTypingIndicator.css'),
+    read('src/components/nodi/NodiCompanion.tsx'),
+    read('src/views/ResearchAssistantModal.tsx'),
+  ]);
+
+  assert.equal((indicator.match(/className="chat-typing-dot"/g) ?? []).length, 3);
+  assert.match(styles, /animation: chat-typing-dot 1\.2s infinite ease-in-out/);
+  assert.match(styles, /transform: translateY\(-4px\)/);
+  assert.match(styles, /\.chat-typing-dot:nth-child\(2\)/);
+  assert.match(styles, /\.chat-typing-dot:nth-child\(3\)/);
+
+  assert.match(nodi, /streaming && i === messages\.length - 1 \? <ChatTypingIndicator/);
+  assert.match(assistant, /message\.id === streamingId \? \(\s*<ChatTypingIndicator/);
+  assert.doesNotMatch(nodi, /escribiendo…<\/span>/);
+});

--- a/src/components/ChatTypingIndicator.tsx
+++ b/src/components/ChatTypingIndicator.tsx
@@ -1,0 +1,12 @@
+import './chatTypingIndicator.css';
+
+/** The animated three-dot waiting state shared by Nodus chat surfaces. */
+export function ChatTypingIndicator({ label }: { label: string }) {
+  return (
+    <span className="chat-typing-indicator" role="status" aria-label={label}>
+      <span className="chat-typing-dot" aria-hidden="true" />
+      <span className="chat-typing-dot" aria-hidden="true" />
+      <span className="chat-typing-dot" aria-hidden="true" />
+    </span>
+  );
+}

--- a/src/components/chatTypingIndicator.css
+++ b/src/components/chatTypingIndicator.css
@@ -1,0 +1,46 @@
+/* Mirrors the Zotero plugin's three-dot typing indicator so waiting for a chat
+   response feels the same in every Nodus surface. */
+.chat-typing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 2px;
+  color: #7c3aed;
+}
+
+.chat-typing-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.35;
+  animation: chat-typing-dot 1.2s infinite ease-in-out;
+}
+
+.chat-typing-dot:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.chat-typing-dot:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@keyframes chat-typing-dot {
+  0%,
+  60%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+
+  30% {
+    opacity: 1;
+    transform: translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-typing-dot {
+    animation: none;
+  }
+}

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -6,6 +6,7 @@ import { vaultTypeColor } from '@shared/vaultTypes';
 import { type NodiRole, type NodiState } from './Nodi';
 import { NodiAvatar } from './NodiAvatar';
 import { NodiCitationCard } from './NodiCitationCard';
+import { ChatTypingIndicator } from '../ChatTypingIndicator';
 import { Markdown, type MarkdownCitation } from '../Markdown';
 import { ModelPicker } from '../ModelPicker';
 import { useAnnouncements } from '../NotificationsPanel';
@@ -1085,7 +1086,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
                         onWorldEntry={citesWorld ? (kind, id) => void window.nodus.nodiOpenWorldEntry(kind, id) : undefined}
                       />
                     ) : m.content.startsWith('> ') ? <Markdown content={m.content} verify={false} /> : m.content
-                    : streaming && i === messages.length - 1 ? <span className="nodi-typing">{t('escribiendo…')}</span> : ''}
+                    : streaming && i === messages.length - 1 ? <ChatTypingIndicator label={t('escribiendo…')} /> : ''}
                 </div>
               ))}
             </div>

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -614,8 +614,6 @@
 .nodi-history::-webkit-scrollbar-thumb:hover,
 .nodi-panel-body::-webkit-scrollbar-thumb:hover,
 .nodi-msg .md pre::-webkit-scrollbar-thumb:hover { background: #748198; }
-.nodi-typing { display: inline-block; color: #8b96a8; font-size: 12px; }
-
 /* Quick notes ───────────────────────────────────────────────────────────── */
 .nodi-panel.nodi-notes-panel { width: 372px; max-height: 480px; }
 
@@ -843,8 +841,7 @@
 .nodi-theme-light .nodi-ntf-time,
 .nodi-theme-light .nodi-ntf-section,
 .nodi-theme-light .nodi-empty,
-.nodi-theme-light .nodi-chat-status,
-.nodi-theme-light .nodi-typing { color: #94a3b8; }
+.nodi-theme-light .nodi-chat-status { color: #94a3b8; }
 
 .nodi-theme-light .nodi-msg.user { background: var(--nodi-vault-accent, #6366f1); color: #ffffff; }
 .nodi-theme-light .nodi-msg.assistant { background: #f1f5f9; color: #1f2937; }

--- a/src/views/ResearchAssistantModal.tsx
+++ b/src/views/ResearchAssistantModal.tsx
@@ -11,6 +11,7 @@ import type {
 import { Icon, modelLabel, sortModelRefs } from '../components/ui';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
 import { ConfirmModal } from '../components/ConfirmModal';
+import { ChatTypingIndicator } from '../components/ChatTypingIndicator';
 import { SaveToNotesModal } from '../components/SaveToNotesModal';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
 import { VirtualList } from '../components/VirtualList';
@@ -749,11 +750,7 @@ export function ResearchAssistantModal({
                             {message.id === streamingId && <span aria-hidden className="stream-caret" />}
                           </div>
                         ) : message.id === streamingId ? (
-                          <span className="stream-dots" aria-label={t('Generando…')}>
-                            <i />
-                            <i />
-                            <i />
-                          </span>
+                          <ChatTypingIndicator label={t('Generando…')} />
                         ) : null
                       ) : (
                         message.content


### PR DESCRIPTION
## Summary

- add a shared, accessible three-dot typing indicator that matches the Zotero plugin
- use it while Nodi and the Research Assistant wait for their first response content
- preserve reduced-motion behavior
- add regression coverage for both chat integrations and the animation contract

## Why

Nodi previously displayed a static “typing” label, while the Research Assistant maintained a separate animation. Sharing the Zotero-style component gives users one consistent waiting state across Nodus chat surfaces.

## User impact

Users now see the same moving three-dot feedback in Nodi and the Research Assistant whenever a reply is pending.

## Root cause

The two desktop chat surfaces implemented their initial waiting states independently instead of reusing the indicator established by the Zotero plugin.

## Validation

- `node --test scripts/test-chat-typing-indicator.mjs`
- `npx eslint src/components/ChatTypingIndicator.tsx src/components/nodi/NodiCompanion.tsx src/views/ResearchAssistantModal.tsx`
- `npm run build`
- `node --test --test-reporter=dot scripts/test-*.mjs` (1,714 tests passed)

Closes #390