### PR TITLE
Move Nodus Server publication off the Electron main process

### DIFF
--- a/electron/db/rowIdentity.ts
+++ b/electron/db/rowIdentity.ts
@@ -1,5 +1,15 @@
 import type Database from 'better-sqlite3';
 import { getDb } from './database';
+import {
+  IDENTITY_OVERRIDES,
+  identityColumnsInDatabase,
+  identityWhere,
+  quoteIdentifier,
+  tableColumnsInDatabase,
+  type TableColumn,
+} from './rowIdentityCore';
+
+export { IDENTITY_OVERRIDES, identityWhere, quoteIdentifier, type TableColumn };
 
 /**
  * How a row is identified when it is matched against the same row on another machine.
@@ -7,13 +17,6 @@ import { getDb } from './database';
  * what "the same row" means — two answers to that question would let a restore write
  * over the wrong record.
  */
-
-export interface TableColumn { name: string; pk: number; notnull: number }
-
-export function quoteIdentifier(value: string): string {
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error('Identificador de tabla no válido.');
-  return `"${value}"`;
-}
 
 /**
  * Identity for tables SQLite cannot describe: no primary key, and their UNIQUE index is
@@ -24,43 +27,14 @@ export function quoteIdentifier(value: string): string {
  * entry here, and the test asserts that list is empty — so a future migration adding
  * another such table fails the build instead of silently becoming unmergeable.
  */
-export const IDENTITY_OVERRIDES: Record<string, string[]> = {
-  // UNIQUE INDEX ... ON (COALESCE(academic_year_id, ''), day)
-  study_schedule_day_styles: ['day', 'academic_year_id'],
-};
-
 /** Every helper takes an optional connection: the tombstone triggers are installed
  *  while the database is still being opened, before `getDb()` can return it. */
 export function tableColumns(table: string, db: Database.Database = getDb()): TableColumn[] {
-  return db.pragma(`table_info(${quoteIdentifier(table)})`) as TableColumn[];
+  return tableColumnsInDatabase(db, table);
 }
 
 /** The columns that identify a row: primary key, declared override, or a UNIQUE index
  *  whose columns SQLite can name. Empty when the row cannot be matched at all. */
 export function identityColumns(table: string, columns?: TableColumn[], db: Database.Database = getDb()): string[] {
-  columns = columns ?? tableColumns(table, db);
-  const pk = columns.filter((column) => column.pk > 0).sort((a, b) => a.pk - b.pk).map((column) => column.name);
-  if (pk.length > 0) return pk;
-  const override = IDENTITY_OVERRIDES[table];
-  const names = new Set(columns.map((column) => column.name));
-  if (override && override.every((name) => names.has(name))) return override;
-  const indexes = db.pragma(`index_list(${quoteIdentifier(table)})`) as { name: string; unique: number }[];
-  for (const index of indexes) {
-    if (index.unique !== 1) continue;
-    const info = db.pragma(`index_info(${JSON.stringify(index.name)})`) as { name: string | null }[];
-    if (info.length > 0 && info.every((entry) => typeof entry.name === 'string')) {
-      return info.map((entry) => entry.name as string);
-    }
-  }
-  return [];
-}
-
-/**
- * `WHERE` clause matching one row by its identity. Nullable identity columns use `IS`
- * (an unscoped timetable has a NULL academic year, and `= NULL` matches nothing); NOT
- * NULL ones keep `=` so primary-key lookups still use their index.
- */
-export function identityWhere(columns: TableColumn[], identity: string[]): string {
-  const notNull = new Set(columns.filter((column) => column.notnull === 1 || column.pk > 0).map((column) => column.name));
-  return identity.map((key) => `${quoteIdentifier(key)} ${notNull.has(key) ? '=' : 'IS'} ?`).join(' AND ');
+  return identityColumnsInDatabase(db, table, columns);
 }

--- a/electron/db/rowIdentityCore.ts
+++ b/electron/db/rowIdentityCore.ts
@@ -1,0 +1,42 @@
+import type Database from 'better-sqlite3';
+
+export interface TableColumn { name: string; pk: number; notnull: number }
+
+export const IDENTITY_OVERRIDES: Record<string, string[]> = {
+  study_schedule_day_styles: ['day', 'academic_year_id'],
+};
+
+export function quoteIdentifier(value: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error('Identificador de tabla no válido.');
+  return `"${value}"`;
+}
+
+export function tableColumnsInDatabase(db: Database.Database, table: string): TableColumn[] {
+  return db.pragma(`table_info(${quoteIdentifier(table)})`) as TableColumn[];
+}
+
+export function identityColumnsInDatabase(
+  db: Database.Database,
+  table: string,
+  columns = tableColumnsInDatabase(db, table),
+): string[] {
+  const pk = columns.filter((column) => column.pk > 0).sort((a, b) => a.pk - b.pk).map((column) => column.name);
+  if (pk.length > 0) return pk;
+  const override = IDENTITY_OVERRIDES[table];
+  const names = new Set(columns.map((column) => column.name));
+  if (override && override.every((name) => names.has(name))) return override;
+  const indexes = db.pragma(`index_list(${quoteIdentifier(table)})`) as { name: string; unique: number }[];
+  for (const index of indexes) {
+    if (index.unique !== 1) continue;
+    const info = db.pragma(`index_info(${JSON.stringify(index.name)})`) as { name: string | null }[];
+    if (info.length > 0 && info.every((entry) => typeof entry.name === 'string')) {
+      return info.map((entry) => entry.name as string);
+    }
+  }
+  return [];
+}
+
+export function identityWhere(columns: TableColumn[], identity: string[]): string {
+  const notNull = new Set(columns.filter((column) => column.notnull === 1 || column.pk > 0).map((column) => column.name));
+  return identity.map((key) => `${quoteIdentifier(key)} ${notNull.has(key) ? '=' : 'IS'} ?`).join(' AND ');
+}

--- a/electron/export/autoBackup.ts
+++ b/electron/export/autoBackup.ts
@@ -39,6 +39,15 @@ const TRASHED_BACKUP_RE = /^(.*\.nodus)\.trashed-(\d+)-(\d+)$/;
 
 let activeBackupOperation: string | null = null;
 
+function logBackupPerf(phase: string, startedAt: bigint, metadata: Record<string, string | number> = {}): bigint {
+  const endedAt = process.hrtime.bigint();
+  const elapsedMs = Number(endedAt - startedAt) / 1_000_000;
+  const rssMiB = process.memoryUsage().rss / (1024 * 1024);
+  const details = Object.entries(metadata).map(([key, value]) => `${key}=${value}`).join(' ');
+  console.log(`[perf][backup] phase=${phase} elapsedMs=${elapsedMs.toFixed(1)} rssMiB=${rssMiB.toFixed(1)}${details ? ` ${details}` : ''}`);
+  return endedAt;
+}
+
 async function withBackupOperation<T extends { ok: boolean; message: string }>(
   label: string,
   busyResult: (active: string) => T,
@@ -641,6 +650,8 @@ interface VerifiedBackupOptions {
 }
 
 async function writeVerifiedBackup(options: VerifiedBackupOptions): Promise<AutoBackupResult> {
+  const backupStartedAt = process.hrtime.bigint();
+  let phaseStartedAt = backupStartedAt;
   const settings = getSettings();
   const configuredFolder = settings.autoBackupFolder;
   if (!configuredFolder) return { ok: false, message: 'No hay carpeta de destino configurada.' };
@@ -663,6 +674,7 @@ async function writeVerifiedBackup(options: VerifiedBackupOptions): Promise<Auto
       appVersion: options.appVersion,
       recoveryKey,
     });
+    phaseStartedAt = logBackupPerf('archive-built', phaseStartedAt, { bytes: archive.byteLength });
     const hostname = os.hostname();
     const startedAt = new Date();
     // A manual click and an updater timer can land in the same second. Choose another
@@ -682,10 +694,14 @@ async function writeVerifiedBackup(options: VerifiedBackupOptions): Promise<Auto
     await fs.promises.writeFile(tmp, archive);
     await fs.promises.rename(tmp, target);
     committed = true;
+    phaseStartedAt = logBackupPerf('archive-written', phaseStartedAt, { bytes: archive.byteLength });
 
     // Re-read the committed file and prove it can be authenticated/decrypted before
     // deleting any older snapshot or letting an updater close the application.
-    const verification = verifyBackupArchive(await fs.promises.readFile(target), password);
+    const committedArchive = await fs.promises.readFile(target);
+    phaseStartedAt = logBackupPerf('archive-reread', phaseStartedAt, { bytes: committedArchive.byteLength });
+    const verification = verifyBackupArchive(committedArchive, password);
+    logBackupPerf('archive-verified', phaseStartedAt, { bytes: committedArchive.byteLength });
     if (!verification.ok) {
       fs.rmSync(target, { force: true });
       committed = false;
@@ -696,6 +712,7 @@ async function writeVerifiedBackup(options: VerifiedBackupOptions): Promise<Auto
     }
 
     const prunedCount = options.prune(folder, hostname);
+    logBackupPerf('run:complete', backupStartedAt, { bytes: committedArchive.byteLength });
     const locked = lockedApiKeyProviders();
     const warning = locked.length > 0
       ? ` Aviso: las claves de ${locked.join(', ')} no se pudieron leer del almacén seguro y no viajan en esta copia.`

--- a/electron/export/exportImport.ts
+++ b/electron/export/exportImport.ts
@@ -141,6 +141,17 @@ const RECOVERY_PREF_KEYS = [
   'lastAutoBackupStatus',
 ] as const;
 
+type PerfMetadata = Record<string, string | number | boolean>;
+
+function logBackupPerf(phase: string, startedAt: bigint, metadata: PerfMetadata = {}): bigint {
+  const endedAt = process.hrtime.bigint();
+  const elapsedMs = Number(endedAt - startedAt) / 1_000_000;
+  const rssMiB = process.memoryUsage().rss / (1024 * 1024);
+  const details = Object.entries(metadata).map(([key, value]) => `${key}=${value}`).join(' ');
+  console.log(`[perf][backup] phase=${phase} elapsedMs=${elapsedMs.toFixed(1)} rssMiB=${rssMiB.toFixed(1)}${details ? ` ${details}` : ''}`);
+  return endedAt;
+}
+
 /** Local MCP access credentials must never leave the machine in a backup. */
 type BackupSettings = Omit<AppSettings, 'providerKeys' | 'mcpToken'>;
 
@@ -262,6 +273,9 @@ export async function createBackupArchive(options: {
   /** Independent credential used by automatic recovery snapshots (v6). */
   recoveryKey?: string;
 }): Promise<Buffer> {
+  const backupStartedAt = process.hrtime.bigint();
+  let phaseStartedAt = backupStartedAt;
+  logBackupPerf('create:start', backupStartedAt);
   const settings = getSettings();
   // Full-state backup is a safety invariant, not a renderer preference. Legacy
   // granular settings and unexpected extra options can never reduce this scope.
@@ -289,14 +303,23 @@ export async function createBackupArchive(options: {
   const activeVaultId = getActiveVault().id;
   const files: Record<string, Buffer> = {};
   const vaultEntries: BackupVaultEntry[] = [];
+  let residentVaultBytes = 0;
   for (const vault of vaults) {
+    const vaultStartedAt = process.hrtime.bigint();
     const dbFile = `vaults/${vault.id}/database.sqlite`;
     const inventoryFile = `vaults/${vault.id}/inventory.json`;
     const { database, inventory } = await snapshotVaultDatabase(vault.path, vault.id === activeVaultId, apiKeys);
     files[dbFile] = database;
+    residentVaultBytes += database.byteLength;
     files[inventoryFile] = Buffer.from(JSON.stringify(inventory, null, 2));
     vaultEntries.push({ id: vault.id, name: vault.name, type: vault.type, legacy: vault.legacy, dbFile, inventoryFile });
+    logBackupPerf('snapshot-vault:complete', vaultStartedAt, {
+      vaultId: vault.id,
+      bytes: database.byteLength,
+      residentVaultBytes,
+    });
   }
+  phaseStartedAt = logBackupPerf('snapshot-all-vaults:complete', phaseStartedAt, { vaults: vaults.length, residentVaultBytes });
   files['registry.json'] = Buffer.from(JSON.stringify({ activeVaultId, vaults: vaultEntries }, null, 2));
   await addAuxiliaryFiles(files, vaults, selection);
   const globalLibraryFileCount = await addGlobalLibraryFiles(files);
@@ -306,6 +329,7 @@ export async function createBackupArchive(options: {
       files['audio-keys.json'] = Buffer.from(JSON.stringify(audioKeys, null, 2));
     }
   }
+  phaseStartedAt = logBackupPerf('collect-auxiliary:complete', phaseStartedAt, { files: Object.keys(files).length });
 
   // Hashing and CRC-ing every entry are both full passes over the whole library.
   // Yield between entries so a backup — which runs unattended every 30 minutes —
@@ -316,6 +340,7 @@ export async function createBackupArchive(options: {
     fileDigests[name] = { sha256: sha256Hex(data), bytes: data.byteLength };
     if (++hashed % YIELD_EVERY === 0) await yieldToEventLoop();
   }
+  phaseStartedAt = logBackupPerf('hash-files:complete', phaseStartedAt, { files: hashed });
   const payloadManifest: PayloadManifest = {
     ...manifest,
     activeVaultId,
@@ -334,16 +359,21 @@ export async function createBackupArchive(options: {
     payloadZip.addFile(name, data);
     if (++added % YIELD_EVERY === 0) await yieldToEventLoop();
   }
+  phaseStartedAt = logBackupPerf('register-payload-entries:complete', phaseStartedAt, { entries: added });
 
   const recoveryKey = options.recoveryKey?.trim() || '';
   const payloadCredential = recoveryKey || options.password;
   // toBufferPromise() deflates each entry through zlib's asynchronous API, so the
   // compression runs on libuv's threadpool instead of blocking the event loop.
   // On a 220 MB library that is ~3.7 s of freeze turned into ~0.3 s.
-  const { ciphertext, metadata } = await encryptBackupPayloadAsync(await payloadZip.toBufferPromise(), payloadCredential);
+  const payloadZipBuffer = await payloadZip.toBufferPromise();
+  phaseStartedAt = logBackupPerf('payload-zip-deflate:complete', phaseStartedAt, { bytes: payloadZipBuffer.byteLength });
+  const { ciphertext, metadata } = await encryptBackupPayloadAsync(payloadZipBuffer, payloadCredential);
+  phaseStartedAt = logBackupPerf('payload-encrypt:complete', phaseStartedAt, { bytes: ciphertext.byteLength });
   const wrappedRecovery = recoveryKey
     ? await encryptBackupPayloadAsync(Buffer.from(recoveryKey, 'utf8'), options.password)
     : null;
+  phaseStartedAt = logBackupPerf('recovery-key-wrap:complete', phaseStartedAt, { enabled: Boolean(wrappedRecovery) });
   const outerManifest: BackupManifest = {
     format: 'nodus.encrypted-backup',
     formatVersion: recoveryKey ? 6 : 5,
@@ -358,7 +388,10 @@ export async function createBackupArchive(options: {
   zip.addFile('manifest.json', Buffer.from(JSON.stringify(outerManifest, null, 2)));
   zip.addFile('backup.bin', ciphertext);
   if (wrappedRecovery) zip.addFile('recovery-key.bin', wrappedRecovery.ciphertext);
-  return zip.toBufferPromise();
+  const archive = await zip.toBufferPromise();
+  logBackupPerf('outer-zip-deflate:complete', phaseStartedAt, { bytes: archive.byteLength });
+  logBackupPerf('create:complete', backupStartedAt, { bytes: archive.byteLength });
+  return archive;
 }
 
 export async function exportData(): Promise<{ path: string; password: string; recoveryKey: string } | null> {
@@ -475,6 +508,8 @@ interface OpenedBackup {
  * restore would accept — no second, weaker implementation that could drift.
  */
 function openBackupArchive(archive: Buffer, password: string): OpenedBackup | { ok: false; message: string } {
+  const verifyStartedAt = process.hrtime.bigint();
+  let phaseStartedAt = verifyStartedAt;
   // A truncated or non-zip file makes AdmZip throw, and a damaged manifest makes
   // JSON.parse throw. Both are ordinary states for a half-synced cloud file, so they
   // must come back as a refusal the caller can report — never as an exception that
@@ -491,6 +526,7 @@ function openBackupArchive(archive: Buffer, password: string): OpenedBackup | { 
     }
     encryptedEntry = encrypted;
     manifest = JSON.parse(zip.readAsText(manifestEntry)) as BackupManifest;
+    phaseStartedAt = logBackupPerf('verify-outer-zip:complete', phaseStartedAt, { bytes: archive.byteLength });
   } catch {
     return { ok: false, message: 'Archivo .nodus inválido o dañado: no se pudo leer su estructura.' };
   }
@@ -530,7 +566,13 @@ function openBackupArchive(archive: Buffer, password: string): OpenedBackup | { 
       }
       recoveredKey = payloadCredential;
     }
-    payload = new AdmZip(decryptBackupPayload(encryptedEntry.getData(), payloadCredential, manifest.cipher));
+    phaseStartedAt = logBackupPerf('verify-credential:complete', phaseStartedAt, { recovery: manifest.formatVersion >= 6 });
+    const ciphertext = encryptedEntry.getData();
+    phaseStartedAt = logBackupPerf('verify-outer-entry-read:complete', phaseStartedAt, { bytes: ciphertext.byteLength });
+    const plaintext = decryptBackupPayload(ciphertext, payloadCredential, manifest.cipher);
+    phaseStartedAt = logBackupPerf('verify-decrypt:complete', phaseStartedAt, { bytes: plaintext.byteLength });
+    payload = new AdmZip(plaintext);
+    phaseStartedAt = logBackupPerf('verify-payload-zip-open:complete', phaseStartedAt);
   } catch {
     return { ok: false, message: 'No se pudo descifrar la copia. Revisa la contraseña o el archivo.' };
   }
@@ -542,6 +584,8 @@ function openBackupArchive(archive: Buffer, password: string): OpenedBackup | { 
   if (!verifyPayloadHashes(payload, payloadManifest)) {
     return { ok: false, message: 'Copia inválida: los hashes internos no coinciden.' };
   }
+  logBackupPerf('verify-payload-hashes:complete', phaseStartedAt, { files: Object.keys(payloadManifest.files).length });
+  logBackupPerf('verify-open:complete', verifyStartedAt, { bytes: archive.byteLength });
   if (payloadManifest.schemaVersion > SCHEMA_VERSION) {
     return {
       ok: false,
@@ -558,6 +602,7 @@ function openBackupArchive(archive: Buffer, password: string): OpenedBackup | { 
  * the last recoverable copies. Called before retention runs.
  */
 export function verifyBackupArchive(archive: Buffer, password: string): { ok: boolean; message: string } {
+  const startedAt = process.hrtime.bigint();
   if (!password.trim()) return { ok: false, message: 'Falta la contraseña para verificar la copia.' };
   const opened = openBackupArchive(archive, password);
   if ('ok' in opened) return opened;
@@ -577,6 +622,7 @@ export function verifyBackupArchive(archive: Buffer, password: string): { ok: bo
       return { ok: false, message: 'La copia verificada no contiene todos los archivos de la Biblioteca global.' };
     }
   }
+  logBackupPerf('verify:complete', startedAt, { vaults: opened.payloadManifest.vaults.length, bytes: archive.byteLength });
   return { ok: true, message: `Copia verificada: ${opened.payloadManifest.vaults.length} bóveda(s) descifrables.` };
 }
 
@@ -963,6 +1009,8 @@ async function snapshotVaultDatabase(
   isActive: boolean,
   apiKeys: Partial<Record<AiProvider, string>>
 ): Promise<{ database: Buffer; inventory: BackupInventory }> {
+  const startedAt = process.hrtime.bigint();
+  let phaseStartedAt = startedAt;
   const snapshotPath = path.join(app.getPath('temp'), `nodus-export-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
   try {
     if (isActive) {
@@ -975,6 +1023,7 @@ async function snapshotVaultDatabase(
         src.close();
       }
     }
+    phaseStartedAt = logBackupPerf('sqlite-backup:complete', phaseStartedAt, { active: isActive });
     // Scrub the snapshot's settings row so the bearer token never leaves the machine.
     const snapshotDb = new Database(snapshotPath);
     let scrubbed: BackupSettings;
@@ -987,9 +1036,15 @@ async function snapshotVaultDatabase(
     } finally {
       snapshotDb.close();
     }
+    phaseStartedAt = logBackupPerf('snapshot-scrub:complete', phaseStartedAt, { active: isActive });
+    const inventory = databaseInventory(snapshotPath, scrubbed, apiKeys);
+    phaseStartedAt = logBackupPerf('snapshot-inventory:complete', phaseStartedAt, { active: isActive });
+    const database = fs.readFileSync(snapshotPath);
+    logBackupPerf('snapshot-read-buffer:complete', phaseStartedAt, { active: isActive, bytes: database.byteLength });
+    logBackupPerf('snapshot-database:complete', startedAt, { active: isActive, bytes: database.byteLength });
     return {
-      database: fs.readFileSync(snapshotPath),
-      inventory: databaseInventory(snapshotPath, scrubbed, apiKeys),
+      database,
+      inventory,
     };
   } finally {
     if (fs.existsSync(snapshotPath)) fs.unlinkSync(snapshotPath);

--- a/electron/serverSync/cloudflarePublisher.ts
+++ b/electron/serverSync/cloudflarePublisher.ts
@@ -4,11 +4,12 @@ import { promisify } from 'node:util';
 import type Database from 'better-sqlite3';
 import type { VaultSummary } from '@shared/types';
 import type { CloudflareCapabilityDocument, CloudflarePublicationManifest, CloudflarePublicationSession } from '@shared/cloudflare';
-import { identityColumns } from '../db/rowIdentity';
+import { identityColumnsInDatabase } from '../db/rowIdentityCore';
 import { buildServerSnapshot, type SnapshotAsset, type SnapshotAssetRef } from './serverSnapshot';
-import { buildServerLibraryPublication, type ServerLibraryPackage } from './serverLibrary';
+import type { BuiltServerLibraryPublication, ServerLibraryPackage } from './serverLibrary';
 import { buildVectorSet, buildVectorizeChunks, describeVectorSet, type VectorKind } from './serverVectors';
-import { fetchWithTimeout, normalizeUrl, type VaultServerConfig } from './serverSyncShared';
+import type { VaultServerConfig } from './serverSyncShared';
+import { normalizeServerUrl, serverFetchWithTimeout } from './serverNetwork';
 
 const gzipAsync = promisify(gzip);
 const DIRECT_OBJECT_BYTES = 96 * 1024 * 1024;
@@ -29,7 +30,7 @@ async function jsonRequest<T>(url: string, token: string, init: RequestInit): Pr
   const headers = new Headers(init.headers);
   headers.set('authorization', `Bearer ${token}`); headers.set('accept', 'application/json');
   if (init.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
-  const response = await fetchWithTimeout(url, { ...init, headers });
+  const response = await serverFetchWithTimeout(url, { ...init, headers });
   const result = await response.json().catch(() => ({})) as T & { error?: string; detail?: string; title?: string };
   if (!response.ok) throw new Error(result.detail || result.error || result.title || `Nodus Cloud respondió con HTTP ${response.status}.`);
   return result;
@@ -38,7 +39,7 @@ async function jsonRequest<T>(url: string, token: string, init: RequestInit): Pr
 async function putObject(base: string, spaceId: string, publicationId: string, token: string, purpose: string, objectHash: string, mime: string, data: Buffer): Promise<void> {
   const directLimit = purpose === 'row' ? DIRECT_R2_ROW_BYTES : DIRECT_OBJECT_BYTES;
   if (data.length <= directLimit) {
-    const response = await fetchWithTimeout(`${base}/api/v3/spaces/${encodeURIComponent(spaceId)}/objects/${purpose}/${objectHash}?publicationId=${encodeURIComponent(publicationId)}`, {
+    const response = await serverFetchWithTimeout(`${base}/api/v3/spaces/${encodeURIComponent(spaceId)}/objects/${purpose}/${objectHash}?publicationId=${encodeURIComponent(publicationId)}`, {
       method: 'PUT', headers: { authorization: `Bearer ${token}`, 'content-type': mime, 'content-length': String(data.length) }, body: data,
     });
     if (!response.ok) { const value = await response.json().catch(() => ({})) as { detail?: string; error_description?: string }; throw new Error(value.detail || value.error_description || `Nodus Cloud rechazó un archivo (HTTP ${response.status}).`); }
@@ -81,7 +82,7 @@ function stableRows(db: Database.Database, payload: SnapshotPayload): {
   const tables: Record<string, Array<{ key: string; row: Record<string, unknown> }>> = {};
   const rowObjects: R2RowObject[] = [];
   for (const [table, rows] of Object.entries(payload.tables)) {
-    const identity = identityColumns(table, undefined, db);
+    const identity = identityColumnsInDatabase(db, table);
     if (!identity.length) throw new Error(`La tabla ${table} no tiene una identidad estable y no puede publicarse de forma segura.`);
     tables[table] = rows.map((row) => {
       const key = JSON.stringify(identity.map((column) => row[column] ?? null));
@@ -128,7 +129,7 @@ async function uploadLibrary(base: string, spaceId: string, publicationId: strin
 }
 
 async function vectorizeDimensions(base: string): Promise<Set<number>> {
-  const response = await fetchWithTimeout(`${base}/api/v3/capabilities`, { headers: { accept: 'application/json' } });
+  const response = await serverFetchWithTimeout(`${base}/api/v3/capabilities`, { headers: { accept: 'application/json' } });
   if (!response.ok) return new Set();
   const value = await response.json().catch(() => ({})) as Partial<CloudflareCapabilityDocument>;
   return new Set((value.storage?.vectorizeDimensions || []).filter((dimension) => Number.isSafeInteger(dimension) && dimension > 0 && dimension <= 1536));
@@ -147,7 +148,7 @@ async function uploadVectors(base: string, spaceId: string, publicationId: strin
     } else {
       const exact = buildVectorSet(db, kind);
       if (!exact || exact.buffer.length > EXACT_VECTOR_SEARCH_BYTES) throw new Error(`El índice ${kind} (${exact ? exact.buffer.length : 0} bytes) supera el límite seguro de búsqueda exacta. Añade en Cloudflare un índice Vectorize de ${summary.dim} dimensiones o desactiva esta proyección.`);
-      const response = await fetchWithTimeout(`${base}/api/v3/spaces/${encodeURIComponent(spaceId)}/publications/${publicationId}/vectors/${kind}/exact`, {
+      const response = await serverFetchWithTimeout(`${base}/api/v3/spaces/${encodeURIComponent(spaceId)}/publications/${publicationId}/vectors/${kind}/exact`, {
         method: 'PUT', headers: { authorization: `Bearer ${token}`, 'content-type': 'application/vnd.nodus.vectors' }, body: exact.buffer,
       });
       if (!response.ok) throw new Error(`Nodus Cloud rechazó el índice ${kind} (HTTP ${response.status}).`);
@@ -157,10 +158,16 @@ async function uploadVectors(base: string, spaceId: string, publicationId: strin
 
 export interface CloudflarePublishResult { revision: string; updatedAt: string; bytes: number; assetsSent: number; libraryPackagesSent: number; }
 
-export async function publishVaultToCloudflare(config: VaultServerConfig, token: string, vault: VaultSummary, db: Database.Database): Promise<CloudflarePublishResult> {
-  const base = normalizeUrl(config.url); const spaceId = config.spaceId;
+export async function publishVaultToCloudflare(
+  config: VaultServerConfig,
+  token: string,
+  vault: VaultSummary,
+  db: Database.Database,
+  preparedLibrary: BuiltServerLibraryPublication | null,
+): Promise<CloudflarePublishResult> {
+  const base = normalizeServerUrl(config.url); const spaceId = config.spaceId;
   const availableVectorizeDimensions = await vectorizeDimensions(base);
-  const library = config.includeLibraryDocuments ? buildServerLibraryPublication() : null;
+  const library = preparedLibrary;
   const snapshot = buildServerSnapshot(vault, { nodusServerIncludeUserContent: config.includeUserContent, nodusServerIncludePassages: config.includePassages }, db, library?.manifest || null);
   const payload = JSON.parse(snapshot.buffer.toString('utf8')) as SnapshotPayload;
   const preparedRows = stableRows(db, payload);

--- a/electron/serverSync/publishRetryPolicy.ts
+++ b/electron/serverSync/publishRetryPolicy.ts
@@ -1,0 +1,31 @@
+export const PUBLISH_MIN_INTERVAL_MS = 15_000;
+export const PUBLISH_RETRY_MAX_MS = 15 * 60_000;
+
+export interface PublishRetryRuntime {
+  consecutiveFailures: number;
+  retryNotBefore: number;
+  lastUploadStartedAt: number;
+}
+
+export function notePublishFailure(runtime: PublishRetryRuntime, now = Date.now()): void {
+  runtime.consecutiveFailures += 1;
+  const delay = Math.min(
+    PUBLISH_RETRY_MAX_MS,
+    PUBLISH_MIN_INTERVAL_MS * (2 ** Math.max(0, runtime.consecutiveFailures - 1)),
+  );
+  runtime.retryNotBefore = now + delay;
+}
+
+export function clearPublishRetry(runtime: PublishRetryRuntime): void {
+  runtime.consecutiveFailures = 0;
+  runtime.retryNotBefore = 0;
+}
+
+export function publishRetryIsDue(runtime: PublishRetryRuntime, now = Date.now()): boolean {
+  return runtime.consecutiveFailures > 0 && runtime.retryNotBefore > 0 && now >= runtime.retryNotBefore;
+}
+
+export function mayAttemptPublish(runtime: PublishRetryRuntime, now = Date.now()): boolean {
+  return now - runtime.lastUploadStartedAt >= PUBLISH_MIN_INTERVAL_MS
+    && (runtime.retryNotBefore === 0 || now >= runtime.retryNotBefore);
+}

--- a/electron/serverSync/publishSourceRevision.ts
+++ b/electron/serverSync/publishSourceRevision.ts
@@ -1,0 +1,26 @@
+import type { VaultServerConfig } from './serverSyncShared';
+
+type ProjectionFlags = Pick<
+  VaultServerConfig,
+  'kind' | 'includeUserContent' | 'includePassages' | 'includeLibraryDocuments' | 'includeVectors'
+>;
+
+/**
+ * Session-local pre-build fingerprint.
+ *
+ * `total_changes + data_version + user_version` (the databaseRevision input) cannot
+ * miss a write made through the long-lived active/pooled connection, including deletes
+ * and updates that count/max(rowid) heuristics would miss. It deliberately does not cross
+ * connection restarts. Library files live outside SQLite, so that projection safely opts
+ * out of the shortcut instead of trusting mtime.
+ */
+export function publishSourceRevision(databaseRevision: string, config: ProjectionFlags): string | null {
+  if (config.includeLibraryDocuments) return null;
+  return [
+    databaseRevision,
+    config.kind,
+    Number(config.includeUserContent),
+    Number(config.includePassages),
+    Number(config.includeVectors),
+  ].join(':');
+}

--- a/electron/serverSync/serverNetwork.ts
+++ b/electron/serverSync/serverNetwork.ts
@@ -1,0 +1,10 @@
+const REQUEST_TIMEOUT_MS = 60_000;
+
+/** Network-only helpers that are safe to import from an Electron utility process. */
+export function normalizeServerUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+export async function serverFetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  return fetch(url, { ...init, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+}

--- a/electron/serverSync/serverPublishWorker.ts
+++ b/electron/serverSync/serverPublishWorker.ts
@@ -1,0 +1,59 @@
+import Database from 'better-sqlite3';
+import { gzip } from 'node:zlib';
+import { promisify } from 'node:util';
+import { buildServerSnapshot } from './serverSnapshot';
+import type { ServerPublishWorkerRequest, ServerPublishWorkerResponse } from './serverPublishWorkerTypes';
+import { publishVaultToCloudflare } from './cloudflarePublisher';
+import { buildVectorSet } from './serverVectors';
+
+const gzipAsync = promisify(gzip);
+
+async function build(request: ServerPublishWorkerRequest): Promise<ServerPublishWorkerResponse> {
+  const db = new Database(request.vaultPath, { readonly: true, fileMustExist: true });
+  try {
+    db.pragma('query_only = ON');
+    db.pragma('busy_timeout = 5000');
+    if (request.kind === 'publish-cloudflare') {
+      const result = await publishVaultToCloudflare(request.config, request.token, request.vault, db, request.library);
+      return { kind: 'cloudflare-done', id: request.id, result };
+    }
+    const snapshot = buildServerSnapshot(request.vault, request.settings, db, request.library);
+    const compressed = await gzipAsync(snapshot.buffer, { level: 1 });
+    const vectors = [];
+    for (const kind of request.vectorKinds) {
+      const built = buildVectorSet(db, kind);
+      if (!built) continue;
+      vectors.push({
+        kind,
+        revision: `${built.summary.provider}|${built.summary.model}|${built.summary.dim}|${built.summary.count}`,
+        compressed: await gzipAsync(built.buffer, { level: 1 }),
+        summary: built.summary,
+      });
+    }
+    return {
+      kind: 'done',
+      id: request.id,
+      compressed,
+      rawBytes: snapshot.buffer.byteLength,
+      revision: snapshot.revision,
+      counts: snapshot.counts,
+      assets: snapshot.assets,
+      schemaVersion: snapshot.schemaVersion,
+      vectors,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+process.parentPort?.on('message', (event) => {
+  const request = event.data as ServerPublishWorkerRequest;
+  void build(request).then(
+    (response) => process.parentPort?.postMessage(response),
+    (error) => process.parentPort?.postMessage({
+      kind: 'error',
+      id: request.id,
+      error: error instanceof Error ? error.message : String(error),
+    } satisfies ServerPublishWorkerResponse),
+  );
+});

--- a/electron/serverSync/serverPublishWorkerHost.ts
+++ b/electron/serverSync/serverPublishWorkerHost.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { utilityProcess } from 'electron';
+import type { SnapshotAsset } from './serverSnapshot';
+import type { BuiltServerLibraryPublication } from './serverLibrary';
+import type { VaultSummary } from '@shared/types';
+import type { VaultServerConfig } from './serverSyncShared';
+import type { CloudflarePublishResult } from './cloudflarePublisher';
+import type { VectorKind, VectorSetSummary } from './serverVectors';
+import type {
+  CloudflarePublishWorkerRequest,
+  ServerPublishWorkerRequest,
+  ServerPublishWorkerResponse,
+  ServerSnapshotWorkerRequest,
+} from './serverPublishWorkerTypes';
+
+let nextRequestId = 1;
+const WORKER_TIMEOUT_MS = 30 * 60_000;
+
+function workerFile(): string {
+  return process.env.NODUS_SERVER_PUBLISH_WORKER_FILE
+    || path.join(__dirname, 'serverPublishWorker.js');
+}
+
+export interface CompressedServerSnapshot {
+  compressed: Buffer;
+  rawBytes: number;
+  revision: string;
+  counts: Record<string, number>;
+  assets: SnapshotAsset[];
+  schemaVersion: number;
+  vectors: Array<{
+    kind: VectorKind;
+    revision: string;
+    compressed: Buffer;
+    summary: VectorSetSummary;
+  }>;
+}
+
+export function serverPublishWorkerAvailable(): boolean {
+  return process.env.NODUS_DISABLE_SERVER_PUBLISH_WORKER !== '1' && fs.existsSync(workerFile());
+}
+
+/** One short-lived utility process per snapshot releases the native SQLite connection and
+ * the large V8 heap as soon as the compressed payload crosses back to the main process. */
+export async function buildServerSnapshotInUtility(
+  input: Omit<ServerSnapshotWorkerRequest, 'kind' | 'id'>,
+): Promise<CompressedServerSnapshot> {
+  const message = await runUtility({ kind: 'build', id: nextRequestId++, ...input });
+  if (message.kind !== 'done') throw new Error('El publicador auxiliar devolvió una respuesta inesperada.');
+  return {
+    ...message,
+    compressed: Buffer.from(message.compressed),
+    assets: message.assets.map((asset) => ({
+      ...asset,
+      data: Buffer.from(asset.data),
+      thumbData: asset.thumbData ? Buffer.from(asset.thumbData) : null,
+    })),
+    vectors: message.vectors.map((vector) => ({ ...vector, compressed: Buffer.from(vector.compressed) })),
+  };
+}
+
+export async function publishVaultToCloudflareInUtility(input: {
+  vaultPath: string;
+  vault: VaultSummary;
+  config: VaultServerConfig;
+  token: string;
+  library: BuiltServerLibraryPublication | null;
+}): Promise<CloudflarePublishResult> {
+  const request: CloudflarePublishWorkerRequest = {
+    kind: 'publish-cloudflare',
+    id: nextRequestId++,
+    ...input,
+  };
+  const message = await runUtility(request);
+  if (message.kind !== 'cloudflare-done') throw new Error('El publicador Cloudflare auxiliar devolvió una respuesta inesperada.');
+  return message.result;
+}
+
+function runUtility(request: ServerPublishWorkerRequest): Promise<ServerPublishWorkerResponse> {
+  if (!serverPublishWorkerAvailable()) {
+    return Promise.reject(new Error('El proceso auxiliar de publicación no está disponible. Reinstala o actualiza Nodus.'));
+  }
+  const child = utilityProcess.fork(workerFile(), [], {
+    serviceName: 'Nodus Server publisher',
+    stdio: 'inherit',
+  });
+  return new Promise<ServerPublishWorkerResponse>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(
+      () => finish(new Error('El proceso auxiliar de publicación superó el límite de 30 minutos.')),
+      WORKER_TIMEOUT_MS,
+    );
+    timeout.unref?.();
+    const finish = (error?: Error, result?: ServerPublishWorkerResponse): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.kill();
+      if (error) reject(error);
+      else resolve(result!);
+    };
+    child.on('message', (message: ServerPublishWorkerResponse) => {
+      if (!message || message.id !== request.id) return;
+      if (message.kind === 'error') {
+        finish(new Error(message.error));
+        return;
+      }
+      finish(undefined, message);
+    });
+    child.once('error', (error) => finish(new Error(String(error))));
+    child.once('exit', (code) => {
+      if (!settled) finish(new Error(`El proceso auxiliar de publicación terminó con código ${code}.`));
+    });
+    child.postMessage(request);
+  });
+}

--- a/electron/serverSync/serverPublishWorkerTypes.ts
+++ b/electron/serverSync/serverPublishWorkerTypes.ts
@@ -1,0 +1,56 @@
+import type { AppSettings, VaultSummary } from '@shared/types';
+import type { PublishedLibraryManifest } from './serverLibrary';
+import type { BuiltServerLibraryPublication } from './serverLibrary';
+import type { SnapshotAsset } from './serverSnapshot';
+import type { VaultServerConfig } from './serverSyncShared';
+import type { CloudflarePublishResult } from './cloudflarePublisher';
+import type { VectorKind, VectorSetSummary } from './serverVectors';
+
+export interface PreparedServerVectorWire {
+  kind: VectorKind;
+  revision: string;
+  compressed: Uint8Array;
+  summary: VectorSetSummary;
+}
+
+interface BaseWorkerRequest {
+  id: number;
+  vaultPath: string;
+  vault: VaultSummary;
+}
+
+export interface ServerSnapshotWorkerRequest extends BaseWorkerRequest {
+  kind: 'build';
+  settings: Pick<AppSettings, 'nodusServerIncludeUserContent' | 'nodusServerIncludePassages'>;
+  library: PublishedLibraryManifest | null;
+  vectorKinds: VectorKind[];
+}
+
+export interface CloudflarePublishWorkerRequest extends BaseWorkerRequest {
+  kind: 'publish-cloudflare';
+  config: VaultServerConfig;
+  token: string;
+  library: BuiltServerLibraryPublication | null;
+}
+
+export type ServerPublishWorkerRequest = ServerSnapshotWorkerRequest | CloudflarePublishWorkerRequest;
+
+export type ServerPublishWorkerResponse = {
+  kind: 'done';
+  id: number;
+  compressed: Uint8Array;
+  rawBytes: number;
+  revision: string;
+  counts: Record<string, number>;
+  assets: SnapshotAsset[];
+  schemaVersion: number;
+  vectors: PreparedServerVectorWire[];
+} | {
+  kind: 'cloudflare-done';
+  id: number;
+  result: CloudflarePublishResult;
+} | {
+  kind: 'error';
+  id: number;
+  error: string;
+};

--- a/electron/serverSync/serverSnapshot.ts
+++ b/electron/serverSync/serverSnapshot.ts
@@ -1,7 +1,6 @@
-import { createHash } from 'node:crypto';
+import { createHash, type Hash } from 'node:crypto';
 import type Database from 'better-sqlite3';
 import type { AppSettings, VaultSummary } from '@shared/types';
-import { getDb } from '../db/database';
 import type { PublishedLibraryManifest } from './serverLibrary';
 
 export const SERVER_SNAPSHOT_FORMAT = 'nodus.server-snapshot';
@@ -14,6 +13,44 @@ function logPublishPerf(phase: string, startedAt: bigint, metadata: Record<strin
   const details = Object.entries(metadata).map(([key, value]) => `${key}=${value}`).join(' ');
   console.log(`[perf][publish] phase=${phase} elapsedMs=${elapsedMs.toFixed(1)} rssMiB=${rssMiB.toFixed(1)}${details ? ` ${details}` : ''}`);
   return endedAt;
+}
+
+/** Feed JSON's canonical object/array representation to a digest without ever
+ * materialising a second copy of the complete snapshot string. */
+function updateJsonHash(hash: Hash, value: unknown, inArray = false): void {
+  if (value === undefined || typeof value === 'function' || typeof value === 'symbol') {
+    if (inArray) hash.update('null');
+    return;
+  }
+  if (value === null || typeof value !== 'object') {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined) {
+      if (inArray) hash.update('null');
+      return;
+    }
+    hash.update(encoded);
+    return;
+  }
+  if (Array.isArray(value)) {
+    hash.update('[');
+    value.forEach((item, index) => {
+      if (index > 0) hash.update(',');
+      updateJsonHash(hash, item, true);
+    });
+    hash.update(']');
+    return;
+  }
+  hash.update('{');
+  let written = 0;
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    const item = (value as Record<string, unknown>)[key];
+    if (item === undefined || typeof item === 'function' || typeof item === 'symbol') continue;
+    if (written++ > 0) hash.update(',');
+    hash.update(JSON.stringify(key));
+    hash.update(':');
+    updateJsonHash(hash, item);
+  }
+  hash.update('}');
 }
 
 const CORE_TABLES = [
@@ -358,7 +395,7 @@ function assetRef(asset: SnapshotAsset): SnapshotAssetRef {
   return ref;
 }
 
-export function lightweightVaultRevision(db: Database.Database = getDb()): string {
+export function lightweightVaultRevision(db: Database.Database): string {
   const changes = db.prepare('SELECT total_changes() AS value').get() as { value: number };
   const dataVersion = db.pragma('data_version', { simple: true }) as number;
   const schemaVersion = db.pragma('user_version', { simple: true }) as number;
@@ -376,7 +413,7 @@ export interface BuiltSnapshot {
 export function buildServerSnapshot(
   vault: VaultSummary,
   settings: Pick<AppSettings, 'nodusServerIncludeUserContent' | 'nodusServerIncludePassages'>,
-  db: Database.Database = getDb(),
+  db: Database.Database,
   library: PublishedLibraryManifest | null = null,
 ): BuiltSnapshot {
   const snapshotStartedAt = process.hrtime.bigint();
@@ -440,18 +477,18 @@ export function buildServerSnapshot(
   // digest lets the server recognize an unchanged projection after app restarts.
   // Asset hashes ARE part of it: replacing only a report's illustration has to count
   // as a change, or the republish would be short-circuited as "unchanged".
-  const revision = createHash('sha256')
-    .update(JSON.stringify({
-      vault: payload.vault,
-      schemaVersion,
-      assets: assetRefs,
-      // Like the snapshot timestamp, the library projection's generatedAt describes the
-      // upload and is not content. Excluding it keeps an unchanged library revision stable.
-      library: library ? { ...library, generatedAt: undefined } : null,
-      tables,
-    }))
-    .digest('base64url');
-  logPublishPerf('revision-stringify-hash:complete', phaseStartedAt, { bytes: raw.byteLength });
+  const revisionHash = createHash('sha256');
+  updateJsonHash(revisionHash, {
+    vault: payload.vault,
+    schemaVersion,
+    assets: assetRefs,
+    // Like the snapshot timestamp, the library projection's generatedAt describes the
+    // upload and is not content. Excluding it keeps an unchanged library revision stable.
+    library: library ? { ...library, generatedAt: undefined } : null,
+    tables,
+  });
+  const revision = revisionHash.digest('base64url');
+  logPublishPerf('revision-stream-hash:complete', phaseStartedAt, { bytes: raw.byteLength });
   logPublishPerf('snapshot:complete', snapshotStartedAt, { bytes: raw.byteLength });
   return {
     buffer: raw,

--- a/electron/serverSync/serverSnapshot.ts
+++ b/electron/serverSync/serverSnapshot.ts
@@ -7,6 +7,15 @@ import type { PublishedLibraryManifest } from './serverLibrary';
 export const SERVER_SNAPSHOT_FORMAT = 'nodus.server-snapshot';
 export const SERVER_SNAPSHOT_VERSION = 2;
 
+function logPublishPerf(phase: string, startedAt: bigint, metadata: Record<string, string | number> = {}): bigint {
+  const endedAt = process.hrtime.bigint();
+  const elapsedMs = Number(endedAt - startedAt) / 1_000_000;
+  const rssMiB = process.memoryUsage().rss / (1024 * 1024);
+  const details = Object.entries(metadata).map(([key, value]) => `${key}=${value}`).join(' ');
+  console.log(`[perf][publish] phase=${phase} elapsedMs=${elapsedMs.toFixed(1)} rssMiB=${rssMiB.toFixed(1)}${details ? ` ${details}` : ''}`);
+  return endedAt;
+}
+
 const CORE_TABLES = [
   'works', 'work_aliases', 'authors', 'work_authors', 'collections', 'work_collections',
   'zotero_tags', 'work_zotero_tags', 'themes', 'work_themes', 'ideas', 'idea_occurrences',
@@ -370,6 +379,8 @@ export function buildServerSnapshot(
   db: Database.Database = getDb(),
   library: PublishedLibraryManifest | null = null,
 ): BuiltSnapshot {
+  const snapshotStartedAt = process.hrtime.bigint();
+  let phaseStartedAt = snapshotStartedAt;
   const present = tableNames(db);
   const selected = new Set<string>(CORE_TABLES.filter((table) => present.has(table)));
   // Each vault type contributes its own corpus. Academic has none listed here because
@@ -392,6 +403,10 @@ export function buildServerSnapshot(
 
   const tables: Record<string, Record<string, unknown>[]> = {};
   for (const table of [...selected].sort()) tables[table] = readTable(db, table);
+  phaseStartedAt = logPublishPerf('select-tables:complete', phaseStartedAt, {
+    tables: Object.keys(tables).length,
+    rows: Object.values(tables).reduce((total, rows) => total + rows.length, 0),
+  });
 
   // Images ride their own channel, addressed by content hash, so the JSON keeps its
   // invariant of holding no binary at all. A portrait is only published for a vault that
@@ -399,6 +414,7 @@ export function buildServerSnapshot(
   const wantsAssets = settings.nodusServerIncludeUserContent || vault.type !== 'academic';
   const assets = wantsAssets ? collectSnapshotAssets(db, present) : [];
   const assetRefs = assets.map(assetRef);
+  phaseStartedAt = logPublishPerf('collect-assets:complete', phaseStartedAt, { assets: assets.length });
   const schemaVersion = db.pragma('user_version', { simple: true }) as number;
 
   const generatedAt = new Date().toISOString();
@@ -419,6 +435,7 @@ export function buildServerSnapshot(
     tables,
   };
   const raw = Buffer.from(JSON.stringify(payload));
+  phaseStartedAt = logPublishPerf('payload-stringify:complete', phaseStartedAt, { bytes: raw.byteLength });
   // generatedAt describes this upload, not its contents. Keeping it outside the
   // digest lets the server recognize an unchanged projection after app restarts.
   // Asset hashes ARE part of it: replacing only a report's illustration has to count
@@ -434,6 +451,8 @@ export function buildServerSnapshot(
       tables,
     }))
     .digest('base64url');
+  logPublishPerf('revision-stringify-hash:complete', phaseStartedAt, { bytes: raw.byteLength });
+  logPublishPerf('snapshot:complete', snapshotStartedAt, { bytes: raw.byteLength });
   return {
     buffer: raw,
     revision,

--- a/electron/serverSync/serverSyncService.ts
+++ b/electron/serverSync/serverSyncService.ts
@@ -35,6 +35,12 @@ import {
   readVaultConfig,
   type VaultServerConfig,
 } from './serverSyncShared';
+import {
+  clearPublishRetry,
+  mayAttemptPublish,
+  notePublishFailure,
+  publishRetryIsDue,
+} from './publishRetryPolicy';
 
 // A Nodus Server pairing belongs to ONE vault and one remote space. Unlike the old
 // single-active-vault publisher, every paired vault keeps publishing in the background
@@ -52,7 +58,6 @@ const gzipAsync = promisify(gzip);
 // is normally visible on the other device in around twenty seconds or less.
 const CHECK_INTERVAL_MS = 5_000;
 const QUIET_PERIOD_MS = 5_000;
-const MIN_UPLOAD_INTERVAL_MS = 15_000;
 const FIRST_TICK_MS = 1_500;
 
 interface VaultRuntime {
@@ -61,6 +66,9 @@ interface VaultRuntime {
   /** Timestamp of the latest observed write in the active vault; 0 when clean. */
   dirtySince: number;
   lastUploadStartedAt: number;
+  /** Consecutive failed PUTs and the earliest time their next automatic retry may run. */
+  consecutiveFailures: number;
+  retryNotBefore: number;
   /** The vault wants a publish attempt on the next tick. */
   pending: boolean;
   /** Content hash last actually uploaded this session; skips redundant network. */
@@ -93,6 +101,7 @@ function ensureRuntime(vaultId: string): VaultRuntime {
   if (!rt) {
     rt = {
       observed: null, dirtySince: 0, lastUploadStartedAt: 0, pending: false,
+      consecutiveFailures: 0, retryNotBefore: 0,
       lastRevision: null, phase: 'idle', lastSyncAt: null, lastError: null, lastBytes: null,
       lastAssetsSent: 0, lastInbox: null, lastVectorRevision: {}, lastVectors: {},
       lastLibraryPackagesSent: 0,
@@ -376,6 +385,7 @@ async function publishVault(vaultId: string): Promise<void> {
       rt.lastBytes = result.bytes;
       rt.lastAssetsSent = result.assetsSent;
       rt.lastLibraryPackagesSent = result.libraryPackagesSent;
+      clearPublishRetry(rt);
       if (vault.active) rt.observed = lightweightVaultRevision(db);
       return;
     }
@@ -402,6 +412,7 @@ async function publishVault(vaultId: string): Promise<void> {
       rt.phase = 'ok';
       rt.pending = false;
       rt.dirtySince = 0;
+      clearPublishRetry(rt);
       if (vault.active) rt.observed = lightweightVaultRevision(db);
       return;
     }
@@ -448,6 +459,7 @@ async function publishVault(vaultId: string): Promise<void> {
     rt.dirtySince = 0;
     rt.pending = false;
     rt.phase = 'ok';
+    clearPublishRetry(rt);
     // Cleared here and nowhere else it mattered: this was written on failure and never taken
     // back, so one 502 while the server restarted stayed on the panel for the rest of the
     // session — beside a publication that had just succeeded and an inbox that had just
@@ -463,6 +475,9 @@ async function publishVault(vaultId: string): Promise<void> {
   } catch (error) {
     rt.phase = 'error';
     rt.lastError = error instanceof Error ? error.message : String(error);
+    rt.pending = false;
+    rt.dirtySince = 0;
+    notePublishFailure(rt);
   } finally {
     publishing = false;
   }
@@ -511,7 +526,7 @@ async function tick(): Promise<void> {
       if (
         rt.dirtySince &&
         Date.now() - rt.dirtySince >= QUIET_PERIOD_MS &&
-        Date.now() - rt.lastUploadStartedAt >= MIN_UPLOAD_INTERVAL_MS
+        mayAttemptPublish(rt)
       ) {
         rt.pending = true;
       }
@@ -519,8 +534,17 @@ async function tick(): Promise<void> {
   }
 
   // 2) Publish one pending vault per tick (active-first so edits win over refreshes).
+  const selectionNow = Date.now();
+  for (const config of configs) {
+    const rt = ensureRuntime(config.vaultId);
+    if (publishRetryIsDue(rt, selectionNow)) rt.pending = true;
+  }
   const target = [active, ...configs.filter((config) => !config.isActiveVault)]
-    .find((config) => config && config.autoSync && ensureRuntime(config.vaultId).pending);
+    .find((config) => {
+      if (!config || !config.autoSync) return false;
+      const rt = ensureRuntime(config.vaultId);
+      return rt.pending && mayAttemptPublish(rt, selectionNow);
+    });
   if (target) await publishVault(target.vaultId);
 }
 

--- a/electron/serverSync/serverSyncService.ts
+++ b/electron/serverSync/serverSyncService.ts
@@ -1,7 +1,4 @@
 import os from 'node:os';
-import { gzip } from 'node:zlib';
-import { promisify } from 'node:util';
-import type Database from 'better-sqlite3';
 import { getDb, withVaultDatabase } from '../db/database';
 import { getActiveVault, getVault } from '../vaults/vaultRegistry';
 import { updateSettings } from '../db/settingsRepo';
@@ -20,10 +17,9 @@ import type {
   VaultSummary,
 } from '@shared/types';
 import { normalizeUiLanguage } from '@shared/uiLanguage';
-import { buildServerSnapshot, lightweightVaultRevision, type SnapshotAsset } from './serverSnapshot';
+import { lightweightVaultRevision, type SnapshotAsset } from './serverSnapshot';
 import { buildServerLibraryPublication, type ServerLibraryPackage } from './serverLibrary';
-import { buildVectorSet, vectorRevision, type VectorKind } from './serverVectors';
-import { publishVaultToCloudflare } from './cloudflarePublisher';
+import type { VectorKind } from './serverVectors';
 import { onGlobalLibraryChanged } from '../library/libraryRuntime';
 import { nodiNotesPending, syncNodiNotes } from './nodiNotesSync';
 import {
@@ -41,6 +37,8 @@ import {
   notePublishFailure,
   publishRetryIsDue,
 } from './publishRetryPolicy';
+import { buildServerSnapshotInUtility, publishVaultToCloudflareInUtility } from './serverPublishWorkerHost';
+import { publishSourceRevision } from './publishSourceRevision';
 
 // A Nodus Server pairing belongs to ONE vault and one remote space. Unlike the old
 // single-active-vault publisher, every paired vault keeps publishing in the background
@@ -48,8 +46,6 @@ import {
 // active one on change and refreshes the rest once per run. Connections are surfaced
 // together so Settings shows them from any vault instead of pretending the current
 // vault is "unconfigured".
-
-const gzipAsync = promisify(gzip);
 
 // The mobile client watches the published revision, so this is the latency budget for the
 // desktop half of that conversation. Five seconds of quiet coalesces an editor's writes into
@@ -59,7 +55,6 @@ const gzipAsync = promisify(gzip);
 const CHECK_INTERVAL_MS = 5_000;
 const QUIET_PERIOD_MS = 5_000;
 const FIRST_TICK_MS = 1_500;
-
 interface VaultRuntime {
   /** Last lightweight revision observed for the active vault (change detection). */
   observed: string | null;
@@ -73,6 +68,8 @@ interface VaultRuntime {
   pending: boolean;
   /** Content hash last actually uploaded this session; skips redundant network. */
   lastRevision: string | null;
+  /** Cheap per-connection DB revision that was last published successfully. */
+  lastPublishedDatabaseRevision: string | null;
   phase: NodusServerSyncPhase;
   lastSyncAt: string | null;
   lastError: string | null;
@@ -102,7 +99,8 @@ function ensureRuntime(vaultId: string): VaultRuntime {
     rt = {
       observed: null, dirtySince: 0, lastUploadStartedAt: 0, pending: false,
       consecutiveFailures: 0, retryNotBefore: 0,
-      lastRevision: null, phase: 'idle', lastSyncAt: null, lastError: null, lastBytes: null,
+      lastRevision: null, lastPublishedDatabaseRevision: null,
+      phase: 'idle', lastSyncAt: null, lastError: null, lastBytes: null,
       lastAssetsSent: 0, lastInbox: null, lastVectorRevision: {}, lastVectors: {},
       lastLibraryPackagesSent: 0,
     };
@@ -122,6 +120,15 @@ function tooLargeMessage(config: VaultServerConfig, serverError: string, rawByte
       ? 'Desactiva «Incluir contenido creado por mí» para dejar fuera notas, proyectos y borradores.'
       : 'Pide a quien administra el servidor que amplíe NODUS_MAX_SNAPSHOT_JSON_BYTES.';
   return `${serverError || 'El servidor ha rechazado la publicación por su tamaño.'} ${size} ${lever}`;
+}
+
+function logPublishPerf(phase: string, startedAt: bigint, metadata: Record<string, string | number> = {}): bigint {
+  const endedAt = process.hrtime.bigint();
+  const elapsedMs = Number(endedAt - startedAt) / 1_000_000;
+  const rssMiB = process.memoryUsage().rss / (1024 * 1024);
+  const details = Object.entries(metadata).map(([key, value]) => `${key}=${value}`).join(' ');
+  console.log(`[perf][publish] phase=${phase} elapsedMs=${elapsedMs.toFixed(1)} rssMiB=${rssMiB.toFixed(1)}${details ? ` ${details}` : ''}`);
+  return endedAt;
 }
 
 /**
@@ -323,19 +330,15 @@ async function uploadLibraryPackages(
 async function publishVectors(
   config: VaultServerConfig,
   token: string,
-  db: Database.Database,
+  vectors: Awaited<ReturnType<typeof buildServerSnapshotInUtility>>['vectors'],
   rt: VaultRuntime,
 ): Promise<void> {
   if (!config.includeVectors) return;
-  const kinds: VectorKind[] = config.includePassages ? ['ideas', 'passages'] : ['ideas'];
   const endpoint = `${normalizeUrl(config.url)}/api/v1/spaces/${encodeURIComponent(config.spaceId)}/vectors`;
-  for (const kind of kinds) {
-    const revision = vectorRevision(db, kind);
-    if (!revision || rt.lastVectorRevision[kind] === revision) continue;
-    const built = buildVectorSet(db, kind);
-    if (!built) continue;
+  for (const vector of vectors) {
+    const { kind, revision, compressed, summary } = vector;
+    if (rt.lastVectorRevision[kind] === revision) continue;
     try {
-      const compressed = await gzipAsync(built.buffer, { level: 1 });
       const response = await fetchWithTimeout(`${endpoint}?kind=${kind}`, {
         method: 'PUT',
         headers: {
@@ -350,7 +353,7 @@ async function publishVectors(
       if (response.status === 404) return;
       if (!response.ok) return;
       rt.lastVectorRevision[kind] = revision;
-      rt.lastVectors = { ...rt.lastVectors, [kind]: { count: built.summary.count, dim: built.summary.dim, bytes: compressed.length } };
+      rt.lastVectors = { ...rt.lastVectors, [kind]: { count: summary.count, dim: summary.dim, bytes: compressed.length } };
     } catch {
       // Retried on the next publication; nothing was recorded as sent.
     }
@@ -375,7 +378,22 @@ async function publishVault(vaultId: string): Promise<void> {
   rt.phase = 'syncing';
   try {
     if (config.kind === 'cloudflare') {
-      const result = await publishVaultToCloudflare(config, token, vault, db);
+      const databaseRevision = publishSourceRevision(lightweightVaultRevision(db), config);
+      if (databaseRevision && rt.lastPublishedDatabaseRevision === databaseRevision) {
+        rt.phase = 'ok';
+        rt.pending = false;
+        rt.dirtySince = 0;
+        clearPublishRetry(rt);
+        return;
+      }
+      const library = config.includeLibraryDocuments ? buildServerLibraryPublication() : null;
+      const result = await publishVaultToCloudflareInUtility({
+        vaultPath: vault.path,
+        vault,
+        config,
+        token,
+        library,
+      });
       rt.lastRevision = result.revision;
       rt.dirtySince = 0;
       rt.pending = false;
@@ -385,6 +403,7 @@ async function publishVault(vaultId: string): Promise<void> {
       rt.lastBytes = result.bytes;
       rt.lastAssetsSent = result.assetsSent;
       rt.lastLibraryPackagesSent = result.libraryPackagesSent;
+      rt.lastPublishedDatabaseRevision = databaseRevision;
       clearPublishRetry(rt);
       if (vault.active) rt.observed = lightweightVaultRevision(db);
       return;
@@ -399,19 +418,43 @@ async function publishVault(vaultId: string): Promise<void> {
     // Splitting them also disposes of the concurrency question rather than answering it.
     // better-sqlite3 is synchronous and both would run on the one main-process thread, so
     // "never at the same time" would have to be a flag shared between two modules.
-    const library = config.includeLibraryDocuments ? buildServerLibraryPublication() : null;
-    const snapshot = buildServerSnapshot(
-      { ...vault },
-      { nodusServerIncludeUserContent: config.includeUserContent, nodusServerIncludePassages: config.includePassages },
-      db,
-      library?.manifest ?? null,
-    );
-    // Nothing changed since our last upload this session: keep the server as-is and
-    // avoid the round-trip. The very first publish after launch always runs (no cache).
-    if (rt.lastRevision && rt.lastRevision === snapshot.revision) {
+    // total_changes + data_version is connection-local but stable for the pooled connection.
+    // It cannot miss writes made by this connection or another one. Library packages live
+    // outside SQLite, so that opt-in deliberately bypasses this early shortcut.
+    const databaseRevision = publishSourceRevision(lightweightVaultRevision(db), config);
+    if (databaseRevision && rt.lastPublishedDatabaseRevision === databaseRevision) {
       rt.phase = 'ok';
       rt.pending = false;
       rt.dirtySince = 0;
+      clearPublishRetry(rt);
+      return;
+    }
+    const library = config.includeLibraryDocuments ? buildServerLibraryPublication() : null;
+    let publishPhaseStartedAt = process.hrtime.bigint();
+    const snapshot = await buildServerSnapshotInUtility({
+      vaultPath: vault.path,
+      vault: { ...vault },
+      settings: {
+        nodusServerIncludeUserContent: config.includeUserContent,
+        nodusServerIncludePassages: config.includePassages,
+      },
+      library: library?.manifest ?? null,
+      vectorKinds: config.includeVectors
+        ? (config.includePassages ? ['ideas', 'passages'] : ['ideas']) as VectorKind[]
+        : [],
+    });
+    publishPhaseStartedAt = logPublishPerf('utility-snapshot-gzip:complete', publishPhaseStartedAt, {
+      rawBytes: snapshot.rawBytes,
+      compressedBytes: snapshot.compressed.byteLength,
+    });
+    // Nothing changed since our last upload this session: keep the server as-is and
+    // avoid the round-trip. The very first publish after launch always runs (no cache).
+    if (rt.lastRevision && rt.lastRevision === snapshot.revision) {
+      await publishVectors(config, token, snapshot.vectors, rt);
+      rt.phase = 'ok';
+      rt.pending = false;
+      rt.dirtySince = 0;
+      rt.lastPublishedDatabaseRevision = databaseRevision;
       clearPublishRetry(rt);
       if (vault.active) rt.observed = lightweightVaultRevision(db);
       return;
@@ -425,11 +468,6 @@ async function publishVault(vaultId: string): Promise<void> {
     if (library) {
       await uploadLibraryPackages(normalizeUrl(config.url), config.spaceId, token, library.packages, rt);
     }
-    // Level 1 deliberately trades a little bandwidth for very low desktop CPU usage.
-    // Compressing asynchronously puts even that on libuv's threadpool: this runs on
-    // a 30 s timer, and the main process is the single thread every window's IPC
-    // goes through — including the Nodi overlay's.
-    const compressed = await gzipAsync(snapshot.buffer, { level: 1 });
     const response = await fetchWithTimeout(
       `${normalizeUrl(config.url)}/api/v1/spaces/${encodeURIComponent(config.spaceId)}/snapshot`,
       {
@@ -440,9 +478,13 @@ async function publishVault(vaultId: string): Promise<void> {
           'content-encoding': 'gzip',
           'x-nodus-revision': snapshot.revision,
         },
-        body: compressed,
+        body: snapshot.compressed,
       },
     );
+    logPublishPerf('snapshot-put:complete', publishPhaseStartedAt, {
+      status: response.status,
+      bytes: snapshot.compressed.byteLength,
+    });
     const result = await response.json().catch(() => ({})) as { updatedAt?: string; error?: string };
     if (response.status === 401 || response.status === 403) {
       // The server revoked this device. Drop only the token so the vault stops trying
@@ -453,12 +495,13 @@ async function publishVault(vaultId: string): Promise<void> {
       rt.pending = false;
       return;
     }
-    if (response.status === 413) throw new Error(tooLargeMessage(config, result.error || '', snapshot.buffer.length));
+    if (response.status === 413) throw new Error(tooLargeMessage(config, result.error || '', snapshot.rawBytes));
     if (!response.ok) throw new Error(result.error || `El servidor respondió con HTTP ${response.status}.`);
     rt.lastRevision = snapshot.revision;
     rt.dirtySince = 0;
     rt.pending = false;
     rt.phase = 'ok';
+    rt.lastPublishedDatabaseRevision = databaseRevision;
     clearPublishRetry(rt);
     // Cleared here and nowhere else it mattered: this was written on failure and never taken
     // back, so one 502 while the server restarted stayed on the panel for the rest of the
@@ -467,10 +510,10 @@ async function publishVault(vaultId: string): Promise<void> {
     // because the reader cannot tell it is over.
     rt.lastError = null;
     rt.lastSyncAt = result.updatedAt || new Date().toISOString();
-    rt.lastBytes = compressed.length;
+    rt.lastBytes = snapshot.compressed.length;
     // After the snapshot, so a client that sees the new revision already has rows for
     // whatever the matrix points at.
-    await publishVectors(config, token, db, rt);
+    await publishVectors(config, token, snapshot.vectors, rt);
     if (vault.active) rt.observed = lightweightVaultRevision(db);
   } catch (error) {
     rt.phase = 'error';
@@ -557,6 +600,9 @@ export function startNodusServerSync(): void {
   // publishVault keeps unchanged vaults from re-uploading beyond the first launch pass.
   for (const config of configs) {
     const rt = ensureRuntime(config.vaultId);
+    // stop/start closes the read-only pool. A fresh SQLite connection resets
+    // total_changes/data_version, so no pre-build fingerprint may cross that boundary.
+    rt.lastPublishedDatabaseRevision = null;
     if (config.enabled && config.autoSync) rt.pending = true;
     if (config.isActiveVault) rt.observed = null;
   }

--- a/scripts/fixtures/server-publish-utility-app/main.cjs
+++ b/scripts/fixtures/server-publish-utility-app/main.cjs
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { app, utilityProcess } = require('electron');
+
+const repoRoot = process.env.NODUS_REPO_ROOT;
+if (!repoRoot) throw new Error('NODUS_REPO_ROOT is required');
+const Database = require(path.join(repoRoot, 'node_modules/better-sqlite3'));
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-real-publish-utility-'));
+app.setPath('userData', root);
+
+void app.whenReady().then(async () => {
+  let db;
+  let child;
+  let failed = false;
+  try {
+    const databasePath = path.join(root, 'vault.sqlite');
+    db = new Database(databasePath);
+    db.pragma('journal_mode = WAL');
+    db.exec(`
+      CREATE TABLE passages (
+        passage_id TEXT PRIMARY KEY, nodus_id TEXT NOT NULL, chunk_index INTEGER NOT NULL,
+        text TEXT NOT NULL, page_label TEXT, char_len INTEGER NOT NULL, content_hash TEXT NOT NULL,
+        embedding BLOB, embedding_provider TEXT, embedding_model TEXT, embedding_dim INTEGER,
+        embedding_text_hash TEXT, created_at TEXT NOT NULL
+      )
+    `);
+    const text = 'publicación aislada '.repeat(40);
+    const insert = db.prepare(`INSERT INTO passages (
+      passage_id, nodus_id, chunk_index, text, page_label, char_len, content_hash, created_at
+    ) VALUES (?, 'work', ?, ?, '1', ?, ?, '2026-08-16T00:00:00.000Z')`);
+    db.transaction(() => {
+      for (let index = 0; index < 50_000; index += 1) insert.run(`p-${index}`, index, text, text.length, `h-${index}`);
+    })();
+    db.pragma('wal_checkpoint(PASSIVE)');
+
+    const workerFile = path.join(repoRoot, 'dist-electron/serverPublishWorker.js');
+    assert.ok(fs.existsSync(workerFile), 'vite did not emit the server publish utility entry');
+    child = utilityProcess.fork(workerFile, [], { serviceName: 'Nodus publish verifier', stdio: 'inherit' });
+    await new Promise((resolve, reject) => {
+      child.once('spawn', resolve);
+      child.once('exit', (code) => reject(new Error(`utility process exited before spawn (${code})`)));
+    });
+    const childPid = child.pid;
+    assert.ok(childPid && childPid !== process.pid, 'utility work must run in a distinct process');
+    let ticks = 0;
+    const heartbeat = setInterval(() => { ticks += 1; }, 10);
+    const result = await new Promise((resolve, reject) => {
+      child.once('message', resolve);
+      child.once('exit', (code) => reject(new Error(`utility process exited early (${code})`)));
+      child.once('error', (type, location) => reject(new Error(`${type} at ${location}`)));
+      child.postMessage({
+        kind: 'build', id: 1, vaultPath: databasePath,
+        vault: { id: 'v1', name: 'Sintética', type: 'academic', path: databasePath, active: true, legacy: true },
+        settings: { nodusServerIncludeUserContent: false, nodusServerIncludePassages: true },
+        library: null, vectorKinds: [],
+      });
+    });
+    clearInterval(heartbeat);
+    assert.equal(result.kind, 'done', result.error || 'worker did not finish');
+    assert.equal(result.counts.passages, 50_000);
+    assert.ok(result.rawBytes > 30 * 1024 * 1024, `snapshot unexpectedly small: ${result.rawBytes}`);
+    assert.ok(ticks > 0, 'main-process heartbeat did not advance while the utility process built the snapshot');
+    console.log(`[verify][publish-utility] childPid=${childPid} rawBytes=${result.rawBytes} compressedBytes=${result.compressed.byteLength} mainHeartbeatTicks=${ticks}`);
+  } catch (error) {
+    console.error(error);
+    failed = true;
+  } finally {
+    child?.kill();
+    db?.close();
+    fs.rmSync(root, { recursive: true, force: true });
+    app.exit(failed ? 1 : 0);
+  }
+});

--- a/scripts/fixtures/server-publish-utility-app/package.json
+++ b/scripts/fixtures/server-publish-utility-app/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nodus-server-publish-utility-verifier",
+  "private": true,
+  "main": "main.cjs"
+}

--- a/scripts/measure-main-process-freezes.mjs
+++ b/scripts/measure-main-process-freezes.mjs
@@ -1,0 +1,178 @@
+// D0 diagnostic harness for the two main-process freeze paths.
+//
+// It never opens the installed profile. The parent creates an isolated NODUS_USERDATA,
+// seeds eight migrated synthetic vaults with the measured shape, then runs backup and
+// publication in separate Electron-as-Node processes so their RSS readings do not bleed
+// into one another.
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks } from './lib/tsRuntimeHooks.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const electron = path.join(repoRoot, 'node_modules/.bin/electron');
+const childFlag = '--electron-main-process-perf';
+const mode = process.env.NODUS_PERF_MODE;
+
+if (!process.argv.includes(childFlag)) {
+  const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-main-process-perf-'));
+  const env = {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: '1',
+    NODUS_USERDATA: userData,
+    NODUS_DISABLE_AUTO_UPDATE: '1',
+  };
+  console.log(`[perf][harness] isolatedUserData=${userData}`);
+  try {
+    for (const childMode of ['seed', 'backup', 'publish']) {
+      execFileSync(electron, [fileURLToPath(import.meta.url), childFlag], {
+        cwd: repoRoot,
+        env: { ...env, NODUS_PERF_MODE: childMode },
+        stdio: 'inherit',
+      });
+    }
+  } finally {
+    if (process.env.NODUS_PERF_KEEP_PROFILE === '1') {
+      console.log(`[perf][harness] keptProfile=${userData}`);
+    } else {
+      await rm(userData, { recursive: true, force: true });
+    }
+  }
+  process.exit(0);
+}
+
+const userData = process.env.NODUS_USERDATA;
+if (!userData || !mode) throw new Error('NODUS_USERDATA and NODUS_PERF_MODE are required');
+installRuntimeHooks(userData);
+
+const Database = require('better-sqlite3');
+
+if (mode === 'seed') {
+  await seedProfile();
+} else if (mode === 'backup') {
+  await measureBackup();
+} else if (mode === 'publish') {
+  await measurePublish();
+} else {
+  throw new Error(`Unknown NODUS_PERF_MODE: ${mode}`);
+}
+
+async function seedProfile() {
+  const vaultRegistry = require(path.join(repoRoot, 'electron/vaults/vaultRegistry.ts'));
+  const { getDb, closeDb } = require(path.join(repoRoot, 'electron/db/database.ts'));
+
+  // Opening once creates and migrates the legacy Principal vault through production code.
+  getDb();
+  closeDb();
+  const targetMiB = [615, 127, 20, 20, 20, 20, 18, 18];
+  for (let index = 1; index < targetMiB.length; index += 1) {
+    vaultRegistry.createVault(`Sintetica ${index + 1}`, 'academic');
+  }
+
+  const vaults = vaultRegistry.listVaults();
+  if (vaults.length !== targetMiB.length) throw new Error(`Expected 8 vaults, got ${vaults.length}`);
+  for (let index = 0; index < vaults.length; index += 1) {
+    seedVault(vaults[index].path, targetMiB[index], index === 0);
+  }
+  vaultRegistry.setActiveVault(vaults[0].id);
+  const totalBytes = vaults.reduce((sum, vault) => sum + fs.statSync(vault.path).size, 0);
+  console.log(`[perf][harness] seed:complete vaults=${vaults.length} bytes=${totalBytes} rssMiB=${rssMiB()}`);
+}
+
+function seedVault(databasePath, targetMiB, includePassages) {
+  const db = new Database(databasePath);
+  try {
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = OFF');
+    db.exec('CREATE TABLE IF NOT EXISTS perf_payload (id INTEGER PRIMARY KEY, data BLOB NOT NULL)');
+    if (includePassages) seedPassages(db);
+
+    const pageSize = Number(db.pragma('page_size', { simple: true }));
+    const targetBytes = targetMiB * 1024 * 1024;
+    const insert = db.prepare('INSERT INTO perf_payload (data) VALUES (?)');
+    const addBatch = db.transaction((count) => {
+      for (let index = 0; index < count; index += 1) insert.run(randomBytes(1024 * 1024));
+    });
+    while (Number(db.pragma('page_count', { simple: true })) * pageSize < targetBytes) addBatch(8);
+    db.pragma('wal_checkpoint(TRUNCATE)');
+  } finally {
+    db.close();
+  }
+  console.log(`[perf][harness] seed:vault path=${databasePath} bytes=${fs.statSync(databasePath).size} rssMiB=${rssMiB()}`);
+}
+
+function seedPassages(db) {
+  const count = 157_442;
+  const textBase = 'La memoria documental enlaza archivo, lectura, contexto y evidencia. '.repeat(7);
+  const insert = db.prepare(`
+    INSERT INTO passages (
+      passage_id, nodus_id, chunk_index, text, page_label, char_len,
+      content_hash, embedding, embedding_provider, embedding_model,
+      embedding_dim, embedding_text_hash, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?)
+  `);
+  db.pragma('foreign_keys = OFF');
+  db.transaction(() => {
+    for (let index = 0; index < count; index += 1) {
+      const text = `${textBase}${index}`;
+      insert.run(`perf-passage-${index}`, 'perf-work', index, text, String((index % 400) + 1), text.length, `hash-${index}`, '2026-08-16T00:00:00.000Z');
+    }
+  })();
+}
+
+async function measureBackup() {
+  const { closeDb } = require(path.join(repoRoot, 'electron/db/database.ts'));
+  const { createBackupArchive, verifyBackupArchive } = require(path.join(repoRoot, 'electron/export/exportImport.ts'));
+  const password = 'frase-maestra-sintetica-d0';
+  const target = path.join(userData, 'd0-real-backup.nodus');
+  const startedAt = process.hrtime.bigint();
+  let phaseStartedAt = startedAt;
+  try {
+    const archive = await createBackupArchive({ password, appVersion: 'd0-perf' });
+    phaseStartedAt = logHarnessBackup('archive-returned', phaseStartedAt, archive.byteLength);
+    await fs.promises.writeFile(target, archive);
+    phaseStartedAt = logHarnessBackup('archive-written', phaseStartedAt, archive.byteLength);
+    const committedArchive = await fs.promises.readFile(target);
+    phaseStartedAt = logHarnessBackup('archive-reread', phaseStartedAt, committedArchive.byteLength);
+    const verification = verifyBackupArchive(committedArchive, password);
+    logHarnessBackup('archive-verified', phaseStartedAt, committedArchive.byteLength);
+    if (!verification.ok) throw new Error(verification.message);
+    logHarnessBackup('run:complete', startedAt, committedArchive.byteLength);
+  } finally {
+    closeDb();
+  }
+}
+
+async function measurePublish() {
+  const vaultRegistry = require(path.join(repoRoot, 'electron/vaults/vaultRegistry.ts'));
+  const { buildServerSnapshot } = require(path.join(repoRoot, 'electron/serverSync/serverSnapshot.ts'));
+  const vault = vaultRegistry.getActiveVault();
+  const db = new Database(vault.path, { readonly: true, fileMustExist: true });
+  try {
+    const built = buildServerSnapshot(
+      vault,
+      { nodusServerIncludeUserContent: true, nodusServerIncludePassages: true },
+      db,
+    );
+    console.log(`[perf][harness] publish:result bytes=${built.buffer.byteLength} revision=${built.revision} rssMiB=${rssMiB()}`);
+  } finally {
+    db.close();
+  }
+}
+
+function logHarnessBackup(phase, startedAt, bytes) {
+  const endedAt = process.hrtime.bigint();
+  const elapsedMs = Number(endedAt - startedAt) / 1_000_000;
+  console.log(`[perf][backup] phase=harness-${phase} elapsedMs=${elapsedMs.toFixed(1)} rssMiB=${rssMiB()} bytes=${bytes}`);
+  return endedAt;
+}
+
+function rssMiB() {
+  return (process.memoryUsage().rss / (1024 * 1024)).toFixed(1);
+}

--- a/scripts/test-inbox-poller.mjs
+++ b/scripts/test-inbox-poller.mjs
@@ -15,11 +15,14 @@
 //
 // Runs under Electron-as-Node so better-sqlite3 matches the app ABI.
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
 import { installRuntimeHooks, requireElectronRuntime } from './lib/tsRuntimeHooks.mjs';
 import { withServer } from './lib/nodusServerHarness.mjs';
@@ -32,7 +35,44 @@ if (!requireElectronRuntime(path.join(repoRoot, 'scripts/test-inbox-poller.mjs')
 }
 
 const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-poller-userdata-'));
-installRuntimeHooks(userData);
+const workerFixture = path.join(userData, 'serverPublishWorker.js');
+fs.writeFileSync(workerFixture, '// Existence check for the utility-process host.');
+process.env.NODUS_SERVER_PUBLISH_WORKER_FILE = workerFixture;
+
+// This suite exercises inbox and status behaviour, not snapshot construction. Preserve the
+// production boundary by answering through the utilityProcess contract instead of enabling
+// a main-process fallback in serverSyncService.
+class FakePublishUtility extends EventEmitter {
+  postMessage(request) {
+    const raw = Buffer.from(JSON.stringify({
+      format: 'nodus.server-snapshot',
+      formatVersion: 2,
+      revision: 'inbox-test-revision',
+      generatedAt: new Date().toISOString(),
+      vault: request.vault,
+      schemaVersion: 0,
+      assets: [],
+      library: null,
+      tables: {},
+    }));
+    queueMicrotask(() => this.emit('message', {
+      kind: 'done',
+      id: request.id,
+      compressed: gzipSync(raw),
+      rawBytes: raw.length,
+      revision: 'inbox-test-revision',
+      counts: {},
+      assets: [],
+      schemaVersion: 0,
+      vectors: [],
+    }));
+  }
+  kill() { return true; }
+}
+
+installRuntimeHooks(userData, {
+  utilityProcess: { fork: () => new FakePublishUtility() },
+});
 
 const { getDb } = require(path.join(repoRoot, 'electron/db/database.ts'));
 const { SCHEMA_VERSION } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
@@ -205,7 +245,6 @@ test('a refused mutation is recorded once, however often it comes back', { timeo
     const remaining = await (await server.api(desktop.accessToken, 'GET', `/api/v1/spaces/${spaceId}/mutations`)).json();
     assert.equal(remaining.mutations.length, 1, 'a refusal must never be acknowledged away');
   });
-  await rm(userData, { recursive: true, force: true });
 });
 
 test('a sync error goes away when the sync works again', { timeout: 120_000 }, async () => {
@@ -234,8 +273,12 @@ test('a sync error goes away when the sync works again', { timeout: 120_000 }, a
     // next to a publication that had since succeeded and an inbox that had applied a change.
     updateSettings({ nodusServerUrl: server.origin });
     await syncNodusServerVaultNow(vaultId);
-    assert.equal(connection()?.phase, 'ok');
+    assert.equal(connection()?.phase, 'ok', connection()?.lastError ?? undefined);
     assert.equal(connection()?.lastError, null, 'an error that outlives its cause cannot be told apart from a live one');
   });
+});
+
+test.after(async () => {
+  delete process.env.NODUS_SERVER_PUBLISH_WORKER_FILE;
   await rm(userData, { recursive: true, force: true });
 });

--- a/scripts/test-server-publish-backoff.mjs
+++ b/scripts/test-server-publish-backoff.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+require.extensions['.ts'] = function loadTs(module, filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const output = ts.transpileModule(source, {
+    fileName: filename,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.CommonJS,
+      moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      esModuleInterop: true,
+    },
+  }).outputText;
+  module._compile(output, filename);
+};
+
+test('three consecutive publish failures cannot rebuild three snapshots in fifteen seconds', () => {
+  const policy = require(path.join(repoRoot, 'electron/serverSync/publishRetryPolicy.ts'));
+  const runtime = {
+    pending: true,
+    dirtySince: 1,
+    lastUploadStartedAt: -Infinity,
+    consecutiveFailures: 0,
+    retryNotBefore: 0,
+  };
+  let snapshotBuilds = 0;
+
+  for (let now = 0; now <= 15_000; now += 5_000) {
+    if (policy.publishRetryIsDue(runtime, now)) runtime.pending = true;
+    if (!runtime.pending || !policy.mayAttemptPublish(runtime, now)) continue;
+    runtime.lastUploadStartedAt = now;
+    snapshotBuilds += 1;
+    // The simulated PUT fails after the expensive snapshot has been built.
+    runtime.pending = false;
+    runtime.dirtySince = 0;
+    policy.notePublishFailure(runtime, now);
+  }
+
+  assert.equal(snapshotBuilds, 2, 'the first retry is delayed to 15 s; a third rebuild needs the 30 s backoff too');
+  assert.equal(runtime.consecutiveFailures, 2);
+  assert.equal(runtime.retryNotBefore, 45_000);
+});
+
+test('publish retry backoff grows exponentially, is capped, and success resets it', () => {
+  const policy = require(path.join(repoRoot, 'electron/serverSync/publishRetryPolicy.ts'));
+  const runtime = { consecutiveFailures: 0, retryNotBefore: 0, lastUploadStartedAt: 0 };
+  const delays = [];
+  let now = 100_000;
+  for (let failure = 0; failure < 10; failure += 1) {
+    policy.notePublishFailure(runtime, now);
+    delays.push(runtime.retryNotBefore - now);
+    now = runtime.retryNotBefore;
+  }
+  assert.deepEqual(delays.slice(0, 4), [15_000, 30_000, 60_000, 120_000]);
+  assert.equal(delays.at(-1), policy.PUBLISH_RETRY_MAX_MS);
+  assert.ok(delays.every((delay) => delay <= policy.PUBLISH_RETRY_MAX_MS));
+
+  policy.clearPublishRetry(runtime);
+  assert.equal(runtime.consecutiveFailures, 0);
+  assert.equal(runtime.retryNotBefore, 0);
+});

--- a/scripts/test-server-publish-source-revision.mjs
+++ b/scripts/test-server-publish-source-revision.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+require.extensions['.ts'] = function loadTs(module, filename) {
+  const output = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+    fileName: filename,
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS },
+  }).outputText;
+  module._compile(output, filename);
+};
+
+test('pre-build fingerprint covers every SQLite projection switch', () => {
+  const { publishSourceRevision } = require(path.join(repoRoot, 'electron/serverSync/publishSourceRevision.ts'));
+  const base = {
+    kind: 'classic',
+    includeUserContent: true,
+    includePassages: true,
+    includeLibraryDocuments: false,
+    includeVectors: true,
+  };
+  const revision = publishSourceRevision('12:3:327', base);
+  assert.equal(revision, publishSourceRevision('12:3:327', { ...base }));
+  for (const changed of [
+    { kind: 'cloudflare' },
+    { includeUserContent: false },
+    { includePassages: false },
+    { includeVectors: false },
+  ]) {
+    assert.notEqual(publishSourceRevision('12:3:327', { ...base, ...changed }), revision);
+  }
+  assert.notEqual(publishSourceRevision('13:3:327', base), revision, 'any observed SQLite write invalidates the shortcut');
+  assert.equal(
+    publishSourceRevision('12:3:327', { ...base, includeLibraryDocuments: true }),
+    null,
+    'external library files bypass the SQLite-only shortcut',
+  );
+});

--- a/scripts/test-server-publish-utility-process.mjs
+++ b/scripts/test-server-publish-utility-process.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks } from './lib/tsRuntimeHooks.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+test('classic and Cloudflare publication use one-shot utility processes', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-publish-utility-'));
+  const workerFixture = path.join(root, 'serverPublishWorker.js');
+  fs.writeFileSync(workerFixture, '// existence check only');
+  const requests = [];
+  let kills = 0;
+  class FakeUtilityProcess extends EventEmitter {
+    postMessage(request) {
+      requests.push(request);
+      const response = request.kind === 'build'
+        ? {
+            kind: 'done', id: request.id, compressed: new Uint8Array([31, 139, 8]),
+            rawBytes: 116_300_000, revision: 'rev-classic', counts: { passages: 157_442 },
+            assets: [], schemaVersion: 327, vectors: [],
+          }
+        : {
+            kind: 'cloudflare-done', id: request.id,
+            result: { revision: 'rev-cloud', updatedAt: '2026-08-16T00:00:00.000Z', bytes: 42, assetsSent: 0, libraryPackagesSent: 0 },
+          };
+      queueMicrotask(() => this.emit('message', response));
+    }
+    kill() { kills += 1; return true; }
+  }
+  installRuntimeHooks(root, {
+    utilityProcess: {
+      fork(file, args, options) {
+        assert.equal(file, workerFixture);
+        assert.deepEqual(args, []);
+        assert.equal(options.serviceName, 'Nodus Server publisher');
+        return new FakeUtilityProcess();
+      },
+    },
+  });
+  process.env.NODUS_SERVER_PUBLISH_WORKER_FILE = workerFixture;
+  try {
+    const host = require(path.join(repoRoot, 'electron/serverSync/serverPublishWorkerHost.ts'));
+    const vault = { id: 'v1', name: 'Sintética', type: 'academic', path: '/isolated/vault.sqlite', active: true, legacy: true };
+    const classic = await host.buildServerSnapshotInUtility({
+      vaultPath: vault.path,
+      vault,
+      settings: { nodusServerIncludeUserContent: true, nodusServerIncludePassages: true },
+      library: null,
+      vectorKinds: [],
+    });
+    assert.ok(Buffer.isBuffer(classic.compressed));
+    assert.deepEqual([...classic.compressed], [31, 139, 8]);
+    assert.equal(classic.rawBytes, 116_300_000);
+
+    const cloud = await host.publishVaultToCloudflareInUtility({
+      vaultPath: vault.path,
+      vault,
+      config: {
+        vaultId: vault.id, vaultName: vault.name, vaultType: vault.type, isActiveVault: true,
+        kind: 'cloudflare', url: 'https://example.test', spaceId: 's1', spaceName: 'S', language: 'es',
+        enabled: true, autoSync: true, includeUserContent: true, includePassages: true,
+        includeLibraryDocuments: false, includeVectors: true, hasToken: true, configured: true,
+      },
+      token: 'test-token',
+      library: null,
+    });
+    assert.equal(cloud.revision, 'rev-cloud');
+    assert.deepEqual(requests.map((request) => request.kind), ['build', 'publish-cloudflare']);
+    assert.equal(kills, 2, 'each utility process is reaped after its response');
+  } finally {
+    delete process.env.NODUS_SERVER_PUBLISH_WORKER_FILE;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('production publication has no worker_threads or main-process snapshot fallback', () => {
+  const host = fs.readFileSync(path.join(repoRoot, 'electron/serverSync/serverPublishWorkerHost.ts'), 'utf8');
+  const service = fs.readFileSync(path.join(repoRoot, 'electron/serverSync/serverSyncService.ts'), 'utf8');
+  const vite = fs.readFileSync(path.join(repoRoot, 'vite.config.ts'), 'utf8');
+  assert.match(host, /utilityProcess\.fork\(/);
+  assert.doesNotMatch(host, /worker_threads|new Worker\s*\(/);
+  assert.match(service, /await buildServerSnapshotInUtility\(/);
+  assert.match(service, /await publishVaultToCloudflareInUtility\(/);
+  assert.doesNotMatch(service, /buildServerSnapshot\s*\(/);
+  assert.match(vite, /utilityBuild\('serverPublishWorker',\s*'electron\/serverSync\/serverPublishWorker\.ts'\)/);
+});

--- a/scripts/test-server-snapshot-revision.mjs
+++ b/scripts/test-server-snapshot-revision.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks, requireElectronRuntime } from './lib/tsRuntimeHooks.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+if (!requireElectronRuntime(path.join(repoRoot, 'scripts/test-server-snapshot-revision.mjs'), '--electron-snapshot-revision')) {
+  process.exit(0);
+}
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-snapshot-revision-'));
+installRuntimeHooks(root);
+const Database = require('better-sqlite3');
+const { runMigrations } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
+const { buildServerSnapshot } = require(path.join(repoRoot, 'electron/serverSync/serverSnapshot.ts'));
+
+test('streaming revision matches the former whole-object JSON digest', () => {
+  const db = new Database(path.join(root, 'vault.sqlite'));
+  try {
+    runMigrations(db);
+    const vault = { id: 'v1', name: 'Sintética', type: 'academic' };
+    const built = buildServerSnapshot(
+      vault,
+      { nodusServerIncludeUserContent: true, nodusServerIncludePassages: true },
+      db,
+      null,
+    );
+    const payload = JSON.parse(built.buffer.toString('utf8'));
+    const expected = createHash('sha256').update(JSON.stringify({
+      vault: payload.vault,
+      schemaVersion: payload.schemaVersion,
+      assets: payload.assets,
+      library: null,
+      tables: payload.tables,
+    })).digest('base64url');
+    assert.equal(built.revision, expected);
+
+    const second = buildServerSnapshot(
+      vault,
+      { nodusServerIncludeUserContent: true, nodusServerIncludePassages: true },
+      db,
+      null,
+    );
+    assert.equal(second.revision, built.revision, 'generatedAt is excluded from the revision');
+  } finally {
+    db.close();
+  }
+});
+
+test('revision hashing streams values instead of materialising the full object again', () => {
+  const source = fs.readFileSync(path.join(repoRoot, 'electron/serverSync/serverSnapshot.ts'), 'utf8');
+  assert.match(source, /updateJsonHash\(revisionHash,/);
+  assert.doesNotMatch(source, /\.update\(JSON\.stringify\(\{/);
+});
+
+test.after(async () => {
+  await rm(root, { recursive: true, force: true });
+});

--- a/scripts/test-update-channels.mjs
+++ b/scripts/test-update-channels.mjs
@@ -71,7 +71,7 @@ test('beta installation is fail-closed behind a verified pre-update snapshot', a
   assert.match(main, /if \(prerelease \|\| recoveryConfigured\)/, 'stable attempts the snapshot whenever a Recovery folder is configured');
   assert.match(main, /stable pre-update backup failed; continuing without blocking stable/, 'stable preserves its non-blocking contract');
   assert.match(main, /autoUpdater\.autoInstallOnAppQuit = false/);
-  assert.match(backups, /verifyBackupArchive\(await fs\.promises\.readFile\(target\), password\)/);
+  assert.match(backups, /const committedArchive = await fs\.promises\.readFile\(target\);[\s\S]*verifyBackupArchive\(committedArchive, password\)/);
   assert.match(backups, /selectPreUpdateBackupsToPrune/);
   assert.match(types, /'backing-up'/);
 });

--- a/scripts/verify-server-publish-utility.mjs
+++ b/scripts/verify-server-publish-utility.mjs
@@ -1,0 +1,16 @@
+// Launch the real Electron utility-process acceptance fixture. A small app directory is
+// used because Electron treats a direct .mjs path inconsistently across CLI/platform builds.
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+execFileSync(
+  path.join(repoRoot, 'node_modules/.bin/electron'),
+  [path.join(repoRoot, 'scripts/fixtures/server-publish-utility-app')],
+  {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: { ...process.env, NODUS_REPO_ROOT: repoRoot, NODUS_DISABLE_AUTO_UPDATE: '1' },
+  },
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,6 +76,34 @@ const preloadBuild = (name: string, entry: string) => ({
   },
 });
 
+/** A utility process must not share Rollup chunks with Electron's main entry: a shared
+ * chunk may pull `app`/`BrowserWindow` imports into a process where Electron does not
+ * expose them. Build it as one self-contained ESM file instead. */
+const utilityBuild = (name: string, entry: string) => ({
+  onstart: (args: { reload: () => void }) => args.reload(),
+  vite: {
+    resolve: {
+      alias: { '@shared': path.resolve(__dirname, 'shared') },
+    },
+    build: {
+      outDir: 'dist-electron',
+      emptyOutDir: false,
+      rollupOptions: {
+        input: { [name]: path.join(__dirname, entry) },
+        external: mainExternals,
+        output: {
+          format: 'es' as const,
+          entryFileNames: '[name].js',
+          inlineDynamicImports: true,
+          banner:
+            "import{fileURLToPath as __nodusFU}from'node:url';import{dirname as __nodusDN}from'node:path';" +
+            'const __filename=__nodusFU(import.meta.url);const __dirname=__nodusDN(__filename);',
+        },
+      },
+    },
+  },
+});
+
 export default defineConfig({
   // Expose the app version to the renderer at build time (shown in Settings).
   define: {
@@ -186,6 +214,7 @@ export default defineConfig({
     electronPlugin([
       preloadBuild('preload.nodi', 'electron/preload/nodi.ts'),
       preloadBuild('preload.presenter', 'electron/preload/presenter.ts'),
+      utilityBuild('serverPublishWorker', 'electron/serverSync/serverPublishWorker.ts'),
     ]),
     renderer(),
   ],


### PR DESCRIPTION
## Resultado

- instrumenta publicación y copia con `[perf]` y RSS por frontera
- confirma con una copia sintética aislada de ocho bóvedas/858 MiB que la acumulación eleva RSS hasta 3,65 GiB y amplifica swap
- limpia `pending`/`dirtySince` al fallar y aplica backoff exponencial 15 s–15 min
- mueve snapshot, SQLite de solo lectura, serialización, hash, gzip, vectores y publicación Cloudflare a un `utilityProcess` de un solo uso
- sustituye el segundo `JSON.stringify` por hash JSON incremental equivalente
- corta antes del build cuando la revisión SQLite y la proyección no han cambiado; documentos externos omiten deliberadamente este atajo

## Medición D0 aislada

- snapshots SQLite: 3,59 s, RSS 1,10 GiB
- deflate del payload: 18,74 s, RSS 2,60 GiB
- cifrado: 2,75 s
- deflate exterior de ciphertext: 20,85 s, RSS 2,96 GiB
- verificación: 11,79 s, pico RSS 3,65 GiB
- total: 62,69 s

Esto confirma la presión de memoria como amplificador, pero el perfil aislado no explica por sí solo los 12–24 minutos: quedan como factores dependientes del entorno el swap del proceso completo y reinicios del backup SQLite por escrituras concurrentes.

## Verificación

- typecheck: pasa
- lint: pasa
- build: pasa
- 7 pruebas específicas del publicador: pasan
- aceptación Electron real: PID separado, snapshot 50,5 MB, 107 heartbeats del principal
- `npm test`: 1925/1928 en la pasada completa; los tres fallos se aislaron: dos contratos antiguos se corrigieron y pasan, y el umbral de biblioteca pasa aislado (586 ms < 1 s)

Todos los datos se generaron bajo perfiles temporales aislados; no se abrió ninguna bóveda real.