### PR TITLE
Fix Chrome connector requests to the local Nodus API

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -48,6 +48,11 @@ exposes a token-authenticated, extension-origin-only API. Cross-site attachment 
 and requested at save time for the exact site involved. The package contains no analytics,
 advertising, remotely hosted code, `eval`, or background worker.
 
+Requests to the local Nodus API use the extension page's XHR transport and carry the installed
+`chrome-extension://` origin explicitly when Chromium permits it. This keeps the server-side origin
+check reliable across Chrome versions where extension `fetch()` requests may omit the `Origin`
+header despite having the required loopback host permission.
+
 See [PRIVACY.md](PRIVACY.md) for the Chrome Web Store disclosure and
 [STORE_LISTING.md](STORE_LISTING.md) for release instructions and permission justifications.
 

--- a/browser-extension/lib/connection.js
+++ b/browser-extension/lib/connection.js
@@ -23,3 +23,47 @@ export async function discoverNodus(preferredPort, probe) {
   }
   return null;
 }
+
+export function extensionOrigin(getUrl) {
+  const url = new URL(getUrl(''));
+  if (!/^(?:chrome|moz)-extension:$/.test(url.protocol) || !url.hostname) {
+    throw new TypeError('Nodus Connector must run from an installed browser extension.');
+  }
+  return `${url.protocol}//${url.hostname}`;
+}
+
+export function requestLocalJson(url, options = {}, createRequest = () => new XMLHttpRequest()) {
+  return new Promise((resolve, reject) => {
+    let request;
+    try {
+      request = createRequest();
+      request.open(options.method || 'GET', url, true);
+      for (const [name, value] of Object.entries(options.headers || {})) {
+        try {
+          request.setRequestHeader(name, value);
+        } catch (error) {
+          // Older Chromium builds forbid setting Origin but XHR still supplies the extension origin.
+          if (name.toLowerCase() !== 'origin') throw error;
+        }
+      }
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const fail = () => reject(new TypeError('Nodus local connection failed.'));
+    request.onerror = fail;
+    request.onabort = fail;
+    request.onload = () => {
+      if (!request.status) {
+        fail();
+        return;
+      }
+      const raw = request.responseText || '';
+      let data = {};
+      try { data = raw ? JSON.parse(raw) : {}; } catch { data = { error: raw }; }
+      resolve({ ok: request.status >= 200 && request.status < 300, status: request.status, data });
+    };
+    request.send(options.body ?? null);
+  });
+}

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -3,7 +3,7 @@
 
 import { detectCapture } from './lib/detector.js';
 import { filterCollectionRows, normalizeTags } from './lib/collections.js';
-import { DEFAULT_NODUS_PORT, discoverNodus, normalizeConnectorPort } from './lib/connection.js';
+import { DEFAULT_NODUS_PORT, discoverNodus, extensionOrigin, normalizeConnectorPort, requestLocalJson } from './lib/connection.js';
 
 const ITEM_TYPES = [
   ['journal-article', 'Journal article'], ['book', 'Book'], ['book-chapter', 'Book chapter'], ['conference-paper', 'Conference paper'],
@@ -106,14 +106,12 @@ async function detectActiveTab() {
 function baseUrl(port = state.port) { return `http://127.0.0.1:${port}`; }
 
 async function api(path, options = {}, token = state.token, port = state.port) {
-  const headers = { ...(options.headers || {}) };
+  const headers = { ...(options.headers || {}), Origin: extensionOrigin(chrome.runtime.getURL) };
   if (token) headers.Authorization = `Bearer ${token}`;
   if (options.body && !(options.body instanceof ArrayBuffer) && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
-  const response = await fetch(`${baseUrl(port)}${path}`, { ...options, headers });
-  const raw = await response.text();
-  let data = {}; try { data = raw ? JSON.parse(raw) : {}; } catch { data = { error: raw }; }
-  if (!response.ok) throw new Error(data.error || `Nodus returned ${response.status}.`);
-  return data;
+  const response = await requestLocalJson(`${baseUrl(port)}${path}`, { ...options, headers });
+  if (!response.ok) throw new Error(response.data.error || `Nodus returned ${response.status}.`);
+  return response.data;
 }
 
 async function findNodus(preferredPort) {

--- a/scripts/e2e-browser-connector.mjs
+++ b/scripts/e2e-browser-connector.mjs
@@ -66,7 +66,21 @@ async function exercise(colorScheme) {
       scripting: { executeScript: async () => [{ result: detected }] },
       storage: { local: { get: async (defaults) => ({ ...defaults, ...values }), set: async (input) => Object.assign(values, input), remove: async (keys) => { for (const key of keys) delete values[key]; } } },
       permissions: { request: async () => true },
-      runtime: { getManifest: () => ({ version: '4.0.0' }), openOptionsPage: async () => undefined },
+      runtime: { getManifest: () => ({ version: '4.0.0' }), getURL: (path = '') => `chrome-extension://abcdefghijklmnopabcdefghijklmnop/${path}`, openOptionsPage: async () => undefined },
+    };
+    globalThis.XMLHttpRequest = class {
+      open(method, url) { this.method = method; this.url = url; }
+      setRequestHeader(name, value) { (this.headers ||= {})[name] = value; }
+      async send(body) {
+        try {
+          const response = await fetch(this.url, { method: this.method, headers: this.headers, body });
+          this.status = response.status;
+          this.responseText = await response.text();
+          this.onload?.();
+        } catch {
+          this.onerror?.();
+        }
+      }
     };
   }, { messages: english, detected: snapshot });
   await page.route('http://127.0.0.1:4323/api/browser/**', (route) => route.abort('connectionrefused'));

--- a/scripts/test-browser-connector.mjs
+++ b/scripts/test-browser-connector.mjs
@@ -8,7 +8,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { filterCollectionRows, hierarchicalCollections, normalizeTags } from '../browser-extension/lib/collections.js';
-import { DEFAULT_NODUS_PORT, connectorPortCandidates, discoverNodus, normalizeConnectorPort } from '../browser-extension/lib/connection.js';
+import { DEFAULT_NODUS_PORT, connectorPortCandidates, discoverNodus, extensionOrigin, normalizeConnectorPort, requestLocalJson } from '../browser-extension/lib/connection.js';
 import { detectCapture } from '../browser-extension/lib/detector.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -116,6 +116,47 @@ test('recovers from a stale connector port by probing the Nodus default', async 
   });
   assert.deepEqual(attempted, [4323, DEFAULT_NODUS_PORT]);
   assert.deepEqual(connection, { port: DEFAULT_NODUS_PORT, health: { ok: true, app: 'nodus', enabled: true } });
+});
+
+test('preserves the installed extension origin on local connector requests', async () => {
+  assert.equal(extensionOrigin((path) => `chrome-extension://abcdefghijklmnopabcdefghijklmnop/${path}`), 'chrome-extension://abcdefghijklmnopabcdefghijklmnop');
+
+  const observed = {};
+  const response = await requestLocalJson('http://127.0.0.1:4321/api/browser/health', {
+    headers: { Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop' },
+  }, () => ({
+    status: 0,
+    responseText: '',
+    open(method, url, async) { Object.assign(observed, { method, url, async }); },
+    setRequestHeader(name, value) { (observed.headers ||= {})[name] = value; },
+    send(body) {
+      observed.body = body;
+      this.status = 200;
+      this.responseText = JSON.stringify({ ok: true, app: 'nodus' });
+      queueMicrotask(() => this.onload());
+    },
+  }));
+
+  assert.deepEqual(observed, {
+    method: 'GET', url: 'http://127.0.0.1:4321/api/browser/health', async: true,
+    headers: { Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop' }, body: null,
+  });
+  assert.deepEqual(response, { ok: true, status: 200, data: { ok: true, app: 'nodus' } });
+
+  const legacyResponse = await requestLocalJson('http://127.0.0.1:4321/api/browser/health', {
+    headers: { Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop' },
+  }, () => ({
+    status: 0,
+    responseText: '',
+    open() {},
+    setRequestHeader(name) { if (name === 'Origin') throw new DOMException('Refused unsafe header'); },
+    send() {
+      this.status = 200;
+      this.responseText = '{"ok":true}';
+      queueMicrotask(() => this.onload());
+    },
+  }));
+  assert.equal(legacyResponse.ok, true, 'older Chromium falls back to the Origin automatically supplied by XHR');
 });
 
 test('Manifest V3 package minimizes permission and contains no remote executable code', () => {


### PR DESCRIPTION
## Summary

- route local Nodus API calls through the extension page's XHR transport
- attach the installed `chrome-extension://` or `moz-extension://` origin explicitly when Chromium permits it
- retain compatibility with older Chromium builds that reject manually setting `Origin` and let XHR supply it automatically
- add regression coverage for extension-origin preservation and update the popup E2E transport mock

## Root cause

Chromium extension `fetch()` requests with loopback host permission can omit the `Origin` header, particularly for GET probes. Nodus intentionally rejects `/api/browser/*` requests without an installed extension origin, so the health probe received `403` and connector discovery displayed the generic unreachable message even while the local server was healthy.

## User impact

The connector can discover, pair with, and call a running local Nodus instance without weakening the server's existing rejection of ordinary web origins.

## Validation

- `node --test scripts/test-browser-connector.mjs` — 8/8 passed
- `npm run test:e2e:browser-connector` — light and dark popup flows passed
- `npm run verify:browser-connector` — pairing, origin isolation, hierarchy, tags, capture, and attachment upload passed
- `npm run browser:zip` and `unzip -t dist-browser/nodus-connector-chrome.zip` — 23-file archive passed integrity validation
- `git diff --check`

Closes #405