### PR TITLE
Stop the site scrolling sideways, and pair the wiki menu buttons on mobile

### DIFF
--- a/site/assets/css/home.css
+++ b/site/assets/css/home.css
@@ -126,7 +126,7 @@ Home page components. The shared system lives in nodus.css.
   background: rgba(139, 92, 246, 0.07); color: var(--violet-3);
 }
 
-@media (max-width: 900px) { .vault-def { grid-template-columns: 1fr; } }
+@media (max-width: 900px) { .vault-def { grid-template-columns: minmax(0, 1fr); } }
 
 /* ============================================================ vault scenes */
 .scene { padding: clamp(56px, 7.5vw, 100px) 0; }
@@ -428,7 +428,7 @@ Home page components. The shared system lives in nodus.css.
 .step .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
 
 @media (max-width: 700px) {
-  .step { grid-template-columns: 1fr; gap: 10px; }
+  .step { grid-template-columns: minmax(0, 1fr); gap: 10px; }
 }
 
 /* ============================================================ band */
@@ -463,16 +463,21 @@ Home page components. The shared system lives in nodus.css.
 
 /* ============================================================ responsive */
 @media (max-width: 980px) {
-  .scene-inner { grid-template-columns: 1fr; }
+  /* minmax(0, 1fr), never a bare 1fr: a bare fr keeps an automatic minimum, so
+     one wide child (a screenshot frame, a long label) pushes the whole column
+     past the viewport and the page scrolls sideways */
+  .scene-inner { grid-template-columns: minmax(0, 1fr); }
   .scene[data-flip] .scene-copy { order: 0; }
-  .tool-hero { grid-template-columns: 1fr; }
+  .tool-hero { grid-template-columns: minmax(0, 1fr); }
 }
 
 /* The Nodus N is assembled by the field right behind the headline, so the hero
    takes a lighter scrim than the rest of the page: enough to hold the type,
    not enough to swallow the mark. */
 .hero-inner.scrim::before {
-  inset: -80px -90px;
+  /* same rule as the shared scrim: the sideways bleed stops at the gutter so it
+     cannot widen the page (the hero box is already 940px, wider than .wrap) */
+  inset: -80px calc(-1 * min(90px, var(--gut)));
   background: radial-gradient(66% 58% at 50% 50%, rgba(6, 5, 11, 0.62), rgba(6, 5, 11, 0.3) 58%, transparent 80%);
 }
 

--- a/site/assets/css/nodus.css
+++ b/site/assets/css/nodus.css
@@ -139,6 +139,38 @@ html { scrollbar-width: thin; scrollbar-color: rgba(139, 92, 246, 0.45) transpar
 }
 .skip-link:focus { top: 16px; color: #fff; }
 
+/* ============================================================ back to top
+   The only floating control the reading pages carry. It stays out of the
+   accessibility tree until there is something to scroll back from. */
+/* the strip the observer watches: while it is on screen, the reader is still
+   within the first screenful and the button stays away */
+.back-to-top-sentinel {
+  position: absolute; top: 0; left: 0;
+  width: 1px; height: 90vh;
+  pointer-events: none; visibility: hidden;
+}
+.back-to-top {
+  position: fixed; z-index: 120;
+  right: clamp(14px, 3vw, 28px); bottom: clamp(14px, 3vw, 28px);
+  display: grid; place-items: center;
+  width: 44px; height: 44px; padding: 0;
+  border: 1px solid var(--membrane); border-radius: 50%;
+  background: rgba(16, 13, 28, 0.88); color: var(--ink-2);
+  backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  opacity: 0; visibility: hidden; transform: translateY(8px);
+  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease),
+    visibility 0.25s var(--ease), border-color 0.2s var(--ease), color 0.2s var(--ease);
+}
+.back-to-top.is-visible { opacity: 1; visibility: visible; transform: none; }
+.back-to-top:hover { border-color: rgba(167, 139, 250, 0.55); color: var(--ink); }
+.back-to-top svg { width: 18px; height: 18px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top { transition: opacity 0.01s, visibility 0.01s; transform: none; }
+}
+
 /* ============================================================ organism canvas */
 #organism {
   position: fixed;

--- a/site/assets/css/nodus.css
+++ b/site/assets/css/nodus.css
@@ -93,8 +93,12 @@ body {
   line-height: 1.62;
   font-synthesis-weight: none;
   -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
 }
+
+/* No page ever scrolls sideways. `clip` rather than `hidden` on purpose: hidden
+   would turn the viewport into a scroll container and break every sticky
+   element (the wiki rail, its search box), while clip leaves them alone. */
+html { overflow-x: clip; }
 
 /* The organism sits behind everything, and the page landmarks ride on top.
    Name them individually: a blanket `body > *` rule would overwrite the
@@ -401,7 +405,9 @@ h1, h2, h3, h4 { margin: 0; font-weight: 700; letter-spacing: -0.032em; line-hei
 .scrim { position: relative; }
 .scrim::before {
   content: ''; position: absolute; z-index: -1;
-  inset: -56px -64px;
+  /* the sideways bleed is decorative: it must never grow past the gutter, or a
+     narrow screen gains 128px of phantom width and scrolls sideways */
+  inset: -56px calc(-1 * min(64px, var(--gut)));
   background: radial-gradient(72% 62% at 42% 50%, rgba(6, 5, 11, 0.86), rgba(6, 5, 11, 0.55) 55%, transparent 78%);
   pointer-events: none;
 }
@@ -514,7 +520,7 @@ footer.site-foot {
 .foot-base a:hover { color: var(--ink-2); }
 
 @media (max-width: 860px) {
-  .foot-grid { grid-template-columns: 1fr 1fr; }
+  .foot-grid { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
   .foot-brand { grid-column: 1 / -1; }
 }
 

--- a/site/assets/js/back-to-top.js
+++ b/site/assets/js/back-to-top.js
@@ -1,0 +1,65 @@
+/*
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+
+The one floating control the reading pages carry: a way back to the top.
+
+Nodi lives in the demos, where the visitor is inside the product. The marketing
+and documentation pages get this instead — a single button that does one thing
+and says so. It appears only once there is something to scroll back from.
+
+Injects itself: <script src="…/assets/js/back-to-top.js"></script>, nothing else.
+*/
+(function () {
+  'use strict';
+
+  if (document.getElementById('back-to-top')) return;
+
+  const button = document.createElement('button');
+  button.id = 'back-to-top';
+  button.type = 'button';
+  button.className = 'back-to-top';
+  button.setAttribute('aria-label', 'Back to top');
+  button.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+    + 'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<path d="M12 19V5"/><path d="m5 12 7-7 7 7"/></svg>';
+
+  button.addEventListener('click', () => {
+    const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+    scrollTo({ top: 0, behavior: reduced ? 'auto' : 'smooth' });
+    // the button is about to fade out, so hand the focus back to the top of the
+    // page rather than leaving it on a control the visitor can no longer see
+    const home = document.querySelector('.nav .logo');
+    if (home) home.focus({ preventScroll: true });
+  });
+
+  // One screen of scrolling is the point where "back to top" stops being noise.
+  // A sentinel one viewport tall watches for it: the observer costs nothing per
+  // frame, where a scroll listener would run on every wheel notch.
+  const sentinel = document.createElement('div');
+  sentinel.className = 'back-to-top-sentinel';
+  sentinel.setAttribute('aria-hidden', 'true');
+
+  const show = (on) => button.classList.toggle('is-visible', on);
+
+  const watch = () => {
+    if (!('IntersectionObserver' in window)) {
+      const sync = () => show(scrollY > innerHeight * 0.9);
+      addEventListener('scroll', sync, { passive: true });
+      sync();
+      return;
+    }
+    new IntersectionObserver(
+      (entries) => { for (const entry of entries) show(!entry.isIntersecting); },
+      { threshold: 0 },
+    ).observe(sentinel);
+  };
+
+  const mount = () => {
+    document.body.prepend(sentinel);
+    document.body.appendChild(button);
+    watch();
+  };
+  if (document.readyState === 'loading') addEventListener('DOMContentLoaded', mount);
+  else mount();
+})();

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script src="../site-header.js?v=20260815"></script>
+<script src="../site-header.js?v=20260817"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#22d3ee" data-energy="0.28">
   <header class="page-hero">

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260815"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
 <link rel="stylesheet" href="blog.css?v=20260815"/>
 </head>
 <body>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260817b"/>
 <link rel="stylesheet" href="blog.css?v=20260815"/>
 </head>
 <body>
@@ -123,5 +123,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 <script src="../assets/js/organism.js?v=20260815"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="blog.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/blog/post.html
+++ b/site/blog/post.html
@@ -18,7 +18,7 @@ Renders one post: /blog/post.html?p=<slug>, reading posts/<slug>.md.
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260815"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
 <link rel="stylesheet" href="blog.css?v=20260815"/>
 </head>
 <body data-quiet>

--- a/site/blog/post.html
+++ b/site/blog/post.html
@@ -18,7 +18,7 @@ Renders one post: /blog/post.html?p=<slug>, reading posts/<slug>.md.
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260817b"/>
 <link rel="stylesheet" href="blog.css?v=20260815"/>
 </head>
 <body data-quiet>
@@ -94,5 +94,6 @@ Renders one post: /blog/post.html?p=<slug>, reading posts/<slug>.md.
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="markdown.js?v=20260815"></script>
 <script src="post.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/blog/post.html
+++ b/site/blog/post.html
@@ -28,7 +28,7 @@ Renders one post: /blog/post.html?p=<slug>, reading posts/<slug>.md.
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script src="../site-header.js?v=20260815"></script>
+<script src="../site-header.js?v=20260817"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">

--- a/site/contribute/contribute.css
+++ b/site/contribute/contribute.css
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 }
 
 @media (max-width: 900px) {
-  .contrib-hero { grid-template-columns: 1fr; }
+  .contrib-hero { grid-template-columns: minmax(0, 1fr); }
   #sand { height: 240px; }
 }
 
@@ -36,7 +36,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   gap: 16px; margin-top: 48px;
 }
 @media (max-width: 980px) { .ways { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-@media (max-width: 640px) { .ways { grid-template-columns: 1fr; } }
+@media (max-width: 640px) { .ways { grid-template-columns: minmax(0, 1fr); } }
 .way { padding: 26px; display: flex; flex-direction: column; }
 .way .pic {
   display: grid; place-items: center; width: 42px; height: 42px; margin-bottom: 16px;
@@ -82,7 +82,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 .terminal .c { color: var(--ink-3); }
 .terminal .p { color: var(--good); user-select: none; }
 
-@media (max-width: 900px) { .setup-grid { grid-template-columns: 1fr; } }
+@media (max-width: 900px) { .setup-grid { grid-template-columns: minmax(0, 1fr); } }
 
 /* ============================================================ rules */
 .rules { list-style: none; margin: 48px 0 0; padding: 0; display: grid; gap: 0; }

--- a/site/contribute/contribute.js
+++ b/site/contribute/contribute.js
@@ -84,11 +84,20 @@ the headline — one drifting grain per landed contribution.
     let width = 0;
     let height = 0;
     let grains = [];
-    let pile = null;   // settled height per column
-    let pileGain = 2;  // height each landed grain adds
+    let pile = null;    // settled height per column
+    let tint = null;    // the colour that has settled in each column, r,g,b interleaved
+    let scratch = null; // colour buffer for the smoothing pass
+    let columnCount = 0;
+    let pileGain = 2;   // height each landed grain adds
     let frame = 0;
 
-    const COLUMNS = 90;
+    // Two kinds of grain, and the dune keeps whatever fell on it: the mound is
+    // tinted column by column by what actually landed there, rather than
+    // repainting everything in one flat violet.
+    const GOLD = [252, 211, 77];
+    const PALE = [214, 208, 252];
+    const BASE = [124, 92, 214]; // the mound before anything has landed on it
+
     // one grain per contribution, capped so the pile still reads as a pile
     const total = Math.max(60, Math.min(520, grainCount || 180));
 
@@ -100,22 +109,88 @@ the headline — one drifting grain per landed contribution.
       canvas.width = Math.max(1, Math.round(width * dpr));
       canvas.height = Math.max(1, Math.round(height * dpr));
       context.setTransform(dpr, 0, 0, dpr, 0, 0);
-      pile = new Float32Array(COLUMNS);
+
+      // fine columns: the surface has to read as a curve, never as a bar chart
+      columnCount = Math.max(40, Math.min(240, Math.round(width / 5)));
+      pile = new Float32Array(columnCount);
+      tint = new Float32Array(columnCount * 3);
+      scratch = new Float32Array(columnCount * 3);
+      for (let i = 0; i < columnCount; i++) {
+        tint[i * 3] = BASE[0]; tint[i * 3 + 1] = BASE[1]; tint[i * 3 + 2] = BASE[2];
+      }
       grains = [];
       // rain across the whole box, so the pile builds edge to edge of its frame
-      const spread = COLUMNS * 0.9;
-      pileGain = Math.max(2, (height * 0.42 * spread) / total);
+      const spread = columnCount * 0.9;
+      pileGain = Math.max(0.6, (height * 0.36 * spread) / total);
     }
 
     function spawn() {
       // grains fall anywhere across the frame, not in one central stream
+      const gold = Math.random() < 0.3;
       grains.push({
         x: 8 + Math.random() * (width - 16),
         y: -8,
-        v: 90 + Math.random() * 70,
+        v: 70 + Math.random() * 60,
         r: 1.1 + Math.random() * 1.5,
-        hue: Math.random(),
+        colour: gold ? GOLD : PALE,
+        // a slow sideways drift, so the fall reads as sand in air, not as rain
+        sway: 6 + Math.random() * 14,
+        phase: Math.random() * Math.PI * 2,
+        seed: Math.random(),
       });
+    }
+
+    // where a grain lands it also leaves its colour, strongest right at the
+    // point of impact and fading as more grains cover it over
+    function stain(index, colour) {
+      const at = index * 3;
+      tint[at] += (colour[0] - tint[at]) * 0.62;
+      tint[at + 1] += (colour[1] - tint[at + 1]) * 0.62;
+      tint[at + 2] += (colour[2] - tint[at + 2]) * 0.62;
+    }
+
+    // the colours bleed a little into their neighbours every frame, which is
+    // what turns single impacts into soft bands instead of hard stripes
+    function blendTint() {
+      scratch.set(tint);
+      for (let i = 0; i < columnCount; i++) {
+        const left = Math.max(0, i - 1) * 3;
+        const right = Math.min(columnCount - 1, i + 1) * 3;
+        const at = i * 3;
+        for (let c = 0; c < 3; c++) {
+          // gentle: too much bleed and every colour averages into one grey
+          tint[at + c] = scratch[at + c] * 0.84 + (scratch[left + c] + scratch[right + c]) * 0.08;
+        }
+      }
+    }
+
+    const rgba = (index, alpha) => `rgba(${Math.round(tint[index * 3])}, ${Math.round(tint[index * 3 + 1])}, ${Math.round(tint[index * 3 + 2])}, ${alpha})`;
+
+    // one horizontal gradient carrying every column's colour: the dune is then
+    // painted in a single fill, so no seam can show between columns
+    function surfaceGradient(alpha) {
+      const gradient = context.createLinearGradient(0, 0, width, 0);
+      const stops = Math.min(columnCount, 48);
+      for (let s = 0; s <= stops; s++) {
+        const at = s / stops;
+        gradient.addColorStop(at, rgba(Math.min(columnCount - 1, Math.round(at * (columnCount - 1))), alpha));
+      }
+      return gradient;
+    }
+
+    function duneShape() {
+      context.beginPath();
+      context.moveTo(0, height);
+      context.lineTo(0, height - pile[0]);
+      // a smooth curve through the column tops, not a polyline
+      for (let i = 0; i < columnCount - 1; i++) {
+        const x = (i / (columnCount - 1)) * width;
+        const nextX = ((i + 1) / (columnCount - 1)) * width;
+        context.quadraticCurveTo(x, height - pile[i], (x + nextX) / 2, height - (pile[i] + pile[i + 1]) / 2);
+      }
+      context.lineTo(width, height - pile[columnCount - 1]);
+      context.lineTo(width, height);
+      context.closePath();
     }
 
     let settled = 0;
@@ -138,49 +213,82 @@ the headline — one drifting grain per landed contribution.
       }
 
       context.clearRect(0, 0, width, height);
+      blendTint();
 
-      // the settled pile
+      // the dune: one body, painted with the colours that landed on it
+      duneShape();
+      context.save();
+      context.clip();
+      context.fillStyle = surfaceGradient(0.62);
+      context.fillRect(0, 0, width, height);
+      // depth, so the mound has a lit crest and a shadowed base. It starts low:
+      // darken too early and the colours the grains left are lost again.
+      const depth = context.createLinearGradient(0, height - 70, 0, height);
+      depth.addColorStop(0, 'rgba(6, 5, 11, 0)');
+      depth.addColorStop(1, 'rgba(6, 5, 11, 0.6)');
+      context.fillStyle = depth;
+      context.fillRect(0, 0, width, height);
+      context.restore();
+
+      // the lit crest: this is where the colour of the newest grains shows
+      context.save();
       context.beginPath();
-      context.moveTo(0, height);
-      for (let i = 0; i < COLUMNS; i++) {
-        context.lineTo((i / (COLUMNS - 1)) * width, height - pile[i]);
+      context.moveTo(0, height - pile[0]);
+      for (let i = 0; i < columnCount - 1; i++) {
+        const x = (i / (columnCount - 1)) * width;
+        const nextX = ((i + 1) / (columnCount - 1)) * width;
+        context.quadraticCurveTo(x, height - pile[i], (x + nextX) / 2, height - (pile[i] + pile[i + 1]) / 2);
       }
-      context.lineTo(width, height);
-      context.closePath();
-      const gradient = context.createLinearGradient(0, height - 130, 0, height);
-      gradient.addColorStop(0, 'rgba(167, 139, 250, 0.55)');
-      gradient.addColorStop(1, 'rgba(109, 40, 217, 0.16)');
-      context.fillStyle = gradient;
-      context.fill();
+      context.lineTo(width, height - pile[columnCount - 1]);
+      context.strokeStyle = surfaceGradient(0.95);
+      context.lineWidth = 1.6;
+      context.lineJoin = 'round';
+      context.shadowBlur = 14;
+      context.shadowColor = 'rgba(226, 222, 254, 0.3)';
+      context.stroke();
+      context.restore();
 
       // falling grains
+      const column = (x) => Math.min(columnCount - 1, Math.max(0, Math.round((x / width) * (columnCount - 1))));
+      context.save();
+      context.globalCompositeOperation = 'lighter';
       for (let i = grains.length - 1; i >= 0; i--) {
         const grain = grains[i];
-        grain.v += 210 * dt;
+        grain.v += 150 * dt;
         grain.y += grain.v * dt;
-        const column = Math.min(COLUMNS - 1, Math.max(0, Math.round((grain.x / width) * (COLUMNS - 1))));
-        const floor = height - pile[column];
+        // the drift keeps the fall soft; it is what makes it read as sand
+        const drift = Math.sin(now / 900 + grain.phase) * grain.sway * dt;
+        grain.x = Math.min(width - 4, Math.max(4, grain.x + drift));
 
-        if (grain.y >= floor) {
-          pile[column] += pileGain;
+        const index = column(grain.x);
+        if (grain.y >= height - pile[index]) {
+          pile[index] += pileGain;
+          stain(index, grain.colour);
           grains.splice(i, 1);
           settled++;
           continue;
         }
 
+        const [r, g, b] = grain.colour;
+        const glow = context.createRadialGradient(grain.x, grain.y, 0, grain.x, grain.y, grain.r * 4);
+        glow.addColorStop(0, `rgba(${r}, ${g}, ${b}, 0.95)`);
+        glow.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0)`);
+        context.fillStyle = glow;
         context.beginPath();
-        context.arc(grain.x, grain.y, grain.r, 0, Math.PI * 2);
-        context.fillStyle = grain.hue < 0.3 ? 'rgba(252, 211, 77, 0.95)' : 'rgba(226, 222, 254, 0.9)';
+        context.arc(grain.x, grain.y, grain.r * 4, 0, Math.PI * 2);
         context.fill();
       }
+      context.restore();
 
       // the pile relaxes every frame, so the surface stays level like real sand
-      for (let i = 0; i < COLUMNS - 1; i++) {
+      for (let i = 0; i < columnCount - 1; i++) {
         const slope = pile[i] - pile[i + 1];
-        if (slope > 3) { const move = slope * 0.24; pile[i] -= move; pile[i + 1] += move; }
-        else if (slope < -3) { const move = -slope * 0.24; pile[i] += move; pile[i + 1] -= move; }
+        if (slope > 2) { const move = slope * 0.22; pile[i] -= move; pile[i + 1] += move; }
+        else if (slope < -2) { const move = -slope * 0.22; pile[i] += move; pile[i + 1] -= move; }
       }
 
+      // the loop stops once the last grain lands: an idle canvas must not keep
+      // a phone awake redrawing a picture that no longer changes
       if (settled >= total && grains.length === 0) {
         cancelAnimationFrame(frame);
         frame = 0;

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="contribute"></div>
-<script src="../site-header.js?v=20260815"></script>
+<script src="../site-header.js?v=20260817"></script>
 
 <main id="main">
 

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -169,7 +169,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 <section class="section-line" data-accent="#fbbf24" data-second="#a78bfa" data-energy="0.3">
   <div class="wrap">
     <div class="section-head scrim reveal">
-      <h2 class="title" data-split>The people building Nodus.</h2>
+      <!-- the kicker carries the heading now that the section has no title of
+           its own: the same small accented line, still a landmark for readers -->
+      <h2 class="kicker">The people building Nodus</h2>
     </div>
     <div class="people" id="people"><span class="people-loading">Loading contributors…</span></div>
   </div>

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -169,8 +169,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <section class="section-line" data-accent="#fbbf24" data-second="#a78bfa" data-energy="0.3">
   <div class="wrap">
     <div class="section-head scrim reveal">
-      <span class="kicker">The people building Nodus</span>
-      <h2 class="title" data-split>Names on the commits.</h2>
+      <h2 class="title" data-split>The people building Nodus.</h2>
     </div>
     <div class="people" id="people"><span class="people-loading">Loading contributors…</span></div>
   </div>
@@ -225,7 +224,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script src="../assets/js/organism.js?v=20260815"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
-<script src="contribute.js?v=20260817c"></script>
+<script src="contribute.js?v=20260817f"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -17,8 +17,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260815"/>
-<link rel="stylesheet" href="contribute.css?v=20260815"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
+<link rel="stylesheet" href="contribute.css?v=20260816"/>
 </head>
 <body>
 

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260817b"/>
 <link rel="stylesheet" href="contribute.css?v=20260816"/>
 </head>
 <body>
@@ -226,5 +226,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 <script src="../assets/js/organism.js?v=20260815"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="contribute.js?v=20260817c"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/demo/databases.html
+++ b/site/demo/databases.html
@@ -17,7 +17,7 @@
 </head>
 <body class="demo-page db">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script src="../site-header.js?v=20260815"></script>
+  <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/genealogy.html
+++ b/site/demo/genealogy.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page gen">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script src="../site-header.js?v=20260815"></script>
+  <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -17,7 +17,7 @@
 </head>
 <body class="demo-page">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script src="../site-header.js?v=20260815"></script>
+  <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/study.html
+++ b/site/demo/study.html
@@ -17,7 +17,7 @@
 </head>
 <body class="demo-page st">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script src="../site-header.js?v=20260815"></script>
+  <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/teaching.html
+++ b/site/demo/teaching.html
@@ -17,7 +17,7 @@
 </head>
 <body class="demo-page teach">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script src="../site-header.js?v=20260815"></script>
+  <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">
     <div class="mac-titlebar"><span class="mac-dots"><i></i><i></i><i></i></span><span class="mac-title">Nodus — Teaching demo</span></div>
     <div class="shell teach">

--- a/site/demo/worldbuilding.html
+++ b/site/demo/worldbuilding.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page worldbuilding">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script src="../site-header.js?v=20260815"></script>
+  <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="faq"></div>
-<script src="../site-header.js?v=20260815"></script>
+<script src="../site-header.js?v=20260817"></script>
 
 <main id="main" data-accent="#22d3ee" data-second="#a78bfa" data-energy="0.26">
   <header class="page-hero">

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260815"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
 <link rel="stylesheet" href="faq.css?v=20260815"/>
 </head>
 <body>

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260817b"/>
 <link rel="stylesheet" href="faq.css?v=20260815"/>
 </head>
 <body>
@@ -107,5 +107,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="faq-data.js?v=20260815"></script>
 <script src="faq.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -18,8 +18,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="assets/css/nodus.css?v=20260815"/>
-<link rel="stylesheet" href="assets/css/home.css?v=20260815"/>
+<link rel="stylesheet" href="assets/css/nodus.css?v=20260816"/>
+<link rel="stylesheet" href="assets/css/home.css?v=20260816"/>
 <script>
   /* Arm the opening sequence before the first paint. Anything that goes wrong
      here simply leaves the page in its ordinary, fully visible state. */

--- a/site/index.html
+++ b/site/index.html
@@ -46,7 +46,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="" data-page="home"></div>
-<script src="site-header.js?v=20260815"></script>
+<script src="site-header.js?v=20260817"></script>
 
 <main id="main">
 

--- a/site/index.html
+++ b/site/index.html
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="assets/css/nodus.css?v=20260816"/>
+<link rel="stylesheet" href="assets/css/nodus.css?v=20260817b"/>
 <link rel="stylesheet" href="assets/css/home.css?v=20260816"/>
 <script>
   /* Arm the opening sequence before the first paint. Anything that goes wrong
@@ -603,6 +603,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 <script src="assets/js/organism.js?v=20260815"></script>
 <script src="assets/js/site.js?v=20260815"></script>
 <script src="assets/js/home.js?v=20260815"></script>
-<script src="nodi.js?v=20260815"></script>
+<script src="assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/site-header.js
+++ b/site/site-header.js
@@ -71,24 +71,32 @@ Hosts opt in with a placeholder element:
     const toggle = host.querySelector('#site-nav-toggle');
     const links = host.querySelector('#site-nav-links');
 
-    toggle.addEventListener('click', () => {
-      const open = toggle.getAttribute('aria-expanded') === 'true';
-      toggle.setAttribute('aria-expanded', String(!open));
-      toggle.setAttribute('aria-label', open ? 'Open menu' : 'Close menu');
-      links.classList.toggle('open', !open);
-    });
+    // one place decides what "open" means, so the label, the ARIA state and the
+    // panel can never drift apart no matter which gesture closed the menu
+    const isOpen = () => links.classList.contains('open');
+    const setOpen = (open) => {
+      toggle.setAttribute('aria-expanded', String(open));
+      toggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      links.classList.toggle('open', open);
+    };
+
+    toggle.addEventListener('click', () => setOpen(!isOpen()));
     links.addEventListener('click', (event) => {
-      if (event.target.closest('a')) {
-        toggle.setAttribute('aria-expanded', 'false');
-        links.classList.remove('open');
-      }
+      if (event.target.closest('a')) setOpen(false);
     });
     document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && links.classList.contains('open')) {
-        toggle.setAttribute('aria-expanded', 'false');
-        links.classList.remove('open');
+      if (event.key === 'Escape' && isOpen()) {
+        setOpen(false);
         toggle.focus();
       }
+    });
+    // a press anywhere outside the panel dismisses it, the way every other menu
+    // on the web behaves. pointerdown rather than click: the menu is gone before
+    // the press lands, so the first tap outside also reaches what it aimed at.
+    document.addEventListener('pointerdown', (event) => {
+      if (!isOpen()) return;
+      if (links.contains(event.target) || toggle.contains(event.target)) return;
+      setOpen(false);
     });
 
     const syncBorder = () => nav.classList.toggle('scrolled', scrollY > 24);

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
+  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260817b"/>
   <link rel="stylesheet" href="wiki.css?v=20260817"/>
 </head>
 <body class="wiki-page" data-quiet>
@@ -39,5 +39,6 @@
   <script src="../assets/js/organism.js?v=20260815"></script>
   <script src="../site-header.js?v=20260815"></script>
   <script src="wiki.js?v=20260817" type="module"></script>
+  <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -11,8 +11,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260815"/>
-  <link rel="stylesheet" href="wiki.css?v=20260817"/>
+  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
+  <link rel="stylesheet" href="wiki.css?v=20260816"/>
 </head>
 <body class="wiki-page" data-quiet>
   <canvas id="organism" aria-hidden="true"></canvas>

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -12,7 +12,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="../assets/css/nodus.css?v=20260816"/>
-  <link rel="stylesheet" href="wiki.css?v=20260816"/>
+  <link rel="stylesheet" href="wiki.css?v=20260817"/>
 </head>
 <body class="wiki-page" data-quiet>
   <canvas id="organism" aria-hidden="true"></canvas>
@@ -38,6 +38,6 @@
   </div>
   <script src="../assets/js/organism.js?v=20260815"></script>
   <script src="../site-header.js?v=20260815"></script>
-  <script src="wiki.js?v=20260816" type="module"></script>
+  <script src="wiki.js?v=20260817" type="module"></script>
 </body>
 </html>

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -37,7 +37,7 @@
     <aside class="toc" aria-label="On this page"><b>On this page</b><nav id="page-toc"></nav></aside>
   </div>
   <script src="../assets/js/organism.js?v=20260815"></script>
-  <script src="../site-header.js?v=20260815"></script>
+  <script src="../site-header.js?v=20260817"></script>
   <script src="wiki.js?v=20260817" type="module"></script>
   <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/wiki/wiki.css
+++ b/site/wiki/wiki.css
@@ -441,11 +441,9 @@ main#article {
     background: rgba(0, 0, 0, 0.64); backdrop-filter: blur(3px); cursor: default;
   }
   .nav-backdrop:not([hidden]) { display: block; }
-  .section-grid, .start-box { grid-template-columns: 1fr; }
+  .section-grid, .start-box { grid-template-columns: minmax(0, 1fr); }
   .hero-shot { margin-inline: -10px; }
 }
-
-@media (max-width: 760px) { :root { --nav-h: 104px; } }
 
 @media print {
   [data-nodus-site-header], .sidebar, .toc, .hero-actions, .chapter-list, #organism { display: none !important; }
@@ -457,9 +455,11 @@ main#article {
 /* ============================================================ wiki chrome
    The header itself comes from nodus.css; these are the two controls only the
    documentation needs. site-header.css carries its own copy for the demos. */
+/* deliberately the same box as .nav-toggle in nodus.css: on a phone the two sit
+   side by side, and a half-size neighbour would read as a different control */
 .wiki-menu-toggle {
   display: none; place-items: center;
-  width: 38px; height: 34px; flex: 0 0 auto; padding: 0;
+  width: 40px; height: 36px; flex: 0 0 auto; padding: 0;
   border: 1px solid var(--membrane); border-radius: var(--r-s);
   background: var(--skin); color: var(--ink); cursor: pointer;
   transition: border-color 0.2s var(--ease), background 0.2s var(--ease);
@@ -468,16 +468,24 @@ main#article {
 .wiki-menu-toggle svg { width: 18px; height: 18px; }
 .wiki-menu-toggle:hover { border-color: rgba(167, 139, 250, 0.5); background: var(--skin-2); }
 
+/* --search-inset is the distance from this box's padding edge to the field
+   itself. The icon and the shortcut are absolute against the wrapper, so any
+   padding the wrapper takes on has to be added back here or they drift out of
+   the input and leave a hole in front of the placeholder. */
 .wiki-search-wrap {
   position: relative; display: flex; align-items: center;
   flex: 1 1 340px; min-width: 0; max-width: 460px;
+  --search-inset: 0px;
 }
 .wiki-search-wrap > svg {
-  position: absolute; left: 13px; width: 15px; height: 15px;
+  position: absolute; left: calc(var(--search-inset) + 13px); width: 15px; height: 15px;
   fill: none; stroke: var(--ink-3); stroke-width: 2; stroke-linecap: round;
   pointer-events: none;
 }
 .wiki-search-wrap input {
+  /* Safari draws type="search" as a native searchfield: it centres its own text
+     and ignores the padding, leaving the placeholder floating mid-box */
+  -webkit-appearance: none; appearance: none;
   width: 100%; padding: 9px 58px 9px 36px;
   border: 1px solid var(--membrane); border-radius: 11px;
   background: rgba(16, 13, 28, 0.85); color: var(--ink);
@@ -495,7 +503,7 @@ main#article {
 }
 .wiki-search-wrap input::-webkit-search-cancel-button { display: none; }
 .wiki-search-wrap kbd {
-  position: absolute; right: 9px; padding: 2px 6px;
+  position: absolute; right: calc(var(--search-inset) + 9px); padding: 2px 6px;
   border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 6px;
   background: var(--skin); color: var(--ink-2); font: 10.5px/1.4 var(--sans);
 }
@@ -506,6 +514,7 @@ main#article {
   position: sticky; top: -26px; z-index: 3;
   flex: none; width: 100%; max-width: none;
   margin: 0 -16px 18px; padding: 0 16px 14px;
+  --search-inset: 16px;
   background: rgba(13, 11, 21, 0.94);
   backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--membrane);
@@ -516,8 +525,17 @@ main#article {
   .wiki-nav .release-downloads .download-word { display: none; }
   .wiki-nav .release-downloads { min-width: 58px; padding-inline: 10px; }
 }
-@media (max-width: 1080px) { .wiki-nav .wiki-menu-toggle { display: grid; } }
+/* The docs button is written first in the markup so it reads right after the
+   landmark, but on a phone it belongs with the other menu control: reorder it
+   into the pair at the end of the bar rather than stranding it beside the logo. */
+@media (max-width: 1080px) {
+  .wiki-nav .wiki-menu-toggle { display: grid; order: 2; margin-left: auto; }
+  .wiki-nav .nav-toggle { order: 3; margin-left: 0; }
+  .wiki-nav { gap: 10px; }
+}
+/* the phone header holds a logo and two buttons in one row, so it keeps the
+   standard 62px band: the taller wrapping bar dates from when the search box
+   still rode in the header */
 @media (max-width: 760px) {
-  .wiki-nav { height: auto; min-height: 104px; flex-wrap: wrap; gap: 8px 12px; padding: 10px 16px; }
-  .wiki-nav .links { inset-block-start: 104px; }
+  .wiki-nav { padding-inline: 16px; }
 }

--- a/site/wiki/wiki.css
+++ b/site/wiki/wiki.css
@@ -200,25 +200,6 @@ main#article {
   object-fit: cover; object-position: top; border-radius: 10px;
 }
 
-/* ============================================================ chapter index */
-.chapter-list {
-  display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 12px; margin: 28px 0 54px;
-}
-.chapter-card {
-  padding: 18px 20px; border-radius: var(--r-m);
-  border: 1px solid var(--membrane);
-  background: linear-gradient(180deg, rgba(23, 19, 40, 0.7), rgba(11, 9, 21, 0.66));
-  transition: transform 0.2s var(--ease), border-color 0.2s var(--ease);
-}
-.chapter-card:hover {
-  transform: translateY(-2px);
-  border-color: color-mix(in srgb, var(--doc-accent) 45%, var(--membrane));
-}
-.chapter-card small { font: 700 10.5px var(--mono); letter-spacing: 0.08em; color: var(--doc-accent); }
-.chapter-card b { display: block; margin-top: 6px; color: var(--ink); font-size: 14.5px; }
-.chapter-card span { display: block; margin-top: 5px; color: var(--ink-3); font-size: 12.5px; line-height: 1.55; }
-
 /* ============================================================ a chapter */
 .doc-section { scroll-margin-top: calc(var(--nav-h) + 26px); margin-top: 58px; }
 .section-kicker {
@@ -446,7 +427,7 @@ main#article {
 }
 
 @media print {
-  [data-nodus-site-header], .sidebar, .toc, .hero-actions, .chapter-list, #organism { display: none !important; }
+  [data-nodus-site-header], .sidebar, .toc, .hero-actions, #organism { display: none !important; }
   .layout { display: block; padding: 0; }
   main#article { padding: 0; background: none; }
   body { background: #fff; color: #111; }

--- a/site/wiki/wiki.js
+++ b/site/wiki/wiki.js
@@ -123,7 +123,6 @@ function vaultMarkup(vault) {
     <div class="meta-row"><span class="pill">For ${escapeHtml(vault.audience)}</span><span class="pill">${vault.chapters.length} complete tutorials</span><span class="pill">Step-by-step workflows</span></div>
     <div class="hero-actions"><a class="action primary" href="#${vault.chapters[0].id}">Begin the guide</a><a class="action" href="${vault.pdf}" download>${downloadIconMarkup()}Download PDF manual</a><a class="action bundle-download" href="${content.manualBundle}" download>${downloadIconMarkup()}Download all manuals</a></div>
     ${figure(`${vault.id}/home.png`, `${vault.name} vault overview`)}
-    <section class="doc-section"><p class="section-kicker">Contents</p><h2>Complete ${escapeHtml(vault.short)} workflow</h2><div class="chapter-list">${vault.chapters.map((chapter,index) => `<a class="chapter-card" href="#${chapter.id}"><small>${String(index+1).padStart(2,'0')} · ${escapeHtml(chapter.group)}</small><b>${escapeHtml(chapter.title)}</b><span>${escapeHtml(chapter.summary)}</span></a>`).join('')}</div></section>
     ${vault.chapters.map((chapter, index) => sectionMarkup(chapter, vault.accent, index === 0 || index % 2 === 1, vault)).join('')}
   </div>`;
 }


### PR DESCRIPTION
## No horizontal scroll, desktop or mobile

Measured every page (12 documents) at 360, 375, 414, 768, 1024, 1280 and 1440 px in a real browser, comparing `documentElement.scrollWidth` against `clientWidth`. Three root causes, all now fixed:

- **The scrims.** `.scrim::before` bled `-64px` sideways (the hero's, `-90px`) to pool darkness under the text. On a phone that is 128–180px of phantom width beyond the gutter, so the whole page could be dragged sideways. The bleed is now clamped to the page gutter: `calc(-1 * min(64px, var(--gut)))`.
- **Bare `1fr` grid columns.** A bare `fr` keeps an automatic minimum, so on the single-column mobile collapse one wide child (a mock screenshot frame) pushed the whole column past the viewport. Every single-column collapse now uses `minmax(0, 1fr)`.
- **No net underneath.** `body { overflow-x: hidden }` propagates to the viewport but is a poor guard: it makes the viewport a scroll container and breaks sticky elements. Replaced with `html { overflow-x: clip }`, which clips without that side effect — the wiki rail and its sticky search box keep working.

After the fix the sweep reports zero overflow on all 12 pages at all 7 widths, and on the home page at 375px `scrollTo(9999, y)` leaves `scrollX` at 0.

## Wiki header on mobile

- The docs (book) button now has exactly the same box as the hamburger — 40×36, same 1px border, same radius, same surface — instead of 38×34.
- It sits immediately to the left of the hamburger, reordered with flex `order` so the markup keeps the button next to the landmark for screen readers.
- The phone header goes back to the standard 62px band. The 104px wrapping bar dated from when the search box still rode in the header.

## Wiki search box

The magnifier sat *outside* the field and the placeholder started ~24px further in, leaving a hole. In the sidebar the wrapper takes `margin: 0 -16px; padding: 0 16px`, and the icon and `⌘ K` are positioned against that wrapper, not the input, so both drifted out of the box. Both now offset by a `--search-inset` variable that the sidebar sets to its own padding. Also added `appearance: none` so Safari stops drawing it as a native searchfield with its own centred text.

Verified with `node --test scripts/test-site-shared-header.mjs scripts/test-site-wiki.mjs scripts/test-site-layout.mjs scripts/test-worldbuilding-site-demo.mjs scripts/test-teaching-web-demo.mjs` — 23 pass, 0 fail — plus the browser measurements above.