### PR TITLE
Remember the reading, not just the list

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e:saved-authors": "node scripts/e2e-saved-authors.mjs",
     "test:e2e:deep-research-annotations": "npm run build && node scripts/e2e-deep-research-annotations.mjs",
     "test:e2e:library-reader": "npm run build && node scripts/e2e-library-reader.mjs",
+    "test:e2e:view-snapshots": "npm run build && node scripts/e2e-view-snapshots.mjs",
     "test:e2e:global-library": "npm run build && node scripts/e2e-global-library.mjs",
     "test:e2e:browser-connector": "node scripts/e2e-browser-connector.mjs",
     "test:e2e:office-references": "node scripts/e2e-office-references.mjs",

--- a/scripts/e2e-library-reader.mjs
+++ b/scripts/e2e-library-reader.mjs
@@ -303,6 +303,26 @@ ${longReaderBody}
   await page.getByTestId(`library-workspace-tab-document-${globalItemId}`).waitFor({ state: 'visible' });
   assert.equal(await page.locator('[data-testid^="library-workspace-tab-document-"]').count(), 1, 'closing one document leaves the other reader tab intact');
 
+  // Leaving the section unmounts it, tabs and all. What was open has to be open again
+  // on the way back — and at the page it was left on, which the reader stores per
+  // document rather than in the section's snapshot.
+  const cleanScroller = page.locator('main.library-reader-clean-surface');
+  await page.mouse.move(760, 520);
+  await page.mouse.wheel(0, 900);
+  await page.waitForTimeout(400);
+  const leftAtOffset = await cleanScroller.evaluate((element) => element.scrollTop);
+  assert.ok(leftAtOffset > 200, `the wheel moved the document (scrollTop ${leftAtOffset})`);
+  await page.locator('[data-tour="nav-ideas"]').click();
+  await documentRoot.waitFor({ state: 'detached' });
+  await page.locator('[data-tour="nav-library"]').click();
+  await documentRoot.waitFor({ state: 'visible' });
+  assert.equal(await page.locator('[data-testid^="library-workspace-tab-document-"]').count(), 1, 'the open document is open again');
+  await page.getByTestId(`library-workspace-tab-document-${globalItemId}`).waitFor({ state: 'visible' });
+  await page.waitForFunction(
+    (expected) => Math.abs((document.querySelector('main.library-reader-clean-surface')?.scrollTop ?? 0) - expected) <= 4,
+    leftAtOffset,
+  );
+
   assert.match(await documentRoot.innerText(), /Texto introductorio/);
   assert.equal(await documentRoot.locator('img').count(), 1, 'local extracted images render inside the clean document');
   assert.equal(await documentRoot.locator('table').count(), 1, 'Markdown tables remain structured');

--- a/scripts/e2e-view-snapshots.mjs
+++ b/scripts/e2e-view-snapshots.mjs
@@ -1,0 +1,175 @@
+// Real-renderer acceptance test for what a section remembers when you leave it.
+//
+// The repository tests prove the store and read the wiring; only the running app can
+// prove the thing the reader actually notices: that walking out of Deep Research and
+// back in lands on the same report, at the same paragraph, with the same gallery
+// controls — and that the paragraph is found again by what it says, not by how many
+// pixels down the page it happened to be.
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-view-snapshots-ui-'));
+const childEnv = {
+  ...process.env,
+  NODUS_USERDATA: userData,
+  NODUS_DISABLE_AUTO_UPDATE: '1',
+  NODUS_E2E_UPDATE_STATUS: 'not-available',
+  NODUS_E2E_DISABLE_STUDY_BACKGROUND_AI: '1',
+};
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+/** The block under the top edge of the reader, as the reader would read it. */
+const TOP_BLOCK = `(() => {
+  const root = document.querySelector('[data-testid="deep-research-reader-document"]');
+  const scroller = root?.closest('main');
+  if (!root || !scroller) return null;
+  const all = Array.from(root.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote, pre, table, figure'));
+  const blocks = all.filter((block, index) => index + 1 >= all.length || !block.contains(all[index + 1]));
+  const edge = scroller.getBoundingClientRect().top + 1;
+  const found = blocks.find((block) => block.getBoundingClientRect().bottom > edge) ?? null;
+  return found ? (found.textContent ?? '').trim().slice(0, 80) : null;
+})()`;
+
+let app;
+try {
+  app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(30_000);
+  await page.setViewportSize({ width: 1400, height: 900 });
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+
+  await page.evaluate(async (version) => {
+    localStorage.setItem('nodus.lastSeenVersion', version);
+    localStorage.setItem('nodus.mobileTeaserSeen.3.2.4', '1');
+    localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
+    localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
+    await window.nodus.updateSettings({
+      onboardingComplete: true,
+      basicsTutorialVersion: 999,
+      recoverySetupVersion: 999,
+      tourComplete: true,
+      advancedTourComplete: true,
+      uiLanguage: 'es',
+      mascotEnabled: false,
+      reduceMotion: true,
+    });
+    await window.nodus.seedDemoData();
+  }, require(path.join(repoRoot, 'package.json')).version);
+  await page.reload();
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+  const updateModal = page.getByTestId('startup-update-modal');
+  if (await updateModal.count()) {
+    await page.waitForFunction(() => document.querySelector('[data-testid="startup-update-modal"]')?.getAttribute('data-update-status') === 'not-available');
+    await updateModal.getByRole('button', { name: 'Entendido', exact: false }).click();
+    await updateModal.waitFor({ state: 'detached' });
+  }
+
+  // The demo's report is one screen long, and a place only means something in a
+  // document that does not fit on one. This is the demo report with a long body: same
+  // brief, same shape, enough of it to scroll.
+  await page.evaluate(async () => {
+    const drafts = await window.nodus.listWritingWorkshopDrafts();
+    const demo = drafts.find((item) => item.brief.kind === 'deep_research');
+    if (!demo) throw new Error('the demo supplies no Deep Research report');
+    const body = Array.from({ length: 90 }, (_, index) => (
+      `## Sección ${index + 1}\n\nPárrafo ${index + 1} del informe largo, escrito para que la lectura ocupe`
+      + ' bastante más que una pantalla y el sitio en el que se dejó signifique algo.'
+    )).join('\n\n');
+    await window.nodus.saveWritingWorkshopDraft({
+      draft: { ...demo.draft, title: 'AAA informe largo de prueba', draftMarkdown: body },
+      model: demo.model ?? null,
+    });
+  });
+
+  const openDeepResearch = () => page.locator('[data-tour="nav-deepResearch"]').click();
+  const readerDocument = page.locator('[data-testid="deep-research-reader-document"]');
+  const sortSelect = page.locator('select').filter({ hasText: 'Más recientes' });
+
+  // ── The gallery's own controls ──────────────────────────────────────────────
+  await openDeepResearch();
+  await sortSelect.selectOption('title');
+
+  // ── A report, and a place inside it ─────────────────────────────────────────
+  await page.getByRole('button', { name: 'Leer', exact: true }).first().click();
+  await readerDocument.waitFor({ state: 'visible' });
+  const reportTitle = await page.locator('header .truncate.text-sm.font-semibold').first().innerText();
+
+  // A real wheel, not an assignment to scrollTop: the capture deliberately waits for
+  // the reader's own hands before it starts overwriting the stored place.
+  await page.mouse.move(700, 500);
+  await page.mouse.wheel(0, 1_600);
+  await page.waitForTimeout(400);
+  const leftAt = await page.evaluate(TOP_BLOCK);
+  assert.ok(leftAt, 'the reader is somewhere inside the report');
+  const scrolled = await page.evaluate(() => document.querySelector('[data-testid="deep-research-reader-document"]').closest('main').scrollTop);
+  assert.ok(scrolled > 200, `the wheel moved the report (scrollTop ${scrolled})`);
+
+  // ── Out of the section, and back in ─────────────────────────────────────────
+  await page.locator('[data-tour="nav-ideas"]').click();
+  await page.waitForSelector('[data-testid="deep-research-reader-document"]', { state: 'detached' });
+  await openDeepResearch();
+  await readerDocument.waitFor({ state: 'visible' });
+
+  const backAt = await page.evaluate(TOP_BLOCK);
+  assert.equal(backAt, leftAt, 'the report reopens at the paragraph it was left on');
+  const backTitle = await page.locator('header .truncate.text-sm.font-semibold').first().innerText();
+  assert.equal(backTitle, reportTitle, 'and it is the same report');
+
+  // The same place after a resize, which is the whole reason it is a block and not a
+  // pixel offset: the text rewraps and the offset it was read at no longer exists.
+  await page.setViewportSize({ width: 1000, height: 700 });
+  await page.locator('[data-tour="nav-ideas"]').click();
+  await page.waitForSelector('[data-testid="deep-research-reader-document"]', { state: 'detached' });
+  await openDeepResearch();
+  await readerDocument.waitFor({ state: 'visible' });
+  assert.equal(await page.evaluate(TOP_BLOCK), leftAt, 'a narrower window still finds the same paragraph');
+
+  // ── Back to the gallery, with its controls as they were left ────────────────
+  await page.getByRole('button', { name: 'Volver a la galería' }).click();
+  await page.getByTitle('Vista lista').click();
+  await page.locator('[data-tour="nav-ideas"]').click();
+  await openDeepResearch();
+  await readerDocument.waitFor({ state: 'detached' });
+  assert.equal(await sortSelect.inputValue(), 'title', 'the ordering survives leaving the section');
+  const listActive = await page.evaluate(() => Boolean(document.querySelector('.space-y-2 [data-anchor-id]')));
+  assert.ok(listActive, 'and so does the list/grid choice');
+  const firstCard = await page.evaluate(() => document.querySelector('[data-anchor-id]')?.textContent?.includes('AAA informe largo'));
+  assert.ok(firstCard, 'the ordering is the restored one, not the default');
+
+  // ── Inmersión: the session that was open, open again ────────────────────────
+  //
+  // The session carries its own progress, so the only thing lost on the way out is
+  // that it was open at all. Reopening it is a read, and it lands on the same step.
+  await page.locator('[data-tour="nav-immersion"]').click();
+  const immersionExit = page.getByRole('button', { name: 'Salir', exact: true });
+  await page.locator('[data-anchor-id]').first().click();
+  await immersionExit.waitFor({ state: 'visible' });
+  const step = await page.locator('header .text-\\[11px\\]').first().innerText();
+  await page.locator('[data-tour="nav-ideas"]').click();
+  await immersionExit.waitFor({ state: 'detached' });
+  await page.locator('[data-tour="nav-immersion"]').click();
+  await immersionExit.waitFor({ state: 'visible' });
+  assert.equal(await page.locator('header .text-\\[11px\\]').first().innerText(), step, 'the immersion reopens on the step it was left on');
+
+  // And leaving the player is leaving it: the gallery does not reopen it by itself.
+  await immersionExit.click();
+  await page.locator('[data-tour="nav-ideas"]').click();
+  await page.locator('[data-tour="nav-immersion"]').click();
+  await immersionExit.waitFor({ state: 'detached' });
+
+  assert.deepEqual(pageErrors.map((error) => error.message), [], 'no renderer errors');
+  console.log('View snapshots e2e passed.');
+} finally {
+  await app?.close();
+  await rm(userData, { recursive: true, force: true });
+}

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -35,6 +35,7 @@ const bundleOf = (source, name) => {
 };
 const store = bundleOf('src/app/viewSnapshots.ts', 'viewSnapshots.cjs');
 const { topAnchorId } = bundleOf('src/listPlacement.ts', 'listPlacement.cjs');
+const { readingBlocks, topBlockIndex } = bundleOf('src/readingPlace.ts', 'readingPlace.cjs');
 
 test.after(async () => { await rm(bundleDir, { recursive: true, force: true }); });
 
@@ -328,7 +329,8 @@ test('Biblioteca keeps a cut per scope, and only what nothing else already persi
   }
   // Sorting and columns are already written to disk, and the scope lives in settings.
   assert.doesNotMatch(types, /visibleColumns|columnWidths/, 'the snapshot does not duplicate what the Library persists itself');
-  assert.doesNotMatch(types, /scope: LibraryScope/, 'the scope is settings, not a snapshot');
+  const librarySnapshot = types.match(/export interface LibrarySnapshot \{[^}]*\}/)?.[0] ?? '';
+  assert.doesNotMatch(librarySnapshot, /scope/, 'the scope switch is settings, not a snapshot');
 });
 
 test('the page and the row are one field, so neither can be restored without the other', async () => {
@@ -340,9 +342,13 @@ test('the page and the row are one field, so neither can be restored without the
   const declarations = types.match(/^\s*(pageOffset|anchorId)[?]?:/gm) ?? [];
   assert.equal(declarations.length, 2, 'the page and the row are declared once each, inside ListPlacement');
 
-  // Six sections, one contract.
+  // Eight sections, one contract.
   const placements = (types.match(/placement: ListPlacement \| null/g) ?? []).length;
-  assert.equal(placements, 6, 'authors, ideas, both libraries, the workspace and the argument routes');
+  assert.equal(
+    placements,
+    8,
+    'authors, ideas, both libraries, the workspace, the argument routes and the two galleries',
+  );
 });
 
 test('ephemeral state dies on the way out', async () => {
@@ -361,4 +367,143 @@ test('ephemeral state dies on the way out', async () => {
   assert.match(authors, /report\.current\?\.\(\{ query: queryFilter,/);
   const global = await readSource('src/views/GlobalLibraryView.tsx');
   assert.match(global, /currentSnapshot = useCallback\(\(\): LibraryGlobalSnapshot => \(\{\s*search,/, 'the global catalogue stores the applied search');
+});
+
+// ── Phase three: the reading sections ─────────────────────────────────────────
+
+/**
+ * A document whose blocks are 100px tall, stacked from the top of the scroller. Only
+ * the two calls the search makes are needed, so it can be tested for real.
+ */
+function fakeDocument({ blockCount, blockHeight = 100, scrollTop = 0 }) {
+  const blocks = Array.from({ length: blockCount }, (_, index) => ({
+    getBoundingClientRect: () => ({
+      top: index * blockHeight - scrollTop,
+      bottom: (index + 1) * blockHeight - scrollTop,
+    }),
+  }));
+  return { scroller: { getBoundingClientRect: () => ({ top: 0, bottom: 600 }) }, blocks };
+}
+
+test('the place in a report is the block under the top edge', () => {
+  const at = (scrollTop) => {
+    const { scroller, blocks } = fakeDocument({ blockCount: 300, scrollTop });
+    return topBlockIndex(scroller, blocks);
+  };
+  assert.equal(at(0), 0, 'a report opened at the top is at its first block');
+  assert.equal(at(1_200), 12);
+  assert.equal(at(1_250), 12, 'a paragraph half off the top is still the one being read');
+  assert.equal(topBlockIndex(fakeDocument({ blockCount: 0 }).scroller, []), null, 'an empty document has no place');
+});
+
+test('a wrapper is not a second block over the same words', () => {
+  // A blockquote around a paragraph, or a list around its items, would otherwise be
+  // counted twice — and its bottom edge does not increase down the page, which is
+  // what the search above relies on.
+  const paragraph = { id: 'p', contains: () => false };
+  const heading = { id: 'h', contains: () => false };
+  const quote = { id: 'quote', contains: (other) => other === paragraph };
+  const all = [heading, quote, paragraph];
+  const root = { querySelectorAll: () => all };
+
+  assert.deepEqual(readingBlocks(root).map((block) => block.id), ['h', 'p']);
+});
+
+test('a place in a report is a block, and it says which rendering it was counted in', async () => {
+  const [types, reader] = await Promise.all([
+    readSource('src/readingPlace.ts'),
+    readSource('src/views/DeepResearchView.tsx'),
+  ]);
+  assert.match(types, /blockIndex: number/);
+  assert.match(types, /rendering: string/);
+  // The pixel a sentence sits at depends on the width of the window, on the font and
+  // on whether the cover image had loaded yet.
+  assert.doesNotMatch(types, /^\s*scrollTop[?]?:/m, 'a scrollTop is not a place');
+  // A translated report is a different document with a different block count.
+  assert.match(reader, /rendering: annotationScope/);
+  assert.match(types, /restore && restore\.rendering === rendering \? restore\.blockIndex : null/);
+  // A report grows after it first paints, and each of those changes pushes the text
+  // down under a scroll position that was already set.
+  assert.match(types, /new ResizeObserver\(place\)/);
+  assert.match(types, /if \(!settled\.current \|\| frame\.current !== null\) return/, 'capture waits for the reader to take over');
+  // React replaces the document's nodes when it re-renders. A list kept between
+  // frames measures elements that are no longer on the page, and the block it
+  // reports is then somewhere else entirely — which is exactly what the running app
+  // did before this was read fresh.
+  assert.match(types, /const blocks = readingBlocks\(root\);\s*const index = topBlockIndex\(scroller, blocks\);/);
+});
+
+test('Deep Research restores its gallery, the report it was left in and the place inside it', async () => {
+  const view = await readSource('src/views/DeepResearchView.tsx');
+  for (const restored of ['search', 'readFilter', 'sortKey', 'viewMode']) {
+    assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
+  }
+  // A reader with no report in it would render the gallery anyway.
+  assert.match(view, /snapshot\?\.surface === 'reader' && snapshot\.openReport \? 'reader' : 'gallery'/);
+  // The gallery is the only source of a saved report, so the reopen waits for it
+  // instead of fetching the report a second way.
+  assert.match(view, /const id = reopening\.current;\s*if \(!id \|\| !galleryRead\) return;/);
+  assert.match(view, /restoredReading\.current = null;\s*setMode\('gallery'\)/, 'a report that is gone falls back to the gallery');
+  assert.match(view, /useReadingPlace\(\{/);
+  // The composer is a draft, not a place.
+  const types = await readSource('src/app/viewSnapshots.ts');
+  for (const field of ['objective', 'language', 'structureMode', 'unitOutline', 'audience']) {
+    assert.doesNotMatch(types, new RegExp(`^\\s*${field}[?]?:`, 'm'), `${field} belongs to the composer, not to a place`);
+  }
+});
+
+test('the gallery scroller is born and dies with the gallery', async () => {
+  const view = await readSource('src/views/DeepResearchView.tsx');
+  // The gallery is unmounted while a report is open. A hook called in the view would
+  // come back from the reader still listening to the scroller that was thrown away.
+  assert.match(view, /function GalleryScroller\(\{/);
+  assert.match(view, /<GalleryScroller/);
+  assert.match(view, /data-anchor-id=\{saved\.id\}/);
+});
+
+test('Inmersión restores its gallery and reopens the session it was left in', async () => {
+  const view = await readSource('src/views/ImmersionView.tsx');
+  for (const restored of ['search', 'sortKey', 'viewMode']) {
+    assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
+  }
+  assert.match(view, /data-anchor-id=\{s\.id\}/);
+  // The session carries its own progress, so reopening it lands on the step it was
+  // left on. Reporting waits for the reopen, or the empty state on the way in would
+  // erase the very session being restored.
+  assert.match(view, /resuming = useRef<string \| null>\(snapshot\?\.openSession\?\.id \?\? null\)/);
+  assert.match(view, /if \(resuming\.current\) return;/);
+  assert.match(view, /const resume = fromDossier \|\| resuming\.current;/);
+  // The scope screen is a pass over the corpus; redrawing it means paying for it again.
+  const types = await readSource('src/app/viewSnapshots.ts');
+  assert.doesNotMatch(types, /ImmersionScope|openScope/, 'the scope screen is not restored');
+});
+
+test('Biblioteca reopens the documents that were open, and the reader finds its own page', async () => {
+  const [view, docReader] = await Promise.all([
+    readSource('src/views/GlobalLibraryView.tsx'),
+    readSource('src/views/LibraryDocumentReader.tsx'),
+  ]);
+  assert.match(view, /useState<LibraryWorkspaceTab\[\]>\(\(\) => snapshot\?\.readers\?\.tabs \?\? \[\]\)/);
+  // A tab that is no longer open cannot be the active one.
+  assert.match(view, /snapshot\?\.readers\?\.tabs\.some\(\(tab\) => tab\.key === snapshot\.readers\?\.activeKey\)/);
+  assert.match(view, /reportReaders\.current\?\.\(\{ readers: \{ tabs: workspaceTabs, activeKey: activeReaderKey \} \}\)/);
+  // The place inside a document is not in the snapshot because it is not lost: the
+  // reader writes it per document and restores it whenever it mounts.
+  assert.match(docReader, /localStorage\.setItem\(readingPositionKey\(reader\.storageId\)/);
+  assert.match(docReader, /localStorage\.getItem\(readingPositionKey\(reader\.storageId\)/);
+});
+
+test('the three sections added here receive their snapshot the way the others do', async () => {
+  const [corpus, study, teaching] = await Promise.all([
+    readSource('src/app/views/corpus.tsx'),
+    readSource('src/app/views/study.tsx'),
+    readSource('src/app/views/teaching.tsx'),
+  ]);
+  for (const view of ['deepResearch', 'immersion']) {
+    assert.match(corpus, new RegExp(`snapshots\\.read\\('${view}'\\)`), `${view} is handed its snapshot`);
+    assert.match(corpus, new RegExp(`snapshots\\.patch\\('${view}',`), `${view} reports its snapshot back`);
+  }
+  // The same surface under the three names the app gives it, each with its own cut.
+  assert.match(study, /snapshots\.read\('studyDeepResearch'\)/);
+  assert.match(teaching, /snapshots\.read\('teachingUnits'\)/);
 });

--- a/src/app/viewSnapshots.ts
+++ b/src/app/viewSnapshots.ts
@@ -29,15 +29,18 @@
 // written on every filter change; as state it would re-render the whole shell on
 // every keystroke in a search box, and this repo has paid for that before.
 import type { View } from '../navigation';
-import type { LibraryCatalogItem, LibraryItemSource, LibraryItemType } from '@shared/libraryTypes';
+import type { LibraryCatalogItem, LibraryItemSource, LibraryItemType, LibraryScope } from '@shared/libraryTypes';
 // Type-only, so the lazy view chunks are not pulled in: the unions stay declared
 // once, where the selects that produce them live.
 import type { SortKey as AuthorsSortKey, SynthFilter as AuthorsSynthFilter } from '../views/AuthorsView';
 import type { SortKey as IdeasSortKey } from '../views/IdeasView';
 import type { RouteSortKey as ArgumentRouteSortKey } from '../views/ArgumentMapView';
+import type { ReadFilter as ReportReadFilter, SortKey as ReportSortKey } from '../views/DeepResearchView';
+import type { ImmersionSortKey } from '../views/ImmersionView';
 import type { WorkspaceItemKind } from '../views/WorkspaceView';
-import type { IdeaType, WorkFilter } from '@shared/types';
+import type { IdeaType, LibraryReaderReference, WorkFilter } from '@shared/types';
 import type { SortState } from '../views/Library';
+import type { ReadingPlace } from '../readingPlace';
 
 /** An open inner tab: enough to redraw the tab strip and refetch its contents. */
 export interface OpenEntityTab {
@@ -174,14 +177,78 @@ export interface LibraryVaultSnapshot {
 }
 
 /**
+ * One document left open in the reader strip. The reference is what the tab was
+ * opened with, so reopening it is the same read as opening it the first time; the
+ * page the reader had reached inside it is not here, because the reader already
+ * writes that to disk per document and restores it whenever it mounts.
+ */
+export interface LibraryReaderTabSnapshot {
+  key: string;
+  scope: LibraryScope;
+  reference: LibraryReaderReference;
+  /** Which rendering was on show: the clean text, or one of the attachments. */
+  sourceId?: string;
+}
+
+/** The reader tabs and which one was in front. Null means the catalogue was. */
+export interface LibraryReadersSnapshot {
+  tabs: LibraryReaderTabSnapshot[];
+  activeKey: string | null;
+}
+
+/**
  * One section, two engines: the Biblioteca entry renders the vault library or the
  * global catalogue depending on the scope switch, and each keeps its own cut so
  * that flipping the switch does not blend two unrelated sets of filters. The scope
  * itself is not here — it already lives in settings.
+ *
+ * The open readings sit beside both, not inside either, because that is where they
+ * sit on screen: the tab strip spans the section and a document opened from the vault
+ * library stays open across a switch to the global catalogue.
  */
 export interface LibrarySnapshot {
   vault?: LibraryVaultSnapshot;
   global?: LibraryGlobalSnapshot;
+  readers?: LibraryReadersSnapshot;
+}
+
+/**
+ * Deep Research: the gallery's cut, the report left open, and the place inside it.
+ *
+ * Reopening a report is a read of something already written, so it costs nothing to
+ * restore. What is deliberately absent is the composer: an objective half typed into
+ * the new-report form is a draft, not a place, and restoring the form would also mean
+ * deciding whether the model, the length and the outline in it are still the ones the
+ * reader meant.
+ */
+export interface DeepResearchSnapshot {
+  surface: 'gallery' | 'reader';
+  /** id and title of the open report; the report itself is re-read from the gallery. */
+  openReport: OpenEntityTab | null;
+  search: string;
+  readFilter: ReportReadFilter;
+  sortKey: ReportSortKey;
+  viewMode: 'grid' | 'list';
+  /** The place in the gallery. */
+  placement: ListPlacement | null;
+  /** The place inside the open report. */
+  reading: ReadingPlace | null;
+}
+
+/**
+ * Inmersión: the gallery's cut and the session left open.
+ *
+ * The session's own progress — which step the player was on, the answers given — is
+ * already stored with the session, so reopening it lands exactly where it was left.
+ * The scope screen is not kept: it is the result of a pass over the corpus, and
+ * redrawing it means paying for that pass again just to walk back into the section.
+ */
+export interface ImmersionSnapshot {
+  openSession: OpenEntityTab | null;
+  search: string;
+  sortKey: ImmersionSortKey;
+  viewMode: 'grid' | 'list';
+  placement: ListPlacement | null;
 }
 
 /** One optional entry per section that has opted in. Keys are `View` members. */
@@ -197,6 +264,17 @@ export interface ViewSnapshots {
    */
   notes?: WorkspaceSnapshot;
   argument?: ArgumentSnapshot;
+  immersion?: ImmersionSnapshot;
+  /**
+   * The same surface under the three names the app gives it: Deep Research in an
+   * academic vault, Investigación de estudio in a study one, Diseño de unidades in a
+   * teaching one. Separate entries for the same reason `workspace` and `notes` are
+   * separate: they are different sections, and a key per section is what keeps the
+   * store honest about which one a cut belongs to.
+   */
+  deepResearch?: DeepResearchSnapshot;
+  studyDeepResearch?: DeepResearchSnapshot;
+  teachingUnits?: DeepResearchSnapshot;
 }
 
 export type SnapshotView = keyof ViewSnapshots;

--- a/src/app/views/corpus.tsx
+++ b/src/app/views/corpus.tsx
@@ -68,7 +68,14 @@ export const corpusViews = {
       onOpenGraph={(target) => navigate('graph', target)}
     />
   ),
-  immersion: ({ navigate, settings }) => <ImmersionView settings={settings} onOpenGraph={(target) => navigate('graph', target)} />,
+  immersion: ({ navigate, settings, snapshots }) => (
+    <ImmersionView
+      settings={settings}
+      snapshot={snapshots.read('immersion')}
+      onSnapshotChange={(patch) => snapshots.patch('immersion', patch)}
+      onOpenGraph={(target) => navigate('graph', target)}
+    />
+  ),
   // Cobertura y Huecos son el mismo espacio con dos pestañas. 'gaps' ya no tiene
   // entrada en la barra lateral, pero sigue siendo una vista enrutable —Inicio,
   // Buscar y el tour avanzado navegan a ella— y entra por la pestaña de huecos.
@@ -107,8 +114,14 @@ export const corpusViews = {
     <ReadingPathView onOpenGraph={(target) => navigate('graph', target)} onOpenAssistant={openAssistant} />
   ),
   writing: ({ navigate, settings }) => <WritingWorkshopView settings={settings} onOpenGraph={(target) => navigate('graph', target)} />,
-  deepResearch: ({ isGenealogy, navigate, settings }) => (
-    <DeepResearchView settings={settings} isGenealogy={isGenealogy} onOpenGraph={(target) => navigate('graph', target)} />
+  deepResearch: ({ isGenealogy, navigate, settings, snapshots }) => (
+    <DeepResearchView
+      settings={settings}
+      isGenealogy={isGenealogy}
+      snapshot={snapshots.read('deepResearch')}
+      onSnapshotChange={(patch) => snapshots.patch('deepResearch', patch)}
+      onOpenGraph={(target) => navigate('graph', target)}
+    />
   ),
   projects: ({ settings }) => <ProjectsView settings={settings} />,
 

--- a/src/app/views/study.tsx
+++ b/src/app/views/study.tsx
@@ -103,6 +103,8 @@ export const studyViews = {
       settings={ctx.settings}
       isStudy
       isTeaching={ctx.isDocencia}
+      snapshot={ctx.snapshots.read('studyDeepResearch')}
+      onSnapshotChange={(patch) => ctx.snapshots.patch('studyDeepResearch', patch)}
       onOpenGraph={(target) => ctx.navigate('graph', target)}
       onOpenStudyDocument={openDocument(ctx)}
       onOpenStudyMaterial={openMaterial(ctx)}

--- a/src/app/views/teaching.tsx
+++ b/src/app/views/teaching.tsx
@@ -23,6 +23,8 @@ export const teachingViews = {
       settings={ctx.settings}
       isStudy
       isTeaching
+      snapshot={ctx.snapshots.read('teachingUnits')}
+      onSnapshotChange={(patch) => ctx.snapshots.patch('teachingUnits', patch)}
       onOpenGraph={(target) => { ctx.setStudyGraphTarget({ ...target, nonce: Date.now() }); ctx.setView('studyGraph'); }}
       onOpenStudyDocument={studyJumps.openDocument(ctx)}
       onOpenStudyMaterial={studyJumps.openMaterial(ctx)}

--- a/src/readingPlace.ts
+++ b/src/readingPlace.ts
@@ -1,0 +1,178 @@
+// Keeping the reader's place inside a document, by block.
+//
+// This is the prose half of what `listPlacement.ts` does for lists. A list has rows
+// with ids; a report has none, so what is stored is WHICH BLOCK was under the top
+// edge — the nth paragraph, heading, quote or table of the rendered document.
+//
+// Not a `scrollTop`, for the same reason a list does not store one: the pixel a
+// sentence sits at depends on the width of the window, on the font and on whether the
+// cover image had loaded yet, and none of those are the same on the next visit. The
+// block is the same block.
+//
+// The index is only meaningful in the rendering it was counted in, so it travels with
+// one: a report read in Spanish and the same report with a translation applied are two
+// different documents with two different block counts, and a place taken in one says
+// nothing about the other. A place whose rendering no longer matches is dropped, not
+// approximated.
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+/** The reader's place in a document. See the note above on why it is not a pixel. */
+export interface ReadingPlace {
+  /** Which block was under the top edge, counted over `readingBlocks`. */
+  blockIndex: number;
+  /** The rendering it was counted in: the source text, or a translation over it. */
+  rendering: string;
+}
+
+/** What counts as a block. Anything that carries prose and stacks vertically. */
+export const READING_BLOCK_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, li, blockquote, pre, table, figure';
+
+/**
+ * The blocks of a document, in document order and never nested inside one another.
+ *
+ * Only the leaves are kept. A `blockquote` around a `p`, or a `li` around a `p`, would
+ * otherwise appear as two blocks covering the same text, and — worse — their bottom
+ * edges would not increase down the page, which is what the search below relies on.
+ *
+ * A block with any matched descendant has that descendant as the very next match in
+ * document order, so one comparison per block is enough to recognise a wrapper.
+ */
+export function readingBlocks(root: HTMLElement): HTMLElement[] {
+  const all = Array.from(root.querySelectorAll<HTMLElement>(READING_BLOCK_SELECTOR));
+  return all.filter((block, index) => index + 1 >= all.length || !block.contains(all[index + 1]));
+}
+
+/**
+ * The first block still crossing the top edge of the scroller, or null if the document
+ * has no blocks yet. Binary search, as in `topAnchorId`: this runs on every scroll
+ * frame and a long report is hundreds of blocks.
+ */
+export function topBlockIndex(scroller: HTMLElement, blocks: HTMLElement[]): number | null {
+  if (blocks.length === 0) return null;
+  const edge = scroller.getBoundingClientRect().top + 1;
+  let low = 0;
+  let high = blocks.length - 1;
+  let found = blocks.length - 1;
+  while (low <= high) {
+    const middle = (low + high) >> 1;
+    if (blocks[middle].getBoundingClientRect().bottom > edge) {
+      found = middle;
+      high = middle - 1;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return found;
+}
+
+export interface ReadingPlaceOptions<S extends HTMLElement, R extends HTMLElement> {
+  /** The element that scrolls. */
+  scrollerRef: RefObject<S | null>;
+  /** The element the blocks are counted inside. */
+  documentRef: RefObject<R | null>;
+  /** Where the reader was, or null. Ignored unless it was taken in this rendering. */
+  restore: ReadingPlace | null;
+  /** What is on screen now: 'source', or the id of the translation applied over it. */
+  rendering: string;
+  /** Changes when the document's content does, so the restore can wait for it. */
+  revision: unknown;
+  /** The block now under the top edge, reported as the reader moves. */
+  onCapture: (place: ReadingPlace | null) => void;
+}
+
+/**
+ * Restores the reader's place once the document is on screen, then follows them.
+ *
+ * The restore does not settle when it succeeds — it settles when the reader takes
+ * over. A report grows after it first paints: the cover image loads, a diagram
+ * resolves, a font swaps, and each of those pushes the text down under a scroll
+ * position that was already set. So the target block is put back under the top edge
+ * again on every change of the document's size, and only a hand on the wheel, the
+ * trackpad or the keyboard ends that.
+ *
+ * Capture is the mirror image: it stays silent until the reader has moved, so the
+ * scrolling this hook does itself can never overwrite the place it is restoring.
+ */
+export function useReadingPlace<S extends HTMLElement, R extends HTMLElement>({
+  scrollerRef,
+  documentRef,
+  restore,
+  rendering,
+  revision,
+  onCapture,
+}: ReadingPlaceOptions<S, R>): void {
+  // Read once: a place that changed under the reader is this hook's own report coming
+  // back around, and re-restoring on it would fight them for the scrollbar.
+  const wanted = useRef(restore && restore.rendering === rendering ? restore.blockIndex : null);
+  const settled = useRef(wanted.current === null);
+  const frame = useRef<number | null>(null);
+  const capture = useRef(onCapture);
+  capture.current = onCapture;
+  const renderingRef = useRef(rendering);
+  renderingRef.current = rendering;
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    const root = documentRef.current;
+    if (!scroller || !root) return;
+
+    const place = () => {
+      if (settled.current) return;
+      const index = wanted.current;
+      if (index === null) return;
+      const blocks = readingBlocks(root);
+      if (blocks.length === 0) return;
+      const target = blocks[index];
+      if (!target) {
+        // The report is not the one the place was taken in — translated away,
+        // regenerated, shorter than it was. Half a placement is worse than none.
+        settled.current = true;
+        wanted.current = null;
+        scroller.scrollTop = 0;
+        capture.current(null);
+        return;
+      }
+      scroller.scrollTop += target.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+    };
+
+    place();
+    const observer = new ResizeObserver(place);
+    observer.observe(root);
+
+    const takeOver = () => {
+      settled.current = true;
+      wanted.current = null;
+    };
+    const handleScroll = () => {
+      if (!settled.current || frame.current !== null) return;
+      frame.current = requestAnimationFrame(() => {
+        frame.current = null;
+        // Read fresh: React replaces the document's nodes when it re-renders, and a
+        // cached list would keep measuring elements that are no longer on the page.
+        const blocks = readingBlocks(root);
+        const index = topBlockIndex(scroller, blocks);
+        capture.current(index === null ? null : { blockIndex: index, rendering: renderingRef.current });
+      });
+    };
+
+    for (const event of ['wheel', 'touchstart', 'pointerdown'] as const) {
+      scroller.addEventListener(event, takeOver, { passive: true });
+    }
+    // Keys go to the document: scrolling with the arrows or the space bar does not
+    // need the scroller focused, so the event never reaches it.
+    const owner = scroller.ownerDocument;
+    owner.addEventListener('keydown', takeOver, { passive: true });
+    scroller.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      observer.disconnect();
+      for (const event of ['wheel', 'touchstart', 'pointerdown'] as const) {
+        scroller.removeEventListener(event, takeOver);
+      }
+      owner.removeEventListener('keydown', takeOver);
+      scroller.removeEventListener('scroll', handleScroll);
+      if (frame.current !== null) cancelAnimationFrame(frame.current);
+      frame.current = null;
+    };
+  }, [documentRef, rendering, revision, scrollerRef]);
+}

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -2,7 +2,7 @@
 // chained generation queue, and an immersive reader that expands one report to
 // full width with a back button to the gallery. The heavy lifting (generation,
 // saving, citations) is shared with the Writing workshop via writingShared.
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type {
   AppSettings,
   DeepResearchArchiveFormat,
@@ -25,6 +25,9 @@ import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
 import { toReadingCopy } from '@shared/readingCopy';
 import { stripLeadingAbstract } from '@shared/writingDocument';
 import type { PendingGraphNavigationTarget } from '../navigation';
+import type { DeepResearchSnapshot } from '../app/viewSnapshots';
+import { useListPlacement } from '../listPlacement';
+import { useReadingPlace, type ReadingPlace } from '../readingPlace';
 import { HoverLabelButton, Icon, modelLabel } from '../components/ui';
 import { SectionHeader } from '../components/SectionHeader';
 import { ModelPicker } from '../components/ModelPicker';
@@ -75,8 +78,10 @@ const DEEP_SECTION_OPTIONS: { value: DeepResearchSectionLimit; label: string }[]
   { value: 10, label: 'Máx. 10 secciones' },
 ];
 
-type SortKey = 'recent' | 'oldest' | 'title';
-type ReadFilter = 'all' | 'read' | 'unread';
+// Exported because the section's snapshot stores them; the unions stay declared here,
+// next to the selects that produce them.
+export type SortKey = 'recent' | 'oldest' | 'title';
+export type ReadFilter = 'all' | 'read' | 'unread';
 
 /**
  * One surface, four readers. The machinery is identical — queue, gallery, reader,
@@ -236,6 +241,8 @@ export function DeepResearchView({
   isGenealogy = false,
   isStudy = false,
   isTeaching = false,
+  snapshot,
+  onSnapshotChange,
   onOpenGraph,
   onOpenStudyDocument,
   onOpenStudyMaterial,
@@ -246,6 +253,9 @@ export function DeepResearchView({
   isStudy?: boolean;
   /** Teaching vaults: Unit design — same surface, plus the teacher-defined structure. */
   isTeaching?: boolean;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: DeepResearchSnapshot;
+  onSnapshotChange?: (patch: Partial<DeepResearchSnapshot>) => void;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
   onOpenStudyDocument?: (id: string) => void;
   onOpenStudyMaterial?: (id: string) => void;
@@ -253,7 +263,11 @@ export function DeepResearchView({
 }) {
   const variant: DeepResearchVariant = isTeaching ? 'unit' : isGenealogy ? 'genealogy' : isStudy ? 'study' : 'academic';
   const copy = DEEP_RESEARCH_COPY[variant];
-  const [mode, setMode] = useState<'gallery' | 'reader'>('gallery');
+  // A report can only be the surface if there was one open; the pair is stored
+  // together, and a reader with nothing in it would render the gallery anyway.
+  const [mode, setMode] = useState<'gallery' | 'reader'>(
+    () => (snapshot?.surface === 'reader' && snapshot.openReport ? 'reader' : 'gallery')
+  );
 
   // Composer (new report) state.
   const [composerOpen, setComposerOpen] = useState(false);
@@ -278,6 +292,8 @@ export function DeepResearchView({
   // Data.
   const [savedDrafts, setSavedDrafts] = useState<WritingWorkshopSavedDraft[]>([]);
   const [loadingSavedDrafts, setLoadingSavedDrafts] = useState(false);
+  /** True once the gallery has been read at least once, empty or not. */
+  const [galleryRead, setGalleryRead] = useState(false);
   const [queue, setQueue] = useState<DeepResearchQueueItem[]>(() => getDeepResearchQueue());
   // The main-process lane, which also holds reports queued by MCP clients.
   const [laneJobs, setLaneJobs] = useState<DeepResearchJobRecord[]>([]);
@@ -285,11 +301,13 @@ export function DeepResearchView({
     getBackgroundJob(DEEP_RESEARCH_MAIN_JOB_KEY)
   );
 
-  // Gallery controls.
-  const [search, setSearch] = useState('');
-  const [readFilter, setReadFilter] = useState<ReadFilter>('all');
-  const [sortKey, setSortKey] = useState<SortKey>('recent');
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  // Gallery controls. Restored as initial values only: a reactive `snapshot` prop
+  // would fight the reader for their own filters on every render of the shell.
+  const [search, setSearch] = useState(() => snapshot?.search ?? '');
+  const [readFilter, setReadFilter] = useState<ReadFilter>(() => snapshot?.readFilter ?? 'all');
+  const [sortKey, setSortKey] = useState<SortKey>(() => snapshot?.sortKey ?? 'recent');
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>(() => snapshot?.viewMode ?? 'grid');
+  const [galleryAnchorId, setGalleryAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
   const [showTutorial, setShowTutorial] = useState(false);
   const [selecting, setSelecting] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -312,6 +330,64 @@ export function DeepResearchView({
   const hasModel = !!selectedModel;
   const deepRunning = deepJob?.status === 'running';
   const deepProgress = deepJob?.progress ?? null;
+
+  /**
+   * The report that was open, found again once the gallery has been read.
+   *
+   * The gallery is the only source of a saved report, so this waits for it rather
+   * than fetching the report a second way. If it is no longer there — deleted, or
+   * written in a vault this is not — the section falls back to the gallery instead
+   * of showing an empty reader.
+   */
+  const reopening = useRef(snapshot?.surface === 'reader' ? snapshot.openReport?.id ?? null : null);
+
+  // The registry builds `onSnapshotChange` inline, so its identity changes on every
+  // render of the shell; a ref keeps that out of the effects' dependencies.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
+  useEffect(() => {
+    // Silent until the report being reopened has landed: on the way in the reader is
+    // empty, and saying so would erase the very report that is on its way back.
+    if (reopening.current) return;
+    report.current?.({
+      surface: mode,
+      openReport: openDraft ? { id: openDraft.id, label: openDraft.title } : null,
+      search,
+      readFilter,
+      sortKey,
+      viewMode,
+    });
+  }, [mode, openDraft, readFilter, search, sortKey, viewMode]);
+
+  // The place inside the open report. Kept in a ref rather than in state because it
+  // is written on every scroll frame and read only when the reader mounts.
+  const restoredReading = useRef<ReadingPlace | null>(snapshot?.reading ?? null);
+
+  useEffect(() => {
+    const id = reopening.current;
+    if (!id || !galleryRead) return;
+    reopening.current = null;
+    const found = savedDrafts.find((item) => item.id === id);
+    if (found) {
+      setOpenDraft(found);
+      return;
+    }
+    restoredReading.current = null;
+    setMode('gallery');
+  }, [galleryRead, savedDrafts]);
+
+  // Changing the cut throws the place in the gallery away with it: a card at the top
+  // of one filter means nothing under another. It skips its own first run, or
+  // arriving with a restored filter would drop the restored place a frame later.
+  const cutChanged = useRef(false);
+  useEffect(() => {
+    if (!cutChanged.current) {
+      cutChanged.current = true;
+      return;
+    }
+    setGalleryAnchorId(null);
+    report.current?.({ placement: null });
+  }, [readFilter, search, sortKey]);
 
   useEffect(() => subscribeBackgroundJob(DEEP_RESEARCH_MAIN_JOB_KEY, setDeepJob), []);
   useEffect(() => subscribeDeepResearchQueue(setQueue), []);
@@ -340,6 +416,7 @@ export function DeepResearchView({
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoadingSavedDrafts(false);
+      setGalleryRead(true);
     }
   }, []);
 
@@ -416,6 +493,8 @@ export function DeepResearchView({
   };
 
   const openReader = (saved: WritingWorkshopSavedDraft) => {
+    // A place taken in another report is not a place in this one.
+    restoredReading.current = null;
     setOpenDraft(saved);
     setMode('reader');
     setShowMatrix(false);
@@ -428,6 +507,8 @@ export function DeepResearchView({
   const backToGallery = () => {
     setMode('gallery');
     setOpenDraft(null);
+    restoredReading.current = null;
+    report.current?.({ reading: null });
     setTranslationOpen(false);
     setAppliedTranslation(null);
     void refreshSavedDrafts();
@@ -687,6 +768,8 @@ export function DeepResearchView({
         <ReaderView
           saved={openDraft}
           settings={settings}
+          initialReading={restoredReading.current}
+          onReadingChange={(place) => report.current?.({ reading: place })}
           showMatrix={showMatrix}
           exporting={exporting}
           message={message}
@@ -871,7 +954,15 @@ export function DeepResearchView({
         </div>
       )}
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+      <GalleryScroller
+        anchorId={galleryAnchorId}
+        revision={visibleDrafts}
+        onMissed={() => {
+          setGalleryAnchorId(null);
+          report.current?.({ placement: null });
+        }}
+        onCapture={(anchorId) => report.current?.({ placement: anchorId ? { anchorId } : null })}
+      >
         {visibleDrafts.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
             <Icon name="compass" size={28} className="text-neutral-600" />
@@ -929,7 +1020,7 @@ export function DeepResearchView({
             ))}
           </div>
         )}
-      </div>
+      </GalleryScroller>
 
       {archiveIds && (
         <ArchiveModal
@@ -983,6 +1074,37 @@ export function DeepResearchView({
 // ─────────────────────────────────────────────────────────────────────────────
 // Gallery cards
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The gallery's scroller, and the reader's place in it.
+ *
+ * A component rather than a hook call in the view, because the gallery is unmounted
+ * while a report is open: the hook has to be born and die with the element it listens
+ * to, or it would come back from the reader still holding the scroller that was
+ * thrown away. It also means the trip into a report and back out lands on the same
+ * card, not at the top.
+ */
+function GalleryScroller({
+  anchorId,
+  revision,
+  onMissed,
+  onCapture,
+  children,
+}: {
+  anchorId: string | null;
+  revision: unknown;
+  onMissed: () => void;
+  onCapture: (anchorId: string | null) => void;
+  children: ReactNode;
+}) {
+  const scrollerRef = useListPlacement<HTMLDivElement>({
+    restoreAnchorId: anchorId,
+    revision,
+    onRestoreMissed: onMissed,
+    onCapture,
+  });
+  return <div ref={scrollerRef} className="min-h-0 flex-1 overflow-y-auto p-4">{children}</div>;
+}
 
 function SelectCheck({ checked }: { checked: boolean }) {
   return (
@@ -1058,6 +1180,7 @@ function DraftGridCard({
   const primary = selecting ? onToggle : onOpen;
   return (
     <div
+      data-anchor-id={saved.id}
       className={`card group flex flex-col overflow-hidden p-0 transition-colors ${
         selected ? 'border-indigo-600/70 ring-1 ring-indigo-600/40' : 'hover:border-indigo-700/60'
       }`}
@@ -1156,6 +1279,7 @@ function DraftListRow({
   const primary = selecting ? onToggle : onOpen;
   return (
     <div
+      data-anchor-id={saved.id}
       className={`card flex items-center gap-3 p-2.5 transition-colors ${
         selected ? 'border-indigo-600/70 ring-1 ring-indigo-600/40' : 'hover:border-indigo-700/60'
       }`}
@@ -1335,6 +1459,8 @@ function ArchiveModal({
 function ReaderView({
   saved,
   settings,
+  initialReading,
+  onReadingChange,
   showMatrix,
   exporting,
   message,
@@ -1356,6 +1482,9 @@ function ReaderView({
 }: {
   saved: WritingWorkshopSavedDraft;
   settings: AppSettings;
+  /** How far into the report the reader had got last time. */
+  initialReading: ReadingPlace | null;
+  onReadingChange: (place: ReadingPlace | null) => void;
   showMatrix: boolean;
   exporting: boolean;
   message: string | null;
@@ -1424,6 +1553,18 @@ function ReaderView({
     setAnnotations((current) => current.filter((item) => item.id !== id));
     setAnnotationError(null);
   };
+  // Where the reader was in the report, restored once the prose is on screen. The
+  // rendering travels with the place: a translation is a different document, and a
+  // block counted in one of them is not the same block in the other.
+  useReadingPlace({
+    scrollerRef: mainRef,
+    documentRef,
+    restore: initialReading,
+    rendering: annotationScope,
+    revision: appliedTranslation?.id ?? saved.id,
+    onCapture: onReadingChange,
+  });
+
   const contextTitle = appliedTranslation?.title ?? saved.draft.title;
   const contextMarkdown = appliedTranslation?.markdown
     ?? `# ${saved.draft.title}\n\n${saved.draft.abstract ? `${saved.draft.abstract}\n\n` : ''}${stripLeadingAbstract(saved.draft.draftMarkdown, saved.draft.abstract)}`;

--- a/src/views/GlobalLibraryView.tsx
+++ b/src/views/GlobalLibraryView.tsx
@@ -1642,8 +1642,23 @@ export function GlobalLibraryView({
   const preferredScope = requestedScope ?? (settings.libraryGlobalEnabled ? settings.libraryScope : 'vault');
   const [scope, setScope] = useState<LibraryScope>(preferredScope);
   const [switching, setSwitching] = useState(false);
-  const [workspaceTabs, setWorkspaceTabs] = useState<LibraryWorkspaceTab[]>([]);
-  const [activeReaderKey, setActiveReaderKey] = useState<string | null>(null);
+  // The documents left open, restored as initial values. Reopening one is the same
+  // read as opening it was, and the page the reader had reached inside it comes back
+  // with it: the reader writes its own position per document and restores it on mount.
+  const [workspaceTabs, setWorkspaceTabs] = useState<LibraryWorkspaceTab[]>(() => snapshot?.readers?.tabs ?? []);
+  const [activeReaderKey, setActiveReaderKey] = useState<string | null>(() => (
+    snapshot?.readers?.tabs.some((tab) => tab.key === snapshot.readers?.activeKey)
+      ? snapshot.readers.activeKey
+      : null
+  ));
+
+  // The registry builds `onSnapshotChange` inline, so its identity changes on every
+  // render of the shell; a ref keeps that out of the effect's dependencies.
+  const reportReaders = useRef(onSnapshotChange);
+  reportReaders.current = onSnapshotChange;
+  useEffect(() => {
+    reportReaders.current?.({ readers: { tabs: workspaceTabs, activeKey: activeReaderKey } });
+  }, [activeReaderKey, workspaceTabs]);
 
   // Contextual entries (Home health buckets and Zotero reader links) choose their
   // scope once. After arrival the user remains free to change the switcher.

--- a/src/views/ImmersionView.tsx
+++ b/src/views/ImmersionView.tsx
@@ -30,6 +30,8 @@ import type {
 } from '@shared/types';
 import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
 import type { PendingGraphNavigationTarget } from '../navigation';
+import type { ImmersionSnapshot } from '../app/viewSnapshots';
+import { useListPlacement } from '../listPlacement';
 import { Badge, Icon, TypeDot } from '../components/ui';
 import { SectionHeader } from '../components/SectionHeader';
 import { ModelPicker } from '../components/ModelPicker';
@@ -166,9 +168,14 @@ function GraphBox({
 
 export function ImmersionView({
   settings,
+  snapshot,
+  onSnapshotChange,
   onOpenGraph,
 }: {
   settings: AppSettings;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: ImmersionSnapshot;
+  onSnapshotChange?: (patch: Partial<ImmersionSnapshot>) => void;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
 }) {
   const [mode, setMode] = useState<'home' | 'scope' | 'player'>('home');
@@ -291,7 +298,7 @@ export function ImmersionView({
     });
   };
 
-  const openSession = async (id: string, restart = false) => {
+  const openSession = async (id: string, restart = false): Promise<ImmersionSession | null> => {
     setError(null);
     setOpeningId(id);
     try {
@@ -302,20 +309,44 @@ export function ImmersionView({
         setSession(loaded);
         setMode('player');
       }
+      return loaded ?? null;
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+      return null;
     } finally {
       setOpeningId(null);
     }
   };
 
+  // The registry builds `onSnapshotChange` inline, so its identity changes on every
+  // render of the shell; a ref keeps that out of the effects' dependencies.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
+  /** The session to reopen, read once. Silences the report until it has landed. */
+  const resuming = useRef<string | null>(snapshot?.openSession?.id ?? null);
+  useEffect(() => {
+    if (resuming.current) return;
+    report.current?.({ openSession: session ? { id: session.id, label: session.plan.title } : null });
+  }, [session]);
+
   useEffect(() => {
     const dossier = findLatestBackgroundJob<unknown, unknown, unknown>(IMMERSION_DOSSIER_JOB_PREFIX);
-    if (!dossier) return;
-    const sessionId = dossier.key.slice(IMMERSION_DOSSIER_JOB_PREFIX.length);
-    if (sessionId) void openSession(sessionId);
+    const fromDossier = dossier ? dossier.key.slice(IMMERSION_DOSSIER_JOB_PREFIX.length) : '';
+    // A dossier still being written wins over the session that was merely left open:
+    // it is the more recent thing, and it is the same section either way.
+    const resume = fromDossier || resuming.current;
+    if (!resume) {
+      resuming.current = null;
+      return;
+    }
     // Reconnect only when this view is mounted. The session itself persists its
-    // current player step, so opening it returns directly to the report card.
+    // current player step, so opening it returns directly to the step it was left on.
+    // Reporting here rather than in the effect above, because the report has to say
+    // what actually loaded: a session deleted elsewhere leaves the section at home.
+    void openSession(resume).then((opened) => {
+      resuming.current = null;
+      report.current?.({ openSession: opened ? { id: opened.id, label: opened.plan.title } : null });
+    });
   }, []);
 
   const deleteSession = async (summary: ImmersionSessionSummary) => {
@@ -362,6 +393,8 @@ export function ImmersionView({
             loadingSessions={loadingSessions}
             openingId={openingId}
             error={error}
+            snapshot={snapshot}
+            onSnapshotChange={onSnapshotChange}
             onNew={() => {
               setError(null);
               setComposerOpen(true);
@@ -456,7 +489,9 @@ export function ImmersionView({
 // Home — hero launcher + saved sessions
 // ─────────────────────────────────────────────────────────────────────────────
 
-type ImmersionSortKey = 'recent' | 'oldest' | 'title';
+// Exported because the section's snapshot stores it; the union stays declared here,
+// next to the select that produces it.
+export type ImmersionSortKey = 'recent' | 'oldest' | 'title';
 
 function formatImmersionDate(iso: string): string {
   try {
@@ -472,6 +507,8 @@ function ImmersionHome({
   loadingSessions,
   openingId,
   error,
+  snapshot,
+  onSnapshotChange,
   onNew,
   onOpenSession,
   onDeleteSession,
@@ -482,16 +519,40 @@ function ImmersionHome({
   loadingSessions: boolean;
   openingId: string | null;
   error: string | null;
+  snapshot?: ImmersionSnapshot;
+  onSnapshotChange?: (patch: Partial<ImmersionSnapshot>) => void;
   onNew: () => void;
   onOpenSession: (id: string, restart: boolean) => void;
   onDeleteSession: (s: ImmersionSessionSummary) => void;
   onDeleteSessions: (ids: string[]) => Promise<boolean>;
 }) {
-  const [search, setSearch] = useState('');
-  const [sortKey, setSortKey] = useState<ImmersionSortKey>('recent');
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  // Restored as initial values only, never as a reactive prop.
+  const [search, setSearch] = useState(() => snapshot?.search ?? '');
+  const [sortKey, setSortKey] = useState<ImmersionSortKey>(() => snapshot?.sortKey ?? 'recent');
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>(() => snapshot?.viewMode ?? 'grid');
+  const [anchorId, setAnchorId] = useState<string | null>(() => snapshot?.placement?.anchorId ?? null);
   const [selecting, setSelecting] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  // The gallery reports its own half of the snapshot; the section above reports the
+  // session that was open.
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
+  useEffect(() => {
+    report.current?.({ search, sortKey, viewMode });
+  }, [search, sortKey, viewMode]);
+
+  // Changing the cut throws the place away with it, skipping its own first run so a
+  // restored filter does not drop the restored place a frame later.
+  const cutChanged = useRef(false);
+  useEffect(() => {
+    if (!cutChanged.current) {
+      cutChanged.current = true;
+      return;
+    }
+    setAnchorId(null);
+    report.current?.({ placement: null });
+  }, [search, sortKey]);
 
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -515,6 +576,18 @@ function ImmersionHome({
     setSelecting(false);
     setSelected(new Set());
   };
+
+  // Back to the card that was under the top edge, once the list holding it is on
+  // screen. If that session is gone, the gallery starts from the top instead.
+  const scrollerRef = useListPlacement<HTMLDivElement>({
+    restoreAnchorId: anchorId,
+    revision: visible,
+    onRestoreMissed: () => {
+      setAnchorId(null);
+      report.current?.({ placement: null });
+    },
+    onCapture: (topId) => report.current?.({ placement: topId ? { anchorId: topId } : null }),
+  });
 
   const allVisibleSelected = visible.length > 0 && visible.every((s) => selected.has(s.id));
   const toggleAll = () =>
@@ -598,7 +671,7 @@ function ImmersionHome({
         </div>
       )}
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+      <div ref={scrollerRef} className="min-h-0 flex-1 overflow-y-auto p-4">
         {visible.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
             <Icon name="target" size={28} className="text-neutral-600" />
@@ -688,6 +761,7 @@ function SessionGridCard({
   const primary = selecting ? onToggle : onOpen;
   return (
     <div
+      data-anchor-id={s.id}
       className={`card group relative flex flex-col gap-3 p-3 transition-colors ${
         selected ? 'border-indigo-600/70 ring-1 ring-indigo-600/40' : 'hover:border-indigo-700/60'
       }`}
@@ -751,6 +825,7 @@ function SessionListRow({
   const primary = selecting ? onToggle : onOpen;
   return (
     <div
+      data-anchor-id={s.id}
       className={`card flex items-center gap-3 p-2.5 transition-colors ${
         selected ? 'border-indigo-600/70 ring-1 ring-indigo-600/40' : 'hover:border-indigo-700/60'
       }`}


### PR DESCRIPTION
Closes #437.

#433 taught the list sections to remember their cut. This does the same for the three sections a reader stays inside the longest, and adds the thing lists have no answer for: how far into a document you had read.

## What each section keeps

**Deep Research**, under all three of its names (`deepResearch`, `studyDeepResearch`, `teachingUnits` — a key per section, as with `workspace` and `notes`): the gallery's search, read filter, ordering and grid/list choice, the card that was under the top edge, the report that was open, and the place inside it. The report is found again in the gallery the section reads anyway rather than fetched a second way; if it has been deleted the section falls back to the gallery instead of showing an empty reader.

**Inmersión**: the gallery's search, ordering, view mode and place, plus the session that was open. The session carries its own progress, so reopening it lands on the step it was left on. A dossier still being written wins over a merely open session — it is the more recent thing.

**Biblioteca**: the documents open in the tab strip and which one was in front. Nothing is added for the place inside them, because nothing is lost: the reader already writes its position per document and restores it whenever it mounts. Reopening the tab is the whole fix.

## The place inside a report

`src/readingPlace.ts` is the prose half of `listPlacement.ts`. A list has rows with ids; a report has none, so what is stored is **which block was under the top edge** — the nth paragraph, heading, quote or table. Not a `scrollTop`: the pixel a sentence sits at moves with the width of the window, with the font and with whether the cover image had loaded, and none of those are the same on the next visit.

The index only means something in the rendering it was counted in, so it travels with one (`source`, or the id of the translation applied). A place whose rendering no longer matches is dropped, not approximated.

Restoring settles when the reader takes over, not when it first succeeds: a report grows after it paints, and each change pushes the text down under a scroll position that was already set, so the block is put back under the top edge on every resize until a hand reaches the wheel, the trackpad or a key. Capture is the mirror image — silent until then, so the hook can never overwrite the place it is restoring.

## Not kept

The new-report composer, Inmersión's scope screen (a fresh pass over the corpus), applied translations, selection mode, open modals and in-flight errors. Restoring those is work, not a place.

## Tests

- `scripts/test-view-snapshots.mjs`: eight new assertions covering the three sections, the block search and the wrapper filter, run against the real modules.
- `scripts/e2e-view-snapshots.mjs` (new, `npm run test:e2e:view-snapshots`): the running app — scroll a long report with a real wheel, leave the section, come back, and land on the same paragraph; do it again at a narrower window, where a pixel offset would land somewhere else; then check the gallery's ordering and view mode, and that an immersion reopens on its step while a closed one stays closed.
- `scripts/e2e-library-reader.mjs`: extended to leave the section and return, asserting the document tab is open again at the same offset.

The e2e caught a real bug that no repository test would have: the block list was cached between frames, and React had replaced the document's nodes underneath it, so the capture reported a block a long way from the one on screen. It is now read fresh.

`npm test` (1896) and both acceptance runs are green.
