### PR TITLE
Fix Nodus Cloud bootstrap failing with HTTP 500 (PBKDF2 iteration cap on Workers)

### DIFF
--- a/cloudflare/.dev.vars.example
+++ b/cloudflare/.dev.vars.example
@@ -1,3 +1,3 @@
-# Nodus Desktop genera este verificador localmente. Cloudflare lo almacena
-# como secreto; no es una clave de API ni da acceso a la cuenta del usuario.
-NODUS_BOOTSTRAP_SECRET_HASH=PEGA_AQUI_EL_CODIGO_MOSTRADO_POR_NODUS
+# Nodus Desktop generates this verifier locally. Cloudflare stores it as a
+# secret; it is not an API key and grants no access to the user's account.
+NODUS_BOOTSTRAP_SECRET_HASH=PASTE_THE_CODE_SHOWN_BY_NODUS_HERE

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -1,33 +1,33 @@
-# Nodus Cloud para Cloudflare
+# Nodus Cloud for Cloudflare
 
-Servidor de sincronización y publicación de Nodus que se instala directamente en la cuenta de Cloudflare de cada usuario. Cloudflare ejecuta el Worker, guarda los datos estructurados en D1 y los archivos privados en R2. Nodus no recibe credenciales ni permisos sobre esa cuenta.
+Nodus synchronisation and publication server, installed directly into each user's own Cloudflare account. Cloudflare runs the Worker, keeps structured data in D1 and private files in R2. Nodus receives no credentials and no permissions over that account.
 
-## Despliegue recomendado
+## Recommended deployment
 
-Nodus Desktop abre el asistente oficial **Deploy to Cloudflare** con esta carpeta como plantilla. Cloudflare:
+Nodus Desktop opens the official **Deploy to Cloudflare** wizard with this folder as the template. Cloudflare then:
 
-1. crea una copia del código en la cuenta de GitHub o GitLab elegida por el usuario;
-2. crea D1 y R2 y conecta ambos recursos al Worker;
-3. solicita el valor secreto `NODUS_BOOTSTRAP_SECRET_HASH` que muestra Desktop;
-4. aplica las migraciones y publica una URL gratuita `workers.dev`.
+1. creates a copy of the code in the GitHub or GitLab account the user chooses;
+2. creates D1 and R2 and connects both resources to the Worker;
+3. asks for the `NODUS_BOOTSTRAP_SECRET_HASH` secret that Desktop displays;
+4. applies the migrations and publishes a free `workers.dev` URL.
 
-No hace falta comprar un dominio, contratar hosting tradicional ni entregar a Nodus un token de Cloudflare. La ubicación de D1 y R2 es la selección automática de Cloudflare en este flujo. El botón oficial no documenta un parámetro para fijar jurisdicción; quien necesite fijación estricta debe crear esos recursos manualmente y revisar las opciones vigentes de Cloudflare.
+There is no domain to buy, no traditional hosting to arrange and no Cloudflare token to hand over to Nodus. The location of D1 and R2 is whatever Cloudflare selects automatically in this flow. The official button documents no parameter for pinning jurisdiction; anyone who needs strict pinning should create those resources manually and review Cloudflare's current options.
 
-Documentación oficial: [Deploy to Cloudflare](https://developers.cloudflare.com/workers/platform/deploy-buttons/), [D1](https://developers.cloudflare.com/d1/), [R2](https://developers.cloudflare.com/r2/).
+Official documentation: [Deploy to Cloudflare](https://developers.cloudflare.com/workers/platform/deploy-buttons/), [D1](https://developers.cloudflare.com/d1/), [R2](https://developers.cloudflare.com/r2/).
 
-## Qué contiene la plantilla
+## What the template contains
 
-- `src/`: Worker y API de Nodus Cloud.
-- `migrations/`: esquema versionado de D1.
-- `wrangler.jsonc`: bindings D1/R2 y tarea de mantenimiento.
-- `.dev.vars.example`: variable secreta que Cloudflare solicita durante el despliegue.
-- `package.json`: aplica migraciones antes de publicar el Worker.
+- `src/`: the Nodus Cloud Worker and API.
+- `migrations/`: the versioned D1 schema.
+- `wrangler.jsonc`: the D1/R2 bindings and the maintenance task.
+- `.dev.vars.example`: the secret variable Cloudflare asks for during deployment.
+- `package.json`: applies the migrations before publishing the Worker.
 
-Vectorize es opcional. Sus índices requieren una dimensión concreta que depende del modelo de embeddings de cada vault, algo que una plantilla pública estática no conoce. El despliegue directo usa matrices portables en R2 y búsqueda exacta; si el propietario añade bindings `VECTORS_<dim>`, el Worker los anuncia y Desktop los utiliza automáticamente.
+Vectorize is optional. Its indexes require a specific dimension that depends on each vault's embedding model, which a static public template cannot know. Direct deployment uses portable matrices in R2 and exact search; if the owner adds `VECTORS_<dim>` bindings, the Worker announces them and Desktop uses them automatically.
 
-## Desarrollo local
+## Local development
 
-Se necesita Node 20 o posterior. Calcula primero el SHA-256 de un secreto de prueba y pásalo al Worker; el verificador usa el secreto original.
+Wrangler 4.123 or later requires Node 22 or later. Compute the SHA-256 of a test secret first and pass it to the Worker; the verifier uses the original secret.
 
 ```sh
 cd cloudflare
@@ -37,14 +37,20 @@ NODUS_TEST_BOOTSTRAP_HASH="$(printf %s final-local-secret | shasum -a 256 | awk 
 npx wrangler dev --local --port 8799 --var "NODUS_BOOTSTRAP_SECRET_HASH:$NODUS_TEST_BOOTSTRAP_HASH"
 ```
 
-En otra terminal, desde la raíz del repositorio:
+In another terminal, from the repository root:
 
 ```sh
 node scripts/verify-cloudflare-local.mjs
 ```
 
-Para comprobar el mantenimiento programado, inicia Wrangler con `--test-scheduled` y abre `http://localhost:8799/__scheduled?cron=17+3+*+*+*`.
+To exercise scheduled maintenance, start Wrangler with `--test-scheduled` and open `http://localhost:8799/__scheduled?cron=17+3+*+*+*`.
 
-## Licencia y actualizaciones
+### Limits that only appear on a real deployment
 
-El código se distribuye bajo AGPL-3.0-only. La respuesta de capacidades enlaza al código fuente correspondiente. La copia creada por el asistente pertenece al usuario; los commits de esa copia activan Workers Builds. Consulta `UPDATING.md` antes de incorporar una nueva versión de Nodus Cloud.
+The open-source workerd behind `wrangler dev` does not enforce every limit of Cloudflare's production runtime. The known case is PBKDF2: Workers rejects more than **100,000 iterations** with `NotSupportedError`, while local development accepts any count, so an invalid constant passes local verification and breaks the real deployment with an HTTP 500. `scripts/test-cloudflare-bootstrap.mjs` reproduces that ceiling against the real `auth.mjs` and runs as part of `npm test`.
+
+That ceiling is the platform's, not a choice: it sits below the 600,000 iterations OWASP recommends for PBKDF2-SHA256, and Workers offers no alternative. Raising it the day Cloudflare lifts the cap means changing `PASSWORD_ITERATIONS` in `src/auth.mjs` and nothing else: every password records in `password_scheme` the count it was computed with, and `verifyPassword` replays it, so passwords already on record keep verifying.
+
+## Licence and updates
+
+The code is distributed under AGPL-3.0-only. The capabilities response links to the corresponding source code. The copy created by the wizard belongs to the user; commits to that copy trigger Workers Builds. Read `UPDATING.md` before taking in a new version of Nodus Cloud.

--- a/cloudflare/UPDATING.md
+++ b/cloudflare/UPDATING.md
@@ -1,18 +1,18 @@
-# Actualizar y revertir Nodus Cloud
+# Updating and rolling back Nodus Cloud
 
-La instalación creada por **Deploy to Cloudflare** vive en una copia del repositorio que pertenece al usuario. Nodus Desktop no tiene acceso a esa copia ni a la cuenta de Cloudflare.
+The installation created by **Deploy to Cloudflare** lives in a copy of the repository that belongs to the user. Nodus Desktop has no access to that copy or to the Cloudflare account.
 
-## Actualizar
+## Updating
 
-1. Comprueba las notas de la nueva versión de Nodus y sus migraciones.
-2. Incorpora a tu copia los cambios publicados en `https://github.com/Drakonis96/nodus/tree/main/cloudflare` mediante la interfaz de GitHub/GitLab o Git.
-3. Confirma los cambios. Workers Builds ejecutará `npm run deploy`, aplicará las migraciones D1 y publicará el Worker.
-4. Abre Nodus Desktop y fuerza una sincronización para verificar la conexión.
+1. Read the release notes for the new version of Nodus and its migrations.
+2. Bring the changes published at `https://github.com/Drakonis96/nodus/tree/main/cloudflare` into your copy, through the GitHub/GitLab interface or with Git.
+3. Commit the changes. Workers Builds runs `npm run deploy`, applies the D1 migrations and publishes the Worker.
+4. Open Nodus Desktop and force a synchronisation to confirm the connection.
 
-Las migraciones deben ser compatibles hacia delante. Haz un export de D1 y conserva la clave de recuperación antes de una actualización importante.
+Migrations must be forward compatible. Export D1 and keep the recovery key before a major update.
 
-## Revertir
+## Rolling back
 
-Cloudflare permite volver a una versión o despliegue anterior del Worker desde su panel. Esto revierte el código, no la base D1. No reviertas una migración destructiva sin un procedimiento de restauración específico.
+Cloudflare can return the Worker to an earlier version or deployment from its dashboard. That rolls back the code, not the D1 database. Do not roll back a destructive migration without a specific restore procedure.
 
-Documentación oficial: [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), [versiones y despliegues](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/), [exportar e importar D1](https://developers.cloudflare.com/d1/best-practices/import-export-data/).
+Official documentation: [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), [versions and deployments](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/), [import and export D1](https://developers.cloudflare.com/d1/best-practices/import-export-data/).

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -12,13 +12,13 @@
   "cloudflare": {
     "bindings": {
       "NODUS_BOOTSTRAP_SECRET_HASH": {
-        "description": "Pega el **código de configuración** mostrado por Nodus Desktop. Es un verificador de un solo uso y no permite acceder a tu cuenta de Cloudflare."
+        "description": "Paste the **setup code** shown by Nodus Desktop. It is a one-time verifier and grants no access to your Cloudflare account."
       },
       "DB": {
-        "description": "Base privada para los datos estructurados de tu vault. Puedes conservar el nombre propuesto."
+        "description": "Private database for your vault's structured data. You can keep the proposed name."
       },
       "OBJECTS": {
-        "description": "Almacenamiento privado para archivos, snapshots y recuperación. Puedes conservar el nombre propuesto."
+        "description": "Private storage for files, snapshots and recovery. You can keep the proposed name."
       }
     }
   },

--- a/cloudflare/src/auth.mjs
+++ b/cloudflare/src/auth.mjs
@@ -16,7 +16,16 @@ import {
   strictRateLimit,
 } from './util.mjs';
 
-const PASSWORD_ITERATIONS = 210_000;
+// Cloudflare Workers refuses PBKDF2 above 100_000 iterations: crypto.subtle.deriveBits
+// throws NotSupportedError, so every request that hashes a password answers HTTP 500 and
+// bootstrap can never create the first administrator. The open-source workerd behind
+// `wrangler dev` does not enforce the cap, so the ceiling only shows on a real deployment;
+// scripts/test-cloudflare-bootstrap.mjs reproduces it so the regression cannot come back.
+// It sits below the 600_000 OWASP recommends for PBKDF2-SHA256 and is the platform ceiling
+// rather than a choice. Raising it the day Cloudflare lifts the cap is safe on its own:
+// verifyPassword replays the count recorded in password_scheme, so passwords already on
+// record keep verifying at the count that produced them.
+const PASSWORD_ITERATIONS = 100_000;
 const ACCESS_TTL_MS = 15 * 60_000;
 const REFRESH_TTL_MS = 30 * 86400_000;
 const DEVICE_TTL_MS = 3650 * 86400_000;
@@ -38,16 +47,28 @@ function decodeHex(value) {
   return Uint8Array.from(clean.match(/.{2}/g).map((part) => Number.parseInt(part, 16)));
 }
 
-export async function hashPassword(password, saltHex = null) {
+export async function hashPassword(password, saltHex = null, iterations = PASSWORD_ITERATIONS) {
   const salt = saltHex ? decodeHex(saltHex) : crypto.getRandomValues(new Uint8Array(16));
   const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(String(password)), 'PBKDF2', false, ['deriveBits']);
-  const bits = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations: PASSWORD_ITERATIONS }, key, 256);
-  return { scheme: `pbkdf2-sha256:${PASSWORD_ITERATIONS}`, salt: encodeHex(salt), hash: encodeHex(new Uint8Array(bits)) };
+  const bits = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations }, key, 256);
+  return { scheme: `pbkdf2-sha256:${iterations}`, salt: encodeHex(salt), hash: encodeHex(new Uint8Array(bits)) };
+}
+
+// Every record stores the count it was hashed with, so verification replays that count
+// instead of the current constant. Otherwise tuning PASSWORD_ITERATIONS would silently
+// invalidate every password already on record. Unreadable schemes fail closed.
+function schemeIterations(scheme) {
+  const match = /^pbkdf2-sha256:(\d+)$/.exec(String(scheme || ''));
+  if (!match) return null;
+  const iterations = Number(match[1]);
+  return Number.isSafeInteger(iterations) && iterations > 0 ? iterations : null;
 }
 
 export async function verifyPassword(password, user) {
-  if (!user?.password_hash || !user?.password_salt || !String(user.password_scheme || '').startsWith('pbkdf2-sha256:')) return false;
-  const calculated = await hashPassword(password, user.password_salt);
+  if (!user?.password_hash || !user?.password_salt) return false;
+  const iterations = schemeIterations(user.password_scheme);
+  if (!iterations) return false;
+  const calculated = await hashPassword(password, user.password_salt, iterations);
   return constantTimeEqual(calculated.hash, user.password_hash);
 }
 

--- a/electron/cloudflare/deployment.ts
+++ b/electron/cloudflare/deployment.ts
@@ -90,8 +90,8 @@ async function capabilityDocument(url: string): Promise<CloudflareCapabilityDocu
   const response = await fetch(`${url}/api/v3/capabilities`, {
     headers: { accept: 'application/json' }, signal: AbortSignal.timeout(30_000),
   });
-  const value = await response.json().catch(() => ({})) as Partial<CloudflareCapabilityDocument> & { detail?: string };
-  if (!response.ok) throw new Error(value.detail || `El Worker respondió con HTTP ${response.status}.`);
+  const value = await response.json().catch(() => ({})) as Partial<CloudflareCapabilityDocument> & { error_description?: string; detail?: string };
+  if (!response.ok) throw new Error(value.error_description || value.detail || `El Worker respondió con HTTP ${response.status}.`);
   if (value.service !== NODUS_CLOUDFLARE_SERVICE || Number(value.protocolVersion) < NODUS_CLOUDFLARE_PROTOCOL) {
     throw new Error('Esta dirección no corresponde a un despliegue compatible de Nodus Cloud.');
   }
@@ -122,10 +122,12 @@ async function bootstrap(url: string, secret: string, input: CloudflareCompleteD
     }),
     signal: AbortSignal.timeout(60_000),
   });
-  const value = await response.json().catch(() => ({})) as Partial<BootstrapResult> & { error?: string; detail?: string };
+  const value = await response.json().catch(() => ({})) as Partial<BootstrapResult> & { error?: string; error_description?: string; detail?: string };
   if (response.status === 409 && value.error === 'already_bootstrapped') throw new AlreadyBootstrappedError();
   if (!response.ok || !value.installationId || !value.space || !value.deviceToken || !value.recoveryKey) {
-    throw new Error(value.detail || `No se pudo inicializar Nodus Cloud (HTTP ${response.status}).`);
+    // The Worker reports failures as error_description (see problem() in cloudflare/src/util.mjs).
+    // Reading only detail collapsed every Worker error into a bare status code on screen.
+    throw new Error(value.error_description || value.detail || `No se pudo inicializar Nodus Cloud (HTTP ${response.status}).`);
   }
   return value as BootstrapResult;
 }

--- a/scripts/test-cloudflare-bootstrap.mjs
+++ b/scripts/test-cloudflare-bootstrap.mjs
@@ -1,0 +1,87 @@
+// Regression coverage for a Nodus Cloud bootstrap that could never complete. Cloudflare
+// Workers refuses PBKDF2 above 100_000 iterations, so hashing the administrator password
+// threw NotSupportedError and POST /api/v3/bootstrap always answered HTTP 500. The
+// open-source workerd behind `wrangler dev` does not enforce that ceiling, so local
+// verification stayed green while every real deployment failed; these tests apply the
+// ceiling themselves, against the real auth.mjs, so the gap cannot reopen.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+
+const WORKERS_PBKDF2_CEILING = 100_000;
+
+// The restriction the production runtime applies, reproduced over Node's WebCrypto.
+const deriveBits = crypto.subtle.deriveBits.bind(crypto.subtle);
+Object.defineProperty(crypto.subtle, 'deriveBits', {
+  configurable: true,
+  writable: true,
+  value: async (algorithm, key, length) => {
+    const iterations = Number(algorithm?.iterations);
+    if (algorithm?.name === 'PBKDF2' && iterations > WORKERS_PBKDF2_CEILING) {
+      const error = new Error(`Pbkdf2 failed: iteration counts above ${WORKERS_PBKDF2_CEILING} are not supported (requested ${iterations}).`);
+      error.name = 'NotSupportedError';
+      throw error;
+    }
+    return deriveBits(algorithm, key, length);
+  },
+});
+
+const { hashPassword, verifyPassword } = await import('../cloudflare/src/auth.mjs');
+const { errorResponse } = await import('../cloudflare/src/util.mjs');
+
+const password = 'una contraseña de administrador';
+const iterationsOf = (scheme) => Number(/^pbkdf2-sha256:(\d+)$/.exec(String(scheme))[1]);
+
+test('hashing an administrator password survives the Workers PBKDF2 ceiling', async () => {
+  const record = await hashPassword(password);
+  const iterations = iterationsOf(record.scheme);
+  assert.ok(iterations > 0 && iterations <= WORKERS_PBKDF2_CEILING,
+    `PASSWORD_ITERATIONS is ${iterations}; Cloudflare Workers rejects anything above ${WORKERS_PBKDF2_CEILING} and bootstrap answers HTTP 500`);
+  assert.match(record.salt, /^[0-9a-f]{32}$/);
+  assert.match(record.hash, /^[0-9a-f]{64}$/);
+});
+
+test('a stored password verifies, a wrong one does not', async () => {
+  const record = await hashPassword(password);
+  const user = { password_hash: record.hash, password_salt: record.salt, password_scheme: record.scheme };
+  assert.equal(await verifyPassword(password, user), true);
+  assert.equal(await verifyPassword(`${password} `, user), false);
+});
+
+test('verification replays the iteration count recorded with each password', async () => {
+  // Raising or lowering PASSWORD_ITERATIONS must not lock out passwords already on record.
+  for (const iterations of [60_000, WORKERS_PBKDF2_CEILING]) {
+    const record = await hashPassword(password, null, iterations);
+    assert.equal(record.scheme, `pbkdf2-sha256:${iterations}`);
+    assert.equal(await verifyPassword(password, {
+      password_hash: record.hash, password_salt: record.salt, password_scheme: record.scheme,
+    }), true, `a password hashed at ${iterations} iterations stopped verifying`);
+  }
+});
+
+test('an unreadable password scheme fails closed instead of throwing', async () => {
+  const record = await hashPassword(password);
+  for (const scheme of [null, undefined, '', 'bcrypt:12', 'pbkdf2-sha256:', 'pbkdf2-sha256:0', 'pbkdf2-sha256:abc', 'pbkdf2-sha512:100000']) {
+    assert.equal(await verifyPassword(password, {
+      password_hash: record.hash, password_salt: record.salt, password_scheme: scheme,
+    }), false, `scheme ${JSON.stringify(scheme)} was accepted`);
+  }
+});
+
+test('desktop reads the field the Worker actually reports failures in', async () => {
+  const body = await errorResponse(new Error('anything unexpected')).json();
+  assert.equal(body.error, 'internal_error');
+  assert.ok(body.error_description, 'the Worker reports failures as error_description');
+  assert.equal(body.detail, undefined);
+  // Reading only `detail` collapsed every Worker failure into a bare status code on screen,
+  // which is what made this bootstrap bug take a live deployment to diagnose.
+  const deployment = read('electron/cloudflare/deployment.ts');
+  for (const match of deployment.matchAll(/throw new Error\(([^)]*HTTP \$\{response\.status\}[^)]*)\)/g)) {
+    assert.match(match[1], /value\.error_description/, `a Worker failure is surfaced without reading error_description: ${match[1]}`);
+  }
+  assert.equal(deployment.match(/value\.error_description/g)?.length, 2);
+});


### PR DESCRIPTION
Fixes #454. Carries the fix diagnosed by @mbradaschia in #443 (closed by its author without explanation), reproduced independently first, plus the three gaps that fix left open.

## The bug

Cloudflare Workers refuses PBKDF2 above 100,000 iterations, but `cloudflare/src/auth.mjs` requested 210,000. `hashPassword()` is the first thing `bootstrap()` does, so it threw before anything was written and `errorResponse()` turned it into a generic HTTP 500. Nodus Cloud could never be initialised on Cloudflare, and since no `installation` row was created, retries repeated the same failure instead of reaching the `already_bootstrapped` 409.

## Why no test caught it

The open-source workerd behind `wrangler dev` does not enforce the ceiling — locally it accepts 210,000 iterations, and even 100,000,000. `scripts/verify-cloudflare-local.mjs` therefore passed end to end while every real deployment failed.

## Changes

**`PASSWORD_ITERATIONS` 210,000 → 100,000.** The platform ceiling. Since the 210,000 path could never succeed on Workers, no deployment holds a password hashed at that count and no migration is needed.

**`verifyPassword()` replays the count stored in `password_scheme`** instead of always rehashing with the current constant. The column already recorded it (`pbkdf2-sha256:<n>`) but nothing read it back, so changing the constant would have silently invalidated every password on record. Unreadable schemes fail closed.

**`scripts/test-cloudflare-bootstrap.mjs`** wraps `crypto.subtle.deriveBits` so it throws above 100,000 exactly as production does, then exercises the real `auth.mjs`: the constant must stay within the ceiling, passwords hashed at other counts must keep verifying, and malformed schemes must be rejected without throwing. All five tests fail on the pre-fix code.

**The deployment flow reads `error_description`.** The Worker reports failures in that field (`problem()` in `cloudflare/src/util.mjs`) while `electron/cloudflare/deployment.ts` read `value.detail`, so every Worker error reached the user as a bare status code. That is what made this take a live deployment to diagnose. The test pins both sides of the contract.

**The public deploy template is now in English.** `cloudflare/` is cloned into each user's own GitHub or GitLab account, and its README, UPDATING, `.dev.vars.example` and the binding descriptions Cloudflare shows in its deploy wizard were the only Spanish-language documents in the repository. The README also gains a short section on limits that only appear on a real deployment, and on how to raise the iteration count if Cloudflare ever lifts the cap.

## Verification

With the production ceiling simulated locally over the real Worker sources:

| | before | after |
|---|---|---|
| `POST /api/v3/bootstrap` | HTTP 500 `internal_error` | HTTP 201, administrator, space, device token and recovery key |
| retry | HTTP 500 again | HTTP 409 `already_bootstrapped` |
| `POST /auth/login` right / wrong password | — | HTTP 200 / HTTP 401 |
| `GET /me` with the bootstrap device token | — | HTTP 200 |
| stored scheme | — | `pbkdf2-sha256:100000` |

`scripts/verify-cloudflare-local.mjs`, the repository's own end-to-end script, passes against the patched Worker with the ceiling applied: publication, oversized rows, semantic search, multipart integrity, mutation atomicity and recovery included.

`npm run typecheck` and `eslint` are clean. `npm test` passes except `test-prosopography-e2e.mjs`, which launches the real Electron app and fails in any worktree without a build; it references nothing touched here.

## Note

`PASSWORD_ITERATIONS` at 100,000 is below the 600,000 OWASP recommends for PBKDF2-SHA256. It is the platform ceiling ([workerd#1346](https://github.com/cloudflare/workerd/issues/1346)), not a choice, and Workers offers no alternative KDF. Now that verification replays the recorded count, raising it is a one-constant change whenever Cloudflare lifts the cap.

`cloudflare/package.json` still declares `"engines": { "node": ">=20" }` while its pinned `wrangler ^4.123.0` requires Node 22; the README now states Node 22, but the field is left alone in case the lower bound is deliberate.
