### PR TITLE
Give the RSS feed a face, and measure the site

### DIFF
--- a/scripts/build-blog-feed.mjs
+++ b/scripts/build-blog-feed.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const blogRoot = path.join(repoRoot, 'site/blog');
-const SITE = 'https://drakonis96.github.io/nodus';
+const SITE = 'https://nodusresearch.com';
 
 const escapeXml = (value) => String(value).replace(/[&<>"']/g, (character) => (
   { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' }[character]
@@ -27,13 +27,15 @@ const pubDate = (value) => new Date(`${value}T12:00:00Z`).toUTCString();
 const items = posts.map((post) => `    <item>
       <title>${escapeXml(post.title)}</title>
       <link>${SITE}/blog/post.html?p=${encodeURIComponent(post.slug)}</link>
-      <guid isPermaLink="false">nodus-blog-${escapeXml(post.slug)}</guid>
+      <guid isPermaLink="true">${SITE}/blog/post.html?p=${encodeURIComponent(post.slug)}</guid>
       <pubDate>${pubDate(post.date)}</pubDate>
       <description>${escapeXml(post.summary || post.title)}</description>
 ${(post.tags || []).map((tag) => `      <category>${escapeXml(tag)}</category>`).join('\n')}
     </item>`).join('\n');
 
+// the stylesheet is browsers-only: feed readers skip the instruction
 const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="feed.xsl"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Nodus Blog</title>

--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const SITE = 'https://drakonis96.github.io/nodus';
+const SITE = 'https://nodusresearch.com';
 
 const PAGES = [
   { file: 'index.html', url: '/' },

--- a/scripts/test-site-blog.mjs
+++ b/scripts/test-site-blog.mjs
@@ -87,9 +87,36 @@ test('the RSS feed carries the published posts and nothing else', () => {
   }
 });
 
+test('the feed is readable in a browser, not just in a reader', () => {
+  const feed = read('feed.xml');
+  assert.match(
+    feed,
+    /<\?xml-stylesheet type="text\/xsl" href="feed\.xsl"\?>/,
+    'feed.xml points at the stylesheet, so a browser renders a page instead of raw XML',
+  );
+  const stylesheet = read('feed.xsl');
+  assert.match(stylesheet, /<xsl:template match="\/rss\/channel">/, 'the stylesheet transforms the channel');
+  assert.match(stylesheet, /<xsl:template match="item">/, 'the stylesheet renders each post');
+
+  // the address only helps when it can be taken to a reader in one click
+  const html = read('index.html');
+  assert.match(html, /id="feed-copy"[^>]*data-url="https:\/\/nodusresearch\.com\/blog\/feed\.xml"/);
+  assert.match(read('blog.js'), /navigator\.clipboard/, 'the copy button is wired');
+});
+
+test('regenerating the feed keeps what the published feed says', () => {
+  // build-blog-feed.mjs overwrites feed.xml wholesale: if it drifts from the
+  // shipped feed, one `npm run blog:feed` silently undoes the domain move and
+  // changes every guid, which shows old posts again in everyone's reader
+  const generator = fs.readFileSync(path.join(repoRoot, 'scripts', 'build-blog-feed.mjs'), 'utf8');
+  assert.match(generator, /const SITE = 'https:\/\/nodusresearch\.com'/, 'the generator uses the live domain');
+  assert.match(generator, /xml-stylesheet type="text\/xsl" href="feed\.xsl"/, 'the generator keeps the stylesheet');
+  assert.match(generator, /<guid isPermaLink="true">/, 'the generator keeps the guids already published');
+});
+
 test('the site addresses the blog by its own domain', () => {
   // the sitemap is validated against the verified Search Console property
-  for (const file of ['index.html', 'post.html', 'feed.xml']) {
+  for (const file of ['index.html', 'post.html', 'feed.xml', 'feed.xsl']) {
     assert.doesNotMatch(read(file), /drakonis96\.github\.io/, `${file} uses nodusresearch.com`);
   }
   const sitemap = fs.readFileSync(path.join(repoRoot, 'site', 'sitemap.xml'), 'utf8');

--- a/scripts/test-site-pages.mjs
+++ b/scripts/test-site-pages.mjs
@@ -48,6 +48,35 @@ test('the home page presents the four main vaults, the rest, and the toolkit', (
   }
 });
 
+test('every page of the site carries the Google Tag Manager container', () => {
+  // a page added later without the snippet goes uncounted and nobody notices,
+  // so the container is checked across the whole site rather than page by page
+  const pages = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.html')) pages.push(full);
+    }
+  };
+  walk(siteRoot);
+  assert.ok(pages.length >= 12, 'the walk found the pages of the site');
+
+  for (const page of pages) {
+    const html = fs.readFileSync(page, 'utf8');
+    const name = path.relative(siteRoot, page);
+    assert.match(html, /googletagmanager\.com\/gtm\.js/, `${name} loads the GTM container`);
+    assert.match(html, /googletagmanager\.com\/ns\.html\?id=GTM-MP3BX78N/, `${name} carries the noscript fallback`);
+    // the container must be reachable before anything else can delay it
+    const headStart = html.indexOf('<!-- Google Tag Manager -->');
+    assert.ok(headStart > -1 && headStart < html.indexOf('<title'), `${name} puts GTM high in the head`);
+    assert.ok(
+      html.indexOf('<!-- Google Tag Manager (noscript) -->') > html.indexOf('<body'),
+      `${name} puts the noscript iframe right after <body>`,
+    );
+  }
+});
+
 test('the tutorial gallery lives in the wiki and is generated from the file the desktop app also reads', () => {
   const script = read('wiki/wiki.js');
   assert.match(script, /fetch\('\.\.\/tutorials\.json'\)/);

--- a/site/assets/css/home.css
+++ b/site/assets/css/home.css
@@ -96,7 +96,6 @@ Home page components. The shared system lives in nodus.css.
   color: transparent; -webkit-text-stroke: 1.2px var(--accent);
   opacity: 0.75;
 }
-.scene-index .tag-status { transform: translateY(-4px); }
 
 .scene h2 {
   font-size: clamp(30px, 4.2vw, 52px);

--- a/site/blog/blog.css
+++ b/site/blog/blog.css
@@ -3,9 +3,22 @@ SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 SPDX-License-Identifier: AGPL-3.0-only
 */
 
-.hero-feed { margin-top: 24px; }
+.hero-feed { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 22px; margin-top: 24px; }
 .hero-feed .arrow-link svg { transform: none; }
 .hero-feed .arrow-link:hover svg { transform: scale(1.12); }
+
+/* the RSS link leads to XML, which is right for a reader and puzzling in a
+   browser, so the address can also be taken straight to the clipboard */
+.feed-copy {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  border: 1px solid var(--membrane); background: rgba(255, 255, 255, 0.045);
+  color: var(--ink-2); font: 600 13.5px var(--sans); cursor: pointer;
+  transition: border-color 0.3s var(--ease), color 0.3s var(--ease), background 0.3s var(--ease);
+}
+.feed-copy svg { width: 15px; height: 15px; }
+.feed-copy:hover { color: var(--ink); border-color: var(--membrane-2); background: rgba(255, 255, 255, 0.07); }
+.feed-copy.copied { color: var(--good); border-color: rgba(52, 211, 153, 0.45); }
 
 /* ============================================================ the list */
 .post-list { display: grid; gap: 16px; }

--- a/site/blog/blog.js
+++ b/site/blog/blog.js
@@ -8,6 +8,30 @@ tag and by free text. With no published posts it shows what is coming instead.
 (function () {
   'use strict';
 
+  // The feed address is only useful pasted into a reader, so offer it as a copy
+  // rather than as one more link into raw XML. Shown only where copying works.
+  const copyButton = document.getElementById('feed-copy');
+  if (copyButton && navigator.clipboard && window.isSecureContext) {
+    const label = document.getElementById('feed-copy-label');
+    const idle = label.textContent;
+    let restore;
+    copyButton.hidden = false;
+    copyButton.addEventListener('click', () => {
+      navigator.clipboard.writeText(copyButton.dataset.url).then(() => {
+        label.textContent = 'Copied — paste it into your feed reader';
+        copyButton.classList.add('copied');
+        clearTimeout(restore);
+        restore = setTimeout(() => {
+          label.textContent = idle;
+          copyButton.classList.remove('copied');
+        }, 3200);
+      }).catch(() => {
+        // clipboard refused: show the address so it can be selected by hand
+        label.textContent = copyButton.dataset.url;
+      });
+    });
+  }
+
   const list = document.getElementById('blog-list');
   const filters = document.getElementById('blog-filters');
   const tagsHost = document.getElementById('blog-tags');

--- a/site/blog/feed.xml
+++ b/site/blog/feed.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="feed.xsl"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Nodus Blog</title>
@@ -6,13 +7,12 @@
     <atom:link href="https://nodusresearch.com/blog/feed.xml" rel="self" type="application/rss+xml"/>
     <description>Notes from the Nodus project: comparisons with the tools around it, workflows worth stealing, and what is being built next.</description>
     <language>en</language>
-    <lastBuildDate>Sun, 16 Aug 2026 09:00:00 GMT</lastBuildDate>
-
+    <lastBuildDate>Sun, 16 Aug 2026 12:00:00 GMT</lastBuildDate>
     <item>
       <title>Nodus: an open source research workspace for academic work</title>
       <link>https://nodusresearch.com/blog/post.html?p=nodus-open-source-research-workspace</link>
       <guid isPermaLink="true">https://nodusresearch.com/blog/post.html?p=nodus-open-source-research-workspace</guid>
-      <pubDate>Sun, 16 Aug 2026 09:00:00 GMT</pubDate>
+      <pubDate>Sun, 16 Aug 2026 12:00:00 GMT</pubDate>
       <description>Research is spread across reference managers, PDF folders, note apps and chatbots. Nodus keeps sources, ideas and the evidence behind them in one local-first workspace.</description>
       <category>Project</category>
       <category>Research</category>

--- a/site/blog/feed.xsl
+++ b/site/blog/feed.xsl
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+
+Browsers stopped rendering RSS years ago, so anyone who clicks the feed link
+lands on raw XML. This stylesheet gives that page a readable face. Feed readers
+ignore it entirely: it only ever runs in a browser.
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <xsl:output method="html" encoding="UTF-8" indent="yes"/>
+
+  <xsl:template match="/rss/channel">
+    <html lang="en">
+      <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="robots" content="noindex"/>
+        <title><xsl:value-of select="title"/> — RSS feed</title>
+        <link rel="icon" type="image/svg+xml" href="../assets/nodus-logo.svg"/>
+        <style>
+          :root {
+            --void: #06050b;
+            --raised: #100d1c;
+            --membrane: rgba(255, 255, 255, 0.09);
+            --ink: #f6f4fd;
+            --ink-2: #a9a3c2;
+            --ink-3: #6f6a86;
+            --accent: #c084fc;
+          }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0;
+            padding: clamp(28px, 6vw, 72px) 20px clamp(48px, 8vw, 96px);
+            background:
+              radial-gradient(900px 520px at 12% -10%, rgba(192, 132, 252, 0.16), transparent 68%),
+              var(--void);
+            color: var(--ink);
+            font: 400 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, Helvetica, Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+          }
+          .wrap { max-width: 820px; margin: 0 auto; }
+          a { color: var(--accent); text-decoration: none; }
+          a:hover { text-decoration: underline; }
+          .brand {
+            display: inline-flex; align-items: center; gap: 9px;
+            font-size: 14px; font-weight: 600; color: var(--ink-2);
+            letter-spacing: 0.02em;
+          }
+          .brand img { width: 22px; height: 22px; }
+          h1 {
+            margin: 22px 0 10px;
+            font-size: clamp(28px, 5vw, 42px);
+            letter-spacing: -0.03em; line-height: 1.12;
+          }
+          .lead { margin: 0; max-width: 60ch; color: var(--ink-2); }
+          .note {
+            margin: 30px 0 0; padding: 22px 24px;
+            border: 1px solid var(--membrane); border-radius: 16px;
+            background: linear-gradient(180deg, rgba(34, 22, 54, 0.7), rgba(12, 9, 22, 0.6));
+          }
+          .note h2 {
+            margin: 0 0 8px; font-size: 13px; font-weight: 700;
+            letter-spacing: 0.09em; text-transform: uppercase; color: var(--accent);
+          }
+          .note p { margin: 0 0 14px; color: var(--ink-2); font-size: 15px; }
+          .note p:last-child { margin-bottom: 0; }
+          .url {
+            display: block; width: 100%; padding: 12px 14px;
+            border: 1px solid var(--membrane); border-radius: 10px;
+            background: rgba(255, 255, 255, 0.04);
+            color: var(--ink); font: 500 14px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            word-break: break-all;
+          }
+          .items { margin-top: 42px; display: grid; gap: 14px; }
+          .items h2.section {
+            margin: 0; font-size: 13px; font-weight: 700;
+            letter-spacing: 0.09em; text-transform: uppercase; color: var(--ink-3);
+          }
+          .item {
+            padding: 24px 26px;
+            border: 1px solid var(--membrane); border-radius: 16px;
+            background: linear-gradient(180deg, rgba(23, 19, 40, 0.82), rgba(11, 9, 21, 0.78));
+          }
+          .item .date {
+            font: 600 12px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            letter-spacing: 0.05em; text-transform: uppercase; color: var(--ink-3);
+          }
+          .item h3 { margin: 12px 0 8px; font-size: clamp(19px, 2.4vw, 24px); letter-spacing: -0.02em; }
+          .item h3 a { color: var(--ink); }
+          .item h3 a:hover { color: var(--accent); text-decoration: none; }
+          .item p { margin: 0; color: var(--ink-2); font-size: 15px; }
+          .tags { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 16px; }
+          .tags span {
+            padding: 4px 11px; border-radius: 999px;
+            border: 1px solid var(--membrane); background: rgba(255, 255, 255, 0.045);
+            font-size: 11.5px; font-weight: 600; color: var(--ink-3);
+          }
+          .foot { margin-top: 40px; font-size: 14px; color: var(--ink-3); }
+        </style>
+      </head>
+      <body>
+        <div class="wrap">
+          <a class="brand" href="{link}">
+            <img src="../assets/nodus-logo.svg" alt=""/>
+            <xsl:text>Nodus</xsl:text>
+          </a>
+
+          <h1><xsl:value-of select="title"/></h1>
+          <p class="lead"><xsl:value-of select="description"/></p>
+
+          <div class="note">
+            <h2>This page is an RSS feed</h2>
+            <p>
+              It is meant for a feed reader, not for a browser. Paste the address below into
+              Feedly, NetNewsWire, Reeder, Thunderbird or whatever you use, and every new post
+              will arrive there on its own.
+            </p>
+            <code class="url"><xsl:value-of select="atom:link/@href"/></code>
+            <p style="margin-top:14px">
+              <xsl:text>Prefer to read in the browser? </xsl:text>
+              <a href="{link}">Open the blog instead.</a>
+            </p>
+          </div>
+
+          <div class="items">
+            <h2 class="section">
+              <xsl:value-of select="count(item)"/>
+              <xsl:text> post</xsl:text>
+              <xsl:if test="count(item) != 1">s</xsl:if>
+              <xsl:text> in this feed</xsl:text>
+            </h2>
+            <xsl:apply-templates select="item"/>
+          </div>
+
+          <p class="foot">Nodus — a free, open-source, local-first workspace for research, teaching and study.</p>
+        </div>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="item">
+    <div class="item">
+      <div class="date"><xsl:value-of select="substring(pubDate, 6, 11)"/></div>
+      <h3><a href="{link}"><xsl:value-of select="title"/></a></h3>
+      <p><xsl:value-of select="description"/></p>
+      <xsl:if test="category">
+        <div class="tags">
+          <xsl:for-each select="category">
+            <span><xsl:value-of select="."/></span>
+          </xsl:for-each>
+        </div>
+      </xsl:if>
+    </div>
+  </xsl:template>
+</xsl:stylesheet>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -6,6 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Nodus Blog</title>
 <meta name="description" content="Notes from the Nodus project: how it compares to the tools around it, workflows worth stealing, and what is being built next."/>
@@ -19,9 +26,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="../assets/css/nodus.css?v=20260817c"/>
-<link rel="stylesheet" href="blog.css?v=20260816"/>
+<link rel="stylesheet" href="blog.css?v=20260817"/>
 </head>
 <body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 <a class="skip-link" href="#main">Skip to the posts</a>
 <canvas id="organism" aria-hidden="true"></canvas>
@@ -39,6 +50,10 @@ SPDX-License-Identifier: AGPL-3.0-only
         <p class="hero-feed">
           <a class="arrow-link" href="feed.xml">Subscribe by RSS
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1.6" fill="currentColor"/></svg></a>
+          <button class="feed-copy" id="feed-copy" type="button" data-url="https://nodusresearch.com/blog/feed.xml" hidden>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>
+            <span id="feed-copy-label">Copy the feed URL</span>
+          </button>
         </p>
       </div>
     </div>
@@ -122,7 +137,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script src="../assets/js/organism.js?v=20260815"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
-<script src="blog.js?v=20260816"></script>
+<script src="blog.js?v=20260817"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/blog/post.html
+++ b/site/blog/post.html
@@ -8,6 +8,13 @@ Renders one post: /blog/post.html?p=<slug>, reading posts/<slug>.md.
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Nodus Blog</title>
 <meta name="description" content="A post from the Nodus blog."/>
@@ -21,9 +28,13 @@ Renders one post: /blog/post.html?p=<slug>, reading posts/<slug>.md.
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="../assets/css/nodus.css?v=20260817c"/>
-<link rel="stylesheet" href="blog.css?v=20260816"/>
+<link rel="stylesheet" href="blog.css?v=20260817"/>
 </head>
 <body data-quiet>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 <a class="skip-link" href="#article">Skip to the post</a>
 <canvas id="organism" aria-hidden="true"></canvas>

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -6,6 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Contribute to Nodus</title>
 <meta name="description" content="Nodus grows one contribution at a time. Report a bug, translate the interface, improve the docs, test a beta or send a pull request — here is how, and the rules the project holds itself to."/>
@@ -21,6 +28,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="stylesheet" href="contribute.css?v=20260816"/>
 </head>
 <body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 <a class="skip-link" href="#main">Skip to content</a>
 <canvas id="organism" aria-hidden="true"></canvas>

--- a/site/demo/databases.html
+++ b/site/demo/databases.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <title>Nodus — Databases demo</title>
   <meta name="description" content="Interactive demo of Nodus in Databases mode: structured data as typed tables — single/multi-select, numbers, dates, relations and an AI-summary column — with a computed Analysis section (statistics, histograms, box-plots, correlations) and a data chat."/>
@@ -16,6 +23,10 @@
   <link rel="stylesheet" href="../site-header.css?v=20260815"/>
 </head>
 <body class="demo-page db">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
   <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">

--- a/site/demo/genealogy.html
+++ b/site/demo/genealogy.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <title>Nodus — Genealogy demo</title>
   <meta name="description" content="Interactive demo of Nodus in Genealogy mode: reconstruct a family from primary sources — persons, family tree, timeline, evidence archive, map and a family-history report."/>
@@ -17,6 +24,10 @@
   <link rel="stylesheet" href="../site-header.css?v=20260815"/>
 </head>
 <body class="demo-page gen">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
   <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <title>Nodus — Live demo</title>
   <meta name="description" content="Interactive demo of Nodus: a free, open-source, local-first desktop app that turns your Zotero library into a navigable graph of ideas."/>
@@ -16,6 +23,10 @@
   <link rel="stylesheet" href="../site-header.css?v=20260815"/>
 </head>
 <body class="demo-page">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
   <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">

--- a/site/demo/study.html
+++ b/site/demo/study.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <title>Nodus — Study demo</title>
   <meta name="description" content="Interactive demo of Nodus in Study mode: courses and subjects, a schedule and calendar, materials, recorded classes with transcripts, an idea map per subject, a question bank and spaced review — all local."/>
@@ -16,6 +23,10 @@
   <link rel="stylesheet" href="../site-header.css?v=20260815"/>
 </head>
 <body class="demo-page st">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
   <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">

--- a/site/demo/teaching.html
+++ b/site/demo/teaching.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <title>Nodus — Teaching demo</title>
   <meta name="description" content="Interactive demo of Nodus in Teaching mode: courses, student groups, timetables, materials, weighted rubrics, printable exams and a private gradebook."/>
@@ -16,6 +23,10 @@
   <link rel="stylesheet" href="../site-header.css?v=20260815"/>
 </head>
 <body class="demo-page teach">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
   <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">

--- a/site/demo/worldbuilding.html
+++ b/site/demo/worldbuilding.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <title>Nodus — Worldbuilding demo</title>
   <meta name="description" content="Interactive Worldbuilding demo of Nodus: a connected cast, atlas, encyclopedia, chronology, factions, cultures, rules, conflicts, narrative arcs, continuity checks, scenes and manuscript."/>
@@ -17,6 +24,10 @@
   <link rel="stylesheet" href="../site-header.css?v=20260815"/>
 </head>
 <body class="demo-page worldbuilding">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
   <script src="../site-header.js?v=20260817"></script>
   <div class="demo-frame">

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -6,6 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Nodus FAQ — questions before you begin</title>
 <meta name="description" content="Clear answers about Nodus: what to expect and what not to, how to get started safely, choosing an AI setup, citations and academic rigour, and what the app can and cannot do."/>
@@ -21,6 +28,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="stylesheet" href="faq.css?v=20260815"/>
 </head>
 <body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 <a class="skip-link" href="#main">Skip to the questions</a>
 <canvas id="organism" aria-hidden="true"></canvas>

--- a/site/index.html
+++ b/site/index.html
@@ -6,6 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Nodus: a local-first workspace for research, teaching and study</title>
 <meta name="description" content="Nodus is a free, open-source, local-first desktop app for academic work. Each vault picks a mode — academic research, teaching, study, structured databases and more — over the same private engine. No accounts, no subscriptions, no telemetry."/>
@@ -19,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="assets/css/nodus.css?v=20260817c"/>
-<link rel="stylesheet" href="assets/css/home.css?v=20260816"/>
+<link rel="stylesheet" href="assets/css/home.css?v=20260817"/>
 <script>
   /* Arm the opening sequence before the first paint. Anything that goes wrong
      here simply leaves the page in its ordinary, fully visible state. */
@@ -40,6 +47,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 </script>
 </head>
 <body data-formation="on">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 <a class="skip-link" href="#main">Skip to content</a>
 <canvas id="organism" aria-hidden="true"></canvas>
@@ -102,7 +113,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap scene-inner">
     <div class="scene-copy scrim reveal">
       <div class="scene-index">
-        <b>01</b><span class="tag-status">Available now</span>
+        <b>01</b>
       </div>
       <h2>Academic <span class="glow">research</span></h2>
       <p class="lead">Build your own library inside Nodus, or connect the Zotero collection you already keep. Either way, every work becomes a network of claims, findings and methods, and each idea keeps the exact passage and page that support it.</p>
@@ -146,7 +157,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap scene-inner">
     <div class="scene-copy scrim reveal">
       <div class="scene-index">
-        <b>02</b><span class="tag-status">Available now</span>
+        <b>02</b>
       </div>
       <h2><span class="glow">Teaching</span></h2>
       <p class="lead">Plan courses and classes, prepare activities and assessments, and track learner progress. All your teaching work stays connected to the materials and evidence behind it.</p>
@@ -189,7 +200,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap scene-inner">
     <div class="scene-copy scrim reveal">
       <div class="scene-index">
-        <b>03</b><span class="tag-status">Available now</span>
+        <b>03</b>
       </div>
       <h2><span class="glow">Study</span></h2>
       <p class="lead">Organise subjects, notes and materials in one place. Study at your own pace, prepare for assessments and track progress.</p>
@@ -231,7 +242,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap scene-inner">
     <div class="scene-copy scrim reveal">
       <div class="scene-index">
-        <b>04</b><span class="tag-status">Available now</span>
+        <b>04</b>
       </div>
       <h2><span class="glow">Databases</span></h2>
       <p class="lead">Organise fieldwork, corpora, catalogues and coding sheets in structured databases. Analyse the information while preserving the field types, relationships and categories in your data.</p>

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MP3BX78N');</script>
+<!-- End Google Tag Manager -->
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Nodus Wiki - Complete vault guides</title>
   <meta name="description" content="Complete documentation for Nodus Academic Research, Genealogy, Databases, Study and Teaching vaults."/>
@@ -15,6 +22,10 @@
   <link rel="stylesheet" href="wiki.css?v=20260817"/>
 </head>
 <body class="wiki-page" data-quiet>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MP3BX78N"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   <canvas id="organism" aria-hidden="true"></canvas>
   <a class="skip-link" href="#article">Skip to documentation</a>
   <div data-nodus-site-header data-base="../" data-page="wiki" data-context="wiki"></div>


### PR DESCRIPTION
## Why

Clicking **Subscribe by RSS** on the blog landed visitors on raw XML with the browser's "This XML file does not appear to have any style information" warning. The feed was valid the whole time — browsers simply stopped rendering feeds years ago.

## What changed

**The feed is readable in a browser.** New `site/blog/feed.xsl`, referenced from `feed.xml` with an `<?xml-stylesheet?>` instruction. Browsers now render a styled page: what RSS is, the address to paste into a reader, a link back to the blog, and the posts with dates, summaries and tags. Feed readers skip the instruction, so nothing changes for existing subscribers.

**The address can be copied.** A "Copy the feed URL" button sits beside the RSS link in the blog hero. It only appears where the clipboard is available, so there is no dead button without JavaScript.

**The feed generator no longer contradicts the feed.** `build-blog-feed.mjs` still used `drakonis96.github.io/nodus` and a different guid scheme. One `npm run blog:feed` after adding a post would have undone the domain move of 99c50ed and changed every guid — showing all posts as new again in every subscriber's reader. Same stale domain fixed in `build-sitemap.mjs`.

**"Available now" badges removed** from the four vault scenes on the home page, along with the CSS rule that positioned them.

**Google Tag Manager installed** (`GTM-MP3BX78N`) on all twelve pages of the site: the container high in the `<head>`, right after the charset declaration, and the `<noscript>` iframe immediately after `<body>`.

## Verification

- Feed page, copy button and vault scenes checked in a real browser against the compiled CSS, desktop and mobile. No console errors.
- GTM verified live on home, blog, a demo, the wiki and the FAQ: `gtm.js` is requested and the container reaches `gtm.js → gtm.dom → gtm.load`.
- Ran the feed generator and confirmed it reproduces the published feed, guids included.
- All five `test-site-*.mjs` suites pass (32 tests), including four new ones covering the stylesheet, the copy button, the generator contract and GTM coverage across every page.

## Worth deciding separately

The site has no cookie banner or Consent Mode. GTM alone sets no cookies, but a GA4 or advertising tag inside the container will need prior consent in the EU. The home page and FAQ also say "no telemetry" — true of the app, and worth a line on the privacy page separating the app from the website now that the site measures visits.