### PR TITLE
Improve update modal performance and keep idea markers circular

### DIFF
--- a/scripts/test-ideas-ui.mjs
+++ b/scripts/test-ideas-ui.mjs
@@ -15,6 +15,15 @@ test('Ideas opens as a library-style metadata catalogue', async () => {
   }
 });
 
+test('idea type markers stay circular beside long labels', async () => {
+  const ui = await readSource('src/components/ui.tsx');
+  assert.match(
+    ui,
+    /function TypeDot[\s\S]*className="[^"]*h-2\.5[^"]*w-2\.5[^"]*shrink-0[^"]*rounded-full"/,
+    'the flex row must not squeeze a type dot into an oval',
+  );
+});
+
 test('Ideas catalogue can be searched, filtered and sorted', async () => {
   const view = await readSource('src/views/IdeasView.tsx');
   assert.match(view, /data-testid="ideas-filters-toggle"/);

--- a/scripts/test-modal-animation-performance.mjs
+++ b/scripts/test-modal-animation-performance.mjs
@@ -6,8 +6,9 @@ import { fileURLToPath } from 'node:url';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (file) => readFile(path.join(root, file), 'utf8');
-const [avatar, classicCss, orbCss, whatsNew, startupUpdate, app, styles, main] = await Promise.all([
+const [avatar, orb, classicCss, orbCss, whatsNew, startupUpdate, app, styles, main] = await Promise.all([
   read('src/components/nodi/NodiAvatar.tsx'),
+  read('src/components/nodi/NodiOrb.tsx'),
   read('src/components/nodi/nodi.css'),
   read('src/components/nodi/nodiOrb.css'),
   read('src/components/WhatsNewModal.tsx'),
@@ -20,12 +21,20 @@ const [avatar, classicCss, orbCss, whatsNew, startupUpdate, app, styles, main] =
 test('cinematic modals bound the expensive Nodi SVG animation', () => {
   assert.match(avatar, /restAfterMs\?: number/);
   assert.match(avatar, /QUIESCENT\.has\(state\) \|\| restAfterMs !== undefined/);
-  assert.match(avatar, /\[state, settled, reduceMotion, restAfterMs\]/);
+  assert.match(avatar, /useState\(\(\) => settled && delay <= 0\)/);
+  assert.match(avatar, /if \(delay <= 0\) \{\s*setAtRest\(true\)/);
+  assert.match(avatar, /\[state, settled, delay\]/);
   assert.match(avatar, /export const NodiAvatar = memo\(NodiAvatarComponent\)/);
   assert.match(whatsNew, /const WhatsNewNodi = memo/);
-  assert.match(whatsNew, /<NodiAvatar state="celebrating" height=\{205\} restAfterMs=\{1_200\} \/>/);
+  assert.match(whatsNew, /<NodiAvatar[\s\S]*settings=\{settings\}[\s\S]*activeVaultType=\{activeVaultType\}[\s\S]*state="celebrating"[\s\S]*restAfterMs=\{0\}/);
   assert.match(startupUpdate, /const StartupUpdateNodi = memo/);
-  assert.match(startupUpdate, /<NodiAvatar state=\{state\} height=\{162\} restAfterMs=\{1_200\} \/>/);
+  assert.match(startupUpdate, /<NodiAvatar[\s\S]*settings=\{settings\}[\s\S]*activeVaultType=\{activeVaultType\}[\s\S]*state=\{state\}[\s\S]*restAfterMs=\{0\}/);
+  assert.match(whatsNew, /restAfterMs=\{0\}[\s\S]*lightweight/);
+  assert.match(startupUpdate, /restAfterMs=\{0\}[\s\S]*lightweight/);
+  assert.match(orb, /!lightweight && \([\s\S]*feTurbulence/);
+  assert.match(orb, /!lightweight && <g className="fx fx-celebrating">/);
+  assert.match(app, /<WhatsNewModal[\s\S]*settings=\{settings\}[\s\S]*activeVaultType=\{activeVault\?\.type \?\? null\}/);
+  assert.match(app, /<StartupUpdateModal[\s\S]*settings=\{settings\}[\s\S]*activeVaultType=\{activeVault\?\.type \?\? null\}/);
   assert.match(classicCss, /\.nodi-svg\.nodi-at-rest \* \{ animation-play-state: paused !important; \}/);
   assert.match(orbCss, /\.nodi-orb\.nodi-at-rest \* \{ animation-play-state: paused !important; \}/);
 });
@@ -43,7 +52,7 @@ test('cinematic decoration finishes instead of repainting forever', () => {
 test('closing the update modal removes its listener and progress is throttled', () => {
   assert.match(startupUpdate, /if \(!shouldShow \|\| !open\) return;/);
   assert.match(startupUpdate, /\[attempt, open, shouldShow\]/);
-  assert.match(app, /!manualWhatsNewOpen && !updateSettled && <StartupUpdateModal/);
+  assert.match(app, /!manualWhatsNewOpen && !updateSettled && \(\s*<StartupUpdateModal/);
   assert.match(main, /const UPDATE_PROGRESS_MIN_INTERVAL_MS = 500;/);
   assert.match(main, /roundedPercent === lastDownloadProgressPercent/);
   assert.match(main, /now - lastDownloadProgressEmitAt < UPDATE_PROGRESS_MIN_INTERVAL_MS/);

--- a/scripts/test-nodi-style-choice.mjs
+++ b/scripts/test-nodi-style-choice.mjs
@@ -90,7 +90,7 @@ test('the one-time modal is gated on the flag and behind the update check', asyn
   const app = await read('src/App.tsx');
   assert.match(app, /updateSettled &&[\s\S]{0,400}?!settings\.mascotStyleChosen &&[\s\S]{0,80}?<NodiStyleModal/);
   // It has to wait for the update modal rather than fight it for the foreground.
-  assert.match(app, /<StartupUpdateModal onSettled=\{\(\) => setUpdateSettled\(true\)\}/);
+  assert.match(app, /<StartupUpdateModal[\s\S]*settings=\{settings\}[\s\S]*onSettled=\{\(\) => setUpdateSettled\(true\)\}/);
   // Users still in the tutorial pick there instead.
   assert.match(app, /settings\.basicsTutorialVersion > 0 &&[\s\S]{0,200}?<NodiStyleModal/);
 });

--- a/scripts/test-site-shared-header.mjs
+++ b/scripts/test-site-shared-header.mjs
@@ -48,7 +48,8 @@ test('the shared component owns every control visible in the main header', () =>
     'id="release-downloads"',
     'data-i18n="nav.demo"',
   ]) assert.ok(headerScript.includes(token), `shared header includes ${token}`);
-  assert.equal((headerScript.match(/return `<nav class="nav" id="site-header">/g) ?? []).length, 1);
+  assert.equal((headerScript.match(/return `<nav class="nav/g) ?? []).length, 1);
+  assert.match(headerScript, /class="nav\$\{isWiki \? ' wiki-nav' : ''\}" id="site-header"/);
 });
 
 test('desktop and mobile use the same fixed header dimensions on every page', () => {

--- a/scripts/test-startup-update-modal.mjs
+++ b/scripts/test-startup-update-modal.mjs
@@ -16,7 +16,7 @@ const [modal, app, main, styles, translations] = await Promise.all([
 test('the app performs one visible update check per launch after the update guides settle', () => {
   // Every one-time guide — release notes, the two update tours and the video tutorials
   // announcement — must have settled before the update check takes the foreground.
-  assert.match(app, /whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && <StartupUpdateModal[\s\S]*?\/>/);
+  assert.match(app, /whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && \(\s*<StartupUpdateModal[\s\S]*?\/>/);
   assert.match(app, /<WhatsNewModal[\s\S]*onSettled=\{\(\) => setWhatsNewSettled\(true\)\}/);
   // The one-time Nodi choice queues behind this modal, so a launch that never shows it
   // must still settle or that modal would wait forever.

--- a/scripts/test-tutorial-videos.mjs
+++ b/scripts/test-tutorial-videos.mjs
@@ -332,7 +332,7 @@ test('the videos are announced once to installs that predate them', async () => 
   // modals never fight for the foreground.
   const order = ['<WhatsNewModal', '<PlatformHighlightsUpdateTour', '<ToolkitBetaUpdateTour', '<TutorialVideosUpdateTour', '<StartupUpdateModal'].map((tag) => app.indexOf(tag));
   assert.deepEqual(order, [...order].sort((a, b) => a - b), 'the videos announcement sits between the toolkit tour and the update check');
-  assert.match(app, /toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && <StartupUpdateModal/);
+  assert.match(app, /toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && \(\s*<StartupUpdateModal/);
 });
 
 test('the announcement speaks every interface language', async () => {

--- a/scripts/test-whats-new-support.mjs
+++ b/scripts/test-whats-new-support.mjs
@@ -26,7 +26,7 @@ assert.ok(VAULT_TYPES.length >= 9, `expected the VaultType union to parse, got $
 
 assert.match(modal, /data-testid="whats-new-paypal-support"/);
 assert.match(modal, /data-testid="whats-new-cinematic-modal"/);
-assert.match(modal, /NodiAvatar state="celebrating"/);
+assert.match(modal, /<NodiAvatar[\s\S]*state="celebrating"/);
 assert.match(modal, /whats-new-confetti/);
 assert.doesNotMatch(modal, /from 'framer-motion'/);
 assert.match(styles, /@keyframes whats-new-modal-in/);

--- a/scripts/verify-modal-animation-performance.mjs
+++ b/scripts/verify-modal-animation-performance.mjs
@@ -89,11 +89,22 @@ try {
 
   const whatsNew = page.getByTestId('whats-new-cinematic-modal');
   await whatsNew.waitFor();
+  const firstCommit = await whatsNew.evaluate((modal) => ({
+    avatarPresent: Boolean(modal.querySelector('svg.nodi-svg, svg.nodi-orb')),
+    atRest: Boolean(modal.querySelector('svg.nodi-at-rest')),
+  }));
+  assert.deepEqual(firstCommit, { avatarPresent: true, atRest: true }, "What's New must commit Nodi already rendered and paused");
   await assertAvatarPaused(whatsNew, 'celebrating', "What's New classic Nodi");
 
   // The same pause contract must cover the alternate, filter-heavy orb.
   await page.evaluate(() => window.nodus.updateSettings({ mascotStyle: 'orb' }));
   await whatsNew.locator('svg.nodi-orb.nodi-at-rest').waitFor();
+  const lightweightOrb = await whatsNew.locator('svg.nodi-orb').evaluate((svg) => ({
+    lightweight: svg.classList.contains('nodi-orb-lightweight'),
+    turbulenceFilters: svg.querySelectorAll('feTurbulence').length,
+    celebrationParticles: svg.querySelectorAll('.party').length,
+  }));
+  assert.deepEqual(lightweightOrb, { lightweight: true, turbulenceFilters: 0, celebrationParticles: 0 });
   await assertAvatarPaused(whatsNew, 'celebrating', "What's New orb Nodi");
   await page.screenshot({ path: path.join(shots, 'whats-new-paused.png') });
   await whatsNew.getByRole('button', { name: /Explorar las novedades/ }).click();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1901,11 +1901,18 @@ export function App() {
         (!isTestimonios || settings.testimonyTourComplete) &&
         (!isEstudio || settings.studyTourComplete) &&
         (!isDocencia || settings.docenciaTourComplete) && (
-          <WhatsNewModal uiLanguage={settings.uiLanguage} onSettled={() => setWhatsNewSettled(true)} />
+          <WhatsNewModal
+            settings={settings}
+            activeVaultType={activeVault?.type ?? null}
+            uiLanguage={settings.uiLanguage}
+            onSettled={() => setWhatsNewSettled(true)}
+          />
         )}
 
       {!isPreviewVault && recoveryStatus?.needsSetup && recoveryStatus.previousInstallation && !whatsNewSettled && (
         <WhatsNewModal
+          settings={settings}
+          activeVaultType={activeVault?.type ?? null}
           uiLanguage={settings.uiLanguage}
           onSettled={() => setWhatsNewSettled(true)}
         />
@@ -1913,6 +1920,8 @@ export function App() {
 
       {manualWhatsNewOpen && (
         <WhatsNewModal
+          settings={settings}
+          activeVaultType={activeVault?.type ?? null}
           uiLanguage={settings.uiLanguage}
           showSeenReleaseNotes
           onSettled={() => setManualWhatsNewOpen(false)}
@@ -1950,7 +1959,13 @@ export function App() {
         />
       )}
 
-      {whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && <StartupUpdateModal onSettled={() => setUpdateSettled(true)} />}
+      {whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && (
+        <StartupUpdateModal
+          settings={settings}
+          activeVaultType={activeVault?.type ?? null}
+          onSettled={() => setUpdateSettled(true)}
+        />
+      )}
 
       {/* Users who already saw the cinematic tutorial were never offered the choice of
           Nodi, so it is made here instead — once, behind the update check. New users

--- a/src/components/StartupUpdateModal.tsx
+++ b/src/components/StartupUpdateModal.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
-import type { UpdateCheckResponse, UpdateCheckStatus, UpdateErrorCode } from '@shared/types';
+import type { AppSettings, UpdateCheckResponse, UpdateCheckStatus, UpdateErrorCode, VaultType } from '@shared/types';
 import { t } from '../i18n';
 import { Icon } from './ui';
 import { type NodiState } from './nodi/Nodi';
@@ -138,11 +138,36 @@ function sameVisibleUpdate(a: UpdateCheckResponse, b: UpdateCheckResponse): bool
     && progressA === progressB;
 }
 
-const StartupUpdateNodi = memo(function StartupUpdateNodi({ state }: { state: NodiState }) {
-  return <NodiAvatar state={state} height={162} restAfterMs={1_200} />;
+const StartupUpdateNodi = memo(function StartupUpdateNodi({
+  settings,
+  activeVaultType,
+  state,
+}: {
+  settings: AppSettings;
+  activeVaultType: VaultType | null;
+  state: NodiState;
+}) {
+  return (
+    <NodiAvatar
+      settings={settings}
+      activeVaultType={activeVaultType}
+      state={state}
+      height={162}
+      restAfterMs={0}
+      lightweight
+    />
+  );
 });
 
-export function StartupUpdateModal({ onSettled }: { onSettled?: () => void } = {}) {
+export function StartupUpdateModal({
+  settings,
+  activeVaultType,
+  onSettled,
+}: {
+  settings: AppSettings;
+  activeVaultType: VaultType | null;
+  onSettled?: () => void;
+}) {
   const [shouldShow] = useState(shouldShowThisSession);
   const [open, setOpen] = useState(false);
   const [attempt, setAttempt] = useState(0);
@@ -273,7 +298,11 @@ export function StartupUpdateModal({ onSettled }: { onSettled?: () => void } = {
             <p>{t('Comprobamos automáticamente que tengas la versión más reciente y segura de Nodus.')}</p>
           </div>
           <div className="startup-update-nodi">
-            <StartupUpdateNodi state={presentation.nodiState} />
+            <StartupUpdateNodi
+              settings={settings}
+              activeVaultType={activeVaultType}
+              state={presentation.nodiState}
+            />
           </div>
         </header>
 

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { releaseNotesForMajor, releaseNotesSince, type ReleaseNote, type ReleaseNoteScope } from '@shared/releaseNotes';
 import { NODUS_SOCIAL_LINKS } from '@shared/socialLinks';
-import type { AppLanguage, VaultType } from '@shared/types';
+import type { AppLanguage, AppSettings, VaultType } from '@shared/types';
 import { VAULT_TYPE_COLORS } from '@shared/vaultTypes';
 import { Icon } from './ui';
 import { t } from '../i18n';
@@ -235,8 +235,23 @@ const VersionPicker = memo(function VersionPicker({
   );
 });
 
-const WhatsNewNodi = memo(function WhatsNewNodi() {
-  return <NodiAvatar state="celebrating" height={205} restAfterMs={1_200} />;
+const WhatsNewNodi = memo(function WhatsNewNodi({
+  settings,
+  activeVaultType,
+}: {
+  settings: AppSettings;
+  activeVaultType: VaultType | null;
+}) {
+  return (
+    <NodiAvatar
+      settings={settings}
+      activeVaultType={activeVaultType}
+      state="celebrating"
+      height={205}
+      restAfterMs={0}
+      lightweight
+    />
+  );
 });
 
 export function hasPendingWhatsNew(): boolean {
@@ -246,10 +261,14 @@ export function hasPendingWhatsNew(): boolean {
 }
 
 export function WhatsNewModal({
+  settings,
+  activeVaultType,
   uiLanguage,
   onSettled,
   showSeenReleaseNotes = false,
 }: {
+  settings: AppSettings;
+  activeVaultType: VaultType | null;
   uiLanguage: AppLanguage;
   onSettled?: () => void;
   showSeenReleaseNotes?: boolean;
@@ -314,7 +333,7 @@ export function WhatsNewModal({
           </div>
           <div className="whats-new-nodi">
             <div className="whats-new-nodi-glow" />
-            <WhatsNewNodi />
+            <WhatsNewNodi settings={settings} activeVaultType={activeVaultType} />
             <span>{t('¡Tenemos novedades!')}</span>
           </div>
         </header>

--- a/src/components/nodi/NodiAvatar.tsx
+++ b/src/components/nodi/NodiAvatar.tsx
@@ -34,21 +34,27 @@ function useAtRest(
 ): boolean {
   const mayRest = QUIESCENT.has(state) || restAfterMs !== undefined;
   const settled = mayRest && !raiseArm && !hovered;
-  const [atRest, setAtRest] = useState(false);
+  const delay = reduceMotion ? 0 : restAfterMs ?? REST_DELAY_MS;
+  // A zero allowance is used by startup surfaces: begin paused in the very first
+  // render instead of starting every filtered SVG animation and stopping it from an
+  // effect one frame later. That first animated paint is the expensive one.
+  const [atRest, setAtRest] = useState(() => settled && delay <= 0);
   useEffect(() => {
     if (!settled) {
       setAtRest(false);
+      return;
+    }
+    if (delay <= 0) {
+      setAtRest(true);
       return;
     }
     // A bounded active state starts its allowance again whenever the state changes.
     // This lets an update visibly move from checking to downloading, for example,
     // without leaving a costly SVG repaint running for the lifetime of the modal.
     setAtRest(false);
-    // Someone who asked for less motion gets the still pose immediately.
-    const delay = reduceMotion ? 0 : restAfterMs ?? REST_DELAY_MS;
     const timer = window.setTimeout(() => setAtRest(true), Math.max(0, delay));
     return () => window.clearTimeout(timer);
-  }, [state, settled, reduceMotion, restAfterMs]);
+  }, [state, settled, delay]);
   return atRest;
 }
 
@@ -62,12 +68,14 @@ function useAtRest(
  */
 function NodiAvatarComponent({
   settings,
+  activeVaultType,
   state = 'idle',
   role = 'none',
   height = 200,
   draggable = false,
   raiseArm = false,
   restAfterMs,
+  lightweight = false,
   className,
   style,
 }: {
@@ -77,6 +85,11 @@ function NodiAvatarComponent({
    * always-on-top overlay window must, living outside that tree — to self-subscribe.
    */
   settings?: AppSettings | null;
+  /**
+   * The active vault type when the caller already has it. Pass null when no vault is
+   * active; omit only in a standalone surface that must subscribe for itself.
+   */
+  activeVaultType?: VaultType | null;
   state?: NodiState;
   role?: NodiRole;
   height?: number;
@@ -84,6 +97,8 @@ function NodiAvatarComponent({
   raiseArm?: boolean;
   /** Pause all internal SVG motion after this many milliseconds, even in an active state. */
   restAfterMs?: number;
+  /** Skip the orb's costly procedural clouds and celebration particles. */
+  lightweight?: boolean;
   className?: string;
   style?: CSSProperties;
 }) {
@@ -96,19 +111,25 @@ function NodiAvatarComponent({
   }, [selfFetch]);
   const resolved = selfFetch ? fetched : settings;
 
-  // The orb's colour can follow the active vault, so it has to know which one is open
-  // even on surfaces that otherwise don't care.
-  const [vaultType, setVaultType] = useState<VaultType | null>(null);
+  // The orb's colour can follow the active vault. App-owned surfaces already know
+  // that vault, so only standalone surfaces need another IPC read and subscription.
+  const selfFetchVault = activeVaultType === undefined;
+  const [fetchedVaultType, setFetchedVaultType] = useState<VaultType | null>(null);
   useEffect(() => {
-    window.nodus.getActiveVault().then((vault) => setVaultType(vault?.type ?? null)).catch(() => {});
-    return window.nodus.onVaultChanged((vault) => setVaultType(vault?.type ?? null));
-  }, []);
+    if (!selfFetchVault || resolved?.mascotStyle !== 'orb') return;
+    window.nodus.getActiveVault().then((vault) => setFetchedVaultType(vault?.type ?? null)).catch(() => {});
+    return window.nodus.onVaultChanged((vault) => setFetchedVaultType(vault?.type ?? null));
+  }, [resolved?.mascotStyle, selfFetchVault]);
+  const resolvedVaultType = selfFetchVault ? fetchedVaultType : activeVaultType;
 
   const [hovered, setHovered] = useState(false);
   const atRest = useAtRest(state, raiseArm, hovered, resolved?.reduceMotion ?? false, restAfterMs);
   // Reaching for Nodi wakes it before the pointer arrives, so it is already moving
   // by the time it is grabbed rather than starting with a jolt.
-  const wake = {
+  // A zero animation allowance is a genuinely static rendering contract. Do not let
+  // an incidental pointer position during startup turn the costly repaint loop back
+  // on before the user has interacted with the modal itself.
+  const wake = restAfterMs === 0 ? {} : {
     onPointerEnter: () => setHovered(true),
     onPointerLeave: () => setHovered(false),
   };
@@ -122,10 +143,11 @@ function NodiAvatarComponent({
     return (
       <NodiOrb
         state={state}
-        hue={orbHue(resolved, vaultType)}
+        hue={orbHue(resolved, resolvedVaultType)}
         height={height}
         draggable={draggable}
         raiseArm={raiseArm}
+        lightweight={lightweight}
         className={classes}
         style={style}
         {...wake}

--- a/src/components/nodi/NodiOrb.tsx
+++ b/src/components/nodi/NodiOrb.tsx
@@ -153,6 +153,7 @@ export function NodiOrb({
   height = 200,
   draggable = false,
   raiseArm = false,
+  lightweight = false,
   className,
   style,
   onPointerEnter,
@@ -165,6 +166,12 @@ export function NodiOrb({
   draggable?: boolean;
   /** Flag an unread notification — the orb's equivalent of the classic Nodi's raised arm. */
   raiseArm?: boolean;
+  /**
+   * Omit the procedural cloud filters and particle burst for small startup cameos.
+   * The sphere, stars, constellation, core and rings remain, so it keeps its identity
+   * without making the first frame wait for Chromium to rasterise feTurbulence.
+   */
+  lightweight?: boolean;
   className?: string;
   style?: CSSProperties;
   onPointerEnter?: PointerEventHandler<SVGSVGElement>;
@@ -186,7 +193,7 @@ export function NodiOrb({
 
   return (
     <svg
-      className={['nodi-orb', draggable ? 'nodi-draggable' : '', raiseArm ? 'arm-up' : '', className].filter(Boolean).join(' ')}
+      className={['nodi-orb', lightweight ? 'nodi-orb-lightweight' : '', draggable ? 'nodi-draggable' : '', raiseArm ? 'arm-up' : '', className].filter(Boolean).join(' ')}
       style={{ height, ['--nodi-hue' as string]: `${resolvedHue}deg`, ...style }}
       viewBox="0 0 320 340"
       role="img"
@@ -200,13 +207,16 @@ export function NodiOrb({
         <filter id={u('b2')} x="-80%" y="-80%" width="260%" height="260%"><feGaussianBlur stdDeviation="2.2" /></filter>
         <filter id={u('b4')} x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="4" /></filter>
         <filter id={u('b6')} x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="6" /></filter>
-        <filter id={u('b10')} x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="10" /></filter>
-        <filter id={u('b14')} x="-160%" y="-160%" width="420%" height="420%"><feGaussianBlur stdDeviation="14" /></filter>
-
-        <filter id={u('clouds')} x="-20%" y="-20%" width="140%" height="140%">
-          <feTurbulence type="fractalNoise" baseFrequency="0.028" numOctaves="4" seed="11" result="n" />
-          <feColorMatrix in="n" type="matrix" values={cloudTintMatrix(resolvedHue)} />
-        </filter>
+        {!lightweight && (
+          <>
+            <filter id={u('b10')} x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="10" /></filter>
+            <filter id={u('b14')} x="-160%" y="-160%" width="420%" height="420%"><feGaussianBlur stdDeviation="14" /></filter>
+            <filter id={u('clouds')} x="-20%" y="-20%" width="140%" height="140%">
+              <feTurbulence type="fractalNoise" baseFrequency="0.028" numOctaves="4" seed="11" result="n" />
+              <feColorMatrix in="n" type="matrix" values={cloudTintMatrix(resolvedHue)} />
+            </filter>
+          </>
+        )}
 
         <radialGradient id={u('deepSpace')} cx="42%" cy="36%" r="85%">
           <stop offset="0%" className="st-deep1" />
@@ -336,16 +346,19 @@ export function NodiOrb({
           <circle cx="160" cy="160" r="79" fill={ref('deepSpace')} />
 
           <g clipPath={ref('sphereClip')}>
-            <circle className="add" cx="160" cy="160" r="79" filter={ref('clouds')} opacity=".5" />
-
-            <g className="neb-spin">
-              <ellipse className="neb-arm1 add" cx="160" cy="160" rx="52" ry="20" fill="none" strokeWidth="16" transform="rotate(28 160 160)" filter={ref('b10')} opacity=".6" />
-              <ellipse className="neb-arm1b add" cx="164" cy="156" rx="60" ry="13" fill="none" strokeWidth="9" transform="rotate(6 160 160)" filter={ref('b10')} opacity=".38" />
-            </g>
-            <g className="neb-spin2">
-              <ellipse className="neb-arm2 add" cx="156" cy="164" rx="42" ry="26" fill="none" strokeWidth="13" transform="rotate(-22 160 160)" filter={ref('b14')} opacity=".42" />
-              <circle className="neb-cloud add" cx="150" cy="150" r="30" filter={ref('b14')} opacity=".5" />
-            </g>
+            {!lightweight && (
+              <>
+                <circle className="add" cx="160" cy="160" r="79" filter={ref('clouds')} opacity=".5" />
+                <g className="neb-spin">
+                  <ellipse className="neb-arm1 add" cx="160" cy="160" rx="52" ry="20" fill="none" strokeWidth="16" transform="rotate(28 160 160)" filter={ref('b10')} opacity=".6" />
+                  <ellipse className="neb-arm1b add" cx="164" cy="156" rx="60" ry="13" fill="none" strokeWidth="9" transform="rotate(6 160 160)" filter={ref('b10')} opacity=".38" />
+                </g>
+                <g className="neb-spin2">
+                  <ellipse className="neb-arm2 add" cx="156" cy="164" rx="42" ry="26" fill="none" strokeWidth="13" transform="rotate(-22 160 160)" filter={ref('b14')} opacity=".42" />
+                  <circle className="neb-cloud add" cx="150" cy="150" r="30" filter={ref('b14')} opacity=".5" />
+                </g>
+              </>
+            )}
 
             <g>
               {starfield.map((s, i) => (
@@ -490,7 +503,7 @@ export function NodiOrb({
           <g transform="translate(160,64) scale(.8)"><use href={`#${u('star4')}`} className="noti-star" /></g>
         </g>
 
-        <g className="fx fx-celebrating">
+        {!lightweight && <g className="fx fx-celebrating">
           {party.map((p, i) =>
             p.star ? (
               <g key={i} transform={`translate(160,160) scale(${p.scale.toFixed(2)})`}>
@@ -511,7 +524,7 @@ export function NodiOrb({
               />
             )
           )}
-        </g>
+        </g>}
 
         <g className="fx fx-sleeping">
           <path className="moon" d="M216,84 a13,13 0 1 0 10,21 a10.5,10.5 0 1 1 -10,-21 Z" filter={ref('b1')} />

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -364,7 +364,7 @@ export function Spinner({ label }: { label?: string }) {
 
 export function TypeDot({ type }: { type: GraphNodeType }) {
   const color = type === 'author' ? '#a3a3a3' : NODE_COLORS[type];
-  return <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />;
+  return <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />;
 }
 
 /**


### PR DESCRIPTION
Closes #415

## Summary

- make Nodi visible immediately in the What's New and startup update modals
- reuse app-owned settings and active-vault state instead of issuing redundant IPC reads
- pause update-modal avatars from the first render and use a lightweight orb variant that skips the most expensive procedural filters and celebration particles on these small surfaces
- prevent shared idea type markers from shrinking into ovals beside long labels
- extend regression coverage for modal rendering performance and marker geometry
- update the stale shared-header assertion to recognize the existing conditional Wiki navigation class that already ships on `main`

## Root cause

The update surfaces mounted Nodi without the settings and active-vault data already loaded by the app. The orb therefore waited on duplicate IPC reads while Chromium also rasterized expensive animated SVG turbulence and blur filters during the first paint. Separately, the shared type dot had equal width and height but was still shrinkable inside flex rows, allowing long idea labels to compress only its horizontal dimension.

The first CI run also exposed an unrelated stale assertion from `main`: the public site header test expected an exact `class="nav"` literal even though the existing Wiki navigation conditionally appends `wiki-nav`. The updated assertion still requires exactly one shared header and now validates the conditional class explicitly.

## User impact

Update-related modals render responsively with Nodi present from the first frame, while idea type indicators remain circular at every supported label length. Full-detail Nodi rendering elsewhere in the app is unchanged.

## Validation

- `npm run typecheck`
- `npm run lint`
- 72 targeted modal, Ideas, Study, and tutorial tests
- shared public-site header tests
- production build
- real Electron modal performance verification
- visual QA of the optimized orb and idea list
- `git diff --check`