### PR TITLE
Fix Coverage question loading and queue workflow

### DIFF
--- a/scripts/test-coverage-question-queue.mjs
+++ b/scripts/test-coverage-question-queue.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'nodus-coverage-question-queue-'));
+
+const waitFor = async (predicate, label) => {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`Timed out waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+
+const detail = (id, question) => ({
+  rq: { id, question },
+  subQuestions: [],
+  stale: false,
+  summary: { covered: 0, partial: 0, uncovered: 0, disputed: 0, unmapped: 0 },
+});
+
+try {
+  const outfile = path.join(tmp, 'coverageQuestionQueue.mjs');
+  await build({
+    entryPoints: [path.join(repoRoot, 'src/coverageQuestionQueue.ts')],
+    outfile,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    external: ['@shared/*'],
+    logLevel: 'silent',
+  });
+  const { CoverageQuestionQueue } = await import(pathToFileURL(outfile).href);
+
+  // Multiple submissions share one lane and become visible only after each
+  // decomposition has finished.
+  {
+    let sequence = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const gates = [];
+    const ready = [];
+    const queue = new CoverageQuestionQueue({
+      activeVaultId: async () => 'vault-1',
+      create: async ({ question }) => detail(`rq-${++sequence}`, question),
+      decompose: (rqId) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return new Promise((resolve) => gates.push(() => {
+          inFlight -= 1;
+          resolve(detail(rqId, rqId));
+        }));
+      },
+      remove: async () => {},
+    });
+    queue.subscribe((_jobs, event) => {
+      if (event.type === 'ready') ready.push(event.rqId);
+    });
+
+    queue.enqueue({ vaultId: 'vault-1', question: 'Primera' });
+    queue.enqueue({ vaultId: 'vault-1', question: 'Segunda' });
+    await waitFor(() => gates.length === 1, 'the first question to start');
+    assert.deepEqual(queue.snapshot().map((job) => job.status), ['running', 'queued']);
+    assert.equal(maxInFlight, 1);
+
+    gates[0]();
+    await waitFor(() => ready.length === 1 && gates.length === 2, 'the second question to start');
+    assert.deepEqual(ready, ['rq-1']);
+    assert.deepEqual(queue.snapshot().map((job) => job.status), ['running']);
+
+    gates[1]();
+    await waitFor(() => ready.length === 2, 'both questions to finish');
+    assert.deepEqual(ready, ['rq-1', 'rq-2']);
+    assert.deepEqual(queue.snapshot(), []);
+    assert.equal(maxInFlight, 1, 'question decomposition stays serial');
+  }
+
+  // One failed question is cleaned up and does not prevent the next queued one.
+  {
+    let sequence = 0;
+    const removed = [];
+    const ready = [];
+    const queue = new CoverageQuestionQueue({
+      activeVaultId: async () => 'vault-1',
+      create: async ({ question }) => detail(`rq-${++sequence}`, question),
+      decompose: async (rqId) => {
+        if (rqId === 'rq-1') throw new Error('provider unavailable');
+        return detail(rqId, rqId);
+      },
+      remove: async (rqId) => { removed.push(rqId); },
+    });
+    queue.subscribe((_jobs, event) => {
+      if (event.type === 'ready') ready.push(event.rqId);
+    });
+
+    queue.enqueue({ vaultId: 'vault-1', question: 'Fallará' });
+    queue.enqueue({ vaultId: 'vault-1', question: 'Continuará' });
+    await waitFor(() => ready.length === 1, 'the lane to continue after an error');
+
+    assert.deepEqual(removed, ['rq-1'], 'a failed half-created draft is removed');
+    assert.deepEqual(ready, ['rq-2']);
+    const failed = queue.snapshot();
+    assert.equal(failed.length, 1);
+    assert.equal(failed[0].status, 'failed');
+    assert.match(failed[0].error, /provider unavailable/);
+  }
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}
+
+console.log('coverage question queue test passed');

--- a/scripts/test-coverage-workspace-ui.mjs
+++ b/scripts/test-coverage-workspace-ui.mjs
@@ -29,6 +29,26 @@ test('Debates remains routable but internal links switch the workspace tab', asy
   assert.doesNotMatch(navigation, /\{ id: 'debate',/);
 });
 
+test('Coverage reloads with the active vault and confirms destructive deletion', async () => {
+  const [workspace, map] = await Promise.all([
+    readSource('src/views/CoverageWorkspace.tsx'),
+    readSource('src/views/ResearchMapView.tsx'),
+  ]);
+  assert.match(workspace, /<ResearchMapView[\s\S]*vaultId=\{vaultId\}/);
+  assert.match(map, /const reloadList = useCallback\([\s\S]*\}, \[vaultId\]\)/);
+  assert.match(map, /const approved = await confirm\(/);
+  assert.match(map, /Se eliminará «\{title\}». Esta acción no se puede deshacer\./);
+  assert.match(map, /if \(!approved\) return/);
+});
+
+test('Coverage accepts several questions into a serial queue and reveals ready results', async () => {
+  const map = await readSource('src/views/ResearchMapView.tsx');
+  assert.match(map, /coverageQuestionQueue\.enqueue/);
+  assert.match(map, /data-testid="coverage-question-queue"/);
+  assert.match(map, /event\.type === 'ready'[\s\S]*reloadList\(\)/);
+  assert.match(map, /visibleQuestions = questions\.filter/);
+});
+
 test('the academic section name uses the native term in every supported language', async () => {
   const expected = [
     ['src/i18n.en.ts', 'State of the art'],

--- a/src/coverageQuestionQueue.ts
+++ b/src/coverageQuestionQueue.ts
@@ -1,0 +1,151 @@
+import type { ResearchQuestionDetail } from '@shared/types';
+
+export type CoverageQuestionJobStatus = 'queued' | 'running' | 'failed';
+
+export interface CoverageQuestionJob {
+  id: string;
+  vaultId: string;
+  question: string;
+  notes?: string;
+  status: CoverageQuestionJobStatus;
+  rqId: string | null;
+  error: string | null;
+}
+
+export type CoverageQuestionQueueEvent =
+  | { type: 'changed' }
+  | { type: 'ready'; vaultId: string; rqId: string };
+
+interface CoverageQuestionQueueDeps {
+  activeVaultId(): Promise<string | null>;
+  create(input: { question: string; notes?: string }): Promise<ResearchQuestionDetail>;
+  decompose(rqId: string): Promise<ResearchQuestionDetail>;
+  remove(rqId: string): Promise<void>;
+}
+
+type QueueListener = (jobs: readonly CoverageQuestionJob[], event: CoverageQuestionQueueEvent) => void;
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * A small renderer-side lane for question decomposition.
+ *
+ * Creating a coverage question used to await the provider call directly from the
+ * form, so the form was locked until it finished and a second question could not
+ * be submitted. This queue accepts all of them immediately and runs exactly one
+ * decomposition at a time. The database row is only announced to the catalogue
+ * after its sub-questions are ready.
+ */
+export class CoverageQuestionQueue {
+  private jobs: CoverageQuestionJob[] = [];
+  private listeners = new Set<QueueListener>();
+  private draining = false;
+  private sequence = 0;
+
+  constructor(private readonly deps: CoverageQuestionQueueDeps) {}
+
+  snapshot(): readonly CoverageQuestionJob[] {
+    return this.jobs.map((job) => ({ ...job }));
+  }
+
+  subscribe(listener: QueueListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  enqueue(input: { vaultId: string; question: string; notes?: string }): CoverageQuestionJob {
+    const job: CoverageQuestionJob = {
+      id: `coverage-question-${Date.now()}-${++this.sequence}`,
+      vaultId: input.vaultId,
+      question: input.question.trim(),
+      notes: input.notes?.trim() || undefined,
+      status: 'queued',
+      rqId: null,
+      error: null,
+    };
+    this.jobs.push(job);
+    this.emit({ type: 'changed' });
+    void this.drain();
+    return { ...job };
+  }
+
+  dismiss(id: string): void {
+    const job = this.jobs.find((item) => item.id === id);
+    if (!job || job.status !== 'failed') return;
+    this.jobs = this.jobs.filter((item) => item.id !== id);
+    this.emit({ type: 'changed' });
+  }
+
+  private emit(event: CoverageQuestionQueueEvent): void {
+    const jobs = this.snapshot();
+    for (const listener of this.listeners) listener(jobs, event);
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      let job = this.jobs.find((item) => item.status === 'queued');
+      while (job) {
+        job.status = 'running';
+        this.emit({ type: 'changed' });
+
+        try {
+          const activeVaultId = await this.deps.activeVaultId();
+          if (activeVaultId !== job.vaultId) {
+            throw new Error('La bóveda activa cambió antes de procesar esta pregunta.');
+          }
+
+          const created = await this.deps.create({ question: job.question, notes: job.notes });
+          job.rqId = created.rq.id;
+          this.emit({ type: 'changed' });
+
+          if ((await this.deps.activeVaultId()) !== job.vaultId) {
+            throw new Error('La bóveda activa cambió antes de procesar esta pregunta.');
+          }
+          await this.deps.decompose(created.rq.id);
+          this.jobs = this.jobs.filter((item) => item.id !== job!.id);
+          this.emit({ type: 'ready', vaultId: job.vaultId, rqId: created.rq.id });
+        } catch (error) {
+          // A half-created draft is not a ready queue result. Remove it when it is
+          // still safe to address the same vault, while preserving the original
+          // provider error in the queue for the user to inspect.
+          let removed = false;
+          let activeVaultId: string | null = null;
+          try {
+            activeVaultId = await this.deps.activeVaultId();
+          } catch {
+            // Keep the draft hidden in the catalogue if the active vault cannot be checked.
+          }
+          if (job.rqId && activeVaultId === job.vaultId) {
+            try {
+              await this.deps.remove(job.rqId);
+              removed = true;
+            } catch {
+              // The decomposition error is the actionable one; cleanup is best-effort.
+            }
+          }
+          if (removed) job.rqId = null;
+          job.status = 'failed';
+          job.error = messageFromError(error);
+          this.emit({ type: 'changed' });
+        }
+
+        job = this.jobs.find((item) => item.status === 'queued');
+      }
+    } finally {
+      this.draining = false;
+      // A submission can land between the last lookup and this finally block.
+      if (this.jobs.some((item) => item.status === 'queued')) void this.drain();
+    }
+  }
+}
+
+export const coverageQuestionQueue = new CoverageQuestionQueue({
+  activeVaultId: async () => (await window.nodus.getActiveVault())?.id ?? null,
+  create: (input) => window.nodus.createResearchQuestion(input),
+  decompose: (rqId) => window.nodus.decomposeResearchQuestion({ rqId, model: null }),
+  remove: (rqId) => window.nodus.deleteResearchQuestion(rqId),
+});

--- a/src/views/CoverageWorkspace.tsx
+++ b/src/views/CoverageWorkspace.tsx
@@ -101,6 +101,7 @@ export function CoverageWorkspace({
       >
         {tab === 'map' && (
           <ResearchMapView
+            vaultId={vaultId}
             onOpenGraph={onOpenGraph}
             onOpenAssistant={onOpenAssistant}
             onOpenDebates={openDebates}

--- a/src/views/ResearchMapView.tsx
+++ b/src/views/ResearchMapView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   ResearchQuestion,
   ResearchQuestionDetail,
@@ -7,15 +7,21 @@ import type {
   RqMapProgress,
   RqSubQuestion,
 } from '@shared/types';
+import { localizeRuntimeError } from '@shared/uiLanguage';
 import { Badge, Icon, Spinner } from '../components/ui';
+import { confirm } from '../components/feedback';
 import { SourceCitationModal, type CitationTarget } from '../components/SourceCitationModal';
+import {
+  coverageQuestionQueue,
+  type CoverageQuestionJob,
+} from '../coverageQuestionQueue';
 import { useDataRefresh } from '../hooks';
 import {
   ASSISTANT_CONTEXTS,
   type PendingAssistantNavigationTarget,
   type PendingGraphNavigationTarget,
 } from '../navigation';
-import { t, tx } from '../i18n';
+import { getActiveLang, t, tx } from '../i18n';
 
 type BadgeColor = 'green' | 'amber' | 'red' | 'indigo' | 'neutral' | 'cyan';
 const STATUS: Record<RqCoverageStatus, { label: string; color: BadgeColor; icon: string }> = {
@@ -31,18 +37,24 @@ interface SubDraft {
   rationale: string | null;
 }
 
-type Busy = 'create' | 'decompose' | 'map' | 'save' | null;
+type Busy = 'decompose' | 'map' | 'save' | null;
 
 export function ResearchMapView({
+  vaultId,
   onOpenGraph,
   onOpenAssistant,
   onOpenDebates,
 }: {
+  vaultId: string | null;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
   onOpenAssistant: (target?: PendingAssistantNavigationTarget) => void;
   onOpenDebates: () => void;
 }) {
   const [questions, setQuestions] = useState<ResearchQuestion[]>([]);
+  const [questionsLoading, setQuestionsLoading] = useState(true);
+  const [queuedQuestions, setQueuedQuestions] = useState<readonly CoverageQuestionJob[]>(() =>
+    coverageQuestionQueue.snapshot()
+  );
   const [detail, setDetail] = useState<ResearchQuestionDetail | null>(null);
   const [newQuestion, setNewQuestion] = useState('');
   const [newNotes, setNewNotes] = useState('');
@@ -51,20 +63,51 @@ export function ResearchMapView({
   const [progress, setProgress] = useState<RqMapProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [citation, setCitation] = useState<CitationTarget>(null);
+  const listRequest = useRef(0);
 
-  const reloadList = useCallback(() => {
-    void window.nodus.listResearchQuestions().then(setQuestions);
-  }, []);
+  const reloadList = useCallback(async () => {
+    const request = ++listRequest.current;
+    if (!vaultId) {
+      setQuestions([]);
+      setQuestionsLoading(false);
+      return;
+    }
+    setQuestionsLoading(true);
+    try {
+      const next = await window.nodus.listResearchQuestions();
+      if (request === listRequest.current) setQuestions(next);
+    } catch (err) {
+      if (request === listRequest.current) setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (request === listRequest.current) setQuestionsLoading(false);
+    }
+  }, [vaultId]);
 
   useEffect(() => {
     reloadList();
   }, [reloadList]);
   useDataRefresh(reloadList);
 
+  useEffect(
+    () =>
+      coverageQuestionQueue.subscribe((jobs, event) => {
+        setQueuedQuestions(jobs);
+        if (event.type === 'ready' && event.vaultId === vaultId) void reloadList();
+      }),
+    [reloadList, vaultId]
+  );
+
   const syncDetail = useCallback((d: ResearchQuestionDetail | null) => {
     setDetail(d);
     setSubDraft(d ? d.subQuestions.map((s) => ({ id: s.id, text: s.text, rationale: s.rationale })) : []);
   }, []);
+
+  useEffect(() => {
+    syncDetail(null);
+    setError(null);
+    setNewQuestion('');
+    setNewNotes('');
+  }, [syncDetail, vaultId]);
 
   const openQuestion = useCallback(
     (id: string) => {
@@ -87,16 +130,13 @@ export function ResearchMapView({
     }
   }, []);
 
-  const createAndDecompose = () =>
-    run('create', async () => {
-      const created = await window.nodus.createResearchQuestion({ question: newQuestion.trim(), notes: newNotes.trim() || undefined });
-      setNewQuestion('');
-      setNewNotes('');
-      reloadList();
-      const decomposed = await window.nodus.decomposeResearchQuestion({ rqId: created.rq.id, model: null });
-      syncDetail(decomposed);
-      reloadList();
-    });
+  const enqueueQuestion = () => {
+    const question = newQuestion.trim();
+    if (!vaultId || !question) return;
+    coverageQuestionQueue.enqueue({ vaultId, question, notes: newNotes.trim() || undefined });
+    setNewQuestion('');
+    setNewNotes('');
+  };
 
   const redecompose = () =>
     detail &&
@@ -136,12 +176,20 @@ export function ResearchMapView({
       reloadList();
     });
 
-  const removeQuestion = (id: string) =>
-    run(null, async () => {
+  const removeQuestion = async (id: string, question: string) => {
+    const approved = await confirm({
+      title: t('Eliminar'),
+      message: tx('Se eliminará «{title}». Esta acción no se puede deshacer.', { title: question }),
+      confirmLabel: t('Eliminar'),
+      danger: true,
+    });
+    if (!approved) return;
+    void run(null, async () => {
       await window.nodus.deleteResearchQuestion(id);
       if (detail?.rq.id === id) syncDetail(null);
-      reloadList();
+      await reloadList();
     });
+  };
 
   const exportMap = () =>
     detail &&
@@ -162,6 +210,10 @@ export function ResearchMapView({
       return next;
     });
 
+  const queueForVault = queuedQuestions.filter((job) => job.vaultId === vaultId);
+  const inFlightIds = new Set(queueForVault.map((job) => job.rqId).filter((id): id is string => Boolean(id)));
+  const visibleQuestions = questions.filter((question) => !inFlightIds.has(question.id));
+
   return (
     <div data-testid="coverage-catalog" className="flex h-full min-h-0 bg-white dark:bg-neutral-950">
       <aside className="flex w-64 min-h-0 shrink-0 flex-col border-r border-neutral-200 dark:border-neutral-800">
@@ -171,8 +223,9 @@ export function ResearchMapView({
           </button>
         </div>
         <div className="flex-1 min-h-0 overflow-auto p-2 space-y-1">
-          {questions.length === 0 && <p className="text-xs text-neutral-500 p-2">{t('Aún no hay preguntas.')}</p>}
-          {questions.map((q) => (
+          {questionsLoading && <div className="p-2"><Spinner label={t('Cargando…')} /></div>}
+          {!questionsLoading && visibleQuestions.length === 0 && <p className="text-xs text-neutral-500 p-2">{t('Aún no hay preguntas.')}</p>}
+          {visibleQuestions.map((q) => (
             <button
               key={q.id}
               className={`w-full rounded-md p-2 text-left text-sm ${detail?.rq.id === q.id ? 'bg-indigo-50 text-indigo-700 dark:bg-neutral-800 dark:text-neutral-100' : 'hover:bg-neutral-100 dark:hover:bg-neutral-900'}`}
@@ -211,9 +264,35 @@ export function ResearchMapView({
               value={newNotes}
               onChange={(e) => setNewNotes(e.target.value)}
             />
-            <button className="btn btn-primary text-sm gap-1.5" onClick={createAndDecompose} disabled={!newQuestion.trim() || busy === 'create'}>
-              {busy === 'create' ? <Spinner label={t('Descomponiendo…')} /> : (<><Icon name="wand" size={14} /> {t('Crear y descomponer')}</>)}
+            <button className="btn btn-primary text-sm gap-1.5" onClick={enqueueQuestion} disabled={!vaultId || !newQuestion.trim()}>
+              <Icon name="layers" size={14} /> {t('Añadir a la cola')}
             </button>
+
+            {queueForVault.length > 0 && (
+              <div className="mt-4 space-y-2" data-testid="coverage-question-queue">
+                {queueForVault.map((job) => (
+                  <div key={job.id} className={`rounded-md border px-3 py-2 text-xs ${job.status === 'failed' ? 'border-red-300 bg-red-50 dark:border-red-900/60 dark:bg-red-950/30' : 'border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/60'}`}>
+                    <div className="flex items-center gap-2">
+                      <Icon
+                        name={job.status === 'running' ? 'sync' : job.status === 'failed' ? 'alert' : 'clock'}
+                        size={12}
+                        className={job.status === 'running' ? 'animate-spin text-indigo-300' : job.status === 'failed' ? 'text-red-400' : 'text-neutral-500'}
+                      />
+                      <span className="min-w-0 flex-1 truncate text-neutral-700 dark:text-neutral-300" title={job.question}>{job.question}</span>
+                      <span className={job.status === 'failed' ? 'text-red-400' : 'text-neutral-500'}>
+                        {job.status === 'running' ? t('Descomponiendo…') : job.status === 'failed' ? t('Falló') : t('En cola')}
+                      </span>
+                      {job.status === 'failed' && (
+                        <button className="text-neutral-500 hover:text-neutral-300" onClick={() => coverageQuestionQueue.dismiss(job.id)} title={t('Quitar')}>
+                          <Icon name="x" size={12} />
+                        </button>
+                      )}
+                    </div>
+                    {job.error && <p className="mt-1 text-red-500/90 dark:text-red-400/80">{localizeRuntimeError(job.error, getActiveLang())}</p>}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
 
@@ -222,7 +301,7 @@ export function ResearchMapView({
             <div className="card p-4 mb-4">
               <div className="flex items-start gap-3">
                 <p className="text-base font-medium flex-1">{detail.rq.question}</p>
-                <button className="btn btn-ghost text-xs" onClick={() => removeQuestion(detail.rq.id)} title={t('Borrar')}>
+                <button className="btn btn-ghost text-xs" onClick={() => void removeQuestion(detail.rq.id, detail.rq.question)} title={t('Borrar')}>
                   <Icon name="trash" size={14} />
                 </button>
               </div>


### PR DESCRIPTION
## Summary

- reload saved Coverage questions whenever the active vault becomes available or changes
- require destructive confirmation before deleting a coverage question
- allow multiple questions to be queued and decomposed serially
- reveal each question in the catalogue only after it is ready
- keep later jobs moving after a failure and clean up half-created drafts when safe

## Root cause

The Coverage catalogue loaded only on the component's initial mount and did not depend on the active vault, so an early empty response could remain visible. Question creation also awaited decomposition directly inside the form, which locked submissions to one at a time, and deletion called the repository without a confirmation boundary.

## User impact

Saved questions now appear reliably, destructive deletion is guarded, and researchers can submit several questions without waiting for each decomposition to finish.

## Validation

- `node scripts/test-coverage-question-queue.mjs`
- `node --test scripts/test-coverage-workspace-ui.mjs`
- `node --test scripts/test-i18n-coverage.mjs`
- `eslint src/coverageQuestionQueue.ts src/views/ResearchMapView.tsx src/views/CoverageWorkspace.tsx`
- `tsc --noEmit -p tsconfig.json`

Closes #424