### PR TITLE
Show works before author ideas

### DIFF
--- a/scripts/test-authors-ui.mjs
+++ b/scripts/test-authors-ui.mjs
@@ -32,12 +32,13 @@ test('author and synthesis-matrix clicks open persistent internal tabs', async (
   assert.match(view, /surface === 'matrix' \? 'h-full p-5' : 'hidden'/, 'the synthesis matrix remains mounted as a tab');
 });
 
-test('author detail reads synthesis, searchable ideas and strongest connected authors in that order', async () => {
+test('author detail reads synthesis, works, searchable ideas and strongest connected authors in that order', async () => {
   const view = await readSource('src/views/AuthorsView.tsx');
   const synthesis = view.indexOf('data-testid="author-synthesis"');
+  const works = view.indexOf("{/* 2. Works */}");
   const ideas = view.indexOf('<AuthorIdeasSection');
   const connections = view.indexOf('data-testid="author-connections"');
-  assert.ok(synthesis >= 0 && ideas > synthesis && connections > ideas, 'detail sections follow the requested reading order');
+  assert.ok(synthesis >= 0 && works > synthesis && ideas > works && connections > ideas, 'detail sections follow the requested reading order');
   assert.match(view, /data-testid="author-ideas-search"/);
   assert.match(view, /right\.weight - left\.weight/, 'connected authors are ordered from strongest to weakest');
 });

--- a/src/views/AuthorsView.tsx
+++ b/src/views/AuthorsView.tsx
@@ -617,10 +617,24 @@ function AuthorDossierDetail({
         {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
       </section>
 
-      {/* 2. Searchable idea list */}
+      {/* 2. Works */}
+      {dossier.works.length > 0 && (
+        <section>
+          <h4 className="font-medium mb-2 flex items-center gap-2">
+            <Icon name="book" size={15} className="text-neutral-400" /> {t('Obras')}
+          </h4>
+          <div className="space-y-1">
+            {dossier.works.map((w) => (
+              <AuthorWorkRow key={w.nodus_id} work={w} onOpenIdeas={(work) => setIdeasWork(work)} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 3. Searchable idea list */}
       <AuthorIdeasSection ideas={dossier.ideas} onOpenIdea={setSelectedIdeaId} />
 
-      {/* 3. Connected authors, strongest connection first */}
+      {/* 4. Connected authors, strongest connection first */}
       {connectedAuthors.length > 0 && (
         <section data-testid="author-connections">
           <h4 className="font-medium mb-2 flex items-center gap-2">
@@ -643,19 +657,6 @@ function AuthorDossierDetail({
         </section>
       )}
 
-      {/* Works */}
-      {dossier.works.length > 0 && (
-        <section>
-          <h4 className="font-medium mb-2 flex items-center gap-2">
-            <Icon name="book" size={15} className="text-neutral-400" /> {t('Obras')}
-          </h4>
-          <div className="space-y-1">
-            {dossier.works.map((w) => (
-              <AuthorWorkRow key={w.nodus_id} work={w} onOpenIdeas={(work) => setIdeasWork(work)} />
-            ))}
-          </div>
-        </section>
-      )}
       {worksOpen && (
         <AuthorWorksModal
           authorName={dossier.fullName || author.name}


### PR DESCRIPTION
## Summary

Fixes #429.

The author dossier now displays **Works** immediately after **Synthesis**, before the searchable **Author ideas** section. Connections remain after ideas.

## Root cause

The works block was rendered after the connected-authors block, although the intended reading flow starts from an author's source works.

## Validation

- `node --test scripts/test-authors-ui.mjs`
- `npm run typecheck`
- `npm run build`
- `npm run test:e2e:saved-authors`