### PR TITLE
Bound Codex and Copilot subprocess lifetimes

### DIFF
--- a/electron/ai/codexAppServerClient.ts
+++ b/electron/ai/codexAppServerClient.ts
@@ -16,6 +16,10 @@ export interface CodexAppServerClientOptions {
   codexHome: string;
   appVersion: string;
   requestTimeoutMs?: number;
+  /** Keep OAuth/model state warm briefly, then reap the native runtime. */
+  idleTimeoutMs?: number;
+  /** Hard ceiling for one child generation, including a wedged request. */
+  maxLifetimeMs?: number;
   env?: NodeJS.ProcessEnv;
 }
 
@@ -62,6 +66,8 @@ export class CodexAppServerClient {
   private pending = new Map<JsonRpcId, PendingRequest>();
   private notificationHandlers = new Set<CodexNotificationHandler>();
   private stderrTail = '';
+  private idleTimer: NodeJS.Timeout | null = null;
+  private lifetimeTimer: NodeJS.Timeout | null = null;
 
   constructor(private readonly options: CodexAppServerClientOptions) {}
 
@@ -71,8 +77,13 @@ export class CodexAppServerClient {
   }
 
   async request<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T> {
+    this.clearIdleTimer();
     await this.ensureStarted();
-    return this.sendRequest<T>(method, params, timeoutMs);
+    try {
+      return await this.sendRequest<T>(method, params, timeoutMs);
+    } finally {
+      this.armIdleTimer();
+    }
   }
 
   /** Live child, without starting one. Lets callers skip best-effort teardown
@@ -82,6 +93,7 @@ export class CodexAppServerClient {
   }
 
   async stop(): Promise<void> {
+    this.clearLifecycleTimers();
     this.stopping = true;
     const child = this.child;
     this.child = null;
@@ -119,6 +131,7 @@ export class CodexAppServerClient {
    * synchronous handler.
    */
   killNow(): void {
+    this.clearLifecycleTimers();
     this.stopping = true;
     const child = this.child;
     this.child = null;
@@ -163,6 +176,7 @@ export class CodexAppServerClient {
       }
     );
     this.child = child;
+    this.armLifetimeTimer(child);
 
     // A dying child races every write: the `exitCode === null` guards below can pass
     // and the pipe still be gone by the time the data lands, and an unhandled stream
@@ -229,6 +243,37 @@ export class CodexAppServerClient {
     delete env.NODE_OPTIONS;
     env.CODEX_HOME = this.options.codexHome;
     return env;
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = null;
+  }
+
+  private clearLifecycleTimers(): void {
+    this.clearIdleTimer();
+    if (this.lifetimeTimer) clearTimeout(this.lifetimeTimer);
+    this.lifetimeTimer = null;
+  }
+
+  private armIdleTimer(): void {
+    this.clearIdleTimer();
+    const delay = this.options.idleTimeoutMs ?? 5 * 60_000;
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      if (this.pending.size === 0) void this.stop();
+    }, Math.max(1, delay));
+    this.idleTimer.unref?.();
+  }
+
+  private armLifetimeTimer(child: ChildProcessWithoutNullStreams): void {
+    if (this.lifetimeTimer) clearTimeout(this.lifetimeTimer);
+    this.lifetimeTimer = setTimeout(() => {
+      this.lifetimeTimer = null;
+      if (this.child !== child || child.exitCode !== null) return;
+      this.killNow();
+    }, Math.max(1, this.options.maxLifetimeMs ?? 30 * 60_000));
+    this.lifetimeTimer.unref?.();
   }
 
   private sendRequest<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T> {

--- a/electron/ai/githubCopilotSubscription.ts
+++ b/electron/ai/githubCopilotSubscription.ts
@@ -59,9 +59,16 @@ let loginDiagnostic = '';
 let lastSession: GitHubCopilotSessionUsage | null = null;
 let modelCache: CopilotModelInfo[] | null = null;
 let modelCacheAt = 0;
+let activeRuntimeRequests = 0;
+let idleTimer: NodeJS.Timeout | null = null;
+let lifetimeTimer: NodeJS.Timeout | null = null;
 /** The catalogue follows the GitHub plan, so a tier change or a newly released model
  *  has to become visible without making the user sign out or restart Nodus. */
 const MODEL_CACHE_TTL_MS = 10 * 60_000;
+// Keep the authenticated runtime warm between nearby requests, but never let a
+// vendor subprocess live for days just because Electron's main process does.
+const COPILOT_IDLE_TIMEOUT_MS = 2 * 60_000;
+const COPILOT_MAX_LIFETIME_MS = 30 * 60_000;
 
 function copilotHome(): string {
   const dir = path.join(app.getPath('userData'), 'github-copilot-subscription');
@@ -132,7 +139,40 @@ function getClient(): CopilotClient {
     useLoggedInUser: true,
     logLevel: 'none',
   });
+  if (lifetimeTimer) clearTimeout(lifetimeTimer);
+  lifetimeTimer = setTimeout(() => {
+    lifetimeTimer = null;
+    forceStopClient();
+  }, COPILOT_MAX_LIFETIME_MS);
+  lifetimeTimer.unref?.();
   return client;
+}
+
+function clearIdleTimer(): void {
+  if (!idleTimer) return;
+  clearTimeout(idleTimer);
+  idleTimer = null;
+}
+
+function armIdleTimer(): void {
+  clearIdleTimer();
+  if (!client || activeRuntimeRequests > 0) return;
+  idleTimer = setTimeout(() => {
+    idleTimer = null;
+    void stopClient();
+  }, COPILOT_IDLE_TIMEOUT_MS);
+  idleTimer.unref?.();
+}
+
+async function withCopilotRuntime<T>(work: (runtime: CopilotClient) => Promise<T>): Promise<T> {
+  clearIdleTimer();
+  activeRuntimeRequests += 1;
+  try {
+    return await work(getClient());
+  } finally {
+    activeRuntimeRequests = Math.max(0, activeRuntimeRequests - 1);
+    armIdleTimer();
+  }
 }
 
 function emit(status: GitHubCopilotSubscriptionStatus): void {
@@ -168,39 +208,40 @@ function mapQuota(id: string, raw: any): GitHubCopilotSubscriptionQuotaWindow {
 
 async function readStatus(): Promise<GitHubCopilotSubscriptionStatus> {
   try {
-    const runtime = getClient();
-    await runtime.start();
-    const auth = await runtime.getAuthStatus();
-    if (!auth.isAuthenticated) {
+    return await withCopilotRuntime(async (runtime) => {
+      await runtime.start();
+      const auth = await runtime.getAuthStatus();
+      if (!auth.isAuthenticated) {
+        return {
+          ...EMPTY_STATUS,
+          available: true,
+          loginPending: loginProcess !== null,
+          statusMessage: auth.statusMessage ?? null,
+          lastSession,
+          error: loginDiagnostic || null,
+        };
+      }
+      let quota: GitHubCopilotSubscriptionQuotaWindow[] = [];
+      try {
+        const response = await runtime.rpc.account.getQuota({});
+        quota = Object.entries(response.quotaSnapshots ?? {})
+          .flatMap(([id, value]) => value ? [mapQuota(id, value)] : [])
+          .sort((a, b) => Number(b.id === 'premium_interactions') - Number(a.id === 'premium_interactions') || a.id.localeCompare(b.id));
+      } catch { /* authentication/catalogue still useful without a quota snapshot */ }
       return {
-        ...EMPTY_STATUS,
         available: true,
+        connected: true,
         loginPending: loginProcess !== null,
+        login: auth.login ?? null,
+        authType: auth.authType ?? null,
         statusMessage: auth.statusMessage ?? null,
+        // Never log the user out of GitHub CLI or revoke environment credentials.
+        canLogout: auth.authType === 'user',
+        quota,
         lastSession,
-        error: loginDiagnostic || null,
+        error: null,
       };
-    }
-    let quota: GitHubCopilotSubscriptionQuotaWindow[] = [];
-    try {
-      const response = await runtime.rpc.account.getQuota({});
-      quota = Object.entries(response.quotaSnapshots ?? {})
-        .flatMap(([id, value]) => value ? [mapQuota(id, value)] : [])
-        .sort((a, b) => Number(b.id === 'premium_interactions') - Number(a.id === 'premium_interactions') || a.id.localeCompare(b.id));
-    } catch { /* authentication/catalogue still useful without a quota snapshot */ }
-    return {
-      available: true,
-      connected: true,
-      loginPending: loginProcess !== null,
-      login: auth.login ?? null,
-      authType: auth.authType ?? null,
-      statusMessage: auth.statusMessage ?? null,
-      // Never log the user out of GitHub CLI or revoke environment credentials.
-      canLogout: auth.authType === 'user',
-      quota,
-      lastSession,
-      error: null,
-    };
+    });
   } catch (error) {
     return {
       ...EMPTY_STATUS,
@@ -264,30 +305,32 @@ export async function cancelGitHubCopilotSubscriptionLogin(): Promise<GitHubCopi
 }
 
 export async function logoutGitHubCopilotSubscription(): Promise<GitHubCopilotSubscriptionStatus> {
-  const runtime = getClient();
-  await runtime.start();
-  const auth = await runtime.getAuthStatus();
-  if (auth.authType !== 'user') {
-    throw new Error('Esta conexión procede de GitHub CLI o del entorno. Nodus no cerrará una sesión global de GitHub; gestiónala en GitHub CLI.');
-  }
-  const current = await runtime.rpc.account.getCurrentAuth();
-  if (current.authInfo) await runtime.rpc.account.logout({ authInfo: current.authInfo });
+  await withCopilotRuntime(async (runtime) => {
+    await runtime.start();
+    const auth = await runtime.getAuthStatus();
+    if (auth.authType !== 'user') {
+      throw new Error('Esta conexión procede de GitHub CLI o del entorno. Nodus no cerrará una sesión global de GitHub; gestiónala en GitHub CLI.');
+    }
+    const current = await runtime.rpc.account.getCurrentAuth();
+    if (current.authInfo) await runtime.rpc.account.logout({ authInfo: current.authInfo });
+  });
   await stopClient();
   return refresh();
 }
 
 async function copilotModels(): Promise<CopilotModelInfo[]> {
   if (modelCache && Date.now() - modelCacheAt < MODEL_CACHE_TTL_MS) return modelCache;
-  const runtime = getClient();
-  await runtime.start();
-  const auth = await runtime.getAuthStatus();
-  if (!auth.isAuthenticated) {
-    throw new ProviderRuntimeError('Conecta primero tu cuenta de GitHub Copilot en Proveedores y modelos.', 'auth');
-  }
-  const models = await runtime.listModels();
-  modelCache = models;
-  modelCacheAt = Date.now();
-  return models;
+  return withCopilotRuntime(async (runtime) => {
+    await runtime.start();
+    const auth = await runtime.getAuthStatus();
+    if (!auth.isAuthenticated) {
+      throw new ProviderRuntimeError('Conecta primero tu cuenta de GitHub Copilot en Proveedores y modelos.', 'auth');
+    }
+    const models = await runtime.listModels();
+    modelCache = models;
+    modelCacheAt = Date.now();
+    return models;
+  });
 }
 
 export async function listGitHubCopilotSubscriptionModels(): Promise<ModelInfo[]> {
@@ -311,11 +354,11 @@ export async function completeWithGitHubCopilotSubscription(options: CompletionO
   const workdir = await fs.promises.mkdtemp(path.join(app.getPath('temp') || os.tmpdir(), 'nodus-github-copilot-'));
   try { await fs.promises.chmod(workdir, 0o700); } catch { /* Windows */ }
   try {
-    const result = await runIsolatedGitHubCopilotCompletion(getClient(), {
-      ...options,
-      supportsReasoning: Boolean(selected.capabilities?.supports?.reasoningEffort),
-      workdir,
-    });
+    const result = await withCopilotRuntime((runtime) => runIsolatedGitHubCopilotCompletion(runtime, {
+        ...options,
+        supportsReasoning: Boolean(selected.capabilities?.supports?.reasoningEffort),
+        workdir,
+      }));
     if (result.usage) lastSession = result.usage;
     void refresh();
     return result.text;
@@ -325,6 +368,9 @@ export async function completeWithGitHubCopilotSubscription(options: CompletionO
 }
 
 async function stopClient(): Promise<void> {
+  clearIdleTimer();
+  if (lifetimeTimer) clearTimeout(lifetimeTimer);
+  lifetimeTimer = null;
   const current = client;
   client = null;
   modelCache = null;
@@ -339,4 +385,29 @@ export async function stopGitHubCopilotSubscription(): Promise<void> {
     try { child.kill('SIGTERM'); } catch { /* already exited */ }
   }
   await stopClient();
+}
+
+function forceStopClient(): void {
+  clearIdleTimer();
+  if (lifetimeTimer) clearTimeout(lifetimeTimer);
+  lifetimeTimer = null;
+  const current = client;
+  client = null;
+  modelCache = null;
+  modelCacheAt = 0;
+  if (current) void current.forceStop();
+}
+
+/** before-quit cannot await. Detach the SDK first, then issue its synchronous
+ * SIGKILL path so neither Copilot nor a pending login can outlive Electron. */
+export function killGitHubCopilotSubscriptionServer(): void {
+  clearIdleTimer();
+  if (lifetimeTimer) clearTimeout(lifetimeTimer);
+  lifetimeTimer = null;
+  const child = loginProcess;
+  loginProcess = null;
+  if (child && child.exitCode === null) {
+    try { child.kill('SIGKILL'); } catch { /* already exited */ }
+  }
+  forceStopClient();
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,7 +39,7 @@ import { hasBackupPassword } from './secrets/secretStore';
 import type { UpdateCheckResponse, UpdateProgressEvent } from '@shared/types';
 import { TUTORIAL_VIDEO_EMBED_ORIGIN } from '@shared/tutorialVideos';
 import { killChatGptSubscriptionServer } from './ai/codexSubscription';
-import { stopGitHubCopilotSubscription } from './ai/githubCopilotSubscription';
+import { killGitHubCopilotSubscriptionServer } from './ai/githubCopilotSubscription';
 import { installProcessSafetyNet } from './util/processSafety';
 import { restoreAppWindows } from './windowLifecycle';
 import { registerImageProtocol, registerImageSchemePrivileges } from './imageProtocol';
@@ -979,7 +979,7 @@ app.on('before-quit', () => {
   // Kill synchronously: this handler cannot await, so the graceful stops below would
   // be abandoned mid-drain and leave the vendor runtimes running as orphans.
   killChatGptSubscriptionServer();
-  void stopGitHubCopilotSubscription();
+  killGitHubCopilotSubscriptionServer();
   closeGlobalLibraryRuntime();
   closeDb();
 });
@@ -1008,7 +1008,7 @@ updateAwareApp.on('before-quit-for-update', () => {
   // Kill synchronously: this handler cannot await, so the graceful stops below would
   // be abandoned mid-drain and leave the vendor runtimes running as orphans.
   killChatGptSubscriptionServer();
-  void stopGitHubCopilotSubscription();
+  killGitHubCopilotSubscriptionServer();
   closeGlobalLibraryRuntime();
   closeDb();
 });

--- a/scripts/test-codex-subscription.mjs
+++ b/scripts/test-codex-subscription.mjs
@@ -142,6 +142,21 @@ test('Codex App Server is reaped after its explicit idle limit', async () => {
   assert.equal(client.isRunning(), false, 'an unused @openai/codex process cannot survive indefinitely');
 });
 
+test('Codex App Server hard lifetime also reaps a wedged request', async () => {
+  const home = path.join(outDir, 'codex-lifetime-home');
+  fs.mkdirSync(home);
+  const client = new CodexAppServerClient({
+    binaryPath: fakeAppServer(),
+    codexHome: home,
+    appVersion: 'test',
+    requestTimeoutMs: 5_000,
+    idleTimeoutMs: 5_000,
+    maxLifetimeMs: 30,
+  });
+  await assert.rejects(client.request('never-replies'), /se ha cerrado/);
+  assert.equal(client.isRunning(), false, 'a stuck request cannot extend the child lifetime ceiling');
+});
+
 class CompletionTransport {
   handlers = new Set();
   calls = [];

--- a/scripts/test-codex-subscription.mjs
+++ b/scripts/test-codex-subscription.mjs
@@ -126,6 +126,22 @@ test('Codex App Server is forced to managed ChatGPT auth and receives no ambient
   }
 });
 
+test('Codex App Server is reaped after its explicit idle limit', async () => {
+  const home = path.join(outDir, 'codex-idle-home');
+  fs.mkdirSync(home);
+  const client = new CodexAppServerClient({
+    binaryPath: fakeAppServer(),
+    codexHome: home,
+    appVersion: 'test',
+    idleTimeoutMs: 20,
+    maxLifetimeMs: 200,
+  });
+  await client.request('probe');
+  assert.equal(client.isRunning(), true);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.equal(client.isRunning(), false, 'an unused @openai/codex process cannot survive indefinitely');
+});
+
 class CompletionTransport {
   handlers = new Set();
   calls = [];

--- a/scripts/test-subscription-failure-paths.mjs
+++ b/scripts/test-subscription-failure-paths.mjs
@@ -15,6 +15,19 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('vendor subscription runtimes have explicit bounded lifecycles', () => {
+  const codex = fs.readFileSync(path.join(repoRoot, 'electron/ai/codexAppServerClient.ts'), 'utf8');
+  const copilot = fs.readFileSync(path.join(repoRoot, 'electron/ai/githubCopilotSubscription.ts'), 'utf8');
+  const main = fs.readFileSync(path.join(repoRoot, 'electron/main.ts'), 'utf8');
+  assert.match(codex, /idleTimeoutMs \?\? 5 \* 60_000/);
+  assert.match(codex, /maxLifetimeMs \?\? 30 \* 60_000/);
+  assert.match(codex, /this\.killNow\(\)/, 'the Codex lifetime ceiling also terminates a wedged request');
+  assert.match(copilot, /COPILOT_IDLE_TIMEOUT_MS = 2 \* 60_000/);
+  assert.match(copilot, /COPILOT_MAX_LIFETIME_MS = 30 \* 60_000/);
+  assert.match(copilot, /forceStopClient\(\)/, 'the Copilot lifetime ceiling reaches the SDK SIGKILL path');
+  assert.match(main, /killGitHubCopilotSubscriptionServer\(\)/);
+});
 const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-subscription-failures-'));
 const bundle = path.join(outDir, 'failure-paths.cjs');
 const entry = path.join(outDir, 'entry.ts');


### PR DESCRIPTION
## Resultado

Hace explícita y acotada la persistencia de los runtimes de suscripción.

- Codex: 5 min de inactividad, 30 min de vida máxima
- GitHub Copilot: 2 min de inactividad, 30 min de vida máxima
- el techo máximo mata también una petición bloqueada
- `before-quit` y `before-quit-for-update` usan cierre síncrono/SIGKILL para que ningún hijo quede huérfano
- la caché de modelos se invalida al reciclar Copilot

La decisión es mantenerlos calientes brevemente para amortizar autenticación/arranque, con un límite duro en vez de procesos residentes durante días.

## Verificación

- typecheck y lint
- 34/34 tests de proveedores
- prueba roja/verde del límite duro: sin el cierre falló al timeout de 5 s; con el cierre rechazó y terminó el hijo en ~34 ms
- commits sin coautoría.