### PR TITLE
Fix the wiki sidebar searchbar geometry

### DIFF
--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="../assets/css/nodus.css?v=20260815"/>
-  <link rel="stylesheet" href="wiki.css?v=20260817"/>
+  <link rel="stylesheet" href="wiki.css?v=20260818"/>
 </head>
 <body class="wiki-page" data-quiet>
   <canvas id="organism" aria-hidden="true"></canvas>

--- a/site/wiki/wiki.css
+++ b/site/wiki/wiki.css
@@ -417,13 +417,6 @@ main#article {
   }
   body.nav-open .sidebar { transform: none; }
   body.nav-open { overflow: hidden; }
-  /* the drawer scrolls as one block; only the header stays pinned */
-  .sidebar .wiki-search-wrap {
-    position: static;
-    margin: 0 10px 18px; padding: 0;
-    background: none; backdrop-filter: none; -webkit-backdrop-filter: none;
-    border-bottom: 0;
-  }
   .sidebar-head {
     position: sticky; z-index: 2; top: -26px;
     margin: -26px -16px 16px; padding: 20px 18px 14px 26px;
@@ -500,11 +493,30 @@ main#article {
    navigation scrolls past underneath it */
 .sidebar .wiki-search-wrap {
   position: sticky; top: -26px; z-index: 3;
-  flex: none; width: 100%; max-width: none;
+  flex: none; width: auto; max-width: none;
   margin: 0 -16px 18px; padding: 0 16px 14px;
   background: rgba(13, 11, 21, 0.94);
   backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--membrane);
+}
+/* the wrap is padded to go full-bleed over the rail padding: the input must
+   stretch as a flex item (width: 100% re-applies the padding and shrinks it),
+   and the absolute icon and kbd are anchored to the input edges, 16px in */
+.sidebar .wiki-search-wrap input { flex: 1 1 auto; width: auto; min-width: 0; }
+.sidebar .wiki-search-wrap > svg { left: 29px; }
+.sidebar .wiki-search-wrap kbd { right: 25px; }
+
+/* in the drawer the search scrolls with the rail instead of staying pinned;
+   relative keeps the icon and kbd anchored to the field, not to the drawer */
+@media (max-width: 900px) {
+  .sidebar .wiki-search-wrap {
+    position: relative;
+    margin: 0 10px 18px; padding: 0;
+    background: none; backdrop-filter: none; -webkit-backdrop-filter: none;
+    border-bottom: 0;
+  }
+  .sidebar .wiki-search-wrap > svg { left: 13px; }
+  .sidebar .wiki-search-wrap kbd { right: 9px; }
 }
 
 @media (max-width: 1180px) {


### PR DESCRIPTION
## What was wrong

On the wiki, the searchbar pinned at the top of the left rail had two visible problems:

- **Icon and ⌘ K badge hung outside the field.** The wrapper goes full-bleed over the rail padding (`margin: 0 -16px; padding: 0 16px`), but the input was sized with `width: 100%` (re-applying the padding and shrinking it) while the absolutely-positioned magnifier and kbd stayed anchored to the wrapper's padding box. Measured overflow: icon 3px past the left edge, kbd 7px past the right.
- **The field sat off-centre in the rail** (16px inset on the left, 49px on the right).

There was also a dead cascade bug from the redesign: the mobile-drawer override lived *above* the desktop rule with the same specificity, so the drawer got the sticky full-bleed treatment, and `position: static` made the kbd anchor to the fixed drawer itself instead of the field.

## The fix (site/wiki/wiki.css)

- The input now stretches as a flex item (`flex: 1 1 auto; width: auto; min-width: 0`), filling the rail's content box exactly (verified 16px→269px inside a 286px rail at every breakpoint).
- Icon/kbd are re-anchored to the input edges (`left: 29px` / `right: 25px` on desktop, base values restored in the drawer), so both sit fully inside the field.
- The drawer override moved below the desktop rule and switched to `position: relative`, keeping the icon/kbd anchored to the field rather than the fixed drawer.

Cache-buster for `wiki.css` bumped so returning visitors get the fix.

## Verification

- Re-measured with headless Chromium at 1600/1440/1200/1000/950/700/420px: input flush with the rail content box on both sides, icon 13px inside the left edge, kbd 9px inside the right edge at every width.
- `node --test scripts/test-site-wiki.mjs scripts/test-site-pages.mjs scripts/test-site-layout.mjs scripts/test-site-shared-header.mjs` — 41/41 pass.
