### PR TITLE
Unify the academic section headers, swap three icons, fold Debates into a tab

### DIFF
--- a/scripts/test-argument-map-tree.mjs
+++ b/scripts/test-argument-map-tree.mjs
@@ -112,10 +112,13 @@ test('a manual toggle takes over from the automatic unfold', () => {
 });
 
 test('the back button sits to the left of the Automatic / AI toggle', () => {
-  const header = view.slice(view.indexOf('{/* Header / setup */}'), view.indexOf('{/* Body */}'));
+  // La fila de configuración ya no es el encabezado de la sección: ese lo pone ahora
+  // SectionHeader, compartido con el resto de la bóveda. El botón de volver sigue
+  // perteneciendo a la configuración, que es lo que esta prueba fija.
+  const header = view.slice(view.indexOf('{/* Setup */}'), view.indexOf('{/* Body */}'));
   const backButton = header.indexOf("t('Volver al selector')");
   const modeToggle = header.indexOf("t('Automático')");
-  assert.ok(backButton > -1, 'the back button lives in the header');
+  assert.ok(backButton > -1, 'the back button lives in the setup row');
   assert.ok(modeToggle > -1 && backButton < modeToggle, 'and renders before the mode toggle');
   assert.match(header, /className="btn btn-ghost text-xs gap-1\.5 px-2\.5 py-1\.5 mr-1 border/, 'keeping its own margin');
   const body = view.slice(view.indexOf('{/* Body */}'));

--- a/scripts/test-section-headers.mjs
+++ b/scripts/test-section-headers.mjs
@@ -1,0 +1,82 @@
+// Una sola identidad visual para las secciones de la bóveda académica.
+//
+// La Biblioteca, Inmersión y Deep Research ya compartían encabezado; el resto había ido
+// inventando el suyo —unas con `h1`, otras con `h2`, unas con padding interior, cada una
+// con su tamaño de icono— y saltando entre secciones se notaba como si cada pantalla
+// fuera de un programa distinto.
+//
+// Lo que fija esta prueba no es el aspecto, que puede cambiar: es que el aspecto viva en
+// UN sitio. Una sección nueva que se pinte su propio encabezado a mano vuelve a abrir la
+// deriva, y eso es lo que aquí falla.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readSource } from './ipc-channel-census.mjs';
+
+/** Las secciones que comparten encabezado. La Biblioteca tiene el suyo, propio y probado
+ *  aparte, porque además lleva el conmutador de ámbito en el centro. */
+const SECTIONS = [
+  'src/views/IdeasView.tsx',
+  'src/views/AuthorsView.tsx',
+  'src/views/ArgumentMapView.tsx',
+  'src/views/DebateView.tsx',
+  'src/views/ImmersionView.tsx',
+  'src/views/DeepResearchView.tsx',
+];
+
+test('the section header lives in one component, and every section uses it', async () => {
+  const header = await readSource('src/components/SectionHeader.tsx');
+  assert.match(header, /export function SectionHeader\(/);
+  assert.match(header, /export function SectionToolbar\(/);
+  // Icono + título + subtítulo + acciones a la derecha: la forma que ya tenían las tres
+  // pantallas mejor acabadas.
+  assert.match(header, /<Icon name=\{icon\} className="text-indigo-300" \/> \{title\}/);
+  assert.match(header, /\{subtitle && <p className="mt-0\.5 text-xs text-neutral-500">\{subtitle\}<\/p>\}/);
+  assert.match(header, /<div className="flex-1" \/>\s*\{actions\}/);
+
+  for (const file of SECTIONS) {
+    const source = await readSource(file);
+    assert.match(source, /import \{ SectionHeader[^}]*\} from '\.\.\/components\/SectionHeader'/, `${file} imports the shared header`);
+    assert.match(source, /<SectionHeader\s/, `${file} renders it`);
+    assert.ok(
+      !/<h1 className="flex items-center gap-2 text-xl font-semibold">/.test(source),
+      `${file} must not hand-roll the header it just adopted`
+    );
+  }
+});
+
+test('every academic section header carries an icon, a title and one line saying what it is for', async () => {
+  for (const file of SECTIONS) {
+    const source = await readSource(file);
+    const block = source.slice(source.indexOf('<SectionHeader'), source.indexOf('/>', source.indexOf('<SectionHeader')) + 2);
+    assert.match(block, /icon="[a-zA-Z]+"/, `${file} names its icon`);
+    assert.match(block, /title=\{t\(/, `${file} translates its title`);
+    assert.match(block, /subtitle=\{t\(/, `${file} says in one line what the section is for`);
+  }
+});
+
+// Los iconos identifican la sección en la barra lateral plegada, donde no hay texto: dos
+// secciones visibles a la vez con el mismo icono no se distinguen de ninguna manera.
+test('no two sections that can share a sidebar share an icon', async () => {
+  const navigation = await readSource('src/navigation.ts');
+  const items = [...navigation.matchAll(/\{ id: '([a-zA-Z]+)', label: '[^']*', icon: '([a-zA-Z]+)'/g)]
+    .map(([, id, icon]) => ({ id, icon }));
+  assert.ok(items.length > 40, 'the nav list was parsed');
+
+  // El grafo y el mapa de argumentos se intercambiaron el icono con Deep Research; lo que
+  // no puede pasar es que el intercambio deje un duplicado.
+  const byId = Object.fromEntries(items.map((item) => [item.id, item.icon]));
+  assert.equal(byId.graph, 'network', 'Grafo takes the network icon');
+  assert.equal(byId.argument, 'layers', 'Mapa de argumentos takes the layers icon');
+  assert.equal(byId.deepResearch, 'telescope', 'Deep Research takes the telescope');
+  assert.equal(byId.studyGraph, 'network', 'and the study variants follow');
+  assert.equal(byId.studyDeepResearch, 'telescope');
+  assert.equal(byId.research, 'compass', 'Estado de la cuestión takes the compass');
+
+  // Una bóveda genealógica muestra la navegación completa: el grafo y las relaciones
+  // sociales conviven en ella, así que no pueden llevar el mismo icono.
+  assert.notEqual(byId.graph, byId.relations, 'Grafo and Relaciones sociales stay distinguishable');
+
+  const view = await readSource('src/views/DeepResearchView.tsx');
+  assert.match(view, /icon="telescope"/, 'the section header follows the sidebar icon');
+});

--- a/scripts/test-view-registry.mjs
+++ b/scripts/test-view-registry.mjs
@@ -67,11 +67,11 @@ test('the registry adds the render and nothing else: labels and gating stay put'
   assert.match(readSource('shared/vaultTypes.ts'), /VAULT_TYPE_SCOPED_VIEWS/);
 });
 
-// Gaps is the one view deliberately reachable without a sidebar entry of its own:
-// it is a tab inside Coverage. What makes that safe is that it stays a routable
-// view — Home, Search and the advanced tour all navigate to it — so the guard has
+// Gaps and Debates are reachable without a sidebar entry of their own: both are tabs
+// inside "Estado de la cuestión". What makes that safe is that they stay routable
+// views — Home, Search and the advanced tour all navigate to them — so each guard has
 // to hold BOTH halves at once. Losing the renderer would 404 those callers; growing
-// a NAV_ITEM back would put a second, full-screen Huecos beside the tab.
+// a NAV_ITEM back would put a second, full-screen copy beside the tab.
 test('gaps is routable without a sidebar section, and lands on the Coverage tab', () => {
   const navigation = readSource('src/navigation.ts');
   assert.ok(viewUnion().includes('gaps'), 'gaps must stay in the View union');
@@ -89,6 +89,47 @@ test('gaps is routable without a sidebar section, and lands on the Coverage tab'
   // The callers that still navigate to it must keep working.
   assert.match(readSource('src/app/views/corpus.tsx'), /onOpenGaps=\{\(\) => setView\('gaps'\)\}/);
   assert.match(readSource('src/views/AdvancedTour.tsx'), /view: 'gaps'/);
+});
+
+// Debates joined them: a contradiction only means something beside what the corpus
+// covers and what it is missing, so it stopped being a section and became the middle
+// tab. The invariant is the same one gaps has, and it is written out separately
+// because the two can break independently.
+test('debate is routable without a sidebar section, and lands on its own tab', () => {
+  const navigation = readSource('src/navigation.ts');
+  assert.ok(viewUnion().includes('debate'), 'debate must stay in the View union');
+  assert.ok(
+    !/\{ id: 'debate',/.test(navigation),
+    'debate must NOT have a NAV_ITEM: it is a tab inside Estado de la cuestión, not a section'
+  );
+
+  // The section that holds it keeps its own entry, renamed and with the compass.
+  assert.match(
+    navigation,
+    /\{ id: 'research', label: 'Estado de la cuestión', icon: 'compass', group: 'analyze' \}/,
+    'the three tabs live under one renamed section'
+  );
+
+  // All three ids render the same workspace, each entering by its own tab.
+  const corpus = readSource('src/app/views/corpus.tsx');
+  assert.match(corpus, /debate: \([^)]*\) => \(\s*<CoverageWorkspace\s+vaultId=\{[^}]*\}\s+initialTab="debate"/);
+  assert.equal(registeredViews().get('debate'), 'corpus.tsx');
+  assert.ok(!corpus.includes('DebateView'), 'the registry no longer mounts DebateView on its own');
+
+  // The tabs, in the agreed order.
+  const workspace = readSource('src/views/CoverageWorkspace.tsx');
+  assert.match(
+    workspace,
+    /\['map', 'Cobertura', '[a-z]+'\],\s*\['debate', 'Debates', '[a-z]+'\],\s*\['gaps', 'Huecos', '[a-z]+'\]/,
+    'the order is Cobertura → Debates → Huecos'
+  );
+
+  // What used to navigate away to a section is now a tab change that keeps the place.
+  assert.match(workspace, /const openDebates = \(\) => setTab\('debate'\)/);
+  assert.ok(
+    !corpus.includes("onOpenDebates"),
+    'nothing outside the workspace still routes to a Debates section'
+  );
 });
 
 // The two labs that need a deeply analysed corpus are hidden by default, but hiding

--- a/src/app/views/corpus.tsx
+++ b/src/app/views/corpus.tsx
@@ -9,7 +9,6 @@ const ArgumentMapView = lazy(() => import('../../views/ArgumentMapView').then((m
 const IdeasView = lazy(() => import('../../views/IdeasView').then((module) => ({ default: module.IdeasView })));
 const AuthorsView = lazy(() => import('../../views/AuthorsView').then((module) => ({ default: module.AuthorsView })));
 const CoverageWorkspace = lazy(() => import('../../views/CoverageWorkspace').then((module) => ({ default: module.CoverageWorkspace })));
-const DebateView = lazy(() => import('../../views/DebateView').then((module) => ({ default: module.DebateView })));
 const HypothesisLabView = lazy(() => import('../../views/HypothesisLabView').then((module) => ({ default: module.HypothesisLabView })));
 const ReadingPathView = lazy(() => import('../../views/ReadingPathView').then((module) => ({ default: module.ReadingPathView })));
 const WritingWorkshopView = lazy(() => import('../../views/WritingWorkshopView').then((module) => ({ default: module.WritingWorkshopView })));
@@ -59,25 +58,28 @@ export const corpusViews = {
   // Cobertura y Huecos son el mismo espacio con dos pestañas. 'gaps' ya no tiene
   // entrada en la barra lateral, pero sigue siendo una vista enrutable —Inicio,
   // Buscar y el tour avanzado navegan a ella— y entra por la pestaña de huecos.
-  gaps: ({ activeVault, navigate, openAssistant, setView }) => (
+  gaps: ({ activeVault, navigate, openAssistant }) => (
     <CoverageWorkspace
       vaultId={activeVault?.id ?? null}
       initialTab="gaps"
       onOpenGraph={(target) => navigate('graph', target)}
       onOpenAssistant={openAssistant}
-      onOpenDebates={() => setView('debate')}
     />
   ),
-  debate: ({ navigate, openAssistant }) => (
-    <DebateView onOpenGraph={(target) => navigate('graph', target)} onOpenAssistant={openAssistant} />
+  debate: ({ activeVault, navigate, openAssistant }) => (
+    <CoverageWorkspace
+      vaultId={activeVault?.id ?? null}
+      initialTab="debate"
+      onOpenGraph={(target) => navigate('graph', target)}
+      onOpenAssistant={openAssistant}
+    />
   ),
-  research: ({ activeVault, navigate, openAssistant, setView }) => (
+  research: ({ activeVault, navigate, openAssistant }) => (
     <CoverageWorkspace
       vaultId={activeVault?.id ?? null}
       initialTab="map"
       onOpenGraph={(target) => navigate('graph', target)}
       onOpenAssistant={openAssistant}
-      onOpenDebates={() => setView('debate')}
     />
   ),
   hypothesis: ({ navigate, openAssistant, settings }) => (

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,64 @@
+// El encabezado de una sección.
+//
+// La Biblioteca, Inmersión y Deep Research ya lo hacían igual —icono e identidad a la
+// izquierda, una línea que explica para qué sirve la sección, y las acciones a la
+// derecha— y el resto de secciones de la bóveda académica había ido inventando su propia
+// versión: unas con `h1`, otras con `h2`, unas con padding interior, otras sin subtítulo,
+// cada una con su tamaño de icono. En una aplicación donde se salta de sección cada pocos
+// minutos, esa deriva se nota como si cada pantalla fuera de un programa distinto.
+//
+// Esto no añade una capa: extrae la que ya existía en las tres pantallas mejor acabadas y
+// la deja en un sitio, para que la siguiente sección nazca con la identidad puesta.
+//
+// La barra de filtros NO va aquí. Es parte de cada sección —cada una filtra por cosas
+// distintas— y solo comparte el sitio donde se pinta: justo debajo, con `SectionToolbar`.
+
+import type { ReactNode } from 'react';
+import { Icon } from './ui';
+
+export function SectionHeader({
+  icon,
+  title,
+  subtitle,
+  badge,
+  actions,
+  testId,
+}: {
+  icon: string;
+  title: string;
+  /** Para qué sirve la sección, en una línea. Se omite donde el título ya lo dice todo. */
+  subtitle?: string;
+  /** Un dato que cualifica al título (un recuento, un estado), pegado a él. */
+  badge?: ReactNode;
+  actions?: ReactNode;
+  testId?: string;
+}) {
+  return (
+    <header
+      data-testid={testId}
+      className="section-header flex shrink-0 flex-wrap items-center gap-3 border-b border-neutral-800 px-4 py-3"
+    >
+      <div className="min-w-0">
+        <h1 className="flex items-center gap-2 text-xl font-semibold">
+          <Icon name={icon} className="text-indigo-300" /> {title}
+          {badge}
+        </h1>
+        {subtitle && <p className="mt-0.5 text-xs text-neutral-500">{subtitle}</p>}
+      </div>
+      <div className="flex-1" />
+      {actions}
+    </header>
+  );
+}
+
+/** La fila de filtros de una sección, bajo su encabezado. */
+export function SectionToolbar({ children, testId }: { children: ReactNode; testId?: string }) {
+  return (
+    <div
+      data-testid={testId}
+      className="section-toolbar flex shrink-0 flex-wrap items-center gap-2 border-b border-neutral-800 px-4 py-2.5"
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -179,6 +179,7 @@ const ICON_PATHS: Record<string, string> = {
   exam: '<path d="M6 3h9l3 3v15H6z"/><path d="M14 3v4h4"/><path d="M9 11h6"/><path d="M9 15h4"/><path d="m15 18 4-4"/>',
   flashcards: '<rect x="5" y="4" width="15" height="16" rx="2"/><path d="M5 8H3a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2"/><path d="M9 9h7"/><path d="M9 13h5"/>',
   map: '<line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>',
+  telescope: '<path d="m10.065 12.493-6.18 1.318a.934.934 0 0 1-1.108-.702l-.537-2.15a1.07 1.07 0 0 1 .691-1.265l13.504-4.44"/><path d="m13.56 11.747 4.332-.924"/><path d="m16 21-3.105-6.21"/><path d="M16.485 5.94a2 2 0 0 1 1.455-2.425l1.09-.272a1 1 0 0 1 1.212.727l1.515 6.06a1 1 0 0 1-.727 1.213l-1.09.272a2 2 0 0 1-2.425-1.455z"/><path d="m6.158 8.633 1.114 4.456"/><path d="m8 21 3.105-6.21"/><circle cx="12" cy="13" r="2"/>',
   network: '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>',
   scale: '<path d="M12 3v18"/><path d="M7 21h10"/><path d="M5 7h14"/><path d="M6 4l-1 3"/><path d="M18 4l1 3"/><path d="M5 7l-3 6a3 3 0 0 0 6 0z"/><path d="M19 7l-3 6a3 3 0 0 0 6 0z"/>',
   flask: '<path d="M9 3h6"/><path d="M10 3v5.6L4.2 18.7A2.2 2.2 0 0 0 6.1 22h11.8a2.2 2.2 0 0 0 1.9-3.3L14 8.6V3"/><path d="M7.5 16h9"/><path d="M8.8 19h6.4"/>',

--- a/src/i18n.workspace.ts
+++ b/src/i18n.workspace.ts
@@ -1,7 +1,17 @@
 // Espacio de trabajo: la sección que unifica Notas, Escritura y Proyectos en la bóveda
-// académica, y los enlaces entre lo que se escribe y la biblioteca.
+// académica, y los enlaces entre lo que se escribe y la biblioteca. Con ella viaja el
+// «Estado de la cuestión», la otra sección unificada de esta bóveda.
+//
+// Ese nombre NO se traduce literalmente: cada lengua tiene su propio término académico
+// para la misma parte de un trabajo de investigación —Forschungsstand, état de la
+// question, stato dell'arte— y usar un calco delataría que la interfaz está traducida
+// en vez de escrita en ese idioma.
 
 const en = {
+  'Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.': 'Every claim, finding, construct, method and framework the analysis drew from your works, and who holds them.',
+  'Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.': 'Who holds what in your corpus: a profile per author, their synthesis, and the matrix that sets them against each other.',
+  'El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.': 'The argumentative skeleton of your corpus: which idea supports, refines or contradicts which, walked step by step.',
+  'Estado de la cuestión': 'State of the art',
   'Espacio de trabajo': 'Workspace',
   '{n} nota(s) e idea(s) · {c} colección(es)': '{n} note(s) and idea(s) · {c} collection(s)',
   'Agrupa tus notas e ideas en colecciones para trabajar por temas o capítulos.': 'Group your notes and ideas into collections to work by topic or chapter.',
@@ -25,6 +35,10 @@ const en = {
 export const WORKSPACE_TRANSLATIONS = {
   en,
   fr: {
+    'Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.': 'Chaque affirmation, résultat, construit, méthode et cadre que l’analyse a tirés de vos œuvres, et qui les soutient.',
+    'Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.': 'Qui soutient quoi dans votre corpus : une fiche par autrice ou auteur, sa synthèse et la matrice qui les confronte.',
+    'El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.': 'Le squelette argumentatif de votre corpus : quelle idée appuie, affine ou contredit quelle autre, parcouru pas à pas.',
+    'Estado de la cuestión': 'État de la question',
     'Espacio de trabajo': 'Espace de travail',
     '{n} nota(s) e idea(s) · {c} colección(es)': '{n} note(s) et idée(s) · {c} collection(s)',
     'Agrupa tus notas e ideas en colecciones para trabajar por temas o capítulos.': 'Regroupez vos notes et vos idées en collections pour travailler par thème ou par chapitre.',
@@ -45,6 +59,10 @@ export const WORKSPACE_TRANSLATIONS = {
     '{n} elemento(s) de biblioteca enlazado(s)': '{n} élément(s) de bibliothèque lié(s)',
   },
   de: {
+    'Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.': 'Jede Behauptung, jeder Befund, jedes Konstrukt, jede Methode und jeder Rahmen aus Ihren Werken – und wer sie vertritt.',
+    'Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.': 'Wer in Ihrem Korpus was vertritt: ein Profil je Autorschaft, ihre Synthese und die Matrix, die sie gegenüberstellt.',
+    'El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.': 'Das Argumentationsgerüst Ihres Korpus: welche Idee welche stützt, verfeinert oder ihr widerspricht – Schritt für Schritt.',
+    'Estado de la cuestión': 'Forschungsstand',
     'Espacio de trabajo': 'Arbeitsbereich',
     '{n} nota(s) e idea(s) · {c} colección(es)': '{n} Notiz(en) und Idee(n) · {c} Sammlung(en)',
     'Agrupa tus notas e ideas en colecciones para trabajar por temas o capítulos.': 'Fassen Sie Notizen und Ideen in Sammlungen zusammen, um nach Thema oder Kapitel zu arbeiten.',
@@ -65,6 +83,10 @@ export const WORKSPACE_TRANSLATIONS = {
     '{n} elemento(s) de biblioteca enlazado(s)': '{n} verknüpfte(r) Bibliothekseintrag/-einträge',
   },
   pt: {
+    'Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.': 'Cada afirmação, achado, constructo, método e enquadramento que a análise extraiu das suas obras, e quem os sustenta.',
+    'Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.': 'Quem sustenta o quê no seu corpus: uma ficha por autoria, a sua síntese e a matriz que as confronta.',
+    'El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.': 'O esqueleto argumentativo do seu corpus: que ideia apoia, refina ou contradiz qual, percorrido passo a passo.',
+    'Estado de la cuestión': 'Estado da arte',
     'Espacio de trabajo': 'Espaço de trabalho',
     '{n} nota(s) e idea(s) · {c} colección(es)': '{n} nota(s) e ideia(s) · {c} coleção(ões)',
     'Agrupa tus notas e ideas en colecciones para trabajar por temas o capítulos.': 'Agrupe as suas notas e ideias em coleções para trabalhar por temas ou capítulos.',
@@ -85,6 +107,10 @@ export const WORKSPACE_TRANSLATIONS = {
     '{n} elemento(s) de biblioteca enlazado(s)': '{n} elemento(s) de biblioteca ligado(s)',
   },
   ptBR: {
+    'Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.': 'Cada afirmação, achado, constructo, método e enquadramento que a análise extraiu das suas obras, e quem os sustenta.',
+    'Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.': 'Quem sustenta o quê no seu corpus: uma ficha por autoria, sua síntese e a matriz que as confronta.',
+    'El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.': 'O esqueleto argumentativo do seu corpus: que ideia apoia, refina ou contradiz qual, percorrido passo a passo.',
+    'Estado de la cuestión': 'Estado da arte',
     'Espacio de trabajo': 'Espaço de trabalho',
     '{n} nota(s) e idea(s) · {c} colección(es)': '{n} nota(s) e ideia(s) · {c} coleção(ões)',
     'Agrupa tus notas e ideas en colecciones para trabajar por temas o capítulos.': 'Agrupe suas notas e ideias em coleções para trabalhar por tema ou capítulo.',
@@ -105,6 +131,10 @@ export const WORKSPACE_TRANSLATIONS = {
     '{n} elemento(s) de biblioteca enlazado(s)': '{n} item(ns) de biblioteca vinculado(s)',
   },
   it: {
+    'Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.': 'Ogni affermazione, risultato, costrutto, metodo e quadro che l’analisi ha tratto dalle tue opere, e chi li sostiene.',
+    'Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.': 'Chi sostiene che cosa nel tuo corpus: una scheda per autore, la sua sintesi e la matrice che le mette a confronto.',
+    'El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.': 'Lo scheletro argomentativo del tuo corpus: quale idea sostiene, affina o contraddice quale, percorso passo dopo passo.',
+    'Estado de la cuestión': 'Stato dell’arte',
     'Espacio de trabajo': 'Spazio di lavoro',
     '{n} nota(s) e idea(s) · {c} colección(es)': '{n} nota/e e idea/e · {c} raccolta/e',
     'Agrupa tus notas e ideas en colecciones para trabajar por temas o capítulos.': 'Raggruppa note e idee in raccolte per lavorare per temi o capitoli.',
@@ -125,6 +155,10 @@ export const WORKSPACE_TRANSLATIONS = {
     '{n} elemento(s) de biblioteca enlazado(s)': '{n} elemento/i di biblioteca collegato/i',
   },
   tr: {
+    'Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.': 'Çözümlemenin eserlerinizden çıkardığı her sav, bulgu, yapı, yöntem ve çerçeve; ve bunları kimin savunduğu.',
+    'Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.': 'Derleminizde kim neyi savunuyor: her yazar için bir künye, sentezi ve onları karşılaştıran dizey.',
+    'El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.': 'Derleminizin savlar iskeleti: hangi düşünce hangisini destekliyor, inceltiyor ya da çürütüyor; adım adım.',
+    'Estado de la cuestión': 'Alanyazın',
     'Espacio de trabajo': 'Çalışma alanı',
     '{n} nota(s) e idea(s) · {c} colección(es)': '{n} not ve fikir · {c} koleksiyon',
     'Agrupa tus notas e ideas en colecciones para trabajar por temas o capítulos.': 'Konuya veya bölüme göre çalışmak için notlarınızı ve fikirlerinizi koleksiyonlarda toplayın.',

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -41,8 +41,8 @@ export const NAV_ITEMS: NavItem[] = [
   // Explorar — recorrer el corpus, el grafo y sus ideas/autores.
   { id: 'search', label: 'Buscar', icon: 'search', group: 'explore' },
   { id: 'library', label: 'Biblioteca', icon: 'book', group: 'explore' },
-  { id: 'graph', label: 'Grafo', icon: 'layers', group: 'explore' },
-  { id: 'argument', label: 'Mapa de argumentos', icon: 'map', group: 'explore' },
+  { id: 'graph', label: 'Grafo', icon: 'network', group: 'explore' },
+  { id: 'argument', label: 'Mapa de argumentos', icon: 'layers', group: 'explore' },
   { id: 'ideas', label: 'Ideas', icon: 'bulb', group: 'explore' },
   { id: 'authors', label: 'Autores', icon: 'graduation', group: 'explore' },
   // Prosopography uses dedicated views: its persons and sources must never fall
@@ -57,7 +57,10 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'persons', label: 'Personas', icon: 'users', group: 'explore' },
   { id: 'timeline', label: 'Línea temporal', icon: 'clock', group: 'explore' },
   { id: 'tree', label: 'Árbol genealógico', icon: 'tree', group: 'explore' },
-  { id: 'relations', label: 'Relaciones sociales', icon: 'network', group: 'explore' },
+  // 'link', y no el icono de red, porque el Grafo se quedó con ese: las dos secciones
+  // conviven en una bóveda genealógica y dos iconos iguales en la misma barra no
+  // distinguen nada cuando está plegada a iconos.
+  { id: 'relations', label: 'Relaciones sociales', icon: 'link', group: 'explore' },
   { id: 'map', label: 'Mapa', icon: 'map', group: 'explore' },
   { id: 'archive', label: 'Archivo', icon: 'archive', group: 'explore' },
   // Worldbuilding mode — shown only for the 'worldbuilding' vault type. It shares the
@@ -98,10 +101,10 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'studyRecordings', label: 'Grabaciones', icon: 'microphone', group: 'explore' },
   { id: 'studyChat', label: 'Chat de estudio', icon: 'chat', group: 'analyze' },
   { id: 'studyIdeas', label: 'Ideas de estudio', icon: 'bulb', group: 'analyze' },
-  { id: 'studyGraph', label: 'Grafo de estudio', icon: 'layers', group: 'analyze' },
+  { id: 'studyGraph', label: 'Grafo de estudio', icon: 'network', group: 'analyze' },
   { id: 'studyQuestions', label: 'Banco de preguntas', icon: 'help', group: 'analyze' },
   { id: 'studyReview', label: 'Revisión', icon: 'flashcards', group: 'analyze' },
-  { id: 'studyDeepResearch', label: 'Investigación de estudio', icon: 'network', group: 'analyze' },
+  { id: 'studyDeepResearch', label: 'Investigación de estudio', icon: 'telescope', group: 'analyze' },
   // Teaching mode — surfaces scoped to the 'docencia' vault type.
   { id: 'teachingGroups', label: 'Grupos', icon: 'users', group: 'explore' },
   { id: 'teachingGrades', label: 'Calificaciones', icon: 'chartBar', group: 'analyze' },
@@ -110,15 +113,18 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'teachingUnits', label: 'Diseño de unidades', icon: 'compass', group: 'create' },
   // Analizar — superficies derivadas del grafo y síntesis.
   { id: 'immersion', label: 'Inmersión', icon: 'target', group: 'analyze' },
-  // 'gaps' NO tiene entrada propia: los huecos son una pestaña dentro de Cobertura,
-  // porque solo significan algo mirando qué le falta a una pregunta concreta. Sigue
-  // siendo una vista enrutable —Inicio, Buscar y el tour navegan a ella— y aterriza
+  // 'gaps' NO tiene entrada propia: los huecos son una pestaña dentro del Estado de la
+  // cuestión, porque solo significan algo mirando qué le falta a una pregunta concreta.
+  // Sigue siendo una vista enrutable —Inicio, Buscar y el tour navegan a ella— y aterriza
   // en esa pestaña; ver src/app/views/corpus.tsx.
-  { id: 'debate', label: 'Debates', icon: 'scale', group: 'analyze' },
-  { id: 'research', label: 'Cobertura', icon: 'help', group: 'analyze' },
+  // 'debate' NO tiene entrada propia, por la misma razón que 'gaps': un debate solo
+  // significa algo junto a lo que el corpus cubre y a lo que le falta. Sigue siendo una
+  // vista enrutable —Inicio, Buscar y el tour avanzado navegan a ella— y aterriza en su
+  // pestaña; ver src/app/views/corpus.tsx.
+  { id: 'research', label: 'Estado de la cuestión', icon: 'compass', group: 'analyze' },
   { id: 'hypothesis', label: 'Hipótesis', icon: 'flask', group: 'analyze' },
   { id: 'reading', label: 'Ruta de lectura', icon: 'route', group: 'analyze' },
-  { id: 'deepResearch', label: 'Deep Research', icon: 'network', group: 'analyze' },
+  { id: 'deepResearch', label: 'Deep Research', icon: 'telescope', group: 'analyze' },
   // Escribir — producir salidas con citas.
   // El Espacio de trabajo REEMPLAZA a Escritura, Proyectos y Notas en la bóveda
   // académica: las tres contaban la misma historia por separado. Las tres siguen

--- a/src/views/ArgumentMapView.tsx
+++ b/src/views/ArgumentMapView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { AppSettings, ArgumentBlock, ArgumentMap, ArgumentRouteSuggestion, EdgeDetail, EdgeType, IdeaDetail, IdeaPickerItem, IdeaType } from '@shared/types';
 import { EDGE_LABELS, NODE_COLORS, NODE_LABELS, Icon, Spinner } from '../components/ui';
+import { SectionHeader } from '../components/SectionHeader';
 import { ModelPicker } from '../components/ModelPicker';
 import {
   NodeDetailPanel,
@@ -274,7 +275,13 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
 
   return (
     <div className="h-full flex flex-col min-h-0">
-      {/* Header / setup */}
+      <SectionHeader
+        icon="layers"
+        title={t('Mapa de argumentos')}
+        subtitle={t('El esqueleto argumental de tu corpus: qué idea apoya, refina o contradice a cuál, recorrido paso a paso.')}
+      />
+
+      {/* Setup */}
       <div className="border-b border-neutral-800 p-3 flex flex-wrap gap-2 items-end text-xs">
         {map && (
           <button

--- a/src/views/AuthorsView.tsx
+++ b/src/views/AuthorsView.tsx
@@ -10,6 +10,7 @@ import type {
   SynthesisMatrixCell,
 } from '@shared/types';
 import { Badge, Icon, Spinner, TypeDot } from '../components/ui';
+import { SectionHeader, SectionToolbar } from '../components/SectionHeader';
 import { IdeaDetailModal } from '../components/IdeaDetailModal';
 import { ModelPicker } from '../components/ModelPicker';
 import { WorkIdeasModal } from './WorkIdeasModal';
@@ -70,12 +71,20 @@ export function AuthorsView({
   const [model, setModel] = useFeatureModel(settings, 'authorModel');
 
   return (
-    <div className="h-full flex flex-col min-h-0 p-6">
-      <div className="flex flex-wrap items-center gap-3 mb-4">
-        <div className="flex items-center gap-2">
-          <Icon name="graduation" size={20} className="text-indigo-400" />
-          <h2 className="text-lg font-semibold">{t('Autores')}</h2>
-        </div>
+    <div className="h-full flex flex-col min-h-0">
+      <SectionHeader
+        icon="graduation"
+        title={t('Autores')}
+        subtitle={t('Quién sostiene qué en tu corpus: una ficha por autoría, su síntesis y la matriz que las enfrenta.')}
+        actions={(
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-neutral-500">{t('Modelo de síntesis')}</span>
+            <ModelPicker settings={settings} value={model} onChange={setModel} compact />
+          </div>
+        )}
+      />
+
+      <SectionToolbar>
         <div className="flex rounded-lg bg-neutral-900 p-0.5 text-sm">
           <button
             data-testid="authors-tab-dossier"
@@ -100,12 +109,7 @@ export function AuthorsView({
             {t('Autores guardados')}
           </button>
         </div>
-        <div className="flex-1" />
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-neutral-500">{t('Modelo de síntesis')}</span>
-          <ModelPicker settings={settings} value={model} onChange={setModel} compact />
-        </div>
-      </div>
+      </SectionToolbar>
 
       {tab === 'dossier' ? (
         <DossierTab key="all-authors" vaultId={vaultId} onOpenGraph={onOpenGraph} model={model} savedOnly={false} />

--- a/src/views/CoverageWorkspace.tsx
+++ b/src/views/CoverageWorkspace.tsx
@@ -1,12 +1,19 @@
-// Cobertura y Huecos responden la misma pregunta —¿qué le falta a mi corpus?— desde
-// los dos extremos: el mapa de cobertura mide la biblioteca contra la pregunta que
-// escribe el investigador, y los huecos son lo que las propias obras declaran que
-// queda pendiente. Sueltos en el menú parecían alternativas; aquí son dos pestañas
-// del mismo sitio.
+// El estado de la cuestión: qué se ha dicho ya sobre el tema, dónde se contradice y
+// qué queda por decir. Tres lecturas de la misma pregunta, y por eso tres pestañas del
+// mismo sitio en vez de tres secciones del menú:
 //
-// Los dos hijos se montan tal cual, cada uno con su encabezado: la pestaña dice en
-// qué sección estás y el encabezado explica qué hace. Solo vive una a la vez, así
-// que cambiar de pestaña no paga el coste de la otra.
+//   · Cobertura mide la biblioteca contra la pregunta que escribe el investigador;
+//   · Debates enfrenta las contradicciones que el corpus ya contiene;
+//   · Huecos recoge lo que las propias obras declaran que queda pendiente.
+//
+// Sueltas en el menú parecían alternativas entre las que elegir. Juntas son el recorrido
+// que se hace de una sentada: leo qué cubro, veo dónde se pelean mis fuentes, y salgo con
+// la lista de lo que falta. Los saltos que antes llevaban de Cobertura o de Huecos a la
+// sección de Debates son ahora un cambio de pestaña, sin perder el sitio.
+//
+// Los tres hijos se montan tal cual, cada uno con su encabezado: la pestaña dice en qué
+// parte estás y el encabezado explica qué hace. Solo vive una a la vez, así que cambiar
+// de pestaña no paga el coste de las otras.
 import { useState } from 'react';
 import { Icon } from '../components/ui';
 import type {
@@ -14,13 +21,15 @@ import type {
   PendingGraphNavigationTarget,
 } from '../navigation';
 import { t } from '../i18n';
+import { DebateView } from './DebateView';
 import { GapsView } from './GapsView';
 import { ResearchMapView } from './ResearchMapView';
 
-export type CoverageTab = 'map' | 'gaps';
+export type CoverageTab = 'map' | 'debate' | 'gaps';
 
 const TABS: readonly (readonly [CoverageTab, string, string])[] = [
-  ['map', 'Cobertura', 'compass'],
+  ['map', 'Cobertura', 'help'],
+  ['debate', 'Debates', 'scale'],
   ['gaps', 'Huecos', 'gap'],
 ] as const;
 
@@ -29,23 +38,22 @@ export function CoverageWorkspace({
   initialTab,
   onOpenGraph,
   onOpenAssistant,
-  onOpenDebates,
 }: {
   vaultId: string | null;
-  /** Qué pestaña abre. Navegar a 'gaps' entra directamente por los huecos. */
+  /** Qué pestaña abre. Navegar a 'gaps' o a 'debate' entra directamente por la suya. */
   initialTab: CoverageTab;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
   onOpenAssistant: (target?: PendingAssistantNavigationTarget) => void;
-  onOpenDebates: () => void;
 }) {
   const [tab, setTab] = useState<CoverageTab>(initialTab);
+  const openDebates = () => setTab('debate');
 
   return (
     <div className="h-full flex flex-col min-h-0">
       <nav
         className="shrink-0 flex border-b border-neutral-800 px-3"
         role="tablist"
-        aria-label={t('Cobertura y huecos')}
+        aria-label={t('Estado de la cuestión')}
       >
         {TABS.map(([value, label, icon], index) => (
           <button
@@ -85,18 +93,22 @@ export function CoverageWorkspace({
         aria-labelledby={`coverage-tab-${tab}`}
         className="flex-1 min-h-0"
       >
-        {tab === 'map' ? (
+        {tab === 'map' && (
           <ResearchMapView
             onOpenGraph={onOpenGraph}
             onOpenAssistant={onOpenAssistant}
-            onOpenDebates={onOpenDebates}
+            onOpenDebates={openDebates}
           />
-        ) : (
+        )}
+        {tab === 'debate' && (
+          <DebateView onOpenGraph={onOpenGraph} onOpenAssistant={onOpenAssistant} />
+        )}
+        {tab === 'gaps' && (
           <GapsView
             vaultId={vaultId}
             onOpenGraph={onOpenGraph}
             onOpenAssistant={onOpenAssistant}
-            onOpenDebates={onOpenDebates}
+            onOpenDebates={openDebates}
           />
         )}
       </div>

--- a/src/views/DebateView.tsx
+++ b/src/views/DebateView.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import type { Debate, DebateSide, DebateSideKey, DebateTimelineEntry } from '@shared/types';
 import { Badge, EDGE_LABELS, Icon, Spinner } from '../components/ui';
+import { SectionHeader, SectionToolbar } from '../components/SectionHeader';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
 import { SaveToNotesModal } from '../components/SaveToNotesModal';
@@ -149,20 +150,17 @@ export function DebateView({
   }, []);
 
   return (
-    <div className="h-full flex flex-col min-h-0 p-6">
-      <div className="shrink-0">
-        <div className="flex items-center gap-3 mb-2">
-          <Icon name="scale" size={22} className="text-rose-300" />
-          <h1 className="text-xl font-semibold">{t('Debates')}</h1>
-          <Badge>{tx('{n} sin reconciliar', { n: debates.length })}</Badge>
-        </div>
-        <p className="text-sm text-neutral-400 mb-4">
-          {t(
-            'Cada contradicción o refutación del corpus, enfrentada: las dos posiciones, los autores de cada bando, su evidencia textual y la cronología de la disputa.'
-          )}
-        </p>
+    <div className="h-full flex flex-col min-h-0">
+      <SectionHeader
+        icon="scale"
+        title={t('Debates')}
+        subtitle={t(
+          'Cada contradicción o refutación del corpus, enfrentada: las dos posiciones, los autores de cada bando, su evidencia textual y la cronología de la disputa.'
+        )}
+        badge={<Badge>{tx('{n} sin reconciliar', { n: debates.length })}</Badge>}
+      />
 
-        <div className="flex flex-wrap items-center gap-2 mb-4">
+      <SectionToolbar>
           <div className="relative">
             <Icon name="search" size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none" />
             <input
@@ -190,10 +188,9 @@ export function DebateView({
               ['leaning', t('Inclinados')],
             ]}
           />
-        </div>
-      </div>
+      </SectionToolbar>
 
-      <div className="flex-1 min-h-0 overflow-auto pr-1 space-y-4">
+      <div className="flex-1 min-h-0 overflow-auto p-6 space-y-4">
         {filtered.length === 0 && (
           <div className="text-neutral-500 text-sm">
             {debates.length === 0

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -26,6 +26,7 @@ import { toReadingCopy } from '@shared/readingCopy';
 import { stripLeadingAbstract } from '@shared/writingDocument';
 import type { PendingGraphNavigationTarget } from '../navigation';
 import { HoverLabelButton, Icon, modelLabel } from '../components/ui';
+import { SectionHeader } from '../components/SectionHeader';
 import { ModelPicker } from '../components/ModelPicker';
 import { confirm } from '../components/feedback';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
@@ -743,15 +744,11 @@ export function DeepResearchView({
 
   return (
     <div className="h-full flex flex-col min-h-0">
-      <header className="flex flex-wrap items-center gap-3 border-b border-neutral-800 px-4 py-3">
-        <div className="min-w-0">
-          <h1 className="flex items-center gap-2 text-xl font-semibold">
-            <Icon name="compass" className="text-indigo-300" /> {t(copy.heading)}
-          </h1>
-          <p className="mt-0.5 text-xs text-neutral-500">{t(copy.subtitle)}</p>
-        </div>
-
-        <div className="flex-1" />
+      <SectionHeader
+        icon="telescope"
+        title={t(copy.heading)}
+        subtitle={t(copy.subtitle)}
+        actions={(<>
         <button className="btn btn-ghost gap-1.5 border border-neutral-700" onClick={() => setShowTutorial((v) => !v)}>
           <Icon name="help" /> {showTutorial ? t('Ocultar tutorial') : t('Tutorial')}
         </button>
@@ -768,7 +765,8 @@ export function DeepResearchView({
         <button className="btn btn-primary gap-1.5" onClick={() => setComposerOpen(true)}>
           <Icon name="plus" /> {t(copy.newAction)}
         </button>
-      </header>
+        </>)}
+      />
 
       {showTutorial && <DeepResearchTutorial steps={copy.tutorial} />}
 

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -470,7 +470,7 @@ function getRecommendation(settings: AppSettings, stats: AcademicHomeStats): Rec
       title: t('Completa el análisis ligero'),
       body: t('El primer resultado visible del mapa depende de los temas extraídos a partir de título y resumen. Analiza temas antes de profundizar.'),
       action: { kind: 'view', target: 'library', icon: 'tag', label: t('Analizar temas') },
-      secondary: { target: 'graph', icon: 'map', label: t('Ver grafo') },
+      secondary: { target: 'graph', icon: 'network', label: t('Ver grafo') },
     };
   }
   if (stats.deepDone === 0 || (stats.deepTarget > 0 && stats.deepDone < stats.deepTarget)) {
@@ -508,7 +508,7 @@ function getRecommendation(settings: AppSettings, stats: AcademicHomeStats): Rec
   return {
     title: t('Explora el grafo con el Tutor'),
     body: t('El corpus está en buen estado para una lectura guiada. Abre el grafo o pregunta al asistente con el contexto completo.'),
-    action: { kind: 'view', target: 'graph', icon: 'map', label: t('Abrir grafo') },
+    action: { kind: 'view', target: 'graph', icon: 'network', label: t('Abrir grafo') },
     secondary: { target: 'ideas', icon: 'bulb', label: t('Ver ideas') },
   };
 }

--- a/src/views/IdeasView.tsx
+++ b/src/views/IdeasView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import type { GraphEdge, IdeaConnection, IdeaDetail, IdeaListItem, IdeaType, EdgeDetail } from '@shared/types';
 import { Badge, EDGE_LABELS, NODE_LABELS, Icon, TypeDot } from '../components/ui';
+import { SectionHeader, SectionToolbar } from '../components/SectionHeader';
 import {
   OccurrenceCard,
   EvidenceLocationLink,
@@ -201,15 +202,14 @@ export function IdeasView({
     <div className="h-full flex min-h-0 bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100" data-testid={testId}>
       {/* List */}
       <div className="flex-1 min-w-0 flex flex-col min-h-0">
-        <div className="p-6 pb-4">
-          <div className="flex items-center gap-3 mb-4">
-            <Icon name="bulb" size={22} className="text-indigo-300" />
-            <h1 className="text-xl font-semibold">{t('Ideas')}</h1>
-            <span className="text-sm text-neutral-500">{tx('{n} ideas extraídas', { n: totalIdeas })}</span>
-          </div>
+        <SectionHeader
+          icon="bulb"
+          title={t('Ideas')}
+          subtitle={t('Cada afirmación, hallazgo, constructo, método y marco que el análisis extrajo de tus obras, con quién los sostiene.')}
+          badge={<span className="text-sm font-normal text-neutral-500">{tx('{n} ideas extraídas', { n: totalIdeas })}</span>}
+        />
 
-          {/* Filters */}
-          <div className="flex flex-wrap items-center gap-2">
+        <SectionToolbar>
             {scopeControl}
             <input
               className="input text-sm w-60"
@@ -238,15 +238,14 @@ export function IdeasView({
               <option value="connections">{t('Ordenar: conexiones')}</option>
               <option value="confidence">{t('Ordenar: confianza')}</option>
             </select>
-          </div>
-        </div>
+        </SectionToolbar>
 
         {/* Idea cards */}
         <VirtualList
           items={ideas}
           itemHeight={IDEA_ROW_HEIGHT}
           getKey={(node) => node.id}
-          className="flex-1 min-h-0 px-6 pb-6"
+          className="flex-1 min-h-0 p-6"
           empty={
             <div className="text-neutral-500 text-sm">
               {totalIdeas === 0

--- a/src/views/ImmersionView.tsx
+++ b/src/views/ImmersionView.tsx
@@ -31,6 +31,7 @@ import type {
 import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
 import type { PendingGraphNavigationTarget } from '../navigation';
 import { Badge, Icon, TypeDot } from '../components/ui';
+import { SectionHeader } from '../components/SectionHeader';
 import { ModelPicker } from '../components/ModelPicker';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
@@ -526,20 +527,16 @@ function ImmersionHome({
 
   return (
     <div className="h-full flex flex-col min-h-0">
-      <header className="flex flex-wrap items-center gap-3 border-b border-neutral-800 px-4 py-3">
-        <div className="min-w-0">
-          <h1 className="flex items-center gap-2 text-xl font-semibold">
-            <Icon name="target" className="text-indigo-300" /> {t('Inmersión')}
-          </h1>
-          <p className="mt-0.5 text-xs text-neutral-500">
-            {t('Domina un tema de tu corpus: el contenido y el progreso se guardan para retomarlos; tus respuestas se borran al reiniciar.')}
-          </p>
-        </div>
-        <div className="flex-1" />
-        <button className="btn btn-primary gap-1.5" onClick={onNew}>
-          <Icon name="plus" /> {t('Nueva inmersión')}
-        </button>
-      </header>
+      <SectionHeader
+        icon="target"
+        title={t('Inmersión')}
+        subtitle={t('Domina un tema de tu corpus: el contenido y el progreso se guardan para retomarlos; tus respuestas se borran al reiniciar.')}
+        actions={(
+          <button className="btn btn-primary gap-1.5" onClick={onNew}>
+            <Icon name="plus" /> {t('Nueva inmersión')}
+          </button>
+        )}
+      />
 
       {error && <div className="border-b border-red-900/60 bg-red-950/40 px-4 py-2 text-xs text-red-300">{error}</div>}
 


### PR DESCRIPTION
## One visual identity for the academic vault

Three changes that are really one: the academic vault stops looking like several
programs stitched together.

### One section header

The Library, Immersion and Deep Research already agreed on what a section header
looks like — icon and identity left, one line saying what the section is for,
actions right. Everything else had invented its own: some `h1`, some `h2`, some
with inner padding, each with its own icon size. Jumping between sections read
like jumping between programs.

`SectionHeader` extracts that shape from the three screens that had it right.
**Ideas, Authors, Argument map, Debates, Immersion and Deep Research** now render
it. `SectionToolbar` does the same for the filter row underneath, which stays
each section's own because each filters by different things.

Three sections had no subtitle at all and now say in one line what they are for.

### Three swapped icons

| Section | Before | After |
|---|---|---|
| Graph | layers | **network** (Deep Research's old one) |
| Deep Research | network | **telescope** (new icon) |
| Argument map | map | **layers** (Graph's old one) |
| Estado de la cuestión | help | **compass** (freed by Deep Research) |

Applied in **every vault** that shows those sections, study variants included
(`studyGraph`, `studyDeepResearch`). The Deep Research view header followed its
sidebar icon, and Home's two "open the graph" shortcuts were pointing at `map`,
which never matched the sidebar anyway.

One extra change that was not requested but follows from the swap: **Relaciones
sociales moves to the `link` icon.** It shares a genealogy sidebar with Graph,
and after Graph took `network` the two would have been identical — which
distinguishes nothing when the sidebar is collapsed to icons, the one case those
icons exist for. Easy to revert if you'd rather pick a different glyph.

### Debates becomes a tab

Coverage and Gaps were already one section with two tabs, and Debates belonged
with them: a contradiction only means something beside what the corpus covers and
what it is missing. The three read as one pass — what I cover, where my sources
fight, what is left — so the section is renamed to what that pass is called in a
thesis: **Estado de la cuestión**, tabs in the order Cobertura → Debates → Huecos.

Debates keeps its routable view id and loses its sidebar entry, exactly as Gaps
did; Home, Search and the advanced tour still reach it and land on its tab. The
jumps that used to leave Coverage or Gaps for a Debates section are now a tab
change that keeps your place.

The name is **not translated literally**: every language has its own academic
term for that part of a research work, and a calque would give away that the
interface was translated rather than written in that language.

| | |
|---|---|
| en | State of the art |
| fr | État de la question |
| de | **Forschungsstand** |
| pt · pt-BR | Estado da arte |
| it | Stato dell'arte |
| tr | Alanyazın |

### Verification

- `scripts/test-view-registry.mjs` — new invariant for Debates mirroring the one
  Gaps already had: routable, no `NAV_ITEM`, lands on its own tab, tabs in the
  agreed order, and nothing outside the workspace still routes to a Debates
  section.
- `scripts/test-section-headers.mjs` — the header lives in one component and
  every section uses it; each header carries icon, title and subtitle; no two
  sections that can share a sidebar share an icon.
- Both new tests were checked by breaking what they guard and watching them fail.
- Typecheck clean, lint clean, **1805 tests passing**.
- Driven manually in the real app on an isolated profile with synthetic
  pre-v130 data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
