### PR TITLE
Fix Nodus Server image publication

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     paths:
+      - 'package.json'
+      - 'package-lock.json'
       - 'server/**'
       - 'scripts/test-nodus-server.mjs'
       - 'scripts/test-nodus-server-deployment.mjs'
@@ -43,6 +45,10 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+
+      - name: Install test dependencies
+        run: npm ci
 
       - name: Test server and deployment contract
         # Every suite that exercises the server, not just the two that predate the client

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -23,6 +23,9 @@ test('the main workflow tests then publishes amd64 and arm64 images', () => {
   const workflow = read('.github/workflows/nodus-server-image.yml');
   assert.doesNotMatch(read('.gitignore'), /^\.github\/$/m);
   assert.match(workflow, /branches:\s*\[main\]/);
+  assert.match(workflow, /- 'package\.json'/, 'server publishing reruns when its test dependencies change');
+  assert.match(workflow, /- 'package-lock\.json'/, 'server publishing reruns when the dependency lock changes');
+  assert.match(workflow, /Install test dependencies[\s\S]*?run:\s*npm ci[\s\S]*?Test server and deployment contract/, 'dependencies are installed before server tests');
   // Every server suite has to run before an image is published, not just the two that
   // predate the client API: an image that fails a role check or an asset rejection is
   // exactly what this job exists to stop.


### PR DESCRIPTION
## What changed

- install the root dependencies before running the Nodus Server publication tests
- cache npm downloads in the image workflow
- rerun the workflow when `package.json` or `package-lock.json` changes
- assert this ordering and trigger contract in the deployment test

## Root cause

The Nodus Server 4.1.0 workflow imported `adm-zip` from `scripts/test-nodus-server.mjs` without first running `npm ci`. The test job stopped with `ERR_MODULE_NOT_FOUND`, so GHCR never received the 4.1.0 image and `:main` remained on 4.0.1.

## Impact

Once merged into `main`, the server workflow will test and publish the 4.1.0 amd64/arm64 image. Portainer can then pull and recreate the stack from the updated `:main` tag.

## Validation

- clean `npm ci`
- all dedicated server publication suites: 56/56 passing
- `git diff --check`

The local Docker smoke test could not run because Docker Desktop is not running on this machine; the workflow retains its existing container health smoke test.