### PR TITLE
Prepare Nodus v4.1.4

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -65,7 +65,7 @@ jobs:
           scripts/test-server-vectors.mjs
 
       - name: Build smoke-test image
-        run: docker build --build-arg NODUS_VERSION=4.1.3 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
+        run: docker build --build-arg NODUS_VERSION=4.1.4 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
 
       - name: Run image health smoke test
         shell: bash
@@ -115,7 +115,7 @@ jobs:
             org.opencontainers.image.description=Experimental self-hosted Nodus MCP server
             org.opencontainers.image.source=https://github.com/Drakonis96/nodus
             org.opencontainers.image.licenses=AGPL-3.0-only
-            org.opencontainers.image.version=4.1.3
+            org.opencontainers.image.version=4.1.4
             org.opencontainers.image.revision=${{ github.sha }}
             app.nodus.stability=experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 4.1.4 — 2026-08-16
+
+Nodus 4.1.4 keeps the desktop responsive during automatic backups and connected-vault
+publication, fixes the first administrator setup in production Cloudflare deployments,
+and introduces the project’s new public home at nodusresearch.com.
+
+- Automatic backups and connected-vault publication now run outside the main process with
+  bounded memory, hard process deadlines, retry backoff and unchanged-data shortcuts.
+- Nodus Cloud can initialise its first administrator on Cloudflare Workers and surfaces the
+  server’s real error when deployment setup fails.
+- The notification centre reports the outcome of a manual refresh and preserves its last
+  valid snapshot when the remote feed is unavailable.
+- The redesigned website brings together the wiki, manuals, interactive demos, FAQ, blog
+  and contribution paths at nodusresearch.com.
+- The What’s New modal presents this release in all eight interface languages.
+
 ## 4.1.3 — 2026-08-15
 
 Nodus 4.1.3 extends the section snapshots of 4.1.2 to the three places a reader stays inside the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "4.1.3"
-date-released: "2026-08-15"
+version: "4.1.4"
+date-released: "2026-08-16"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://drakonis96.github.io/nodus/"

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.1.3 is licensed exclusively under the GNU Affero General Public
+Nodus 4.1.4 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.1.3 release is available
+The preferred form for modifying the official Nodus 4.1.4 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.3
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.3
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.3.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.3.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.4
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.4
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.1.3 is free software distributed exclusively under the GNU Affero
+Nodus 4.1.4 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/electron/library/libraryCslStyles.ts
+++ b/electron/library/libraryCslStyles.ts
@@ -155,7 +155,7 @@ function repositoryStyleTitle(id: string): string {
 async function officialRepositoryIndex(): Promise<LibraryCitationStyleRepositoryEntry[]> {
   if (!repositoryIndexPromise) {
     repositoryIndexPromise = fetch(OFFICIAL_STYLES_TREE_URL, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.1.3' },
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.1.4' },
     }).then(async (response) => {
       if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
       const payload = await response.json() as { tree?: Array<{ path?: string; type?: string }>; truncated?: boolean };
@@ -246,7 +246,7 @@ export async function installRepositoryCitationStyle(rawId: string): Promise<Lib
   const id = repositoryIdFromUrl(rawId) ?? rawId.trim().toLowerCase().replace(/\.csl$/i, '');
   if (!/^[a-z0-9][a-z0-9._-]{1,199}$/.test(id)) throw new Error('Introduce el identificador de un estilo del repositorio oficial de CSL.');
   const response = await fetch(`${OFFICIAL_STYLES_RAW_URL}/${encodeURIComponent(id)}.csl`, {
-    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.1.3' },
+    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.1.4' },
   });
   if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
   const declaredLength = Number(response.headers.get('content-length') || 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "AGPL-3.0-only",

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '4.1.3';
+const VERSION = '4.1.4';
 
 test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 4.1.3 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 4.1.4 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -74,7 +74,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '4.1.3');
+      assert.equal(info.version, '4.1.4');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,13 +25,21 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '4.1.3');
-  assert.equal(currentRelease?.date, '2026-08-15');
-  assert.equal(currentRelease?.highlights.length, 2);
-  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['general', 'general']);
-  // The two halves of the release: the item that was open, and the place inside it.
-  assert.ok(currentRelease?.highlights.some((highlight) => /the immersion or the document you had open/.test(highlight.en)));
-  assert.ok(currentRelease?.highlights.some((highlight) => /instead of a pixel position/.test(highlight.en)));
+  assert.equal(currentRelease?.version, '4.1.4');
+  assert.equal(currentRelease?.date, '2026-08-16');
+  assert.equal(currentRelease?.highlights.length, 4);
+  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['general', 'general', 'general', 'nodi']);
+  assert.ok(currentRelease?.highlights.some((highlight) => /new home at nodusresearch\.com/.test(highlight.en)));
+  assert.ok(currentRelease?.highlights.some((highlight) => /no longer block the app/.test(highlight.en)));
+  assert.ok(currentRelease?.highlights.some((highlight) => /first administrator account/.test(highlight.en)));
+  assert.ok(currentRelease?.highlights.some((highlight) => /notification centre now gives a clear answer/.test(highlight.en)));
+
+  // 4.1.3 keeps the two it shipped with. They are published history.
+  const readingPositionRelease = RELEASE_NOTES.find((note) => note.version === '4.1.3');
+  assert.equal(readingPositionRelease?.date, '2026-08-15');
+  assert.equal(readingPositionRelease?.highlights.length, 2);
+  assert.ok(readingPositionRelease?.highlights.some((highlight) => /the immersion or the document you had open/.test(highlight.en)));
+  assert.ok(readingPositionRelease?.highlights.some((highlight) => /instead of a pixel position/.test(highlight.en)));
 
   // 4.1.2 keeps the four it shipped with. They are published history.
   const dossierRelease = RELEASE_NOTES.find((note) => note.version === '4.1.2');

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '4.1.3');
+  assert.equal(pluginManifest.version, '4.1.4');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,10 +54,10 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '4\.1\.3'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '4\.1\.4'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.1\.3\.tar\.gz/);
-  assert.match(citation, /^date-released: "2026-08-15"$/m);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.1\.4\.tar\.gz/);
+  assert.match(citation, /^date-released: "2026-08-16"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);
   }

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1244,9 +1244,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '4.1.3', 'the add-on shares the Nodus 4 release version');
+  assert.equal(manifest.version, '4.1.4', 'the add-on shares the Nodus 4 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.1\.3/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.1\.4/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,13 +3,13 @@
 
 FROM node:22-alpine
 
-ARG NODUS_VERSION=4.1.3
+ARG NODUS_VERSION=4.1.4
 ARG NODUS_REVISION=unknown
 LABEL org.opencontainers.image.title="Nodus Server" \
       org.opencontainers.image.description="Experimental self-hosted Nodus MCP server" \
       org.opencontainers.image.source="https://github.com/Drakonis96/nodus" \
       org.opencontainers.image.url="https://github.com/Drakonis96/nodus" \
-      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.1.3/server/README.md" \
+      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.1.4/server/README.md" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.version="${NODUS_VERSION}" \
       org.opencontainers.image.revision="${NODUS_REVISION}" \
@@ -24,7 +24,7 @@ COPY LICENSE SOURCE_CODE.md THIRD_PARTY_NOTICES.md ./
 ENV NODUS_DATA_DIR=/data \
     NODUS_HOST=0.0.0.0 \
     NODUS_PORT=7443 \
-    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.1.3
+    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.1.4
 
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.1.3 is licensed exclusively under the GNU Affero General Public
+Nodus 4.1.4 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.1.3 release is available
+The preferred form for modifying the official Nodus 4.1.4 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.3
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.3
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.3.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.3.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.4
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.4
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.1.3 is free software distributed exclusively under the GNU Affero
+Nodus 4.1.4 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -36,7 +36,7 @@ services:
       # With the pair, the account is created on first boot and its password is rotated
       # whenever you change the value here.
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.3}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       # Optional ceilings. Unset they default to 8 MiB per image, 2 GiB of images per

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -21,7 +21,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.3}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
       # Optional ceilings. Left unset they default to 8 MiB per image, 2 GiB of images per
       # space, and the snapshot limits documented in the README.
       NODUS_MAX_ASSET_BYTES: ${NODUS_MAX_ASSET_BYTES:-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.3}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
     volumes:
       - nodus_data:/data
     ports:

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '4.1.3';
+export const NODUS_VERSION = '4.1.4';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/server/portainer-stack.yml
+++ b/server/portainer-stack.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.3}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
     volumes:
       - nodus_data:/data
     expose:

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -155,6 +155,12 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "4.1.4": [
+    "Nodus ha una nuova casa su nodusresearch.com. Il nuovo sito riunisce wiki, manuali, demo interattive, domande frequenti, blog e una pagina per contribuire. È stato riprogettato per orientarti al primo sguardo e funziona meglio sugli schermi piccoli. L’applicazione ti avviserà una sola volta e il centro notifiche aprirà il nuovo indirizzo.",
+    "I backup automatici e la pubblicazione dei vault connessi non bloccano più l’applicazione. Il lavoro pesante ora avviene fuori dalla finestra principale, usa una quantità di memoria limitata e si interrompe se un processo esterno si blocca. Puoi continuare a usare Nodus mentre un vault grande viene cifrato, compresso o inviato al server. Le pubblicazioni non riuscite attendono prima di riprovare e i dati invariati non vengono ricostruiti.",
+    "Una distribuzione di Nodus Cloud su Cloudflare può ora creare il primo account amministratore. Il servizio di produzione rifiutava un’operazione sulla password accettata dall’ambiente di test. La procedura guidata terminava quindi sempre con un errore 500 e non riusciva a inizializzare il server. La configurazione ora rispetta il limite di Cloudflare, resta compatibile con le password esistenti e mostra il motivo restituito dal server quando qualcosa non funziona.",
+    "L’aggiornamento del centro notifiche ora dà una risposta chiara. Dopo aver premuto il pulsante, Nodus indica se l’elenco è stato aggiornato, se non ci sono novità, se gli avvisi sono disattivati o se non è stato possibile consultare la fonte. L’elenco conserva l’ultima copia valida quando la rete non funziona.",
+  ],
   "4.1.3": [
     "Le sezioni in cui si legge si riaprono dall'interno. Deep Research, Immersione e le schede della Biblioteca recuperano il rapporto, l'immersione o il documento che avevi aperto, oltre alla ricerca e all'ordine dell'elenco. Un'immersione torna al passo in cui l'hai lasciata. Quello che stavi scrivendo non viene ripristinato, perché è lavoro e non un luogo.",
     "Un rapporto si riapre dal punto in cui eri arrivato. Nodus salva quale blocco stava sotto il bordo superiore invece di una posizione in pixel, così cambiare la larghezza della finestra o il carattere non lo sposta più. Il punto viene mantenuto mentre il rapporto finisce di crescere e viene lasciato appena tocchi la rotellina o la tastiera. Se avevi applicato una traduzione, il punto viene scartato invece che approssimato, perché quella è un'altra impaginazione.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -95,6 +95,12 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "4.1.4": [
+    "Nodus artık nodusresearch.com adresinde yeni bir eve sahip. Yeni site wiki’yi, kılavuzları, etkileşimli demoları, sık sorulan soruları, blogu ve katkıda bulunma sayfasını bir araya getiriyor. İlk bakışta yönünüzü bulmanız için yeniden tasarlandı ve küçük ekranlarda daha iyi çalışıyor. Uygulama size bunu yalnızca bir kez bildirecek ve bildirim merkezi yeni adresi açacak.",
+    "Otomatik yedeklemeler ve bağlı kasaların yayımlanması artık uygulamayı engellemiyor. Ağır işler ana pencerenin dışında çalışıyor, sınırlı bellek kullanıyor ve harici bir süreç takılırsa durduruluyor. Büyük bir kasa şifrelenirken, sıkıştırılırken veya sunucuya gönderilirken Nodus’u kullanmaya devam edebilirsiniz. Başarısız yayımlar yeniden denemeden önce bekliyor ve değişmeyen veriler yeniden oluşturulmuyor.",
+    "Cloudflare üzerindeki bir Nodus Cloud dağıtımı artık ilk yönetici hesabını oluşturabiliyor. Üretim hizmeti, test ortamının kabul ettiği bir parola işlemini reddediyordu. Bu yüzden sihirbaz her zaman 500 hatasıyla bitiyor ve sunucuyu başlatamıyordu. Kurulum artık Cloudflare sınırına uyuyor, mevcut parolalarla uyumluluğu koruyor ve bir şey başarısız olduğunda sunucunun döndürdüğü nedeni gösteriyor.",
+    "Bildirim merkezini yenilemek artık net bir yanıt veriyor. Düğmeye bastıktan sonra Nodus listenin güncellenip güncellenmediğini, yeni bir şey olmadığını, duyuruların devre dışı olduğunu veya kaynağa ulaşılamadığını bildiriyor. Ağ başarısız olduğunda liste son geçerli kopyasını koruyor.",
+  ],
   "4.1.3": [
     "İçinde okuduğunuz bölümler artık içeriden yeniden açılıyor. Deep Research, Daldırma ve Kitaplık sekmeleri açık bıraktığınız raporu, daldırmayı ya da belgeyi listenin aramasıyla ve sıralamasıyla birlikte geri getiriyor. Bir daldırma bıraktığınız adıma dönüyor. Yazmakta olduğunuz şey geri yüklenmiyor, çünkü o bir yer değil iştir.",
     "Bir rapor kaldığınız yerden yeniden açılıyor. Nodus piksel konumu yerine üst kenarın altında hangi bloğun durduğunu saklıyor, bu yüzden pencere genişliğini ya da yazı tipini değiştirmek onu artık kaydırmıyor. Rapor büyümeyi bitirene kadar yer korunuyor ve tekerleğe ya da klavyeye dokunduğunuz anda bırakılıyor. Bir çeviri uygulamışsanız yer yaklaştırılmak yerine bırakılıyor, çünkü o başka bir dizgidir.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1106,6 +1106,46 @@ const RELEASE_4_1_3_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+/** 4.1.4 — a new public home and a desktop that stays responsive during upkeep. */
+const RELEASE_4_1_4_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'Nodus estrena casa en nodusresearch.com. La nueva web reúne la wiki, los manuales, las demos interactivas, las preguntas frecuentes, el blog y una página para contribuir. Está rediseñada para orientarte desde el primer vistazo y funciona mejor en pantallas pequeñas. La aplicación te avisará una sola vez y el centro de notificaciones abrirá la nueva dirección.',
+    en: 'Nodus has a new home at nodusresearch.com. The new website brings together the wiki, manuals, interactive demos, frequently asked questions, the blog and a page for contributing. It has been redesigned to orient you at first glance and works better on small screens. The app will tell you once, and the notification centre will open the new address.',
+    fr: 'Nodus a une nouvelle adresse, nodusresearch.com. Le nouveau site réunit le wiki, les manuels, les démos interactives, les questions fréquentes, le blog et une page pour contribuer. Il a été repensé pour vous orienter dès le premier regard et fonctionne mieux sur les petits écrans. L’application vous préviendra une seule fois et le centre de notifications ouvrira la nouvelle adresse.',
+    de: 'Nodus hat unter nodusresearch.com ein neues Zuhause. Die neue Website vereint Wiki, Handbücher, interaktive Demos, häufige Fragen, Blog und eine Seite zum Mitmachen. Sie wurde neu gestaltet, damit Sie sich auf den ersten Blick zurechtfinden, und funktioniert besser auf kleinen Bildschirmen. Die App weist Sie einmal darauf hin und die Mitteilungszentrale öffnet die neue Adresse.',
+    pt: 'O Nodus tem uma nova casa em nodusresearch.com. O novo site reúne a wiki, os manuais, as demonstrações interativas, as perguntas frequentes, o blogue e uma página para contribuir. Foi redesenhado para orientar à primeira vista e funciona melhor em ecrãs pequenos. A aplicação avisará uma única vez e o centro de notificações abrirá o novo endereço.',
+    'pt-BR': 'O Nodus tem uma nova casa em nodusresearch.com. O novo site reúne a wiki, os manuais, as demonstrações interativas, as perguntas frequentes, o blog e uma página para contribuir. Ele foi redesenhado para orientar logo de início e funciona melhor em telas pequenas. O aplicativo avisará uma única vez e a central de notificações abrirá o novo endereço.',
+  },
+  {
+    scope: 'general',
+    es: 'Las copias de seguridad automáticas y la publicación de bóvedas conectadas dejan de bloquear la aplicación. El trabajo pesado ocurre ahora fuera de la ventana principal, usa memoria de forma acotada y se detiene si un proceso externo queda colgado. Puedes seguir usando Nodus mientras una bóveda grande se cifra, comprime o envía al servidor. Los fallos de publicación esperan antes de volver a intentarlo y los datos sin cambios no se reconstruyen.',
+    en: 'Automatic backups and publishing connected vaults no longer block the app. Heavy work now runs outside the main window, uses bounded memory and stops if an external process hangs. You can keep using Nodus while a large vault is encrypted, compressed or sent to the server. Failed publications wait before trying again, and unchanged data is not rebuilt.',
+    fr: 'Les sauvegardes automatiques et la publication des coffres connectés ne bloquent plus l’application. Le travail lourd s’effectue désormais hors de la fenêtre principale, utilise une quantité de mémoire limitée et s’arrête si un processus externe se fige. Vous pouvez continuer à utiliser Nodus pendant le chiffrement, la compression ou l’envoi au serveur d’un grand coffre. Les publications échouées attendent avant de réessayer et les données inchangées ne sont pas reconstruites.',
+    de: 'Automatische Sicherungen und die Veröffentlichung verbundener Tresore blockieren die App nicht mehr. Aufwendige Arbeit läuft nun außerhalb des Hauptfensters, nutzt begrenzten Speicher und wird beendet, falls ein externer Prozess hängen bleibt. Sie können Nodus weiterverwenden, während ein großer Tresor verschlüsselt, komprimiert oder an den Server gesendet wird. Fehlgeschlagene Veröffentlichungen warten vor dem nächsten Versuch und unveränderte Daten werden nicht neu aufgebaut.',
+    pt: 'As cópias de segurança automáticas e a publicação de cofres ligados deixam de bloquear a aplicação. O trabalho pesado passa a decorrer fora da janela principal, usa memória de forma limitada e termina se um processo externo ficar bloqueado. Pode continuar a usar o Nodus enquanto um cofre grande é cifrado, comprimido ou enviado para o servidor. As publicações falhadas aguardam antes de tentar novamente e os dados inalterados não são reconstruídos.',
+    'pt-BR': 'Os backups automáticos e a publicação de cofres conectados não bloqueiam mais o aplicativo. O trabalho pesado agora acontece fora da janela principal, usa memória de forma limitada e é interrompido se um processo externo travar. Você pode continuar usando o Nodus enquanto um cofre grande é criptografado, compactado ou enviado ao servidor. As publicações com falha aguardam antes de tentar novamente e os dados inalterados não são reconstruídos.',
+  },
+  {
+    scope: 'general',
+    es: 'El despliegue de Nodus Cloud en Cloudflare ya puede crear su primera cuenta de administración. El servicio real rechazaba la operación de contraseña que aceptaba el entorno de prueba, por lo que el asistente terminaba siempre con un error 500 y no dejaba iniciar el servidor. La configuración respeta ahora el límite de Cloudflare, conserva la compatibilidad con las contraseñas existentes y muestra el motivo que devuelve el servidor cuando algo falla.',
+    en: 'A Nodus Cloud deployment on Cloudflare can now create its first administrator account. The production service rejected a password operation that the test environment accepted, so the wizard always ended with a 500 error and could not initialise the server. The setup now respects Cloudflare’s limit, remains compatible with existing passwords and shows the reason returned by the server when something fails.',
+    fr: 'Un déploiement de Nodus Cloud sur Cloudflare peut désormais créer son premier compte administrateur. Le service de production refusait une opération de mot de passe acceptée par l’environnement de test. L’assistant se terminait donc toujours par une erreur 500 et ne pouvait pas initialiser le serveur. La configuration respecte maintenant la limite de Cloudflare, reste compatible avec les mots de passe existants et affiche la raison renvoyée par le serveur en cas d’échec.',
+    de: 'Eine Nodus-Cloud-Bereitstellung auf Cloudflare kann jetzt ihr erstes Administratorkonto anlegen. Der Produktionsdienst lehnte einen Passwortvorgang ab, den die Testumgebung akzeptierte. Deshalb endete der Assistent immer mit Fehler 500 und konnte den Server nicht initialisieren. Die Einrichtung hält nun das Cloudflare-Limit ein, bleibt mit vorhandenen Passwörtern kompatibel und zeigt bei einem Fehler den vom Server zurückgegebenen Grund an.',
+    pt: 'Uma instalação do Nodus Cloud na Cloudflare já pode criar a primeira conta de administração. O serviço de produção recusava uma operação de palavra-passe que o ambiente de teste aceitava. Por isso, o assistente terminava sempre com um erro 500 e não conseguia iniciar o servidor. A configuração respeita agora o limite da Cloudflare, mantém a compatibilidade com as palavras-passe existentes e mostra o motivo devolvido pelo servidor quando algo falha.',
+    'pt-BR': 'Uma implantação do Nodus Cloud na Cloudflare agora pode criar a primeira conta de administração. O serviço de produção recusava uma operação de senha aceita pelo ambiente de teste. Por isso, o assistente sempre terminava com um erro 500 e não conseguia iniciar o servidor. A configuração agora respeita o limite da Cloudflare, mantém a compatibilidade com as senhas existentes e mostra o motivo devolvido pelo servidor quando algo falha.',
+  },
+  {
+    scope: 'nodi',
+    es: 'Actualizar el centro de notificaciones ya da una respuesta clara. Después de pulsar el botón, Nodus indica si la lista se ha actualizado, si no hay novedades, si los avisos están desactivados o si no ha podido consultar la fuente. La lista sigue conservando la última copia válida cuando la red falla.',
+    en: 'Refreshing the notification centre now gives a clear answer. After you press the button, Nodus says whether the list was updated, there is nothing new, announcements are disabled or the source could not be reached. The list keeps its last valid copy when the network fails.',
+    fr: 'L’actualisation du centre de notifications donne désormais une réponse claire. Après avoir appuyé sur le bouton, Nodus indique si la liste a été mise à jour, s’il n’y a rien de nouveau, si les annonces sont désactivées ou si la source n’a pas pu être consultée. La liste conserve sa dernière copie valide en cas de panne du réseau.',
+    de: 'Das Aktualisieren der Mitteilungszentrale liefert jetzt eine klare Rückmeldung. Nach dem Drücken der Schaltfläche sagt Nodus, ob die Liste aktualisiert wurde, ob es nichts Neues gibt, ob Hinweise deaktiviert sind oder ob die Quelle nicht erreicht werden konnte. Bei einem Netzfehler behält die Liste ihre letzte gültige Kopie.',
+    pt: 'Atualizar o centro de notificações passa a dar uma resposta clara. Depois de premir o botão, o Nodus indica se a lista foi atualizada, se não há novidades, se os avisos estão desativados ou se não foi possível consultar a fonte. A lista conserva a última cópia válida quando a rede falha.',
+    'pt-BR': 'Atualizar a central de notificações agora dá uma resposta clara. Depois de apertar o botão, o Nodus informa se a lista foi atualizada, se não há novidades, se os avisos estão desativados ou se não foi possível consultar a fonte. A lista mantém a última cópia válida quando a rede falha.',
+  },
+];
+
 /**
  * 4.1.2 — the author dossier gets read in a sensible order and stops flashing its own
  * seams, every section remembers where you left it, and the Cloudflare wizard from 4.1.1
@@ -1395,6 +1435,11 @@ const RELEASE_4_0_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '4.1.4',
+    date: '2026-08-16',
+    highlights: RELEASE_4_1_4_HIGHLIGHTS,
+  },
   {
     version: '4.1.3',
     date: '2026-08-15',

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
## Summary

- add the approved v4.1.4 What's New content in Spanish, English, French, German, Portuguese, Brazilian Portuguese, Italian, and Turkish
- synchronize version and source-offer metadata across the desktop app, Nodus Server, browser extension, Zotero plugin, containers, citation, and CI workflow
- document the patch release in the changelog and update release-readiness coverage

## Validation

- npm run build
- node scripts/test-prosopography-e2e.mjs
- npm test: 1,932 tests passed
- git diff --check

Closes #462