### PR TITLE
Prepare Nodus 4.1.1

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -65,7 +65,7 @@ jobs:
           scripts/test-server-vectors.mjs
 
       - name: Build smoke-test image
-        run: docker build --build-arg NODUS_VERSION=4.1.0 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
+        run: docker build --build-arg NODUS_VERSION=4.1.1 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
 
       - name: Run image health smoke test
         shell: bash
@@ -115,7 +115,7 @@ jobs:
             org.opencontainers.image.description=Experimental self-hosted Nodus MCP server
             org.opencontainers.image.source=https://github.com/Drakonis96/nodus
             org.opencontainers.image.licenses=AGPL-3.0-only
-            org.opencontainers.image.version=4.1.0
+            org.opencontainers.image.version=4.1.1
             org.opencontainers.image.revision=${{ github.sha }}
             app.nodus.stability=experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 4.1.1 — 2026-08-14
+
+Nodus 4.1.1 adds a Cloudflare deployment owned entirely by the person who runs it, publishes the
+complete Nodus Wiki and vault manuals, and corrects Global Library file handling, Coverage question
+loading, the Contradictions graph and several editor and modal details.
+
+### Added
+
+- Direct user-owned Cloudflare deployment through the official Deploy to Cloudflare wizard, which
+  creates D1 and R2 in the owner's own account and publishes a free workers.dev address. Nodus
+  receives no Cloudflare credentials or permissions.
+- Global Library settings for attachment naming, with three author, year and title formats, per
+  file-type selection, name synchronisation and an automatic reading-preparation switch.
+- The complete Nodus Wiki and per-vault manuals on the website, with mobile navigation and
+  downloadable PDF manuals.
+
+### Changed
+
+- The Contradictions graph preset is routed through the bounded semantic atlas and preserves both
+  sides of every retained debate.
+- Coverage questions are processed through a serial queue, so several can be launched in a row.
+
+### Fixed
+
+- Saved Coverage questions are reloaded for the active vault, and destructive deletion of a question
+  or a Library note is confirmed first.
+- Internal protected-span markers no longer leak into text-improvement previews or document content,
+  and the synonyms action no longer keeps a persistent outline.
+- Nodi renders immediately in update-related modals, and idea type markers stay circular inside flex
+  layouts.
+- Nodus Server image publication installs workflow dependencies before the server tests and reruns
+  when dependency manifests change.
+
 ## 4.1.0 — 2026-08-13
 
 Nodus 4.1 aligns its research views, workspaces, server and mobile reader around the same

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "4.1.0"
-date-released: "2026-08-13"
+version: "4.1.1"
+date-released: "2026-08-14"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.1.0 is licensed exclusively under the GNU Affero General Public
+Nodus 4.1.1 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.1.0 release is available
+The preferred form for modifying the official Nodus 4.1.1 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.0
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.0
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.0.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.0.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.1
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.1
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.1.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.1.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.1.0 is free software distributed exclusively under the GNU Affero
+Nodus 4.1.1 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/electron/library/libraryCslStyles.ts
+++ b/electron/library/libraryCslStyles.ts
@@ -155,7 +155,7 @@ function repositoryStyleTitle(id: string): string {
 async function officialRepositoryIndex(): Promise<LibraryCitationStyleRepositoryEntry[]> {
   if (!repositoryIndexPromise) {
     repositoryIndexPromise = fetch(OFFICIAL_STYLES_TREE_URL, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.1.0' },
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.1.1' },
     }).then(async (response) => {
       if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
       const payload = await response.json() as { tree?: Array<{ path?: string; type?: string }>; truncated?: boolean };
@@ -246,7 +246,7 @@ export async function installRepositoryCitationStyle(rawId: string): Promise<Lib
   const id = repositoryIdFromUrl(rawId) ?? rawId.trim().toLowerCase().replace(/\.csl$/i, '');
   if (!/^[a-z0-9][a-z0-9._-]{1,199}$/.test(id)) throw new Error('Introduce el identificador de un estilo del repositorio oficial de CSL.');
   const response = await fetch(`${OFFICIAL_STYLES_RAW_URL}/${encodeURIComponent(id)}.csl`, {
-    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.1.0' },
+    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.1.1' },
   });
   if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
   const declaredLength = Number(response.headers.get('content-length') || 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "AGPL-3.0-only",

--- a/scripts/e2e-browser-connector.mjs
+++ b/scripts/e2e-browser-connector.mjs
@@ -66,7 +66,7 @@ async function exercise(colorScheme) {
       scripting: { executeScript: async () => [{ result: detected }] },
       storage: { local: { get: async (defaults) => ({ ...defaults, ...values }), set: async (input) => Object.assign(values, input), remove: async (keys) => { for (const key of keys) delete values[key]; } } },
       permissions: { request: async () => true },
-      runtime: { getManifest: () => ({ version: '4.1.0' }), getURL: (path = '') => `chrome-extension://abcdefghijklmnopabcdefghijklmnop/${path}`, openOptionsPage: async () => undefined },
+      runtime: { getManifest: () => ({ version: '4.1.1' }), getURL: (path = '') => `chrome-extension://abcdefghijklmnopabcdefghijklmnop/${path}`, openOptionsPage: async () => undefined },
     };
   }, { messages: english, detected: { ...snapshot, startPaired: colorScheme === 'dark' } });
   let pairRequests = 0;

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '4.1.0';
+const VERSION = '4.1.1';
 
 test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 4.1.0 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 4.1.1 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -74,7 +74,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '4.1.0');
+      assert.equal(info.version, '4.1.1');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,22 +25,27 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '4.1.0');
-  assert.equal(currentRelease?.date, '2026-08-13');
-  assert.equal(currentRelease?.highlights.length, 9);
+  assert.equal(currentRelease?.version, '4.1.1');
+  assert.equal(currentRelease?.date, '2026-08-14');
+  assert.equal(currentRelease?.highlights.length, 6);
   assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), [
     'academic',
     'academic',
     'academic',
-    'academic',
     'general',
     'general',
     'general',
-    'plugin',
-    'toolkit',
   ]);
-  assert.ok(currentRelease?.highlights.some((highlight) => /hierarchical collections/.test(highlight.en)));
-  assert.ok(currentRelease?.highlights.some((highlight) => /Chrome Web Store/.test(highlight.en)));
+  // The two things a person can go and look at: a deployment they own, and a wiki they can read.
+  assert.ok(currentRelease?.highlights.some((highlight) => /Cloudflare account/.test(highlight.en)));
+  assert.ok(currentRelease?.highlights.some((highlight) => /complete wiki/.test(highlight.en)));
+
+  // 4.1.0 keeps the nine it shipped with. They are published history.
+  const libraryViewsRelease = RELEASE_NOTES.find((note) => note.version === '4.1.0');
+  assert.equal(libraryViewsRelease?.date, '2026-08-13');
+  assert.equal(libraryViewsRelease?.highlights.length, 9);
+  assert.ok(libraryViewsRelease?.highlights.some((highlight) => /hierarchical collections/.test(highlight.en)));
+  assert.ok(libraryViewsRelease?.highlights.some((highlight) => /Chrome Web Store/.test(highlight.en)));
 
   const connectorRelease = RELEASE_NOTES.find((note) => note.version === '4.0.1');
   assert.equal(connectorRelease?.date, '2026-08-12');

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '4.1.0');
+  assert.equal(pluginManifest.version, '4.1.1');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,10 +54,10 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '4\.1\.0'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '4\.1\.1'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.1\.0\.tar\.gz/);
-  assert.match(citation, /^date-released: "2026-08-13"$/m);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.1\.1\.tar\.gz/);
+  assert.match(citation, /^date-released: "2026-08-14"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);
   }

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1244,9 +1244,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '4.1.0', 'the add-on shares the Nodus 4 release version');
+  assert.equal(manifest.version, '4.1.1', 'the add-on shares the Nodus 4 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.1\.0/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.1\.1/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/scripts/verify-browser-connector-server.mjs
+++ b/scripts/verify-browser-connector-server.mjs
@@ -67,7 +67,7 @@ try {
 
   const markerPair = await (await fetch(`${base}/api/browser/pair`, {
     method: 'POST', headers: { ...markerHeaders, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ extensionVersion: '4.1.0', pageUrl: 'https://journal.example/marker' }),
+    body: JSON.stringify({ extensionVersion: '4.1.1', pageUrl: 'https://journal.example/marker' }),
   })).json();
   assert.equal(markerPair.token, 'browser-test-token');
   const markerCatalog = await (await fetch(`${base}/api/browser/catalog`, {
@@ -77,7 +77,7 @@ try {
 
   const pair = await (await fetch(`${base}/api/browser/pair`, {
     method: 'POST', headers: { ...extensionHeaders, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ extensionVersion: '4.1.0', pageUrl: 'https://journal.example/article' }),
+    body: JSON.stringify({ extensionVersion: '4.1.1', pageUrl: 'https://journal.example/article' }),
   })).json();
   assert.equal(pair.token, 'browser-test-token');
   assert.equal(nativePromptCalls, 0, 'enabling the connector is sufficient; pairing never opens a native prompt');

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,13 +3,13 @@
 
 FROM node:22-alpine
 
-ARG NODUS_VERSION=4.1.0
+ARG NODUS_VERSION=4.1.1
 ARG NODUS_REVISION=unknown
 LABEL org.opencontainers.image.title="Nodus Server" \
       org.opencontainers.image.description="Experimental self-hosted Nodus MCP server" \
       org.opencontainers.image.source="https://github.com/Drakonis96/nodus" \
       org.opencontainers.image.url="https://github.com/Drakonis96/nodus" \
-      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.1.0/server/README.md" \
+      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.1.1/server/README.md" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.version="${NODUS_VERSION}" \
       org.opencontainers.image.revision="${NODUS_REVISION}" \
@@ -24,7 +24,7 @@ COPY LICENSE SOURCE_CODE.md THIRD_PARTY_NOTICES.md ./
 ENV NODUS_DATA_DIR=/data \
     NODUS_HOST=0.0.0.0 \
     NODUS_PORT=7443 \
-    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.1.0
+    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.1.1
 
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.1.0 is licensed exclusively under the GNU Affero General Public
+Nodus 4.1.1 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.1.0 release is available
+The preferred form for modifying the official Nodus 4.1.1 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.0
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.0
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.0.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.0.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.1
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.1
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.1.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.1.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.1.0 is free software distributed exclusively under the GNU Affero
+Nodus 4.1.1 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -36,7 +36,7 @@ services:
       # With the pair, the account is created on first boot and its password is rotated
       # whenever you change the value here.
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.1}
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       # Optional ceilings. Unset they default to 8 MiB per image, 2 GiB of images per

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -21,7 +21,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.1}
       # Optional ceilings. Left unset they default to 8 MiB per image, 2 GiB of images per
       # space, and the snapshot limits documented in the README.
       NODUS_MAX_ASSET_BYTES: ${NODUS_MAX_ASSET_BYTES:-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.1}
     volumes:
       - nodus_data:/data
     ports:

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '4.1.0';
+export const NODUS_VERSION = '4.1.1';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/server/portainer-stack.yml
+++ b/server/portainer-stack.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.1}
     volumes:
       - nodus_data:/data
     expose:

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -155,6 +155,14 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "4.1.1": [
+    "La Biblioteca globale ha ora una propria finestra di opzioni. Decidi come vengono nominati i file che aggiungi, con tre formati costruiti da autore, anno e titolo, e a quali tipi si applica. Puoi anche disattivare la preparazione automatica della copia leggibile. Eliminare una nota ora chiede conferma.",
+    "Copertura recupera le tue domande salvate all'apertura del vault attivo. Puoi lanciarne diverse di seguito e vengono elaborate in ordine, una dopo l'altra, senza sovrapporsi. Eliminare una domanda chiede prima conferma.",
+    "Le Contraddizioni ora vengono disegnate nell'atlante semantico, come il resto del grafo. La vista mantiene una dimensione limitata e conserva entrambi i lati di ogni dibattito mostrato. Prima poteva restare con un solo lato della discussione.",
+    "Sono corretti tre dettagli dell'editor e delle finestre. Il pulsante dei sinonimi non resta più con un contorno marcato dopo l'uso. I segni interni che proteggono citazioni e collegamenti smettono di comparire nei miglioramenti del testo e nel documento. Nodi viene disegnato subito nelle finestre di aggiornamento e novità, e i marcatori del tipo di idea tornano rotondi.",
+    "Puoi ospitare il tuo Nodus Cloud sul tuo account Cloudflare. Le Impostazioni aprono l'assistente ufficiale di Cloudflare, che crea il database e l'archiviazione e pubblica un indirizzo gratuito. Nodus non riceve mai le tue credenziali né permessi su quell'account. Il codice pubblicato è tuo e si aggiorna quando lo decidi tu.",
+    "Il sito di Nodus inaugura una wiki completa con manuali per ogni tipo di vault. Ogni sezione spiega le schermate con immagini reali e si legge bene anche dal telefono. I manuali si possono anche scaricare in PDF.",
+  ],
   "4.1.0": [
     "Autori, Idee e Mappa degli argomenti adottano la vista Biblioteca. Gli elenchi riuniscono metadati, etichette e filtri, e ogni elemento apre una scheda ordinata con sintesi, relazioni e contenuto. Stato della ricerca riunisce Copertura, Dibattiti e Lacune nello stesso linguaggio visivo.",
     "Lo Spazio di lavoro ora si comporta come una biblioteca di note e idee in ogni vault. Puoi aggiungere etichette, filtrarle, selezionare più elementi, aprire le azioni con il tasto destro e recuperare il lavoro eliminato dal Cestino.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -95,6 +95,14 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "4.1.1": [
+    "Genel Kitaplık artık kendi seçenekler penceresine sahip. Eklediğiniz dosyaların nasıl adlandırılacağına karar verirsiniz: yazar, yıl ve başlıktan kurulan üç biçim ve bunun hangi dosya türlerine uygulanacağı. Okunabilir kopyanın otomatik hazırlanmasını da kapatabilirsiniz. Bir notu silmek artık onay ister.",
+    "Kapsam, etkin kasayı açtığınızda kayıtlı sorularınızı geri getiriyor. Arka arkaya birkaç tane başlatabilirsiniz ve bunlar sırayla, biri bitince diğeri, çakışmadan işlenir. Bir soruyu silmek önce onay ister.",
+    "Çelişkiler artık grafiğin geri kalanı gibi anlamsal atlasta çiziliyor. Görünüm sınırlı bir boyutta kalıyor ve gösterdiği her tartışmanın iki tarafını da koruyor. Önceden tartışmanın yalnızca bir tarafı elde kalabiliyordu.",
+    "Düzenleyici ve pencerelerle ilgili üç ayrıntı düzeltildi. Eş anlamlılar düğmesi kullanıldıktan sonra artık belirgin bir çerçeveyle kalmıyor. Alıntıları ve bağlantıları koruyan iç işaretler, metin iyileştirmelerinde ve belgede görünmeyi bırakıyor. Nodi güncelleme ve yenilik pencerelerinde hemen çiziliyor ve fikir türü işaretleri yeniden yuvarlak.",
+    "Kendi Nodus Cloud kurulumunuzu kendi Cloudflare hesabınızda çalıştırabilirsiniz. Ayarlar, veritabanını ve depolamayı oluşturan ve ücretsiz bir adres yayımlayan resmî Cloudflare sihirbazını açar. Nodus kimlik bilgilerinizi ya da o hesap üzerinde herhangi bir yetkiyi asla almaz. Yayımlanan kod sizindir ve siz istediğinizde güncellenir.",
+    "Nodus sitesi, her kasa türü için el kitapları içeren eksiksiz bir wiki kazanıyor. Her bölüm ekranları gerçek görüntülerle anlatıyor ve telefondan da rahatça okunuyor. El kitapları ayrıca PDF olarak indirilebiliyor.",
+  ],
   "4.1.0": [
     "Yazarlar, Fikirler ve Argüman Haritası artık Kitaplık görünümünü kullanıyor. Listeler üst verileri, etiketleri ve filtreleri bir araya getiriyor, her öğe sentezi, ilişkileri ve içeriği düzenli bir sekmede açıyor. Araştırmanın Durumu da Kapsam, Tartışmalar ve Boşlukları aynı görsel dilde birleştiriyor.",
     "Çalışma alanı artık her kasada not ve fikirlerden oluşan bir kitaplık gibi davranıyor. Etiket ekleyebilir, etiketlere göre filtreleyebilir, birden fazla öğe seçebilir, sağ tıkla işlemleri açabilir ve silinen çalışmaları Çöp Kutusundan geri getirebilirsiniz.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1080,6 +1080,70 @@ const RELEASE_3_2_4_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+/**
+ * 4.1.1 — the patch that follows 4.1, written for someone who never saw the pull requests.
+ *
+ * Three corrections inside a vault, then three things that appear outside it: your own
+ * Cloudflare deployment, the website wiki, and the small editor and window details that
+ * 4.1 shipped with. Short sentences, no semicolons, no em dashes.
+ */
+const RELEASE_4_1_1_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'academic',
+    es: 'La Biblioteca global estrena su propia ventana de opciones. Decides cómo se nombran los archivos que añades, con tres formatos a partir de autor, año y título, y a qué tipos se aplica. También puedes desactivar la preparación automática de la copia legible. Borrar una nota ahora pide confirmación.',
+    en: 'The Global Library gains its own settings window. You decide how added files are named, with three formats built from author, year and title, and which file types it applies to. You can also turn off the automatic preparation of the readable copy. Deleting a note now asks for confirmation.',
+    fr: 'La Bibliothèque globale reçoit sa propre fenêtre d’options. Vous décidez comment sont nommés les fichiers ajoutés, avec trois formats construits à partir de l’auteur, de l’année et du titre, et à quels types ils s’appliquent. Vous pouvez aussi désactiver la préparation automatique de la copie lisible. La suppression d’une note demande désormais confirmation.',
+    de: 'Die globale Bibliothek erhält ein eigenes Einstellungsfenster. Sie legen fest, wie hinzugefügte Dateien benannt werden, mit drei Formaten aus Autor, Jahr und Titel, und für welche Dateitypen das gilt. Auch die automatische Aufbereitung der lesbaren Kopie lässt sich abschalten. Das Löschen einer Notiz fragt jetzt nach.',
+    pt: 'A Biblioteca global passa a ter a sua própria janela de opções. Decide como são nomeados os ficheiros que adiciona, com três formatos a partir de autor, ano e título, e a que tipos se aplica. Também pode desativar a preparação automática da cópia legível. Apagar uma nota passa a pedir confirmação.',
+    'pt-BR': 'A Biblioteca global ganha sua própria janela de opções. Você decide como são nomeados os arquivos que adiciona, com três formatos a partir de autor, ano e título, e a quais tipos se aplica. Também pode desativar a preparação automática da cópia legível. Excluir uma nota agora pede confirmação.',
+  },
+  {
+    scope: 'academic',
+    es: 'Cobertura recupera tus preguntas guardadas al abrir el vault activo. Puedes lanzar varias seguidas y se procesan en orden, una detrás de otra, sin pisarse. Borrar una pregunta pide confirmación antes de hacerlo.',
+    en: 'Coverage brings back your saved questions when you open the active vault. You can launch several in a row and they are processed in order, one after another, without colliding. Deleting a question asks for confirmation first.',
+    fr: 'Couverture retrouve vos questions enregistrées à l’ouverture du coffre actif. Vous pouvez en lancer plusieurs de suite et elles sont traitées dans l’ordre, l’une après l’autre, sans se gêner. La suppression d’une question demande confirmation au préalable.',
+    de: 'Abdeckung holt Ihre gespeicherten Fragen zurück, wenn Sie den aktiven Tresor öffnen. Sie können mehrere hintereinander starten, und sie werden der Reihe nach abgearbeitet, ohne sich zu stören. Das Löschen einer Frage fragt vorher nach.',
+    pt: 'A Cobertura recupera as suas perguntas guardadas ao abrir o cofre ativo. Pode lançar várias seguidas e são processadas por ordem, uma a seguir à outra, sem se atropelarem. Apagar uma pergunta pede confirmação antes.',
+    'pt-BR': 'A Cobertura recupera suas perguntas salvas ao abrir o cofre ativo. Você pode lançar várias seguidas e elas são processadas em ordem, uma após a outra, sem se atropelar. Excluir uma pergunta pede confirmação antes.',
+  },
+  {
+    scope: 'academic',
+    es: 'Contradicciones se dibuja ahora en el atlas semántico, igual que el resto del grafo. La vista mantiene un tamaño acotado y conserva las dos partes de cada debate que muestra. Antes podía quedarse con un solo lado de la discusión.',
+    en: 'Contradictions is now drawn in the semantic atlas, like the rest of the graph. The view stays within a bounded size and keeps both sides of every debate it shows. Before, it could end up holding only one side of the argument.',
+    fr: 'Contradictions se dessine désormais dans l’atlas sémantique, comme le reste du graphe. La vue conserve une taille bornée et garde les deux côtés de chaque débat affiché. Auparavant, elle pouvait ne retenir qu’un seul côté de la discussion.',
+    de: 'Widersprüche wird jetzt im semantischen Atlas gezeichnet, wie der übrige Graph. Die Ansicht bleibt in ihrer Größe begrenzt und behält beide Seiten jeder gezeigten Debatte. Zuvor konnte nur eine Seite der Auseinandersetzung übrig bleiben.',
+    pt: 'As Contradições passam a desenhar-se no atlas semântico, como o resto do grafo. A vista mantém um tamanho limitado e conserva os dois lados de cada debate que mostra. Antes podia ficar apenas com um lado da discussão.',
+    'pt-BR': 'As Contradições agora são desenhadas no atlas semântico, como o resto do grafo. A visualização mantém um tamanho limitado e conserva os dois lados de cada debate que mostra. Antes podia ficar só com um lado da discussão.',
+  },
+  {
+    scope: 'general',
+    es: 'Se corrigen tres detalles del editor y de las ventanas. El botón de sinónimos ya no se queda con un contorno marcado después de usarlo. Las marcas internas que protegen citas y enlaces dejan de aparecer en las mejoras de texto y en el documento. Nodi se dibuja de inmediato en las ventanas de actualización y novedades, y los marcadores de tipo de idea vuelven a ser redondos.',
+    en: 'Three details of the editor and the windows are corrected. The synonyms button no longer keeps a marked outline after you use it. The internal marks that protect citations and links stop appearing in text improvements and in the document. Nodi is drawn immediately in the update and what’s-new windows, and idea type markers are round again.',
+    fr: 'Trois détails de l’éditeur et des fenêtres sont corrigés. Le bouton des synonymes ne conserve plus un contour marqué après usage. Les marques internes qui protègent citations et liens cessent d’apparaître dans les améliorations de texte et dans le document. Nodi se dessine immédiatement dans les fenêtres de mise à jour et de nouveautés, et les marqueurs de type d’idée redeviennent ronds.',
+    de: 'Drei Details des Editors und der Fenster sind korrigiert. Die Synonym-Schaltfläche behält nach der Nutzung keinen markierten Rahmen mehr. Die internen Marken, die Zitate und Links schützen, erscheinen nicht mehr in Textverbesserungen und im Dokument. Nodi wird in den Update- und Neuigkeitenfenstern sofort gezeichnet, und die Ideentyp-Markierungen sind wieder rund.',
+    pt: 'Corrigem-se três pormenores do editor e das janelas. O botão de sinónimos deixa de ficar com um contorno marcado depois de o usar. As marcas internas que protegem citações e ligações deixam de aparecer nas melhorias de texto e no documento. O Nodi é desenhado de imediato nas janelas de atualização e novidades, e os marcadores de tipo de ideia voltam a ser redondos.',
+    'pt-BR': 'Três detalhes do editor e das janelas foram corrigidos. O botão de sinônimos não fica mais com um contorno marcado depois de usado. As marcas internas que protegem citações e links deixam de aparecer nas melhorias de texto e no documento. O Nodi é desenhado de imediato nas janelas de atualização e novidades, e os marcadores de tipo de ideia voltam a ser redondos.',
+  },
+  {
+    scope: 'general',
+    es: 'Puedes montar tu propio Nodus Cloud en tu cuenta de Cloudflare. Desde Ajustes se abre el asistente oficial de Cloudflare, que crea la base de datos y el almacenamiento y publica una dirección gratuita. Nodus no recibe tus credenciales ni permisos sobre esa cuenta. El código desplegado es tuyo y se actualiza cuando tú quieras.',
+    en: 'You can run your own Nodus Cloud on your Cloudflare account. Settings opens the official Cloudflare wizard, which creates the database and the storage and publishes a free address. Nodus never receives your credentials or any permission over that account. The deployed code is yours and updates when you decide.',
+    fr: 'Vous pouvez héberger votre propre Nodus Cloud sur votre compte Cloudflare. Les Paramètres ouvrent l’assistant officiel de Cloudflare, qui crée la base de données et le stockage puis publie une adresse gratuite. Nodus ne reçoit jamais vos identifiants ni aucune autorisation sur ce compte. Le code déployé vous appartient et se met à jour quand vous le décidez.',
+    de: 'Sie können Ihr eigenes Nodus Cloud in Ihrem Cloudflare-Konto betreiben. Die Einstellungen öffnen den offiziellen Cloudflare-Assistenten, der Datenbank und Speicher anlegt und eine kostenlose Adresse veröffentlicht. Nodus erhält niemals Ihre Zugangsdaten oder Rechte an diesem Konto. Der bereitgestellte Code gehört Ihnen und wird aktualisiert, wenn Sie es möchten.',
+    pt: 'Pode montar o seu próprio Nodus Cloud na sua conta Cloudflare. As Definições abrem o assistente oficial da Cloudflare, que cria a base de dados e o armazenamento e publica um endereço gratuito. O Nodus nunca recebe as suas credenciais nem permissões sobre essa conta. O código publicado é seu e atualiza-se quando quiser.',
+    'pt-BR': 'Você pode montar o seu próprio Nodus Cloud na sua conta Cloudflare. As Configurações abrem o assistente oficial da Cloudflare, que cria o banco de dados e o armazenamento e publica um endereço gratuito. O Nodus nunca recebe suas credenciais nem permissões sobre essa conta. O código publicado é seu e se atualiza quando você quiser.',
+  },
+  {
+    scope: 'general',
+    es: 'La web de Nodus estrena una wiki completa con manuales por tipo de bóveda. Cada sección explica las pantallas con capturas reales y se puede leer desde el móvil. Los manuales también se descargan en PDF.',
+    en: 'The Nodus website gains a complete wiki with manuals for each vault type. Every section explains the screens with real captures and reads well on a phone. The manuals can also be downloaded as PDF.',
+    fr: 'Le site de Nodus inaugure un wiki complet avec des manuels par type de coffre. Chaque section explique les écrans avec de vraies captures et se lit depuis un téléphone. Les manuels se téléchargent aussi en PDF.',
+    de: 'Die Nodus-Website erhält ein vollständiges Wiki mit Handbüchern für jeden Tresortyp. Jeder Abschnitt erklärt die Bildschirme mit echten Aufnahmen und liest sich auch auf dem Telefon gut. Die Handbücher lassen sich zudem als PDF herunterladen.',
+    pt: 'O site do Nodus estreia uma wiki completa com manuais por tipo de cofre. Cada secção explica os ecrãs com capturas reais e lê-se a partir do telemóvel. Os manuais também podem ser descarregados em PDF.',
+    'pt-BR': 'O site do Nodus estreia uma wiki completa com manuais por tipo de cofre. Cada seção explica as telas com capturas reais e pode ser lida no celular. Os manuais também podem ser baixados em PDF.',
+  },
+];
+
 const RELEASE_4_1_0_HIGHLIGHTS: RawReleaseHighlight[] = [
   {
     scope: 'academic',
@@ -1261,6 +1325,11 @@ const RELEASE_4_0_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '4.1.1',
+    date: '2026-08-14',
+    highlights: RELEASE_4_1_1_HIGHLIGHTS,
+  },
   {
     version: '4.1.0',
     date: '2026-08-13',

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
Opens 4.1.1 and writes its what's-new notes.

- Bumps the desktop, Nodus Server, browser extension and Zotero plugin to 4.1.1, together with the source-offer documents, container metadata and the tests that pin the release number.
- Adds `RELEASE_4_1_1_HIGHLIGHTS` with six highlights in the eight interface languages, covering Global Library settings, Coverage question loading and queueing, Contradictions in the semantic atlas, the editor and modal corrections, the user-owned Cloudflare deployment and the new website wiki.
- Records the same ground in `CHANGELOG.md`.

`npm test` passes 1863/1863 and `npm run build` (typecheck included) succeeds.