### PR TITLE
Fix Nodus Cloud bootstrap failing with HTTP 500 (PBKDF2 iteration cap on Workers)

### DIFF
--- a/cloudflare/src/auth.mjs
+++ b/cloudflare/src/auth.mjs
@@ -16,7 +16,9 @@ import {
   strictRateLimit,
 } from './util.mjs';
 
-const PASSWORD_ITERATIONS = 210_000;
+// Cloudflare Workers caps PBKDF2 at 100_000 iterations; anything higher makes
+// crypto.subtle.deriveBits throw NotSupportedError and bootstrap fails with a 500.
+const PASSWORD_ITERATIONS = 100_000;
 const ACCESS_TTL_MS = 15 * 60_000;
 const REFRESH_TTL_MS = 30 * 86400_000;
 const DEVICE_TTL_MS = 3650 * 86400_000;
@@ -38,16 +40,28 @@ function decodeHex(value) {
   return Uint8Array.from(clean.match(/.{2}/g).map((part) => Number.parseInt(part, 16)));
 }
 
-export async function hashPassword(password, saltHex = null) {
+export async function hashPassword(password, saltHex = null, iterations = PASSWORD_ITERATIONS) {
   const salt = saltHex ? decodeHex(saltHex) : crypto.getRandomValues(new Uint8Array(16));
   const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(String(password)), 'PBKDF2', false, ['deriveBits']);
-  const bits = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations: PASSWORD_ITERATIONS }, key, 256);
-  return { scheme: `pbkdf2-sha256:${PASSWORD_ITERATIONS}`, salt: encodeHex(salt), hash: encodeHex(new Uint8Array(bits)) };
+  const bits = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations }, key, 256);
+  return { scheme: `pbkdf2-sha256:${iterations}`, salt: encodeHex(salt), hash: encodeHex(new Uint8Array(bits)) };
+}
+
+// Each record stores the iteration count it was hashed with, so verification must
+// replay that count rather than the current constant. Otherwise tuning
+// PASSWORD_ITERATIONS invalidates every password already on record.
+function schemeIterations(scheme) {
+  const match = /^pbkdf2-sha256:(\d+)$/.exec(String(scheme || ''));
+  if (!match) return null;
+  const iterations = Number(match[1]);
+  return Number.isSafeInteger(iterations) && iterations > 0 ? iterations : null;
 }
 
 export async function verifyPassword(password, user) {
-  if (!user?.password_hash || !user?.password_salt || !String(user.password_scheme || '').startsWith('pbkdf2-sha256:')) return false;
-  const calculated = await hashPassword(password, user.password_salt);
+  if (!user?.password_hash || !user?.password_salt) return false;
+  const iterations = schemeIterations(user.password_scheme);
+  if (!iterations) return false;
+  const calculated = await hashPassword(password, user.password_salt, iterations);
   return constantTimeEqual(calculated.hash, user.password_hash);
 }
 


### PR DESCRIPTION
## Summary

`POST /api/v3/bootstrap` always returns HTTP 500, so **Nodus Cloud can never be initialised on Cloudflare**. Desktop surfaces it as `No se pudo inicializar Nodus Cloud (HTTP 500).`

Root cause: `crypto.subtle` in Workers refuses PBKDF2 above 100,000 iterations, but `cloudflare/src/auth.mjs` requests 210,000. Captured from `wrangler tail`:

```
POST https://<worker>.workers.dev/api/v3/bootstrap - Ok
  (error) NotSupportedError: Pbkdf2 failed: iteration counts above 100000 are not supported (requested 210000).
```

`hashPassword()` throws on every call, so bootstrap fails after the R2 recovery object is written but before any D1 rows exist. The installation stays empty, so retries hit the same path rather than the `already_bootstrapped` 409.

## Changes

**1. `PASSWORD_ITERATIONS` 210,000 → 100,000** — the platform ceiling.

Since the 210k path could never succeed on Workers, no deployment has a password hashed at that count. No migration needed.

**2. `verifyPassword()` now replays the iteration count stored in `password_scheme`** rather than always using the current constant.

The scheme column already records the count (`pbkdf2-sha256:<n>`) but nothing read it back, so changing `PASSWORD_ITERATIONS` would silently invalidate every password on record — including via this PR's own change, had any hashes existed. Malformed or missing schemes fail closed.

## Testing

Verified against the real `auth.mjs` exports:

- default hashing records `pbkdf2-sha256:100000` and stays within the cap
- correct password verifies; wrong password rejected
- a record hashed at a *different* count (60,000) still verifies — the regression the old code had
- missing, non-PBKDF2, and zero-iteration schemes are rejected without throwing

Then deployed to a live Worker and completed bootstrap end-to-end: admin user created, space provisioned, device paired, recovery key issued, and vault publication proceeded normally.

## Note on error visibility

This took a while to diagnose because the reason never reaches the user. The Worker reports failures as `error_description` (`cloudflare/src/util.mjs`), but `electron/cloudflare/deployment.ts` reads `value.detail`, so every Worker error collapses to a bare status code. Aligning those two would have made this bug self-describing on screen. Happy to send that as a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)