### PR TITLE
Fix truncated wiki search placeholder

### DIFF
--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -23,7 +23,7 @@
       <div class="sidebar-head"><span>Documentation</span><button id="nav-close" type="button" aria-label="Close documentation menu">×</button></div>
       <div class="wiki-search-wrap sidebar-search">
         <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.4-3.4"/></svg>
-        <input id="search" type="search" placeholder="Search guides, features and workflows…" autocomplete="off" aria-label="Search the Nodus Wiki"/>
+        <input id="search" type="search" placeholder="Search the wiki…" autocomplete="off" aria-label="Search the Nodus Wiki"/>
         <kbd>⌘ K</kbd>
         <div id="search-results" class="search-results" hidden></div>
       </div>

--- a/site/wiki/wiki.css
+++ b/site/wiki/wiki.css
@@ -484,7 +484,11 @@ main#article {
   font: 500 13.5px var(--sans);
   transition: border-color 0.25s var(--ease), box-shadow 0.25s var(--ease);
 }
-.wiki-search-wrap input::placeholder { color: var(--ink-3); }
+/* the sidebar is narrow: a placeholder that overflows must fade, not clip mid-word */
+.wiki-search-wrap input::placeholder {
+  color: var(--ink-3);
+  text-overflow: ellipsis;
+}
 .wiki-search-wrap input:focus {
   outline: none; border-color: rgba(167, 139, 250, 0.62);
   box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.13);


### PR DESCRIPTION
The wiki sidebar search box is ~254px wide, leaving 139px of text room between the magnifier icon and the `⌘ K` badge. The placeholder `Search guides, features and workflows…` measures ~250px, so it was clipped mid-word ("Search guides, feat").

- Shortened the placeholder to `Search the wiki…` (104px — fits with room to spare).
- Added `text-overflow: ellipsis` on the placeholder so any future overflow fades instead of clipping.

Verified in headless Chrome against the real page: the placeholder now renders in full without touching the `⌘ K` badge.