### PR TITLE
Announce the new website with a one-time notice

### DIFF
--- a/scripts/capture-wiki-desktop-screenshots.mjs
+++ b/scripts/capture-wiki-desktop-screenshots.mjs
@@ -74,6 +74,7 @@ try {
       localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
       localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
       localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+      localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
       sessionStorage.setItem('nodus.startupUpdateChecked', '1');
       return window.nodus.updateSettings(nextSettings);
     }, { version: appVersion, nextSettings: settings });

--- a/scripts/e2e-deep-research-annotations.mjs
+++ b/scripts/e2e-deep-research-annotations.mjs
@@ -35,6 +35,7 @@ try {
     localStorage.setItem('nodus.mobileTeaserSeen.3.2.4', '1');
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     await window.nodus.updateSettings({
       onboardingComplete: true,

--- a/scripts/e2e-global-library.mjs
+++ b/scripts/e2e-global-library.mjs
@@ -83,6 +83,7 @@ try {
     localStorage.setItem('nodus.mobileTeaserSeen.3.2.4', '1');
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     await window.nodus.updateSettings({
       onboardingComplete: true, basicsTutorialVersion: 999, recoverySetupVersion: 999,

--- a/scripts/e2e-library-reader.mjs
+++ b/scripts/e2e-library-reader.mjs
@@ -85,6 +85,7 @@ try {
     localStorage.setItem('nodus.mobileTeaserSeen.3.2.4', '1');
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     await window.nodus.updateSettings({
       onboardingComplete: true,

--- a/scripts/e2e-saved-authors.mjs
+++ b/scripts/e2e-saved-authors.mjs
@@ -52,6 +52,7 @@ try {
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     sessionStorage.setItem('nodus.startupUpdateChecked', '1');
     await window.nodus.updateSettings({
       uiLanguage: 'es',

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -431,6 +431,18 @@ try {
   assert.equal(await page.evaluate(() => localStorage.getItem('nodus.tutorialVideosAnnouncementSeen.2026-07')), '1', 'the announcement is marked seen only when dismissed');
   console.log('[e2e] the video tutorials announcement shows the catalogue in-modal, once');
 
+  // Last in the chain: the website notice. A title, a line and the address, so what is
+  // asserted is that it is exactly that — the visit button opens the browser and must
+  // NOT count as having read the notice, only the dismissal does.
+  const websiteNotice = page.getByTestId('website-launch-guide');
+  await websiteNotice.waitFor();
+  await websiteNotice.getByRole('heading', { name: 'Nodus estrena nueva web', exact: true }).waitFor();
+  assert.equal(await page.evaluate(() => localStorage.getItem('nodus.websiteLaunchSeen.2026-08')), null, 'the notice is not marked seen just by appearing');
+  await websiteNotice.getByTestId('website-launch-complete').click();
+  await websiteNotice.waitFor({ state: 'detached' });
+  assert.equal(await page.evaluate(() => localStorage.getItem('nodus.websiteLaunchSeen.2026-08')), '1', 'the notice is marked seen only when dismissed');
+  console.log('[e2e] the website notice closes the update chain, once');
+
   // Back to Spanish for the rest of the suite, which asserts on Spanish copy. The
   // reload above already consumed the once-per-session startup update check, so reset
   // its gate to leave the next reload looking like a fresh session again.

--- a/scripts/e2e-testimony.mjs
+++ b/scripts/e2e-testimony.mjs
@@ -108,6 +108,7 @@ try {
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     sessionStorage.setItem('nodus.startupUpdateChecked', '1');
   }, appVersion);
 

--- a/scripts/e2e-view-snapshots.mjs
+++ b/scripts/e2e-view-snapshots.mjs
@@ -52,6 +52,7 @@ try {
     localStorage.setItem('nodus.mobileTeaserSeen.3.2.4', '1');
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     await window.nodus.updateSettings({
       onboardingComplete: true,

--- a/scripts/test-prosopography-e2e.mjs
+++ b/scripts/test-prosopography-e2e.mjs
@@ -43,6 +43,7 @@ try {
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
   }, appVersion);
 
   const bridge = await page.evaluate(() => ({

--- a/scripts/test-startup-update-modal.mjs
+++ b/scripts/test-startup-update-modal.mjs
@@ -14,9 +14,10 @@ const [modal, app, main, styles, translations] = await Promise.all([
 ]);
 
 test('the app performs one visible update check per launch after the update guides settle', () => {
-  // Every one-time guide — release notes, the two update tours and the video tutorials
-  // announcement — must have settled before the update check takes the foreground.
-  assert.match(app, /whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && \(\s*<StartupUpdateModal[\s\S]*?\/>/);
+  // Every one-time guide — release notes, the two update tours, the video tutorials
+  // announcement and the website notice — must have settled before the update check
+  // takes the foreground.
+  assert.match(app, /whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && websiteLaunchSettled && !manualWhatsNewOpen && !updateSettled && \(\s*<StartupUpdateModal[\s\S]*?\/>/);
   assert.match(app, /<WhatsNewModal[\s\S]*onSettled=\{\(\) => setWhatsNewSettled\(true\)\}/);
   // The one-time Nodi choice queues behind this modal, so a launch that never shows it
   // must still settle or that modal would wait forever.

--- a/scripts/test-tutorial-videos.mjs
+++ b/scripts/test-tutorial-videos.mjs
@@ -332,7 +332,7 @@ test('the videos are announced once to installs that predate them', async () => 
   // modals never fight for the foreground.
   const order = ['<WhatsNewModal', '<PlatformHighlightsUpdateTour', '<ToolkitBetaUpdateTour', '<TutorialVideosUpdateTour', '<StartupUpdateModal'].map((tag) => app.indexOf(tag));
   assert.deepEqual(order, [...order].sort((a, b) => a - b), 'the videos announcement sits between the toolkit tour and the update check');
-  assert.match(app, /toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && \(\s*<StartupUpdateModal/);
+  assert.match(app, /toolkitBetaTourSettled && tutorialVideosSettled && websiteLaunchSettled && !manualWhatsNewOpen && !updateSettled && \(\s*<StartupUpdateModal/);
 });
 
 test('the announcement speaks every interface language', async () => {

--- a/scripts/test-website-launch-guide.mjs
+++ b/scripts/test-website-launch-guide.mjs
@@ -1,0 +1,59 @@
+// "Nodus has a new website" — the one-time notice that points outwards.
+//
+// Two things about it are deliberate and easy to undo by accident: it is a notice and
+// not a tour (a title, one line and the address), and it is gated on its sentinel alone.
+// Pinning it to a release would retire it the moment the next version ships, which is
+// right for a one-off teaser and wrong for a website that exists from now on.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (file) => readFile(path.join(root, file), 'utf8');
+
+const LANGUAGES = ['es', 'en', 'fr', 'de', 'pt', 'pt-BR', 'it', 'tr'];
+
+test('the notice shows once, to installs past the essential guide, on any version', async () => {
+  const guide = await read('src/components/WebsiteLaunchGuide.tsx');
+  assert.match(guide, /nodus\.websiteLaunchSeen/);
+  assert.match(guide, /previousTutorialVersion <= 0\) return false;/);
+  assert.ok(!guide.includes('__APP_VERSION__'), 'a website does not expire with a release');
+  // Seen only when actually dismissed: a launch that never reached the foreground, or
+  // one closed by opening the site, must not consume the single showing.
+  assert.match(guide, /const finish = \(\) => \{ markSeen\(\); onSettled\(\); \};/);
+  assert.match(guide, /localStorage\.setItem\(SEEN_KEY, '1'\)/);
+  // onSettled must fire even when it declines to show, or the update check behind it stalls.
+  assert.match(guide, /useEffect\(\(\) => \{ if \(!eligible\) onSettled\(\); \}, \[eligible, onSettled\]\);/);
+});
+
+test('it carries the address in all eight languages and nothing else', async () => {
+  const guide = await read('src/components/WebsiteLaunchGuide.tsx');
+  assert.match(guide, /NODUS_WEBSITE_URL = 'https:\/\/nodusresearch\.com\/'/);
+  assert.match(guide, /window\.nodus\.openExternal\(NODUS_WEBSITE_URL\)/);
+  for (const language of LANGUAGES) {
+    const key = language.includes('-') ? `'${language}'` : language;
+    assert.match(guide, new RegExp(`\\n  ${key}: \\{`), `missing translation: ${language}`);
+  }
+  const copy = guide.slice(guide.indexOf('const COPY'), guide.indexOf('function shouldPresent'));
+  assert.equal([...copy.matchAll(/^  (?:'pt-BR'|[a-z]{2}): \{/gm)].length, LANGUAGES.length);
+  assert.equal([...copy.matchAll(/^\s+title: /gm)].length, LANGUAGES.length);
+  assert.equal([...copy.matchAll(/^\s+summary: /gm)].length, LANGUAGES.length);
+  assert.equal([...copy.matchAll(/^\s+visit: /gm)].length, LANGUAGES.length);
+  // A title, a line and a link. No stage, no chapters, no feature list.
+  assert.ok(!guide.includes('toolkit-guide-stage'), 'the notice has no stage to fill');
+  assert.match(guide, /data-testid="website-launch-guide"/);
+  assert.match(guide, /data-testid="website-launch-visit"/);
+  assert.match(guide, /data-testid="website-launch-complete"/);
+});
+
+test('it sits behind the video tutorials announcement and in front of the update check', async () => {
+  const [app, styles] = await Promise.all([read('src/App.tsx'), read('src/index.css')]);
+  assert.match(app, /<WebsiteLaunchGuide/);
+  assert.ok(app.indexOf('<TutorialVideosUpdateTour') < app.indexOf('<WebsiteLaunchGuide'));
+  assert.ok(app.indexOf('<WebsiteLaunchGuide') < app.indexOf('<StartupUpdateModal'));
+  // Reopening release notes by hand must not drag the notice back onto the screen.
+  assert.match(app, /!websiteLaunchSettled && !manualWhatsNewOpen/);
+  assert.match(styles, /\.website-launch-guide \{/);
+});

--- a/scripts/verify-deep-research-mcp-queue.mjs
+++ b/scripts/verify-deep-research-mcp-queue.mjs
@@ -61,6 +61,7 @@ try {
     localStorage.setItem('nodus.lastSeenVersion', version);
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     sessionStorage.setItem('nodus.startupUpdateChecked', '1');
   }, appVersion);

--- a/scripts/verify-modal-animation-performance.mjs
+++ b/scripts/verify-modal-animation-performance.mjs
@@ -82,6 +82,7 @@ try {
     localStorage.removeItem('nodus.lastSeenVersion');
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     sessionStorage.clear();
   });
   await page.reload();

--- a/scripts/verify-primary-sources-ui.mjs
+++ b/scripts/verify-primary-sources-ui.mjs
@@ -37,6 +37,7 @@ try {
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     localStorage.setItem(`nodus.mobileTeaserSeen.${version}`, '1');
   }, appVersion);
   await page.evaluate(async () => {

--- a/scripts/verify-testimony-diarization.mjs
+++ b/scripts/verify-testimony-diarization.mjs
@@ -43,6 +43,7 @@ try {
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.websiteLaunchSeen.2026-08', '1');
     sessionStorage.setItem('nodus.startupUpdateChecked', '1');
   }, appVersion);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { PlatformHighlightsUpdateTour } from './components/PlatformHighlightsGui
 import { ToolkitBetaUpdateTour } from './components/ToolkitBetaGuide';
 import { StartupUpdateModal } from './components/StartupUpdateModal';
 import { MobileTeaserGuide } from './components/MobileTeaserGuide';
+import { WebsiteLaunchGuide } from './components/WebsiteLaunchGuide';
 import { recoveryHealthAdvice, recoveryHealthHeadline } from './recoveryHealth';
 import { NodiMascot } from './components/nodi/NodiMascot';
 import { NodiStyleModal } from './components/NodiStyleModal';
@@ -175,6 +176,9 @@ export function App() {
   // Users who completed the essential guide before the video tutorials existed were
   // never asked "video or text", so the catalogue is announced to them once, here.
   const [tutorialVideosSettled, setTutorialVideosSettled] = useState(false);
+  // The website is not part of any tutorial chapter, so it is announced once here, to
+  // anyone past the essential guide. Its own sentinel decides: no version to expire on.
+  const [websiteLaunchSettled, setWebsiteLaunchSettled] = useState(false);
   // Set once the startup update check is done with the screen, so the one-time Nodi
   // choice can queue up behind it instead of fighting it for the foreground.
   const [updateSettled, setUpdateSettled] = useState(false);
@@ -1967,7 +1971,15 @@ export function App() {
         />
       )}
 
-      {whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !manualWhatsNewOpen && !updateSettled && (
+      {whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && !websiteLaunchSettled && !manualWhatsNewOpen && (
+        <WebsiteLaunchGuide
+          uiLanguage={settings.uiLanguage}
+          previousTutorialVersion={settings.basicsTutorialVersion}
+          onSettled={() => setWebsiteLaunchSettled(true)}
+        />
+      )}
+
+      {whatsNewSettled && mobileTeaserSettled && platformHighlightsSettled && toolkitBetaTourSettled && tutorialVideosSettled && websiteLaunchSettled && !manualWhatsNewOpen && !updateSettled && (
         <StartupUpdateModal
           settings={settings}
           activeVaultType={activeVault?.type ?? null}

--- a/src/components/WebsiteLaunchGuide.tsx
+++ b/src/components/WebsiteLaunchGuide.tsx
@@ -1,0 +1,159 @@
+import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import type { AppLanguage } from '@shared/types';
+import { Icon } from './ui';
+import { NodiAvatar } from './nodi/NodiAvatar';
+
+/**
+ * "Nodus has a new website" — the one-time notice, and nothing more than a notice.
+ *
+ * The other update tours explain a feature that shipped inside the app, so they carry
+ * chapters, screenshots or an embedded catalogue. This one points outwards: the whole
+ * message is a title, one line, and the address. Anything else it could list — the wiki,
+ * the videos, the blog — is one click away on the site itself, and listing it here would
+ * only make the modal a worse version of the home page.
+ *
+ * It is NOT pinned to a release. A version-gated notice retires itself the moment the
+ * next version ships, which is right for something that was only true of one build; a
+ * website is true from now on, so the sentinel alone decides, and it shows exactly once.
+ * `previousTutorialVersion` keeps it off the screen of someone still inside the
+ * essential guide, who has not yet reached the app it is talking about.
+ */
+
+const SEEN_KEY = 'nodus.websiteLaunchSeen.2026-08';
+export const NODUS_WEBSITE_URL = 'https://nodusresearch.com/';
+
+type LaunchCopy = {
+  badge: string;
+  title: string;
+  summary: string;
+  visit: string;
+  finish: string;
+};
+
+const COPY: Record<AppLanguage, LaunchCopy> = {
+  es: {
+    badge: 'NUEVO · NODUSRESEARCH.COM',
+    title: 'Nodus estrena nueva web',
+    summary: 'Wiki, tutoriales y blog en un mismo sitio.',
+    visit: 'Visitar nodusresearch.com',
+    finish: 'Entendido',
+  },
+  en: {
+    badge: 'NEW · NODUSRESEARCH.COM',
+    title: 'Nodus has a new website',
+    summary: 'Wiki, tutorials and blog in one place.',
+    visit: 'Visit nodusresearch.com',
+    finish: 'Got it',
+  },
+  fr: {
+    badge: 'NOUVEAU · NODUSRESEARCH.COM',
+    title: 'Nodus a un nouveau site web',
+    summary: 'Wiki, tutoriels et blog au même endroit.',
+    visit: 'Visiter nodusresearch.com',
+    finish: 'J’ai compris',
+  },
+  de: {
+    badge: 'NEU · NODUSRESEARCH.COM',
+    title: 'Nodus hat eine neue Website',
+    summary: 'Wiki, Tutorials und Blog an einem Ort.',
+    visit: 'nodusresearch.com besuchen',
+    finish: 'Verstanden',
+  },
+  pt: {
+    badge: 'NOVO · NODUSRESEARCH.COM',
+    title: 'O Nodus estreia novo site',
+    summary: 'Wiki, tutoriais e blogue num só sítio.',
+    visit: 'Visitar nodusresearch.com',
+    finish: 'Entendido',
+  },
+  'pt-BR': {
+    badge: 'NOVO · NODUSRESEARCH.COM',
+    title: 'O Nodus estreia um novo site',
+    summary: 'Wiki, tutoriais e blog em um só lugar.',
+    visit: 'Visitar nodusresearch.com',
+    finish: 'Entendi',
+  },
+  it: {
+    badge: 'NUOVO · NODUSRESEARCH.COM',
+    title: 'Nodus ha un nuovo sito',
+    summary: 'Wiki, tutorial e blog in un unico posto.',
+    visit: 'Visita nodusresearch.com',
+    finish: 'Ho capito',
+  },
+  tr: {
+    badge: 'YENİ · NODUSRESEARCH.COM',
+    title: 'Nodus’un yeni web sitesi yayında',
+    summary: 'Wiki, eğitim videoları ve blog tek bir yerde.',
+    visit: 'nodusresearch.com adresini ziyaret et',
+    finish: 'Anlaşıldı',
+  },
+};
+
+function shouldPresent(previousTutorialVersion: number): boolean {
+  if (previousTutorialVersion <= 0) return false;
+  try { return localStorage.getItem(SEEN_KEY) !== '1'; } catch { return true; }
+}
+
+function markSeen(): void {
+  try { localStorage.setItem(SEEN_KEY, '1'); } catch { /* storage unavailable: show again next launch */ }
+}
+
+export function WebsiteLaunchGuide({
+  uiLanguage,
+  previousTutorialVersion,
+  onSettled,
+}: {
+  uiLanguage: AppLanguage;
+  previousTutorialVersion: number;
+  onSettled: () => void;
+}) {
+  const [eligible] = useState(() => shouldPresent(previousTutorialVersion));
+  const copy = COPY[uiLanguage] ?? COPY.en;
+
+  useEffect(() => { if (!eligible) onSettled(); }, [eligible, onSettled]);
+  if (!eligible) return null;
+
+  const finish = () => { markSeen(); onSettled(); };
+
+  return <motion.div className="toolkit-guide-backdrop" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: .22 }}>
+    <motion.section
+      className="toolkit-guide-cinema website-launch-guide"
+      data-testid="website-launch-guide"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="website-launch-title"
+      initial={{ opacity: 0, y: 26, scale: .97 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: .44, ease: [0.2, 0.8, 0.2, 1] }}
+    >
+      <header className="toolkit-guide-hero">
+        <div className="toolkit-guide-aurora" aria-hidden="true" />
+        <div className="toolkit-guide-hero-copy">
+          <div className="toolkit-guide-kicker"><Icon name="sparkles" size={14} /> {copy.badge}</div>
+          <h2 id="website-launch-title">{copy.title}</h2>
+          <p>{copy.summary}</p>
+        </div>
+        <div className="toolkit-guide-nodi"><NodiAvatar state="discovering" height={168} /></div>
+      </header>
+
+      <footer className="toolkit-guide-footer website-launch-footer">
+        {/*
+          The link is the point of the modal, so it does not close it: opening the site
+          hands the screen to the browser, and Nodus is still behind it with the notice
+          in place. Dismissing it is the other button's job, and only that marks it seen.
+        */}
+        <button
+          type="button"
+          data-testid="website-launch-visit"
+          onClick={() => void window.nodus.openExternal(NODUS_WEBSITE_URL)}
+        >
+          <Icon name="external" size={14} /> {copy.visit}
+        </button>
+        <button className="primary" data-testid="website-launch-complete" onClick={finish}>
+          {copy.finish} <Icon name="check" size={14} />
+        </button>
+      </footer>
+    </motion.section>
+  </motion.div>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4518,6 +4518,14 @@ body:has(.library-document-reader [data-testid="library-reader-sidebar"]) .app-t
 @media (max-width: 660px) { .toolkit-guide-backdrop { padding: 10px; } .toolkit-guide-cinema { max-height: 95vh; border-radius: 20px; } .toolkit-guide-hero { min-height: 170px; grid-template-columns: 1fr 120px; padding: 24px 20px; } .toolkit-guide-nodi svg { height: 130px !important; } .toolkit-guide-stage { padding: 19px; } .toolkit-guide-tools, .toolkit-guide-models, .toolkit-guide-remote-models, .toolkit-guide-subscriptions, .platform-guide-pair, .platform-guide-feature-list, .platform-guide-feature-list.compact, .platform-guide-tool-grid { grid-template-columns: 1fr; } .toolkit-guide-subscription { grid-template-columns: 38px minmax(0, 1fr); } .toolkit-guide-subscription em { display: none; } }
 @media (prefers-reduced-motion: reduce) { .toolkit-guide-aurora { animation: none; } }
 
+/* "Nodus has a new website" — a title, a line and the address. It reuses the update-tour
+   chrome with no stage at all, so the shared 840px width would leave the hero floating in
+   a modal that says four words. Narrower, and the hero IS the modal. */
+.website-launch-guide { width: min(560px, 100%); }
+.website-launch-guide .toolkit-guide-hero { min-height: 172px; grid-template-columns: minmax(0, 1fr) 168px; padding: 22px 30px; }
+.website-launch-guide .toolkit-guide-hero h2 { font-size: clamp(26px, 3.4vw, 34px); }
+.website-launch-footer { justify-content: space-between; }
+
 /* "A tease of what's coming" — the App Store screenshots beside the copy that explains
    them. The shots are portrait (1320 x 2868), so they get their own narrow column and
    the prose takes the rest of the 840px stage; stacking them would push the survey below


### PR DESCRIPTION
A one-time in-app notice pointing at the new site: a title, one line and the address, and nothing else.

- `WebsiteLaunchGuide` in the update-tour chrome, last in the startup chain, in front of the update check.
- Gated on its own sentinel (`nodus.websiteLaunchSeen.2026-08") plus a completed essential guide. Not pinned to a release, so it does not retire itself on the next version.
- The visit button opens the browser without dismissing the notice. Only the dismissal marks it seen.
- Translated into the eight interface languages.
- Test harnesses that pre-dismiss the startup modals mark it seen too.

Verified: `npm test` (1916 pass), `npm run test:e2e`, `npm run typecheck`, lint, plus a headless render of the modal in dark-wide and light-narrow.