### PR TITLE
Remember where each section was left

### DIFF
--- a/scripts/test-incremental-list.mjs
+++ b/scripts/test-incremental-list.mjs
@@ -94,7 +94,9 @@ test('the debates view pages by cards, not by cluster', () => {
 
 test('the argument route picker pages its suggestions', () => {
   const source = read('src/views/ArgumentMapView.tsx');
-  assert.match(source, /useIncrementalList<ArgumentRouteSuggestion>\(filteredSuggestions, ROUTES_PAGE_SIZE\)/);
+  // Trailing arguments are open on purpose: the list also opens wide enough to reach
+  // a restored anchor. What matters here is that it still pages at all.
+  assert.match(source, /useIncrementalList<ArgumentRouteSuggestion>\(filteredSuggestions, ROUTES_PAGE_SIZE[,)]/);
   assert.match(source, /\{shownSuggestions\.map/, 'the picker must render the paged slice');
   assert.doesNotMatch(
     source,

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -1,0 +1,364 @@
+// Leaving a section and coming back should land on the same cut of the corpus.
+//
+// Two halves are tested here. The store itself is exercised for real: it is a plain
+// TypeScript module with no React in it, so esbuild can bundle it and the vault
+// closure can be proved rather than described. The wiring — which sections opt in,
+// what they restore and, above all, what they deliberately do NOT restore — is
+// asserted against the sources, which is where those decisions are visible.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readSource } from './ipc-channel-census.mjs';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const bundleDir = await mkdtemp(path.join(repoRoot, 'node_modules', '.nodus-view-snapshots-'));
+const bundleOf = (source, name) => {
+  const outfile = path.join(bundleDir, name);
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/esbuild'),
+    [
+      path.join(repoRoot, source),
+      '--bundle', '--platform=node', '--format=cjs', '--target=es2022',
+      '--external:react',
+      `--alias:@shared=${path.join(repoRoot, 'shared')}`,
+      `--outfile=${outfile}`,
+    ],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  return require(outfile);
+};
+const store = bundleOf('src/app/viewSnapshots.ts', 'viewSnapshots.cjs');
+const { topAnchorId } = bundleOf('src/listPlacement.ts', 'listPlacement.cjs');
+
+test.after(async () => { await rm(bundleDir, { recursive: true, force: true }); });
+
+const AUTHORS_CUT = { query: 'ricoeur', sortBy: 'ideas', synthFilter: 'with', savedOnly: true, filtersOpen: true };
+
+test('a section that was left with a cut finds it again on the way back', () => {
+  store.clearViewSnapshots();
+  assert.equal(store.readViewSnapshot('vault-a', 'authors'), undefined, 'nothing is remembered before anything is left');
+
+  store.patchViewSnapshot('vault-a', 'authors', AUTHORS_CUT);
+  assert.deepEqual(store.readViewSnapshot('vault-a', 'authors'), AUTHORS_CUT);
+});
+
+test('the two halves of a section merge instead of overwriting each other', () => {
+  store.clearViewSnapshots();
+  // In Autores the tab strip lives in AuthorsView and the filters in its catalogue
+  // child. Each reports only what it owns, and neither may erase the other's half.
+  store.patchViewSnapshot('vault-a', 'authors', AUTHORS_CUT);
+  store.patchViewSnapshot('vault-a', 'authors', { surface: 'author', openAuthor: { id: 'A1', label: 'Ricoeur' }, matrixOpen: false });
+
+  assert.deepEqual(store.readViewSnapshot('vault-a', 'authors'), {
+    ...AUTHORS_CUT,
+    surface: 'author',
+    openAuthor: { id: 'A1', label: 'Ricoeur' },
+    matrixOpen: false,
+  });
+});
+
+test('sections do not share a snapshot', () => {
+  store.clearViewSnapshots();
+  store.patchViewSnapshot('vault-a', 'authors', AUTHORS_CUT);
+  store.patchViewSnapshot('vault-a', 'ideas', { search: 'mímesis', sortKey: 'connections' });
+
+  assert.equal(store.readViewSnapshot('vault-a', 'authors').query, 'ricoeur');
+  assert.equal(store.readViewSnapshot('vault-a', 'ideas').search, 'mímesis');
+});
+
+test('a snapshot is closed to the vault it was taken in', () => {
+  store.clearViewSnapshots();
+  store.patchViewSnapshot('vault-a', 'authors', AUTHORS_CUT);
+
+  // The whole app assumes a single active vault. Another vault's cut is not merely
+  // hidden, it is discarded: a second surviving set would be a second answer to
+  // "where was I", and the check lives in the read so that a section mounting in the
+  // same commit as a vault change cannot see the old one.
+  assert.equal(store.readViewSnapshot('vault-b', 'authors'), undefined, 'another vault sees nothing');
+
+  store.patchViewSnapshot('vault-b', 'ideas', { search: 'genealogía' });
+  assert.equal(store.readViewSnapshot('vault-a', 'authors'), undefined, 'switching vault discards the previous cut');
+  assert.equal(store.readViewSnapshot('vault-b', 'ideas').search, 'genealogía');
+});
+
+test('with no vault there is nothing to read and nothing to write', () => {
+  store.clearViewSnapshots();
+  store.patchViewSnapshot(null, 'authors', AUTHORS_CUT);
+  assert.equal(store.readViewSnapshot(null, 'authors'), undefined);
+  assert.equal(store.readViewSnapshot('vault-a', 'authors'), undefined, 'a vault-less write is a no-op, not a write to whoever comes next');
+});
+
+test('the shell binds the vault once so a section cannot reach another one', () => {
+  store.clearViewSnapshots();
+  const access = store.viewSnapshotAccess('vault-a');
+  access.patch('authors', AUTHORS_CUT);
+  assert.deepEqual(access.read('authors'), AUTHORS_CUT);
+
+  // A section never holds a vault id for this purpose, so it cannot get it wrong.
+  const other = store.viewSnapshotAccess('vault-b');
+  assert.equal(other.read('authors'), undefined);
+});
+
+// ── Phase two: the place inside the list ──────────────────────────────────────
+
+/**
+ * A scroller whose rows are 100px tall, stacked from its own top edge. Only the four
+ * calls `topAnchorId` makes are needed, which is what lets the binary search be
+ * tested for real instead of described.
+ */
+function fakeScroller({ rowCount, rowHeight = 100, scrollTop = 0, viewportTop = 0 }) {
+  const rows = Array.from({ length: rowCount }, (_, index) => ({
+    getAttribute: () => `row-${index}`,
+    getBoundingClientRect: () => ({
+      top: viewportTop + index * rowHeight - scrollTop,
+      bottom: viewportTop + (index + 1) * rowHeight - scrollTop,
+    }),
+  }));
+  return {
+    getBoundingClientRect: () => ({ top: viewportTop, bottom: viewportTop + 500 }),
+    querySelectorAll: () => rows,
+  };
+}
+
+test('the row reported as the anchor is the one crossing the top edge', () => {
+  assert.equal(topAnchorId(fakeScroller({ rowCount: 500 })), 'row-0', 'at rest the first row is the anchor');
+  assert.equal(topAnchorId(fakeScroller({ rowCount: 500, scrollTop: 300 })), 'row-3', 'an exact boundary belongs to the row below it');
+  assert.equal(topAnchorId(fakeScroller({ rowCount: 500, scrollTop: 350 })), 'row-3', 'a row half off the top is still the one being read');
+  assert.equal(topAnchorId(fakeScroller({ rowCount: 500, scrollTop: 49_900 })), 'row-499', 'the last row is reachable');
+  // The scroller is not always at the top of the window.
+  assert.equal(topAnchorId(fakeScroller({ rowCount: 20, scrollTop: 250, viewportTop: 180 })), 'row-2');
+  assert.equal(topAnchorId(fakeScroller({ rowCount: 0 })), null, 'an empty list has no anchor');
+});
+
+test('a placement is a row id, never a pixel offset', async () => {
+  const types = await readSource('src/app/viewSnapshots.ts');
+  assert.match(types, /anchorId: string/);
+  assert.match(types, /pageOffset\?: number/, 'the page is a hint, absent where the renderer pages');
+  // Row heights change with the window and with the content, and a virtualised list
+  // has not even measured the rows it has not reached.
+  for (const measurement of ['scrollTop', 'scrollOffset', 'scrollY', 'offsetTop']) {
+    assert.doesNotMatch(types, new RegExp(`^\\s*${measurement}[?]?:`, 'm'), `${measurement} is not a place`);
+  }
+});
+
+test('every paged section restores its page and its row together, or neither', async () => {
+  const sections = {
+    'src/views/AuthorsView.tsx': 'authors',
+    'src/views/IdeasView.tsx': 'ideas',
+    'src/views/Library.tsx': 'the vault library',
+    'src/views/GlobalLibraryView.tsx': 'the global catalogue',
+  };
+  for (const [file, label] of Object.entries(sections)) {
+    const source = await readSource(file);
+    assert.match(source, /useState\(\(\) => snapshot\?\.placement\?\.pageOffset \?\? 0\)/, `${label} reopens on the stored page`);
+    assert.match(source, /snapshot\?\.placement\?\.anchorId \?\? null/, `${label} reopens on the stored row`);
+    // A page whose anchor is gone is the half-restored state this exists to avoid.
+    assert.match(source, /setPageOffset\(0\)|setOffset\(0\)/, `${label} falls back to the first page`);
+  }
+});
+
+test('a list that pages in the renderer loads until the anchor appears', async () => {
+  const [hooks, argument] = await Promise.all([readSource('src/hooks.ts'), readSource('src/views/ArgumentMapView.tsx')]);
+  assert.match(hooks, /ensureIndex\?: number/, 'the incremental list can be asked to open wide enough for a row');
+  assert.match(hooks, /Math\.ceil\(\(ensureIndex! \+ 1\) \/ pageSize\) \* pageSize/, 'it opens whole pages up to that row');
+  assert.match(hooks, /!ensured\.current && anchored && items\.length > 0/, 'the first real page does not collapse the pages opened for the anchor');
+  assert.match(argument, /findIndex\(\(suggestion\) => suggestion\.ideaId === anchorId\)/);
+  assert.match(argument, /ROUTES_PAGE_SIZE, undefined, anchorIndex/);
+});
+
+test('a virtualised list anchors against its own geometry, because the row is not in the DOM yet', async () => {
+  const virtualList = await readSource('src/components/VirtualList.tsx');
+  assert.match(virtualList, /anchorKey\?: React\.Key \| null/);
+  assert.match(virtualList, /onAnchorChange\?: \(key: React\.Key \| null\) => void/);
+  assert.match(virtualList, /const target = variableLayout \? variableLayout\.offsets\[index\] : index \* \(itemHeight as number\)/);
+  // Reporting the top row before the restore has run would overwrite the placement
+  // being restored: the list renders at scroll zero first.
+  assert.match(virtualList, /anchorSettled\.current/);
+  for (const library of ['src/views/Library.tsx', 'src/views/GlobalLibraryView.tsx']) {
+    const source = await readSource(library);
+    assert.match(source, /anchorKey=\{restoreAnchorId\}/);
+    // Scroll must not go through React state: it fires every frame, and this view
+    // would re-render whole — sidebar, detail pane and all — for each one.
+    assert.match(source, /placementRef\.current = key === null \? null : \{ anchorId: String\(key\), pageOffset/);
+  }
+});
+
+test('the effects that reset the page skip their own first run', async () => {
+  // Arriving with a restored filter would otherwise reset the restored page a frame
+  // later, and the reader would land on page one having been promised page three.
+  for (const file of ['src/views/AuthorsView.tsx', 'src/views/IdeasView.tsx']) {
+    const source = await readSource(file);
+    assert.match(source, /if \(!cutChanged\.current\) \{\s*cutChanged\.current = true;\s*return;\s*\}/, `${file} guards its page reset`);
+  }
+  const global = await readSource('src/views/GlobalLibraryView.tsx');
+  assert.match(global, /if \(!searchSettled\.current\) \{\s*searchSettled\.current = true;\s*return;\s*\}/, 'the search debounce does not fire on arrival');
+});
+
+test('changing the cut throws the place away with it', async () => {
+  for (const file of ['src/views/AuthorsView.tsx', 'src/views/IdeasView.tsx']) {
+    const source = await readSource(file);
+    assert.match(source, /setAnchorId\(null\);\s*report\.current\?\.\(\{ placement: null \}\)/, `${file} drops the anchor with the filter`);
+  }
+});
+
+test('every anchored list marks its rows with the id they will be found by', async () => {
+  const lists = {
+    'src/views/AuthorsView.tsx': 'author.author_id',
+    'src/views/IdeasView.tsx': 'node.id',
+    'src/views/ArgumentMapView.tsx': 's.ideaId',
+    'src/views/WorkspaceView.tsx': 'note.id',
+  };
+  for (const [file, expression] of Object.entries(lists)) {
+    const source = await readSource(file);
+    assert.match(source, new RegExp(`data-anchor-id=\\{${expression.replace(/\./g, '\\.')}\\}`), `${file} marks its rows`);
+    assert.match(source, /ref=\{(scrollerRef|routesScrollerRef|listRef)\}/, `${file} anchors against its scroller`);
+  }
+});
+
+// ── The two sections added after phase one ────────────────────────────────────
+
+test('the workspace keeps its collection, its filters, its expanded folders and its open notes', async () => {
+  const view = await readSource('src/views/WorkspaceView.tsx');
+  for (const restored of ['scope', 'search', 'kindFilter', 'selectedTags', 'openIds', 'activeId']) {
+    assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
+  }
+  // A Set does not survive a plain object, and the expanded folders are the reader's
+  // route back to what they were reading.
+  assert.match(view, /new Set\(snapshot\?\.expanded \?\? \[\]\)/);
+  assert.match(view, /expanded: \[\.\.\.expanded\]/);
+
+  const registry = await readSource('src/app/views/corpus.tsx');
+  // The same view is a different section of the app under the other vault types.
+  assert.match(registry, /snapshots\.read\('workspace'\)/);
+  assert.match(registry, /snapshots\.read\('notes'\)/);
+});
+
+test('the argument map keeps its route filters but never reopens a built map', async () => {
+  const [view, types] = await Promise.all([
+    readSource('src/views/ArgumentMapView.tsx'),
+    readSource('src/app/viewSnapshots.ts'),
+  ]);
+  for (const restored of ['mode', 'seedId', 'suggestionSearch', 'minConnections', 'routeSort']) {
+    assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
+  }
+  // Redrawing the map means rebuilding it, and in AI mode that is a model call spent
+  // on the act of walking back into the section.
+  assert.doesNotMatch(view, /useState[^\n]*snapshot\?\.openArgumentMap/, 'the open map is not restored');
+  assert.doesNotMatch(types, /openArgumentMap/, 'and it is not even stored');
+  assert.match(view, /const \[surface, setSurface\] = useState<ArgumentMapSurface>\('catalog'\)/, 'a returning reader lands on the catalogue');
+});
+
+test('the snapshot store lives above the single render point and outside React state', async () => {
+  const [app, context] = await Promise.all([readSource('src/App.tsx'), readSource('src/app/ViewContext.ts')]);
+
+  assert.match(app, /viewSnapshotAccess\(activeVault\?\.id \?\? null\)/, 'the active vault is bound in one place');
+  assert.match(app, /const snapshots = useMemo\(/, 'the access object is stable across renders');
+  assert.match(app, /^\s*snapshots,$/m, 'the sections receive it through the view context');
+  assert.match(context, /snapshots: ViewSnapshotAccess/);
+  // As React state, every keystroke in a search box would re-render the whole shell.
+  assert.doesNotMatch(app, /useState[^\n]*ViewSnapshots/, 'the snapshots are not shell state');
+});
+
+test('the three opted-in sections receive their snapshot the way they already receive a target', async () => {
+  const registry = await readSource('src/app/views/corpus.tsx');
+  for (const view of ['library', 'ideas', 'authors']) {
+    assert.match(registry, new RegExp(`snapshots\\.read\\('${view}'\\)`), `${view} is handed its snapshot`);
+    assert.match(registry, new RegExp(`snapshots\\.patch\\('${view}',`), `${view} reports its snapshot back`);
+  }
+});
+
+test('a snapshot is an initial value, never a reactive prop', async () => {
+  const sources = await Promise.all([
+    readSource('src/views/AuthorsView.tsx'),
+    readSource('src/views/IdeasView.tsx'),
+    readSource('src/views/GlobalLibraryView.tsx'),
+    readSource('src/views/Library.tsx'),
+  ]);
+  for (const source of sources) {
+    assert.match(source, /useState\([^)]*\(\) => snapshot\?\./, 'restored through a lazy initialiser');
+    // Re-applying the snapshot after mount would fight the reader for control of
+    // their own filters on every render of the shell.
+    assert.doesNotMatch(source, /useEffect\(\(\) => \{[^}]*\}, \[snapshot\]\)/, 'the snapshot is not re-applied after mount');
+    assert.match(source, /reportSnapshot|report\.current = onSnapshotChange/, 'the callback identity stays out of the effect deps');
+  }
+});
+
+test('Autores restores its filters, its ordering and its open tab', async () => {
+  const view = await readSource('src/views/AuthorsView.tsx');
+  for (const restored of ['sortBy', 'synthFilter', 'savedOnly', 'filtersOpen', 'query']) {
+    assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
+  }
+  // Both halves of the search box start from the stored text, or the debounce fires
+  // on mount and wipes the restored cut back to the whole corpus.
+  assert.match(view, /const \[query, setQuery\] = useState\(\(\) => snapshot\?\.query \?\? ''\)/);
+  assert.match(view, /const \[queryFilter, setQueryFilter\] = useState\(\(\) => snapshot\?\.query \?\? ''\)/);
+  // A tab that is no longer open cannot be the active one.
+  assert.match(view, /surface === 'author' && !snapshot\?\.openAuthor\) return 'catalog'/);
+  assert.match(view, /surface === 'matrix' && !snapshot\?\.matrixOpen\) return 'catalog'/);
+});
+
+test('Ideas restores its filters and its open idea together with the selection behind it', async () => {
+  const view = await readSource('src/views/IdeasView.tsx');
+  for (const restored of ['search', 'typeFilter', 'sortKey', 'filtersOpen', 'openIdea']) {
+    assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
+  }
+  assert.match(view, /setSelectedId[\s\S]{0,120}snapshot\?\.openIdea\?\.id/, 'the open tab and the detail it shows are restored as a pair');
+});
+
+test('Biblioteca keeps a cut per scope, and only what nothing else already persists', async () => {
+  const [wrapper, vaultLibrary, types] = await Promise.all([
+    readSource('src/views/GlobalLibraryView.tsx'),
+    readSource('src/views/Library.tsx'),
+    readSource('src/app/viewSnapshots.ts'),
+  ]);
+
+  // One sidebar section, two engines behind the scope switch. Blending their filters
+  // would apply a cut of the global catalogue to the vault's own library.
+  assert.match(wrapper, /snapshot=\{snapshot\?\.vault\}/);
+  assert.match(wrapper, /snapshot=\{snapshot\?\.global\}/);
+  assert.match(vaultLibrary, /useState<WorkFilter>\(\(\) => snapshot\?\.filter \?\? \{\}\)/);
+  for (const facet of ['source', 'extraction', 'itemType', 'yearFrom', 'yearTo', 'facetTag', 'facetVault', 'attachmentFilter']) {
+    assert.match(wrapper, new RegExp(`snapshot\\?\\.filters\\.${facet}`), `${facet} survives leaving the section`);
+  }
+  // Sorting and columns are already written to disk, and the scope lives in settings.
+  assert.doesNotMatch(types, /visibleColumns|columnWidths/, 'the snapshot does not duplicate what the Library persists itself');
+  assert.doesNotMatch(types, /scope: LibraryScope/, 'the scope is settings, not a snapshot');
+});
+
+test('the page and the row are one field, so neither can be restored without the other', async () => {
+  const types = await readSource('src/app/viewSnapshots.ts');
+  // The whole point of the single field: there is no way to express a restored page
+  // with no row, or a row with no page, because they are not separate values.
+  assert.match(types, /placement: ListPlacement \| null/, 'every section stores its place as one value');
+  assert.doesNotMatch(types, /^\s*pageOffset[?]?: number;\s*$\n\s*$/m, 'the page is never a field of its own');
+  const declarations = types.match(/^\s*(pageOffset|anchorId)[?]?:/gm) ?? [];
+  assert.equal(declarations.length, 2, 'the page and the row are declared once each, inside ListPlacement');
+
+  // Six sections, one contract.
+  const placements = (types.match(/placement: ListPlacement \| null/g) ?? []).length;
+  assert.equal(placements, 6, 'authors, ideas, both libraries, the workspace and the argument routes');
+});
+
+test('ephemeral state dies on the way out', async () => {
+  const types = await readSource('src/app/viewSnapshots.ts');
+  // Open modals, spinners, in-flight errors, export selections and half-typed input
+  // are not a place to return to. `filtersOpen` and `matrixOpen` are not modals:
+  // one is part of the cut and the other is a tab.
+  for (const forbidden of [
+    'loading', 'error', 'exporting', 'exportMsg', 'searchDraft', 'detailId', 'trashMode',
+    'zoteroOpen', 'migrationOpen', 'duplicatesOpen', 'recoveryOpen', 'confirmDelete',
+  ]) {
+    assert.doesNotMatch(types, new RegExp(`\\b${forbidden}\\b`), `${forbidden} is ephemeral`);
+  }
+  // What is stored is the applied search, not the draft in the box.
+  const authors = await readSource('src/views/AuthorsView.tsx');
+  assert.match(authors, /report\.current\?\.\(\{ query: queryFilter,/);
+  const global = await readSource('src/views/GlobalLibraryView.tsx');
+  assert.match(global, /currentSnapshot = useCallback\(\(\): LibraryGlobalSnapshot => \(\{\s*search,/, 'the global catalogue stores the applied search');
+});

--- a/scripts/test-workspace-ui.mjs
+++ b/scripts/test-workspace-ui.mjs
@@ -139,7 +139,7 @@ test('every vault uses the Workspace experience without losing its own section n
     assert.match(vaultTypes, scoped, `${replaced} is no longer offered in the academic vault`);
     assert.match(vaultTypes, new RegExp(`${replaced}: \\[[^\\]]*'genealogy'`), `${replaced} survives untouched elsewhere`);
   }
-  assert.match(registry, /workspace: \(\{ navigate, noteTarget, settings \}\)/, 'the academic Workspace is routable');
+  assert.match(registry, /workspace: \(\{ navigate, noteTarget, settings[,\s}]/, 'the academic Workspace is routable');
   assert.match(registry, /notes:[\s\S]*<WorkspaceView[\s\S]*title="Notas"/,
     'general Notes routes reuse the same Workspace catalogue, tabs and editor');
   assert.match(registry, /isPrimarySources[\s\S]*<PrimarySourcesNotesView/,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import { VIEW_REGISTRY } from './app/viewRegistry';
 import type { ViewContext } from './app/ViewContext';
 import { notifyDataChanged, useDataRefresh } from './hooks';
 import { setActiveVaultQueryScope } from './vaultQueryCache';
+import { viewSnapshotAccess } from './app/viewSnapshots';
 import type {
   PendingAssistantNavigationTarget,
   PendingGraphNavigationTarget,
@@ -185,6 +186,12 @@ export function App() {
   const newInstallRef = useRef<boolean | null>(null);
   const [newInstall, setNewInstall] = useState(false);
   useEffect(() => setActiveVaultQueryScope(activeVault?.id ?? null), [activeVault?.id]);
+  // Where each section was when it was last left. It lives above the single render
+  // point because that is what survives the unmount, and outside React state
+  // because it is read only when a section mounts: as state, every keystroke in a
+  // search box would re-render the whole shell. The active vault is bound in once,
+  // here, so no section can read another vault's cut.
+  const snapshots = useMemo(() => viewSnapshotAccess(activeVault?.id ?? null), [activeVault?.id]);
   // Resolved light/dark (accounts for 'system'); drives the macOS dock icon.
   const [isDark, setIsDark] = useState<boolean>(() =>
     typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -1141,6 +1148,7 @@ export function App() {
     isTestimonios,
     isProsopography,
     isPreviewVault,
+    snapshots,
     hasData,
     demoBusy,
     lastSync,

--- a/src/app/ViewContext.ts
+++ b/src/app/ViewContext.ts
@@ -21,6 +21,7 @@ import type {
 } from '../navigation';
 import type { StudyNavigationTarget } from '../components/StudySidebar';
 import type { DossierTab } from '../components/testimonies/InterviewDossier';
+import type { ViewSnapshotAccess } from './viewSnapshots';
 
 /** A pending navigation carries a nonce so repeating the same target re-triggers it. */
 export type Nonced<T> = T & { nonce: number };
@@ -82,6 +83,13 @@ export interface ViewContext extends VaultFlags {
   studyRecordingTarget: { id: string; timestamp?: number | null } | null;
   studyGraphTarget: Nonced<PendingGraphNavigationTarget> | null;
   studyChatTarget: { prompt: string; nonce: number } | null;
+
+  /**
+   * Where each section was when it was last left: its filters, its ordering and its
+   * open tab, kept above the render point so they outlive the unmount. Already bound
+   * to the active vault, so a section cannot read another vault's cut.
+   */
+  snapshots: ViewSnapshotAccess;
 
   // Navigation.
   setView: (view: View) => void;

--- a/src/app/viewSnapshots.ts
+++ b/src/app/viewSnapshots.ts
@@ -1,0 +1,266 @@
+// What a section remembers when you leave it and come back.
+//
+// Changing `view` swaps the whole element at App.tsx's single render point, so React
+// unmounts the previous section and every `useState` inside it dies. That is on
+// purpose — the alternative, keeping sections mounted and hidden, would leave the
+// heavy lists resident and their effects and timers alive. What it costs is the
+// user's place: the filters, the ordering and the open tab all reset to their
+// defaults, and returning to a section means rebuilding the cut of the corpus by
+// hand.
+//
+// So the sections stay disposable and their *shape* is kept out here instead, above
+// the render point, in a store that outlives them. This is the generalisation of
+// what `toolkitPage` already does in App.tsx for the Toolkit's inner page.
+//
+// Three rules define what belongs in a snapshot:
+//
+//   1. A handful of values per view, not the whole state. What hurts to lose is the
+//      cut: filters, ordering, the active tab. GlobalLibraryView alone holds 91
+//      `useState` calls; 90 of them should die with the view.
+//   2. Nothing ephemeral. Open modals, spinners, in-flight errors, unapplied input
+//      drafts and export selections are gone on the way out, and should be.
+//   3. Page and scroll are one value, never two. See `ListPlacement`.
+//   4. Nothing that costs an action to restore. A snapshot puts the reader back
+//      where they were; it does not re-run work on their behalf. This is why the
+//      argument map's open tab is not kept: redrawing it means rebuilding it, and
+//      in AI mode that would spend a model call for the act of entering a section.
+//
+// The store is deliberately NOT React state. It is read once when a view mounts and
+// written on every filter change; as state it would re-render the whole shell on
+// every keystroke in a search box, and this repo has paid for that before.
+import type { View } from '../navigation';
+import type { LibraryCatalogItem, LibraryItemSource, LibraryItemType } from '@shared/libraryTypes';
+// Type-only, so the lazy view chunks are not pulled in: the unions stay declared
+// once, where the selects that produce them live.
+import type { SortKey as AuthorsSortKey, SynthFilter as AuthorsSynthFilter } from '../views/AuthorsView';
+import type { SortKey as IdeasSortKey } from '../views/IdeasView';
+import type { RouteSortKey as ArgumentRouteSortKey } from '../views/ArgumentMapView';
+import type { WorkspaceItemKind } from '../views/WorkspaceView';
+import type { IdeaType, WorkFilter } from '@shared/types';
+import type { SortState } from '../views/Library';
+
+/** An open inner tab: enough to redraw the tab strip and refetch its contents. */
+export interface OpenEntityTab {
+  id: string;
+  label: string;
+}
+
+/**
+ * The reader's place inside a list — one value, never two.
+ *
+ * Page and scroll only mean something together. A restored page without its scroll
+ * position puts the reader in front of row 201 with no context: neither where they
+ * were nor a clean start, which is worse than restoring nothing. So both live in
+ * this one field, and it is written and read as a unit.
+ *
+ * The place is an id, not a pixel offset. Row heights change with the window width
+ * and with the content, and virtualised lists do not even have the rows measured
+ * until they are near the viewport, so a stored `scrollTop` points somewhere else on
+ * the next visit. An id still means the same row.
+ *
+ * `pageOffset` is a hint, not the answer: it says which page the row was on so the
+ * anchor can be found in one request instead of walking every page from the start.
+ * If the anchor is not on that page — the corpus changed, the row was deleted — the
+ * list falls back to the first page and the top. It never keeps half a placement.
+ */
+export interface ListPlacement {
+  /** The row that was at the top of the viewport. */
+  anchorId: string;
+  /**
+   * Which page it was on, so the anchor is reachable in one request. Absent for the
+   * lists that page inside the renderer, where "load until this id appears" is the
+   * whole of it and there is no page to hint at.
+   */
+  pageOffset?: number;
+}
+
+export interface AuthorsSnapshot {
+  /** 'author' is only reachable with `openAuthor` set; the pair travels together. */
+  surface: 'catalog' | 'author' | 'matrix';
+  openAuthor: OpenEntityTab | null;
+  matrixOpen: boolean;
+  query: string;
+  sortBy: AuthorsSortKey;
+  synthFilter: AuthorsSynthFilter;
+  savedOnly: boolean;
+  filtersOpen: boolean;
+  placement: ListPlacement | null;
+}
+
+export interface IdeasSnapshot {
+  surface: 'catalog' | 'idea';
+  openIdea: OpenEntityTab | null;
+  search: string;
+  typeFilter: IdeaType | '';
+  sortKey: IdeasSortKey;
+  filtersOpen: boolean;
+  placement: ListPlacement | null;
+}
+
+/**
+ * Notes, folders and their open editors. The tree's expanded folders are part of the
+ * cut: collapsing back to the root loses the reader's route to what they were
+ * reading just as surely as dropping the filter does.
+ */
+export interface WorkspaceSnapshot {
+  scope: WorkspaceScope;
+  expanded: string[];
+  search: string;
+  kindFilter: WorkspaceItemKind | '';
+  selectedTags: string[];
+  openIds: string[];
+  activeId: string | null;
+  placement: ListPlacement | null;
+}
+
+/** Mirrors WorkspaceView's `Scope`: the collection or pseudo-collection on show. */
+export type WorkspaceScope =
+  | { kind: 'all' }
+  | { kind: 'unfiled' }
+  | { kind: 'trash' }
+  | { kind: 'collection'; id: string };
+
+/**
+ * The route catalogue only. The open map tab is deliberately absent: it holds no
+ * data of its own, so redrawing it means rebuilding it, and in AI mode that would
+ * spend a model call on the act of walking back into the section. Reopening a map
+ * stays a thing the reader asks for.
+ */
+export interface ArgumentSnapshot {
+  mode: 'auto' | 'ai';
+  seedId: string;
+  suggestionSearch: string;
+  minConnections: number;
+  routeSort: ArgumentRouteSortKey;
+  placement: ListPlacement | null;
+}
+
+/**
+ * The seven facets as one unit, because that is how a reader thinks of them: the
+ * cut is kept or it is dropped, never half of it.
+ */
+export interface LibraryFacetsSnapshot {
+  source: LibraryItemSource | '';
+  extraction: LibraryCatalogItem['extractionStatus'] | '';
+  itemType: LibraryItemType | '';
+  yearFrom: string;
+  yearTo: string;
+  facetTag: string;
+  facetVault: string;
+  attachmentFilter: '' | 'with' | 'without';
+}
+
+/**
+ * Sorting and visible columns are absent on purpose: the global catalogue already
+ * persists those to disk through `setGlobalLibraryViewPreferences`. Only what
+ * nothing else keeps belongs here.
+ */
+export interface LibraryGlobalSnapshot {
+  search: string;
+  selectedCollection: string | null;
+  selectedSavedSearch: string | null;
+  filters: LibraryFacetsSnapshot;
+  filtersOpen: boolean;
+  placement: ListPlacement | null;
+}
+
+/** The vault-scoped library states its whole cut as one `WorkFilter`. */
+export interface LibraryVaultSnapshot {
+  filter: WorkFilter;
+  sort: SortState | null;
+  filtersOpen: boolean;
+  advancedFiltersOpen: boolean;
+  placement: ListPlacement | null;
+}
+
+/**
+ * One section, two engines: the Biblioteca entry renders the vault library or the
+ * global catalogue depending on the scope switch, and each keeps its own cut so
+ * that flipping the switch does not blend two unrelated sets of filters. The scope
+ * itself is not here — it already lives in settings.
+ */
+export interface LibrarySnapshot {
+  vault?: LibraryVaultSnapshot;
+  global?: LibraryGlobalSnapshot;
+}
+
+/** One optional entry per section that has opted in. Keys are `View` members. */
+export interface ViewSnapshots {
+  authors?: AuthorsSnapshot;
+  ideas?: IdeasSnapshot;
+  library?: LibrarySnapshot;
+  workspace?: WorkspaceSnapshot;
+  /**
+   * The same view under the name the non-academic vaults give it. They are separate
+   * sections of the app and only one of them exists at a time, so they keep separate
+   * cuts rather than sharing one.
+   */
+  notes?: WorkspaceSnapshot;
+  argument?: ArgumentSnapshot;
+}
+
+export type SnapshotView = keyof ViewSnapshots;
+
+/** Adding a key that is not a section of the app stops this file compiling. */
+type AssertKeysAreViews = SnapshotView extends View ? true : never;
+const _keysAreViews: AssertKeysAreViews = true;
+void _keysAreViews;
+
+/**
+ * Exactly one vault's snapshots exist at a time. Switching vault discards them
+ * rather than indexing them: the whole app assumes a single active vault, and a
+ * second surviving set would be a second answer to "where was I".
+ */
+let slot: { vaultId: string; values: ViewSnapshots } | null = null;
+
+/**
+ * Undefined for a different vault, and for no vault at all — same contract as
+ * `getVaultQueryCache`. The vault check lives in the read, not in an effect, so a
+ * view that mounts in the same commit as a vault change cannot see the old cut.
+ */
+export function readViewSnapshot<K extends SnapshotView>(
+  vaultId: string | null | undefined,
+  view: K,
+): ViewSnapshots[K] | undefined {
+  if (!vaultId || slot?.vaultId !== vaultId) return undefined;
+  return slot.values[view];
+}
+
+/**
+ * Merges a partial update into the section's snapshot. Partial because a section's
+ * state is not all in one component: in Autores the tab strip lives in AuthorsView
+ * and the filters in its AuthorsCatalog child, and each reports only its own half.
+ */
+export function patchViewSnapshot<K extends SnapshotView>(
+  vaultId: string | null | undefined,
+  view: K,
+  patch: Partial<NonNullable<ViewSnapshots[K]>>,
+): void {
+  if (!vaultId) return;
+  if (slot?.vaultId !== vaultId) slot = { vaultId, values: {} };
+  const current = slot.values[view];
+  slot.values[view] = { ...(current ?? {}), ...patch } as ViewSnapshots[K];
+}
+
+/** Drop everything. For vault deletion, imports and tests. */
+export function clearViewSnapshots(): void {
+  slot = null;
+}
+
+/** What the shell hands to the registry, with the active vault already bound in. */
+export interface ViewSnapshotAccess {
+  read<K extends SnapshotView>(view: K): ViewSnapshots[K] | undefined;
+  patch<K extends SnapshotView>(view: K, patch: Partial<NonNullable<ViewSnapshots[K]>>): void;
+}
+
+/**
+ * Binding the vault once, here, is why a view never receives it for this purpose:
+ * a section cannot read another vault's snapshot by mistake because it never holds
+ * the key to one.
+ */
+export function viewSnapshotAccess(vaultId: string | null | undefined): ViewSnapshotAccess {
+  return {
+    read: (view) => readViewSnapshot(vaultId, view),
+    patch: (view, patch) => patchViewSnapshot(vaultId, view, patch),
+  };
+}

--- a/src/app/views/corpus.tsx
+++ b/src/app/views/corpus.tsx
@@ -22,9 +22,14 @@ const PrimarySourcesNotesView = lazy(() => import('../../views/PrimarySourcesNot
 const TestimonySearchView = lazy(() => import('../../views/TestimonySearchView').then((module) => ({ default: module.TestimonySearchView })));
 
 export const corpusViews = {
-  library: ({ activeVault, isPrimarySources, libraryTarget, navigate, openAssistant, reloadSettings, setCollectionsOpen, settings, setView }) => (
+  // `snapshot` is the same shape as `target` and `initialTab`: a starting value the
+  // shell hands down, read once at mount. `onSnapshotChange` is the return path, so
+  // the cut survives the unmount that leaving the section causes.
+  library: ({ activeVault, isPrimarySources, libraryTarget, navigate, openAssistant, reloadSettings, setCollectionsOpen, settings, setView, snapshots }) => (
     <GlobalLibraryView
       target={libraryTarget}
+      snapshot={snapshots.read('library')}
+      onSnapshotChange={(patch) => snapshots.patch('library', patch)}
       settings={settings}
       vaultId={activeVault?.id ?? null}
       vaultType={activeVault?.type}
@@ -37,19 +42,29 @@ export const corpusViews = {
     />
   ),
   graph: ({ graphTarget, reloadSettings, settings }) => <GraphView settings={settings} onSettingsChange={reloadSettings} target={graphTarget} />,
-  argument: ({ settings }) => <ArgumentMapView settings={settings} />,
-  ideas: ({ activeVault, ideaTarget, navigate, openAssistant }) => (
+  argument: ({ settings, snapshots }) => (
+    <ArgumentMapView
+      settings={settings}
+      snapshot={snapshots.read('argument')}
+      onSnapshotChange={(patch) => snapshots.patch('argument', patch)}
+    />
+  ),
+  ideas: ({ activeVault, ideaTarget, navigate, openAssistant, snapshots }) => (
     <IdeasView
       vaultId={activeVault?.id ?? null}
       target={ideaTarget}
+      snapshot={snapshots.read('ideas')}
+      onSnapshotChange={(patch) => snapshots.patch('ideas', patch)}
       onOpenGraph={(target) => navigate('graph', target)}
       onOpenAssistant={openAssistant}
     />
   ),
-  authors: ({ activeVault, navigate, settings }) => (
+  authors: ({ activeVault, navigate, settings, snapshots }) => (
     <AuthorsView
       vaultId={activeVault?.id ?? null}
       settings={settings}
+      snapshot={snapshots.read('authors')}
+      onSnapshotChange={(patch) => snapshots.patch('authors', patch)}
       onOpenGraph={(target) => navigate('graph', target)}
     />
   ),
@@ -139,20 +154,24 @@ export const corpusViews = {
 
   // Notas, ideas y colecciones con una única experiencia visual. La ruta académica
   // conserva el nombre Espacio de trabajo; el resto entra por su sección Notas.
-  workspace: ({ navigate, noteTarget, settings }) => (
+  workspace: ({ navigate, noteTarget, settings, snapshots }) => (
     <WorkspaceView
       settings={settings}
       focusNote={noteTarget}
+      snapshot={snapshots.read('workspace')}
+      onSnapshotChange={(patch) => snapshots.patch('workspace', patch)}
       onOpenGraph={(target) => navigate('graph', target)}
     />
   ),
 
-  notes: ({ isPrimarySources, isTestimonios, navigate, noteTarget, openPrimarySourceTarget, openTestimonyLink, settings }) => (isPrimarySources
+  notes: ({ isPrimarySources, isTestimonios, navigate, noteTarget, openPrimarySourceTarget, openTestimonyLink, settings, snapshots }) => (isPrimarySources
     ? <PrimarySourcesNotesView focusNote={noteTarget} onOpenSource={openPrimarySourceTarget} />
     : (
       <WorkspaceView
         settings={settings}
         title="Notas"
+        snapshot={snapshots.read('notes')}
+        onSnapshotChange={(patch) => snapshots.patch('notes', patch)}
         onOpenGraph={(target) => navigate('graph', target)}
         focusNote={noteTarget}
         onTestimonyLink={isTestimonios ? openTestimonyLink : undefined}

--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 interface VirtualListProps<T> {
   items: T[];
@@ -10,6 +10,14 @@ interface VirtualListProps<T> {
   style?: React.CSSProperties;
   overscan?: number;
   empty?: React.ReactNode;
+  /**
+   * A row to bring back under the top edge, once, when it appears among `items`.
+   * The DOM-based anchoring the plain lists use cannot work here: the row to scroll
+   * to is usually not rendered yet, and only this component knows where it would be.
+   */
+  anchorKey?: React.Key | null;
+  /** The row now at the top of the viewport, reported as the reader scrolls. */
+  onAnchorChange?: (key: React.Key | null) => void;
 }
 
 export function VirtualList<T>({
@@ -21,10 +29,17 @@ export function VirtualList<T>({
   style,
   overscan = 8,
   empty,
+  anchorKey = null,
+  onAnchorChange,
 }: VirtualListProps<T>) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
+  // Reporting the top row while the restore is still pending would overwrite the
+  // very placement being restored: the list renders at scroll zero first.
+  const anchorSettled = useRef(anchorKey === null);
+  const reportAnchor = useRef(onAnchorChange);
+  reportAnchor.current = onAnchorChange;
 
   useLayoutEffect(() => {
     const el = scrollRef.current;
@@ -46,7 +61,7 @@ export function VirtualList<T>({
     return { heights, offsets };
   }, [itemHeight, items]);
 
-  const { start, end, offset, totalHeight } = useMemo(() => {
+  const { start, end, offset, totalHeight, topIndex } = useMemo(() => {
     const count = items.length;
     if (!variableLayout) {
       const fixedHeight = itemHeight as number;
@@ -54,7 +69,8 @@ export function VirtualList<T>({
       const rawFirst = Math.max(0, Math.floor(scrollTop / fixedHeight) - overscan);
       const first = Math.min(rawFirst, Math.max(0, count - capacity));
       const last = Math.min(count, Math.ceil((scrollTop + viewportHeight) / fixedHeight) + overscan);
-      return { start: first, end: last, offset: first * fixedHeight, totalHeight: count * fixedHeight };
+      const top = count === 0 ? 0 : Math.min(count - 1, Math.floor(scrollTop / fixedHeight));
+      return { start: first, end: last, offset: first * fixedHeight, totalHeight: count * fixedHeight, topIndex: top };
     }
     const { offsets } = variableLayout;
 
@@ -78,10 +94,32 @@ export function VirtualList<T>({
       end: last,
       offset: offsets[first],
       totalHeight: offsets[count],
+      topIndex: count === 0 ? 0 : indexAt(scrollTop),
     };
   }, [itemHeight, items.length, overscan, scrollTop, variableLayout, viewportHeight]);
 
   const visibleItems = items.slice(start, end);
+
+  // Put the anchored row back under the top edge, once, as soon as it exists. A row
+  // that never turns up leaves the list where it is and simply releases the hold on
+  // capture: deciding what to do about a vanished anchor belongs to the caller, which
+  // is the only one that knows how to go back to the first page.
+  useLayoutEffect(() => {
+    if (anchorSettled.current || anchorKey === null || items.length === 0) return;
+    const index = items.findIndex((item, position) => getKey(item, position) === anchorKey);
+    anchorSettled.current = true;
+    if (index < 0) return;
+    const element = scrollRef.current;
+    if (!element) return;
+    const target = variableLayout ? variableLayout.offsets[index] : index * (itemHeight as number);
+    element.scrollTop = target;
+    setScrollTop(target);
+  }, [anchorKey, getKey, itemHeight, items, variableLayout]);
+
+  const topKey = items.length > 0 && topIndex < items.length ? getKey(items[topIndex], topIndex) : null;
+  useEffect(() => {
+    if (anchorSettled.current) reportAnchor.current?.(topKey);
+  }, [topKey]);
 
   return (
     <div

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -91,12 +91,34 @@ export function useScanComplete(onComplete: () => void): void {
 export function useIncrementalList<T, E extends HTMLElement = HTMLDivElement>(
   items: T[],
   pageSize: number,
-  weight?: (item: T) => number
+  weight?: (item: T) => number,
+  /**
+   * A row that must be on screen for the list to be usable — the anchor a returning
+   * reader is being scrolled back to. Here "load until this id appears" is literal:
+   * the list opens with enough pages to include it instead of one. Consumed once, so
+   * the reader's own paging is never fought.
+   *
+   * Only meaningful without `weight`: with one, `count` is a budget rather than a row
+   * count, and a row index says nothing about how much budget reaching it costs.
+   */
+  ensureIndex?: number
 ): { visible: T[]; hasMore: boolean; sentinelRef: RefObject<E>; showMore: () => void } {
-  const [count, setCount] = useState(pageSize);
+  const anchored = ensureIndex !== undefined && ensureIndex >= 0 && !weight;
+  const initialCount = () => (anchored
+    ? Math.max(pageSize, Math.ceil((ensureIndex! + 1) / pageSize) * pageSize)
+    : pageSize);
+  const [count, setCount] = useState(initialCount);
   const sentinelRef = useRef<E>(null);
+  const ensured = useRef(false);
 
   useEffect(() => {
+    // The first page of real rows must not collapse the pages opened for the anchor:
+    // `items` starts empty and its arrival would otherwise reset the count.
+    if (!ensured.current && anchored && items.length > 0) {
+      ensured.current = true;
+      setCount(initialCount());
+      return;
+    }
     setCount(pageSize);
   }, [items, pageSize]);
 

--- a/src/listPlacement.ts
+++ b/src/listPlacement.ts
@@ -1,0 +1,127 @@
+// Keeping the reader's place inside a long list, by id.
+//
+// Every section that pages a list needs the same two halves of one behaviour, and
+// getting either half subtly wrong is what makes restored scrolling feel broken:
+//
+//   Capture — which row is at the top of the viewport right now. Read as an id, so
+//   it still means the same row after a re-sort, a resize or a re-measure.
+//
+//   Restore — put that row back under the top edge, ONCE, after the page it lives on
+//   has arrived. If it is not there, the list must go back to the first page and the
+//   top rather than sit on page 3 with nothing to show for it.
+//
+// Rows opt in by carrying `data-anchor-id`. Virtualised lists cannot use this — the
+// row to scroll to is usually not in the DOM yet — so VirtualList implements the same
+// contract against its own geometry instead.
+import { useCallback, useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+/** The attribute a row carries so it can be found again. */
+export const ANCHOR_ATTRIBUTE = 'data-anchor-id';
+
+/**
+ * The first row still crossing the top edge of the scroller.
+ *
+ * Binary search rather than a walk: the argument-route list grows into the thousands
+ * as the reader scrolls, and this runs on every scroll frame. Rows are stacked in
+ * document order, so their edges are monotonic and a search is valid.
+ */
+export function topAnchorId(scroller: HTMLElement): string | null {
+  const rows = scroller.querySelectorAll<HTMLElement>(`[${ANCHOR_ATTRIBUTE}]`);
+  if (rows.length === 0) return null;
+  const edge = scroller.getBoundingClientRect().top + 1;
+  let low = 0;
+  let high = rows.length - 1;
+  let found = rows.length - 1;
+  while (low <= high) {
+    const middle = (low + high) >> 1;
+    if (rows[middle].getBoundingClientRect().bottom > edge) {
+      found = middle;
+      high = middle - 1;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return rows[found].getAttribute(ANCHOR_ATTRIBUTE);
+}
+
+export interface ListPlacementOptions {
+  /** The row to scroll back to, or null. Honoured once, then the reader is in control. */
+  restoreAnchorId: string | null;
+  /**
+   * Changes whenever a page of rows lands in the DOM. The restore waits for it,
+   * because on the first render the list is still empty.
+   */
+  revision: unknown;
+  /**
+   * The anchor was not among the rows that arrived: the row is gone, or the corpus
+   * changed under it. The list must fall back to the first page and the top — a page
+   * without its anchor is the half-restored state this whole mechanism exists to
+   * avoid.
+   */
+  onRestoreMissed: () => void;
+  /** The row now at the top, reported as the reader scrolls. */
+  onCapture: (anchorId: string | null) => void;
+}
+
+/**
+ * Returns the ref to put on the scrolling element. Capture stays silent until the
+ * restore has settled: the list renders at scroll zero first, and reporting that
+ * would overwrite the very placement being restored.
+ */
+export function useListPlacement<E extends HTMLElement>({
+  restoreAnchorId,
+  revision,
+  onRestoreMissed,
+  onCapture,
+}: ListPlacementOptions): RefObject<E> {
+  const scrollerRef = useRef<E>(null);
+  const settled = useRef(restoreAnchorId === null);
+  const frame = useRef<number | null>(null);
+  const missed = useRef(onRestoreMissed);
+  const capture = useRef(onCapture);
+  missed.current = onRestoreMissed;
+  capture.current = onCapture;
+
+  useEffect(() => {
+    if (settled.current) return;
+    const scroller = scrollerRef.current;
+    if (!scroller || restoreAnchorId === null) return;
+    const target = scroller.querySelector<HTMLElement>(
+      `[${ANCHOR_ATTRIBUTE}="${CSS.escape(restoreAnchorId)}"]`,
+    );
+    if (target) {
+      scroller.scrollTop += target.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+      settled.current = true;
+      return;
+    }
+    // Rows arrived and the anchor is not among them.
+    if (scroller.querySelector(`[${ANCHOR_ATTRIBUTE}]`)) {
+      settled.current = true;
+      scroller.scrollTop = 0;
+      missed.current();
+    }
+  }, [restoreAnchorId, revision]);
+
+  const handleScroll = useCallback(() => {
+    if (!settled.current || frame.current !== null) return;
+    frame.current = requestAnimationFrame(() => {
+      frame.current = null;
+      const scroller = scrollerRef.current;
+      if (scroller) capture.current(topAnchorId(scroller));
+    });
+  }, []);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    scroller.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener('scroll', handleScroll);
+      if (frame.current !== null) cancelAnimationFrame(frame.current);
+      frame.current = null;
+    };
+  }, [handleScroll]);
+
+  return scrollerRef;
+}

--- a/src/views/ArgumentMapView.tsx
+++ b/src/views/ArgumentMapView.tsx
@@ -17,6 +17,8 @@ import {
   type DetailLoading,
 } from '../components/NodeDetailPanel';
 import { useDismissableLayer, useIncrementalList } from '../hooks';
+import type { ArgumentSnapshot } from '../app/viewSnapshots';
+import { useListPlacement } from '../listPlacement';
 import { useFeatureModel } from '../hooks/useFeatureModel';
 import { expandableIdsByDepth } from '../argumentMapTree';
 import { t, tx } from '../i18n';
@@ -57,27 +59,49 @@ function typeColor(type: ArgumentBlock['type']): string {
 // what froze the section; one screenful at a time is enough to scroll from.
 const ROUTES_PAGE_SIZE = 40;
 type ArgumentMapSurface = 'catalog' | 'map';
-type RouteSortKey = 'label' | 'type' | 'connections' | 'debates' | 'confidence';
+/** Exported because the section's snapshot stores it. */
+export type RouteSortKey = 'label' | 'type' | 'connections' | 'debates' | 'confidence';
 type OpenArgumentMap = { ideaId: string; label: string; mode: 'auto' | 'ai' };
 
-export function ArgumentMapView({ settings }: { settings: AppSettings }) {
+export function ArgumentMapView({
+  settings,
+  snapshot,
+  onSnapshotChange,
+}: {
+  settings: AppSettings;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: ArgumentSnapshot;
+  onSnapshotChange?: (patch: Partial<ArgumentSnapshot>) => void;
+}) {
+  // The catalogue is where a returning reader lands, always. The open map holds no
+  // data of its own — redrawing it means rebuilding it, and in AI mode that would
+  // spend a model call on the act of walking back into the section.
   const [surface, setSurface] = useState<ArgumentMapSurface>('catalog');
   const [openArgumentMap, setOpenArgumentMap] = useState<OpenArgumentMap | null>(null);
   const [ideaNodes, setIdeaNodes] = useState<IdeaPickerItem[]>([]);
   const [graphLoaded, setGraphLoaded] = useState(false);
-  const [mode, setMode] = useState<'auto' | 'ai'>('auto');
+  const [mode, setMode] = useState<'auto' | 'ai'>(() => snapshot?.mode ?? 'auto');
   const [suggestions, setSuggestions] = useState<ArgumentRouteSuggestion[]>([]);
   const [suggestionsLoading, setSuggestionsLoading] = useState(false);
   // Only a click on «Actualizar» spins that button's icon. The automatic discovery
   // on entering the section has its own indicator, and spinning both at once read
   // as if the app were refreshing on its own.
   const [refreshing, setRefreshing] = useState(false);
-  const [seedId, setSeedId] = useState('');
+  const [seedId, setSeedId] = useState(() => snapshot?.seedId ?? '');
   const [search, setSearch] = useState('');
   const [seedSearchOpen, setSeedSearchOpen] = useState(false);
-  const [suggestionSearch, setSuggestionSearch] = useState('');
-  const [minConnections, setMinConnections] = useState(0);
-  const [routeSort, setRouteSort] = useState<RouteSortKey>('connections');
+  const [suggestionSearch, setSuggestionSearch] = useState(() => snapshot?.suggestionSearch ?? '');
+  const [minConnections, setMinConnections] = useState(() => snapshot?.minConnections ?? 0);
+  const [routeSort, setRouteSort] = useState<RouteSortKey>(() => snapshot?.routeSort ?? 'connections');
+  const [anchorId, setAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
+
+  // The registry rebuilds the callback on every render of the shell, so a ref keeps
+  // its identity out of the effect's dependencies.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
+  useEffect(() => {
+    report.current?.({ mode, seedId, suggestionSearch, minConnections, routeSort });
+  }, [minConnections, mode, routeSort, seedId, suggestionSearch]);
   const [model, setModel] = useFeatureModel(settings, 'argumentMapModel');
   const [map, setMap] = useState<ArgumentMap | null>(null);
   const [building, setBuilding] = useState(false);
@@ -180,12 +204,27 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
     });
   }, [suggestions, suggestionSearch, minConnections, routeSort]);
 
+  // "Load until this id appears" is literal here: this list pages inside the renderer,
+  // so reaching the anchor and paging to it are the same act.
+  const anchorIndex = anchorId === null
+    ? -1
+    : filteredSuggestions.findIndex((suggestion) => suggestion.ideaId === anchorId);
   const {
     visible: shownSuggestions,
     hasMore: hasMoreSuggestions,
     sentinelRef: suggestionsSentinelRef,
     showMore: showMoreSuggestions,
-  } = useIncrementalList<ArgumentRouteSuggestion>(filteredSuggestions, ROUTES_PAGE_SIZE);
+  } = useIncrementalList<ArgumentRouteSuggestion>(filteredSuggestions, ROUTES_PAGE_SIZE, undefined, anchorIndex);
+
+  const routesScrollerRef = useListPlacement<HTMLDivElement>({
+    restoreAnchorId: anchorId,
+    revision: shownSuggestions,
+    onRestoreMissed: () => {
+      setAnchorId(null);
+      report.current?.({ placement: null });
+    },
+    onCapture: (topId) => report.current?.({ placement: topId ? { anchorId: topId } : null }),
+  });
 
   const stopReveal = useCallback(() => {
     if (revealTimerRef.current != null) {
@@ -449,7 +488,7 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
               </div>
             </div>
           ) : (
-            <div data-testid="argument-routes-table" className="min-h-0 flex-1 overflow-auto">
+            <div ref={routesScrollerRef} data-testid="argument-routes-table" className="min-h-0 flex-1 overflow-auto">
               {error && <div className="m-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-400"><Icon name="alert" /> <span>{error}</span></div>}
               {suggestionsLoading && suggestions.length === 0 ? (
                 <div className="grid h-48 place-items-center text-neutral-500"><Spinner label={t('Detectando recorridos…')} /></div>
@@ -473,6 +512,7 @@ export function ArgumentMapView({ settings }: { settings: AppSettings }) {
                         <button
                           key={s.ideaId}
                           data-testid={`argument-route-${s.ideaId}`}
+                          data-anchor-id={s.ideaId}
                           className="grid min-h-[76px] w-full items-center border-b border-neutral-100 px-4 text-left text-xs transition-colors hover:bg-neutral-50 dark:border-neutral-900 dark:hover:bg-neutral-900/55"
                           style={{ gridTemplateColumns: 'minmax(260px,2fr) 7rem 7rem 6rem 7rem minmax(190px,1.25fr) minmax(230px,1.5fr) 2.5rem' }}
                           onClick={() => build(s.ideaId)}

--- a/src/views/AuthorsView.tsx
+++ b/src/views/AuthorsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   AppSettings,
   AuthorDossier,
@@ -16,6 +16,8 @@ import { WorkIdeasModal } from './WorkIdeasModal';
 import { useDataRefresh, useScanComplete } from '../hooks';
 import { useFeatureModel } from '../hooks/useFeatureModel';
 import type { PendingGraphNavigationTarget } from '../navigation';
+import type { AuthorsSnapshot } from '../app/viewSnapshots';
+import { useListPlacement } from '../listPlacement';
 import { t, tx } from '../i18n';
 import { getVaultQueryCache, invalidateVaultQueryCache, setVaultQueryCache } from '../vaultQueryCache';
 
@@ -40,8 +42,10 @@ const RELATION_COLORS: Record<string, 'red' | 'amber' | 'green' | 'cyan' | 'neut
   coauthor: 'neutral',
 };
 
-type SortKey = 'name' | 'surname' | 'works' | 'ideas' | 'connections';
-type SynthFilter = 'all' | 'with' | 'without';
+// Exported because the section's snapshot stores them; the unions stay declared
+// here, next to the selects that produce them.
+export type SortKey = 'name' | 'surname' | 'works' | 'ideas' | 'connections';
+export type SynthFilter = 'all' | 'with' | 'without';
 const AUTHORS_PAGE_SIZE = 80;
 
 const SORT_LABELS: Record<SortKey, string> = {
@@ -58,20 +62,53 @@ const SYNTH_FILTER_LABELS: Record<SynthFilter, string> = {
   without: 'Sin síntesis',
 };
 
+/**
+ * A tab can only be the active one if it is still open. The pair is written to the
+ * snapshot together, but a closed author with `surface: 'author'` would render an
+ * empty pane, so the surface answers to what actually exists.
+ */
+function restoredSurface(snapshot?: AuthorsSnapshot): AuthorsSurface {
+  const surface = snapshot?.surface ?? 'catalog';
+  if (surface === 'author' && !snapshot?.openAuthor) return 'catalog';
+  if (surface === 'matrix' && !snapshot?.matrixOpen) return 'catalog';
+  return surface;
+}
+
 export function AuthorsView({
   vaultId,
   settings,
+  snapshot,
+  onSnapshotChange,
   onOpenGraph,
 }: {
   vaultId: string | null;
   settings: AppSettings;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: AuthorsSnapshot;
+  onSnapshotChange?: (patch: Partial<AuthorsSnapshot>) => void;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
 }) {
-  const [surface, setSurface] = useState<AuthorsSurface>('catalog');
-  const [openAuthor, setOpenAuthor] = useState<OpenAuthor | null>(null);
-  const [matrixOpen, setMatrixOpen] = useState(false);
+  // Restored as initial values only. A reactive `snapshot` prop would fight the
+  // reader for control of their own tabs on every re-render of the shell.
+  const [openAuthor, setOpenAuthor] = useState<OpenAuthor | null>(() => snapshot?.openAuthor ?? null);
+  const [matrixOpen, setMatrixOpen] = useState(() => snapshot?.matrixOpen ?? false);
+  const [surface, setSurface] = useState<AuthorsSurface>(() => restoredSurface(snapshot));
   const [catalogRevision, setCatalogRevision] = useState(0);
   const [model, setModel] = useFeatureModel(settings, 'authorModel');
+
+  // The registry builds `onSnapshotChange` inline, so its identity changes on every
+  // render of the shell; a ref keeps that out of the effect's dependencies.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
+  useEffect(() => {
+    // Only the id and the label: `saved` is refetched by the tab when it mounts, and
+    // a stale copy of it here would draw the wrong star.
+    report.current?.({
+      surface,
+      matrixOpen,
+      openAuthor: openAuthor ? { id: openAuthor.id, label: openAuthor.label } : null,
+    });
+  }, [matrixOpen, openAuthor, surface]);
 
   const showAuthor = useCallback((author: OpenAuthor) => {
     setOpenAuthor(author);
@@ -135,7 +172,7 @@ export function AuthorsView({
       </header>
 
       <main className="min-h-0 flex-1">
-        <div className={surface === 'catalog' ? 'h-full' : 'hidden'}><AuthorsCatalog vaultId={vaultId} refreshKey={catalogRevision} onOpenAuthor={showAuthor} onOpenMatrix={showMatrix} /></div>
+        <div className={surface === 'catalog' ? 'h-full' : 'hidden'}><AuthorsCatalog vaultId={vaultId} refreshKey={catalogRevision} snapshot={snapshot} onSnapshotChange={onSnapshotChange} onOpenAuthor={showAuthor} onOpenMatrix={showMatrix} /></div>
         {openAuthor && <div className={surface === 'author' ? 'h-full' : 'hidden'}><AuthorDetailTab key={openAuthor.id} author={openAuthor} vaultId={vaultId} model={model} onOpenAuthor={showAuthor} onOpenGraph={onOpenGraph} onSavedChange={() => setCatalogRevision((value) => value + 1)} /></div>}
         {matrixOpen && <div className={surface === 'matrix' ? 'h-full p-5' : 'hidden'}><MatrixTab onOpenGraph={onOpenGraph} model={model} /></div>}
       </main>
@@ -148,25 +185,35 @@ export function AuthorsView({
 function AuthorsCatalog({
   vaultId,
   refreshKey,
+  snapshot,
+  onSnapshotChange,
   onOpenAuthor,
   onOpenMatrix,
 }: {
   vaultId: string | null;
   refreshKey: number;
+  snapshot?: AuthorsSnapshot;
+  onSnapshotChange?: (patch: Partial<AuthorsSnapshot>) => void;
   onOpenAuthor: (author: OpenAuthor) => void;
   onOpenMatrix: () => void;
 }) {
   const [authors, setAuthors] = useState<AuthorSummary[]>([]);
   const [totalAuthors, setTotalAuthors] = useState(0);
-  const [pageOffset, setPageOffset] = useState(0);
+  // The page and the row that was at the top are one restored value. The page alone
+  // would drop the reader in front of row 201 with no context.
+  const [pageOffset, setPageOffset] = useState(() => snapshot?.placement?.pageOffset ?? 0);
+  const [anchorId, setAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [query, setQuery] = useState('');
-  const [queryFilter, setQueryFilter] = useState('');
-  const [sortBy, setSortBy] = useState<SortKey>('surname');
-  const [synthFilter, setSynthFilter] = useState<SynthFilter>('all');
-  const [savedOnly, setSavedOnly] = useState(false);
-  const [filtersOpen, setFiltersOpen] = useState(false);
+  // The search box has two states, the immediate one and the debounced one that
+  // actually queries. Both start from the stored text, or the debounce would fire
+  // on mount and wipe the restored cut back to the whole corpus.
+  const [query, setQuery] = useState(() => snapshot?.query ?? '');
+  const [queryFilter, setQueryFilter] = useState(() => snapshot?.query ?? '');
+  const [sortBy, setSortBy] = useState<SortKey>(() => snapshot?.sortBy ?? 'surname');
+  const [synthFilter, setSynthFilter] = useState<SynthFilter>(() => snapshot?.synthFilter ?? 'all');
+  const [savedOnly, setSavedOnly] = useState(() => snapshot?.savedOnly ?? false);
+  const [filtersOpen, setFiltersOpen] = useState(() => snapshot?.filtersOpen ?? false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [exportFormat, setExportFormat] = useState<'markdown' | 'pdf'>('markdown');
   const [exporting, setExporting] = useState(false);
@@ -214,9 +261,42 @@ function AuthorsCatalog({
     return () => clearTimeout(handle);
   }, [query]);
 
+  // The catalogue reports its own half of the snapshot; the tab strip above reports
+  // the other. The stored text is the applied one, not the draft: half a word typed
+  // on the way out is not a cut worth returning to.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
   useEffect(() => {
+    report.current?.({ query: queryFilter, sortBy, synthFilter, savedOnly, filtersOpen });
+  }, [filtersOpen, queryFilter, savedOnly, sortBy, synthFilter]);
+
+  // Changing the cut throws the place away with it: a row that was at the top of one
+  // filter means nothing under another. It must skip its own first run, though, or
+  // arriving with a restored filter would reset the restored page a frame later.
+  const cutChanged = useRef(false);
+  useEffect(() => {
+    if (!cutChanged.current) {
+      cutChanged.current = true;
+      return;
+    }
     setPageOffset(0);
+    setAnchorId(null);
+    report.current?.({ placement: null });
   }, [queryFilter, savedOnly, sortBy, synthFilter]);
+
+  // Scrolling back to the stored row, once the page holding it has arrived. If it is
+  // not there — deleted, or the corpus changed underneath — the list goes back to the
+  // first page and the top rather than sit on a page with nothing to show for it.
+  const scrollerRef = useListPlacement<HTMLDivElement>({
+    restoreAnchorId: anchorId,
+    revision: authors,
+    onRestoreMissed: () => {
+      setAnchorId(null);
+      setPageOffset(0);
+      report.current?.({ placement: null });
+    },
+    onCapture: (topId) => report.current?.({ placement: topId ? { anchorId: topId, pageOffset } : null }),
+  });
 
   useEffect(() => {
     void reloadAuthors(false);
@@ -341,7 +421,7 @@ function AuthorsCatalog({
         {error && <p role="alert" className="mt-2 text-xs text-red-400">{error}</p>}
       </div>
 
-      <div data-testid="authors-table-scroll" className="min-h-0 flex-1 overflow-auto">
+      <div ref={scrollerRef} data-testid="authors-table-scroll" className="min-h-0 flex-1 overflow-auto">
         <div className="min-w-[1050px]">
           <div className="grid h-10 items-center border-b border-neutral-800 px-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-600" style={{ gridTemplateColumns: '2.25rem minmax(130px,1fr) minmax(150px,1.15fr) 5.5rem 5.5rem 7rem minmax(220px,1.6fr) 6rem 2.5rem' }}>
             <input type="checkbox" checked={allFilteredSelected} onChange={toggleSelectAll} aria-label={t('Seleccionar todos')} />
@@ -357,7 +437,7 @@ function AuthorsCatalog({
           ) : filtered.length === 0 ? (
             <div className="grid h-48 place-items-center p-8 text-center"><div><Icon name="user" size={28} className="mx-auto text-neutral-700" /><p className="mt-3 text-sm text-neutral-400">{t(savedOnly ? queryFilter || synthFilter !== 'all' ? 'No hay autores guardados que coincidan con los filtros.' : 'No has guardado ningún autor todavía.' : 'No hay autores todavía.')}</p></div></div>
           ) : filtered.map((author) => (
-            <div key={author.author_id} data-testid={`author-card-${author.author_id}`} className="grid min-h-[64px] items-center border-b border-neutral-900 px-3 text-xs hover:bg-neutral-900/55" style={{ gridTemplateColumns: '2.25rem minmax(130px,1fr) minmax(150px,1.15fr) 5.5rem 5.5rem 7rem minmax(220px,1.6fr) 6rem 2.5rem' }}>
+            <div key={author.author_id} data-testid={`author-card-${author.author_id}`} data-anchor-id={author.author_id} className="grid min-h-[64px] items-center border-b border-neutral-900 px-3 text-xs hover:bg-neutral-900/55" style={{ gridTemplateColumns: '2.25rem minmax(130px,1fr) minmax(150px,1.15fr) 5.5rem 5.5rem 7rem minmax(220px,1.6fr) 6rem 2.5rem' }}>
               <input type="checkbox" checked={selected.has(author.author_id)} onChange={() => toggleSelect(author.author_id)} aria-label={t('Seleccionar para exportar')} />
               <button data-testid="author-name" className="min-w-0 pr-3 text-left font-medium text-neutral-200 hover:text-indigo-300" onClick={() => onOpenAuthor({ id: author.author_id, label: author.fullName || author.name, saved: author.saved })}><span className="block truncate">{author.firstName || author.fullName || author.name}</span>{author.affiliation && <span className="mt-1 block truncate text-[10px] font-normal text-neutral-600">{author.affiliation}</span>}</button>
               <button className="min-w-0 truncate pr-3 text-left text-neutral-400 hover:text-indigo-300" onClick={() => onOpenAuthor({ id: author.author_id, label: author.fullName || author.name, saved: author.saved })}>{author.lastName || author.name}</button>

--- a/src/views/GlobalLibraryView.tsx
+++ b/src/views/GlobalLibraryView.tsx
@@ -38,6 +38,7 @@ import { confirm, promptText, toast } from '../components/feedback';
 import { t, tx } from '../i18n';
 import type { PendingAssistantNavigationTarget } from '../navigation';
 import type { PendingLibraryNavigationTarget } from '../navigation';
+import type { LibraryGlobalSnapshot, LibrarySnapshot, ListPlacement } from '../app/viewSnapshots';
 import type { PendingGraphNavigationTarget } from '../navigation';
 import { Library } from './Library';
 import { LIBRARY_COLUMN_BY_ID, libraryItemTypeLabel } from '@shared/libraryBibliography';
@@ -727,9 +728,11 @@ function LibraryScopeControls({
 }
 
 function GlobalLibraryContent({
-  target, onOpenSettings, scopeControls, onOpenReader,
+  target, snapshot, onSnapshotChange, onOpenSettings, scopeControls, onOpenReader,
 }: {
   target?: (PendingLibraryNavigationTarget & { nonce: number }) | null;
+  snapshot?: LibraryGlobalSnapshot;
+  onSnapshotChange?: (next: LibraryGlobalSnapshot) => void;
   onOpenSettings: () => void;
   scopeControls: ReactNode;
   onOpenReader: (reference: LibraryReaderReference) => void;
@@ -737,24 +740,27 @@ function GlobalLibraryContent({
   const [status, setStatus] = useState<LibraryStatus | null>(null);
   const [collections, setCollections] = useState<LibraryCollectionView[]>([]);
   const [savedSearches, setSavedSearches] = useState<LibrarySavedSearchRecord[]>([]);
-  const [selectedSavedSearch, setSelectedSavedSearch] = useState<string | null>(null);
+  const [selectedSavedSearch, setSelectedSavedSearch] = useState<string | null>(() => snapshot?.selectedSavedSearch ?? null);
   const [facets, setFacets] = useState<LibraryCatalogFacets>(EMPTY_FACETS);
   const [viewPreferences, setViewPreferences] = useState<LibraryViewPreferences>(DEFAULT_VIEW_PREFERENCES);
   const [librarySettings, setLibrarySettings] = useState<GlobalLibrarySettings>(DEFAULT_GLOBAL_LIBRARY_SETTINGS);
   const [items, setItems] = useState<LibraryCatalogItem[]>([]);
   const [total, setTotal] = useState(0);
-  const [offset, setOffset] = useState(0);
-  const [searchDraft, setSearchDraft] = useState('');
-  const [search, setSearch] = useState('');
-  const [selectedCollection, setSelectedCollection] = useState<string | null>(null);
-  const [source, setSource] = useState<LibraryItemSource | ''>('');
-  const [extraction, setExtraction] = useState<LibraryCatalogItem['extractionStatus'] | ''>('');
-  const [yearFrom, setYearFrom] = useState('');
-  const [yearTo, setYearTo] = useState('');
-  const [itemType, setItemType] = useState<LibraryItemType | ''>('');
-  const [facetTag, setFacetTag] = useState('');
-  const [facetVault, setFacetVault] = useState('');
-  const [attachmentFilter, setAttachmentFilter] = useState<'' | 'with' | 'without'>('');
+  // The page and the row that was at the top are one restored value.
+  const [offset, setOffset] = useState(() => snapshot?.placement?.pageOffset ?? 0);
+  // Restored as initial values only. The draft and the applied search start from the
+  // same text, or the debounce would wipe the restored cut on mount.
+  const [searchDraft, setSearchDraft] = useState(() => snapshot?.search ?? '');
+  const [search, setSearch] = useState(() => snapshot?.search ?? '');
+  const [selectedCollection, setSelectedCollection] = useState<string | null>(() => snapshot?.selectedCollection ?? null);
+  const [source, setSource] = useState<LibraryItemSource | ''>(() => snapshot?.filters.source ?? '');
+  const [extraction, setExtraction] = useState<LibraryCatalogItem['extractionStatus'] | ''>(() => snapshot?.filters.extraction ?? '');
+  const [yearFrom, setYearFrom] = useState(() => snapshot?.filters.yearFrom ?? '');
+  const [yearTo, setYearTo] = useState(() => snapshot?.filters.yearTo ?? '');
+  const [itemType, setItemType] = useState<LibraryItemType | ''>(() => snapshot?.filters.itemType ?? '');
+  const [facetTag, setFacetTag] = useState(() => snapshot?.filters.facetTag ?? '');
+  const [facetVault, setFacetVault] = useState(() => snapshot?.filters.facetVault ?? '');
+  const [attachmentFilter, setAttachmentFilter] = useState<'' | 'with' | 'without'>(() => snapshot?.filters.attachmentFilter ?? '');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [detailId, setDetailId] = useState<string | null>(null);
   const [detail, setDetail] = useState<LibraryItemRecord | null>(null);
@@ -764,7 +770,7 @@ function GlobalLibraryContent({
   const [error, setError] = useState<string | null>(null);
   const [zoteroOpen, setZoteroOpen] = useState(false);
   const [migrationOpen, setMigrationOpen] = useState(false);
-  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(() => snapshot?.filtersOpen ?? false);
   const [collectionTarget, setCollectionTarget] = useState('');
   const [metadataItem, setMetadataItem] = useState<LibraryItemRecord | null>(null);
   const [createReferenceMode, setCreateReferenceMode] = useState<'identifier' | 'manual' | null>(null);
@@ -852,7 +858,55 @@ function GlobalLibraryContent({
     setDetailLinks(links);
   }, []);
 
-  useEffect(() => { const timer = window.setTimeout(() => { setOffset(0); setSearch(searchDraft.trim()); }, 220); return () => window.clearTimeout(timer); }, [searchDraft]);
+  // The debounce must skip its own first run: on arrival the draft already equals the
+  // restored search, and letting it fire would reset the restored page to zero.
+  const searchSettled = useRef(false);
+  useEffect(() => {
+    if (!searchSettled.current) {
+      searchSettled.current = true;
+      return;
+    }
+    const timer = window.setTimeout(() => { setOffset(0); setSearch(searchDraft.trim()); }, 220);
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  // The cut this section will find again on the way back. `search` and not
+  // `searchDraft`: half a word typed on the way out is not a cut worth returning to.
+  // The registry rebuilds the callback on every render of the shell, so a ref keeps
+  // its identity out of the dependencies.
+  const reportSnapshot = useRef(onSnapshotChange);
+  reportSnapshot.current = onSnapshotChange;
+  // The place in the list is a ref, not state: it changes on every scroll frame, and
+  // as state it would re-render this whole view — sidebar, detail pane and all — for
+  // each one.
+  const placementRef = useRef<ListPlacement | null>(snapshot?.placement ?? null);
+  const currentSnapshot = useCallback((): LibraryGlobalSnapshot => ({
+    search,
+    selectedCollection,
+    selectedSavedSearch,
+    filtersOpen,
+    filters: { source, extraction, itemType, yearFrom, yearTo, facetTag, facetVault, attachmentFilter },
+    placement: placementRef.current,
+  }), [attachmentFilter, extraction, facetTag, facetVault, filtersOpen, itemType, search, selectedCollection, selectedSavedSearch, source, yearFrom, yearTo]);
+  const snapshotOf = useRef(currentSnapshot);
+  snapshotOf.current = currentSnapshot;
+  useEffect(() => { reportSnapshot.current?.(currentSnapshot()); }, [currentSnapshot]);
+
+  // The anchor is restored by VirtualList, which is the only thing that knows where a
+  // row that is not rendered yet would be. What it cannot decide is what to do when
+  // the row is gone: that is this view's call, and the answer is the first page.
+  const [restoreAnchorId, setRestoreAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
+  const anchorChecked = useRef(restoreAnchorId === null);
+  useEffect(() => {
+    if (anchorChecked.current || items.length === 0) return;
+    anchorChecked.current = true;
+    if (items.some((item) => item.id === restoreAnchorId)) return;
+    setRestoreAnchorId(null);
+    setOffset(0);
+    placementRef.current = null;
+    reportSnapshot.current?.(snapshotOf.current());
+  }, [items, restoreAnchorId]);
+
   useEffect(() => { void load(); }, [load]);
   useEffect(() => {
     const offChanged = window.nodus.onGlobalLibraryChanged(() => {
@@ -1400,6 +1454,11 @@ function GlobalLibraryContent({
           </div>
           <VirtualList
             items={items} itemHeight={62} getKey={(item) => item.id} className="library-catalog-list h-[calc(100%-2.25rem)] min-h-0 overflow-x-hidden" style={{ minWidth: tableMinWidth }}
+            anchorKey={restoreAnchorId}
+            onAnchorChange={(key) => {
+              placementRef.current = key === null ? null : { anchorId: String(key), pageOffset: offset };
+              reportSnapshot.current?.(snapshotOf.current());
+            }}
             empty={<div className="grid h-full place-items-center p-8 text-center"><div><Icon name={trashMode ? 'trash' : 'book'} size={28} className="mx-auto text-neutral-700" /><p className="mt-3 text-sm text-neutral-400">{t(trashMode ? 'La papelera está vacía.' : 'No hay documentos que coincidan.')}</p><p className="mt-1 text-xs text-neutral-600">{t(trashMode ? 'Los elementos enviados aquí podrán restaurarse antes del vaciado manual.' : 'Añade archivos o importa una biblioteca de Zotero.')}</p></div></div>}
             renderItem={(item) => {
               const activeJob = jobs.find((job) => job.itemId === item.id && ['queued', 'processing'].includes(job.status));
@@ -1556,6 +1615,8 @@ export function GlobalLibraryView({
   settings,
   vaultId,
   vaultType,
+  snapshot,
+  onSnapshotChange,
   onSettingsChange,
   onOpenSettings,
   onOpenCollections,
@@ -1565,6 +1626,9 @@ export function GlobalLibraryView({
 }: {
   target?: (PendingLibraryNavigationTarget & { nonce: number }) | null;
   settings: AppSettings;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: LibrarySnapshot;
+  onSnapshotChange?: (patch: Partial<LibrarySnapshot>) => void;
   vaultId: string | null;
   vaultType?: VaultType;
   onSettingsChange: () => Promise<AppSettings | undefined>;
@@ -1662,6 +1726,8 @@ export function GlobalLibraryView({
             vaultId={vaultId}
             target={target}
             vaultType={vaultType}
+            snapshot={snapshot?.vault}
+            onSnapshotChange={(vault) => onSnapshotChange?.({ vault })}
             onOpenCollections={onOpenCollections}
             onOpenNodusCollections={() => void chooseScope('global')}
             onOpenGraph={onOpenGraph}
@@ -1671,7 +1737,14 @@ export function GlobalLibraryView({
             onOpenReader={openVaultReader}
           />
         ) : (
-          <GlobalLibraryContent target={target} onOpenSettings={onOpenSettings} scopeControls={scopeControls} onOpenReader={openGlobalReader} />
+          <GlobalLibraryContent
+            target={target}
+            snapshot={snapshot?.global}
+            onSnapshotChange={(next) => onSnapshotChange?.({ global: next })}
+            onOpenSettings={onOpenSettings}
+            scopeControls={scopeControls}
+            onOpenReader={openGlobalReader}
+          />
         )}
       </div>
       {activeReader && (

--- a/src/views/IdeasView.tsx
+++ b/src/views/IdeasView.tsx
@@ -14,9 +14,12 @@ import {
 } from '../navigation';
 import { t, tx } from '../i18n';
 import { getVaultQueryCache, setVaultQueryCache } from '../vaultQueryCache';
+import type { IdeasSnapshot } from '../app/viewSnapshots';
+import { useListPlacement } from '../listPlacement';
 import { academicKnowledgeViewSource, type KnowledgeViewSource } from './knowledgeViewSource';
 
-type SortKey = 'label' | 'type' | 'works' | 'connections' | 'confidence';
+// Exported because the section's snapshot stores it.
+export type SortKey = 'label' | 'type' | 'works' | 'connections' | 'confidence';
 type IdeasSurface = 'catalog' | 'idea';
 type OpenIdea = { id: string; label: string };
 const IDEAS_PAGE_SIZE = 80;
@@ -24,6 +27,8 @@ const IDEAS_PAGE_SIZE = 80;
 export function IdeasView({
   vaultId,
   target,
+  snapshot,
+  onSnapshotChange,
   onOpenGraph,
   onOpenAssistant,
   dataSource = academicKnowledgeViewSource,
@@ -33,6 +38,9 @@ export function IdeasView({
 }: {
   vaultId: string | null;
   target?: IdeaNavigationTarget | null;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: IdeasSnapshot;
+  onSnapshotChange?: (patch: Partial<IdeasSnapshot>) => void;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
   onOpenAssistant: (target?: PendingAssistantNavigationTarget) => void;
   dataSource?: KnowledgeViewSource;
@@ -42,16 +50,25 @@ export function IdeasView({
 }) {
   const [ideas, setIdeas] = useState<IdeaListItem[]>([]);
   const [totalIdeas, setTotalIdeas] = useState(0);
-  const [pageOffset, setPageOffset] = useState(0);
+  // The page and the row that was at the top are one restored value. The page alone
+  // would drop the reader in front of row 201 with no context.
+  const [pageOffset, setPageOffset] = useState(() => snapshot?.placement?.pageOffset ?? 0);
+  const [anchorId, setAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
   const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [typeFilter, setTypeFilter] = useState<IdeaType | ''>('');
-  const [sortKey, setSortKey] = useState<SortKey>('label');
-  const [surface, setSurface] = useState<IdeasSurface>('catalog');
-  const [openIdea, setOpenIdea] = useState<OpenIdea | null>(null);
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Restored as initial values only — a reactive `snapshot` prop would fight the
+  // reader for their own filters. The search box keeps its immediate and debounced
+  // halves in step, or the debounce would wipe the restored cut on mount.
+  const [search, setSearch] = useState(() => snapshot?.search ?? '');
+  const [searchQuery, setSearchQuery] = useState(() => snapshot?.search ?? '');
+  const [typeFilter, setTypeFilter] = useState<IdeaType | ''>(() => snapshot?.typeFilter ?? '');
+  const [sortKey, setSortKey] = useState<SortKey>(() => snapshot?.sortKey ?? 'label');
+  const [openIdea, setOpenIdea] = useState<OpenIdea | null>(() => snapshot?.openIdea ?? null);
+  // An idea tab that is no longer open cannot be the active surface.
+  const [surface, setSurface] = useState<IdeasSurface>(() => (snapshot?.surface === 'idea' && snapshot.openIdea ? 'idea' : 'catalog'));
+  const [filtersOpen, setFiltersOpen] = useState(() => snapshot?.filtersOpen ?? false);
+  // Paired with `openIdea` by `showIdea`; restoring one without the other would draw
+  // a tab with an empty pane behind it.
+  const [selectedId, setSelectedId] = useState<string | null>(() => snapshot?.openIdea?.id ?? null);
   const [detail, setDetail] = useState<IdeaDetail | null>(null);
   const [connections, setConnections] = useState<IdeaConnection[]>([]);
   const [detailLoading, setDetailLoading] = useState(false);
@@ -113,9 +130,42 @@ export function IdeasView({
     return () => clearTimeout(handle);
   }, [search]);
 
+  // The registry builds `onSnapshotChange` inline, so its identity changes on every
+  // render of the shell; a ref keeps that out of the effect's dependencies. The
+  // stored text is the applied one, not the draft.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
   useEffect(() => {
+    report.current?.({ surface, openIdea, search: searchQuery, typeFilter, sortKey, filtersOpen });
+  }, [filtersOpen, openIdea, searchQuery, sortKey, surface, typeFilter]);
+
+  // Changing the cut throws the place away with it: a row that was at the top of one
+  // filter means nothing under another. It must skip its own first run, though, or
+  // arriving with a restored filter would reset the restored page a frame later.
+  const cutChanged = useRef(false);
+  useEffect(() => {
+    if (!cutChanged.current) {
+      cutChanged.current = true;
+      return;
+    }
     setPageOffset(0);
+    setAnchorId(null);
+    report.current?.({ placement: null });
   }, [searchQuery, sortKey, typeFilter]);
+
+  // Scrolling back to the stored row, once the page holding it has arrived. If it is
+  // gone, the list returns to the first page and the top rather than sit on a page
+  // with nothing to show for it.
+  const scrollerRef = useListPlacement<HTMLDivElement>({
+    restoreAnchorId: anchorId,
+    revision: ideas,
+    onRestoreMissed: () => {
+      setAnchorId(null);
+      setPageOffset(0);
+      report.current?.({ placement: null });
+    },
+    onCapture: (topId) => report.current?.({ placement: topId ? { anchorId: topId, pageOffset } : null }),
+  });
 
   useEffect(() => {
     const force = initialListLoad.current;
@@ -268,7 +318,7 @@ export function IdeasView({
             )}
           </div>
 
-          <div data-testid="ideas-table-scroll" className="min-h-0 flex-1 overflow-auto">
+          <div ref={scrollerRef} data-testid="ideas-table-scroll" className="min-h-0 flex-1 overflow-auto">
             <div data-testid="ideas-catalog-table" className="min-w-[1080px]">
               <div className="grid h-11 items-center border-b border-neutral-200 px-4 text-[10px] font-semibold uppercase tracking-wider text-neutral-500 dark:border-neutral-800 dark:text-neutral-600" style={{ gridTemplateColumns: 'minmax(360px,2.4fr) 8rem 6.5rem 7.5rem 7rem minmax(220px,1.35fr) 2rem' }}>
                 <IdeaSortHeader label="Idea" sort="label" active={sortKey} onSort={setSortKey} />
@@ -288,6 +338,7 @@ export function IdeasView({
                 <button
                   key={node.id}
                   data-testid={testId ? 'study-idea-card' : `idea-row-${node.id}`}
+                  data-anchor-id={node.id}
                   className="grid min-h-[76px] w-full items-center border-b border-neutral-100 px-4 text-left text-xs transition-colors hover:bg-neutral-50 dark:border-neutral-900 dark:hover:bg-neutral-900/55"
                   style={{ gridTemplateColumns: 'minmax(360px,2.4fr) 8rem 6.5rem 7.5rem 7rem minmax(220px,1.35fr) 2rem' }}
                   onClick={() => showIdea({ id: node.id, label: node.label })}

--- a/src/views/Library.tsx
+++ b/src/views/Library.tsx
@@ -32,6 +32,7 @@ import {
 } from '../navigation';
 import { t, tx } from '../i18n';
 import { getVaultQueryCache, setVaultQueryCache } from '../vaultQueryCache';
+import type { LibraryVaultSnapshot, ListPlacement } from '../app/viewSnapshots';
 
 const LIBRARY_ROW_HEIGHT = 64;
 const LIBRARY_PAGE_SIZE = 200;
@@ -50,7 +51,8 @@ type StatusFlag = 'deep' | 'summary' | 'ideas' | 'passages' | '!deep' | '!summar
  * Readiness has no SQL expression, so the Status column is filtered, not sorted.
  */
 type SortKey = Extract<WorkSortKey, 'title' | 'authors' | 'year' | 'themes' | 'ideas'>;
-type SortState = { key: SortKey; dir: 'asc' | 'desc' };
+/** Exported because the Library section's snapshot stores it. */
+export type SortState = { key: SortKey; dir: 'asc' | 'desc' };
 
 // Counts default to descending (most first); text columns to ascending. A third
 // click clears back to the default backend order (year desc, title asc).
@@ -397,6 +399,8 @@ export function Library({
   vaultId,
   target,
   vaultType,
+  snapshot,
+  onSnapshotChange,
   onOpenCollections,
   onOpenNodusCollections,
   onOpenGraph,
@@ -409,6 +413,9 @@ export function Library({
   /** Incoming navigation that pre-applies a filter (e.g. a corpus-health bucket). */
   target?: LibraryNavigationTarget | null;
   vaultType?: VaultType;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: LibraryVaultSnapshot;
+  onSnapshotChange?: (next: LibraryVaultSnapshot) => void;
   onOpenCollections: () => void;
   onOpenNodusCollections: () => void;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
@@ -423,11 +430,15 @@ export function Library({
   const isRecordsVault = vaultType === 'genealogy' || vaultType === 'primary_sources';
   const [works, setWorks] = useState<WorkView[]>([]);
   const [totalWorks, setTotalWorks] = useState(0);
-  const [pageOffset, setPageOffset] = useState(0);
-  const [filter, setFilter] = useState<WorkFilter>({});
+  // The page and the row that was at the top are one restored value.
+  const [pageOffset, setPageOffset] = useState(() => snapshot?.placement?.pageOffset ?? 0);
+  // Restored as an initial value only — a reactive `snapshot` prop would fight the
+  // reader for their own filters.
+  const [filter, setFilter] = useState<WorkFilter>(() => snapshot?.filter ?? {});
   // Local, instantly-responsive text for the search box. It is debounced into
-  // `filter.search` so keystrokes stay smooth even on large libraries.
-  const [searchDraft, setSearchDraft] = useState('');
+  // `filter.search` so keystrokes stay smooth even on large libraries; both halves
+  // start from the stored text so the debounce cannot wipe the restored cut.
+  const [searchDraft, setSearchDraft] = useState(() => snapshot?.filter.search ?? '');
   const [availableZoteroTags, setAvailableZoteroTags] = useState<ZoteroTag[]>([]);
   const [tagFilterOpen, setTagFilterOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState('');
@@ -440,8 +451,8 @@ export function Library({
   const [passageStatuses, setPassageStatuses] = useState<Map<string, WorkPassageStatus>>(new Map());
   const [reuseAnalysisFromVaults, setReuseAnalysisFromVaults] = useState(false);
   const [reuseNotice, setReuseNotice] = useState<string | null>(null);
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(() => snapshot?.filtersOpen ?? false);
+  const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(() => snapshot?.advancedFiltersOpen ?? false);
   const [collectionsMenuOpen, setCollectionsMenuOpen] = useState(false);
   const [graphWork, setGraphWork] = useState<{ nodus_id: string; title: string } | null>(null);
   const [ideasWork, setIdeasWork] = useState<{ nodus_id: string; title: string } | null>(null);
@@ -452,7 +463,7 @@ export function Library({
   const [queuedByWork, setQueuedByWork] = useState<Map<string, QueueItem[]>>(new Map());
   // Client-side ordering over the already-in-memory filtered set. `null` keeps
   // the backend order (year desc, title asc).
-  const [sort, setSort] = useState<SortState | null>(null);
+  const [sort, setSort] = useState<SortState | null>(() => snapshot?.sort ?? null);
   const loadRequestRef = useRef(0);
   const tagFilterRef = useDismissableLayer<HTMLDivElement>({
     open: tagFilterOpen,
@@ -604,6 +615,35 @@ export function Library({
     }, 250);
     return () => clearTimeout(handle);
   }, [searchDraft]);
+
+  // The cut this section will find again on the way back: the applied filter, not
+  // the draft in the search box. The registry rebuilds the callback on every render
+  // of the shell, so a ref keeps its identity out of the dependencies.
+  const reportSnapshot = useRef(onSnapshotChange);
+  reportSnapshot.current = onSnapshotChange;
+  // The place in the list is a ref, not state: it changes on every scroll frame, and
+  // as state it would re-render this whole view for each one.
+  const placementRef = useRef<ListPlacement | null>(snapshot?.placement ?? null);
+  const currentSnapshot = useCallback((): LibraryVaultSnapshot => ({
+    filter, sort, filtersOpen, advancedFiltersOpen, placement: placementRef.current,
+  }), [advancedFiltersOpen, filter, filtersOpen, sort]);
+  const snapshotOf = useRef(currentSnapshot);
+  snapshotOf.current = currentSnapshot;
+  useEffect(() => { reportSnapshot.current?.(currentSnapshot()); }, [currentSnapshot]);
+
+  // VirtualList restores the anchor, because only it knows where an unrendered row
+  // would be. What to do when the row is gone is this view's call: the first page.
+  const [restoreAnchorId, setRestoreAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
+  const anchorChecked = useRef(restoreAnchorId === null);
+  useEffect(() => {
+    if (anchorChecked.current || works.length === 0) return;
+    anchorChecked.current = true;
+    if (works.some((work) => work.nodus_id === restoreAnchorId)) return;
+    setRestoreAnchorId(null);
+    setPageOffset(0);
+    placementRef.current = null;
+    reportSnapshot.current?.(snapshotOf.current());
+  }, [restoreAnchorId, works]);
 
   const reuseSelectedAnalysis = async (ids: string[], skipKinds: VaultAnalysisReuseKind[]): Promise<string[]> => {
     if (!reuseAnalysisFromVaults || ids.length === 0) return ids;
@@ -1530,6 +1570,11 @@ export function Library({
             items={sortedWorks}
             itemHeight={LIBRARY_ROW_HEIGHT}
             getKey={(w) => w.nodus_id}
+            anchorKey={restoreAnchorId}
+            onAnchorChange={(key) => {
+              placementRef.current = key === null ? null : { anchorId: String(key), pageOffset };
+              reportSnapshot.current?.(snapshotOf.current());
+            }}
             className="flex-1 min-h-0"
             empty={<div className="p-4 text-neutral-500">{t('No hay obras con los filtros actuales.')}</div>}
             renderItem={(w) => {

--- a/src/views/WorkspaceView.tsx
+++ b/src/views/WorkspaceView.tsx
@@ -25,12 +25,15 @@ import { TextInputModal } from '../components/TextInputModal';
 import { WorkspaceTabStrip } from '../components/library/LibraryWorkspaceTabs';
 import { noteAsEditorDocument, workspaceNotePort } from '../components/editor/documentPort';
 import type { PendingGraphNavigationTarget } from '../navigation';
+import type { WorkspaceSnapshot } from '../app/viewSnapshots';
+import { useListPlacement } from '../listPlacement';
 import { t, tx } from '../i18n';
 
 const StudyEditor = lazy(() => import('../components/editor/StudyEditor').then((module) => ({ default: module.StudyEditor })));
 
 /** Lo que se puede crear aquí. Una idea es una nota que además vive en el grafo. */
-type WorkspaceItemKind = 'note' | 'idea';
+/** Exported because the section's snapshot stores it. */
+export type WorkspaceItemKind = 'note' | 'idea';
 
 type Scope = { kind: 'all' } | { kind: 'unfiled' } | { kind: 'trash' } | { kind: 'collection'; id: string };
 
@@ -398,6 +401,8 @@ function WorkspaceTagsEditor({ note, onChanged }: { note: Note; onChanged: () =>
 export function WorkspaceView({
   settings,
   focusNote,
+  snapshot,
+  onSnapshotChange,
   onOpenGraph,
   title = 'Espacio de trabajo',
   onTestimonyLink,
@@ -405,6 +410,9 @@ export function WorkspaceView({
   settings: AppSettings;
   /** Una nota que abrir al entrar (búsqueda global, Nodi); el nonce repite el gesto. */
   focusNote?: { id: string; nonce: number } | null;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: WorkspaceSnapshot;
+  onSnapshotChange?: (patch: Partial<WorkspaceSnapshot>) => void;
   onOpenGraph?: (target: PendingGraphNavigationTarget) => void;
   /** Los demás vaults conservan el nombre de sección «Notas» usando esta misma vista. */
   title?: 'Espacio de trabajo' | 'Notas';
@@ -414,18 +422,22 @@ export function WorkspaceView({
   const [tree, setTree] = useState<NotesTree>({ folders: [], notes: [] });
   const [links, setLinks] = useState<WorkspaceLibraryLink[]>([]);
   const [loading, setLoading] = useState(true);
-  const [scope, setScope] = useState<Scope>({ kind: 'all' });
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const [search, setSearch] = useState('');
-  const [kindFilter, setKindFilter] = useState<'' | WorkspaceItemKind>('');
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  // Restored as initial values only. The expanded folders are part of the cut:
+  // collapsing back to the root loses the reader's route to what they were reading
+  // just as surely as dropping the filter does.
+  const [scope, setScope] = useState<Scope>(() => snapshot?.scope ?? { kind: 'all' });
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(snapshot?.expanded ?? []));
+  const [search, setSearch] = useState(() => snapshot?.search ?? '');
+  const [kindFilter, setKindFilter] = useState<'' | WorkspaceItemKind>(() => snapshot?.kindFilter ?? '');
+  const [selectedTags, setSelectedTags] = useState<string[]>(() => snapshot?.selectedTags ?? []);
   const [tagFilterOpen, setTagFilterOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkTag, setBulkTag] = useState('');
   const [bulkCollection, setBulkCollection] = useState('');
-  const [openIds, setOpenIds] = useState<string[]>([]);
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const [openIds, setOpenIds] = useState<string[]>(() => snapshot?.openIds ?? []);
+  const [activeId, setActiveId] = useState<string | null>(() => snapshot?.activeId ?? null);
+  const [anchorId, setAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
   const [itemContextMenu, setItemContextMenu] = useState<WorkspaceItemContextMenu | null>(null);
   const [renaming, setRenaming] = useState<NoteFolder | null>(null);
   const [creatingCollection, setCreatingCollection] = useState(false);
@@ -525,6 +537,27 @@ export function WorkspaceView({
       })
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   }, [tree.notes, scope, children, kindFilter, search, selectedTags]);
+
+  // The registry rebuilds the callback on every render of the shell, so a ref keeps
+  // its identity out of the effect's dependencies.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
+  useEffect(() => {
+    report.current?.({ scope, expanded: [...expanded], search, kindFilter, selectedTags, openIds, activeId });
+  }, [activeId, expanded, kindFilter, openIds, scope, search, selectedTags]);
+
+  // This list is not paged — the filtered set renders whole — so the placement is
+  // scroll alone. It is still an id: row heights change with the window, and the
+  // notes reorder themselves by modification date under the reader's feet.
+  const listRef = useListPlacement<HTMLDivElement>({
+    restoreAnchorId: anchorId,
+    revision: visible,
+    onRestoreMissed: () => {
+      setAnchorId(null);
+      report.current?.({ placement: null });
+    },
+    onCapture: (topId) => report.current?.({ placement: topId ? { anchorId: topId } : null }),
+  });
 
   const openTabs = useMemo(
     () => openIds
@@ -903,7 +936,7 @@ export function WorkspaceView({
             <span className="text-right">{t('Modificado')}</span>
           </div>
 
-          <div data-testid="workspace-item-list" className="library-catalog-scroll min-h-0 flex-1 overflow-y-auto">
+          <div ref={listRef} data-testid="workspace-item-list" className="library-catalog-scroll min-h-0 flex-1 overflow-y-auto">
             {loading && <p className="px-4 py-6 text-xs text-neutral-500"><Spinner /> {t('Cargando…')}</p>}
             {!loading && visible.length === 0 && (
               <p className="px-4 py-6 text-xs leading-5 text-neutral-500">
@@ -917,6 +950,7 @@ export function WorkspaceView({
                 <div
                   key={note.id}
                   data-testid={`workspace-item-${note.id}`}
+                  data-anchor-id={note.id}
                   role="button"
                   tabIndex={0}
                   draggable={scope.kind !== 'trash'}


### PR DESCRIPTION
Closes #433

Switching sections and coming back no longer starts from scratch. Each section returns to the cut of the corpus it was left in: its filters, its ordering, its active inner tab and the reader's place in the list.

## How

Every section renders through one point in `App.tsx`, so changing the view unmounts the previous section along with all its state. That stays true — keeping the heavy lists mounted and hidden would leave them resident in the DOM with their effects and timers alive — so what survives is a small snapshot held above the render point.

A section receives its snapshot the same way it already receives `target` and `initialTab`: as a starting value, read once at mount and never re-applied, so it never fights the reader for control of their own filters. Changes are reported back through one effect per section.

The store is deliberately not React state. It is read when a section mounts and written on every filter change; as state, every keystroke in a search box would re-render the whole shell.

Snapshots are closed to the active vault, and the check lives in the read rather than in an effect, so a section mounting in the same commit as a vault change cannot see the previous vault's cut.

## Page and scroll

These are one value, never two. Restoring the page without the scroll position drops the reader in front of row 201 with no context — neither where they were nor a clean start.

The place is a row id, not a pixel offset: row heights change with the window and with the content, and virtualised lists have not measured the rows they have not reached. The stored page is only a hint, so the anchored row is reachable in one request instead of walking every page. If that row is gone, the list falls back to the first page and the top rather than keep half a placement.

Three list mechanisms, one contract:

- Plain scrollers anchor by `data-anchor-id`, with a binary search over row edges because the argument-route list grows into the thousands.
- `VirtualList` anchors against its own geometry — the row to scroll to is usually not in the DOM yet.
- `useIncrementalList` takes the anchor's index and opens wide enough to include it, where "load until this id appears" is literal.

## Kept and not kept

Kept: filters, ordering, active inner tab, expanded collections, open note tabs, and the place in the list.

Not kept: open modals, spinners, in-flight errors, unapplied input drafts and export selections. Nor the argument map's open tab — it holds no data of its own, so redrawing it means rebuilding it, and in AI mode that would spend a model call on the act of walking back into the section.

## Sections

Autores, Ideas, Biblioteca (both the vault library and the global catalogue, each with its own cut so flipping the scope switch does not blend two unrelated sets of filters), Espacio de trabajo — and the Notas section other vault types reach the same view by — and the argument route catalogue.

## Verification

- Full suite green at 1887 tests, plus typecheck, lint and build.
- 24 new tests: the store and the anchor search are exercised for real through esbuild; the wiring and the phase-two contract are asserted against the sources.
- Key assertions were mutation-checked — the vault closure, the anchor search and the first-run page-reset guard were each broken on purpose and watched to fail before being restored.
- Verified live in the real app under Electron: with Ideas scrolled, leaving for Autores (confirming the section is genuinely unmounted, not hidden) and returning puts the same row back under the top edge, and changing the filter opens at the top again.
