### PR TITLE
Fix Chrome connector pairing after the Origin-header regression

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -48,10 +48,10 @@ exposes a token-authenticated, extension-origin-only API. Cross-site attachment 
 and requested at save time for the exact site involved. The package contains no analytics,
 advertising, remotely hosted code, `eval`, or background worker.
 
-Requests to the local Nodus API use the extension page's XHR transport and carry the installed
-`chrome-extension://` origin explicitly when Chromium permits it. This keeps the server-side origin
-check reliable across Chrome versions where extension `fetch()` requests may omit the `Origin`
-header despite having the required loopback host permission.
+Requests to the local Nodus API use extension-page `fetch()` with both the standard installed
+extension origin and a dedicated request marker. Current Chromium versions allow extensions with
+explicit loopback host access to set `Origin`; updated Nodus builds accept the marker only when an
+older Chromium build omits that header. Any request carrying an ordinary web origin is rejected.
 
 See [PRIVACY.md](PRIVACY.md) for the Chrome Web Store disclosure and
 [STORE_LISTING.md](STORE_LISTING.md) for release instructions and permission justifications.

--- a/browser-extension/lib/connection.js
+++ b/browser-extension/lib/connection.js
@@ -32,38 +32,10 @@ export function extensionOrigin(getUrl) {
   return `${url.protocol}//${url.hostname}`;
 }
 
-export function requestLocalJson(url, options = {}, createRequest = () => new XMLHttpRequest()) {
-  return new Promise((resolve, reject) => {
-    let request;
-    try {
-      request = createRequest();
-      request.open(options.method || 'GET', url, true);
-      for (const [name, value] of Object.entries(options.headers || {})) {
-        try {
-          request.setRequestHeader(name, value);
-        } catch (error) {
-          // Older Chromium builds forbid setting Origin but XHR still supplies the extension origin.
-          if (name.toLowerCase() !== 'origin') throw error;
-        }
-      }
-    } catch (error) {
-      reject(error);
-      return;
-    }
-
-    const fail = () => reject(new TypeError('Nodus local connection failed.'));
-    request.onerror = fail;
-    request.onabort = fail;
-    request.onload = () => {
-      if (!request.status) {
-        fail();
-        return;
-      }
-      const raw = request.responseText || '';
-      let data = {};
-      try { data = raw ? JSON.parse(raw) : {}; } catch { data = { error: raw }; }
-      resolve({ ok: request.status >= 200 && request.status < 300, status: request.status, data });
-    };
-    request.send(options.body ?? null);
-  });
+export async function requestLocalJson(url, options = {}, request = fetch) {
+  const response = await request(url, options);
+  const raw = await response.text();
+  let data = {};
+  try { data = raw ? JSON.parse(raw) : {}; } catch { data = { error: raw }; }
+  return { ok: response.ok, status: response.status, data };
 }

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -106,7 +106,8 @@ async function detectActiveTab() {
 function baseUrl(port = state.port) { return `http://127.0.0.1:${port}`; }
 
 async function api(path, options = {}, token = state.token, port = state.port) {
-  const headers = { ...(options.headers || {}), Origin: extensionOrigin(chrome.runtime.getURL) };
+  const origin = extensionOrigin(chrome.runtime.getURL);
+  const headers = { ...(options.headers || {}), Origin: origin, 'X-Nodus-Extension-Origin': origin };
   if (token) headers.Authorization = `Bearer ${token}`;
   if (options.body && !(options.body instanceof ArrayBuffer) && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
   const response = await requestLocalJson(`${baseUrl(port)}${path}`, { ...options, headers });

--- a/electron/zotero-plugin/server.ts
+++ b/electron/zotero-plugin/server.ts
@@ -88,7 +88,15 @@ function hasValidToken(req: IncomingMessage, expected: string): boolean {
 
 function extensionOrigin(req: IncomingMessage): string | null {
   const origin = req.headers.origin;
-  return typeof origin === 'string' && /^(?:chrome|moz)-extension:\/\/[a-z0-9-]{16,80}$/i.test(origin) ? origin : null;
+  const validExtensionOrigin = (value: unknown): value is string => (
+    typeof value === 'string' && /^(?:chrome|moz)-extension:\/\/[a-z0-9-]{16,80}$/i.test(value)
+  );
+  if (validExtensionOrigin(origin)) return origin;
+  // A web request always carries its real Origin. Chromium may omit Origin for an extension
+  // with host access, so only allow the explicit extension marker when Origin is absent.
+  if (origin !== undefined) return null;
+  const marker = req.headers['x-nodus-extension-origin'];
+  return validExtensionOrigin(marker) ? marker : null;
 }
 
 function setCors(req: IncomingMessage, res: ServerResponse): void {
@@ -101,6 +109,7 @@ function setCors(req: IncomingMessage, res: ServerResponse): void {
   res.setHeader('Access-Control-Allow-Headers', [
     'Authorization', 'Content-Type', 'X-Nodus-Zotero-Protocol', 'X-Nodus-File-Name',
     'X-Nodus-File-Title', 'X-Nodus-Mime-Type', 'X-Nodus-Attachment-Role', 'X-Nodus-Source-Url',
+    'X-Nodus-Extension-Origin',
   ].join(', '));
   if (browserRoute) res.setHeader('Access-Control-Allow-Private-Network', 'true');
 }

--- a/scripts/e2e-browser-connector.mjs
+++ b/scripts/e2e-browser-connector.mjs
@@ -68,20 +68,6 @@ async function exercise(colorScheme) {
       permissions: { request: async () => true },
       runtime: { getManifest: () => ({ version: '4.0.0' }), getURL: (path = '') => `chrome-extension://abcdefghijklmnopabcdefghijklmnop/${path}`, openOptionsPage: async () => undefined },
     };
-    globalThis.XMLHttpRequest = class {
-      open(method, url) { this.method = method; this.url = url; }
-      setRequestHeader(name, value) { (this.headers ||= {})[name] = value; }
-      async send(body) {
-        try {
-          const response = await fetch(this.url, { method: this.method, headers: this.headers, body });
-          this.status = response.status;
-          this.responseText = await response.text();
-          this.onload?.();
-        } catch {
-          this.onerror?.();
-        }
-      }
-    };
   }, { messages: english, detected: snapshot });
   await page.route('http://127.0.0.1:4323/api/browser/**', (route) => route.abort('connectionrefused'));
   await page.route('http://127.0.0.1:4321/api/browser/**', async (route) => {

--- a/scripts/test-browser-connector.mjs
+++ b/scripts/test-browser-connector.mjs
@@ -123,40 +123,23 @@ test('preserves the installed extension origin on local connector requests', asy
 
   const observed = {};
   const response = await requestLocalJson('http://127.0.0.1:4321/api/browser/health', {
-    headers: { Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop' },
-  }, () => ({
-    status: 0,
-    responseText: '',
-    open(method, url, async) { Object.assign(observed, { method, url, async }); },
-    setRequestHeader(name, value) { (observed.headers ||= {})[name] = value; },
-    send(body) {
-      observed.body = body;
-      this.status = 200;
-      this.responseText = JSON.stringify({ ok: true, app: 'nodus' });
-      queueMicrotask(() => this.onload());
+    headers: {
+      Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
+      'X-Nodus-Extension-Origin': 'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
     },
-  }));
+  }, async (url, options) => {
+    Object.assign(observed, { url, options });
+    return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, app: 'nodus' }) };
+  });
 
   assert.deepEqual(observed, {
-    method: 'GET', url: 'http://127.0.0.1:4321/api/browser/health', async: true,
-    headers: { Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop' }, body: null,
+    url: 'http://127.0.0.1:4321/api/browser/health',
+    options: { headers: {
+      Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
+      'X-Nodus-Extension-Origin': 'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
+    } },
   });
   assert.deepEqual(response, { ok: true, status: 200, data: { ok: true, app: 'nodus' } });
-
-  const legacyResponse = await requestLocalJson('http://127.0.0.1:4321/api/browser/health', {
-    headers: { Origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop' },
-  }, () => ({
-    status: 0,
-    responseText: '',
-    open() {},
-    setRequestHeader(name) { if (name === 'Origin') throw new DOMException('Refused unsafe header'); },
-    send() {
-      this.status = 200;
-      this.responseText = '{"ok":true}';
-      queueMicrotask(() => this.onload());
-    },
-  }));
-  assert.equal(legacyResponse.ok, true, 'older Chromium falls back to the Origin automatically supplied by XHR');
 });
 
 test('Manifest V3 package minimizes permission and contains no remote executable code', () => {

--- a/scripts/verify-browser-connector-server.mjs
+++ b/scripts/verify-browser-connector-server.mjs
@@ -45,6 +45,7 @@ try {
 
   const extensionHeaders = { Origin: origin };
   const authHeaders = { Origin: origin, Authorization: 'Bearer browser-test-token', 'Content-Type': 'application/json' };
+  const markerHeaders = { 'X-Nodus-Extension-Origin': origin };
 
   const healthResponse = await fetch(`${base}/api/browser/health`, { headers: extensionHeaders });
   assert.equal(healthResponse.status, 200);
@@ -53,8 +54,26 @@ try {
   assert.equal(health.libraryReady, true);
   assert.equal(healthResponse.headers.get('access-control-allow-origin'), origin);
 
+  const markerHealthResponse = await fetch(`${base}/api/browser/health`, { headers: markerHeaders });
+  assert.equal(markerHealthResponse.status, 200, 'an extension marker works when Chromium omits Origin');
+  assert.equal(markerHealthResponse.headers.get('access-control-allow-origin'), origin);
+
   assert.equal((await fetch(`${base}/api/browser/health`, { headers: { Origin: 'https://malicious.example' } })).status, 403);
+  assert.equal((await fetch(`${base}/api/browser/health`, {
+    headers: { Origin: 'https://malicious.example', 'X-Nodus-Extension-Origin': origin },
+  })).status, 403, 'a web origin cannot override its identity with the extension marker');
+  assert.equal((await fetch(`${base}/api/browser/health`)).status, 403, 'missing both origin signals remains forbidden');
   assert.equal((await fetch(`${base}/api/browser/catalog`, { headers: extensionHeaders })).status, 401);
+
+  const markerPair = await (await fetch(`${base}/api/browser/pair`, {
+    method: 'POST', headers: { ...markerHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ extensionVersion: '4.0.0', pageUrl: 'https://journal.example/marker' }),
+  })).json();
+  assert.equal(markerPair.token, 'browser-test-token');
+  const markerCatalog = await (await fetch(`${base}/api/browser/catalog`, {
+    headers: { ...markerHeaders, Authorization: 'Bearer browser-test-token' },
+  })).json();
+  assert.deepEqual(markerCatalog.collections.map((entry) => entry.name), ['History', 'Women']);
 
   const pair = await (await fetch(`${base}/api/browser/pair`, {
     method: 'POST', headers: { ...extensionHeaders, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- replace the XHR transport that Chrome rejected with extension-page `fetch()`
- send the installed extension identity through the standard `Origin` header and a compatibility marker
- accept the marker only when Chromium omits the real `Origin`; never allow it to override a web origin
- extend the server-contract regression coverage for marker pairing, catalog access, and spoof rejection
- restore the normal popup E2E transport

This is a follow-up to #406. Chrome 151 supports extension-controlled `Origin` on `fetch()` requests when the extension has explicit host access, so the new extension also works with the currently installed desktop server. The marker keeps updated desktop builds compatible with older Chromium behavior.

Closes #407

## Verification

- `npm run typecheck`
- `node --test scripts/test-browser-connector.mjs`
- `npm run verify:browser-connector`
- `npm run test:e2e:browser-connector`
- `npm run browser:zip`
- `unzip -t dist-browser/nodus-connector-chrome.zip`
- `git diff --check`