### PR TITLE
Fix editor styling and protected marker leaks

### DIFF
--- a/electron/ai/studyImprove.ts
+++ b/electron/ai/studyImprove.ts
@@ -69,9 +69,13 @@ function stripWrappingFence(value: string): string {
 }
 
 function completeProtectedStreamPrefix(value: string): string {
-  const lastOpen = value.lastIndexOf('⟦');
-  const lastClose = value.lastIndexOf('⟧');
-  return lastOpen > lastClose ? value.slice(0, lastOpen) : value;
+  const unicodeOpen = value.lastIndexOf('⟦');
+  const asciiOpen = value.lastIndexOf('[');
+  const incompleteOpen = Math.max(
+    unicodeOpen > value.lastIndexOf('⟧') ? unicodeOpen : -1,
+    asciiOpen > value.lastIndexOf(']') ? asciiOpen : -1,
+  );
+  return incompleteOpen >= 0 ? value.slice(0, incompleteOpen) : value;
 }
 
 function hash(value: string): string {

--- a/scripts/test-study-improve-streaming.mjs
+++ b/scripts/test-study-improve-streaming.mjs
@@ -36,7 +36,7 @@ execFileSync(
 );
 
 const require = createRequire(import.meta.url);
-const { protectStudyText, restoreProtectedSpans } = require(bundle);
+const { missingProtectedSpans, protectStudyText, restoreProtectedSpans } = require(bundle);
 
 /** The original implementation, kept as the correctness oracle. */
 function restoreTheOldWay(text, spans) {
@@ -45,9 +45,13 @@ function restoreTheOldWay(text, spans) {
 
 /** `completeProtectedStreamPrefix` from electron/ai/studyImprove.ts. */
 function safePrefixLength(value) {
-  const lastOpen = value.lastIndexOf('⟦');
-  const lastClose = value.lastIndexOf('⟧');
-  return lastOpen > lastClose ? lastOpen : value.length;
+  const unicodeOpen = value.lastIndexOf('⟦');
+  const asciiOpen = value.lastIndexOf('[');
+  const incompleteOpen = Math.max(
+    unicodeOpen > value.lastIndexOf('⟧') ? unicodeOpen : -1,
+    asciiOpen > value.lastIndexOf(']') ? asciiOpen : -1,
+  );
+  return incompleteOpen >= 0 ? incompleteOpen : value.length;
 }
 
 /** A document with plenty of protectable material: citations, numbers, quotes, code. */
@@ -93,16 +97,19 @@ try {
     assert.equal(restoreProtectedSpans(text, spans), restoreTheOldWay(text, spans));
   }
 
-  // --- 3. An unknown placeholder is left alone, not deleted ----------------
-  // A model can hallucinate a marker that was never minted; dropping it would
-  // silently swallow text.
+  // --- 3. Model-formatted and ghost markers never leak into the document ---
   {
-    const { spans } = protectStudyText('Cita [Autor, 2001].', []);
-    const withGhost = 'Texto ⟦NODUS_PROTECTED_9999⟧ final.';
+    const source = 'Cita [Autor, 2001] y 42 casos.';
+    const { text, spans } = protectStudyText(source, []);
+    const formatted = text.replace(/⟦NODUS_PROTECTED_(\d+)⟧/g, '[NODUS PROTECTED $1]');
+    assert.equal(missingProtectedSpans(formatted, spans).length, 0, 'formatted indexed markers still count as present');
+    assert.equal(restoreProtectedSpans(formatted, spans), source, 'formatted indexed markers restore their original spans');
+
+    const withGhost = `${text}\n[NODUS PROTECTED] ⟦NODUS_PROTECTED_9999⟧`;
     assert.equal(
       restoreProtectedSpans(withGhost, spans),
-      withGhost,
-      'a placeholder with no matching span must be preserved verbatim'
+      `${source}\n `,
+      'generic and unknown internal markers are removed instead of becoming document content'
     );
   }
 
@@ -156,6 +163,24 @@ try {
     }
     visible += restoreProtectedSpans(text.slice(restoredUpTo), spans);
     assert.equal(visible, source, 'the split marker must still restore correctly');
+  }
+
+  {
+    const source = 'Antes [Autor, 1988] después.';
+    const { text, spans } = protectStudyText(source, []);
+    const formatted = text.replace(/⟦NODUS_PROTECTED_(\d+)⟧/g, '[NODUS PROTECTED $1]');
+    const splitAt = formatted.indexOf('[NODUS PROTECTED') + 8;
+    let restoredUpTo = 0;
+    let visible = '';
+    for (const streamed of [formatted.slice(0, splitAt), formatted]) {
+      const safeEnd = safePrefixLength(streamed);
+      if (safeEnd <= restoredUpTo) continue;
+      visible += restoreProtectedSpans(streamed.slice(restoredUpTo, safeEnd), spans);
+      restoredUpTo = safeEnd;
+    }
+    visible += restoreProtectedSpans(formatted.slice(restoredUpTo), spans);
+    assert.equal(visible, source, 'an ASCII marker split across chunks must restore without leaking internals');
+    assert.ok(!visible.includes('NODUS PROTECTED'));
   }
 
   // --- 6. The work is now linear, not quadratic ----------------------------

--- a/scripts/test-study-improve-ui.mjs
+++ b/scripts/test-study-improve-ui.mjs
@@ -8,9 +8,10 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (file) => readFile(path.join(root, file), 'utf8');
 
 test('study improvement is selection-first, streamed in place and committed to the editor history', async () => {
-  const [editor, dialog] = await Promise.all([
+  const [editor, dialog, stylesheet] = await Promise.all([
     read('src/components/editor/StudyEditor.tsx'),
     read('src/components/editor/StudyImproveDialog.tsx'),
+    read('src/index.css'),
   ]);
   assert.match(editor, /data-testid="study-improve-toggle"/);
   assert.match(editor, /resolveImproveSelection/);
@@ -32,6 +33,7 @@ test('study improvement is selection-first, streamed in place and committed to t
   assert.match(editor, /data-testid="study-editor-redo"/);
   assert.match(editor, /data-testid="study-synonyms-toggle"/);
   assert.match(editor, /name="aiSynonyms"/);
+  assert.doesNotMatch(stylesheet, /\.study-milkdown \.milkdown-toolbar \.study-synonyms-trigger\s*\{[^}]*\b(?:border|background)\s*:/, 'the idle synonyms action must not have persistent framed styling');
   assert.match(editor, /studyStyleIcon/);
   assert.doesNotMatch(editor, /style\.icon\s*\|\|\s*['"]✦|fontSize:\s*size/);
   assert.match(editor, /data-testid="study-synonyms-panel"/);

--- a/shared/studyImprove.ts
+++ b/shared/studyImprove.ts
@@ -273,11 +273,21 @@ export function protectStudyText(source: string, terms: string[] = []): StudyPro
 }
 
 export function missingProtectedSpans(text: string, spans: StudyProtectedSpan[]): StudyProtectedSpan[] {
-  return spans.filter((span) => !text.includes(span.placeholder));
+  const tolerantIndexes = new Set<number>();
+  for (const match of text.matchAll(PROTECTED_PLACEHOLDER_RE)) {
+    const index = Number(match[1]);
+    if (Number.isInteger(index) && index > 0) tolerantIndexes.add(index);
+  }
+  return spans.filter((span, index) => !text.includes(span.placeholder) && !tolerantIndexes.has(index + 1));
 }
 
-/** Matches any placeholder minted by `protectStudyText`. */
-const PROTECTED_PLACEHOLDER_RE = /⟦NODUS_PROTECTED_\d+⟧/gu;
+/**
+ * Matches placeholders minted by `protectStudyText` plus the harmless formatting
+ * variants that some models return (ASCII brackets, spaces, hyphens or changed
+ * casing). The optional index also catches a generic `[NODUS PROTECTED]` ghost
+ * so an internal implementation marker can never become document content.
+ */
+const PROTECTED_PLACEHOLDER_RE = /(?:⟦|\[)\s*NODUS[\s_-]+PROTECTED(?:[\s_-]*(\d+))?\s*(?:⟧|\])/giu;
 
 /**
  * Placeholder→value lookups, cached per span list.
@@ -311,7 +321,15 @@ export function restoreProtectedSpans(text: string, spans: StudyProtectedSpan[])
   // placeholder would have been substituted again. Here each match is
   // replaced exactly once and the result is never re-scanned.
   const byPlaceholder = placeholderLookup(spans);
-  return text.replace(PROTECTED_PLACEHOLDER_RE, (match) => byPlaceholder.get(match) ?? match);
+  return text.replace(PROTECTED_PLACEHOLDER_RE, (match, rawIndex: string | undefined) => {
+    const exact = byPlaceholder.get(match);
+    if (exact) return exact;
+    const index = Number(rawIndex);
+    if (Number.isInteger(index) && index > 0) return spans[index - 1]?.value ?? '';
+    // A marker without an index cannot be mapped safely. It is always an
+    // internal model artefact, never user-facing replacement text.
+    return '';
+  });
 }
 
 export function renderStudyStylePrompt(template: string, variables: StudyImproveVariables): string {

--- a/src/index.css
+++ b/src/index.css
@@ -1307,21 +1307,9 @@ body {
   color: currentColor;
 }
 
-.study-milkdown .milkdown-toolbar .study-synonyms-trigger {
-  border: 1px solid rgba(13, 148, 136, 0.24);
-  background: rgba(13, 148, 136, 0.08);
-  color: #0f766e;
-}
-
 .study-milkdown .milkdown-toolbar .study-synonyms-trigger:hover {
   border-color: rgba(13, 148, 136, 0.42);
   background: rgba(13, 148, 136, 0.15);
-}
-
-.dark .study-milkdown .milkdown-toolbar .study-synonyms-trigger {
-  border-color: rgba(45, 212, 191, 0.3);
-  background: rgba(20, 184, 166, 0.12);
-  color: #5eead4;
 }
 
 .dark .study-milkdown .milkdown-toolbar .study-selection-tool {


### PR DESCRIPTION
## What changed

- remove the permanent border, tint, and accent color from the idle AI synonyms toolbar action
- recognize protected-span placeholders when providers change their brackets, separators, or casing
- hold incomplete ASCII and Unicode placeholders during streaming so internal text is never previewed
- discard generic or unknown `NODUS PROTECTED` artifacts instead of inserting them into workspace documents
- add regression coverage for idle synonyms styling and tolerant marker restoration

## Root cause

The synonyms action had dedicated base CSS that made its idle state look active. Separately, protected text used a strict placeholder format and the streaming/restoration path only understood that exact format. Providers that normalized the marker to forms such as `[NODUS PROTECTED 0001]` could expose an implementation detail in the preview or output.

## User impact

Workspace editor actions now share a consistent neutral idle appearance, and text-improvement results preserve protected content without showing Nodus's internal placeholders.

## Validation

- `node scripts/test-study-improve-streaming.mjs`
- `node --test scripts/test-study-improve-ui.mjs`
- `node scripts/test-study-improve.mjs`
- `npm run typecheck`
- `npx eslint shared/studyImprove.ts electron/ai/studyImprove.ts`

Closes #419