### PR TITLE
Rediseña la experiencia del grafo de Nodus

### DIFF
--- a/scripts/test-graph-preset-atlas.mjs
+++ b/scripts/test-graph-preset-atlas.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const output = await mkdtemp(path.join(os.tmpdir(), 'nodus-graph-preset-atlas-'));
+const bundle = path.join(output, 'model.mjs');
+await build({
+  entryPoints: [path.join(repoRoot, 'src/views/graph/model.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: bundle,
+});
+const { buildPresetAtlas } = await import(pathToFileURL(bundle).href);
+test.after(() => rm(output, { recursive: true, force: true }));
+
+const defaultFilters = {
+  search: '',
+  nodeTypes: ['theme', 'claim', 'finding', 'construct', 'method', 'framework'],
+  edgeTypes: ['contains', 'supports', 'extends'],
+  theme: '',
+  workIds: [],
+  authors: [],
+  yearMin: null,
+  yearMax: null,
+  readState: 'all',
+  minConfidence: 0,
+  basis: 'all',
+};
+
+function ideaFixture() {
+  const nodes = [];
+  const edges = [];
+  for (let theme = 0; theme < 3; theme++) {
+    const themeId = `theme:${theme}`;
+    const themeLabel = `Tema ${theme}`;
+    nodes.push({
+      id: themeId, label: themeLabel.toUpperCase(), type: 'theme', workCount: 40,
+      workIds: [], read: theme !== 2, themes: [themeLabel], years: [2020], authors: [], maxConfidence: 1,
+    });
+    for (let index = 0; index < 40; index++) {
+      const id = `idea:${theme}:${index}`;
+      nodes.push({
+        id, label: `Idea ${theme}.${index}`, type: index % 2 ? 'claim' : 'finding', workCount: 1,
+        workIds: [`work:${theme}:${index}`], read: index % 2 === 0, themes: [themeLabel], years: [2000 + index],
+        authors: [`Autor ${index % 8}`], maxConfidence: 0.8,
+      });
+      edges.push({ id: `contains:${id}`, source: themeId, target: id, type: 'contains', basis: 'explicit', confidence: 1 });
+      if (index > 0) {
+        edges.push({
+          id: `semantic:${theme}:${index}`, source: `idea:${theme}:${index - 1}`, target: id,
+          type: index % 3 ? 'supports' : 'extends', basis: 'inferred', confidence: 0.75,
+        });
+      }
+    }
+  }
+  return { nodes, edges };
+}
+
+function authorFixture() {
+  const nodes = Array.from({ length: 300 }, (_, index) => ({
+    id: `author:${index}`, label: `Autor ${String(index).padStart(3, '0')}`, type: 'author',
+    workCount: 1 + (index % 12), workIds: [`work:${index}`], read: index % 3 === 0,
+    themes: [], years: [1980 + (index % 40)], authors: [`Autor ${index}`], maxConfidence: 1,
+  }));
+  const edges = [];
+  for (let index = 1; index < nodes.length; index++) {
+    edges.push({
+      id: `author-edge:${index}`, source: `author:${index - 1}`, target: `author:${index}`,
+      type: 'coauthor', basis: 'inferred', confidence: 0.8,
+    });
+    if (index % 12 !== 0) {
+      edges.push({
+        id: `author-cluster:${index}`, source: `author:${index - (index % 12)}`, target: `author:${index}`,
+        type: 'related', basis: 'inferred', confidence: 0.65,
+      });
+    }
+  }
+  return { nodes, edges };
+}
+
+function assertIntegrity(model) {
+  const ids = new Set(model.nodes.map((node) => node.id));
+  assert.equal(ids.size, model.nodes.length, 'atlas node ids are unique');
+  for (const edge of model.edges) {
+    assert.ok(ids.has(edge.source), `edge source ${edge.source} exists`);
+    assert.ok(ids.has(edge.target), `edge target ${edge.target} exists`);
+  }
+}
+
+test('gaps becomes a bounded thematic atlas of sparse ideas', () => {
+  const model = buildPresetAtlas(ideaFixture(), defaultFilters, 'ideas', 'gaps');
+  assert.ok(model);
+  assert.ok(model.nodes.length <= 112 + 3, 'gap scene stays within its idea cap plus theme hubs');
+  assert.equal(model.nodes.filter((node) => node.type === 'theme').length, 3);
+  assert.ok(model.nodes.filter((node) => node.type !== 'theme').every((node) => node.group));
+  assertIntegrity(model);
+});
+
+test('reading and unread atlases preserve their reading-state boundary', () => {
+  const data = ideaFixture();
+  const reading = buildPresetAtlas(data, { ...defaultFilters, readState: 'read' }, 'ideas', 'reading');
+  const unread = buildPresetAtlas(data, { ...defaultFilters, readState: 'unread' }, 'ideas', 'unread');
+  assert.ok(reading && unread);
+  assert.ok(reading.nodes.filter((node) => node.type !== 'theme').every((node) => node.read));
+  assert.ok(unread.nodes.filter((node) => node.type !== 'theme').every((node) => !node.read));
+  assertIntegrity(reading);
+  assertIntegrity(unread);
+});
+
+test('authors becomes a bounded, coloured community atlas', () => {
+  const model = buildPresetAtlas(authorFixture(), defaultFilters, 'authors', 'authors');
+  assert.ok(model);
+  assert.equal(model.nodes.filter((node) => node.type === 'author').length, 144, 'author scene applies its cap');
+  assert.ok(model.nodes.filter((node) => node.type === 'author').every((node) => node.group?.startsWith('author-network:')));
+  assert.ok(model.nodes.every((node) => /^#[\da-f]{6}$/i.test(node.color ?? '')));
+  assert.ok(new Set(model.nodes.map((node) => node.group)).size <= 10, 'author communities remain legible');
+  assert.ok(model.nodes.some((node) => node.type === 'theme' && /^C\d+$/.test(node.label)), 'author communities have visual hubs');
+  assertIntegrity(model);
+});

--- a/scripts/test-study-ui.mjs
+++ b/scripts/test-study-ui.mjs
@@ -1,11 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
 import { readSource } from './ipc-channel-census.mjs';
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = async (file) => readSource(file);
 
 test('study vault uses its teal header logo and the shared dock accent', async () => {
@@ -71,7 +67,7 @@ test('left sidebar is resizable and remembers the selected width', async () => {
 });
 
 test('sidebar header keeps the Nodus brand centered, stable when hidden and fully clickable', async () => {
-  const app = await read('@shell');
+  const [app, css] = await Promise.all([read('@shell'), read('src/index.css')]);
   assert.match(app, /data-testid="sidebar-header-toggle"/);
   assert.match(
     app,
@@ -81,6 +77,12 @@ test('sidebar header keeps the Nodus brand centered, stable when hidden and full
   assert.ok(
     app.indexOf('data-testid="sidebar-header-toggle"') < app.indexOf('data-testid="nodus-logo"'),
     'the Nodus logo should remain inside the full-width sidebar header control',
+  );
+  assert.match(app, /data-platform=\{IS_MAC \? 'macos' : 'other'\}/);
+  assert.match(
+    css,
+    /\.app-titlebar\[data-platform='macos'\] \[data-testid='sidebar-header-toggle'\]\s*\{[^}]*padding-left:\s*76px/s,
+    'the macOS titlebar must reserve the hiddenInset traffic-light area',
   );
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1142,7 +1142,11 @@ export function App() {
       {/* Top bar. `app-titlebar` makes the empty header area a drag region so the
           window can be moved (its interactive children are auto-marked no-drag in
           index.css). On macOS the traffic lights sit at the very top-left. */}
-      <header ref={setHeaderEl} className="app-titlebar relative flex h-11 items-center border-b border-neutral-800">
+      <header
+        ref={setHeaderEl}
+        className="app-titlebar relative flex h-11 items-center border-b border-neutral-800"
+        data-platform={IS_MAC ? 'macos' : 'other'}
+      >
         <button
           ref={setHeaderLogoEl}
           data-testid="sidebar-header-toggle"

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,13 @@
   -webkit-app-region: drag;
 }
 
+/* hiddenInset puts the macOS traffic lights inside the renderer. Keep the brand
+   centred in the usable part of the sidebar button instead of letting the red,
+   yellow and green controls sit on top of its logo and label. */
+.app-titlebar[data-platform='macos'] [data-testid='sidebar-header-toggle'] {
+  padding-left: 76px;
+}
+
 /* ── Recovery-folder cinematic wizard ─────────────────────────────────────── */
 .recovery-cinema { position: fixed; inset: 0; z-index: 230; display: grid; place-items: center; overflow: auto; padding: 28px; background: #070911; color: #e5e7eb; }
 .recovery-aurora { position: fixed; inset: 0; pointer-events: none; background: radial-gradient(circle at 15% 15%, rgba(45,212,191,.16), transparent 32%), radial-gradient(circle at 85% 75%, rgba(99,102,241,.18), transparent 36%); }
@@ -2478,6 +2485,217 @@ select.input optgroup {
 .light select.input optgroup {
   background-color: #ffffff;
   color: #171717;
+}
+
+/* Knowledge atlas: Sigma stays the rendering engine, while this chrome turns the
+   graph into a layered research landscape with its own hierarchy and atmosphere. */
+.nodus-graph-view {
+  background: #070910;
+}
+.nodus-graph-toolbar {
+  position: relative;
+  z-index: 20;
+  border-color: rgb(38 38 38 / .78);
+  background: rgb(10 12 20 / .94);
+  box-shadow: 0 14px 34px rgb(0 0 0 / .16);
+  backdrop-filter: blur(18px);
+}
+.nodus-graph-toolbar .btn,
+.nodus-graph-toolbar .input {
+  border-radius: 10px;
+}
+.nodus-graph-workspace {
+  background: #070910;
+}
+.nodus-graph-stage {
+  isolation: isolate;
+  background-color: #070910;
+  background-image:
+    radial-gradient(circle at 22% 22%, rgb(79 70 229 / .1), transparent 34%),
+    radial-gradient(circle at 76% 70%, rgb(8 145 178 / .07), transparent 36%),
+    radial-gradient(circle, rgb(148 163 184 / .13) .7px, transparent .8px);
+  background-size: auto, auto, 22px 22px;
+}
+.nodus-graph-stage::after {
+  position: absolute;
+  z-index: 3;
+  inset: 0;
+  background: radial-gradient(circle at 50% 46%, transparent 48%, rgb(3 5 12 / .34) 100%);
+  content: '';
+  pointer-events: none;
+}
+.nodus-graph-territories {
+  z-index: 0;
+  pointer-events: none;
+}
+.nodus-graph-engine {
+  z-index: 1;
+}
+.nodus-graph-atlas-card,
+.nodus-graph-density-card,
+.nodus-graph-legend,
+.nodus-graph-viewport-controls {
+  border: 1px solid rgb(148 163 184 / .16);
+  background: linear-gradient(145deg, rgb(18 21 34 / .9), rgb(9 11 20 / .84));
+  box-shadow: 0 18px 50px rgb(0 0 0 / .28), inset 0 1px 0 rgb(255 255 255 / .04);
+  backdrop-filter: blur(18px) saturate(130%);
+}
+.nodus-graph-atlas-card {
+  min-width: 232px;
+  padding: 12px 14px 11px;
+  border-radius: 15px;
+}
+.nodus-graph-atlas-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #818cf8;
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+}
+.nodus-graph-atlas-mark {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 1px solid rgb(129 140 248 / .32);
+  border-radius: 7px;
+  background: rgb(79 70 229 / .16);
+  box-shadow: 0 0 22px rgb(99 102 241 / .18);
+}
+.nodus-graph-atlas-title {
+  margin-top: 9px;
+  color: #f5f7ff;
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: -.01em;
+}
+.nodus-graph-atlas-description {
+  max-width: 290px;
+  margin-top: 3px;
+  color: #8d95a8;
+  font-size: 10px;
+  line-height: 1.45;
+}
+.nodus-graph-atlas-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 8px 0 1px -5px;
+  padding: 4px 6px;
+  border-radius: 7px;
+  color: #c7d2fe;
+}
+.nodus-graph-atlas-back:hover {
+  background: rgb(99 102 241 / .12);
+  color: #fff;
+}
+.nodus-graph-atlas-metrics {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 5px;
+  color: #71798b;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.nodus-graph-density-card {
+  width: max-content;
+  padding: 8px 11px;
+  border-radius: 12px;
+}
+.nodus-graph-viewport-controls {
+  overflow: hidden;
+  padding: 4px;
+  border-radius: 14px;
+}
+.nodus-graph-viewport-button {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  place-items: center;
+  border-radius: 9px;
+  color: #a5adbd;
+  transition: background-color .16s ease, color .16s ease, transform .16s ease;
+}
+.nodus-graph-viewport-button:hover {
+  background: rgb(99 102 241 / .17);
+  color: #eef2ff;
+  transform: translateY(-1px);
+}
+.nodus-graph-legend {
+  max-height: min(54vh, 420px);
+  overflow: auto;
+  border-radius: 14px;
+  color: #a5adbd;
+}
+.light .nodus-graph-view,
+.light .nodus-graph-workspace {
+  background: #f7f8fc;
+}
+.light .nodus-graph-toolbar {
+  border-color: rgb(203 213 225 / .72);
+  background: rgb(255 255 255 / .9);
+  box-shadow: 0 12px 32px rgb(51 65 85 / .08);
+}
+.light .nodus-graph-stage {
+  background-color: #f8fafc;
+  background-image:
+    radial-gradient(circle at 22% 22%, rgb(99 102 241 / .08), transparent 34%),
+    radial-gradient(circle at 76% 70%, rgb(14 165 233 / .055), transparent 36%),
+    radial-gradient(circle, rgb(100 116 139 / .16) .7px, transparent .8px);
+}
+.light .nodus-graph-stage::after {
+  background: radial-gradient(circle at 50% 46%, transparent 54%, rgb(226 232 240 / .28) 100%);
+}
+.light .nodus-graph-atlas-card,
+.light .nodus-graph-density-card,
+.light .nodus-graph-legend,
+.light .nodus-graph-viewport-controls {
+  border-color: rgb(148 163 184 / .28);
+  background: linear-gradient(145deg, rgb(255 255 255 / .94), rgb(248 250 252 / .88));
+  box-shadow: 0 16px 42px rgb(51 65 85 / .1), inset 0 1px 0 rgb(255 255 255 / .9);
+}
+.light .nodus-graph-atlas-eyebrow {
+  color: #4f46e5;
+}
+.light .nodus-graph-atlas-mark {
+  border-color: rgb(79 70 229 / .22);
+  background: rgb(99 102 241 / .08);
+}
+.light .nodus-graph-atlas-title {
+  color: #172033;
+}
+.light .nodus-graph-atlas-description {
+  color: #64748b;
+}
+.light .nodus-graph-atlas-back {
+  color: #4338ca;
+}
+.light .nodus-graph-atlas-back:hover {
+  background: rgb(99 102 241 / .08);
+  color: #312e81;
+}
+.light .nodus-graph-atlas-metrics {
+  color: #64748b;
+}
+.light .nodus-graph-viewport-button {
+  color: #64748b;
+}
+.light .nodus-graph-viewport-button:hover {
+  background: rgb(99 102 241 / .09);
+  color: #312e81;
+}
+.light .nodus-graph-legend {
+  color: #475569;
+}
+
+@media (max-width: 900px) {
+  .nodus-graph-atlas-hud { max-width: calc(100% - 76px); }
+  .nodus-graph-atlas-card { min-width: 190px; }
+  .nodus-graph-legend { max-width: 184px; }
 }
 
 .graph-detail-panel {

--- a/src/views/GraphView.tsx
+++ b/src/views/GraphView.tsx
@@ -9,7 +9,7 @@ import { IdeaDuplicatesModal } from './IdeaDuplicatesModal';
 import { EdgeAuditModal } from './EdgeAuditModal';
 import { TutorPanel } from './TutorPanel';
 import { SigmaGraph, type SigmaGraphApi, type GraphViewLevel } from './graph/SigmaGraph';
-import { buildThemeConstellation, buildThemeBackbone } from './graph/model';
+import { buildThemeConstellation, buildThemeBackbone, buildPresetAtlas } from './graph/model';
 import { GraphErrorBoundary } from './graph/GraphErrorBoundary';
 import type { GraphNavigationTarget, GraphPresetId } from '../navigation';
 import { t, tx } from '../i18n';
@@ -1068,7 +1068,9 @@ function graphPreset(id: GraphPresetId, target?: GraphNavigationTarget): { lens:
     case 'reading':
       return {
         lens: 'ideas',
-        filters: withTarget,
+        // A direct link to one work keeps all of that work's context. The plain
+        // preset instead maps knowledge grounded only in completed reading.
+        filters: target?.workId ? withTarget : { ...withTarget, readState: 'read' },
         depth: 1,
         layoutMode: 'force',
       };
@@ -1861,13 +1863,25 @@ export function GraphView({
   }, [activeThemeLabel, constellationModel]);
   const backboneShown = backboneModel?.nodes.filter((node) => !node.bridge).length ?? 0;
   const maximumThemeIdeas = Math.min(250, activeThemeTotal);
-  const graphOverrideModel = !levelsActive || graphLevel.level === 'full'
+  const semanticOverrideModel = !levelsActive || graphLevel.level === 'full'
     ? null
     : activeThemeLabel
       ? backboneModel ?? constellationModel
       : constellationModel;
+  const presetAtlasModel = useMemo(
+    () => (USE_SIGMA && !levelsActive && !filters.search.trim()
+      ? buildPresetAtlas(data, filters, lens, activePreset)
+      : null),
+    [activePreset, data, filters, lens, levelsActive]
+  );
+  const graphOverrideModel = semanticOverrideModel ?? presetAtlasModel;
   const graphViewLevel: GraphViewLevel =
-    !levelsActive || graphLevel.level === 'full' ? 'full' : activeThemeLabel && backboneModel ? 'theme' : 'corpus';
+    presetAtlasModel ? 'atlas'
+      : !levelsActive || graphLevel.level === 'full' ? 'full'
+        : activeThemeLabel && backboneModel ? 'theme' : 'corpus';
+  const visibleGraphNodeCount = graphOverrideModel?.nodes.length ?? data.nodes.length;
+  const visibleGraphEdgeCount = graphOverrideModel?.edges.length ?? data.edges.length;
+  const activePresetDefinition = GRAPH_PRESETS.find((preset) => preset.id === activePreset);
 
   const drillIntoTheme = useCallback((_nodeId: string, label: string) => {
     setIdeaDetail(null);
@@ -3229,9 +3243,9 @@ export function GraphView({
   }, [ideaDetail, edgeDetail, detailLoading]);
 
   return (
-    <div className="h-full flex flex-col min-h-0" data-testid={testId}>
+    <div className="nodus-graph-view h-full flex flex-col min-h-0" data-testid={testId}>
       {/* Filter bar */}
-      <div className="border-b border-neutral-800 p-2 text-xs">
+      <div className="nodus-graph-toolbar border-b border-neutral-800 p-2 text-xs">
         <div className="flex flex-wrap gap-2 items-center">
           {scopeControl}
           <div className="flex flex-wrap gap-1">
@@ -3319,9 +3333,7 @@ export function GraphView({
           )}
           <div className="flex-1" />
           <span className="text-neutral-500">{tx('{n} nodos', {
-            n: USE_SIGMA
-              ? (graphOverrideModel?.nodes.length ?? data.nodes.length)
-              : elements.filter((e) => !(e.data as any).source).length,
+            n: USE_SIGMA ? visibleGraphNodeCount : elements.filter((e) => !(e.data as any).source).length,
           })}</span>
         </div>
 
@@ -3417,7 +3429,7 @@ export function GraphView({
         )}
       </div>
 
-      <div className="flex-1 flex min-h-0 relative">
+      <div className="nodus-graph-workspace flex-1 flex min-h-0 relative">
         {lens === 'ideas' && dataSource.capabilities.tutor && tutorOpen && (
           <TutorPanel
             settings={settings}
@@ -3430,7 +3442,7 @@ export function GraphView({
             onClose={() => setTutorOpen(false)}
           />
         )}
-        <div className="flex-1 min-w-0 relative">
+        <div className="nodus-graph-stage flex-1 min-w-0 relative overflow-hidden">
           {USE_SIGMA ? (
             <GraphErrorBoundary>
               <SigmaGraph
@@ -3473,18 +3485,33 @@ export function GraphView({
             </div>
           )}
 
-          {/* Semantic-zoom breadcrumb (Sigma overview) */}
-          {USE_SIGMA && levelsActive && (
-            <div className="absolute top-3 left-3 z-10 flex max-w-[70%] flex-col gap-1.5">
-              {graphViewLevel === 'corpus' ? (
-                <div className="card flex items-center gap-1.5 bg-neutral-900/90 px-2.5 py-1.5 text-xs text-neutral-400">
-                  <Icon name="layers" size={13} />
-                  {tx('{n} temas · haz clic para explorar', { n: themes.length })}
+          {/* Semantic atlas HUD: progressive overview + compact preset scenes. */}
+          {USE_SIGMA && (levelsActive || presetAtlasModel) && (
+            <div
+              className="nodus-graph-atlas-hud absolute top-4 left-4 z-10 flex max-w-[72%] flex-col gap-2"
+              data-testid="knowledge-atlas-hud"
+              data-preset={activePreset}
+            >
+              <div className="nodus-graph-atlas-card">
+                <div className="nodus-graph-atlas-eyebrow">
+                  <span className="nodus-graph-atlas-mark"><Icon name={activePresetDefinition?.icon ?? 'layers'} size={12} /></span>
+                  <span>NODUS · {t('Grafo')}</span>
                 </div>
-              ) : (
-                <div className="card flex items-center gap-0.5 bg-neutral-900/90 px-1 py-1 text-xs">
+                {presetAtlasModel ? (
+                  <>
+                    <div className="nodus-graph-atlas-title">{t(activePresetDefinition?.label ?? activePreset)}</div>
+                    <div className="nodus-graph-atlas-description">
+                      {t(activePresetDefinition?.description ?? '')}
+                    </div>
+                  </>
+                ) : graphViewLevel === 'corpus' ? (
+                  <div className="nodus-graph-atlas-title">
+                    {tx('{n} temas · haz clic para explorar', { n: themes.length })}
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1 text-xs">
                   <button
-                    className="flex items-center gap-1 rounded px-1.5 py-1 text-neutral-300 hover:bg-neutral-800"
+                    className="nodus-graph-atlas-back"
                     onClick={backToCorpus}
                     title={t('Volver a los temas del corpus')}
                   >
@@ -3502,12 +3529,18 @@ export function GraphView({
                   {graphViewLevel === 'full' && (
                     <span className="px-1 text-neutral-400">{t('Idea enfocada')}</span>
                   )}
+                  </div>
+                )}
+                <div className="nodus-graph-atlas-metrics">
+                  <span>{tx('{n} nodos', { n: visibleGraphNodeCount })}</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{tx('{n} relaciones', { n: visibleGraphEdgeCount })}</span>
                 </div>
-              )}
+              </div>
 
               {/* Level-2 density control: how many of the theme's ideas to show. */}
               {graphViewLevel === 'theme' && activeThemeTotal > 0 && (
-                <div className="card flex items-center gap-2.5 bg-neutral-900/90 px-2.5 py-1.5 text-xs text-neutral-300">
+                <div className="nodus-graph-density-card flex items-center gap-2.5 text-xs text-neutral-300">
                   <span className="whitespace-nowrap tabular-nums text-neutral-400">
                     {backboneCap >= maximumThemeIdeas && activeThemeTotal <= 250
                       ? tx('Todas · {n} ideas', { n: activeThemeTotal })
@@ -3537,19 +3570,19 @@ export function GraphView({
           )}
 
           {/* Zoom / fit controls */}
-          <div className="absolute top-3 right-3 flex flex-col gap-1">
-            <button className="card bg-neutral-900/90 p-1.5 hover:bg-neutral-800" title={t('Acercar')} onClick={() => zoomBy(1.25)}>
+          <div className="nodus-graph-viewport-controls absolute top-4 right-4 z-10 flex flex-col gap-1">
+            <button className="nodus-graph-viewport-button" title={t('Acercar')} onClick={() => zoomBy(1.25)}>
               <Icon name="plus" size={16} />
             </button>
-            <button className="card bg-neutral-900/90 p-1.5 hover:bg-neutral-800" title={t('Alejar')} onClick={() => zoomBy(0.8)}>
+            <button className="nodus-graph-viewport-button" title={t('Alejar')} onClick={() => zoomBy(0.8)}>
               <Icon name="minus" size={16} />
             </button>
-            <button className="card bg-neutral-900/90 p-1.5 hover:bg-neutral-800" title={t('Ajustar a la pantalla')} onClick={fitGraph}>
+            <button className="nodus-graph-viewport-button" title={t('Ajustar a la pantalla')} onClick={fitGraph}>
               <Icon name="fit" size={16} />
             </button>
             {USE_SIGMA && lens === 'ideas' && layoutMode === 'force' && (
               <button
-                className="card bg-neutral-900/90 p-1.5 hover:bg-neutral-800"
+                className="nodus-graph-viewport-button"
                 title={t('Animar la evolución del grafo por fecha de creación')}
                 onClick={playGraphHistory}
               >
@@ -3557,7 +3590,7 @@ export function GraphView({
               </button>
             )}
             <button
-              className="card bg-neutral-900/90 p-1.5 hover:bg-neutral-800"
+              className="nodus-graph-viewport-button"
               title={t('Reiniciar grafo (vista y disposición originales)')}
               onClick={resetGraph}
             >
@@ -3578,7 +3611,7 @@ export function GraphView({
           )}
 
           {/* Legend */}
-          <div className="absolute bottom-3 left-3 card p-2 text-[10px] bg-neutral-900/90 max-w-[220px]">
+          <div className="nodus-graph-legend absolute bottom-4 left-4 z-10 max-w-[220px] p-2.5 text-[10px]">
             <div className="flex items-center gap-2">
               <span className="font-medium text-neutral-300">{t('Leyenda')}</span>
               <button
@@ -3591,21 +3624,31 @@ export function GraphView({
             </div>
             {!legendCollapsed && (
               <div className="mt-1 space-y-1">
-                {GRAPH_NODE_TYPES.map((nt) => (
-                  <div key={nt} className="flex items-center gap-1.5">
-                    <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: NODE_COLORS[nt] }} />
-                    {t(NODE_LABELS[nt])}
-                  </div>
-                ))}
-                <div className="pt-1 border-t border-neutral-800 text-neutral-500">{t('○ borde punteado: no leída')}</div>
-                <div className="pt-1 border-t border-neutral-800 space-y-0.5">
-                  {Object.entries(EDGE_TYPE_COLORS).filter(([et]) => et !== 'contains').map(([type, color]) => (
-                    <div key={type} className="flex items-center gap-1.5 text-neutral-400">
-                      <span className="w-3 h-0.5 rounded" style={{ backgroundColor: color }} />
-                      {t(EDGE_LABELS[type as keyof typeof EDGE_LABELS]) ?? type}
+                {lens === 'authors' ? (
+                  <>
+                    <div className="flex items-center gap-1.5">
+                      <span className="h-2.5 w-2.5 rounded-full bg-indigo-500" />
+                      {t('Autores')}
+                    </div>
+                    <div className="text-neutral-500">{t('Relaciones entre autores del corpus.')}</div>
+                  </>
+                ) : GRAPH_NODE_TYPES.map((nt) => (
+                    <div key={nt} className="flex items-center gap-1.5">
+                      <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: NODE_COLORS[nt] }} />
+                      {t(NODE_LABELS[nt])}
                     </div>
                   ))}
-                </div>
+                <div className="pt-1 border-t border-neutral-800 text-neutral-500">{t('○ borde punteado: no leída')}</div>
+                {lens === 'ideas' && (
+                  <div className="pt-1 border-t border-neutral-800 space-y-0.5">
+                    {Object.entries(EDGE_TYPE_COLORS).filter(([et]) => et !== 'contains').map(([type, color]) => (
+                      <div key={type} className="flex items-center gap-1.5 text-neutral-400">
+                        <span className="w-3 h-0.5 rounded" style={{ backgroundColor: color }} />
+                        {t(EDGE_LABELS[type as keyof typeof EDGE_LABELS]) ?? type}
+                      </div>
+                    ))}
+                  </div>
+                )}
                 <div className="text-neutral-500">{t('— sólida: explícita · ·· punteada: inferida')}</div>
               </div>
             )}

--- a/src/views/graph/SigmaGraph.tsx
+++ b/src/views/graph/SigmaGraph.tsx
@@ -37,8 +37,8 @@ export interface SigmaGraphApi {
   reset: () => void;
 }
 
-/** Semantic-zoom level currently on screen. 'full' is the classic idea graph. */
-export type GraphViewLevel = 'corpus' | 'theme' | 'full';
+/** Semantic-zoom level currently on screen. `atlas` is a bounded preset scene. */
+export type GraphViewLevel = 'corpus' | 'theme' | 'atlas' | 'full';
 
 interface SigmaGraphProps {
   data: GraphData;
@@ -143,6 +143,14 @@ interface LabelCollisionState {
   boxes: RenderedLabelBox[];
 }
 
+interface AtlasFieldPoint {
+  x: number;
+  y: number;
+  size: number;
+  color: string;
+  theme: boolean;
+}
+
 type SigmaNodeLabelData = Parameters<NodeLabelDrawingFunction>[1];
 type SigmaLabelSettings = Parameters<NodeLabelDrawingFunction>[2];
 
@@ -213,6 +221,22 @@ function hexLightness(hex: string): number {
   const g = parseInt(value.slice(2, 4), 16);
   const b = parseInt(value.slice(4, 6), 16);
   return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+function colorWithAlpha(color: string, alpha: number): string {
+  const value = color.replace('#', '');
+  if (!/^[\da-f]{6}$/i.test(value)) return `rgba(99,102,241,${alpha})`;
+  return `rgba(${parseInt(value.slice(0, 2), 16)},${parseInt(value.slice(2, 4), 16)},${parseInt(value.slice(4, 6), 16)},${alpha})`;
+}
+
+function atlasFieldRadius(points: AtlasFieldPoint[], centerX: number, centerY: number, viewLevel: GraphViewLevel): number {
+  const distances = points
+    .map((point) => Math.hypot(point.x - centerX, point.y - centerY) + point.size)
+    .sort((a, b) => a - b);
+  const representative = distances[Math.min(distances.length - 1, Math.floor(distances.length * 0.86))] ?? 0;
+  if (viewLevel === 'corpus') return Math.max(44, Math.min(118, representative + 28));
+  if (viewLevel === 'atlas') return Math.max(68, Math.min(290, representative + 44));
+  return Math.max(78, Math.min(340, representative + 52));
 }
 
 function drawWrappedNodeLabel(
@@ -305,6 +329,7 @@ export function SigmaGraph({
   showMinimap = true,
 }: SigmaGraphProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const atlasCanvasRef = useRef<HTMLCanvasElement>(null);
   const minimapRef = useRef<HTMLCanvasElement>(null);
   const sigmaRef = useRef<Sigma | null>(null);
   const detailGraphRef = useRef<Graph | null>(null);
@@ -324,6 +349,7 @@ export function SigmaGraph({
   const cameraRafRef = useRef<number | null>(null);
   const clusterTimerRef = useRef<number | null>(null);
   const minimapRafRef = useRef<number | null>(null);
+  const atlasRafRef = useRef<number | null>(null);
   const minimapFrameRef = useRef<MinimapFrame | null>(null);
   const searchRef = useRef(filters.search);
   const [revealedNodeIds, setRevealedNodeIds] = useState<Set<string>>(() => new Set());
@@ -387,6 +413,7 @@ export function SigmaGraph({
       graph.addNode(n.id, {
         label: n.label,
         kind: n.type,
+        group: n.group,
         // Theme hubs read as bubbles, so give them a larger on-screen radius than ideas.
         size: Math.max(4, n.size / (n.type === 'theme' ? 1.7 : 2.4)),
         color: n.color ?? nodeColor(n.type),
@@ -440,7 +467,9 @@ export function SigmaGraph({
       // Corpus level: only a handful of theme nodes — always keep their captions
       // so the overview reads at a glance (labels sit on Sigma's top canvas, so a
       // neighbouring node can never paint over them).
-      if (viewLevelRef.current === 'corpus') res.forceLabel = true;
+      if (viewLevelRef.current === 'corpus' || (viewLevelRef.current === 'atlas' && dataAttrs.kind === 'theme')) {
+        res.forceLabel = true;
+      }
       const focus = focusRef.current;
       const hover = hoverRef.current;
       // Cross-theme satellites stay quiet (no caption) until a connected idea is
@@ -698,6 +727,101 @@ export function SigmaGraph({
   useEffect(() => {
     onCameraUpdatedRef.current = onCameraUpdated;
   }, [onCameraUpdated]);
+
+  const drawAtlasFields = useCallback(() => {
+    const sigma = sigmaRef.current;
+    const graph = detailGraphRef.current;
+    const canvas = atlasCanvasRef.current;
+    if (!sigma || !graph || !canvas) return;
+    const { width, height } = sigma.getDimensions();
+    const pixelRatio = Math.min(2, window.devicePixelRatio || 1);
+    const targetWidth = Math.max(1, Math.round(width * pixelRatio));
+    const targetHeight = Math.max(1, Math.round(height * pixelRatio));
+    if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+    }
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    context.clearRect(0, 0, width, height);
+    if (graph.order === 0) return;
+
+    const groups = new Map<string, AtlasFieldPoint[]>();
+    graph.forEachNode((_id, attrs) => {
+      if (attrs.historyVisible === false) return;
+      const group = String(attrs.group ?? '').trim();
+      if (!group) return;
+      const rawX = Number(attrs.x);
+      const rawY = Number(attrs.y);
+      if (!Number.isFinite(rawX) || !Number.isFinite(rawY)) return;
+      const point = sigma.graphToViewport({ x: rawX, y: rawY });
+      if (point.x < -380 || point.x > width + 380 || point.y < -380 || point.y > height + 380) return;
+      const list = groups.get(group) ?? [];
+      list.push({
+        x: point.x,
+        y: point.y,
+        size: Math.max(3, Number(attrs.size ?? 3)),
+        color: String(attrs.color ?? nodeColor(String(attrs.kind ?? ''))),
+        theme: attrs.kind === 'theme',
+      });
+      groups.set(group, list);
+    });
+
+    const fieldAlpha = lightTheme ? 0.048 : 0.075;
+    for (const points of groups.values()) {
+      if (points.length === 1 && !points[0].theme && viewLevel === 'full') continue;
+      let weightedX = 0;
+      let weightedY = 0;
+      let totalWeight = 0;
+      for (const point of points) {
+        const weight = point.theme ? 3 : 1;
+        weightedX += point.x * weight;
+        weightedY += point.y * weight;
+        totalWeight += weight;
+      }
+      const centerX = weightedX / Math.max(1, totalWeight);
+      const centerY = weightedY / Math.max(1, totalWeight);
+      const radius = atlasFieldRadius(points, centerX, centerY, viewLevel);
+      const color = points.find((point) => point.theme)?.color ?? points[0].color;
+      const gradient = context.createRadialGradient(centerX, centerY, radius * 0.12, centerX, centerY, radius);
+      gradient.addColorStop(0, colorWithAlpha(color, fieldAlpha * 1.8));
+      gradient.addColorStop(0.68, colorWithAlpha(color, fieldAlpha));
+      gradient.addColorStop(1, colorWithAlpha(color, 0));
+      context.fillStyle = gradient;
+      context.beginPath();
+      context.arc(centerX, centerY, radius, 0, Math.PI * 2);
+      context.fill();
+      context.strokeStyle = colorWithAlpha(color, lightTheme ? 0.16 : 0.2);
+      context.lineWidth = 1;
+      context.setLineDash([3, 8]);
+      context.beginPath();
+      context.arc(centerX, centerY, Math.max(20, radius - 9), 0, Math.PI * 2);
+      context.stroke();
+    }
+    context.setLineDash([]);
+
+    for (const points of groups.values()) {
+      for (const point of points) {
+        if (!point.theme) continue;
+        context.strokeStyle = colorWithAlpha(point.color, lightTheme ? 0.2 : 0.28);
+        context.lineWidth = 1;
+        for (const offset of [8, 15]) {
+          context.beginPath();
+          context.arc(point.x, point.y, point.size + offset, 0, Math.PI * 2);
+          context.stroke();
+        }
+      }
+    }
+  }, [lens, lightTheme, viewLevel]);
+
+  const scheduleAtlasDraw = useCallback(() => {
+    if (atlasRafRef.current != null) return;
+    atlasRafRef.current = window.requestAnimationFrame(() => {
+      atlasRafRef.current = null;
+      drawAtlasFields();
+    });
+  }, [drawAtlasFields]);
 
   // ── Sigma minimap ───────────────────────────────────────────────────────────
   const drawMinimap = useCallback(() => {
@@ -1136,6 +1260,20 @@ export function SigmaGraph({
   useEffect(() => {
     const sigma = sigmaRef.current;
     if (!sigma) return;
+    sigma.on('afterRender', scheduleAtlasDraw);
+    scheduleAtlasDraw();
+    return () => {
+      sigma.removeListener('afterRender', scheduleAtlasDraw);
+      if (atlasRafRef.current != null) {
+        window.cancelAnimationFrame(atlasRafRef.current);
+        atlasRafRef.current = null;
+      }
+    };
+  }, [scheduleAtlasDraw]);
+
+  useEffect(() => {
+    const sigma = sigmaRef.current;
+    if (!sigma) return;
     sigma.on('afterRender', scheduleMinimapDraw);
     scheduleMinimapDraw();
     return () => {
@@ -1414,6 +1552,7 @@ export function SigmaGraph({
   useEffect(() => {
     return () => {
       if (cameraRafRef.current != null) window.cancelAnimationFrame(cameraRafRef.current);
+      if (atlasRafRef.current != null) window.cancelAnimationFrame(atlasRafRef.current);
       if (clusterTimerRef.current != null) window.clearTimeout(clusterTimerRef.current);
       if (minimapRafRef.current != null) window.cancelAnimationFrame(minimapRafRef.current);
       if (historyTimerRef.current != null) window.clearInterval(historyTimerRef.current);
@@ -1424,7 +1563,8 @@ export function SigmaGraph({
 
   return (
     <>
-      <div ref={containerRef} className="absolute inset-0" data-testid="sigma-graph-engine" />
+      <canvas ref={atlasCanvasRef} className="nodus-graph-territories absolute inset-0 size-full" aria-hidden="true" />
+      <div ref={containerRef} className="nodus-graph-engine absolute inset-0" data-testid="sigma-graph-engine" />
       <canvas
         ref={minimapRef}
         width={156}

--- a/src/views/graph/model.ts
+++ b/src/views/graph/model.ts
@@ -52,6 +52,8 @@ export interface NodeModel {
   id: string;
   label: string;
   type: GraphNodeType;
+  /** Primary semantic territory used by the renderer's knowledge-atlas layer. */
+  group?: string;
   createdAt?: string | null;
   workCount: number;
   degree: number;
@@ -329,6 +331,7 @@ export function buildGraphModel(
       id: n.id,
       label: n.label,
       type: n.type,
+      group: n.type === 'theme' ? n.label : n.themes[0],
       createdAt: n.createdAt,
       workCount: n.workCount,
       degree,
@@ -427,6 +430,7 @@ export function buildThemeConstellation(data: GraphData): GraphModel {
       id: theme.id,
       label: theme.label,
       type: 'theme',
+      group: theme.label,
       createdAt: theme.createdAt,
       workCount: count,
       degree: count,
@@ -464,6 +468,278 @@ export function buildThemeConstellation(data: GraphData): GraphModel {
     });
   }
   return { nodes, edges };
+}
+
+// ── Compact atlas scenes for the graph presets ───────────────────────────────
+// The presets used to feed their filtered *complete* graph to Sigma. That kept
+// the WebGL renderer fast, but visually they fell back to the old hairball: no
+// hierarchy, no bounded scene and no thematic geography. These builders retain
+// the precise preset filters while selecting a representative, deterministic
+// scene that the atlas renderer can settle and frame in one pass.
+
+const IDEA_ATLAS_GLOBAL_CAP = 126;
+const GAP_ATLAS_GLOBAL_CAP = 112;
+const AUTHOR_ATLAS_CAP = 144;
+const AUTHOR_ATLAS_MAX_TERRITORIES = 8;
+
+function atlasThemeColorMap(data: GraphData): Map<string, string> {
+  const colors = new Map<string, string>();
+  let index = 0;
+  for (const node of data.nodes) {
+    if (node.type !== 'theme') continue;
+    colors.set(normalizeThemeKey(node.label), THEME_CONSTELLATION_PALETTE[index % THEME_CONSTELLATION_PALETTE.length]);
+    index++;
+  }
+  return colors;
+}
+
+function syntheticThemeId(group: string): string {
+  return `atlas-theme:${Math.round(stableUnit(group) * 1_000_000_000)}`;
+}
+
+function buildIdeaPresetAtlas(
+  data: GraphData,
+  base: GraphModel,
+  preset: Extract<GraphPresetId, 'gaps' | 'reading' | 'unread'>
+): GraphModel {
+  const candidates = base.nodes.filter((node) => node.type !== 'theme');
+  if (candidates.length === 0) return { nodes: [], edges: [] };
+
+  const byGroup = new Map<string, NodeModel[]>();
+  for (const node of candidates) {
+    const group = node.group?.trim() || '∅';
+    const bucket = byGroup.get(group) ?? [];
+    bucket.push(node);
+    byGroup.set(group, bucket);
+  }
+
+  const groupEntries = [...byGroup.entries()].sort((a, b) =>
+    b[1].length - a[1].length || a[0].localeCompare(b[0])
+  );
+  const globalCap = preset === 'gaps' ? GAP_ATLAS_GLOBAL_CAP : IDEA_ATLAS_GLOBAL_CAP;
+  const perGroupCap = preset === 'gaps' ? 8 : 9;
+  const selected: NodeModel[] = [];
+  const totalByGroup = new Map<string, number>();
+
+  for (const [group, nodes] of groupEntries) {
+    totalByGroup.set(group, nodes.length);
+    nodes.sort((a, b) => {
+      if (preset === 'gaps') {
+        // Sparse, unread and low-confidence-peripheral ideas are the places where
+        // the corpus has the least connective tissue — the useful gap signal the
+        // legacy preset was trying to expose with edge filters alone.
+        return a.degree - b.degree || Number(a.read) - Number(b.read)
+          || b.labelRank - a.labelRank || a.label.localeCompare(b.label);
+      }
+      // Reading atlases lead with the ideas that best connect their territory.
+      return b.degree - a.degree || b.workCount - a.workCount
+        || b.labelRank - a.labelRank || a.label.localeCompare(b.label);
+    });
+    const room = Math.max(0, globalCap - selected.length);
+    if (room === 0) break;
+    selected.push(...nodes.slice(0, Math.min(perGroupCap, room)));
+  }
+
+  const selectedIds = new Set(selected.map((node) => node.id));
+  const selectedGroups = new Set(selected.map((node) => node.group?.trim() || '∅'));
+  const themeByKey = new Map(
+    data.nodes
+      .filter((node) => node.type === 'theme')
+      .map((node) => [normalizeThemeKey(node.label), node] as const)
+  );
+  const colorByTheme = atlasThemeColorMap(data);
+  const themeIdByGroup = new Map<string, string>();
+  const themeNodes: NodeModel[] = [];
+
+  for (const group of selectedGroups) {
+    const source = group === '∅' ? undefined : themeByKey.get(normalizeThemeKey(group));
+    const id = source?.id ?? syntheticThemeId(group);
+    themeIdByGroup.set(group, id);
+    const total = totalByGroup.get(group) ?? 0;
+    themeNodes.push({
+      id,
+      label: source?.label ?? '∅',
+      type: 'theme',
+      group,
+      createdAt: source?.createdAt,
+      workCount: total,
+      degree: total,
+      labelRank: 1.2,
+      size: themeConstellationSize(total),
+      read: preset !== 'unread',
+      color: colorByTheme.get(normalizeThemeKey(group))
+        ?? THEME_CONSTELLATION_PALETTE[themeNodes.length % THEME_CONSTELLATION_PALETTE.length],
+    });
+  }
+
+  const rankedSelected = [...selected].sort((a, b) => {
+    if (preset === 'gaps') return a.degree - b.degree || a.label.localeCompare(b.label);
+    return b.degree - a.degree || a.label.localeCompare(b.label);
+  });
+  const selectedNodes = rankedSelected.map((node, index) => ({
+    ...node,
+    size: Math.max(9, Math.min(18, node.size)),
+    labelRank: rankedSelected.length <= 1 ? 1 : 1 - index / (rankedSelected.length - 1),
+  }));
+
+  const semanticEdges = base.edges
+    .filter((edge) => edge.type !== 'contains' && selectedIds.has(edge.source) && selectedIds.has(edge.target))
+    .sort((a, b) => Number(b.layoutEdge) - Number(a.layoutEdge) || b.confidence - a.confidence)
+    .slice(0, 260)
+    .map((edge) => ({ ...edge, layoutEdge: true }));
+  const membershipEdges: EdgeModel[] = selectedNodes.flatMap((node) => {
+    const group = node.group?.trim() || '∅';
+    const source = themeIdByGroup.get(group);
+    if (!source) return [];
+    return [{
+      id: `atlas-membership:${source}:${node.id}`,
+      source,
+      target: node.id,
+      type: 'contains',
+      basis: 'inferred',
+      confidence: 0.72,
+      layoutEdge: true,
+    }];
+  });
+
+  return { nodes: [...themeNodes, ...selectedNodes], edges: [...membershipEdges, ...semanticEdges] };
+}
+
+function buildAuthorPresetAtlas(base: GraphModel): GraphModel {
+  const ranked = base.nodes
+    .filter((node) => node.type === 'author')
+    .sort((a, b) => b.degree - a.degree || b.workCount - a.workCount || a.label.localeCompare(b.label))
+    .slice(0, AUTHOR_ATLAS_CAP);
+  if (ranked.length === 0) return { nodes: [], edges: [] };
+
+  const kept = new Set(ranked.map((node) => node.id));
+  const edges = base.edges
+    .filter((edge) => kept.has(edge.source) && kept.has(edge.target))
+    .sort((a, b) => b.confidence - a.confidence || stableUnit(a.id) - stableUnit(b.id))
+    .slice(0, 120)
+    .map((edge) => ({ ...edge, layoutEdge: true }));
+
+  // Small deterministic label propagation gives the author lens real visual
+  // territories without importing another clustering runtime into the renderer.
+  const adjacency = new Map<string, Array<{ id: string; weight: number }>>();
+  for (const node of ranked) adjacency.set(node.id, []);
+  for (const edge of edges) {
+    const weight = Math.max(0.05, edge.confidence);
+    adjacency.get(edge.source)?.push({ id: edge.target, weight });
+    adjacency.get(edge.target)?.push({ id: edge.source, weight });
+  }
+  const labels = new Map(ranked.map((node) => [node.id, node.id]));
+  const ids = ranked.map((node) => node.id).sort();
+  for (let iteration = 0; iteration < 8; iteration++) {
+    let changed = false;
+    for (const id of ids) {
+      const scores = new Map<string, number>();
+      for (const neighbor of adjacency.get(id) ?? []) {
+        const label = labels.get(neighbor.id) ?? neighbor.id;
+        scores.set(label, (scores.get(label) ?? 0) + neighbor.weight);
+      }
+      let best = labels.get(id) ?? id;
+      let bestScore = -1;
+      for (const [label, score] of [...scores].sort((a, b) => a[0].localeCompare(b[0]))) {
+        if (score > bestScore) {
+          best = label;
+          bestScore = score;
+        }
+      }
+      if (best !== labels.get(id)) {
+        labels.set(id, best);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
+  const membersByLabel = new Map<string, string[]>();
+  for (const id of ids) {
+    const label = labels.get(id) ?? id;
+    const members = membersByLabel.get(label) ?? [];
+    members.push(id);
+    membersByLabel.set(label, members);
+  }
+  const communities = [...membersByLabel.entries()].sort((a, b) =>
+    b[1].length - a[1].length || a[0].localeCompare(b[0])
+  );
+  const retainedLabels = new Set(communities.slice(0, AUTHOR_ATLAS_MAX_TERRITORIES - 1).map(([label]) => label));
+  const territoryById = new Map<string, string>();
+  for (const [label, members] of communities) {
+    const territory = retainedLabels.has(label) ? `author-network:${label}` : 'author-network:periphery';
+    for (const id of members) territoryById.set(id, territory);
+  }
+  const territories = [...new Set(territoryById.values())].sort();
+  const colorByTerritory = new Map(territories.map((territory, index) => [
+    territory,
+    THEME_CONSTELLATION_PALETTE[index % THEME_CONSTELLATION_PALETTE.length],
+  ]));
+  const degreeById = new Map(ranked.map((node) => [node.id, 0]));
+  for (const edge of edges) {
+    degreeById.set(edge.source, (degreeById.get(edge.source) ?? 0) + 1);
+    degreeById.set(edge.target, (degreeById.get(edge.target) ?? 0) + 1);
+  }
+
+  const nodes = ranked.map((node, index) => {
+    const territory = territoryById.get(node.id) ?? 'author-network:periphery';
+    const degree = degreeById.get(node.id) ?? 0;
+    return {
+      ...node,
+      group: territory,
+      color: colorByTerritory.get(territory),
+      degree,
+      size: authorNodeSize(node.workCount, degree),
+      labelRank: ranked.length <= 1 ? 1 : 1 - index / (ranked.length - 1),
+    };
+  });
+  const territoryIndex = new Map(territories.map((territory, index) => [territory, index]));
+  const hubByTerritory = new Map<string, string>();
+  const hubNodes: NodeModel[] = territories.map((territory, index) => {
+    const memberCount = nodes.filter((node) => node.group === territory).length;
+    const id = `author-territory:${index}`;
+    hubByTerritory.set(territory, id);
+    return {
+      id,
+      label: `C${index + 1}`,
+      type: 'theme',
+      group: territory,
+      createdAt: null,
+      workCount: memberCount,
+      degree: memberCount,
+      labelRank: 1.2,
+      size: themeConstellationSize(memberCount),
+      read: true,
+      color: colorByTerritory.get(territory),
+    };
+  });
+  const membershipEdges: EdgeModel[] = nodes.map((node) => {
+    const territory = node.group ?? 'author-network:periphery';
+    const hub = hubByTerritory.get(territory) ?? `author-territory:${territoryIndex.get(territory) ?? 0}`;
+    return {
+      id: `author-membership:${hub}:${node.id}`,
+      source: hub,
+      target: node.id,
+      type: 'contains',
+      basis: 'inferred',
+      confidence: 0.78,
+      layoutEdge: true,
+    };
+  });
+  return { nodes: [...hubNodes, ...nodes], edges: [...membershipEdges, ...edges] };
+}
+
+/** Build the compact semantic scene for a non-overview graph preset. */
+export function buildPresetAtlas(
+  data: GraphData,
+  filters: GraphFilters,
+  lens: GraphLens,
+  preset: GraphPresetId
+): GraphModel | null {
+  if (preset !== 'gaps' && preset !== 'reading' && preset !== 'unread' && preset !== 'authors') return null;
+  const base = buildGraphModel(data, filters, lens, preset);
+  if (preset === 'authors') return buildAuthorPresetAtlas(base);
+  return buildIdeaPresetAtlas(data, base, preset);
 }
 
 function largestComponent(ids: Set<string>, adjacency: Map<string, Set<string>>): Set<string> {
@@ -552,6 +828,7 @@ export function buildThemeBackbone(data: GraphData, themeLabel: string, cap = 90
       id,
       label: node.label,
       type: node.type,
+      group: themeLabel,
       createdAt: node.createdAt,
       workCount: node.workCount,
       degree,
@@ -619,6 +896,7 @@ export function buildThemeBackbone(data: GraphData, themeLabel: string, cap = 90
         id,
         label: node.label,
         type: node.type,
+        group: firstTheme,
         createdAt: node.createdAt,
         workCount: node.workCount,
         degree: bridgeStat.get(id)!.count,


### PR DESCRIPTION
## Resumen

- Rediseña el grafo de conocimiento como un atlas semántico progresivo y legible.
- Adapta Panorama, Huecos, Lectura, Por leer y Autores al motor Sigma con escenas acotadas, territorios temáticos y comunidades visuales.
- Mejora la jerarquía de nodos, etiquetas, conexiones, leyendas y campos de contexto.
- Corrige el comportamiento responsive de la cabecera para mantener sus controles visibles en ventanas compactas y maximizadas.
- Añade cobertura automatizada para los nuevos presets y el layout del encabezado.

## Motivación

Los grafos densos perdían estructura visual y hacían difícil distinguir temas, vacíos de conocimiento, estados de lectura y comunidades de autores. El nuevo diseño limita cada escena, conserva las relaciones más informativas y ofrece una navegación más clara sin bloquear la interfaz.

## Validación

- `npm run typecheck`
- `npm run build`
- ESLint sobre los archivos modificados
- 56 pruebas dirigidas del grafo, layout, internacionalización y UI
- Revalidación posterior al rebase sobre `main`