### PR TITLE
Drop the "What Nodus is" section and let the vaults introduce themselves

### DIFF
--- a/site/assets/css/home.css
+++ b/site/assets/css/home.css
@@ -79,55 +79,6 @@ Home page components. The shared system lives in nodus.css.
   will-change: transform;
 }
 
-/* ============================================================ basics */
-.pillars {
-  display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 16px; margin-top: 52px;
-}
-.pillar { padding: 24px; }
-.pillar .pic {
-  display: grid; place-items: center;
-  width: 42px; height: 42px; margin-bottom: 16px;
-  border-radius: 12px; border: 1px solid var(--membrane);
-  background: var(--accent-soft); color: var(--accent);
-}
-.pillar .pic svg { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
-.pillar h3 { font-size: 17px; margin-bottom: 8px; }
-.pillar p { margin: 0; font-size: 14.5px; color: var(--ink-2); line-height: 1.6; }
-
-/* what a vault is */
-.vault-def {
-  display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
-  gap: clamp(28px, 5vw, 64px); align-items: center;
-  margin-top: 58px; padding: clamp(26px, 3.6vw, 44px);
-  border: 1px solid var(--membrane); border-radius: var(--r-xl);
-  background: linear-gradient(140deg, rgba(32, 22, 58, 0.88), rgba(12, 9, 22, 0.84));
-}
-.vault-def h3 { font-size: clamp(21px, 2.4vw, 28px); margin-bottom: 14px; }
-.vault-def p { margin: 0 0 14px; color: var(--ink-2); font-size: 15.5px; }
-.vault-def p:last-child { margin-bottom: 0; }
-
-/* the little file-with-modes diagram */
-.mode-stack { display: grid; gap: 10px; }
-.mode-row {
-  display: flex; align-items: center; gap: 12px;
-  padding: 12px 15px; border-radius: var(--r-m);
-  border: 1px solid var(--membrane); background: rgba(255, 255, 255, 0.03);
-  font-size: 13.5px; font-weight: 600;
-}
-.mode-row i {
-  width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto;
-  background: var(--dot, var(--violet-2));
-  box-shadow: 0 0 12px var(--dot, var(--violet-2));
-}
-.mode-row span { margin-left: auto; font-weight: 500; font-size: 12.5px; color: var(--ink-3); }
-.mode-row.engine {
-  border-style: dashed; border-color: rgba(167, 139, 250, 0.4);
-  background: rgba(139, 92, 246, 0.07); color: var(--violet-3);
-}
-
-@media (max-width: 900px) { .vault-def { grid-template-columns: minmax(0, 1fr); } }
-
 /* ============================================================ vault scenes */
 .scene { padding: clamp(56px, 7.5vw, 100px) 0; }
 .scene-inner {

--- a/site/index.html
+++ b/site/index.html
@@ -19,7 +19,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="assets/css/nodus.css?v=20260817c"/>
-<link rel="stylesheet" href="assets/css/home.css?v=20260816"/>
+<link rel="stylesheet" href="assets/css/home.css?v=20260817"/>
 <script>
   /* Arm the opening sequence before the first paint. Anything that goes wrong
      here simply leaves the page in its ordinary, fully visible state. */
@@ -86,62 +86,13 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="scroll-cue" aria-hidden="true"><span class="rail"></span>Scroll</div>
 </header>
 
-<!-- ============================================================ the basics -->
-<section id="basics" class="section-line" data-accent="#a78bfa" data-second="#8b5cf6" data-energy="0.26">
-  <div class="wrap">
-    <div class="section-head scrim reveal">
-      <span class="kicker">What Nodus is</span>
-      <h2 class="title" data-split>One desktop app that takes the shape of your work.</h2>
-      <p class="lead">Bring in whatever you already have — your own documents, a Zotero collection, class notes, a recorded lecture, a box of old records, a table of data — and Nodus reads it for what it actually holds, then turns it into something you can question, map and write from. Everything happens on your device.</p>
-    </div>
-
-    <div class="pillars">
-      <article class="card lit pillar reveal" style="--delay:0ms">
-        <span class="pic"><svg viewBox="0 0 24 24"><path d="M12 3 4 6.5v5c0 4.7 3.3 8.4 8 9.5 4.7-1.1 8-4.8 8-9.5v-5L12 3Z"/><path d="m9 12 2 2 4-4"/></svg></span>
-        <h3>It stays on your machine</h3>
-        <p>Vaults are files on your own disk. No account, no server, no telemetry, no upload step. Backups go to a folder you choose.</p>
-      </article>
-      <article class="card lit pillar reveal" style="--delay:80ms">
-        <span class="pic"><svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14Z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg></span>
-        <h3>Every claim keeps its evidence</h3>
-        <p>Nothing is recorded without the passage behind it. Each idea, entity or finding points back to the exact page, note or second it came from.</p>
-      </article>
-      <article class="card lit pillar reveal" style="--delay:160ms">
-        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.2"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9 7 7M17 17l2.1 2.1M19.1 4.9 17 7M7 17l-2.1 2.1"/></svg></span>
-        <h3>AI on your terms</h3>
-        <p>Use your own API key, or run entirely offline with Ollama and LM Studio. The model assists; it never becomes the authority on your corpus.</p>
-      </article>
-      <article class="card lit pillar reveal" style="--delay:240ms">
-        <span class="pic"><svg viewBox="0 0 24 24"><path d="M6 3h9l5 5v13a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/><path d="M14 3v6h6M9 13h6M9 17h4"/></svg></span>
-        <h3>Free, and open to read</h3>
-        <p>Nodus 4 is released under the AGPL-3.0-only licence. The whole source is public, and it will not start charging you later.</p>
-      </article>
-    </div>
-
-    <div class="vault-def reveal">
-      <div>
-        <h3>A vault is one project, and it picks a mode.</h3>
-        <p>Each vault is a single file holding one body of work. Its <b>mode</b> decides which sections appear in the app and how the AI assistant is briefed — an academic library needs debates and citations; a class needs timetables and grades.</p>
-        <p>Underneath, every mode runs the same engine, the same private storage and the same settings. Learn one vault and you already know the others.</p>
-      </div>
-      <div class="mode-stack" aria-hidden="true">
-        <div class="mode-row" style="--dot:#818cf8"><i></i> Academic <span>research library</span></div>
-        <div class="mode-row" style="--dot:#fb923c"><i></i> Teaching <span>courses &amp; assessment</span></div>
-        <div class="mode-row" style="--dot:#2dd4bf"><i></i> Study <span>subjects &amp; revision</span></div>
-        <div class="mode-row" style="--dot:#ff5f7e"><i></i> Databases <span>structured data</span></div>
-        <div class="mode-row engine">One engine · local storage · shared settings</div>
-      </div>
-    </div>
-  </div>
-</section>
-
 <!-- ============================================================ the four vaults -->
 <section id="vaults" class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.3" style="padding-bottom:0">
   <div class="wrap">
     <div class="section-head scrim reveal">
       <span class="kicker">The four main vaults</span>
       <h2 class="title" data-split>Four ways to work. One engine underneath.</h2>
-      <p class="lead">These are the modes most people start from. Each one is a full workspace with its own sections, its own vocabulary and its own live demo you can open right now in this browser.</p>
+      <p class="lead">Nodus is organised into vaults. Each vault is a workspace with a different purpose, its own sections and its own vocabulary, and each one has a live demo you can open right now in this browser.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Follow-up to #446, which was merged before these changes were pushed.

## What changed

**Removed the `#basics` section** from the home page: the "What Nodus is" heading, its four pillar cards, and the "A vault is one project, and it picks a mode." panel with the mode diagram.

The section repeated what the hero and the four vault scenes already say, and its vault-definition panel explained what a vault is immediately before the four scenes that show one.

**The vaults section now introduces the concept itself.** Its lead becomes:

> Nodus is organised into vaults. Each vault is a workspace with a different purpose, its own sections and its own vocabulary, and each one has a live demo you can open right now in this browser.

So a reader still meets the idea of a vault before the first scene that relies on it.

**Removed the CSS that only styled the deleted markup** — `.pillars`, `.pillar`, `.vault-def`, `.mode-stack`, `.mode-row` in `assets/css/home.css` (49 lines). Confirmed those classes appear nowhere else in the site before deleting.

## Verification

- No remaining references to `#basics` or any of the removed classes; the anchor was not linked from the navigation or anywhere else.
- All 29 site tests pass.
- Home page checked in the browser: four vault scenes intact with normal heights, the new lead renders, no console errors.