### PR TITLE
Add synced annotations to the Deep Research reader

### DIFF
--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -10,7 +10,7 @@ export interface Migration {
 
 // Versioned, append-only migrations. Never edit an existing migration's SQL once
 // shipped — add a new one. The current schema version is the highest applied.
-export const SCHEMA_VERSION = 125;
+export const SCHEMA_VERSION = 126;
 
 export const migrations: Migration[] = [
   {
@@ -6309,6 +6309,36 @@ export const migrations: Migration[] = [
         saved_at   TEXT NOT NULL
       );
       CREATE INDEX idx_saved_authors_saved_at ON saved_authors(saved_at DESC);
+    `,
+  },
+  {
+    version: 126,
+    up: /* sql */ `
+      -- Persistent, syncable annotations over saved Deep Research text. They live in
+      -- their own small rows rather than rewriting draft_json for every highlight: a
+      -- fifteen-page report must not go back over the wire because one pastel colour
+      -- or one comment changed.
+      --
+      -- No foreign key on purpose. A connected replica can receive child and parent
+      -- mutations in either order, just as writing_draft_reads can. Repository deletes
+      -- still remove annotations before their report so local data never leaves orphans.
+      CREATE TABLE writing_draft_annotations (
+        id            TEXT PRIMARY KEY,
+        draft_id      TEXT NOT NULL,
+        scope         TEXT NOT NULL DEFAULT 'source',
+        kind          TEXT NOT NULL CHECK (kind IN ('highlight','comment')),
+        color         TEXT CHECK (color IS NULL OR color IN ('yellow','rose','blue','mint','lavender','peach')),
+        start_offset  INTEGER NOT NULL CHECK (start_offset >= 0),
+        end_offset    INTEGER NOT NULL CHECK (end_offset > start_offset),
+        selected_text TEXT NOT NULL,
+        prefix        TEXT NOT NULL DEFAULT '',
+        suffix        TEXT NOT NULL DEFAULT '',
+        comment_text  TEXT,
+        created_at    TEXT NOT NULL,
+        updated_at    TEXT NOT NULL
+      );
+      CREATE INDEX idx_writing_draft_annotations_draft
+        ON writing_draft_annotations(draft_id, scope, start_offset, created_at);
     `,
   },
 ];

--- a/electron/db/syncTables.ts
+++ b/electron/db/syncTables.ts
@@ -37,6 +37,9 @@ const SYNC_GROUPS: { key: SyncGroupKey; prefix?: string; tables?: string[] }[] =
       // beside the report it is about. Why it is a table and not a column on the row
       // above is in the migration that creates it.
       'writing_draft_reads',
+      // Highlights and comments are authored reading work. Small independent rows keep
+      // their newest-wins merge from rewriting the multi-page report they annotate.
+      'writing_draft_annotations',
       'projects',
       'project_sections',
       'project_chapters',

--- a/electron/db/writingAnnotationsRepo.ts
+++ b/electron/db/writingAnnotationsRepo.ts
@@ -1,0 +1,157 @@
+import { v4 as uuid } from 'uuid';
+import type {
+  WritingDraftAnnotation,
+  WritingDraftAnnotationColor,
+  WritingDraftAnnotationInput,
+} from '@shared/types';
+import { getDb } from './database';
+
+interface WritingDraftAnnotationRow {
+  id: string;
+  draft_id: string;
+  scope: string;
+  kind: string;
+  color: string | null;
+  start_offset: number;
+  end_offset: number;
+  selected_text: string;
+  prefix: string;
+  suffix: string;
+  comment_text: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const COLORS = new Set<WritingDraftAnnotationColor>(['yellow', 'rose', 'blue', 'mint', 'lavender', 'peach']);
+
+function toAnnotation(row: WritingDraftAnnotationRow): WritingDraftAnnotation | null {
+  if (row.kind !== 'highlight' && row.kind !== 'comment') return null;
+  if (row.color !== null && !COLORS.has(row.color as WritingDraftAnnotationColor)) return null;
+  if (!Number.isInteger(row.start_offset) || !Number.isInteger(row.end_offset) || row.end_offset <= row.start_offset) return null;
+  return {
+    id: row.id,
+    draftId: row.draft_id,
+    scope: row.scope,
+    kind: row.kind,
+    color: row.color as WritingDraftAnnotationColor | null,
+    startOffset: row.start_offset,
+    endOffset: row.end_offset,
+    selectedText: row.selected_text,
+    prefix: row.prefix,
+    suffix: row.suffix,
+    comment: row.comment_text,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function normalizedInput(input: WritingDraftAnnotationInput) {
+  const scope = input.scope.trim() || 'source';
+  const selectedText = input.selectedText;
+  const startOffset = Math.trunc(input.startOffset);
+  const endOffset = Math.trunc(input.endOffset);
+  if (scope.length > 180) throw new Error('El contexto de la anotación no es válido.');
+  if (!Number.isInteger(startOffset) || !Number.isInteger(endOffset) || startOffset < 0 || endOffset <= startOffset) {
+    throw new Error('El fragmento seleccionado no es válido.');
+  }
+  if (!selectedText.trim() || selectedText.length !== endOffset - startOffset) {
+    throw new Error('El texto seleccionado no coincide con su posición.');
+  }
+  if (input.kind === 'highlight') {
+    if (!input.color || !COLORS.has(input.color)) throw new Error('El color del subrayado no es válido.');
+    return {
+      scope,
+      kind: input.kind,
+      color: input.color,
+      startOffset,
+      endOffset,
+      selectedText,
+      prefix: (input.prefix ?? '').slice(-64),
+      suffix: (input.suffix ?? '').slice(0, 64),
+      comment: null,
+    } as const;
+  }
+  const comment = input.comment?.trim() ?? '';
+  if (!comment) throw new Error('Escribe el comentario antes de guardarlo.');
+  return {
+    scope,
+    kind: input.kind,
+    color: null,
+    startOffset,
+    endOffset,
+    selectedText,
+    prefix: (input.prefix ?? '').slice(-64),
+    suffix: (input.suffix ?? '').slice(0, 64),
+    comment,
+  } as const;
+}
+
+export function listWritingDraftAnnotations(draftId: string): WritingDraftAnnotation[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT * FROM writing_draft_annotations
+       WHERE draft_id = ?
+       ORDER BY scope, start_offset, created_at`
+    )
+    .all(draftId) as WritingDraftAnnotationRow[];
+  return rows.map(toAnnotation).filter((item): item is WritingDraftAnnotation => item !== null);
+}
+
+export function createWritingDraftAnnotation(input: WritingDraftAnnotationInput): WritingDraftAnnotation {
+  const db = getDb();
+  const report = db.prepare('SELECT 1 FROM writing_saved_drafts WHERE id = ?').get(input.draftId);
+  if (!report) throw new Error('El informe ya no existe.');
+  const value = normalizedInput(input);
+  const id = uuid();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO writing_draft_annotations (
+       id, draft_id, scope, kind, color, start_offset, end_offset, selected_text,
+       prefix, suffix, comment_text, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    input.draftId,
+    value.scope,
+    value.kind,
+    value.color,
+    value.startOffset,
+    value.endOffset,
+    value.selectedText,
+    value.prefix,
+    value.suffix,
+    value.comment,
+    now,
+    now,
+  );
+  const row = db.prepare('SELECT * FROM writing_draft_annotations WHERE id = ?').get(id) as WritingDraftAnnotationRow;
+  const annotation = toAnnotation(row);
+  if (!annotation) throw new Error('No se pudo guardar la anotación.');
+  return annotation;
+}
+
+export function updateWritingDraftComment(id: string, comment: string): WritingDraftAnnotation | null {
+  const value = comment.trim();
+  if (!value) throw new Error('Escribe el comentario antes de guardarlo.');
+  const db = getDb();
+  const changed = db.prepare(
+    `UPDATE writing_draft_annotations
+     SET comment_text = ?, updated_at = ?
+     WHERE id = ? AND kind = 'comment'`
+  ).run(value, new Date().toISOString(), id);
+  if (changed.changes === 0) return null;
+  const row = db.prepare('SELECT * FROM writing_draft_annotations WHERE id = ?').get(id) as WritingDraftAnnotationRow;
+  return toAnnotation(row);
+}
+
+export function deleteWritingDraftAnnotation(id: string): string | null {
+  const db = getDb();
+  const row = db.prepare('SELECT draft_id FROM writing_draft_annotations WHERE id = ?').get(id) as { draft_id: string } | undefined;
+  if (!row) return null;
+  db.prepare('DELETE FROM writing_draft_annotations WHERE id = ?').run(id);
+  return row.draft_id;
+}
+
+export function deleteAnnotationsForWritingDraft(draftId: string): number {
+  return getDb().prepare('DELETE FROM writing_draft_annotations WHERE draft_id = ?').run(draftId).changes;
+}

--- a/electron/db/writingDraftsRepo.ts
+++ b/electron/db/writingDraftsRepo.ts
@@ -10,6 +10,7 @@ import type {
 } from '@shared/types';
 import { getDb } from './database';
 import { deleteDecorativeImageRow, getDecorativeImage } from './decorativeImagesRepo';
+import { deleteAnnotationsForWritingDraft } from './writingAnnotationsRepo';
 
 interface SavedWritingDraftRow {
   id: string;
@@ -247,6 +248,7 @@ export function setWritingWorkshopDraftRead(id: string, read: boolean): WritingW
 
 export function deleteWritingWorkshopDraft(id: string): boolean {
   deleteDecorativeImageRow('deep_research', id);
+  deleteAnnotationsForWritingDraft(id);
   // Before the report, so a mark can never be left pointing at nothing.
   getDb().prepare('DELETE FROM writing_draft_reads WHERE draft_id = ?').run(id);
   return getDb().prepare('DELETE FROM writing_saved_drafts WHERE id = ?').run(id).changes > 0;

--- a/electron/ipc/academic.ts
+++ b/electron/ipc/academic.ts
@@ -111,6 +111,7 @@ import type {
   WritingWorkshopDraftRequest,
   WritingWorkshopExportRequest,
   WritingWorkshopSaveDraftRequest,
+  WritingDraftAnnotationInput,
   ZoteroItem,
   ZoteroStudyMaterialImportInput,
 } from '@shared/types';
@@ -125,6 +126,7 @@ import { ingestZoteroItem } from '../sync/syncService';
 import { buildIdeaGraph, buildIdeaGraphOverview, buildIdeaThemeGraph, buildAuthorGraph, getContradictions, getDebates, buildReadingPath } from '../graph/graphService';
 import { streamDebateAnalysis } from '../ai/debate';
 import * as rqRepo from '../db/researchMapRepo';
+import * as writingAnnotations from '../db/writingAnnotationsRepo';
 import { decomposeQuestion, mapCoverage } from '../ai/researchMap';
 import { exportResearchCoverage } from '../export/researchMapExport';
 import { exportData, importData } from '../export/exportImport';
@@ -301,6 +303,14 @@ async function importStudyMaterialPaths(paths: string[], input: StudyMaterialImp
 function announceWritingDrafts(): void {
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed() && !win.webContents.isDestroyed()) win.webContents.send('writing:saved:changed', null);
+  }
+}
+
+function announceWritingDraftAnnotations(draftId: string | null): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+      win.webContents.send('writing:annotations:changed', draftId);
+    }
   }
 }
 
@@ -1226,11 +1236,28 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
     if (saved) announceWritingDrafts();
     return saved;
   });
+  h('writing:annotations:list', async (_e, draftId: string) => writingAnnotations.listWritingDraftAnnotations(draftId));
+  h('writing:annotations:create', async (_e, input: WritingDraftAnnotationInput) => {
+    const annotation = writingAnnotations.createWritingDraftAnnotation(input);
+    announceWritingDraftAnnotations(annotation.draftId);
+    return annotation;
+  });
+  h('writing:annotations:updateComment', async (_e, id: string, comment: string) => {
+    const annotation = writingAnnotations.updateWritingDraftComment(id, comment);
+    if (annotation) announceWritingDraftAnnotations(annotation.draftId);
+    return annotation;
+  });
+  h('writing:annotations:delete', async (_e, id: string) => {
+    const draftId = writingAnnotations.deleteWritingDraftAnnotation(id);
+    if (draftId) announceWritingDraftAnnotations(draftId);
+    return !!draftId;
+  });
   h('writing:saved:delete', async (_e, id: string) => {
     invalidateDecorativeImageGeneration('deep_research', id);
     translationsRepo.deleteEntityTranslations('deep_research', id);
     const removed = writingDrafts.deleteWritingWorkshopDraft(id);
     announceWritingDrafts();
+    announceWritingDraftAnnotations(id);
     return removed;
   });
 

--- a/electron/preload/academic.ts
+++ b/electron/preload/academic.ts
@@ -491,6 +491,15 @@ export const academicApi: AcademicApi = {
     ipcRenderer.on('writing:saved:changed', listener);
     return () => ipcRenderer.removeListener('writing:saved:changed', listener);
   },
+  listWritingDraftAnnotations: (draftId) => ipcRenderer.invoke('writing:annotations:list', draftId),
+  createWritingDraftAnnotation: (input) => ipcRenderer.invoke('writing:annotations:create', input),
+  updateWritingDraftComment: (id, comment) => ipcRenderer.invoke('writing:annotations:updateComment', id, comment),
+  deleteWritingDraftAnnotation: (id) => ipcRenderer.invoke('writing:annotations:delete', id).then(() => undefined),
+  onWritingDraftAnnotationsChanged: (cb) => {
+    const listener = (_event: unknown, draftId: string | null) => cb(draftId);
+    ipcRenderer.on('writing:annotations:changed', listener);
+    return () => ipcRenderer.removeListener('writing:annotations:changed', listener);
+  },
 
   generateDeepResearchReport: async (request, handlers) => {
     const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/electron/serverSync/inboxPoller.ts
+++ b/electron/serverSync/inboxPoller.ts
@@ -128,6 +128,12 @@ async function tick(): Promise<void> {
       if (summary.entries.some((entry) => entry.table === 'writing_saved_drafts' && (entry.outcome === 'applied' || entry.outcome === 'deleted'))) {
         broadcast('writing:saved:changed', null);
       }
+      if (summary.entries.some((entry) => entry.table === 'writing_draft_annotations' && (entry.outcome === 'applied' || entry.outcome === 'deleted'))) {
+        // A deletion carries only its annotation id, so the renderer treats null as
+        // "refresh the report you currently have open". Upserts could be narrowed by
+        // draft_id, but one channel shape keeps both paths honest.
+        broadcast('writing:annotations:changed', null);
+      }
 
       // A refusal did not advance the cursor, so the very same batch would come back.
       if (summary.refused.length > 0) break;

--- a/electron/serverSync/outboxTriggers.ts
+++ b/electron/serverSync/outboxTriggers.ts
@@ -34,6 +34,7 @@ export const MUTABLE_TABLES = [
   'note_folders',
   'note_links',
   'writing_saved_drafts',
+  'writing_draft_annotations',
   'decorative_images',
   'immersion_sessions',
   'saved_searches',

--- a/electron/serverSync/serverSnapshot.ts
+++ b/electron/serverSync/serverSnapshot.ts
@@ -21,7 +21,7 @@ const CORE_TABLES = [
 // agree. The rows carry no prose beyond an optional note.
 
 const USER_TABLES = [
-  'note_folders', 'notes', 'writing_saved_drafts', 'projects', 'project_sections',
+  'note_folders', 'notes', 'writing_saved_drafts', 'writing_draft_annotations', 'projects', 'project_sections',
   'project_chapters', 'project_chapter_versions', 'project_chapter_chunks',
   'project_chapter_ideas', 'project_chapter_idea_relations', 'project_links',
   'project_insertion_suggestions', 'saved_searches', 'immersion_sessions',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "version": "npm run citation:sync && git add CITATION.cff",
     "test:e2e": "node scripts/e2e-smoke.mjs",
     "test:e2e:saved-authors": "node scripts/e2e-saved-authors.mjs",
+    "test:e2e:deep-research-annotations": "npm run build && node scripts/e2e-deep-research-annotations.mjs",
     "test:e2e:local-server": "node scripts/e2e-local-server.mjs",
     "test:e2e:prosopography": "node scripts/test-prosopography-e2e.mjs",
     "test:e2e:testimony": "npm run build && node scripts/e2e-testimony.mjs",

--- a/scripts/e2e-deep-research-annotations.mjs
+++ b/scripts/e2e-deep-research-annotations.mjs
@@ -1,0 +1,199 @@
+// Real-renderer acceptance test for Deep Research annotations. It covers the pieces a
+// repository test cannot: browser selections, the persistent top-bar highlighter, CSS
+// highlights, margin icons, comment editing/confirmation, and the margin bookmark.
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-dr-annotations-ui-'));
+const childEnv = {
+  ...process.env,
+  NODUS_USERDATA: userData,
+  NODUS_DISABLE_AUTO_UPDATE: '1',
+  NODUS_E2E_UPDATE_STATUS: 'not-available',
+  NODUS_E2E_DISABLE_STUDY_BACKGROUND_AI: '1',
+};
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+let app;
+try {
+  app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(30_000);
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+
+  await page.evaluate(async (version) => {
+    localStorage.setItem('nodus.lastSeenVersion', version);
+    localStorage.setItem('nodus.mobileTeaserSeen.3.2.4', '1');
+    localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
+    localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
+    await window.nodus.updateSettings({
+      onboardingComplete: true,
+      basicsTutorialVersion: 999,
+      recoverySetupVersion: 999,
+      tourComplete: true,
+      advancedTourComplete: true,
+      uiLanguage: 'es',
+      mascotStyle: 'orb',
+      mascotStyleChosen: true,
+      mascotEnabled: false,
+      reduceMotion: true,
+    });
+    await window.nodus.seedDemoData();
+  }, require(path.join(repoRoot, 'package.json')).version);
+  await page.reload();
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+  const updateModal = page.getByTestId('startup-update-modal');
+  if (await updateModal.count()) {
+    await page.waitForFunction(() => document.querySelector('[data-testid="startup-update-modal"]')?.getAttribute('data-update-status') === 'not-available');
+    await updateModal.getByRole('button', { name: 'Entendido', exact: false }).click();
+    await updateModal.waitFor({ state: 'detached' });
+  }
+
+  await page.locator('[data-tour="nav-deepResearch"]').click();
+  await page.getByRole('button', { name: 'Leer', exact: true }).first().click();
+  const documentRoot = page.locator('[data-testid="deep-research-reader-document"]');
+  await documentRoot.waitFor({ state: 'visible' });
+  const draftId = await page.evaluate(async () => (
+    (await window.nodus.listWritingWorkshopDrafts()).find((item) => item.brief.kind === 'deep_research')?.id
+  ));
+  assert.ok(draftId, 'the demo supplies a saved Deep Research report');
+
+  async function selectCandidate(index) {
+    return page.evaluate((candidateIndex) => {
+      const root = document.querySelector('[data-testid="deep-research-reader-document"]');
+      if (!(root instanceof HTMLElement)) throw new Error('reader document missing');
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      const candidates = [];
+      let node = walker.nextNode();
+      while (node) {
+        const text = node.data;
+        const start = text.search(/\S/);
+        if (start >= 0 && text.slice(start).trim().length >= 8) {
+          const range = document.createRange();
+          range.setStart(node, start);
+          range.setEnd(node, Math.min(text.length, start + 8));
+          const rect = range.getBoundingClientRect();
+          if (rect.width > 0 && rect.bottom > 0 && rect.top < window.innerHeight) candidates.push({ node, start });
+        }
+        node = walker.nextNode();
+      }
+      const candidate = candidates[candidateIndex % candidates.length];
+      if (!candidate) throw new Error('no selectable reader text');
+      const range = document.createRange();
+      range.setStart(candidate.node, candidate.start);
+      range.setEnd(candidate.node, Math.min(candidate.node.data.length, candidate.start + 8));
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      return range.toString();
+    }, index);
+  }
+
+  async function annotations() {
+    return page.evaluate((id) => window.nodus.listWritingDraftAnnotations(id), draftId);
+  }
+
+  // Contextual selection: exactly six pastel choices and one click persists a highlight.
+  await selectCandidate(0);
+  const selectionBar = page.locator('.reader-selection-actions');
+  await selectionBar.waitFor({ state: 'visible' });
+  assert.equal(await selectionBar.locator('.reader-selection-color').count(), 6);
+  await selectionBar.locator('.reader-selection-color').first().click();
+  await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).filter((item) => item.kind === 'highlight').length === 1, draftId);
+
+  // Fixed mode remains active while two separate selections are made.
+  const fixedHighlighter = page.locator('[data-testid="deep-research-fixed-highlighter"]');
+  await fixedHighlighter.click();
+  await page.locator('.reader-highlighter-palette button').nth(2).click();
+  assert.equal(await fixedHighlighter.getAttribute('aria-pressed'), 'true');
+  await selectCandidate(1);
+  await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).filter((item) => item.kind === 'highlight').length === 2, draftId);
+  assert.equal(await fixedHighlighter.getAttribute('aria-pressed'), 'true', 'fixed highlighter stays active after a selection');
+  await fixedHighlighter.click();
+  await page.locator('.reader-highlighter-off').click();
+
+  // Clicking painted text exposes only the trash action; deletion is immediate and
+  // deliberately does not open the confirmation dialog reserved for comments.
+  const firstHighlight = (await annotations()).find((item) => item.kind === 'highlight');
+  const highlightPoint = await page.evaluate((annotation) => {
+    const root = document.querySelector('[data-testid="deep-research-reader-document"]');
+    if (!(root instanceof HTMLElement)) throw new Error('reader document missing');
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const range = document.createRange();
+    let offset = 0;
+    let started = false;
+    let node = walker.nextNode();
+    while (node) {
+      const next = offset + node.data.length;
+      if (!started && annotation.startOffset >= offset && annotation.startOffset <= next) {
+        range.setStart(node, annotation.startOffset - offset);
+        started = true;
+      }
+      if (started && annotation.endOffset >= offset && annotation.endOffset <= next) {
+        range.setEnd(node, annotation.endOffset - offset);
+        break;
+      }
+      offset = next;
+      node = walker.nextNode();
+    }
+    range.startContainer.parentElement?.scrollIntoView({ block: 'center' });
+    const rect = range.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  }, firstHighlight);
+  await page.mouse.click(highlightPoint.x, highlightPoint.y);
+  await selectionBar.waitFor({ state: 'visible' });
+  assert.equal(await selectionBar.locator('.reader-selection-color').count(), 0);
+  await selectionBar.locator('button[data-tone="danger"]').click();
+  await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).filter((item) => item.kind === 'highlight').length === 1, draftId);
+  assert.equal(await page.getByRole('dialog').count(), 0, 'highlight deletion never asks for confirmation');
+
+  // Comments appear in the margin, reopen for editing, and require confirmation to delete.
+  await selectCandidate(2);
+  await selectionBar.waitFor({ state: 'visible' });
+  await selectionBar.getByRole('button', { name: 'Añadir comentario' }).click();
+  const commentEditor = page.locator('.reader-comment-editor');
+  await commentEditor.locator('textarea').fill('Primera observación');
+  await commentEditor.getByRole('button', { name: 'Guardar', exact: true }).click();
+  await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).some((item) => item.comment === 'Primera observación'), draftId);
+  const commentMarker = page.locator('.reader-margin-marker-comment');
+  await commentMarker.waitFor({ state: 'visible' });
+  await commentMarker.click();
+  await commentEditor.locator('textarea').fill('Observación revisada');
+  await commentEditor.getByRole('button', { name: 'Guardar', exact: true }).click();
+  await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).some((item) => item.comment === 'Observación revisada'), draftId);
+
+  // The reading bookmark now uses an aligned margin icon instead of painting the text.
+  await selectCandidate(3);
+  await selectionBar.waitFor({ state: 'visible' });
+  await selectionBar.getByRole('button', { name: 'Añadir marcador de lectura' }).click();
+  const bookmarkMarker = page.locator('.reader-margin-marker-bookmark');
+  await bookmarkMarker.waitFor({ state: 'visible' });
+  await bookmarkMarker.click();
+  await selectionBar.locator('button[data-tone="danger"]').click();
+  await bookmarkMarker.waitFor({ state: 'detached' });
+
+  await commentMarker.click();
+  await commentEditor.getByRole('button', { name: 'Eliminar', exact: true }).click();
+  const confirmation = page.getByRole('dialog').filter({ hasText: '¿Eliminar esta anotación? No se puede deshacer.' });
+  await confirmation.getByRole('button', { name: 'Eliminar', exact: true }).click();
+  await page.waitForFunction(async (id) => !(await window.nodus.listWritingDraftAnnotations(id)).some((item) => item.kind === 'comment'), draftId);
+
+  assert.deepEqual(pageErrors, [], pageErrors.map((error) => error.stack ?? String(error)).join('\n'));
+  const final = await annotations();
+  assert.equal(final.filter((item) => item.kind === 'highlight').length, 1);
+  console.log('deep research annotation UI test passed');
+} finally {
+  if (app) await app.close().catch(() => undefined);
+  await rm(userData, { recursive: true, force: true });
+}

--- a/scripts/lib/nodusServerFixtures.mjs
+++ b/scripts/lib/nodusServerFixtures.mjs
@@ -108,6 +108,14 @@ export function academicSnapshot(overrides = {}) {
         created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z',
       },
     ],
+    writing_draft_annotations: [
+      {
+        id: 'ann-1', draft_id: 'dr-1', scope: 'source', kind: 'highlight', color: 'yellow',
+        start_offset: 0, end_offset: 5, selected_text: 'Texto', prefix: '', suffix: '.',
+        comment_text: null,
+        created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
     immersion_sessions: [
       { id: 'im-1', topic: 'Archivo', title: 'Inmersión en el archivo', language: 'es', minutes: 20, model_json: '{}', plan_json: JSON.stringify({ stations: [] }), progress_json: '{}', stats_json: JSON.stringify({ stations: 3 }), created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z' },
     ],

--- a/scripts/test-deep-research-annotations.mjs
+++ b/scripts/test-deep-research-annotations.mjs
@@ -1,0 +1,144 @@
+// Persistent Deep Research highlights and comments, against the real schema and
+// repositories. Runs under Electron-as-Node so better-sqlite3 matches the app ABI.
+//
+// This pins the feature at the persistence boundary: annotations are independent rows,
+// editing them never rewrites the report, comment/highlight rules differ as intended,
+// deleting a report cleans up its children, and the table travels in both sync systems.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+if (!process.argv.includes('--electron-deep-research-annotations-test')) {
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/electron'),
+    [path.join(repoRoot, 'scripts/test-deep-research-annotations.mjs'), '--electron-deep-research-annotations-test'],
+    { cwd: repoRoot, env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, stdio: 'inherit' },
+  );
+  process.exit(0);
+}
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-dr-annotations-'));
+installTsHook();
+
+try {
+  const Database = require('better-sqlite3');
+  const { runMigrations, SCHEMA_VERSION } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
+  const db = new Database(path.join(root, 'vault.sqlite'));
+  runMigrations(db);
+  assert.ok(SCHEMA_VERSION >= 126);
+
+  stubModule('electron/db/database.ts', { getDb: () => db });
+  const drafts = require(path.join(repoRoot, 'electron/db/writingDraftsRepo.ts'));
+  const annotations = require(path.join(repoRoot, 'electron/db/writingAnnotationsRepo.ts'));
+
+  const brief = { kind: 'deep_research', objective: 'La memoria de la posguerra' };
+  const draft = { title: brief.objective, brief, selection: {}, draftMarkdown: 'Memoria compartida y archivo.' };
+  const saved = drafts.saveWritingWorkshopDraft({ draft, title: draft.title, model: null });
+  const reportRow = () => JSON.stringify(db.prepare('SELECT * FROM writing_saved_drafts WHERE id = ?').get(saved.id));
+  const before = reportRow();
+
+  const highlight = annotations.createWritingDraftAnnotation({
+    draftId: saved.id,
+    scope: 'source',
+    kind: 'highlight',
+    color: 'yellow',
+    startOffset: 0,
+    endOffset: 7,
+    selectedText: 'Memoria',
+    prefix: '',
+    suffix: ' compartida',
+  });
+  assert.equal(highlight.kind, 'highlight');
+  assert.equal(highlight.color, 'yellow');
+  assert.equal(highlight.comment, null);
+
+  const comment = annotations.createWritingDraftAnnotation({
+    draftId: saved.id,
+    scope: 'source',
+    kind: 'comment',
+    startOffset: 8,
+    endOffset: 18,
+    selectedText: 'compartida',
+    prefix: 'Memoria ',
+    suffix: ' y archivo',
+    comment: 'Contrastar con la fuente oral.',
+  });
+  assert.equal(comment.kind, 'comment');
+  assert.equal(comment.color, null);
+  assert.equal(annotations.listWritingDraftAnnotations(saved.id).length, 2);
+  assert.equal(reportRow(), before, 'annotations never rewrite the multi-page report row');
+
+  const updated = annotations.updateWritingDraftComment(comment.id, 'Añadir una referencia cruzada.');
+  assert.equal(updated?.comment, 'Añadir una referencia cruzada.');
+  assert.equal(annotations.updateWritingDraftComment(highlight.id, 'No se puede'), null, 'a highlight is not editable as a comment');
+  assert.throws(
+    () => annotations.createWritingDraftAnnotation({
+      draftId: saved.id, scope: 'source', kind: 'highlight', color: 'neon',
+      startOffset: 0, endOffset: 1, selectedText: 'M',
+    }),
+    /color/i,
+  );
+
+  assert.equal(annotations.deleteWritingDraftAnnotation(highlight.id), saved.id);
+  assert.equal(annotations.listWritingDraftAnnotations(saved.id).length, 1);
+
+  const { syncedTableNames, syncedTablesByGroup } = require(path.join(repoRoot, 'electron/db/syncTables.ts'));
+  assert.ok(syncedTableNames(db).includes('writing_draft_annotations'));
+  assert.ok(
+    syncedTablesByGroup(db).find((group) => group.key === 'writing')?.tables.includes('writing_draft_annotations'),
+    'annotations travel beside their saved reports in .nodussync packages',
+  );
+  const { MUTABLE_TABLES } = require(path.join(repoRoot, 'electron/serverSync/outboxTriggers.ts'));
+  assert.ok(MUTABLE_TABLES.includes('writing_draft_annotations'), 'connected replicas send annotation edits through the ledger');
+
+  drafts.deleteWritingWorkshopDraft(saved.id);
+  assert.equal(db.prepare('SELECT COUNT(*) AS n FROM writing_draft_annotations').get().n, 0, 'deleting a report removes its comments');
+
+  db.close();
+  console.log('deep research annotations test passed');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+function stubModule(relative, exports) {
+  const filename = path.join(repoRoot, relative);
+  const Module = require('node:module');
+  const stub = new Module(filename, null);
+  stub.filename = filename;
+  stub.loaded = true;
+  stub.exports = exports;
+  require.cache[filename] = stub;
+}
+
+function installTsHook() {
+  const ts = require('typescript');
+  const Module = require('node:module');
+  const originalResolveFilename = Module._resolveFilename;
+  Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+    if (request.startsWith('@shared/')) return path.join(repoRoot, `${request.replace('@shared/', 'shared/')}.ts`);
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+  require.extensions['.ts'] = function loadTs(module, filename) {
+    const source = fs.readFileSync(filename, 'utf8');
+    const output = ts.transpileModule(source, {
+      fileName: filename,
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        esModuleInterop: true,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+      },
+    }).outputText;
+    module._compile(output, filename);
+  };
+}

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -76,7 +76,7 @@ test('Nodi context is explicit, bounded and rejects invented product claims', as
   assert.match(backend, /relevant_materials/);
 });
 
-test('report selection offers icon-only copy, bookmark and Nodi quote actions', async () => {
+test('report selection offers icon-only copy, margin bookmark and Nodi quote actions', async () => {
   const [actions, css, companion, ipc, preload, types, windows, deepResearch, immersion] = await Promise.all([
     read('src/components/ReaderSelectionActions.tsx'),
     read('src/components/readerSelectionActions.css'),
@@ -93,14 +93,14 @@ test('report selection offers icon-only copy, bookmark and Nodi quote actions', 
   assert.match(actions, /name="quote"/);
   assert.match(actions, /role="toolbar"/);
   assert.match(actions, /contextmenu/);
-  assert.match(actions, /navigator\.clipboard\.writeText\(active\.text\)/);
+  assert.match(actions, /navigator\.clipboard\.writeText\(active\.selectedText\)/);
   assert.match(actions, /localStorage\.setItem\(storageKey\(contextId\)/);
   assert.match(actions, /localStorage\.removeItem\(storageKey\(contextId\)/);
-  assert.match(actions, /range\.getClientRects\(\)/, 'the painted bookmark is hit-tested so it can be clicked');
+  assert.match(actions, /range\.getClientRects\(\)/, 'the margin markers stay aligned with their text ranges');
   assert.match(actions, /useImperativeHandle\(ref, \(\) => \(\{ goToMark \}\)/);
   assert.match(actions, /updateSettings\(\{ mascotEnabled: true \}\)/);
   assert.match(actions, /quoteNodiSelection\(text\)/);
-  assert.match(css, /::highlight\(nodus-reader-mark\)/);
+  assert.match(css, /\.reader-margin-marker-bookmark/);
   assert.match(companion, /consumeNodiQuoteSelection/);
   assert.match(companion, /setQuotedSelection\(selection\.text\)/);
   assert.match(companion, /setPanel\('chat'\)/);
@@ -111,7 +111,8 @@ test('report selection offers icon-only copy, bookmark and Nodi quote actions', 
   assert.match(ipc, /nodi:quoteSelection:set/);
   assert.match(ipc, /webContents\.send\('nodi:quoteSelection'/);
   assert.match(windows, /'consumeNodiQuoteSelection'/);
-  assert.match(deepResearch, /ReaderSelectionActions[^>]*targetRef=\{mainRef\}/);
+  assert.match(deepResearch, /ReaderSelectionActions[^>]*targetRef=\{documentRef\}/);
+  assert.match(deepResearch, /ReaderSelectionActions[^>]*scrollRef=\{mainRef\}/);
   assert.match(deepResearch, /label=\{t\('Ir al marcador de lectura'\)\}/);
   assert.match(deepResearch, /markActionsRef\.current\?\.goToMark\(\)/);
   assert.match(immersion, /ReaderSelectionActions[^>]*contextId=\{`immersion:/);

--- a/scripts/test-nodus-server-mutations.mjs
+++ b/scripts/test-nodus-server-mutations.mjs
@@ -32,7 +32,7 @@ function mutation(overrides = {}) {
 
 test('the whitelist covers user-authored tables and nothing derived from the corpus', () => {
   const tables = Object.keys(MUTABLE_TABLES);
-  for (const allowed of ['notes', 'note_folders', 'writing_saved_drafts', 'immersion_sessions', 'edge_feedback']) {
+  for (const allowed of ['notes', 'note_folders', 'writing_saved_drafts', 'writing_draft_annotations', 'immersion_sessions', 'edge_feedback']) {
     assert.ok(tables.includes(allowed), `${allowed} is authored by the user and may travel back`);
   }
   // Everything below is produced by the owner's analysis pipeline, or is not shareable at
@@ -52,6 +52,7 @@ test('row keys serialize exactly as the tombstone triggers write them', () => {
   // a delete silently fails to match the row it means.
   assert.equal(rowKey('notes', ['n-1']), '["n-1"]');
   assert.equal(rowKey('decorative_images', ['deep_research', 'dr-1']), '["deep_research","dr-1"]');
+  assert.equal(rowKey('writing_draft_annotations', ['ann-1']), '["ann-1"]');
   assert.equal(rowKey('edge_feedback', ['i-a', 'i-b', 'contradicts']), '["i-a","i-b","contradicts"]');
   assert.equal(rowKey('notes', [null]), '[null]');
   assert.equal(rowKey('notes', [42]), '["42"]', 'numeric ids are stringified, as SQLite hands them over');
@@ -71,6 +72,18 @@ test('validation refuses everything the ledger must not carry', () => {
   assert.equal(check(mutation({ key: [] })).reason, 'bad_key');
   assert.equal(check(mutation({ key: ['a', 'b'] })).reason, 'bad_key', 'notes has a single-column identity');
   assert.equal(check(mutation({ row: undefined })).reason, 'missing_row');
+
+  const annotation = mutation({
+    table: 'writing_draft_annotations',
+    key: ['ann-2'],
+    row: {
+      id: 'ann-2', draft_id: 'dr-1', scope: 'source', kind: 'comment', color: null,
+      start_offset: 2, end_offset: 7, selected_text: 'Texto', prefix: '', suffix: '.',
+      comment_text: 'Revisar esta afirmación.',
+      created_at: '2026-02-02T00:00:00.000Z', updated_at: '2026-02-02T00:00:00.000Z',
+    },
+  });
+  assert.equal(check(annotation).ok, true, 'a small report annotation travels through the existing ledger');
 
   // The column check reads the shape of the published snapshot, so a column nobody has ever
   // published cannot be written — without the server knowing any SQL.

--- a/server/lib/core/mutations.mjs
+++ b/server/lib/core/mutations.mjs
@@ -29,6 +29,7 @@ export const MUTABLE_TABLES = {
   note_folders: { key: ['id'] },
   note_links: { key: ['link_id'] },
   writing_saved_drafts: { key: ['id'] },
+  writing_draft_annotations: { key: ['id'] },
   decorative_images: { key: ['entity_kind', 'entity_id'], require: { entity_kind: 'deep_research' } },
   immersion_sessions: { key: ['id'] },
   saved_searches: { key: ['id'] },

--- a/shared/api/academic.ts
+++ b/shared/api/academic.ts
@@ -177,6 +177,8 @@ import type {
   WritingWorkshopExportRequest,
   WritingWorkshopSaveDraftRequest,
   WritingWorkshopSavedDraft,
+  WritingDraftAnnotation,
+  WritingDraftAnnotationInput,
   WritingWorkshopSnapshot,
   ZoteroItem,
   ZoteroTag,
@@ -595,6 +597,13 @@ export interface AcademicApi {
    * Returns its own unsubscribe.
    */
   onWritingDraftsChanged(cb: () => void): () => void;
+  /** Persistent highlights and margin comments attached to one saved report. */
+  listWritingDraftAnnotations(draftId: string): Promise<WritingDraftAnnotation[]>;
+  createWritingDraftAnnotation(input: WritingDraftAnnotationInput): Promise<WritingDraftAnnotation>;
+  updateWritingDraftComment(id: string, comment: string): Promise<WritingDraftAnnotation | null>;
+  deleteWritingDraftAnnotation(id: string): Promise<void>;
+  /** Push notification for local edits and annotations received through server sync. */
+  onWritingDraftAnnotationsChanged(cb: (draftId: string | null) => void): () => void;
 
   // deep research (orchestrated, coverage-guided multi-page report over the whole corpus)
   /** Plan → write section by section (guided by coverage) → assemble a fully cited 5–20 page report. */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6072,6 +6072,46 @@ export interface WritingWorkshopSavedDraft {
   updatedAt: string;
 }
 
+/** The six quiet colours offered by the Deep Research reader highlighter. */
+export type WritingDraftAnnotationColor = 'yellow' | 'rose' | 'blue' | 'mint' | 'lavender' | 'peach';
+
+/**
+ * A text annotation belongs to one immutable rendering of a saved report.
+ *
+ * `scope` is `source` for the original report and `translation:<id>` for a saved
+ * translation. Offsets make the common path exact and cheap; the selected text plus
+ * its two short contexts let the reader recover the range if Markdown changes how it
+ * splits text nodes between releases.
+ */
+export interface WritingDraftAnnotation {
+  id: string;
+  draftId: string;
+  scope: string;
+  kind: 'highlight' | 'comment';
+  color: WritingDraftAnnotationColor | null;
+  startOffset: number;
+  endOffset: number;
+  selectedText: string;
+  prefix: string;
+  suffix: string;
+  comment: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WritingDraftAnnotationInput {
+  draftId: string;
+  scope: string;
+  kind: WritingDraftAnnotation['kind'];
+  color?: WritingDraftAnnotationColor | null;
+  startOffset: number;
+  endOffset: number;
+  selectedText: string;
+  prefix?: string;
+  suffix?: string;
+  comment?: string | null;
+}
+
 export interface WritingWorkshopSaveDraftRequest {
   draft: WritingWorkshopDraft;
   model?: ModelRef | null;

--- a/src/components/ReaderSelectionActions.tsx
+++ b/src/components/ReaderSelectionActions.tsx
@@ -1,6 +1,20 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useState, type RefObject } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
 import { createPortal } from 'react-dom';
+import type {
+  WritingDraftAnnotation,
+  WritingDraftAnnotationColor,
+  WritingDraftAnnotationInput,
+} from '@shared/types';
 import { t } from '../i18n';
+import { confirm } from './feedback';
 import { Icon } from './ui';
 import './readerSelectionActions.css';
 
@@ -10,21 +24,68 @@ interface ReaderMark {
   text: string;
 }
 
-interface ActiveSelection extends ReaderMark {
+interface ReaderAnchor {
+  startOffset: number;
+  endOffset: number;
+  selectedText: string;
+  prefix: string;
+  suffix: string;
+}
+
+interface ActiveSelection extends ReaderAnchor {
   left: number;
   top: number;
 }
 
-interface ActiveMarkActions {
+interface FloatingAction<T = undefined> {
+  value: T;
   left: number;
   top: number;
 }
+
+interface MarginPosition {
+  id: string;
+  kind: 'bookmark' | 'comment';
+  left: number;
+  top: number;
+}
+
+type CommentEditor = {
+  annotation: WritingDraftAnnotation | null;
+  anchor: ReaderAnchor;
+  body: string;
+  left: number;
+  top: number;
+};
 
 export interface ReaderSelectionActionsHandle {
   goToMark: () => boolean;
 }
 
-const HIGHLIGHT_NAME = 'nodus-reader-mark';
+type AnnotationCreate = Omit<WritingDraftAnnotationInput, 'draftId' | 'scope'>;
+
+export const READER_ANNOTATION_COLORS: ReadonlyArray<{
+  id: WritingDraftAnnotationColor;
+  hex: string;
+}> = [
+  { id: 'yellow', hex: '#fde68a' },
+  { id: 'rose', hex: '#fecdd3' },
+  { id: 'blue', hex: '#bfdbfe' },
+  { id: 'mint', hex: '#bbf7d0' },
+  { id: 'lavender', hex: '#ddd6fe' },
+  { id: 'peach', hex: '#fed7aa' },
+];
+
+const HIGHLIGHT_NAMES: Record<WritingDraftAnnotationColor, string> = {
+  yellow: 'nodus-reader-yellow',
+  rose: 'nodus-reader-rose',
+  blue: 'nodus-reader-blue',
+  mint: 'nodus-reader-mint',
+  lavender: 'nodus-reader-lavender',
+  peach: 'nodus-reader-peach',
+};
+const COMMENT_HIGHLIGHT_NAME = 'nodus-reader-comment';
+const ALL_HIGHLIGHT_NAMES = [...Object.values(HIGHLIGHT_NAMES), COMMENT_HIGHLIGHT_NAME];
 
 function storageKey(contextId: string): string {
   return `nodus.readerMark.${contextId}`;
@@ -71,11 +132,37 @@ function rangeFromOffsets(root: HTMLElement, start: number, end: number): Range 
   return null;
 }
 
+function findAnchoredText(root: HTMLElement, anchor: ReaderAnchor): Range | null {
+  const content = root.textContent || '';
+  let bestIndex = -1;
+  let bestScore = -1;
+  let from = 0;
+  while (from <= content.length) {
+    const index = content.indexOf(anchor.selectedText, from);
+    if (index < 0) break;
+    let score = 0;
+    if (anchor.prefix && content.slice(Math.max(0, index - anchor.prefix.length), index) === anchor.prefix) score += 2;
+    const after = index + anchor.selectedText.length;
+    if (anchor.suffix && content.slice(after, after + anchor.suffix.length) === anchor.suffix) score += 2;
+    score -= Math.min(1, Math.abs(index - anchor.startOffset) / Math.max(1, content.length));
+    if (score > bestScore) {
+      bestScore = score;
+      bestIndex = index;
+    }
+    from = index + Math.max(1, anchor.selectedText.length);
+  }
+  return bestIndex >= 0 ? rangeFromOffsets(root, bestIndex, bestIndex + anchor.selectedText.length) : null;
+}
+
+function annotationRange(root: HTMLElement, annotation: WritingDraftAnnotation): Range | null {
+  const direct = rangeFromOffsets(root, annotation.startOffset, annotation.endOffset);
+  if (direct?.toString() === annotation.selectedText) return direct;
+  return findAnchoredText(root, annotation);
+}
+
 function markRange(root: HTMLElement, mark: ReaderMark): Range | null {
   const direct = rangeFromOffsets(root, mark.start, mark.end);
   if (direct?.toString() === mark.text) return direct;
-  // Markdown links and translated content can slightly change the surrounding
-  // node split. The selected words remain the safest recovery anchor.
   const index = (root.textContent || '').indexOf(mark.text);
   return index >= 0 ? rangeFromOffsets(root, index, index + mark.text.length) : null;
 }
@@ -89,7 +176,7 @@ function selectionInside(root: HTMLElement): { range: Range; text: string } | nu
   return text.trim() ? { range, text } : null;
 }
 
-function selectionOffsets(root: HTMLElement, range: Range): Pick<ReaderMark, 'start' | 'end'> {
+function selectionOffsets(root: HTMLElement, range: Range): { start: number; end: number } {
   const beforeStart = document.createRange();
   beforeStart.selectNodeContents(root);
   beforeStart.setEnd(range.startContainer, range.startOffset);
@@ -97,6 +184,18 @@ function selectionOffsets(root: HTMLElement, range: Range): Pick<ReaderMark, 'st
   beforeEnd.selectNodeContents(root);
   beforeEnd.setEnd(range.endContainer, range.endOffset);
   return { start: beforeStart.toString().length, end: beforeEnd.toString().length };
+}
+
+function anchorFromRange(root: HTMLElement, range: Range, selectedText: string): ReaderAnchor {
+  const { start, end } = selectionOffsets(root, range);
+  const content = root.textContent || '';
+  return {
+    startOffset: start,
+    endOffset: end,
+    selectedText,
+    prefix: content.slice(Math.max(0, start - 64), start),
+    suffix: content.slice(end, end + 64),
+  };
 }
 
 function wordAtPoint(event: MouseEvent, root: HTMLElement): Range | null {
@@ -117,58 +216,246 @@ function wordAtPoint(event: MouseEvent, root: HTMLElement): Range | null {
   return range;
 }
 
-function markRectAtPoint(range: Range, x: number, y: number): DOMRect | null {
+function rectAtPoint(range: Range, x: number, y: number): DOMRect | null {
   for (const rect of Array.from(range.getClientRects())) {
-    // A small tolerance includes the underline painted just outside the text box and
-    // makes a short, one-word bookmark much less fiddly to hit.
     if (x >= rect.left - 3 && x <= rect.right + 3 && y >= rect.top - 3 && y <= rect.bottom + 3) return rect;
   }
   return null;
 }
 
-/** Icon-only copy, reading-bookmark and Nodi-quote actions for document text. */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Fixed highlighter in the Deep Research top bar. A chosen colour stays active. */
+export function ReaderHighlighterControl({
+  value,
+  onChange,
+}: {
+  value: WritingDraftAnnotationColor | null;
+  onChange: (value: WritingDraftAnnotationColor | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const active = READER_ANNOTATION_COLORS.find((item) => item.id === value);
+
+  useEffect(() => {
+    if (!open) return;
+    const dismiss = (event: PointerEvent) => {
+      if (!ref.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', dismiss, true);
+    return () => document.removeEventListener('pointerdown', dismiss, true);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="reader-highlighter-control">
+      <button
+        type="button"
+        className={`btn btn-ghost h-9 min-h-9 gap-1.5 border ${value ? 'border-indigo-600/70 text-indigo-200' : 'border-neutral-700'}`}
+        aria-label={t('Subrayar')}
+        aria-pressed={!!value}
+        data-testid="deep-research-fixed-highlighter"
+        onClick={() => setOpen((current) => !current)}
+      >
+        <Icon name="highlighter" size={16} />
+        {active && <span className="reader-active-color" style={{ backgroundColor: active.hex }} />}
+        <Icon name="chevronDown" size={13} />
+      </button>
+      {open && (
+        <div className="reader-highlighter-palette" role="menu" aria-label={t('Color')}>
+          {READER_ANNOTATION_COLORS.map((item, index) => (
+            <button
+              key={item.id}
+              type="button"
+              className={value === item.id ? 'is-active' : ''}
+              aria-label={`${t('Subrayar')} ${index + 1}`}
+              onClick={() => {
+                onChange(item.id);
+                setOpen(false);
+              }}
+            >
+              <span style={{ backgroundColor: item.hex }} />
+            </button>
+          ))}
+          <button
+            type="button"
+            className="reader-highlighter-off"
+            aria-label={t('Seleccionar o desplazar')}
+            onClick={() => {
+              onChange(null);
+              setOpen(false);
+            }}
+          >
+            <Icon name="cursor" size={15} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Selection actions, persistent annotations and marginal reader markers. */
 export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
   targetRef: RefObject<HTMLElement | null>;
+  scrollRef?: RefObject<HTMLElement | null>;
   contextId: string;
+  annotations?: WritingDraftAnnotation[];
+  highlighterColor?: WritingDraftAnnotationColor | null;
+  onCreateAnnotation?: (input: AnnotationCreate) => Promise<void>;
+  onUpdateComment?: (id: string, comment: string) => Promise<void>;
+  onDeleteAnnotation?: (id: string) => Promise<void>;
+  onAnnotationError?: (message: string) => void;
   onMarkChange?: (hasMark: boolean) => void;
-}>(function ReaderSelectionActions({ targetRef, contextId, onMarkChange }, ref) {
+}>(function ReaderSelectionActions({
+  targetRef,
+  scrollRef,
+  contextId,
+  annotations = [],
+  highlighterColor = null,
+  onCreateAnnotation,
+  onUpdateComment,
+  onDeleteAnnotation,
+  onAnnotationError,
+  onMarkChange,
+}, ref) {
   const [active, setActive] = useState<ActiveSelection | null>(null);
-  const [activeMarkActions, setActiveMarkActions] = useState<ActiveMarkActions | null>(null);
+  const [activeMarkActions, setActiveMarkActions] = useState<FloatingAction | null>(null);
+  const [activeHighlightActions, setActiveHighlightActions] = useState<FloatingAction<WritingDraftAnnotation> | null>(null);
+  const [commentEditor, setCommentEditor] = useState<CommentEditor | null>(null);
+  const [savingComment, setSavingComment] = useState(false);
+  const [commentError, setCommentError] = useState<string | null>(null);
   const [mark, setMark] = useState<ReaderMark | null>(() => loadMark(contextId));
+  const [marginPositions, setMarginPositions] = useState<MarginPosition[]>([]);
   const markLabel = t(mark ? 'Mover marcador aquí' : 'Añadir marcador de lectura');
 
   useEffect(() => {
     const next = loadMark(contextId);
     setActive(null);
     setActiveMarkActions(null);
+    setActiveHighlightActions(null);
+    setCommentEditor(null);
     setMark(next);
     onMarkChange?.(!!next);
   }, [contextId, onMarkChange]);
 
-  const showSelection = useCallback((event?: MouseEvent) => {
+  useEffect(() => {
+    if (activeHighlightActions && !annotations.some((item) => item.id === activeHighlightActions.value.id)) {
+      setActiveHighlightActions(null);
+    }
+    if (commentEditor?.annotation && !annotations.some((item) => item.id === commentEditor.annotation?.id)) {
+      setCommentEditor(null);
+    }
+  }, [activeHighlightActions, annotations, commentEditor]);
+
+  const captureSelection = useCallback((event?: MouseEvent): ActiveSelection | null => {
     const root = targetRef.current;
-    if (!root) return false;
+    if (!root) return null;
     let selected = selectionInside(root);
     if (!selected && event) {
       const range = wordAtPoint(event, root);
       if (range) selected = { range, text: range.toString() };
     }
-    if (!selected) {
+    if (!selected) return null;
+    const rect = selected.range.getBoundingClientRect();
+    const anchor = anchorFromRange(root, selected.range, selected.text);
+    const width = 350;
+    return {
+      ...anchor,
+      left: Math.max(8, Math.min(window.innerWidth - Math.min(width, window.innerWidth - 16) - 8, rect.left + rect.width / 2 - width / 2)),
+      top: Math.max(8, rect.top - 48),
+    };
+  }, [targetRef]);
+
+  const clearSelection = useCallback(() => {
+    window.getSelection()?.removeAllRanges();
+    setActive(null);
+  }, []);
+
+  const createHighlight = useCallback((selection: ReaderAnchor, color: WritingDraftAnnotationColor) => {
+    if (!onCreateAnnotation) return;
+    const duplicate = annotations.some((item) =>
+      item.kind === 'highlight'
+      && item.color === color
+      && item.startOffset === selection.startOffset
+      && item.endOffset === selection.endOffset
+      && item.selectedText === selection.selectedText
+    );
+    clearSelection();
+    if (duplicate) return;
+    void onCreateAnnotation({ ...selection, kind: 'highlight', color }).catch((error) => {
+      onAnnotationError?.(errorMessage(error));
+    });
+  }, [annotations, clearSelection, onAnnotationError, onCreateAnnotation]);
+
+  const showSelection = useCallback((event?: MouseEvent) => {
+    const selection = captureSelection(event);
+    if (!selection) {
       setActive(null);
       return false;
     }
-    const rect = selected.range.getBoundingClientRect();
-    const { start, end } = selectionOffsets(root, selected.range);
-    const width = 118;
-    setActive({
-      start,
-      end,
-      text: selected.text,
-      left: Math.max(8, Math.min(window.innerWidth - width - 8, rect.left + rect.width / 2 - width / 2)),
-      top: Math.max(8, rect.top - 48),
-    });
+    if (highlighterColor) {
+      createHighlight(selection, highlighterColor);
+      return true;
+    }
+    setActive(selection);
     return true;
-  }, [targetRef]);
+  }, [captureSelection, createHighlight, highlighterColor]);
+
+  const updateMarginPositions = useCallback(() => {
+    const root = targetRef.current;
+    if (!root) {
+      setMarginPositions([]);
+      return;
+    }
+    const viewport = (scrollRef?.current ?? root).getBoundingClientRect();
+    const rootRect = root.getBoundingClientRect();
+    const left = Math.min(window.innerWidth - 36, rootRect.right + 10);
+    const next: MarginPosition[] = [];
+    if (mark) {
+      const range = markRange(root, mark);
+      const rect = range ? Array.from(range.getClientRects())[0] : null;
+      if (rect && rect.bottom >= viewport.top && rect.top <= viewport.bottom) {
+        next.push({ id: 'bookmark', kind: 'bookmark', left, top: rect.top });
+      }
+    }
+    for (const annotation of annotations) {
+      if (annotation.kind !== 'comment') continue;
+      const range = annotationRange(root, annotation);
+      const rect = range ? Array.from(range.getClientRects())[0] : null;
+      if (rect && rect.bottom >= viewport.top && rect.top <= viewport.bottom) {
+        next.push({ id: annotation.id, kind: 'comment', left, top: rect.top });
+      }
+    }
+    next.sort((a, b) => a.top - b.top || a.kind.localeCompare(b.kind));
+    for (let index = 1; index < next.length; index += 1) {
+      if (next[index].top < next[index - 1].top + 27) next[index].top = next[index - 1].top + 27;
+    }
+    setMarginPositions(next);
+  }, [annotations, mark, scrollRef, targetRef]);
+
+  useEffect(() => {
+    const root = targetRef.current;
+    const scroller = scrollRef?.current ?? root;
+    if (!root || !scroller) return;
+    let frame = 0;
+    const schedule = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(updateMarginPositions);
+    };
+    schedule();
+    const observer = new ResizeObserver(schedule);
+    observer.observe(root);
+    observer.observe(scroller);
+    scroller.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      scroller.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+    };
+  }, [scrollRef, targetRef, updateMarginPositions]);
 
   useEffect(() => {
     const root = targetRef.current;
@@ -181,19 +468,26 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
       if (showSelection(event)) event.preventDefault();
     };
     const onClick = (event: MouseEvent) => {
-      if (!mark) return;
-      const range = markRange(root, mark);
-      if (!range) return;
-      const rect = markRectAtPoint(range, event.clientX, event.clientY);
-      if (!rect) return;
+      // A drag ending over an existing highlight is still a new selection. Its
+      // contextual palette must win over the one-click delete action.
+      if (selectionInside(root)) return;
+      if (event.target instanceof Element && event.target.closest('button, a, input, textarea')) return;
+      const matches = annotations
+        .filter((item) => item.kind === 'highlight')
+        .map((annotation) => ({ annotation, range: annotationRange(root, annotation) }))
+        .map((item) => ({ ...item, rect: item.range ? rectAtPoint(item.range, event.clientX, event.clientY) : null }))
+        .filter((item): item is typeof item & { rect: DOMRect } => !!item.rect)
+        .sort((a, b) => (a.annotation.endOffset - a.annotation.startOffset) - (b.annotation.endOffset - b.annotation.startOffset));
+      const match = matches[0];
+      if (!match) return;
       event.preventDefault();
       event.stopPropagation();
-      window.getSelection()?.removeAllRanges();
-      setActive(null);
-      const width = 43;
-      setActiveMarkActions({
-        left: Math.max(8, Math.min(window.innerWidth - width - 8, rect.left + rect.width / 2 - width / 2)),
-        top: Math.max(8, rect.top - 48),
+      clearSelection();
+      setActiveMarkActions(null);
+      setActiveHighlightActions({
+        value: match.annotation,
+        left: Math.max(8, Math.min(window.innerWidth - 51, match.rect.left + match.rect.width / 2 - 22)),
+        top: Math.max(8, match.rect.top - 48),
       });
     };
     const hide = (event: Event) => {
@@ -201,50 +495,54 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
       if (target instanceof Element && target.closest('[data-reader-selection-actions]')) return;
       setActive(null);
       setActiveMarkActions(null);
+      setActiveHighlightActions(null);
     };
     root.addEventListener('pointerup', onPointerUp);
     root.addEventListener('keyup', onKeyUp);
     root.addEventListener('contextmenu', onContextMenu);
     root.addEventListener('click', onClick);
     document.addEventListener('pointerdown', hide, true);
-    window.addEventListener('resize', hide);
-    root.addEventListener('scroll', hide, { passive: true });
     return () => {
       root.removeEventListener('pointerup', onPointerUp);
       root.removeEventListener('keyup', onKeyUp);
       root.removeEventListener('contextmenu', onContextMenu);
       root.removeEventListener('click', onClick);
       document.removeEventListener('pointerdown', hide, true);
-      window.removeEventListener('resize', hide);
-      root.removeEventListener('scroll', hide);
     };
-  }, [mark, showSelection, targetRef]);
+  }, [annotations, clearSelection, showSelection, targetRef]);
 
   useEffect(() => {
     const root = targetRef.current;
     const registry = (CSS as unknown as { highlights?: Map<string, unknown> }).highlights;
     const HighlightConstructor = (window as unknown as { Highlight?: new (...ranges: Range[]) => unknown }).Highlight;
-    registry?.delete(HIGHLIGHT_NAME);
-    if (!root || !mark || !registry || !HighlightConstructor) return;
-    const range = markRange(root, mark);
-    if (range) registry.set(HIGHLIGHT_NAME, new HighlightConstructor(range));
-    return () => { registry.delete(HIGHLIGHT_NAME); };
-  }, [mark, targetRef]);
-
-  const clearSelection = () => {
-    window.getSelection()?.removeAllRanges();
-    setActive(null);
-  };
+    for (const name of ALL_HIGHLIGHT_NAMES) registry?.delete(name);
+    if (!root || !registry || !HighlightConstructor) return;
+    for (const item of READER_ANNOTATION_COLORS) {
+      const ranges = annotations
+        .filter((annotation) => annotation.kind === 'highlight' && annotation.color === item.id)
+        .map((annotation) => annotationRange(root, annotation))
+        .filter((range): range is Range => range !== null);
+      if (ranges.length > 0) registry.set(HIGHLIGHT_NAMES[item.id], new HighlightConstructor(...ranges));
+    }
+    const commentRanges = annotations
+      .filter((annotation) => annotation.kind === 'comment')
+      .map((annotation) => annotationRange(root, annotation))
+      .filter((range): range is Range => range !== null);
+    if (commentRanges.length > 0) registry.set(COMMENT_HIGHLIGHT_NAME, new HighlightConstructor(...commentRanges));
+    return () => {
+      for (const name of ALL_HIGHLIGHT_NAMES) registry.delete(name);
+    };
+  }, [annotations, targetRef]);
 
   const copy = async () => {
     if (!active) return;
-    await navigator.clipboard.writeText(active.text);
+    await navigator.clipboard.writeText(active.selectedText);
     clearSelection();
   };
 
   const saveMark = () => {
     if (!active) return;
-    const next: ReaderMark = { start: active.start, end: active.end, text: active.text };
+    const next: ReaderMark = { start: active.startOffset, end: active.endOffset, text: active.selectedText };
     localStorage.setItem(storageKey(contextId), JSON.stringify(next));
     setMark(next);
     onMarkChange?.(true);
@@ -260,63 +558,234 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
 
   const goToMark = useCallback(() => {
     const root = targetRef.current;
-    if (!root || !mark) return false;
+    const scroller = scrollRef?.current ?? root;
+    if (!root || !scroller || !mark) return false;
     const range = markRange(root, mark);
     if (!range) return false;
     const rect = range.getBoundingClientRect();
-    const rootRect = root.getBoundingClientRect();
-    const top = root.scrollTop + rect.top - rootRect.top - root.clientHeight / 2 + rect.height / 2;
+    const scrollRect = scroller.getBoundingClientRect();
+    const top = scroller.scrollTop + rect.top - scrollRect.top - scroller.clientHeight / 2 + rect.height / 2;
     setActive(null);
     setActiveMarkActions(null);
-    root.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+    setActiveHighlightActions(null);
+    scroller.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
     return true;
-  }, [mark, targetRef]);
+  }, [mark, scrollRef, targetRef]);
 
   useImperativeHandle(ref, () => ({ goToMark }), [goToMark]);
 
   const quoteInNodi = async () => {
     if (!active) return;
-    const text = active.text.replace(/\s+/g, ' ').trim();
+    const text = active.selectedText.replace(/\s+/g, ' ').trim();
     const settings = await window.nodus.getSettings();
     if (!settings.mascotEnabled) await window.nodus.updateSettings({ mascotEnabled: true });
     await window.nodus.quoteNodiSelection(text);
     clearSelection();
   };
 
-  if (!active && !activeMarkActions) return null;
-  return createPortal(
-    <div
-      className="reader-selection-actions"
-      data-reader-selection-actions
-      role="toolbar"
-      aria-label={active ? t('Acciones de selección') : t('Eliminar marcador de lectura')}
-      style={{ left: (active ?? activeMarkActions)?.left, top: (active ?? activeMarkActions)?.top }}
-      onPointerDown={(event) => event.preventDefault()}
-    >
-      {active ? (
-        <>
-          <button type="button" onClick={() => void copy()} title={t('Copiar')} aria-label={t('Copiar')}>
-            <Icon name="copy" size={17} />
-          </button>
-          <button type="button" onClick={saveMark} title={markLabel} aria-label={markLabel}>
-            <Icon name={mark ? 'bookmarkFill' : 'bookmark'} size={17} />
-          </button>
-          <button type="button" onClick={() => void quoteInNodi()} title={t('Citar en Nodi')} aria-label={t('Citar en Nodi')}>
-            <Icon name="quote" size={17} />
-          </button>
-        </>
-      ) : (
-        <button
-          type="button"
-          data-tone="danger"
-          onClick={deleteMark}
-          title={t('Eliminar marcador de lectura')}
-          aria-label={t('Eliminar marcador de lectura')}
-        >
-          <Icon name="trash" size={17} />
-        </button>
+  const openNewComment = () => {
+    if (!active) return;
+    setCommentError(null);
+    setCommentEditor({
+      annotation: null,
+      anchor: active,
+      body: '',
+      left: active.left,
+      top: Math.max(8, Math.min(window.innerHeight - 270, active.top)),
+    });
+    clearSelection();
+  };
+
+  const openComment = (annotation: WritingDraftAnnotation, position: MarginPosition) => {
+    setCommentError(null);
+    setActive(null);
+    setActiveMarkActions(null);
+    setActiveHighlightActions(null);
+    const width = 330;
+    setCommentEditor({
+      annotation,
+      anchor: annotation,
+      body: annotation.comment ?? '',
+      left: Math.max(8, Math.min(window.innerWidth - width - 8, position.left - width - 8)),
+      top: Math.max(8, Math.min(window.innerHeight - 250, position.top - 8)),
+    });
+  };
+
+  const saveComment = async () => {
+    if (!commentEditor || !commentEditor.body.trim()) return;
+    setSavingComment(true);
+    setCommentError(null);
+    try {
+      if (commentEditor.annotation) {
+        await onUpdateComment?.(commentEditor.annotation.id, commentEditor.body);
+      } else {
+        await onCreateAnnotation?.({ ...commentEditor.anchor, kind: 'comment', color: null, comment: commentEditor.body });
+      }
+      setCommentEditor(null);
+    } catch (error) {
+      const message = errorMessage(error);
+      setCommentError(message);
+      onAnnotationError?.(message);
+    } finally {
+      setSavingComment(false);
+    }
+  };
+
+  const deleteComment = async () => {
+    const annotation = commentEditor?.annotation;
+    if (!annotation || !onDeleteAnnotation) return;
+    const accepted = await confirm({
+      title: t('Eliminar'),
+      message: t('¿Eliminar esta anotación? No se puede deshacer.'),
+      confirmLabel: t('Eliminar'),
+      danger: true,
+      zIndex: 2147483000,
+    });
+    if (!accepted) return;
+    try {
+      await onDeleteAnnotation(annotation.id);
+      setCommentEditor(null);
+    } catch (error) {
+      const message = errorMessage(error);
+      setCommentError(message);
+      onAnnotationError?.(message);
+    }
+  };
+
+  const action = active ?? activeMarkActions ?? activeHighlightActions;
+
+  return (
+    <>
+      {marginPositions.length > 0 && createPortal(
+        <div data-reader-selection-actions>
+          {marginPositions.map((position) => (
+            <button
+              key={`${position.kind}:${position.id}`}
+              type="button"
+              className={`reader-margin-marker reader-margin-marker-${position.kind}`}
+              style={{ left: position.left, top: position.top }}
+              aria-label={position.kind === 'bookmark' ? t('Eliminar marcador de lectura') : t('Comentario lateral')}
+              onClick={() => {
+                if (position.kind === 'bookmark') {
+                  setActiveHighlightActions(null);
+                  setActiveMarkActions({ value: undefined, left: position.left - 4, top: Math.max(8, position.top - 45) });
+                  return;
+                }
+                const annotation = annotations.find((item) => item.id === position.id);
+                if (annotation) openComment(annotation, position);
+              }}
+            >
+              <Icon name={position.kind === 'bookmark' ? 'bookmarkFill' : 'chat'} size={15} />
+            </button>
+          ))}
+        </div>,
+        document.body,
       )}
-    </div>,
-    document.body,
+
+      {action && createPortal(
+        <div
+          className="reader-selection-actions"
+          data-reader-selection-actions
+          role="toolbar"
+          aria-label={active ? t('Acciones de selección') : t('Editar o eliminar')}
+          style={{ left: action.left, top: action.top }}
+          onPointerDown={(event) => event.preventDefault()}
+        >
+          {active ? (
+            <>
+              <div className="reader-selection-colors" aria-label={t('Color')}>
+                {READER_ANNOTATION_COLORS.map((item, index) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="reader-selection-color"
+                    onClick={() => createHighlight(active, item.id)}
+                    title={`${t('Subrayar')} ${index + 1}`}
+                    aria-label={`${t('Subrayar')} ${index + 1}`}
+                  >
+                    <span style={{ backgroundColor: item.hex }} />
+                  </button>
+                ))}
+              </div>
+              <span className="reader-selection-divider" />
+              <button type="button" onClick={openNewComment} title={t('Añadir comentario')} aria-label={t('Añadir comentario')}>
+                <Icon name="chat" size={17} />
+              </button>
+              <span className="reader-selection-divider" />
+              <button type="button" onClick={() => void copy()} title={t('Copiar')} aria-label={t('Copiar')}>
+                <Icon name="copy" size={17} />
+              </button>
+              <button type="button" onClick={saveMark} title={markLabel} aria-label={markLabel}>
+                <Icon name={mark ? 'bookmarkFill' : 'bookmark'} size={17} />
+              </button>
+              <button type="button" onClick={() => void quoteInNodi()} title={t('Citar en Nodi')} aria-label={t('Citar en Nodi')}>
+                <Icon name="quote" size={17} />
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              data-tone="danger"
+              onClick={() => {
+                if (activeHighlightActions) {
+                  const id = activeHighlightActions.value.id;
+                  setActiveHighlightActions(null);
+                  void onDeleteAnnotation?.(id).catch((error) => onAnnotationError?.(errorMessage(error)));
+                } else {
+                  deleteMark();
+                }
+              }}
+              title={activeHighlightActions ? t('Eliminar') : t('Eliminar marcador de lectura')}
+              aria-label={activeHighlightActions ? t('Eliminar') : t('Eliminar marcador de lectura')}
+            >
+              <Icon name="trash" size={17} />
+            </button>
+          )}
+        </div>,
+        document.body,
+      )}
+
+      {commentEditor && createPortal(
+        <section
+          className="reader-comment-editor"
+          data-reader-selection-actions
+          role="dialog"
+          aria-label={t('Comentario lateral')}
+          style={{ left: commentEditor.left, top: commentEditor.top }}
+        >
+          <header>
+            <Icon name="chat" size={15} />
+            <strong>{commentEditor.annotation ? t('Comentario') : t('Nuevo comentario lateral')}</strong>
+            <button type="button" onClick={() => setCommentEditor(null)} aria-label={t('Cerrar')}><Icon name="x" size={14} /></button>
+          </header>
+          <p className="reader-comment-quote">“{commentEditor.anchor.selectedText.replace(/\s+/g, ' ').trim()}”</p>
+          <textarea
+            autoFocus
+            className="input"
+            value={commentEditor.body}
+            placeholder={t('Escribe el comentario')}
+            onChange={(event) => setCommentEditor((current) => current ? { ...current, body: event.target.value } : current)}
+            onKeyDown={(event) => {
+              if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') void saveComment();
+              if (event.key === 'Escape') setCommentEditor(null);
+            }}
+          />
+          {commentError && <p className="reader-comment-error">{commentError}</p>}
+          <footer>
+            {commentEditor.annotation && (
+              <button type="button" className="btn btn-ghost text-red-500" onClick={() => void deleteComment()}>
+                <Icon name="trash" size={14} /> {t('Eliminar')}
+              </button>
+            )}
+            <span />
+            <button type="button" className="btn btn-ghost" onClick={() => setCommentEditor(null)}>{t('Cancelar')}</button>
+            <button type="button" className="btn btn-primary" disabled={savingComment || !commentEditor.body.trim()} onClick={() => void saveComment()}>
+              {savingComment ? t('Guardando…') : t('Guardar')}
+            </button>
+          </footer>
+        </section>,
+        document.body,
+      )}
+    </>
   );
 });

--- a/src/components/readerSelectionActions.css
+++ b/src/components/readerSelectionActions.css
@@ -2,8 +2,10 @@
   position: fixed;
   z-index: 2147482500;
   display: flex;
+  align-items: center;
   gap: 3px;
   width: max-content;
+  max-width: calc(100vw - 16px);
   padding: 5px;
   border: 1px solid rgb(82 82 91 / 0.9);
   border-radius: 11px;
@@ -16,6 +18,7 @@
   display: grid;
   width: 31px;
   height: 31px;
+  flex: 0 0 auto;
   place-items: center;
   border: 0;
   border-radius: 7px;
@@ -30,36 +33,98 @@
   outline: none;
 }
 
-.reader-selection-actions button[data-tone='danger'] {
-  color: #f87171;
-}
-
+.reader-selection-actions button[data-tone='danger'] { color: #f87171; }
 .reader-selection-actions button[data-tone='danger']:hover,
-.reader-selection-actions button[data-tone='danger']:focus-visible {
-  background: #7f1d1d;
-  color: #fff;
-}
+.reader-selection-actions button[data-tone='danger']:focus-visible { background: #7f1d1d; color: #fff; }
 
-::highlight(nodus-reader-mark) {
-  background-color: rgb(250 204 21 / 0.42);
-  color: inherit;
-  text-decoration: underline 2px rgb(234 179 8 / 0.9);
-  text-underline-offset: 3px;
+.reader-selection-colors { display: flex; gap: 1px; }
+.reader-selection-actions .reader-selection-color { width: 25px; }
+.reader-selection-color span,
+.reader-highlighter-palette button span {
+  width: 16px;
+  height: 16px;
+  border: 1px solid rgb(255 255 255 / 0.42);
+  border-radius: 999px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.18);
 }
+.reader-selection-divider { width: 1px; height: 21px; margin: 0 2px; background: rgb(82 82 91 / 0.75); }
 
-.light .reader-selection-actions {
+.reader-highlighter-control { position: relative; }
+.reader-active-color { width: 9px; height: 9px; border-radius: 999px; box-shadow: 0 0 0 1px rgb(255 255 255 / 0.45); }
+.reader-highlighter-palette {
+  position: absolute;
+  z-index: 80;
+  top: calc(100% + 7px);
+  right: 0;
+  display: flex;
+  gap: 3px;
+  padding: 6px;
+  border: 1px solid rgb(82 82 91 / 0.9);
+  border-radius: 10px;
+  background: rgb(24 24 27 / 0.98);
+  box-shadow: 0 12px 30px rgb(0 0 0 / 0.32);
+}
+.reader-highlighter-palette button { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 7px; color: #d4d4d8; }
+.reader-highlighter-palette button:hover,
+.reader-highlighter-palette button.is-active { background: #3730a3; }
+.reader-highlighter-palette .reader-highlighter-off { margin-left: 2px; border-left: 1px solid #52525b; border-radius: 0 7px 7px 0; }
+
+.reader-margin-marker {
+  position: fixed;
+  z-index: 75;
+  display: grid;
+  width: 25px;
+  height: 25px;
+  place-items: center;
+  border: 1px solid;
+  border-radius: 7px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.18);
+  transition: transform 120ms ease, filter 120ms ease;
+}
+.reader-margin-marker:hover { transform: translateX(2px); filter: brightness(1.08); }
+.reader-margin-marker-bookmark { border-color: #d97706; background: #fef3c7; color: #92400e; }
+.reader-margin-marker-comment { border-color: #6366f1; background: #e0e7ff; color: #3730a3; }
+
+.reader-comment-editor {
+  position: fixed;
+  z-index: 2147482600;
+  width: min(330px, calc(100vw - 16px));
+  padding: 12px;
+  border: 1px solid rgb(82 82 91 / 0.92);
+  border-radius: 12px;
+  background: rgb(24 24 27 / 0.99);
+  box-shadow: 0 18px 42px rgb(0 0 0 / 0.42);
+  color: #e4e4e7;
+}
+.reader-comment-editor header { display: flex; align-items: center; gap: 7px; color: #c7d2fe; }
+.reader-comment-editor header strong { flex: 1; font-size: 12px; }
+.reader-comment-editor header button { display: grid; width: 26px; height: 26px; place-items: center; border-radius: 6px; color: #a1a1aa; }
+.reader-comment-editor header button:hover { background: #27272a; color: #f4f4f5; }
+.reader-comment-quote { overflow: hidden; margin: 7px 0; color: #a1a1aa; font-size: 11px; font-style: italic; line-height: 1.45; text-overflow: ellipsis; white-space: nowrap; }
+.reader-comment-editor textarea { min-height: 98px; width: 100%; resize: vertical; font-size: 13px; line-height: 1.45; }
+.reader-comment-editor footer { display: grid; grid-template-columns: auto 1fr auto auto; align-items: center; gap: 6px; margin-top: 9px; }
+.reader-comment-editor footer .btn { min-height: 31px; padding: 5px 9px; font-size: 12px; }
+.reader-comment-error { margin-top: 6px; color: #fca5a5; font-size: 11px; }
+
+::highlight(nodus-reader-yellow) { background-color: rgb(253 230 138 / 0.47); color: inherit; text-decoration: underline 2px rgb(217 119 6 / 0.78); text-underline-offset: 3px; }
+::highlight(nodus-reader-rose) { background-color: rgb(254 205 211 / 0.45); color: inherit; text-decoration: underline 2px rgb(225 29 72 / 0.7); text-underline-offset: 3px; }
+::highlight(nodus-reader-blue) { background-color: rgb(191 219 254 / 0.43); color: inherit; text-decoration: underline 2px rgb(37 99 235 / 0.7); text-underline-offset: 3px; }
+::highlight(nodus-reader-mint) { background-color: rgb(187 247 208 / 0.4); color: inherit; text-decoration: underline 2px rgb(22 163 74 / 0.68); text-underline-offset: 3px; }
+::highlight(nodus-reader-lavender) { background-color: rgb(221 214 254 / 0.43); color: inherit; text-decoration: underline 2px rgb(124 58 237 / 0.68); text-underline-offset: 3px; }
+::highlight(nodus-reader-peach) { background-color: rgb(254 215 170 / 0.44); color: inherit; text-decoration: underline 2px rgb(234 88 12 / 0.68); text-underline-offset: 3px; }
+::highlight(nodus-reader-comment) { color: inherit; text-decoration: underline 2px dotted rgb(129 140 248 / 0.86); text-underline-offset: 4px; }
+
+.light .reader-selection-actions,
+.light .reader-highlighter-palette,
+.light .reader-comment-editor {
   border-color: rgb(212 212 216 / 0.95);
-  background: rgb(255 255 255 / 0.98);
+  background: rgb(255 255 255 / 0.99);
   box-shadow: 0 12px 30px rgb(24 24 27 / 0.16);
   color: #27272a;
 }
-
-.light .reader-selection-actions button[data-tone='danger'] {
-  color: #dc2626;
-}
-
+.light .reader-selection-actions button[data-tone='danger'] { color: #dc2626; }
 .light .reader-selection-actions button[data-tone='danger']:hover,
-.light .reader-selection-actions button[data-tone='danger']:focus-visible {
-  background: #fee2e2;
-  color: #991b1b;
-}
+.light .reader-selection-actions button[data-tone='danger']:focus-visible { background: #fee2e2; color: #991b1b; }
+.light .reader-selection-divider { background: #d4d4d8; }
+.light .reader-highlighter-palette button { color: #52525b; }
+.light .reader-comment-editor header button:hover { background: #f4f4f5; color: #18181b; }

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -16,6 +16,9 @@ import type {
   DecorativeImage,
   DecorativeImageStyle,
   ContentTranslation,
+  WritingDraftAnnotation,
+  WritingDraftAnnotationColor,
+  WritingDraftAnnotationInput,
 } from '@shared/types';
 import type { StudyDeepResearchAudience } from '@shared/studyDeepResearchAudience';
 import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
@@ -35,7 +38,11 @@ import { DecorativeImageCard } from '../components/DecorativeImageCard';
 import { AudioPanel } from '../components/AudioPanel';
 import { FindInPage } from '../components/FindInPage';
 import { NodiViewContextSource } from '../components/NodiViewContextSource';
-import { ReaderSelectionActions, type ReaderSelectionActionsHandle } from '../components/ReaderSelectionActions';
+import {
+  ReaderHighlighterControl,
+  ReaderSelectionActions,
+  type ReaderSelectionActionsHandle,
+} from '../components/ReaderSelectionActions';
 import { t, tx, getActiveLang } from '../i18n';
 import {
   DEEP_RESEARCH_MAIN_JOB_KEY,
@@ -1371,8 +1378,54 @@ function ReaderView({
   onOpenStudyRecording?: (id: string, timestamp?: number | null) => void;
 }) {
   const mainRef = useRef<HTMLElement | null>(null);
+  const documentRef = useRef<HTMLDivElement | null>(null);
   const markActionsRef = useRef<ReaderSelectionActionsHandle | null>(null);
   const [hasReaderMark, setHasReaderMark] = useState(false);
+  const [annotations, setAnnotations] = useState<WritingDraftAnnotation[]>([]);
+  const [highlighterColor, setHighlighterColor] = useState<WritingDraftAnnotationColor | null>(null);
+  const [annotationError, setAnnotationError] = useState<string | null>(null);
+  const annotationScope = appliedTranslation ? `translation:${appliedTranslation.id}` : 'source';
+  const visibleAnnotations = useMemo(
+    () => annotations.filter((annotation) => annotation.scope === annotationScope),
+    [annotationScope, annotations],
+  );
+  const refreshAnnotations = useCallback(async () => {
+    try {
+      setAnnotations(await window.nodus.listWritingDraftAnnotations(saved.id));
+      setAnnotationError(null);
+    } catch (nextError) {
+      setAnnotationError(nextError instanceof Error ? nextError.message : String(nextError));
+    }
+  }, [saved.id]);
+
+  useEffect(() => {
+    void refreshAnnotations();
+    return window.nodus.onWritingDraftAnnotationsChanged((draftId) => {
+      if (draftId === null || draftId === saved.id) void refreshAnnotations();
+    });
+  }, [refreshAnnotations, saved.id]);
+
+  const createAnnotation = async (input: Omit<WritingDraftAnnotationInput, 'draftId' | 'scope'>) => {
+    const created = await window.nodus.createWritingDraftAnnotation({ ...input, draftId: saved.id, scope: annotationScope });
+    setAnnotations((current) => [...current.filter((item) => item.id !== created.id), created]);
+    setAnnotationError(null);
+  };
+
+  const updateComment = async (id: string, comment: string) => {
+    const updated = await window.nodus.updateWritingDraftComment(id, comment);
+    if (!updated) {
+      await refreshAnnotations();
+      return;
+    }
+    setAnnotations((current) => current.map((item) => (item.id === updated.id ? updated : item)));
+    setAnnotationError(null);
+  };
+
+  const deleteAnnotation = async (id: string) => {
+    await window.nodus.deleteWritingDraftAnnotation(id);
+    setAnnotations((current) => current.filter((item) => item.id !== id));
+    setAnnotationError(null);
+  };
   const contextTitle = appliedTranslation?.title ?? saved.draft.title;
   const contextMarkdown = appliedTranslation?.markdown
     ?? `# ${saved.draft.title}\n\n${saved.draft.abstract ? `${saved.draft.abstract}\n\n` : ''}${stripLeadingAbstract(saved.draft.draftMarkdown, saved.draft.abstract)}`;
@@ -1398,6 +1451,7 @@ function ReaderView({
           onSaveToNotes={onSaveToNotes}
           onExport={onExport}
         />
+        <ReaderHighlighterControl value={highlighterColor} onChange={setHighlighterColor} />
         <HoverLabelButton
           icon={hasReaderMark ? 'bookmarkFill' : 'bookmark'}
           label={t('Ir al marcador de lectura')}
@@ -1430,9 +1484,9 @@ function ReaderView({
         />
       </header>
 
-      {(message || error) && (
-        <div className={`px-4 py-2 text-sm border-b ${error ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200' : 'border-neutral-200 text-neutral-500 dark:border-neutral-800 dark:text-neutral-400'}`}>
-          {error ?? message}
+      {(message || error || annotationError) && (
+        <div className={`px-4 py-2 text-sm border-b ${(error || annotationError) ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200' : 'border-neutral-200 text-neutral-500 dark:border-neutral-800 dark:text-neutral-400'}`}>
+          {error ?? annotationError ?? message}
         </div>
       )}
 
@@ -1448,28 +1502,37 @@ function ReaderView({
               onChange={onImageChange}
             />
             <AudioPanel entityKind="deep_research" entityId={saved.id} />
-            {appliedTranslation ? <Markdown content={appliedTranslation.markdown} className="text-[15px] leading-7" onCitation={(citation) => onCitation(citation)} onStudyDocument={onOpenStudyDocument} onStudyMaterial={onOpenStudyMaterial} onStudyRecording={onOpenStudyRecording} /> : <DraftResultMain
-              draft={saved.draft}
-              exporting={exporting}
-              savingDraft={false}
-              draftSaved
-              hideActions
-              justify
-              onCopy={onCopy}
-              onSaveToNotes={onSaveToNotes}
-              onExport={onExport}
-              onCitation={onCitation}
-              onStudyDocument={onOpenStudyDocument}
-              onStudyMaterial={onOpenStudyMaterial}
-              onStudyRecording={onOpenStudyRecording}
-            />}
+            <div ref={documentRef} className="relative" data-testid="deep-research-reader-document">
+              {appliedTranslation ? <Markdown content={appliedTranslation.markdown} className="text-[15px] leading-7" onCitation={(citation) => onCitation(citation)} onStudyDocument={onOpenStudyDocument} onStudyMaterial={onOpenStudyMaterial} onStudyRecording={onOpenStudyRecording} /> : <DraftResultMain
+                draft={saved.draft}
+                exporting={exporting}
+                savingDraft={false}
+                draftSaved
+                hideActions
+                justify
+                onCopy={onCopy}
+                onSaveToNotes={onSaveToNotes}
+                onExport={onExport}
+                onCitation={onCitation}
+                onStudyDocument={onOpenStudyDocument}
+                onStudyMaterial={onOpenStudyMaterial}
+                onStudyRecording={onOpenStudyRecording}
+              />}
+            </div>
           </div>
         </main>
         <ReaderSelectionActions
           key={appliedTranslation?.id ?? 'source'}
           ref={markActionsRef}
-          targetRef={mainRef}
-          contextId={`deep-research:${saved.id}`}
+          targetRef={documentRef}
+          scrollRef={mainRef}
+          contextId={appliedTranslation ? `deep-research:${saved.id}:translation:${appliedTranslation.id}` : `deep-research:${saved.id}`}
+          annotations={visibleAnnotations}
+          highlighterColor={highlighterColor}
+          onCreateAnnotation={createAnnotation}
+          onUpdateComment={updateComment}
+          onDeleteAnnotation={deleteAnnotation}
+          onAnnotationError={setAnnotationError}
           onMarkChange={setHasReaderMark}
         />
         {showMatrix && (


### PR DESCRIPTION
## Summary

- add six pastel highlight colors to the text-selection menu and a persistent highlighter control to the reader toolbar
- add editable margin comments aligned with their annotated text
- replace the in-text reading bookmark treatment with a discreet margin bookmark icon
- let users delete highlights directly while retaining confirmation for comment deletion
- preserve separate annotation scopes for source reports and saved translations

## Persistence and synchronization

Annotations are stored in a dedicated `writing_draft_annotations` table instead of rewriting the full saved-report payload for each edit. The table is wired into desktop snapshot sync, connected-vault mutation outboxes, server mutation validation, inbox refresh notifications, and report deletion cleanup.

## Validation

- `npm run typecheck`
- targeted ESLint for changed TypeScript/TSX files
- `node scripts/test-deep-research-annotations.mjs`
- `node scripts/test-deep-research-read.mjs`
- `node --test scripts/test-nodus-server-mutations.mjs`
- `node scripts/test-connected-vault-replica.mjs`
- `npm run build`
- `node scripts/e2e-deep-research-annotations.mjs`

Closes #393