### PR TITLE
Sync Deep Research annotations and prepare 3.2.7

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "3.2.6"
-date-released: "2026-08-09"
+version: "3.2.7"
+date-released: "2026-08-10"
 license: MIT
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -10,7 +10,7 @@ export interface Migration {
 
 // Versioned, append-only migrations. Never edit an existing migration's SQL once
 // shipped — add a new one. The current schema version is the highest applied.
-export const SCHEMA_VERSION = 126;
+export const SCHEMA_VERSION = 127;
 
 export const migrations: Migration[] = [
   {
@@ -6337,6 +6337,41 @@ export const migrations: Migration[] = [
         created_at    TEXT NOT NULL,
         updated_at    TEXT NOT NULL
       );
+      CREATE INDEX idx_writing_draft_annotations_draft
+        ON writing_draft_annotations(draft_id, scope, start_offset, created_at);
+    `,
+  },
+  {
+    version: 127,
+    up: /* sql */ `
+      -- Reading bookmarks use the same anchored, syncable rows as highlights and
+      -- comments. Rebuilding is required because SQLite cannot widen a CHECK in
+      -- place; every column and existing annotation is copied byte for byte.
+      ALTER TABLE writing_draft_annotations RENAME TO writing_draft_annotations_v126;
+      CREATE TABLE writing_draft_annotations (
+        id            TEXT PRIMARY KEY,
+        draft_id      TEXT NOT NULL,
+        scope         TEXT NOT NULL DEFAULT 'source',
+        kind          TEXT NOT NULL CHECK (kind IN ('highlight','comment','bookmark')),
+        color         TEXT CHECK (color IS NULL OR color IN ('yellow','rose','blue','mint','lavender','peach')),
+        start_offset  INTEGER NOT NULL CHECK (start_offset >= 0),
+        end_offset    INTEGER NOT NULL CHECK (end_offset > start_offset),
+        selected_text TEXT NOT NULL,
+        prefix        TEXT NOT NULL DEFAULT '',
+        suffix        TEXT NOT NULL DEFAULT '',
+        comment_text  TEXT,
+        created_at    TEXT NOT NULL,
+        updated_at    TEXT NOT NULL
+      );
+      INSERT INTO writing_draft_annotations (
+        id, draft_id, scope, kind, color, start_offset, end_offset, selected_text,
+        prefix, suffix, comment_text, created_at, updated_at
+      )
+      SELECT
+        id, draft_id, scope, kind, color, start_offset, end_offset, selected_text,
+        prefix, suffix, comment_text, created_at, updated_at
+      FROM writing_draft_annotations_v126;
+      DROP TABLE writing_draft_annotations_v126;
       CREATE INDEX idx_writing_draft_annotations_draft
         ON writing_draft_annotations(draft_id, scope, start_offset, created_at);
     `,

--- a/electron/db/writingAnnotationsRepo.ts
+++ b/electron/db/writingAnnotationsRepo.ts
@@ -25,7 +25,7 @@ interface WritingDraftAnnotationRow {
 const COLORS = new Set<WritingDraftAnnotationColor>(['yellow', 'rose', 'blue', 'mint', 'lavender', 'peach']);
 
 function toAnnotation(row: WritingDraftAnnotationRow): WritingDraftAnnotation | null {
-  if (row.kind !== 'highlight' && row.kind !== 'comment') return null;
+  if (row.kind !== 'highlight' && row.kind !== 'comment' && row.kind !== 'bookmark') return null;
   if (row.color !== null && !COLORS.has(row.color as WritingDraftAnnotationColor)) return null;
   if (!Number.isInteger(row.start_offset) || !Number.isInteger(row.end_offset) || row.end_offset <= row.start_offset) return null;
   return {
@@ -71,6 +71,19 @@ function normalizedInput(input: WritingDraftAnnotationInput) {
       comment: null,
     } as const;
   }
+  if (input.kind === 'bookmark') {
+    return {
+      scope,
+      kind: input.kind,
+      color: null,
+      startOffset,
+      endOffset,
+      selectedText,
+      prefix: (input.prefix ?? '').slice(-64),
+      suffix: (input.suffix ?? '').slice(0, 64),
+      comment: null,
+    } as const;
+  }
   const comment = input.comment?.trim() ?? '';
   if (!comment) throw new Error('Escribe el comentario antes de guardarlo.');
   return {
@@ -102,13 +115,28 @@ export function createWritingDraftAnnotation(input: WritingDraftAnnotationInput)
   const report = db.prepare('SELECT 1 FROM writing_saved_drafts WHERE id = ?').get(input.draftId);
   if (!report) throw new Error('El informe ya no existe.');
   const value = normalizedInput(input);
-  const id = uuid();
+  // One bookmark per rendering. Both clients derive the same row id, so moving it
+  // offline on two devices converges through the ordinary newest-wins merge instead
+  // of leaving two competing places in the report.
+  const id = value.kind === 'bookmark' ? `reader-bookmark:${input.draftId}:${value.scope}` : uuid();
   const now = new Date().toISOString();
   db.prepare(
     `INSERT INTO writing_draft_annotations (
        id, draft_id, scope, kind, color, start_offset, end_offset, selected_text,
        prefix, suffix, comment_text, created_at, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       draft_id = excluded.draft_id,
+       scope = excluded.scope,
+       kind = excluded.kind,
+       color = excluded.color,
+       start_offset = excluded.start_offset,
+       end_offset = excluded.end_offset,
+       selected_text = excluded.selected_text,
+       prefix = excluded.prefix,
+       suffix = excluded.suffix,
+       comment_text = excluded.comment_text,
+       updated_at = excluded.updated_at`
   ).run(
     id,
     input.draftId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "MIT",

--- a/scripts/test-deep-research-annotations.mjs
+++ b/scripts/test-deep-research-annotations.mjs
@@ -33,7 +33,7 @@ try {
   const { runMigrations, SCHEMA_VERSION } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
   const db = new Database(path.join(root, 'vault.sqlite'));
   runMigrations(db);
-  assert.ok(SCHEMA_VERSION >= 126);
+  assert.ok(SCHEMA_VERSION >= 127);
 
   stubModule('electron/db/database.ts', { getDb: () => db });
   const drafts = require(path.join(repoRoot, 'electron/db/writingDraftsRepo.ts'));
@@ -73,7 +73,31 @@ try {
   });
   assert.equal(comment.kind, 'comment');
   assert.equal(comment.color, null);
-  assert.equal(annotations.listWritingDraftAnnotations(saved.id).length, 2);
+  const bookmark = annotations.createWritingDraftAnnotation({
+    draftId: saved.id,
+    scope: 'source',
+    kind: 'bookmark',
+    startOffset: 19,
+    endOffset: 20,
+    selectedText: 'y',
+    prefix: 'Memoria compartida ',
+    suffix: ' archivo',
+  });
+  assert.equal(bookmark.id, `reader-bookmark:${saved.id}:source`);
+  assert.equal(bookmark.color, null);
+  const movedBookmark = annotations.createWritingDraftAnnotation({
+    draftId: saved.id,
+    scope: 'source',
+    kind: 'bookmark',
+    startOffset: 21,
+    endOffset: 28,
+    selectedText: 'archivo',
+    prefix: 'Memoria compartida y ',
+    suffix: '.',
+  });
+  assert.equal(movedBookmark.id, bookmark.id, 'moving a bookmark updates the cross-device row');
+  assert.equal(movedBookmark.selectedText, 'archivo');
+  assert.equal(annotations.listWritingDraftAnnotations(saved.id).length, 3);
   assert.equal(reportRow(), before, 'annotations never rewrite the multi-page report row');
 
   const updated = annotations.updateWritingDraftComment(comment.id, 'Añadir una referencia cruzada.');
@@ -88,7 +112,7 @@ try {
   );
 
   assert.equal(annotations.deleteWritingDraftAnnotation(highlight.id), saved.id);
-  assert.equal(annotations.listWritingDraftAnnotations(saved.id).length, 1);
+  assert.equal(annotations.listWritingDraftAnnotations(saved.id).length, 2);
 
   const { syncedTableNames, syncedTablesByGroup } = require(path.join(repoRoot, 'electron/db/syncTables.ts'));
   assert.ok(syncedTableNames(db).includes('writing_draft_annotations'));

--- a/scripts/test-nodus-server-api.mjs
+++ b/scripts/test-nodus-server-api.mjs
@@ -86,6 +86,8 @@ test('every collection endpoint answers with the MCP page envelope and honours i
 
     const report = await readJson(await server.api(reader.deviceToken, 'GET', `/api/v1/spaces/${spaceId}/deep-research/dr-1`));
     assert.match(report.report.draft.draftMarkdown, /## Resumen/);
+    assert.deepEqual(report.annotations.map((annotation) => annotation.id), ['ann-1']);
+    assert.equal(report.annotations[0].kind, 'highlight');
 
     const session = await readJson(await server.api(reader.deviceToken, 'GET', `/api/v1/spaces/${spaceId}/immersion/im-1`));
     assert.ok(session.session.plan, 'the immersion plan replays without new AI calls');

--- a/scripts/test-nodus-server-mutations.mjs
+++ b/scripts/test-nodus-server-mutations.mjs
@@ -84,6 +84,24 @@ test('validation refuses everything the ledger must not carry', () => {
     },
   });
   assert.equal(check(annotation).ok, true, 'a small report annotation travels through the existing ledger');
+  const bookmarkId = 'reader-bookmark:dr-1:source';
+  const bookmark = mutation({
+    id: 'mut-bookmark',
+    table: 'writing_draft_annotations',
+    key: [bookmarkId],
+    row: {
+      ...annotation.row,
+      id: bookmarkId,
+      kind: 'bookmark',
+      color: null,
+      comment_text: null,
+    },
+  });
+  assert.equal(check(bookmark).ok, true, 'the shared deterministic bookmark row travels');
+  assert.equal(check(mutation({ ...bookmark, key: ['another-bookmark'] })).reason, 'constraint');
+  assert.equal(check(mutation({ ...annotation, row: { ...annotation.row, kind: 'highlight', color: 'neon' } })).reason, 'constraint');
+  assert.equal(check(mutation({ ...annotation, row: { ...annotation.row, kind: 'highlight', color: 'mint' } })).reason, 'constraint', 'highlights cannot smuggle comment text');
+  assert.equal(check(mutation({ ...annotation, row: { ...annotation.row, color: 'mint' } })).reason, 'constraint', 'comments have no highlight color');
 
   // The column check reads the shape of the published snapshot, so a column nobody has ever
   // published cannot be written — without the server knowing any SQL.
@@ -272,6 +290,83 @@ test('a writer sends, the owner drains and acknowledges, and a replay changes no
     });
     assert.equal(enormous.status, 413);
     assert.equal((await enormous.json()).limit, 200);
+  });
+});
+
+test('reader annotations cross the server in both directions without changing shape', { timeout: 60_000 }, async () => {
+  await withServer({ label: 'reader-annotation-sync' }, async (server) => {
+    const spaceId = await server.createSpace('Corpus');
+    const owner = await server.deviceToken(server.adminEmail, server.adminPassword, spaceId);
+    await server.createUser('movil@example.test', 'mobile-account-password', [{ spaceId, role: 'writer' }]);
+    const mobile = await server.deviceToken('movil@example.test', 'mobile-account-password', spaceId);
+    const initial = academicSnapshot();
+    await publish(server.origin, owner.deviceToken, spaceId, initial);
+
+    // Desktop → mobile: annotations are part of the report detail, not a device-local sidecar.
+    const firstRead = await (await server.api(
+      mobile.deviceToken,
+      'GET',
+      `/api/v1/spaces/${spaceId}/deep-research/dr-1`,
+    )).json();
+    assert.deepEqual(firstRead.annotations.map((row) => row.id), ['ann-1']);
+
+    const stamp = '2026-08-10T00:00:00.000Z';
+    const row = (overrides) => ({
+      id: 'mobile-highlight', draft_id: 'dr-1', scope: 'source', kind: 'highlight', color: 'mint',
+      start_offset: 0, end_offset: 5, selected_text: 'Texto', prefix: '', suffix: '.',
+      comment_text: null, created_at: stamp, updated_at: stamp, ...overrides,
+    });
+    const mobileRows = [
+      row({}),
+      row({ id: 'mobile-comment', kind: 'comment', color: null, comment_text: 'Comprobar en la fuente.' }),
+      row({ id: 'reader-bookmark:dr-1:source', kind: 'bookmark', color: null, comment_text: null }),
+    ];
+    const changes = mobileRows.map((annotation, index) => mutation({
+      id: `mobile-annotation-${index}`,
+      table: 'writing_draft_annotations',
+      key: [annotation.id],
+      row: annotation,
+      schemaVersion: 127,
+      createdAt: stamp,
+    }));
+    const receipt = await (await server.api(
+      mobile.deviceToken,
+      'POST',
+      `/api/v1/spaces/${spaceId}/mutations`,
+      { json: { mutations: changes } },
+    )).json();
+    assert.deepEqual(receipt.accepted, changes.map((change) => change.id));
+
+    // Mobile → desktop: the owner drains the exact scalar rows the phone wrote.
+    const drained = await (await server.api(
+      owner.deviceToken,
+      'GET',
+      `/api/v1/spaces/${spaceId}/mutations?since=0`,
+    )).json();
+    assert.deepEqual(drained.mutations.map((change) => change.row), mobileRows);
+    await server.api(owner.deviceToken, 'POST', `/api/v1/spaces/${spaceId}/mutations/ack`, {
+      json: { cursor: drained.cursor },
+    });
+
+    // The owner's ensuing publication is what makes the rows readable everywhere,
+    // including back on their authoring phone.
+    await publish(server.origin, owner.deviceToken, spaceId, academicSnapshot({
+      tables: {
+        writing_draft_annotations: [
+          ...initial.payload.tables.writing_draft_annotations,
+          ...mobileRows,
+        ],
+      },
+    }));
+    const republished = await (await server.api(
+      mobile.deviceToken,
+      'GET',
+      `/api/v1/spaces/${spaceId}/deep-research/dr-1`,
+    )).json();
+    assert.deepEqual(
+      republished.annotations.map((annotation) => annotation.kind).sort(),
+      ['bookmark', 'comment', 'highlight', 'highlight'],
+    );
   });
 });
 

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,13 +25,23 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '3.2.6');
-  assert.equal(currentRelease?.date, '2026-08-09');
-  // Reasoning by job, fresh ideas, both Nodi improvements, saved authors, calm startup
-  // modals, and complete MCP reads. A floor leaves room for a last release-day fix.
-  assert.ok(currentRelease?.highlights.length >= 8, 'the release must describe everything shipped since 3.2.5');
-  assert.ok(currentRelease?.highlights.some((highlight) => highlight.scope === 'mcp'));
-  assert.ok(currentRelease?.highlights.filter((highlight) => highlight.scope === 'nodi').length >= 2);
+  assert.equal(currentRelease?.version, '3.2.7');
+  assert.equal(currentRelease?.date, '2026-08-10');
+  assert.equal(currentRelease?.highlights.length, 4);
+  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), [
+    'academic',
+    'academic',
+    'academic',
+    'nodi',
+  ]);
+
+  // 3.2.6 keeps the eight it shipped with, including its MCP and Nodi improvements.
+  // They are published history and stay as they were written.
+  const previousRelease = RELEASE_NOTES.find((note) => note.version === '3.2.6');
+  assert.equal(previousRelease?.date, '2026-08-09');
+  assert.equal(previousRelease?.highlights.length, 8);
+  assert.ok(previousRelease?.highlights.some((highlight) => highlight.scope === 'mcp'));
+  assert.ok(previousRelease?.highlights.filter((highlight) => highlight.scope === 'nodi').length >= 2);
 
   // 3.2.5 keeps the four it shipped with, including the two that describe the rule this
   // release reverses. They are published history and stay as they were written.

--- a/server/lib/core/mutations.mjs
+++ b/server/lib/core/mutations.mjs
@@ -40,6 +40,8 @@ export const MUTABLE_TABLES = {
 };
 
 export const MUTATION_KINDS = new Set(['upsert', 'delete']);
+const ANNOTATION_KINDS = new Set(['highlight', 'comment', 'bookmark']);
+const ANNOTATION_COLORS = new Set(['yellow', 'rose', 'blue', 'mint', 'lavender', 'peach']);
 /**
  * How large one row may be, by default.
  *
@@ -108,6 +110,25 @@ export function validateMutation(mutation, { snapshot, hasAsset, maxBytes = DEFA
 
   const row = mutation.row;
   if (!row || typeof row !== 'object' || Array.isArray(row)) return fail('missing_row');
+
+  if (table === 'writing_draft_annotations') {
+    const start = Number(row.start_offset);
+    const end = Number(row.end_offset);
+    const selected = typeof row.selected_text === 'string' ? row.selected_text : '';
+    const kind = String(row.kind ?? '');
+    if (String(row.id ?? '') !== String(mutation.key[0] ?? '')) return fail('constraint');
+    if (typeof row.draft_id !== 'string' || !row.draft_id || typeof row.scope !== 'string' || !row.scope) return fail('constraint');
+    if (!ANNOTATION_KINDS.has(kind) || !Number.isInteger(start) || !Number.isInteger(end)
+        || start < 0 || end <= start || !selected.trim() || selected.length !== end - start) return fail('constraint');
+    if (kind === 'highlight'
+        && (!ANNOTATION_COLORS.has(row.color) || row.comment_text !== null)) return fail('constraint');
+    if (kind === 'comment'
+        && (row.color !== null || typeof row.comment_text !== 'string' || !row.comment_text.trim())) return fail('constraint');
+    if (kind === 'bookmark') {
+      const expected = `reader-bookmark:${row.draft_id}:${row.scope}`;
+      if (row.id !== expected || row.color !== null || row.comment_text !== null) return fail('constraint');
+    }
+  }
 
   const known = knownColumns(snapshot, table);
   for (const [column, value] of Object.entries(row)) {

--- a/server/lib/routes/corpus.mjs
+++ b/server/lib/routes/corpus.mjs
@@ -515,6 +515,9 @@ export function createCorpusRoutes({ readSnapshot, readAssetBytes }) {
         report: { ...draftSummary(row), draft },
         image: assets.get(wanted) ?? null,
         translations: rows(snapshot, 'content_translations').filter((entry) => entry.entity_kind === 'deep_research' && String(entry.entity_id) === wanted),
+        // Small anchored rows, included with the document they decorate. A phone
+        // should not need a full snapshot merely to draw a comment in this report.
+        annotations: rows(snapshot, 'writing_draft_annotations').filter((entry) => String(entry.draft_id) === wanted),
         revision: space.revision,
       });
     }

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -12,4 +12,4 @@
  * this drifts from the root `package.json`, from `server/package.json`, or from the two iOS
  * targets in `ios/project.yml`.
  */
-export const NODUS_VERSION = '3.2.6';
+export const NODUS_VERSION = '3.2.7';

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "type": "module",
   "engines": {

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -116,6 +116,13 @@ const RELEASE_3_2_3_IT: string[] = [
   "Ogni opera sul telefono ha ora un pulsante che la apre in Zotero per iPhone e iPad. La chiave di Zotero smette di essere una riga morta della scheda e diventa la via di ritorno al PDF, alle note e alle annotazioni che stanno nell'altra applicazione.",
 ];
 
+const RELEASE_3_2_7_IT: string[] = [
+  "Deep Research introduce evidenziazioni in sei colori, commenti a margine e un evidenziatore che può restare attivo. Anche i segnalibri passano al margine. Tutto viene salvato nel deposito e sincronizzato tramite Nodus Server tra computer e dispositivo mobile, anche se il telefono perde la connessione mentre annoti.",
+  "Tornare a un rapporto è più facile. La biblioteca può separare i rapporti letti da quelli ancora da leggere, e i loro indicatori restano chiari sia in modalità chiara sia scura. Il segnalibro porta al passaggio esatto dalla barra e si rimuove dalla sua icona a margine. Le evidenziazioni spariscono con un clic, mentre i commenti si possono modificare o eliminare con conferma.",
+  "Il Grafo ora si apre come un atlante leggibile del corpus. Prima mostra una costellazione di temi, entrando in uno rivela le idee più collegate, e le viste di contraddizioni, lettura, elementi in attesa e autori presentano scene delimitate. I corpora grandi si caricano per livelli invece di trasformarsi in un groviglio.",
+  "Le risposte in corso non sembrano più un messaggio vuoto. Nodi e l'Assistente di ricerca mostrano lo stesso indicatore animato a tre punti mentre pensano, adattato sia alla finestra principale sia a quella mobile.",
+];
+
 const RELEASE_3_2_6_IT: string[] = [
   "Il livello di ragionamento appartiene ora a ogni attività. Prima, alzarlo su Immersione lo alzava anche su Deep Research e su tutte le altre che usavano quel modello. Ora ogni attività conserva il proprio, e in Fornitori si continua a fissare il valore predefinito del modello.",
   "Quel livello comanda anche sulle scansioni. L'estrazione, i riassunti e la fusione lo ignoravano del tutto e giravano sempre al livello più economico, qualunque cosa dicesse il selettore. Se non ne scegli nessuno, continuano a girare senza ragionamento ed esattamente alla stessa velocità.",
@@ -148,6 +155,7 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "3.2.7": RELEASE_3_2_7_IT,
   "3.2.6": RELEASE_3_2_6_IT,
   "3.2.5": RELEASE_3_2_5_IT,
   "3.2.4": RELEASE_3_2_4_IT,

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -56,6 +56,13 @@ const RELEASE_3_2_3_TR: string[] = [
   "Telefondaki her eser artık onu iPhone ve iPad için Zotero'da açan bir düğme taşıyor. Zotero anahtarı kayıttaki ölü bir satır olmaktan çıkıp diğer uygulamadaki PDF'e, notlara ve işaretlemelere dönüş yolu oluyor.",
 ];
 
+const RELEASE_3_2_7_TR: string[] = [
+  "Deep Research altı renkli vurgulara, kenar yorumlarına ve açık bırakılabilen bir vurgulayıcıya kavuşuyor. Yer imleri de kenara taşınıyor. Her şey kasada saklanıp Nodus Server üzerinden masaüstü ile mobil arasında eşitleniyor, telefon siz not alırken bağlantısını kaybetse bile.",
+  "Bir rapora geri dönmek artık daha kolay. Kitaplık okunan raporları bekleyenlerden ayırabiliyor ve rozetleri açık ya da koyu modda aynı ölçüde okunaklı kalıyor. Yer imi çubuktan tam pasaja götürüyor ve kenardaki simgesinden kaldırılabiliyor. Vurgular tek tıklamayla siliniyor, yorumlar ise düzenlenebiliyor ya da onayla silinebiliyor.",
+  "Grafik artık derlemin okunabilir bir atlası olarak açılıyor. Önce temalardan oluşan bir takımyıldız gösteriyor, birine girince en bağlantılı fikirlerini açıyor ve çelişkiler, okuma, bekleyenler ile yazar görünümleri sınırlı sahneler sunuyor. Büyük derlemler bir düğüme dönüşmek yerine katman katman yükleniyor.",
+  "Sürmekte olan yanıtlar artık boş bir ileti gibi görünmüyor. Nodi ile Araştırma Asistanı düşünürken aynı hareketli üç nokta göstergesini kullanıyor ve gösterge hem ana pencereye hem de yüzen pencereye uyum sağlıyor.",
+];
+
 const RELEASE_3_2_6_TR: string[] = [
   "Akıl yürütme düzeyi artık her görevin kendisine ait. Önceden Daldırma'da yükseltmek onu Deep Research'te ve o modeli kullanan diğer bütün görevlerde de yükseltiyordu. Artık her görev kendi düzeyini saklıyor, Sağlayıcılar'da ise modelin varsayılanını belirlemeye devam ediyorsunuz.",
   "Bu düzey artık taramalarda da geçerli. Çıkarım, özetler ve birleştirme onu tamamen yok sayıyor ve seçici ne derse desin hep en ucuz düzeyde çalışıyordu. Hiçbirini seçmezseniz akıl yürütmesiz ve tam olarak eskisi kadar hızlı çalışmaya devam ederler.",
@@ -88,6 +95,7 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "3.2.7": RELEASE_3_2_7_TR,
   "3.2.6": RELEASE_3_2_6_TR,
   "3.2.5": RELEASE_3_2_5_TR,
   "3.2.4": RELEASE_3_2_4_TR,

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -823,6 +823,49 @@ const RELEASE_3_2_3_HIGHLIGHTS: RawReleaseHighlight[] = [
  * that were laying out without their icon.
  */
 /**
+ * v3.2.7 — Deep Research annotations synchronize with mobile, the library and graph
+ * become easier to navigate, and assistant activity is visible while replies stream.
+ */
+const RELEASE_3_2_7_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'academic',
+    es: 'Deep Research estrena subrayados en seis colores, comentarios laterales y un subrayador que puede quedarse encendido. Los marcadores también pasan al margen. Todo se guarda en el vault y se sincroniza por Nodus Server entre el escritorio y el móvil, incluso si el teléfono pierde la conexión mientras anotas.',
+    en: 'Deep Research gains highlights in six colors, margin comments, and a highlighter that can stay on. Bookmarks move to the margin too. Everything is stored in the vault and synchronized through Nodus Server between desktop and mobile, even if the phone loses its connection while you annotate.',
+    fr: 'Deep Research accueille des surlignages en six couleurs, des commentaires en marge et un surligneur qui peut rester actif. Les marque-pages passent eux aussi dans la marge. Tout est conservé dans le coffre et synchronisé par Nodus Server entre l’ordinateur et le mobile, même si le téléphone perd sa connexion pendant que vous annotez.',
+    de: 'Deep Research erhält Hervorhebungen in sechs Farben, Randkommentare und einen Textmarker, der eingeschaltet bleiben kann. Auch Lesezeichen wandern an den Rand. Alles wird im Tresor gespeichert und über Nodus Server zwischen Desktop und Mobilgerät synchronisiert, selbst wenn das Telefon beim Annotieren die Verbindung verliert.',
+    pt: 'O Deep Research ganha sublinhados em seis cores, comentários laterais e um marcador que pode ficar ligado. Os marcadores de leitura também passam para a margem. Tudo fica guardado no cofre e é sincronizado pelo Nodus Server entre o computador e o telemóvel, mesmo que o telefone perca a ligação enquanto anota.',
+    'pt-BR': 'O Deep Research ganha destaques em seis cores, comentários laterais e um marcador que pode ficar ligado. Os marcadores de leitura também passam para a margem. Tudo fica salvo no cofre e é sincronizado pelo Nodus Server entre o computador e o celular, mesmo que o telefone perca a conexão enquanto você anota.',
+  },
+  {
+    scope: 'academic',
+    es: 'Volver a un informe es más fácil. La biblioteca puede separar los informes leídos de los pendientes, y sus distintivos se leen igual de bien en claro y oscuro. El marcador te lleva al pasaje exacto desde la barra y se elimina desde su icono del margen. Los subrayados se borran con un clic y los comentarios se pueden editar o eliminar con confirmación.',
+    en: 'Returning to a report is easier. The library can separate read reports from those still waiting, and their badges remain clear in light and dark mode. The bookmark takes you to the exact passage from the toolbar and can be removed from its margin icon. Highlights disappear with one click, while comments can be edited or deleted with confirmation.',
+    fr: 'Revenir à un rapport est plus simple. La bibliothèque peut séparer les rapports lus de ceux qui restent à lire, et leurs badges restent lisibles en mode clair comme sombre. Le marque-page ramène au passage exact depuis la barre et se retire par son icône en marge. Les surlignages se suppriment en un clic, tandis que les commentaires se modifient ou se suppriment après confirmation.',
+    de: 'Zu einem Bericht zurückzukehren ist einfacher. Die Bibliothek kann gelesene Berichte von noch offenen trennen, und ihre Kennzeichen bleiben im hellen wie im dunklen Modus gut lesbar. Das Lesezeichen führt über die Leiste zur genauen Passage und lässt sich über sein Randsymbol entfernen. Hervorhebungen verschwinden mit einem Klick, Kommentare lassen sich bearbeiten oder nach Bestätigung löschen.',
+    pt: 'Voltar a um relatório é mais fácil. A biblioteca pode separar os relatórios lidos dos que ainda aguardam, e os seus distintivos continuam legíveis nos modos claro e escuro. O marcador leva à passagem exata a partir da barra e remove-se pelo ícone da margem. Os sublinhados apagam-se com um clique, enquanto os comentários podem ser editados ou eliminados com confirmação.',
+    'pt-BR': 'Voltar a um relatório ficou mais fácil. A biblioteca pode separar os relatórios lidos dos que ainda aguardam, e seus indicadores continuam legíveis nos modos claro e escuro. O marcador leva ao trecho exato pela barra e pode ser removido pelo ícone da margem. Os destaques são apagados com um clique, enquanto os comentários podem ser editados ou excluídos com confirmação.',
+  },
+  {
+    scope: 'academic',
+    es: 'El Grafo abre ahora como un atlas legible del corpus. Primero muestra una constelación de temas, al entrar en uno enseña sus ideas más conectadas y las vistas de contradicciones, lectura, pendientes y autores presentan escenas acotadas. Los corpus grandes cargan por niveles en vez de convertirse en una maraña.',
+    en: 'The Graph now opens as a readable atlas of the corpus. It first shows a constellation of themes, entering one reveals its most connected ideas, and the contradiction, reading, waiting, and author views present bounded scenes. Large corpora load in levels instead of turning into a hairball.',
+    fr: 'Le Graphe s’ouvre désormais comme un atlas lisible du corpus. Il montre d’abord une constellation de thèmes, entrer dans l’un révèle ses idées les plus connectées, et les vues des contradictions, de lecture, d’attente et des auteurs présentent des scènes limitées. Les grands corpus se chargent par niveaux au lieu de devenir un enchevêtrement.',
+    de: 'Der Graph öffnet sich jetzt als lesbarer Atlas des Korpus. Zuerst zeigt er eine Konstellation von Themen, beim Öffnen eines Themas erscheinen dessen am stärksten vernetzte Ideen, und die Ansichten für Widersprüche, Lesen, Offenes und Autoren zeigen begrenzte Szenen. Große Korpora laden stufenweise, statt zu einem unlesbaren Knäuel zu werden.',
+    pt: 'O Grafo abre agora como um atlas legível do corpus. Primeiro mostra uma constelação de temas, entrar num deles revela as ideias mais ligadas, e as vistas de contradições, leitura, pendentes e autores apresentam cenas limitadas. Os corpora grandes carregam por níveis em vez de se transformarem num emaranhado.',
+    'pt-BR': 'O Grafo agora abre como um atlas legível do corpus. Primeiro mostra uma constelação de temas, entrar em um deles revela as ideias mais conectadas, e as telas de contradições, leitura, pendentes e autores apresentam cenas limitadas. Os corpus grandes carregam por níveis em vez de virarem um emaranhado.',
+  },
+  {
+    scope: 'nodi',
+    es: 'Las respuestas en curso ya no se confunden con un mensaje vacío. Nodi y el Asistente de investigación muestran el mismo indicador animado de tres puntos mientras piensan, adaptado a la ventana principal y a la flotante.',
+    en: 'Replies in progress no longer look like an empty message. Nodi and the Research Assistant show the same animated three-dot indicator while they think, adapted to both the main window and the floating one.',
+    fr: 'Les réponses en cours ne ressemblent plus à un message vide. Nodi et l’Assistant de recherche affichent le même indicateur animé à trois points pendant leur réflexion, adapté à la fenêtre principale comme à la fenêtre flottante.',
+    de: 'Laufende Antworten sehen nicht mehr wie eine leere Nachricht aus. Nodi und der Forschungsassistent zeigen beim Denken denselben animierten Dreipunkt-Indikator, angepasst an das Hauptfenster und das schwebende Fenster.',
+    pt: 'As respostas em curso deixam de parecer uma mensagem vazia. O Nodi e o Assistente de investigação mostram o mesmo indicador animado de três pontos enquanto pensam, adaptado à janela principal e à flutuante.',
+    'pt-BR': 'As respostas em andamento não parecem mais uma mensagem vazia. O Nodi e o Assistente de pesquisa mostram o mesmo indicador animado de três pontos enquanto pensam, adaptado à janela principal e à flutuante.',
+  },
+];
+
+/**
  * v3.2.6 — each job owns its reasoning level, Nodi becomes a real report reader,
  * authors can be kept on a shelf, startup modals settle down, and MCP clients can
  * retrieve every readable layer and every saved Deep Research report.
@@ -1035,6 +1078,11 @@ const RELEASE_3_2_4_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '3.2.7',
+    date: '2026-08-10',
+    highlights: RELEASE_3_2_7_HIGHLIGHTS,
+  },
   {
     version: '3.2.6',
     date: '2026-08-09',

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6087,7 +6087,7 @@ export interface WritingDraftAnnotation {
   id: string;
   draftId: string;
   scope: string;
-  kind: 'highlight' | 'comment';
+  kind: 'highlight' | 'comment' | 'bookmark';
   color: WritingDraftAnnotationColor | null;
   startOffset: number;
   endOffset: number;

--- a/src/components/ReaderSelectionActions.tsx
+++ b/src/components/ReaderSelectionActions.tsx
@@ -325,19 +325,59 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
   const [commentEditor, setCommentEditor] = useState<CommentEditor | null>(null);
   const [savingComment, setSavingComment] = useState(false);
   const [commentError, setCommentError] = useState<string | null>(null);
-  const [mark, setMark] = useState<ReaderMark | null>(() => loadMark(contextId));
+  const [localMark, setLocalMark] = useState<ReaderMark | null>(() => loadMark(contextId));
   const [marginPositions, setMarginPositions] = useState<MarginPosition[]>([]);
+  const migratedBookmark = useRef<string | null>(null);
+  const usesSyncedBookmark = !!onCreateAnnotation && !!onDeleteAnnotation;
+  const bookmarkAnnotation = annotations.find((item) => item.kind === 'bookmark') ?? null;
+  const mark = usesSyncedBookmark
+    ? bookmarkAnnotation && {
+      start: bookmarkAnnotation.startOffset,
+      end: bookmarkAnnotation.endOffset,
+      text: bookmarkAnnotation.selectedText,
+    }
+    : localMark;
+  const hasMark = !!mark;
   const markLabel = t(mark ? 'Mover marcador aquí' : 'Añadir marcador de lectura');
 
   useEffect(() => {
-    const next = loadMark(contextId);
+    const next = usesSyncedBookmark ? null : loadMark(contextId);
     setActive(null);
     setActiveMarkActions(null);
     setActiveHighlightActions(null);
     setCommentEditor(null);
-    setMark(next);
-    onMarkChange?.(!!next);
-  }, [contextId, onMarkChange]);
+    setLocalMark(next);
+  }, [contextId, usesSyncedBookmark]);
+
+  useEffect(() => {
+    onMarkChange?.(hasMark);
+  }, [hasMark, onMarkChange]);
+
+  // Bookmarks created by the first reader implementation lived in localStorage.
+  // Move one into the syncable row the first time this saved report opens, so the
+  // server-backed feature does not make an existing place silently disappear.
+  useEffect(() => {
+    if (!usesSyncedBookmark || bookmarkAnnotation || !onCreateAnnotation) return;
+    if (migratedBookmark.current === contextId) return;
+    const legacy = loadMark(contextId);
+    if (!legacy) return;
+    migratedBookmark.current = contextId;
+    const content = targetRef.current?.textContent || '';
+    void onCreateAnnotation({
+      kind: 'bookmark',
+      color: null,
+      startOffset: legacy.start,
+      endOffset: legacy.end,
+      selectedText: legacy.text,
+      prefix: content.slice(Math.max(0, legacy.start - 64), legacy.start),
+      suffix: content.slice(legacy.end, legacy.end + 64),
+    }).then(() => {
+      localStorage.removeItem(storageKey(contextId));
+    }).catch((error) => {
+      migratedBookmark.current = null;
+      onAnnotationError?.(errorMessage(error));
+    });
+  }, [bookmarkAnnotation, contextId, onAnnotationError, onCreateAnnotation, targetRef, usesSyncedBookmark]);
 
   useEffect(() => {
     if (activeHighlightActions && !annotations.some((item) => item.id === activeHighlightActions.value.id)) {
@@ -543,17 +583,27 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
   const saveMark = () => {
     if (!active) return;
     const next: ReaderMark = { start: active.startOffset, end: active.endOffset, text: active.selectedText };
-    localStorage.setItem(storageKey(contextId), JSON.stringify(next));
-    setMark(next);
-    onMarkChange?.(true);
     clearSelection();
+    if (usesSyncedBookmark && onCreateAnnotation) {
+      void onCreateAnnotation({ ...active, kind: 'bookmark', color: null }).catch((error) => {
+        onAnnotationError?.(errorMessage(error));
+      });
+      return;
+    }
+    localStorage.setItem(storageKey(contextId), JSON.stringify(next));
+    setLocalMark(next);
   };
 
   const deleteMark = () => {
+    if (usesSyncedBookmark && bookmarkAnnotation && onDeleteAnnotation) {
+      const id = bookmarkAnnotation.id;
+      setActiveMarkActions(null);
+      void onDeleteAnnotation(id).catch((error) => onAnnotationError?.(errorMessage(error)));
+      return;
+    }
     localStorage.removeItem(storageKey(contextId));
-    setMark(null);
+    setLocalMark(null);
     setActiveMarkActions(null);
-    onMarkChange?.(false);
   };
 
   const goToMark = useCallback(() => {


### PR DESCRIPTION
## Summary

- publish Deep Research highlights, comments, and bookmarks with report details
- make the reading bookmark a deterministic synced annotation while migrating legacy local bookmarks
- validate annotation rows at the server boundary and preserve newest-write-wins convergence
- extend schema 127 to support bookmark rows
- set desktop and server metadata to 3.2.7 and add the multilingual release-notes modal without creating a tag or release

## Sync flow

Desktop publications expose annotation rows to mobile readers. Mobile mutations enter the existing server ledger, are drained by the owner desktop, and become visible to every client after the next publication.

## Verification

- npm run build
- release-note, localization, citation, and version-agreement tests
- isolated prosopography Electron smoke test
- server round-trip test covering desktop to mobile and mobile to desktop

Companion mobile PR: https://github.com/Drakonis96/nodus-mobile/pull/18