### PR TITLE
Make the website say what Nodus is for

### DIFF
--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -10,6 +10,9 @@ const SITE = 'https://nodusresearch.com';
 
 const PAGES = [
   { file: 'index.html', url: '/' },
+  { file: 'research/index.html', url: '/research/' },
+  { file: 'zotero/index.html', url: '/zotero/' },
+  { file: 'ai-research/index.html', url: '/ai-research/' },
   { file: 'demo/index.html', url: '/demo/' },
   { file: 'demo/study.html', url: '/demo/study.html' },
   { file: 'demo/teaching.html', url: '/demo/teaching.html' },

--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -13,6 +13,7 @@ const PAGES = [
   { file: 'research/index.html', url: '/research/' },
   { file: 'zotero/index.html', url: '/zotero/' },
   { file: 'ai-research/index.html', url: '/ai-research/' },
+  { file: 'open-source/index.html', url: '/open-source/' },
   { file: 'demo/index.html', url: '/demo/' },
   { file: 'demo/study.html', url: '/demo/study.html' },
   { file: 'demo/teaching.html', url: '/demo/teaching.html' },

--- a/scripts/test-site-pages.mjs
+++ b/scripts/test-site-pages.mjs
@@ -171,7 +171,7 @@ test('the organism degrades for visitors who cannot or do not want to run it', (
   assert.match(site, /matchMedia\('\(prefers-reduced-motion: reduce\)'\)/, 'reveals and the cursor respect reduced motion');
 
   // every page that paints the organism has to provide its canvas
-  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'wiki/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html']) {
+  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'wiki/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html', 'open-source/index.html']) {
     assert.ok(read(page).includes('<canvas id="organism" aria-hidden="true"></canvas>'), `${page} carries the organism canvas`);
   }
 });
@@ -210,6 +210,7 @@ const TOPIC_PAGES = [
   ['research/index.html', 'https://nodusresearch.com/research/'],
   ['zotero/index.html', 'https://nodusresearch.com/zotero/'],
   ['ai-research/index.html', 'https://nodusresearch.com/ai-research/'],
+  ['open-source/index.html', 'https://nodusresearch.com/open-source/'],
 ];
 
 test('the topic pages are indexable, canonical and described only once each', () => {
@@ -243,16 +244,17 @@ test('the topic pages are indexable, canonical and described only once each', ()
 
 test('the topic pages are linked from the home page and to each other', () => {
   const home = read('index.html');
-  for (const href of ['research/', 'zotero/', 'ai-research/']) {
+  for (const href of ['research/', 'zotero/', 'ai-research/', 'open-source/']) {
     assert.ok(home.includes(`href="${href}"`), `the home page links to /${href}`);
   }
   // descriptive anchors, not "click here" — the anchor text is the link's whole signal
   assert.match(home, /Nodus for academic research/, 'the home page names the research page');
 
   const links = {
-    'research/index.html': ['../zotero/', '../ai-research/'],
-    'zotero/index.html': ['../research/'],
-    'ai-research/index.html': ['../research/', '../zotero/'],
+    'research/index.html': ['../zotero/', '../ai-research/', '../open-source/'],
+    'zotero/index.html': ['../research/', '../open-source/'],
+    'ai-research/index.html': ['../research/', '../zotero/', '../open-source/'],
+    'open-source/index.html': ['../research/', '../zotero/', '../ai-research/'],
   };
   for (const [page, required] of Object.entries(links)) {
     const html = read(page);
@@ -270,6 +272,7 @@ test('the sitemap lists every static page of the site', () => {
     'https://nodusresearch.com/research/',
     'https://nodusresearch.com/zotero/',
     'https://nodusresearch.com/ai-research/',
+    'https://nodusresearch.com/open-source/',
     'https://nodusresearch.com/wiki/',
     'https://nodusresearch.com/faq/',
     'https://nodusresearch.com/contribute/',
@@ -285,7 +288,7 @@ test('the sitemap lists every static page of the site', () => {
 });
 
 test('every page is reachable by keyboard and readable by a screen reader', () => {
-  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html']) {
+  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html', 'open-source/index.html']) {
     const html = read(page);
     assert.match(html, /class="skip-link" href="#/, `${page} offers a skip link`);
     assert.match(html, /<html lang="en">/, `${page} declares its language`);

--- a/scripts/test-site-pages.mjs
+++ b/scripts/test-site-pages.mjs
@@ -171,7 +171,7 @@ test('the organism degrades for visitors who cannot or do not want to run it', (
   assert.match(site, /matchMedia\('\(prefers-reduced-motion: reduce\)'\)/, 'reveals and the cursor respect reduced motion');
 
   // every page that paints the organism has to provide its canvas
-  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'wiki/index.html']) {
+  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'wiki/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html']) {
     assert.ok(read(page).includes('<canvas id="organism" aria-hidden="true"></canvas>'), `${page} carries the organism canvas`);
   }
 });
@@ -205,8 +205,87 @@ test('the home page opens with the mark forming, and can never strand a visitor'
   assert.match(script, /addEventListener\('keydown', onKey\)/, 'any key ends it');
 });
 
+// The three long-form topic pages, and the URL each one is published at.
+const TOPIC_PAGES = [
+  ['research/index.html', 'https://nodusresearch.com/research/'],
+  ['zotero/index.html', 'https://nodusresearch.com/zotero/'],
+  ['ai-research/index.html', 'https://nodusresearch.com/ai-research/'],
+];
+
+test('the topic pages are indexable, canonical and described only once each', () => {
+  const titles = new Set();
+  const descriptions = new Set();
+
+  for (const [page, url] of TOPIC_PAGES) {
+    const html = read(page);
+    assert.ok(html.includes(`<link rel="canonical" href="${url}"/>`), `${page} declares its canonical URL`);
+    assert.ok(html.includes(`<meta property="og:url" content="${url}"/>`), `${page} declares its Open Graph URL`);
+    assert.match(html, /<meta name="twitter:card"/, `${page} carries Twitter card metadata`);
+    // a stray noindex here would quietly undo the whole point of the page
+    assert.doesNotMatch(html, /content="[^"]*noindex/, `${page} is not marked noindex`);
+    assert.equal((html.match(/<h1[ >]/g) ?? []).length, 1, `${page} has exactly one h1`);
+    assert.ok((html.match(/<h2[ >]/g) ?? []).length >= 3, `${page} builds a real heading hierarchy`);
+
+    const title = html.match(/<title>([^<]+)<\/title>/)[1];
+    const description = html.match(/<meta name="description" content="([^"]+)"/)[1];
+    assert.ok(!titles.has(title), `${page} has a title of its own`);
+    assert.ok(!descriptions.has(description), `${page} has a description of its own`);
+    titles.add(title);
+    descriptions.add(description);
+
+    // structured data has to parse, or search engines silently drop it
+    for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+      assert.doesNotThrow(() => JSON.parse(block[1]), `${page} ships valid JSON-LD`);
+    }
+    assert.match(html, /"@type": "BreadcrumbList"/, `${page} declares its place in the hierarchy`);
+  }
+});
+
+test('the topic pages are linked from the home page and to each other', () => {
+  const home = read('index.html');
+  for (const href of ['research/', 'zotero/', 'ai-research/']) {
+    assert.ok(home.includes(`href="${href}"`), `the home page links to /${href}`);
+  }
+  // descriptive anchors, not "click here" — the anchor text is the link's whole signal
+  assert.match(home, /Nodus for academic research/, 'the home page names the research page');
+
+  const links = {
+    'research/index.html': ['../zotero/', '../ai-research/'],
+    'zotero/index.html': ['../research/'],
+    'ai-research/index.html': ['../research/', '../zotero/'],
+  };
+  for (const [page, required] of Object.entries(links)) {
+    const html = read(page);
+    for (const href of required) {
+      assert.ok(html.includes(`href="${href}"`), `${page} links to ${href}`);
+    }
+    assert.ok(html.includes('href="../index.html"'), `${page} links back to the home page`);
+  }
+});
+
+test('the sitemap lists every static page of the site', () => {
+  const sitemap = read('sitemap.xml');
+  for (const url of [
+    'https://nodusresearch.com/',
+    'https://nodusresearch.com/research/',
+    'https://nodusresearch.com/zotero/',
+    'https://nodusresearch.com/ai-research/',
+    'https://nodusresearch.com/wiki/',
+    'https://nodusresearch.com/faq/',
+    'https://nodusresearch.com/contribute/',
+  ]) {
+    assert.ok(sitemap.includes(`<loc>${url}</loc>`), `the sitemap lists ${url}`);
+  }
+  // robots must keep the whole site crawlable and point at that sitemap
+  const robots = read('robots.txt');
+  assert.match(robots, /^User-agent: \*$/m);
+  assert.match(robots, /^Allow: \/$/m);
+  assert.doesNotMatch(robots, /^Disallow: \/\s*$/m, 'nothing blocks the crawlers');
+  assert.match(robots, /Sitemap: https:\/\/nodusresearch\.com\/sitemap\.xml/);
+});
+
 test('every page is reachable by keyboard and readable by a screen reader', () => {
-  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html']) {
+  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html']) {
     const html = read(page);
     assert.match(html, /class="skip-link" href="#/, `${page} offers a skip link`);
     assert.match(html, /<html lang="en">/, `${page} declares its language`);

--- a/scripts/test-site-shared-header.mjs
+++ b/scripts/test-site-shared-header.mjs
@@ -13,6 +13,9 @@ const systemStyles = read('site/assets/css/nodus.css');
 // Pages that carry the site design system and get the header from nodus.css.
 const systemPages = [
   ['site/index.html', 'home', ''],
+  ['site/research/index.html', 'research', '../'],
+  ['site/zotero/index.html', 'zotero', '../'],
+  ['site/ai-research/index.html', 'ai-research', '../'],
   ['site/faq/index.html', 'faq', '../'],
   ['site/blog/index.html', 'blog', '../'],
   ['site/blog/post.html', 'blog', '../'],

--- a/scripts/test-site-shared-header.mjs
+++ b/scripts/test-site-shared-header.mjs
@@ -16,6 +16,7 @@ const systemPages = [
   ['site/research/index.html', 'research', '../'],
   ['site/zotero/index.html', 'zotero', '../'],
   ['site/ai-research/index.html', 'ai-research', '../'],
+  ['site/open-source/index.html', 'open-source', '../'],
   ['site/faq/index.html', 'faq', '../'],
   ['site/blog/index.html', 'blog', '../'],
   ['site/blog/post.html', 'blog', '../'],

--- a/site/ai-research/index.html
+++ b/site/ai-research/index.html
@@ -270,11 +270,11 @@ SPDX-License-Identifier: AGPL-3.0-only
         <span class="arrow-link">Read the FAQ
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
-      <a class="card lit next-card reveal" href="https://github.com/Drakonis96/nodus/blob/main/PRIVACY.md" target="_blank" rel="noopener" style="--delay:210ms">
-        <span class="pic"><svg viewBox="0 0 24 24"><path d="M12 3 4.5 6v5.5c0 4.7 3.2 7.8 7.5 9.5 4.3-1.7 7.5-4.8 7.5-9.5V6L12 3Z"/><path d="m9 12 2 2 4-4"/></svg></span>
-        <h3>The privacy policy</h3>
-        <p>Exactly what leaves your computer, when, and under whose terms — written out rather than summarised in a marketing line.</p>
-        <span class="arrow-link">Read the policy
+      <a class="card lit next-card reveal" href="../open-source/" style="--delay:210ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M8 6l-5 6 5 6M16 6l5 6-5 6M13.5 4l-3 16"/></svg></span>
+        <h3>Open source and local-first</h3>
+        <p>What the AGPL gives you, where your work is stored, and the complete list of what leaves your computer and what triggers it.</p>
+        <span class="arrow-link">Read about the licence and your data
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
     </div>
@@ -295,7 +295,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a href="../research/">Academic research</a>
         <a href="../zotero/">Nodus and Zotero</a>
         <a href="./">AI for research</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../open-source/">Open source</a>
       </div>
       <div class="foot-col">
         <h4>Learn</h4>

--- a/site/ai-research/index.html
+++ b/site/ai-research/index.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>AI for Academic Research | Nodus</title>
-<meta name="description" content="What AI-assisted academic research looks like when the model works on your own sources: extracting ideas with their evidence, relating and contrasting them, semantic search, research gaps and cited drafts — with local models or the provider you choose."/>
+<meta name="description" content="What AI-assisted academic research looks like when the model works on your own sources. Extract ideas with their evidence, relate and contrast them, search semantically, find research gaps and produce cited drafts, using local models or the provider you choose."/>
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
 <meta property="og:title" content="AI for Academic Research | Nodus"/>
 <meta property="og:description" content="Nodus is not a chatbot with a search box. Its AI works on the documents, sources and notes you brought in, and every interpretation it stores keeps the passage behind it."/>
@@ -62,7 +62,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </nav>
       <span class="kicker">AI-assisted research</span>
       <h1 class="display" data-split>AI for Academic Research</h1>
-      <p class="lead">A general chatbot answers from whatever it absorbed during training. Nodus asks a model to work on something much narrower and far more useful: the documents, sources and notes <em>you</em> brought in. Every interpretation it produces is stored with the passage behind it, so the output is something you can check against the page rather than something you have to take on faith.</p>
+      <p class="lead">A general chatbot answers from whatever it absorbed during training. Nodus asks a model to work on something much narrower and far more useful, namely the documents, sources and notes <em>you</em> brought in. Every interpretation it produces is stored with the passage behind it, so you can check the output against the page instead of taking it on faith.</p>
       <div class="guide-actions">
         <a class="btn primary" href="../demo/index.html">
           <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
@@ -89,15 +89,15 @@ SPDX-License-Identifier: AGPL-3.0-only
       <h2 class="title" data-split>Grounded in your corpus, not in the internet.</h2>
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
-      <p>The failure mode researchers know best is a fluent answer with a citation that does not exist. It happens because a general assistant is asked to produce a scholarly-sounding paragraph without having any particular scholarship in front of it.</p>
-      <p>Nodus inverts the arrangement. You assemble the corpus first — from <a href="../zotero/">your Zotero library</a>, from bibliographic exports, or from your own files — and the model is then asked to work inside it. When Nodus records a claim, it records which work it came from and which excerpt supports it, with the page where the source provides one. A citation cannot be invented, because the thing being cited is an item already sitting in your Library.</p>
-      <p>That is the whole design principle: <b>the AI proposes, and the evidence stays attached so you can dispose.</b> Nothing in Nodus asks you to trust a paragraph on its own merits.</p>
+      <p>The failure researchers know best is a fluent answer with a citation that turns out not to exist. It happens because a general assistant is asked to produce a scholarly sounding paragraph without having any particular scholarship in front of it.</p>
+      <p>Nodus turns that around. You assemble the corpus first, from <a href="../zotero/">your Zotero library</a>, from bibliographic exports, or from your own files, and only then is the model asked to work inside it. When Nodus records a claim, it records which work it came from and which excerpt supports it, along with the page where the source provides one. A citation cannot be invented, because the thing being cited is an item already sitting in your Library.</p>
+      <p>That is the whole idea. <b>The AI proposes, the evidence stays attached, and you decide.</b> Nothing in Nodus asks you to trust a paragraph on its own merits.</p>
     </div>
 
     <div class="guide-grid reveal">
       <article class="card lit guide-card">
         <h3>A general assistant</h3>
-        <p>Answers from training data and whatever it can fetch. Sources are recalled or searched for at answer time. You verify afterwards, if you can work out what to verify.</p>
+        <p>Answers from training data and whatever it can fetch. Sources are recalled or searched for at the moment of answering. You verify afterwards, if you can work out what to verify.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Nodus</h3>
@@ -105,7 +105,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </article>
       <article class="card lit guide-card">
         <h3>What neither can do</h3>
-        <p>Judge whether an argument is sound, or whether a literature is worth building on. Both are your job, and Nodus is built to make that job possible rather than to take it over.</p>
+        <p>Judge whether an argument is sound, or whether a literature is worth building on. Both of those are your job, and Nodus is built to make that job easier rather than to take it over.</p>
       </article>
     </div>
   </div>
@@ -117,7 +117,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">02 · What the AI actually does</span>
       <h2 class="title" data-split>Specific jobs, not a single magic button.</h2>
-      <p class="lead">AI in Nodus is split into distinct tasks. Each one has a narrow brief, its own output shape and, if you want, its own model.</p>
+      <p class="lead">AI in Nodus is split into separate tasks. Each one has a narrow brief, its own output shape and, if you want, its own model.</p>
     </div>
 
     <div class="guide-steps reveal">
@@ -125,49 +125,49 @@ SPDX-License-Identifier: AGPL-3.0-only
         <em>01</em>
         <div>
           <h3>Extracting ideas from a work</h3>
-          <p>Analysis reads a source and proposes typed units — <b>claims, findings, constructs, methods and frameworks</b> — each one recorded with the excerpt that supports it and whether that excerpt is quoted or paraphrased. A source with only an abstract available yields correspondingly little; Nodus records that rather than padding the result.</p>
+          <p>Analysis reads a source and proposes units of five kinds, <b>claims, findings, constructs, methods and frameworks</b>. Each one is recorded with the excerpt that supports it, and with a note of whether that excerpt is quoted or paraphrased. If only an abstract was available, you get correspondingly little back, and Nodus says so rather than padding the result.</p>
         </div>
       </div>
       <div class="guide-step">
         <em>02</em>
         <div>
           <h3>Relating and contrasting them</h3>
-          <p>Ideas are connected with relations that carry a meaning — one supports, contradicts, refines, extends or applies to another, shares its method or is a precondition for it. Each edge records whether the relation was stated in the source or inferred during analysis, so an inference never passes itself off as a quotation.</p>
+          <p>Ideas are connected with relations that carry a meaning, such as supports, contradicts, refines, extends or applies to. A relation can also record a shared method or a precondition. Each connection notes whether the source stated the relation or the analysis inferred it, so an inference never passes itself off as a quotation.</p>
         </div>
       </div>
       <div class="guide-step">
         <em>03</em>
         <div>
           <h3>Surfacing debates and research gaps</h3>
-          <p>Disagreements between sources become debate views grouped by stance; unanswered questions, acknowledged limitations, flagged future work and unresolved contradictions become gaps with their evidence and what is still missing. Coverage analysis measures how well the corpus actually supports a theme, which is what tells you whether a gap is real or simply an area you have not read yet.</p>
+          <p>Disagreements between sources become debate views grouped by stance. Unanswered questions, acknowledged limitations, flagged future work and unresolved contradictions become gaps, each with the evidence that exists and a note of what is still missing. Coverage analysis then measures how well the corpus supports a theme, which is what tells you whether a gap is real or simply an area you have not read yet.</p>
         </div>
       </div>
       <div class="guide-step">
         <em>04</em>
         <div>
           <h3>Semantic search</h3>
-          <p>Embeddings let you find the passage that means what you asked, even when it uses none of your words and is written in another language. This is the one AI task that runs over everything, and it can be computed entirely on your own machine.</p>
+          <p>Embeddings let you find the passage that means what you asked, even when it uses none of your words and is written in another language. This is the one AI task that runs across everything, and it can be computed entirely on your own machine.</p>
         </div>
       </div>
       <div class="guide-step">
         <em>05</em>
         <div>
           <h3>Long-form synthesis</h3>
-          <p>Deep Research runs as a queued job over the scoped corpus and returns a structured, citation-rich report whose citations open the source they point at. Immersion builds a guided route through a research question. Both are drafts for a reader who will check them, and Nodus presents them that way.</p>
+          <p>Deep Research runs as a queued job over the scoped corpus and returns a structured report full of citations that open the source they point at. Immersion builds a guided route through a research question. Both are drafts written for a reader who will check them, and Nodus presents them that way.</p>
         </div>
       </div>
       <div class="guide-step">
         <em>06</em>
         <div>
           <h3>Hypotheses and writing</h3>
-          <p>A hypothesis pairs a statement with the ideas that support it, the risks against it and a proposed test — separate fields, so speculation cannot masquerade as a result. In the writing workspace, drafts are composed beside the corpus with citations that resolve to real items in your Library.</p>
+          <p>A hypothesis pairs a statement with the ideas that support it, the risks against it and a proposed test. Those are separate fields on purpose, so speculation cannot pass for a result. In the writing workspace, drafts are composed beside the corpus with citations that resolve to real items in your Library.</p>
         </div>
       </div>
       <div class="guide-step">
         <em>07</em>
         <div>
           <h3>Reading what a scan hides</h3>
-          <p>Vision-capable models can read pages as images for scanned documents, figures, tables and formulas that a plain text layer misses. The OCR Workspace puts that behind a page-by-page review, so nothing enters your corpus before you have looked at it.</p>
+          <p>Vision-capable models can read pages as images, which is how scanned documents, figures, tables and formulas get in when a plain text layer misses them. The OCR Workspace puts that behind a page by page review, so nothing enters your corpus before you have looked at it.</p>
         </div>
       </div>
     </div>
@@ -184,10 +184,10 @@ SPDX-License-Identifier: AGPL-3.0-only
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
       <p>For text, Nodus supports <b>Anthropic</b>, <b>OpenAI</b>, <b>ChatGPT · Codex</b>, <b>GitHub Copilot</b>, <b>OpenCode Go</b>, <b>OpenRouter</b>, <b>Groq</b>, <b>Cerebras</b>, <b>DeepSeek</b>, <b>Google Gemini</b>, <b>Xiaomi MiMo</b>, and the local runtimes <b>Ollama</b> and <b>LM Studio</b>. For embeddings it supports OpenAI, Google Gemini, OpenRouter, Ollama, LM Studio and a small multilingual model that Nodus manages and runs itself.</p>
-      <p>Model settings come in two modes. In the simplified mode you make one choice and everything follows it. In the advanced mode the tasks are separate selectors, because they genuinely want different things: extraction runs many times over long documents and rewards a cheap, reliable model; long-form synthesis rewards a strong one; the small deduplication and relation calls during a deep scan reward a fast one. Vision, chat, Deep Research, Immersion, writing, the argument map, author synthesis and hypotheses each keep their own choice, so retuning one never silently retargets another.</p>
+      <p>Model settings come in two modes. In the simplified mode you make one choice and everything follows it. In the advanced mode each task gets its own selector, because they want different things. Extraction runs many times over long documents, so a cheap and reliable model pays off. Long-form synthesis rewards a strong model. The small deduplication and relation calls during a deep scan reward a fast one. Vision, chat, Deep Research, Immersion, writing, the argument map, author synthesis and hypotheses each keep their own choice, so changing one never quietly retargets another.</p>
     </div>
     <div class="guide-note reveal">
-      <p><b>Nothing runs until you say so.</b> Model-assisted features stay inactive until a provider or a local model has been configured, and the application is fully usable without one — a corpus, its documents, exact search, notes and writing all work with no AI at all.</p>
+      <p><b>Nothing runs until you say so.</b> Model-assisted features stay inactive until a provider or a local model has been configured, and the application is perfectly usable without one. A corpus, its documents, exact search, notes and writing all work with no AI at all.</p>
     </div>
   </div>
 </section>
@@ -198,25 +198,25 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">04 · Local models</span>
       <h2 class="title" data-split>Research material that never leaves the machine.</h2>
-      <p class="lead">Unpublished work, confidential interviews and material you are not licensed to send anywhere are ordinary facts of academic life. Nodus can run its AI features entirely offline.</p>
+      <p class="lead">Unpublished work, confidential interviews and material you are not licensed to send anywhere are ordinary facts of academic life. Nodus can run its AI features completely offline.</p>
     </div>
 
     <div class="guide-grid two reveal">
       <article class="card lit guide-card">
         <h3>Ollama and LM Studio</h3>
-        <p>Point Nodus at a local runtime and the same tasks — extraction, synthesis, chat, embeddings — run against a model on your own hardware. No key, no request leaving the machine, no provider terms to read.</p>
+        <p>Point Nodus at a local runtime and the same tasks run against a model on your own hardware, whether that is extraction, synthesis, chat or embeddings. No key, no request leaving the machine, no provider terms to read.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Embeddings on device</h3>
-        <p>Semantic search does not need an external provider at all: Nodus can manage a small multilingual embedding model itself, and the resulting index lives on your disk with the rest of the vault.</p>
+        <p>Semantic search does not need an external provider at all. Nodus can manage a small multilingual embedding model itself, and the resulting index lives on your disk with the rest of the vault.</p>
       </article>
       <article class="card lit guide-card">
         <h3>The honest trade-off</h3>
-        <p>Local analysis is slower — often substantially — and smaller models are less reliable at returning the structured output the analysis pipeline expects. That is a real cost, not a footnote, and it is worth testing a model on a handful of sources before committing a whole corpus to it.</p>
+        <p>Local analysis is slower, often a great deal slower, and smaller models are less reliable at returning the structured output the analysis pipeline expects. That is a real cost rather than a footnote, so it is worth trying a model on a handful of sources before you commit a whole corpus to it.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Mixing is allowed</h3>
-        <p>Because the tasks are separate, a common arrangement is local embeddings and local extraction with a stronger hosted model reserved for long-form synthesis — or the reverse, depending on what your material permits.</p>
+        <p>Because the tasks are separate, a common arrangement is local embeddings and local extraction, with a stronger hosted model kept for long-form synthesis. Some people do the reverse, depending on what their material allows.</p>
       </article>
     </div>
   </div>
@@ -228,15 +228,15 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">05 · Limits</span>
       <h2 class="title" data-split>What this does not promise.</h2>
-      <p class="lead">A research tool that oversells its AI is worse than one that has none, because it costs you the habit of checking.</p>
+      <p class="lead">A research tool that oversells its AI is worse than one with no AI at all, because it teaches you to stop checking.</p>
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
       <p>Nodus does not automate research and does not replace the researcher. It cannot guarantee that an extracted idea faithfully represents its source, that a proposed relation holds, or that a generated report reaches a correct conclusion. Extraction is a first pass over your material, and it can be wrong.</p>
-      <p>What Nodus does instead is make the checking cheap. Every idea carries its excerpt; every excerpt points at a preserved original you already have on disk; report citations open the work they refer to; and an audit ledger records what happened in the vault. The evidence audit in the <a href="../zotero/#plugin">Zotero plugin</a> works the same way — it flags claims whose support looks thin, and then sends you back to the sources.</p>
+      <p>What Nodus does instead is make checking cheap. Every idea carries its excerpt. Every excerpt points at a preserved original you already have on disk. Report citations open the work they refer to, and an audit ledger records what happened in the vault. The evidence audit in the <a href="../zotero/#plugin">Zotero plugin</a> works the same way, flagging claims whose support looks thin and sending you back to the sources.</p>
       <h3>Where AI deliberately does not go</h3>
       <p>The teaching vault generates teaching material only. Nodus does not send student rosters, grades or answers to a model, and does not use AI to grade, profile or evaluate students. Nodus Protect processes documents entirely on your computer and never sends them to a provider. In the databases vault, AI columns work with the fields and values actually present in your rows.</p>
       <h3>A note on academic use</h3>
-      <p>Whether AI assistance is acceptable in a given piece of work is a decision for you, your supervisor, your journal and your institution — not for a piece of software. Nodus keeps the provenance you would need in order to answer that question honestly.</p>
+      <p>Whether AI assistance is acceptable in a given piece of work is for you, your supervisor, your journal and your institution to decide, not for a piece of software. What Nodus does is keep the provenance you would need in order to answer that question honestly.</p>
     </div>
   </div>
 </section>

--- a/site/ai-research/index.html
+++ b/site/ai-research/index.html
@@ -1,0 +1,324 @@
+<!--
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>AI for Academic Research | Nodus</title>
+<meta name="description" content="What AI-assisted academic research looks like when the model works on your own sources: extracting ideas with their evidence, relating and contrasting them, semantic search, research gaps and cited drafts — with local models or the provider you choose."/>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
+<meta property="og:title" content="AI for Academic Research | Nodus"/>
+<meta property="og:description" content="Nodus is not a chatbot with a search box. Its AI works on the documents, sources and notes you brought in, and every interpretation it stores keeps the passage behind it."/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://nodusresearch.com/ai-research/"/>
+<meta property="og:site_name" content="Nodus"/>
+<meta property="og:locale" content="en_GB"/>
+<meta property="og:image" content="https://nodusresearch.com/favicon.png"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="AI for Academic Research"/>
+<meta name="twitter:description" content="AI that works on your own research corpus, with local models or the provider you choose."/>
+<meta name="twitter:image" content="https://nodusresearch.com/favicon.png"/>
+<link rel="canonical" href="https://nodusresearch.com/ai-research/"/>
+<link rel="icon" href="../favicon.ico" sizes="any"/>
+  <link rel="icon" type="image/png" href="../favicon.png" sizes="512x512"/>
+  <link rel="icon" type="image/svg+xml" href="../assets/nodus-logo.svg"/>
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260818"/>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Nodus", "item": "https://nodusresearch.com/" },
+    { "@type": "ListItem", "position": 2, "name": "AI for academic research", "item": "https://nodusresearch.com/ai-research/" }
+  ]
+}
+</script>
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+<canvas id="organism" aria-hidden="true"></canvas>
+
+<div data-nodus-site-header data-base="../" data-page="ai-research"></div>
+<script src="../site-header.js?v=20260817"></script>
+
+<main id="main">
+
+<header class="page-hero guide-hero" data-accent="#22d3ee" data-second="#a78bfa" data-energy="0.36">
+  <div class="wrap">
+    <div class="scrim" style="max-width:820px">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="../index.html">Nodus</a>
+        <span class="sep" aria-hidden="true">/</span>
+        <span aria-current="page">AI for academic research</span>
+      </nav>
+      <span class="kicker">AI-assisted research</span>
+      <h1 class="display" data-split>AI for Academic Research</h1>
+      <p class="lead">A general chatbot answers from whatever it absorbed during training. Nodus asks a model to work on something much narrower and far more useful: the documents, sources and notes <em>you</em> brought in. Every interpretation it produces is stored with the passage behind it, so the output is something you can check against the page rather than something you have to take on faith.</p>
+      <div class="guide-actions">
+        <a class="btn primary" href="../demo/index.html">
+          <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
+          See it on a sample corpus
+        </a>
+        <a class="btn" href="../research/">Nodus for academic research</a>
+      </div>
+      <nav class="guide-jump" aria-label="On this page">
+        <a href="#difference"><em>01</em> Not a chatbot</a>
+        <a href="#what"><em>02</em> What the AI does</a>
+        <a href="#models"><em>03</em> Choosing models</a>
+        <a href="#local"><em>04</em> Running it locally</a>
+        <a href="#limits"><em>05</em> Limits and checking</a>
+      </nav>
+    </div>
+  </div>
+</header>
+
+<!-- ============================================================ difference -->
+<section id="difference" class="section-line" data-accent="#a78bfa" data-second="#22d3ee" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">01 · The difference</span>
+      <h2 class="title" data-split>Grounded in your corpus, not in the internet.</h2>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>The failure mode researchers know best is a fluent answer with a citation that does not exist. It happens because a general assistant is asked to produce a scholarly-sounding paragraph without having any particular scholarship in front of it.</p>
+      <p>Nodus inverts the arrangement. You assemble the corpus first — from <a href="../zotero/">your Zotero library</a>, from bibliographic exports, or from your own files — and the model is then asked to work inside it. When Nodus records a claim, it records which work it came from and which excerpt supports it, with the page where the source provides one. A citation cannot be invented, because the thing being cited is an item already sitting in your Library.</p>
+      <p>That is the whole design principle: <b>the AI proposes, and the evidence stays attached so you can dispose.</b> Nothing in Nodus asks you to trust a paragraph on its own merits.</p>
+    </div>
+
+    <div class="guide-grid reveal">
+      <article class="card lit guide-card">
+        <h3>A general assistant</h3>
+        <p>Answers from training data and whatever it can fetch. Sources are recalled or searched for at answer time. You verify afterwards, if you can work out what to verify.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Nodus</h3>
+        <p>Answers from a corpus you chose and imported. Each stored interpretation carries its work, its excerpt and its page. Verification is a click, because the preserved original is already on your disk.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>What neither can do</h3>
+        <p>Judge whether an argument is sound, or whether a literature is worth building on. Both are your job, and Nodus is built to make that job possible rather than to take it over.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ what -->
+<section id="what" class="section-line" data-accent="#818cf8" data-second="#34d399" data-energy="0.34">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">02 · What the AI actually does</span>
+      <h2 class="title" data-split>Specific jobs, not a single magic button.</h2>
+      <p class="lead">AI in Nodus is split into distinct tasks. Each one has a narrow brief, its own output shape and, if you want, its own model.</p>
+    </div>
+
+    <div class="guide-steps reveal">
+      <div class="guide-step">
+        <em>01</em>
+        <div>
+          <h3>Extracting ideas from a work</h3>
+          <p>Analysis reads a source and proposes typed units — <b>claims, findings, constructs, methods and frameworks</b> — each one recorded with the excerpt that supports it and whether that excerpt is quoted or paraphrased. A source with only an abstract available yields correspondingly little; Nodus records that rather than padding the result.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>02</em>
+        <div>
+          <h3>Relating and contrasting them</h3>
+          <p>Ideas are connected with relations that carry a meaning — one supports, contradicts, refines, extends or applies to another, shares its method or is a precondition for it. Each edge records whether the relation was stated in the source or inferred during analysis, so an inference never passes itself off as a quotation.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>03</em>
+        <div>
+          <h3>Surfacing debates and research gaps</h3>
+          <p>Disagreements between sources become debate views grouped by stance; unanswered questions, acknowledged limitations, flagged future work and unresolved contradictions become gaps with their evidence and what is still missing. Coverage analysis measures how well the corpus actually supports a theme, which is what tells you whether a gap is real or simply an area you have not read yet.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>04</em>
+        <div>
+          <h3>Semantic search</h3>
+          <p>Embeddings let you find the passage that means what you asked, even when it uses none of your words and is written in another language. This is the one AI task that runs over everything, and it can be computed entirely on your own machine.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>05</em>
+        <div>
+          <h3>Long-form synthesis</h3>
+          <p>Deep Research runs as a queued job over the scoped corpus and returns a structured, citation-rich report whose citations open the source they point at. Immersion builds a guided route through a research question. Both are drafts for a reader who will check them, and Nodus presents them that way.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>06</em>
+        <div>
+          <h3>Hypotheses and writing</h3>
+          <p>A hypothesis pairs a statement with the ideas that support it, the risks against it and a proposed test — separate fields, so speculation cannot masquerade as a result. In the writing workspace, drafts are composed beside the corpus with citations that resolve to real items in your Library.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>07</em>
+        <div>
+          <h3>Reading what a scan hides</h3>
+          <p>Vision-capable models can read pages as images for scanned documents, figures, tables and formulas that a plain text layer misses. The OCR Workspace puts that behind a page-by-page review, so nothing enters your corpus before you have looked at it.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ models -->
+<section id="models" class="section-line" data-accent="#fbbf24" data-second="#a78bfa" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">03 · Choosing models</span>
+      <h2 class="title" data-split>You pick the provider, and you can pick it per task.</h2>
+      <p class="lead">Nodus has no model of its own and no bundled subscription. It talks to the providers you configure with your own credentials, and none of them is required for the application to run.</p>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>For text, Nodus supports <b>Anthropic</b>, <b>OpenAI</b>, <b>ChatGPT · Codex</b>, <b>GitHub Copilot</b>, <b>OpenCode Go</b>, <b>OpenRouter</b>, <b>Groq</b>, <b>Cerebras</b>, <b>DeepSeek</b>, <b>Google Gemini</b>, <b>Xiaomi MiMo</b>, and the local runtimes <b>Ollama</b> and <b>LM Studio</b>. For embeddings it supports OpenAI, Google Gemini, OpenRouter, Ollama, LM Studio and a small multilingual model that Nodus manages and runs itself.</p>
+      <p>Model settings come in two modes. In the simplified mode you make one choice and everything follows it. In the advanced mode the tasks are separate selectors, because they genuinely want different things: extraction runs many times over long documents and rewards a cheap, reliable model; long-form synthesis rewards a strong one; the small deduplication and relation calls during a deep scan reward a fast one. Vision, chat, Deep Research, Immersion, writing, the argument map, author synthesis and hypotheses each keep their own choice, so retuning one never silently retargets another.</p>
+    </div>
+    <div class="guide-note reveal">
+      <p><b>Nothing runs until you say so.</b> Model-assisted features stay inactive until a provider or a local model has been configured, and the application is fully usable without one — a corpus, its documents, exact search, notes and writing all work with no AI at all.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ local -->
+<section id="local" class="section-line" data-accent="#34d399" data-second="#22d3ee" data-energy="0.32">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">04 · Local models</span>
+      <h2 class="title" data-split>Research material that never leaves the machine.</h2>
+      <p class="lead">Unpublished work, confidential interviews and material you are not licensed to send anywhere are ordinary facts of academic life. Nodus can run its AI features entirely offline.</p>
+    </div>
+
+    <div class="guide-grid two reveal">
+      <article class="card lit guide-card">
+        <h3>Ollama and LM Studio</h3>
+        <p>Point Nodus at a local runtime and the same tasks — extraction, synthesis, chat, embeddings — run against a model on your own hardware. No key, no request leaving the machine, no provider terms to read.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Embeddings on device</h3>
+        <p>Semantic search does not need an external provider at all: Nodus can manage a small multilingual embedding model itself, and the resulting index lives on your disk with the rest of the vault.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>The honest trade-off</h3>
+        <p>Local analysis is slower — often substantially — and smaller models are less reliable at returning the structured output the analysis pipeline expects. That is a real cost, not a footnote, and it is worth testing a model on a handful of sources before committing a whole corpus to it.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Mixing is allowed</h3>
+        <p>Because the tasks are separate, a common arrangement is local embeddings and local extraction with a stronger hosted model reserved for long-form synthesis — or the reverse, depending on what your material permits.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ limits -->
+<section id="limits" class="section-line" data-accent="#f87171" data-second="#fbbf24" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">05 · Limits</span>
+      <h2 class="title" data-split>What this does not promise.</h2>
+      <p class="lead">A research tool that oversells its AI is worse than one that has none, because it costs you the habit of checking.</p>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>Nodus does not automate research and does not replace the researcher. It cannot guarantee that an extracted idea faithfully represents its source, that a proposed relation holds, or that a generated report reaches a correct conclusion. Extraction is a first pass over your material, and it can be wrong.</p>
+      <p>What Nodus does instead is make the checking cheap. Every idea carries its excerpt; every excerpt points at a preserved original you already have on disk; report citations open the work they refer to; and an audit ledger records what happened in the vault. The evidence audit in the <a href="../zotero/#plugin">Zotero plugin</a> works the same way — it flags claims whose support looks thin, and then sends you back to the sources.</p>
+      <h3>Where AI deliberately does not go</h3>
+      <p>The teaching vault generates teaching material only. Nodus does not send student rosters, grades or answers to a model, and does not use AI to grade, profile or evaluate students. Nodus Protect processes documents entirely on your computer and never sends them to a provider. In the databases vault, AI columns work with the fields and values actually present in your rows.</p>
+      <h3>A note on academic use</h3>
+      <p>Whether AI assistance is acceptable in a given piece of work is a decision for you, your supervisor, your journal and your institution — not for a piece of software. Nodus keeps the provenance you would need in order to answer that question honestly.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ next -->
+<section class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.26">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">Keep going</span>
+      <h2 class="title" data-split>Where to go from here.</h2>
+    </div>
+    <div class="next-grid">
+      <a class="card lit next-card reveal" href="../research/">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="7" r="2.4"/><circle cx="11" cy="18" r="2.4"/><path d="M8 7l7.6.6M7.2 8.2l3 7.4M16.6 9.2l-4.4 6.6"/></svg></span>
+        <h3>Nodus for academic research</h3>
+        <p>The workspace these models operate inside: sources, typed ideas with their evidence, semantic search, research gaps and cited writing.</p>
+        <span class="arrow-link">Read the research guide
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../zotero/" style="--delay:70ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14Z"/><path d="M9 7h6M9 11h6"/></svg></span>
+        <h3>Nodus and Zotero</h3>
+        <p>Where the corpus comes from: a read-only link to your Zotero library, and a plugin that brings cited retrieval into Zotero itself.</p>
+        <span class="arrow-link">Read about the Zotero integration
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../faq/" style="--delay:140ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9.5 9a2.5 2.5 0 1 1 3.7 2.2c-.7.4-1.2 1-1.2 1.8v.5M12 17h.01"/></svg></span>
+        <h3>Nodus, AI and academic rigour</h3>
+        <p>The questions people ask before they begin: providers, cost, citations, and what the app can and cannot be relied on for.</p>
+        <span class="arrow-link">Read the FAQ
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="https://github.com/Drakonis96/nodus/blob/main/PRIVACY.md" target="_blank" rel="noopener" style="--delay:210ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M12 3 4.5 6v5.5c0 4.7 3.2 7.8 7.5 9.5 4.3-1.7 7.5-4.8 7.5-9.5V6L12 3Z"/><path d="m9 12 2 2 4-4"/></svg></span>
+        <h3>The privacy policy</h3>
+        <p>Exactly what leaves your computer, when, and under whose terms — written out rather than summarised in a marketing line.</p>
+        <span class="arrow-link">Read the policy
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<footer class="site-foot">
+  <div class="wrap">
+    <div class="foot-grid">
+      <div class="foot-brand">
+        <span class="logo"><img src="../assets/nodus-logo.svg" alt=""/> Nodus</span>
+        <p>A free, open-source, local-first research workspace for connecting sources, ideas and evidence. Your corpus stays on your machine.</p>
+      </div>
+      <div class="foot-col">
+        <h4>Research</h4>
+        <a href="../research/">Academic research</a>
+        <a href="../zotero/">Nodus and Zotero</a>
+        <a href="./">AI for research</a>
+        <a href="../demo/index.html">Live demos</a>
+      </div>
+      <div class="foot-col">
+        <h4>Learn</h4>
+        <a href="../wiki/">Wiki</a>
+        <a href="../blog/">Blog</a>
+        <a href="../faq/">FAQ</a>
+      </div>
+      <div class="foot-col">
+        <h4>Project</h4>
+        <a href="../contribute/">Contribute</a>
+        <a href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/Drakonis96/nodus/releases" target="_blank" rel="noopener">Releases</a>
+      </div>
+    </div>
+    <div class="foot-base">
+      <span>© 2026 Jorge Pérez Burgueño and Nodus contributors.</span>
+      <a href="https://github.com/Drakonis96/nodus/blob/main/LICENSE" target="_blank" rel="noopener">AGPL-3.0-only</a>
+    </div>
+  </div>
+</footer>
+
+<script src="../assets/js/organism.js?v=20260815"></script>
+<script src="../assets/js/site.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
+</body>
+</html>

--- a/site/assets/css/guide.css
+++ b/site/assets/css/guide.css
@@ -1,0 +1,146 @@
+/*
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+
+Long-form topic pages (/research/, /zotero/, /ai-research/).
+The shared system lives in nodus.css; this file only adds the few components
+those pages need that the home page does not already define.
+*/
+
+/* ============================================================ breadcrumb */
+.breadcrumb {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  margin-bottom: 22px;
+  font-size: 13px; color: var(--ink-3);
+}
+.breadcrumb a { color: var(--ink-3); }
+.breadcrumb a:hover { color: var(--ink-2); }
+.breadcrumb .sep { opacity: 0.55; }
+.breadcrumb [aria-current="page"] { color: var(--ink-2); }
+
+/* ============================================================ hero extras */
+.guide-hero .display { max-width: 18ch; }
+.guide-actions { display: flex; flex-wrap: wrap; gap: 13px; margin-top: 34px; }
+
+/* the anchor row under the hero: a plain, wrapping list of the page's sections */
+.guide-jump {
+  display: flex; flex-wrap: wrap; gap: 9px;
+  margin-top: 34px; padding-top: 26px;
+  border-top: 1px solid var(--membrane);
+}
+.guide-jump a {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 15px; border-radius: 999px;
+  border: 1px solid var(--membrane); background: var(--skin);
+  font-size: 13px; font-weight: 600; color: var(--ink-2);
+  transition: color 0.25s var(--ease), border-color 0.25s var(--ease), background 0.25s var(--ease);
+}
+.guide-jump a:hover { color: var(--ink); border-color: rgba(167, 139, 250, 0.5); background: var(--skin-2); }
+.guide-jump a em {
+  font-style: normal; font-family: var(--mono); font-size: 11px; color: var(--ink-3);
+}
+
+/* ============================================================ body copy */
+/* Long-form sections keep a comfortable measure while the cards below them are
+   free to use the full width of the wrap. */
+.guide-body { max-width: 760px; }
+.guide-body.prose > h2:first-child,
+.guide-body.prose > h3:first-child { margin-top: 0; }
+
+.guide-note {
+  max-width: 820px;
+  margin-top: 34px; padding: 20px 24px;
+  border-radius: var(--r-m); border: 1px solid var(--membrane);
+  border-left: 2px solid var(--accent);
+  background: rgba(255, 255, 255, 0.022);
+  font-size: 14.5px; line-height: 1.65; color: var(--ink-2);
+}
+.guide-note b, .guide-note strong { color: var(--ink); font-weight: 620; }
+.guide-note p { margin: 0; }
+.guide-note p + p { margin-top: 0.8em; }
+
+/* ============================================================ card grids */
+.guide-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(268px, 1fr));
+  gap: 16px; margin-top: 42px;
+}
+.guide-grid.two { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+.guide-card { padding: 26px; }
+.guide-card h3 { font-size: 17px; margin-bottom: 10px; }
+.guide-card p { margin: 0; font-size: 14px; line-height: 1.62; color: var(--ink-2); }
+.guide-card p + p { margin-top: 0.85em; }
+.guide-card p b, .guide-card p strong { color: var(--ink); font-weight: 620; }
+.guide-card .arrow-link { margin-top: 15px; font-size: 13.5px; }
+.guide-card .pic {
+  display: grid; place-items: center; width: 38px; height: 38px;
+  margin-bottom: 16px; border-radius: 11px;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  background: color-mix(in srgb, var(--accent) 13%, transparent);
+  color: var(--accent);
+}
+.guide-card .pic svg {
+  width: 19px; height: 19px; fill: none; stroke: currentColor;
+  stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round;
+}
+.guide-card .tags { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 15px; }
+.guide-card .tags span {
+  padding: 5px 11px; border-radius: 999px;
+  border: 1px solid var(--membrane); background: var(--skin);
+  font-size: 11.5px; font-weight: 600; color: var(--ink-3);
+}
+
+/* ============================================================ numbered flow */
+/* the step text keeps a readable measure rather than running the full wrap */
+.guide-steps { max-width: 820px; margin-top: 42px; display: grid; gap: 2px; }
+.guide-step {
+  display: grid; grid-template-columns: 42px minmax(0, 1fr);
+  gap: 18px; align-items: start;
+  padding: 22px 0; border-top: 1px solid var(--membrane);
+  transition: padding-left 0.3s var(--ease), background 0.3s var(--ease);
+}
+.guide-step:last-child { border-bottom: 1px solid var(--membrane); }
+.guide-step:hover { background: rgba(255, 255, 255, 0.022); padding-left: 12px; }
+.guide-step em {
+  font-style: normal; font-family: var(--mono); font-size: 12px;
+  color: var(--accent); padding-top: 3px;
+}
+.guide-step h3 { font-size: 17px; margin-bottom: 8px; }
+.guide-step p { margin: 0; font-size: 14.5px; line-height: 1.62; color: var(--ink-2); }
+.guide-step p + p { margin-top: 0.8em; }
+.guide-step p b, .guide-step p strong { color: var(--ink); font-weight: 620; }
+
+/* ============================================================ compare table */
+.guide-table-scroll { max-width: 1000px; margin-top: 40px; overflow-x: auto; }
+.guide-table { width: 100%; min-width: 560px; border-collapse: collapse; font-size: 14.5px; }
+.guide-table th, .guide-table td {
+  padding: 15px 16px; border-bottom: 1px solid var(--membrane);
+  text-align: left; vertical-align: top; color: var(--ink-2); line-height: 1.6;
+}
+.guide-table thead th {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--ink-3);
+}
+.guide-table tbody th { color: var(--ink); font-weight: 620; width: 30%; }
+
+/* ============================================================ next steps */
+.next-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 16px; margin-top: 44px;
+}
+.next-card { display: block; padding: 26px; color: inherit; }
+.next-card:hover { color: inherit; }
+.next-card .pic { color: var(--accent); margin-bottom: 15px; }
+.next-card .pic svg {
+  width: 22px; height: 22px; fill: none; stroke: currentColor;
+  stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round;
+}
+.next-card h3 { font-size: 17px; margin-bottom: 9px; }
+.next-card p { margin: 0 0 16px; font-size: 14px; line-height: 1.55; color: var(--ink-2); }
+
+/* ============================================================ responsive */
+@media (max-width: 720px) {
+  .guide-hero .display { max-width: none; }
+  .guide-step { grid-template-columns: minmax(0, 1fr); gap: 8px; }
+  .guide-step em { padding-top: 0; }
+  .guide-step:hover { padding-left: 0; }
+}

--- a/site/assets/css/home.css
+++ b/site/assets/css/home.css
@@ -18,16 +18,13 @@ Home page components. The shared system lives in nodus.css.
 
 @keyframes float-in { from { opacity: 0; transform: translateY(14px); } }
 
-/* The headline is a sentence rather than a three-word motto, so it is set a
-   good deal smaller than a display word would be: the longest line has to fit
-   its row without wrapping, or the masked reveal below plays against two rows. */
 .hero h1 {
   margin: 30px 0 0;
   font-family: var(--serif);
   font-weight: 600;
-  font-size: clamp(31px, 5vw, 62px);
-  line-height: 1.06;
-  letter-spacing: -0.032em;
+  font-size: clamp(40px, 7.6vw, 96px);
+  line-height: 0.99;
+  letter-spacing: -0.038em;
   text-wrap: balance;
 }
 /* one masked row per line, so each can rise on its own beat */

--- a/site/assets/css/home.css
+++ b/site/assets/css/home.css
@@ -18,13 +18,16 @@ Home page components. The shared system lives in nodus.css.
 
 @keyframes float-in { from { opacity: 0; transform: translateY(14px); } }
 
+/* The headline is a sentence rather than a three-word motto, so it is set a
+   good deal smaller than a display word would be: the longest line has to fit
+   its row without wrapping, or the masked reveal below plays against two rows. */
 .hero h1 {
   margin: 30px 0 0;
   font-family: var(--serif);
   font-weight: 600;
-  font-size: clamp(40px, 7.6vw, 96px);
-  line-height: 0.99;
-  letter-spacing: -0.038em;
+  font-size: clamp(31px, 5vw, 62px);
+  line-height: 1.06;
+  letter-spacing: -0.032em;
   text-wrap: balance;
 }
 /* one masked row per line, so each can rise on its own beat */
@@ -52,6 +55,12 @@ Home page components. The shared system lives in nodus.css.
   font-size: 13.5px; color: var(--ink-3);
 }
 .hero .meta b { color: var(--ink-2); font-weight: 620; }
+.hero .hero-links {
+  margin: 16px auto 0; max-width: 62ch;
+  font-size: 13.5px; color: var(--ink-3);
+}
+.hero .hero-links a { color: var(--ink-2); text-decoration: underline; text-decoration-color: var(--membrane-2); text-underline-offset: 3px; }
+.hero .hero-links a:hover { color: var(--ink); text-decoration-color: var(--accent); }
 
 .scroll-cue {
   position: absolute; left: 50%; bottom: 30px; transform: translateX(-50%);
@@ -381,20 +390,16 @@ Home page components. The shared system lives in nodus.css.
   .step { grid-template-columns: minmax(0, 1fr); gap: 10px; }
 }
 
-/* ============================================================ band */
-.band { text-align: center; }
-.band .lead { margin-inline: auto; }
-.band .pills {
-  display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;
-  margin-top: 38px;
+/* The centred `band` section moved to nodus.css when the research pages
+   started using it too. */
+
+/* ============================================================ topic pages */
+/* The three long-form pages under the hero. Same card as `paths`, so the two
+   rows of destinations on the page read as one family. */
+.home-topics {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(272px, 1fr));
+  gap: 16px; margin-top: 46px;
 }
-.band .pill {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 10px 17px; border-radius: 999px;
-  border: 1px solid rgba(52, 211, 153, 0.22); background: rgba(52, 211, 153, 0.07);
-  font-size: 13.5px; font-weight: 600; color: var(--ink);
-}
-.band .pill svg { width: 14px; height: 14px; fill: none; stroke: var(--good); stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; }
 
 /* ============================================================ paths (learn more) */
 .paths { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-top: 46px; }
@@ -467,6 +472,7 @@ html.intro-armed { overflow: hidden; }
 .intro-armed .hero .sub,
 .intro-armed .hero .ctas,
 .intro-armed .hero .meta,
+.intro-armed .hero .hero-links,
 .intro-armed .scroll-cue,
 .intro-armed main > section,
 .intro-armed .site-foot { opacity: 0; }
@@ -489,6 +495,7 @@ html.intro-armed { overflow: hidden; }
 .intro-run .hero .sub   { animation: intro-rise 0.9s var(--ease) 1.20s both; }
 .intro-run .hero .ctas  { animation: intro-rise 0.9s var(--ease) 1.36s both; }
 .intro-run .hero .meta  { animation: intro-rise 0.9s var(--ease) 1.52s both; }
+.intro-run .hero .hero-links { animation: intro-rise 0.9s var(--ease) 1.62s both; }
 .intro-run .nav         { animation: intro-drop 0.8s var(--ease) 1.52s both; }
 .intro-run .scroll-cue  { animation: intro-rise 0.9s var(--ease) 1.78s both; }
 .intro-run #scroll-progress,

--- a/site/assets/css/nodus.css
+++ b/site/assets/css/nodus.css
@@ -519,6 +519,24 @@ h1, h2, h3, h4 { margin: 0; font-weight: 700; letter-spacing: -0.032em; line-hei
 }
 
 /* ============================================================ footer */
+/* ============================================================ band */
+/* A centred, full-width statement with a row of reassurance pills under it.
+   Shared by the home page and the long-form research pages. */
+.band { text-align: center; }
+.band .lead { margin-inline: auto; }
+.band .pills {
+  display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;
+  margin-top: 38px;
+}
+.band .pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 17px; border-radius: 999px;
+  border: 1px solid rgba(52, 211, 153, 0.22); background: rgba(52, 211, 153, 0.07);
+  font-size: 13.5px; font-weight: 600; color: var(--ink);
+}
+.band .pill svg { width: 14px; height: 14px; fill: none; stroke: var(--good); stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; }
+
+/* ============================================================ footer */
 footer.site-foot {
   position: relative;
   padding: clamp(56px, 7vw, 90px) 0 46px;
@@ -530,6 +548,8 @@ footer.site-foot {
   grid-template-columns: minmax(0, 1.5fr) repeat(3, minmax(0, 1fr));
   gap: 40px 32px;
 }
+/* the home page carries one column more than the inner pages */
+.foot-grid.wide { grid-template-columns: minmax(0, 1.4fr) repeat(4, minmax(0, 1fr)); }
 .foot-brand { display: flex; flex-direction: column; gap: 14px; }
 .foot-brand .logo {
   display: inline-flex; align-items: center; gap: 10px;

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260817c"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
 <link rel="stylesheet" href="contribute.css?v=20260816"/>
 </head>
 <body>

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260817c"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
 <link rel="stylesheet" href="faq.css?v=20260815"/>
 </head>
 <body>

--- a/site/index.html
+++ b/site/index.html
@@ -7,12 +7,20 @@ SPDX-License-Identifier: AGPL-3.0-only
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Nodus: a local-first workspace for research, teaching and study</title>
-<meta name="description" content="Nodus is a free, open-source, local-first desktop app for academic work. Each vault picks a mode — academic research, teaching, study, structured databases and more — over the same private engine. No accounts, no subscriptions, no telemetry."/>
-<meta property="og:title" content="Nodus: a local-first workspace for research, teaching and study"/>
-<meta property="og:description" content="Free and open source, local-first. Vault modes over one engine: an academic research library, a teaching workspace, a study workspace, structured databases, genealogy and worldbuilding."/>
+<title>Nodus | Open Source Research Workspace</title>
+<meta name="description" content="Nodus is a free, open source, local-first research workspace for academic work. Connect your Zotero library or your own documents, turn what you read into ideas anchored to the passage that supports them, and search, question and cite your own corpus."/>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
+<meta property="og:title" content="Nodus | Open Source Research Workspace"/>
+<meta property="og:description" content="An open source research workspace for connecting sources, ideas and evidence. Build a corpus from Zotero or your own files, search it semantically and write with citations you can open. Free, local-first, no accounts."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://nodusresearch.com/"/>
+<meta property="og:site_name" content="Nodus"/>
+<meta property="og:locale" content="en_GB"/>
+<meta property="og:image" content="https://nodusresearch.com/favicon.png"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="Nodus | Open Source Research Workspace"/>
+<meta name="twitter:description" content="An open source research workspace for connecting sources, ideas and evidence. Free, local-first, and built around your own library."/>
+<meta name="twitter:image" content="https://nodusresearch.com/favicon.png"/>
 <link rel="canonical" href="https://nodusresearch.com/"/>
 <link rel="icon" href="favicon.ico" sizes="any"/>
   <link rel="icon" type="image/png" href="favicon.png" sizes="512x512"/>
@@ -21,8 +29,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="assets/css/nodus.css?v=20260817c"/>
-<link rel="stylesheet" href="assets/css/home.css?v=20260817"/>
+<link rel="stylesheet" href="assets/css/nodus.css?v=20260818"/>
+<link rel="stylesheet" href="assets/css/home.css?v=20260818"/>
 <script>
   /* Arm the opening sequence before the first paint. Anything that goes wrong
      here simply leaves the page in its ordinary, fully visible state. */
@@ -40,6 +48,37 @@ SPDX-License-Identifier: AGPL-3.0-only
       }, 9000);
     }
   } catch (error) {}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://nodusresearch.com/#website",
+      "url": "https://nodusresearch.com/",
+      "name": "Nodus",
+      "description": "An open source research workspace for connecting sources, ideas and evidence.",
+      "inLanguage": "en"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://nodusresearch.com/#app",
+      "name": "Nodus",
+      "url": "https://nodusresearch.com/",
+      "applicationCategory": "EducationalApplication",
+      "applicationSubCategory": "Research workspace",
+      "operatingSystem": "macOS, Windows, Linux",
+      "description": "Nodus is a free, open source, local-first desktop workspace for academic research. It builds a corpus from a Zotero library or your own documents, records ideas with the passage and page that support them, and supports semantic search, research gaps, debates and writing with verifiable citations.",
+      "license": "https://github.com/Drakonis96/nodus/blob/main/LICENSE",
+      "isAccessibleForFree": true,
+      "downloadUrl": "https://github.com/Drakonis96/nodus/releases/latest",
+      "softwareHelp": "https://nodusresearch.com/wiki/",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "author": { "@type": "Person", "name": "Jorge Pérez Burgueño" }
+    }
+  ]
+}
 </script>
 </head>
 <body data-formation="on">
@@ -65,11 +104,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       <circle cx="46" cy="48" r="6.5" fill="#8b5cf6"/><circle cx="46" cy="16" r="6.5" fill="#7c3aed"/>
     </svg>
     <h1 class="hero-title">
-      <span class="line"><i><span class="verb">Research</span> deeper</i></span>
-      <span class="line"><i><span class="verb">Teach</span> smarter</i></span>
-      <span class="line"><i><span class="verb">Study</span> better</i></span>
+      <span class="line"><i>An open source <span class="verb">research</span></i></span>
+      <span class="line"><i>workspace for connecting</i></span>
+      <span class="line"><i>sources, ideas and evidence</i></span>
     </h1>
-    <p class="sub">A local-first workspace for researchers, teachers and students to connect sources, notes, data, ideas and learning materials — on your own machine.</p>
+    <p class="sub">Nodus is a free desktop app for academic research. Connect your Zotero library or your own documents, and turn what you read into ideas, notes and evidence you can search, question and cite — every claim anchored to the passage behind it. For scholars, students and teachers.</p>
     <div class="ctas">
       <a class="btn primary" href="demo/index.html" data-magnet="0.16">
         <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
@@ -85,9 +124,45 @@ SPDX-License-Identifier: AGPL-3.0-only
       </button>
     </div>
     <p class="meta"><b>Completely free and open source.</b> No accounts, no subscriptions, no telemetry, and your corpus never leaves your machine.</p>
+    <p class="hero-links">Read on: <a href="research/">Nodus for academic research</a> · <a href="zotero/">the Zotero integration</a> · <a href="ai-research/">AI for academic research</a></p>
   </div>
   <div class="scroll-cue" aria-hidden="true"><span class="rail"></span>Scroll</div>
 </header>
+
+<!-- ============================================================ what nodus is -->
+<section id="what-nodus-is" class="section-line" data-accent="#818cf8" data-second="#22d3ee" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">What Nodus is</span>
+      <h2 class="title" data-split>A research workspace, not another notes app.</h2>
+      <p class="lead">Nodus is a desktop application for academic research. You bring in the papers, books and documents you already work with — from Zotero, from a bibliographic export or straight from disk — and Nodus records what they claim, with the exact passage and page that support each claim. A bibliography knows what you have read and a notebook knows what you thought; Nodus knows which source stands behind which idea, which is the link scholarly work actually runs on.</p>
+    </div>
+
+    <div class="home-topics">
+      <a class="card lit path-card reveal" href="research/">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="7" r="2.4"/><circle cx="11" cy="18" r="2.4"/><path d="M8 7l7.6.6M7.2 8.2l3 7.4M16.6 9.2l-4.4 6.6"/></svg></span>
+        <h3>Nodus for academic research</h3>
+        <p>Sources, typed ideas with their evidence, semantic search, debates, research gaps and writing with citations you can open. The full picture for researchers and students.</p>
+        <span class="arrow-link">Read the research guide
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit path-card reveal" href="zotero/" style="--delay:70ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14Z"/><path d="M9 7h6M9 11h6"/></svg></span>
+        <h3>Nodus and Zotero</h3>
+        <p>Nodus does not replace your reference manager. Connect your Zotero library read-only and work around it — plus a standalone plugin that lives inside Zotero itself.</p>
+        <span class="arrow-link">Read about the Zotero integration
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit path-card reveal" href="ai-research/" style="--delay:140ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M18.4 5.6l-2.1 2.1M7.7 16.3l-2.1 2.1"/></svg></span>
+        <h3>AI for academic research</h3>
+        <p>What the models are actually asked to do over your own documents, how to run them offline with Ollama or LM Studio, and where the output still has to be checked.</p>
+        <span class="arrow-link">Read about AI-assisted research
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+    </div>
+  </div>
+</section>
 
 <!-- ============================================================ the four vaults -->
 <section id="vaults" class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.3" style="padding-bottom:0">
@@ -494,10 +569,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <footer class="site-foot">
   <div class="wrap">
-    <div class="foot-grid">
+    <div class="foot-grid wide">
       <div class="foot-brand">
         <span class="logo"><img src="assets/nodus-logo.svg" alt=""/> Nodus</span>
-        <p>A free, open-source, local-first workspace for research, teaching and study. Your corpus stays on your machine.</p>
+        <p>A free, open-source, local-first research workspace for connecting sources, ideas and evidence. Your corpus stays on your machine.</p>
+      </div>
+      <div class="foot-col">
+        <h4>Research</h4>
+        <a href="research/">Academic research</a>
+        <a href="zotero/">Nodus and Zotero</a>
+        <a href="ai-research/">AI for research</a>
       </div>
       <div class="foot-col">
         <h4>Product</h4>

--- a/site/index.html
+++ b/site/index.html
@@ -30,7 +30,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="assets/css/nodus.css?v=20260818"/>
-<link rel="stylesheet" href="assets/css/home.css?v=20260818"/>
+<link rel="stylesheet" href="assets/css/home.css?v=20260818b"/>
 <script>
   /* Arm the opening sequence before the first paint. Anything that goes wrong
      here simply leaves the page in its ordinary, fully visible state. */
@@ -104,9 +104,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       <circle cx="46" cy="48" r="6.5" fill="#8b5cf6"/><circle cx="46" cy="16" r="6.5" fill="#7c3aed"/>
     </svg>
     <h1 class="hero-title">
-      <span class="line"><i>An open source <span class="verb">research</span></i></span>
-      <span class="line"><i>workspace for connecting</i></span>
-      <span class="line"><i>sources, ideas and evidence</i></span>
+      <span class="line"><i><span class="verb">Research</span> deeper</i></span>
+      <span class="line"><i><span class="verb">Teach</span> smarter</i></span>
+      <span class="line"><i><span class="verb">Study</span> better</i></span>
     </h1>
     <p class="sub">Nodus is a free desktop app for academic research. Connect your Zotero library or your own documents, and turn what you read into ideas, notes and evidence you can search, question and cite — every claim anchored to the passage behind it. For scholars, students and teachers.</p>
     <div class="ctas">
@@ -134,8 +134,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="section-head scrim reveal">
       <span class="kicker">What Nodus is</span>
-      <h2 class="title" data-split>A research workspace, not another notes app.</h2>
-      <p class="lead">Nodus is a desktop application for academic research. You bring in the papers, books and documents you already work with — from Zotero, from a bibliographic export or straight from disk — and Nodus records what they claim, with the exact passage and page that support each claim. A bibliography knows what you have read and a notebook knows what you thought; Nodus knows which source stands behind which idea, which is the link scholarly work actually runs on.</p>
+      <h2 class="title" data-split>An open source research workspace for connecting sources, ideas and evidence.</h2>
+      <p class="lead">Not another notes app: Nodus is a desktop application for academic research. You bring in the papers, books and documents you already work with — from Zotero, from a bibliographic export or straight from disk — and Nodus records what they claim, with the exact passage and page that support each claim. A bibliography knows what you have read and a notebook knows what you thought; Nodus knows which source stands behind which idea, which is the link scholarly work actually runs on.</p>
     </div>
 
     <div class="home-topics">

--- a/site/index.html
+++ b/site/index.html
@@ -124,7 +124,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </button>
     </div>
     <p class="meta"><b>Completely free and open source.</b> No accounts, no subscriptions, no telemetry, and your corpus never leaves your machine.</p>
-    <p class="hero-links">Read on: <a href="research/">Nodus for academic research</a> · <a href="zotero/">the Zotero integration</a> · <a href="ai-research/">AI for academic research</a></p>
+    <p class="hero-links">Read on: <a href="research/">Nodus for academic research</a> · <a href="zotero/">the Zotero integration</a> · <a href="ai-research/">AI for academic research</a> · <a href="open-source/">open source and local-first</a></p>
   </div>
   <div class="scroll-cue" aria-hidden="true"><span class="rail"></span>Scroll</div>
 </header>
@@ -158,6 +158,13 @@ SPDX-License-Identifier: AGPL-3.0-only
         <h3>AI for academic research</h3>
         <p>What the models are actually asked to do over your own documents, how to run them offline with Ollama or LM Studio, and where the output still has to be checked.</p>
         <span class="arrow-link">Read about AI-assisted research
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit path-card reveal" href="open-source/" style="--delay:210ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M8 6l-5 6 5 6M16 6l5 6-5 6M13.5 4l-3 16"/></svg></span>
+        <h3>Open source and local-first</h3>
+        <p>What the AGPL gives you, where your vaults and indexes actually live, and the complete list of what leaves your computer and what triggers it.</p>
+        <span class="arrow-link">Read about the licence and your data
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
     </div>
@@ -579,6 +586,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a href="research/">Academic research</a>
         <a href="zotero/">Nodus and Zotero</a>
         <a href="ai-research/">AI for research</a>
+        <a href="open-source/">Open source</a>
       </div>
       <div class="foot-col">
         <h4>Product</h4>

--- a/site/index.html
+++ b/site/index.html
@@ -108,7 +108,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <span class="line"><i><span class="verb">Teach</span> smarter</i></span>
       <span class="line"><i><span class="verb">Study</span> better</i></span>
     </h1>
-    <p class="sub">Nodus is a free desktop app for academic research. Connect your Zotero library or your own documents, and turn what you read into ideas, notes and evidence you can search, question and cite — every claim anchored to the passage behind it. For scholars, students and teachers.</p>
+    <p class="sub">Nodus is a free desktop app for academic research. Connect your Zotero library or your own documents, and turn what you read into ideas, notes and evidence you can search, question and cite. Every claim stays anchored to the passage it came from. Built for scholars, students and teachers.</p>
     <div class="ctas">
       <a class="btn primary" href="demo/index.html" data-magnet="0.16">
         <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
@@ -135,35 +135,35 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">What Nodus is</span>
       <h2 class="title" data-split>An open source research workspace for connecting sources, ideas and evidence.</h2>
-      <p class="lead">Not another notes app: Nodus is a desktop application for academic research. You bring in the papers, books and documents you already work with — from Zotero, from a bibliographic export or straight from disk — and Nodus records what they claim, with the exact passage and page that support each claim. A bibliography knows what you have read and a notebook knows what you thought; Nodus knows which source stands behind which idea, which is the link scholarly work actually runs on.</p>
+      <p class="lead">Nodus is a desktop application for academic research, not a general notes app. You bring in the papers, books and documents you already work with. They can come from Zotero, from a bibliographic export, or straight from a folder on your disk. Nodus then records what each one claims, and keeps the exact passage and page that back it up. A bibliography knows what you have read. A notebook knows what you thought about it. Neither of them knows which source stands behind which idea, and that is the link Nodus is built to keep.</p>
     </div>
 
     <div class="home-topics">
       <a class="card lit path-card reveal" href="research/">
         <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="7" r="2.4"/><circle cx="11" cy="18" r="2.4"/><path d="M8 7l7.6.6M7.2 8.2l3 7.4M16.6 9.2l-4.4 6.6"/></svg></span>
         <h3>Nodus for academic research</h3>
-        <p>Sources, typed ideas with their evidence, semantic search, debates, research gaps and writing with citations you can open. The full picture for researchers and students.</p>
+        <p>Sources, ideas with the evidence behind them, semantic search, debates, research gaps and writing with citations you can open. The whole picture, for researchers and students.</p>
         <span class="arrow-link">Read the research guide
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
       <a class="card lit path-card reveal" href="zotero/" style="--delay:70ms">
         <span class="pic"><svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14Z"/><path d="M9 7h6M9 11h6"/></svg></span>
         <h3>Nodus and Zotero</h3>
-        <p>Nodus does not replace your reference manager. Connect your Zotero library read-only and work around it — plus a standalone plugin that lives inside Zotero itself.</p>
+        <p>Nodus does not replace your reference manager. Connect your Zotero library read-only and build your work around it. There is also a standalone plugin that runs inside Zotero itself.</p>
         <span class="arrow-link">Read about the Zotero integration
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
       <a class="card lit path-card reveal" href="ai-research/" style="--delay:140ms">
         <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M18.4 5.6l-2.1 2.1M7.7 16.3l-2.1 2.1"/></svg></span>
         <h3>AI for academic research</h3>
-        <p>What the models are actually asked to do over your own documents, how to run them offline with Ollama or LM Studio, and where the output still has to be checked.</p>
+        <p>What Nodus asks a model to do with your own documents, how to run it offline with Ollama or LM Studio, and where you still have to check the result yourself.</p>
         <span class="arrow-link">Read about AI-assisted research
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
       <a class="card lit path-card reveal" href="open-source/" style="--delay:210ms">
         <span class="pic"><svg viewBox="0 0 24 24"><path d="M8 6l-5 6 5 6M16 6l5 6-5 6M13.5 4l-3 16"/></svg></span>
         <h3>Open source and local-first</h3>
-        <p>What the AGPL gives you, where your vaults and indexes actually live, and the complete list of what leaves your computer and what triggers it.</p>
+        <p>What the AGPL licence gives you, where your vaults and search indexes are stored, and the full list of what leaves your computer and what sets each request off.</p>
         <span class="arrow-link">Read about the licence and your data
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
@@ -177,7 +177,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">The four main vaults</span>
       <h2 class="title" data-split>Four ways to work. One engine underneath.</h2>
-      <p class="lead">Nodus is organised around vaults. A vault is a workspace with a purpose of its own — its own sections, its own vocabulary and its own live demo you can open right now in this browser. These four are the ones most people start from.</p>
+      <p class="lead">Nodus is organised around vaults. A vault is a workspace with a purpose of its own, so it has its own sections, its own vocabulary and its own live demo you can open right now in this browser. These four are the ones most people start from.</p>
     </div>
   </div>
 </section>
@@ -192,7 +192,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <h2>Academic <span class="glow">research</span></h2>
       <p class="lead">Build your own library inside Nodus, or connect the Zotero collection you already keep. Either way, every work becomes a network of claims, findings and methods, and each idea keeps the exact passage and page that support it.</p>
       <div class="caps">
-        <div class="cap"><em>01</em><p><b>Turn your own library — or your Zotero collection — into a graph of ideas</b>, linking claims, findings and methods to their exact passage and page.</p></div>
+        <div class="cap"><em>01</em><p><b>Turn your own library, or your Zotero collection, into a graph of ideas</b>, linking claims, findings and methods to their exact passage and page.</p></div>
         <div class="cap"><em>02</em><p><b>Surface debates, contradictions and research gaps</b>, then explore them through semantic search, coverage analysis and reading paths.</p></div>
         <div class="cap"><em>03</em><p><b>Research and write with verifiable citations</b> through Deep Research, the writing workshop and copilots for Word and LibreOffice.</p></div>
       </div>
@@ -321,7 +321,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <h2><span class="glow">Databases</span></h2>
       <p class="lead">Organise fieldwork, corpora, catalogues and coding sheets in structured databases. Analyse the information while preserving the field types, relationships and categories in your data.</p>
       <div class="caps">
-        <div class="cap"><em>01</em><p><b>Build structured databases with different field types</b> — relations, formulas, rollups, attachments, CSV import and reusable filtered views.</p></div>
+        <div class="cap"><em>01</em><p><b>Build structured databases with different field types</b>, from relations, formulas and rollups to attachments, CSV import and reusable filtered views.</p></div>
         <div class="cap"><em>02</em><p><b>Run reproducible analysis and charts over your actual rows</b>, from correlations and chi-square to ANOVA and regressions.</p></div>
         <div class="cap"><em>03</em><p><b>Ask questions and automate classification with AI columns</b>, without inventing a field or value that is not in your data.</p></div>
       </div>
@@ -425,7 +425,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <div>
         <span class="kicker">Present differently</span>
         <h3>PDF Presenter</h3>
-        <p>Present PDFs and external presentations as slides, with a presenter view, speaker notes and live annotations. Give every page its own speaker text, import existing notes or write them in Nodus, and read them from your computer or your phone — which doubles as a remote for the slides and the live tools.</p>
+        <p>Present PDFs and external presentations as slides, with a presenter view, speaker notes and live annotations. Give every page its own speaker text, import existing notes or write them in Nodus, and read them from your computer or your phone, which doubles as a remote for the slides and the live tools.</p>
         <div class="tool-pills">
           <span class="chip">Phone remote</span><span class="chip">Laser pointer</span>
           <span class="chip">Spotlight</span><span class="chip">Live drawing</span><span class="chip">Zoom</span>
@@ -448,7 +448,7 @@ SPDX-License-Identifier: AGPL-3.0-only
           <button type="button" data-tool="laser" aria-pressed="false"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/></svg>Laser</button>
           <button type="button" data-tool="zoom" aria-pressed="false"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4M11 8v6M8 11h6"/></svg>Zoom</button>
         </div>
-        <p class="stage-hint">Pick a tool, then move over the slide — these are the real presenter tools.</p>
+        <p class="stage-hint">Pick a tool, then move over the slide. These are the real presenter tools.</p>
       </div>
     </article>
 
@@ -462,7 +462,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <article class="card lit tool-card reveal" style="--tc:#34d399;--delay:70ms">
         <span class="pic"><svg viewBox="0 0 24 24"><path d="M7 7h11l-3-3M17 17H6l3 3M18 7l-3 3M6 17l3-3"/></svg></span>
         <h3>Nodus Convert</h3>
-        <p>Convert documents, PDFs and images, with light OCR and text utilities, one at a time or in a batch — without bouncing between online services or losing the original.</p>
+        <p>Convert documents, PDFs and images, with light OCR and text utilities, one at a time or in a batch, without bouncing between online services or losing the original.</p>
         <div class="tags"><span>Batch conversion</span><span>Original preserved</span></div>
       </article>
       <article class="card lit tool-card reveal" style="--tc:#f472b6;--delay:140ms">

--- a/site/open-source/index.html
+++ b/site/open-source/index.html
@@ -1,0 +1,315 @@
+<!--
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Open Source Research Software | Nodus</title>
+<meta name="description" content="Nodus is open source under the AGPL-3.0-only licence and local-first by design: your corpus, Library and search indexes stay on your own computer. What the licence gives you, where your work lives, and exactly what leaves the machine and when."/>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
+<meta property="og:title" content="Open Source Research Software | Nodus"/>
+<meta property="og:description" content="Free and open source under AGPL-3.0-only, with no accounts, no subscriptions and no telemetry. Your research corpus stays on your own machine."/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://nodusresearch.com/open-source/"/>
+<meta property="og:site_name" content="Nodus"/>
+<meta property="og:locale" content="en_GB"/>
+<meta property="og:image" content="https://nodusresearch.com/favicon.png"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="Open source and local-first"/>
+<meta name="twitter:description" content="What the AGPL gives you, where your research lives, and exactly what leaves your computer."/>
+<meta name="twitter:image" content="https://nodusresearch.com/favicon.png"/>
+<link rel="canonical" href="https://nodusresearch.com/open-source/"/>
+<link rel="icon" href="../favicon.ico" sizes="any"/>
+  <link rel="icon" type="image/png" href="../favicon.png" sizes="512x512"/>
+  <link rel="icon" type="image/svg+xml" href="../assets/nodus-logo.svg"/>
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Nodus", "item": "https://nodusresearch.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Open source and local-first", "item": "https://nodusresearch.com/open-source/" }
+  ]
+}
+</script>
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+<canvas id="organism" aria-hidden="true"></canvas>
+
+<div data-nodus-site-header data-base="../" data-page="open-source"></div>
+<script src="../site-header.js?v=20260817"></script>
+
+<main id="main">
+
+<header class="page-hero guide-hero" data-accent="#34d399" data-second="#22d3ee" data-energy="0.32">
+  <div class="wrap">
+    <div class="scrim" style="max-width:820px">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="../index.html">Nodus</a>
+        <span class="sep" aria-hidden="true">/</span>
+        <span aria-current="page">Open source</span>
+      </nav>
+      <span class="kicker">Open source and local-first</span>
+      <h1 class="display" data-split>Open source, and local-first</h1>
+      <p class="lead">Research software asks for a great deal of trust. It holds unpublished work, material you may not be licensed to share, and years of reading. Nodus answers that in the only two ways that can actually be checked: the source is published under a licence that keeps it published, and the corpus never leaves your computer unless you ask it to.</p>
+      <div class="guide-actions">
+        <a class="btn primary" href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">
+          <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.23c-3.34.72-4.04-1.42-4.04-1.42-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.8 5.62-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/></svg>
+          Browse the source
+        </a>
+        <a class="btn" href="../contribute/">Contribute</a>
+      </div>
+      <nav class="guide-jump" aria-label="On this page">
+        <a href="#licence"><em>01</em> The licence</a>
+        <a href="#where"><em>02</em> Where your work lives</a>
+        <a href="#leaves"><em>03</em> What leaves the machine</a>
+        <a href="#cite"><em>04</em> Citing Nodus</a>
+      </nav>
+    </div>
+  </div>
+</header>
+
+<!-- ============================================================ licence -->
+<section id="licence" class="section-line" data-accent="#34d399" data-second="#a78bfa" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">01 · The licence</span>
+      <h2 class="title" data-split>Published under a licence that keeps it published.</h2>
+      <p class="lead">Nodus 4.0.0 and later are released exclusively under the GNU Affero General Public License v3.0, SPDX <code>AGPL-3.0-only</code>. Versions through 3.2.7 remain available under the MIT licence that accompanied them.</p>
+    </div>
+
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>The practical effect for a researcher is simple. You may read the code, run it for any purpose, modify it, and pass it on. If you distribute a modified version — or run one as a network service that other people use — you have to publish your source under the same terms. That last clause is what the <em>Affero</em> in AGPL adds, and it is the reason the licence was chosen: it means a future hosted version of Nodus cannot become a closed product built on this work.</p>
+      <p>Every published build links to its <b>Corresponding Source</b>: the exact immutable tag and source archives the release was made from, so a binary you downloaded can be traced back to code you can read. The third-party notices list every dependency and its licence, and the repository follows the REUSE convention, with an SPDX header on its files.</p>
+    </div>
+
+    <div class="guide-grid reveal">
+      <article class="card lit guide-card">
+        <h3>Read the code</h3>
+        <p>The whole application — desktop app, server, Zotero plugin, browser connector and this website — lives in one public repository.</p>
+        <a class="arrow-link" href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">Open the repository
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Read the licence</h3>
+        <p>The complete, unmodified AGPL-3.0 text ships with the source, and the corresponding-source document names the tag every release was built from.</p>
+        <a class="arrow-link" href="https://github.com/Drakonis96/nodus/blob/main/LICENSE" target="_blank" rel="noopener">AGPL-3.0-only
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Read the dependencies</h3>
+        <p>Third-party notices list what Nodus is built on and under which terms, so an institution can review the whole stack rather than one name.</p>
+        <a class="arrow-link" href="https://github.com/Drakonis96/nodus/blob/main/THIRD_PARTY_NOTICES.md" target="_blank" rel="noopener">Third-party notices
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Report a vulnerability</h3>
+        <p>Security issues have their own private disclosure route rather than a public issue, so a fix can ship before the details do.</p>
+        <a class="arrow-link" href="https://github.com/Drakonis96/nodus/blob/main/SECURITY.md" target="_blank" rel="noopener">Security policy
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ where -->
+<section id="where" class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">02 · Where your work lives</span>
+      <h2 class="title" data-split>On your disk, in a folder you chose.</h2>
+      <p class="lead">Local-first is a claim about storage, not a slogan. In Nodus it means every vault, the cross-vault Library and every search index are files on your own computer.</p>
+    </div>
+
+    <div class="guide-steps reveal">
+      <div class="guide-step">
+        <em>01</em>
+        <div>
+          <h3>No account, ever</h3>
+          <p>There is no sign-up, no licence key and no subscription. You download an installer, open it, and create a vault. Nothing about the application depends on a server run by the project, because there is no such server.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>02</em>
+        <div>
+          <h3>You choose the folder</h3>
+          <p>Vaults and the shared Library sit under a backup folder you pick, which means they can live on an encrypted disk, a departmental drive or wherever your institution requires. Moving them is moving files.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>03</em>
+        <div>
+          <h3>Backups you can verify</h3>
+          <p>Nodus makes encrypted automatic backups, and a complete Nodus 4 backup contains every vault together with the shared Library. Before Nodus 4 opens an existing database it creates and verifies a one-time pre-v4 recovery copy, and Nodus 4 can still open backups made by Nodus 3.x.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>04</em>
+        <div>
+          <h3>A record of what happened</h3>
+          <p>An audit ledger records the operations performed in a vault, which matters when the question months later is not <em>what does my corpus say</em> but <em>when did this change, and why</em>.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="guide-note reveal">
+      <p><b>No advertising, telemetry or remote analytics.</b> The application does not send your content to a cloud operated by the project, because the project operates none. This website carries no analytics container either — no Tag Manager, no Google Analytics, no tracking pixel — and a test in the repository fails the build if one is ever added.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ leaves -->
+<section id="leaves" class="section-line" data-accent="#22d3ee" data-second="#fbbf24" data-energy="0.32">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">03 · What leaves the machine</span>
+      <h2 class="title" data-split>Every outgoing request, and what triggers it.</h2>
+      <p class="lead">"Local-first" does not mean a program that never touches the network. It means nothing goes out unless you asked for something that requires it. Here is the complete shape of that.</p>
+    </div>
+
+    <div class="guide-grid two reveal">
+      <article class="card lit guide-card">
+        <h3>AI providers — only once you configure one</h3>
+        <p>Model-assisted features stay inactive until you set up a provider or a local model. When you use one, that provider receives the text or page image the task needs. Run <b>Ollama</b> or <b>LM Studio</b> instead and the content never leaves the device at all.</p>
+        <a class="arrow-link" href="../ai-research/">How Nodus uses AI
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Bibliographic lookups — only the identifier</h3>
+        <p>Ask Nodus to resolve metadata and it sends Crossref, Open Library, NCBI or arXiv the single DOI, ISBN, ISSN, PMID or arXiv id you selected — nothing else. Bulk requests are rate-limited and cancelable, and candidates are shown for review rather than applied for you.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Updates — checked, not installed behind your back</h3>
+        <p>Nodus checks GitHub for new releases and can download one, but downloading is not automatic and an update is never installed without you. GitHub sees what any web request exposes, such as an IP address.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Announcements — a static file, and switchable off</h3>
+        <p>Nodus fetches a public static file from this website so it can warn about known issues between releases. It is a plain conditional GET, at most once every four hours, carrying no identifier, no account, no vault name and nothing about your corpus. Turn it off in <b>Settings → Updates and news</b> and no request is made at all.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Zotero — a connection that never leaves the computer</h3>
+        <p>The Zotero integration talks to the Zotero application on the same machine over a local connection. There is no API key and no round-trip through zotero.org.</p>
+        <a class="arrow-link" href="../zotero/">How the Zotero link works
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Sharing — opt-in, and a copy rather than the original</h3>
+        <p>Nodus Server publishes a filtered projection of a vault you explicitly choose to share, while the original database and documents stay on your computer. Nothing is published until you set it up.</p>
+      </article>
+    </div>
+
+    <div class="guide-note reveal">
+      <p>This page is a summary written for readers deciding whether to try Nodus. The <a href="https://github.com/Drakonis96/nodus/blob/main/PRIVACY.md" target="_blank" rel="noopener">privacy policy</a> is the authoritative document and goes considerably further, service by service — read it before putting confidential or personal research material into any application, including this one.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ cite -->
+<section id="cite" class="section-line" data-accent="#fbbf24" data-second="#34d399" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">04 · Citing Nodus</span>
+      <h2 class="title" data-split>Software you can cite like any other instrument.</h2>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>If Nodus contributes substantially to research that leads to a publication, cite the version you used. The repository ships machine-readable citation metadata in <code>CITATION.cff</code>, including an ORCID for the author and the released version and date, which GitHub renders directly in APA and BibTeX.</p>
+      <p>Citing the version matters more here than it does for a general-purpose editor: analysis pipelines change between releases, and a reviewer asking how a corpus was processed deserves an answer that points at a specific, archived tag.</p>
+    </div>
+    <div class="guide-note reveal">
+      <p><b>Nodus is one person's project, plus everyone who has added to it since.</b> Bug reports, translations, documentation and a precise account of what broke are all worth as much as code — the <a href="../contribute/">contribute page</a> sets out the ways in.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ next -->
+<section class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.26">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">Keep going</span>
+      <h2 class="title" data-split>Where to go from here.</h2>
+    </div>
+    <div class="next-grid">
+      <a class="card lit next-card reveal" href="../research/">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="7" r="2.4"/><circle cx="11" cy="18" r="2.4"/><path d="M8 7l7.6.6M7.2 8.2l3 7.4M16.6 9.2l-4.4 6.6"/></svg></span>
+        <h3>Nodus for academic research</h3>
+        <p>What all of this is in service of: sources, typed ideas with their evidence, semantic search, research gaps and cited writing.</p>
+        <span class="arrow-link">Read the research guide
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../zotero/" style="--delay:70ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14Z"/><path d="M9 7h6M9 11h6"/></svg></span>
+        <h3>Nodus and Zotero</h3>
+        <p>A read-only link to the library you already keep, and a standalone plugin that runs inside Zotero itself.</p>
+        <span class="arrow-link">Read about the Zotero integration
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../ai-research/" style="--delay:140ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M18.4 5.6l-2.1 2.1M7.7 16.3l-2.1 2.1"/></svg></span>
+        <h3>AI for academic research</h3>
+        <p>Which models Nodus can use, how to keep every one of them on your own hardware, and where the output still has to be checked.</p>
+        <span class="arrow-link">Read about AI-assisted research
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../contribute/" style="--delay:210ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.6"/><circle cx="6" cy="18" r="2.6"/><circle cx="18" cy="18" r="2.6"/><path d="M6 8.6v6.8M18 15.4V12a3 3 0 0 0-3-3h-3"/></svg></span>
+        <h3>Contribute</h3>
+        <p>Code, translations, documentation, bug reports or simply telling us what broke. Every grain counts.</p>
+        <span class="arrow-link">Join in
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<footer class="site-foot">
+  <div class="wrap">
+    <div class="foot-grid">
+      <div class="foot-brand">
+        <span class="logo"><img src="../assets/nodus-logo.svg" alt=""/> Nodus</span>
+        <p>A free, open-source, local-first research workspace for connecting sources, ideas and evidence. Your corpus stays on your machine.</p>
+      </div>
+      <div class="foot-col">
+        <h4>Research</h4>
+        <a href="../research/">Academic research</a>
+        <a href="../zotero/">Nodus and Zotero</a>
+        <a href="../ai-research/">AI for research</a>
+        <a href="./">Open source</a>
+      </div>
+      <div class="foot-col">
+        <h4>Learn</h4>
+        <a href="../wiki/">Wiki</a>
+        <a href="../blog/">Blog</a>
+        <a href="../faq/">FAQ</a>
+      </div>
+      <div class="foot-col">
+        <h4>Project</h4>
+        <a href="../contribute/">Contribute</a>
+        <a href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/Drakonis96/nodus/releases" target="_blank" rel="noopener">Releases</a>
+      </div>
+    </div>
+    <div class="foot-base">
+      <span>© 2026 Jorge Pérez Burgueño and Nodus contributors.</span>
+      <a href="https://github.com/Drakonis96/nodus/blob/main/LICENSE" target="_blank" rel="noopener">AGPL-3.0-only</a>
+    </div>
+  </div>
+</footer>
+
+<script src="../assets/js/organism.js?v=20260815"></script>
+<script src="../assets/js/site.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
+</body>
+</html>

--- a/site/open-source/index.html
+++ b/site/open-source/index.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Open Source Research Software | Nodus</title>
-<meta name="description" content="Nodus is open source under the AGPL-3.0-only licence and local-first by design: your corpus, Library and search indexes stay on your own computer. What the licence gives you, where your work lives, and exactly what leaves the machine and when."/>
+<meta name="description" content="Nodus is open source under the AGPL-3.0-only licence and local-first by design, so your corpus, Library and search indexes stay on your own computer. What the licence gives you, where your work lives, and exactly what leaves the machine and when."/>
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
 <meta property="og:title" content="Open Source Research Software | Nodus"/>
 <meta property="og:description" content="Free and open source under AGPL-3.0-only, with no accounts, no subscriptions and no telemetry. Your research corpus stays on your own machine."/>
@@ -61,8 +61,8 @@ SPDX-License-Identifier: AGPL-3.0-only
         <span aria-current="page">Open source</span>
       </nav>
       <span class="kicker">Open source and local-first</span>
-      <h1 class="display" data-split>Open source, and local-first</h1>
-      <p class="lead">Research software asks for a great deal of trust. It holds unpublished work, material you may not be licensed to share, and years of reading. Nodus answers that in the only two ways that can actually be checked: the source is published under a licence that keeps it published, and the corpus never leaves your computer unless you ask it to.</p>
+      <h1 class="display" data-split>Open source and local-first</h1>
+      <p class="lead">Research software asks for a great deal of trust. It holds unpublished work, material you may not be licensed to share, and years of reading. Nodus answers that in the only two ways you can check for yourself. The source is published under a licence that keeps it published, and the corpus never leaves your computer unless you ask it to.</p>
       <div class="guide-actions">
         <a class="btn primary" href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">
           <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.23c-3.34.72-4.04-1.42-4.04-1.42-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.8 5.62-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/></svg>
@@ -90,14 +90,14 @@ SPDX-License-Identifier: AGPL-3.0-only
     </div>
 
     <div class="guide-body prose reveal" style="margin-top:26px">
-      <p>The practical effect for a researcher is simple. You may read the code, run it for any purpose, modify it, and pass it on. If you distribute a modified version — or run one as a network service that other people use — you have to publish your source under the same terms. That last clause is what the <em>Affero</em> in AGPL adds, and it is the reason the licence was chosen: it means a future hosted version of Nodus cannot become a closed product built on this work.</p>
-      <p>Every published build links to its <b>Corresponding Source</b>: the exact immutable tag and source archives the release was made from, so a binary you downloaded can be traced back to code you can read. The third-party notices list every dependency and its licence, and the repository follows the REUSE convention, with an SPDX header on its files.</p>
+      <p>What that means for you in practice is short. You may read the code, run it for any purpose, modify it and pass it on. If you distribute a modified version, or run one as a network service that other people use, you have to publish your source under the same terms. That last part is what the <em>Affero</em> in AGPL adds, and it is why the licence was chosen. It means a future hosted version of Nodus cannot quietly become a closed product built on this work.</p>
+      <p>Every published build links to its <b>Corresponding Source</b>, which is the exact immutable tag and the source archives the release was made from. A binary you downloaded can therefore be traced back to code you can read. The third-party notices list every dependency and its licence, and the repository follows the REUSE convention, with an SPDX header on its files.</p>
     </div>
 
     <div class="guide-grid reveal">
       <article class="card lit guide-card">
         <h3>Read the code</h3>
-        <p>The whole application — desktop app, server, Zotero plugin, browser connector and this website — lives in one public repository.</p>
+        <p>One public repository holds the whole thing. The desktop app, the server, the Zotero plugin, the browser connector and this website are all in there.</p>
         <a class="arrow-link" href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">Open the repository
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
       </article>
@@ -151,20 +151,20 @@ SPDX-License-Identifier: AGPL-3.0-only
         <em>03</em>
         <div>
           <h3>Backups you can verify</h3>
-          <p>Nodus makes encrypted automatic backups, and a complete Nodus 4 backup contains every vault together with the shared Library. Before Nodus 4 opens an existing database it creates and verifies a one-time pre-v4 recovery copy, and Nodus 4 can still open backups made by Nodus 3.x.</p>
+          <p>Nodus makes encrypted automatic backups, and a complete Nodus 4 backup holds every vault together with the shared Library. Before Nodus 4 opens an existing database it creates and verifies a one-time pre-v4 recovery copy, and Nodus 4 can still open backups made by Nodus 3.x.</p>
         </div>
       </div>
       <div class="guide-step">
         <em>04</em>
         <div>
           <h3>A record of what happened</h3>
-          <p>An audit ledger records the operations performed in a vault, which matters when the question months later is not <em>what does my corpus say</em> but <em>when did this change, and why</em>.</p>
+          <p>An audit ledger records the operations performed in a vault. That matters when the question months later is not <em>what does my corpus say</em> but <em>when did this change, and why</em>.</p>
         </div>
       </div>
     </div>
 
     <div class="guide-note reveal">
-      <p><b>No advertising, telemetry or remote analytics.</b> The application does not send your content to a cloud operated by the project, because the project operates none. This website carries no analytics container either — no Tag Manager, no Google Analytics, no tracking pixel — and a test in the repository fails the build if one is ever added.</p>
+      <p><b>No advertising, telemetry or remote analytics.</b> The application does not send your content to a cloud run by the project, because the project runs none. This website carries no analytics container either, so no Tag Manager, no Google Analytics and no tracking pixel, and a test in the repository fails the build if anyone ever adds one.</p>
     </div>
   </div>
 </section>
@@ -175,42 +175,42 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">03 · What leaves the machine</span>
       <h2 class="title" data-split>Every outgoing request, and what triggers it.</h2>
-      <p class="lead">"Local-first" does not mean a program that never touches the network. It means nothing goes out unless you asked for something that requires it. Here is the complete shape of that.</p>
+      <p class="lead">Local-first does not mean a program that never touches the network. It means nothing goes out unless you asked for something that needs it. Here is the whole list.</p>
     </div>
 
     <div class="guide-grid two reveal">
       <article class="card lit guide-card">
-        <h3>AI providers — only once you configure one</h3>
-        <p>Model-assisted features stay inactive until you set up a provider or a local model. When you use one, that provider receives the text or page image the task needs. Run <b>Ollama</b> or <b>LM Studio</b> instead and the content never leaves the device at all.</p>
+        <h3>AI providers, only once you configure one</h3>
+        <p>Model-assisted features stay inactive until you set up a provider or a local model. When you use one, that provider receives the text or page image the task needs. Run <b>Ollama</b> or <b>LM Studio</b> instead and the content never leaves your device at all.</p>
         <a class="arrow-link" href="../ai-research/">How Nodus uses AI
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
       </article>
       <article class="card lit guide-card">
-        <h3>Bibliographic lookups — only the identifier</h3>
-        <p>Ask Nodus to resolve metadata and it sends Crossref, Open Library, NCBI or arXiv the single DOI, ISBN, ISSN, PMID or arXiv id you selected — nothing else. Bulk requests are rate-limited and cancelable, and candidates are shown for review rather than applied for you.</p>
+        <h3>Bibliographic lookups, only the identifier</h3>
+        <p>Ask Nodus to resolve metadata and it sends Crossref, Open Library, NCBI or arXiv the single DOI, ISBN, ISSN, PMID or arXiv id you selected, and nothing else. Bulk requests are rate limited and can be cancelled, and candidates are shown for review rather than applied for you.</p>
       </article>
       <article class="card lit guide-card">
-        <h3>Updates — checked, not installed behind your back</h3>
-        <p>Nodus checks GitHub for new releases and can download one, but downloading is not automatic and an update is never installed without you. GitHub sees what any web request exposes, such as an IP address.</p>
+        <h3>Updates, checked but never installed for you</h3>
+        <p>Nodus checks GitHub for new releases and can download one, but the download is not automatic and an update is never installed behind your back. GitHub sees what any web request exposes, such as an IP address.</p>
       </article>
       <article class="card lit guide-card">
-        <h3>Announcements — a static file, and switchable off</h3>
-        <p>Nodus fetches a public static file from this website so it can warn about known issues between releases. It is a plain conditional GET, at most once every four hours, carrying no identifier, no account, no vault name and nothing about your corpus. Turn it off in <b>Settings → Updates and news</b> and no request is made at all.</p>
+        <h3>Announcements, a static file you can switch off</h3>
+        <p>Nodus fetches a public static file from this website so it can warn you about known issues between releases. It is a plain conditional GET, at most once every four hours, carrying no identifier, no account, no vault name and nothing about your corpus. Turn it off in <b>Settings → Updates and news</b> and no request is made at all.</p>
       </article>
       <article class="card lit guide-card">
-        <h3>Zotero — a connection that never leaves the computer</h3>
-        <p>The Zotero integration talks to the Zotero application on the same machine over a local connection. There is no API key and no round-trip through zotero.org.</p>
+        <h3>Zotero, a connection that never leaves the computer</h3>
+        <p>The Zotero integration talks to the Zotero application on the same machine over a local connection. There is no API key and no round trip through zotero.org.</p>
         <a class="arrow-link" href="../zotero/">How the Zotero link works
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
       </article>
       <article class="card lit guide-card">
-        <h3>Sharing — opt-in, and a copy rather than the original</h3>
-        <p>Nodus Server publishes a filtered projection of a vault you explicitly choose to share, while the original database and documents stay on your computer. Nothing is published until you set it up.</p>
+        <h3>Sharing, opt-in and always a copy</h3>
+        <p>Nodus Server publishes a filtered copy of a vault you explicitly choose to share, while the original database and documents stay on your computer. Nothing is published until you set it up.</p>
       </article>
     </div>
 
     <div class="guide-note reveal">
-      <p>This page is a summary written for readers deciding whether to try Nodus. The <a href="https://github.com/Drakonis96/nodus/blob/main/PRIVACY.md" target="_blank" rel="noopener">privacy policy</a> is the authoritative document and goes considerably further, service by service — read it before putting confidential or personal research material into any application, including this one.</p>
+      <p>This page is a summary written for people deciding whether to try Nodus. The <a href="https://github.com/Drakonis96/nodus/blob/main/PRIVACY.md" target="_blank" rel="noopener">privacy policy</a> is the authoritative document and goes a good deal further, service by service. Please read it before you put confidential or personal research material into any application, this one included.</p>
     </div>
   </div>
 </section>
@@ -224,10 +224,10 @@ SPDX-License-Identifier: AGPL-3.0-only
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
       <p>If Nodus contributes substantially to research that leads to a publication, cite the version you used. The repository ships machine-readable citation metadata in <code>CITATION.cff</code>, including an ORCID for the author and the released version and date, which GitHub renders directly in APA and BibTeX.</p>
-      <p>Citing the version matters more here than it does for a general-purpose editor: analysis pipelines change between releases, and a reviewer asking how a corpus was processed deserves an answer that points at a specific, archived tag.</p>
+      <p>Citing the version matters more here than it does for a general purpose editor. Analysis pipelines change between releases, and a reviewer asking how a corpus was processed deserves an answer that points at a specific archived tag.</p>
     </div>
     <div class="guide-note reveal">
-      <p><b>Nodus is one person's project, plus everyone who has added to it since.</b> Bug reports, translations, documentation and a precise account of what broke are all worth as much as code — the <a href="../contribute/">contribute page</a> sets out the ways in.</p>
+      <p><b>Nodus started as one person's project, and it now includes everyone who has added to it since.</b> Bug reports, translations, documentation and a precise account of what broke are worth as much as code. The <a href="../contribute/">contribute page</a> sets out the ways in.</p>
     </div>
   </div>
 </section>
@@ -243,7 +243,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <a class="card lit next-card reveal" href="../research/">
         <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="7" r="2.4"/><circle cx="11" cy="18" r="2.4"/><path d="M8 7l7.6.6M7.2 8.2l3 7.4M16.6 9.2l-4.4 6.6"/></svg></span>
         <h3>Nodus for academic research</h3>
-        <p>What all of this is in service of: sources, typed ideas with their evidence, semantic search, research gaps and cited writing.</p>
+        <p>What all of this is in service of. Sources, ideas with the evidence behind them, semantic search, research gaps and cited writing.</p>
         <span class="arrow-link">Read the research guide
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
@@ -257,7 +257,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <a class="card lit next-card reveal" href="../ai-research/" style="--delay:140ms">
         <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M18.4 5.6l-2.1 2.1M7.7 16.3l-2.1 2.1"/></svg></span>
         <h3>AI for academic research</h3>
-        <p>Which models Nodus can use, how to keep every one of them on your own hardware, and where the output still has to be checked.</p>
+        <p>Which models Nodus can use, how to keep every one of them on your own hardware, and where you still have to check the result yourself.</p>
         <span class="arrow-link">Read about AI-assisted research
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>

--- a/site/research/index.html
+++ b/site/research/index.html
@@ -1,0 +1,383 @@
+<!--
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Nodus for Academic Research | Open Source Research Workspace</title>
+<meta name="description" content="How researchers use Nodus, a free and open source research workspace: build a corpus from Zotero or your own documents, turn papers into ideas anchored to their exact passage and page, search it semantically, and write with citations you can verify."/>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
+<meta property="og:title" content="Nodus for Academic Research | Open Source Research Workspace"/>
+<meta property="og:description" content="A local-first research workspace for academic work: sources from Zotero or your own files, ideas linked to the passage that supports them, semantic search, research gaps, and writing with verifiable citations."/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://nodusresearch.com/research/"/>
+<meta property="og:site_name" content="Nodus"/>
+<meta property="og:locale" content="en_GB"/>
+<meta property="og:image" content="https://nodusresearch.com/favicon.png"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="Nodus for Academic Research"/>
+<meta name="twitter:description" content="An open source, local-first research workspace for connecting sources, ideas and evidence."/>
+<meta name="twitter:image" content="https://nodusresearch.com/favicon.png"/>
+<link rel="canonical" href="https://nodusresearch.com/research/"/>
+<link rel="icon" href="../favicon.ico" sizes="any"/>
+  <link rel="icon" type="image/png" href="../favicon.png" sizes="512x512"/>
+  <link rel="icon" type="image/svg+xml" href="../assets/nodus-logo.svg"/>
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260818"/>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Nodus", "item": "https://nodusresearch.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Academic research", "item": "https://nodusresearch.com/research/" }
+  ]
+}
+</script>
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+<canvas id="organism" aria-hidden="true"></canvas>
+
+<div data-nodus-site-header data-base="../" data-page="research"></div>
+<script src="../site-header.js?v=20260817"></script>
+
+<main id="main">
+
+<header class="page-hero guide-hero" data-accent="#818cf8" data-second="#a78bfa" data-energy="0.34">
+  <div class="wrap">
+    <div class="scrim" style="max-width:820px">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="../index.html">Nodus</a>
+        <span class="sep" aria-hidden="true">/</span>
+        <span aria-current="page">Academic research</span>
+      </nav>
+      <span class="kicker">Academic research</span>
+      <h1 class="display" data-split>Nodus for Academic Research</h1>
+      <p class="lead">Nodus is a free, open source, local-first workspace for academic research. It sits between your reference manager and your manuscript: you bring in the papers, books and documents you already work with, and Nodus turns them into a corpus of ideas, relations and evidence that you can search, question and cite — without any of it leaving your computer.</p>
+      <div class="guide-actions">
+        <a class="btn primary" href="../demo/index.html">
+          <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
+          Open the academic demo
+        </a>
+        <a class="btn" href="../wiki/">Read the manual</a>
+      </div>
+      <nav class="guide-jump" aria-label="On this page">
+        <a href="#sources"><em>01</em> Sources</a>
+        <a href="#ideas"><em>02</em> Ideas and evidence</a>
+        <a href="#search"><em>03</em> Search</a>
+        <a href="#questions"><em>04</em> Gaps and debates</a>
+        <a href="#writing"><em>05</em> Writing</a>
+        <a href="#private"><em>06</em> What stays local</a>
+      </nav>
+    </div>
+  </div>
+</header>
+
+<!-- ============================================================ what it is -->
+<section class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">The shape of the tool</span>
+      <h2 class="title" data-split>A research application, not a general note app.</h2>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>Most tools that hold research material are either bibliographies or notebooks. A bibliography knows what you have read; a notebook knows what you thought. Neither of them knows <b>which passage of which work supports which claim</b>, and that link is the one scholarly work actually runs on.</p>
+      <p>Nodus is built around that link. Every interpretation it stores — a claim, a finding, a construct, a method, a framework — carries the work it came from and the excerpt that supports it, with its page where the source provides one. Everything else in the application is a way of moving through those anchored units: a graph of how they relate, a map of an argument, a list of the questions your corpus cannot yet answer, a report whose citations you can open and check.</p>
+      <p>Nodus organises work into <b>vaults</b>, and the academic vault is the one described on this page. Other vaults reuse the same engine for <a href="../index.html#more-vaults">teaching, study, structured databases, genealogy and more</a>, but the research vault is the one designed for literature reviews, theses and research projects.</p>
+    </div>
+
+    <div class="guide-grid reveal">
+      <article class="card lit guide-card">
+        <h3>Who it is for</h3>
+        <p>Doctoral candidates, postdocs and academics working through a literature review or a thesis chapter; students building a serious reading base; and anyone whose writing has to stand on sources rather than recollection.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>What it costs</h3>
+        <p>Nothing. Nodus is released under the <b>AGPL-3.0-only</b> licence, with no accounts, no subscriptions and no telemetry. The desktop app runs on macOS, Windows and Linux.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>What it does not do</h3>
+        <p>It does not replace your reference manager, it does not read for you, and it does not decide whether an argument is sound. It records interpretations with their evidence so that <em>you</em> can judge them.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ sources -->
+<section id="sources" class="section-line" data-accent="#a78bfa" data-second="#22d3ee" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">01 · Sources</span>
+      <h2 class="title" data-split>Academic papers, books and documents, wherever you keep them.</h2>
+      <p class="lead">Nodus keeps one cross-vault Library that holds bibliographic metadata, files and searchable text. A source lives there once and can be linked into any compatible vault without being copied.</p>
+    </div>
+
+    <div class="guide-steps reveal">
+      <div class="guide-step">
+        <em>01</em>
+        <div>
+          <h3>Connect the research library you already have</h3>
+          <p>Nodus can mirror a complete <a href="../zotero/">Zotero library</a> — its collection hierarchy, stable item keys, attachments and child notes — from the Zotero application running on the same computer. It can also import <b>RIS, BibTeX and CSL JSON</b> exported from Mendeley or another manager, or take local documents directly.</p>
+          <p>The optional Nodus Connector for Chrome captures the academic page or document you are looking at into the Library, detecting embedded bibliographic metadata, DOI or ISBN and any available file.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>02</em>
+        <div>
+          <h3>Keep the original and get a readable copy</h3>
+          <p>For each item, Nodus preserves the original attachment untouched and builds a clean Markdown reading copy beside it, along with extracted figures, structured tables and page mappings. PDF, EPUB, image, web, text and office attachments all stay openable in their preserved form.</p>
+          <p>The reader asks once whether you prefer the clean copy or the preserved original, and that choice can be reset at any time. Page-accurate verification always goes back to the original.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>03</em>
+        <div>
+          <h3>Decide what belongs in this project</h3>
+          <p>Linking an item into a vault is what places it in that project's corpus. Removing the link does not destroy the global source, so a paper can inform a thesis vault and a teaching vault at once without being duplicated or falling out of either.</p>
+          <p>Collections, tags and filtered views keep a large corpus navigable, and duplicate records are worth resolving before analysis so a single source is not counted twice.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>04</em>
+        <div>
+          <h3>Read, highlight and annotate in place</h3>
+          <p>Text can be highlighted in both the reflowable and the PDF viewers, and images accept region highlights. Highlights, notes and document chat stay attached to the source, which is what later lets an idea point back at an exact excerpt.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ ideas -->
+<section id="ideas" class="section-line" data-accent="#818cf8" data-second="#34d399" data-energy="0.34">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">02 · Ideas and evidence</span>
+      <h2 class="title" data-split>From what you read to what it claims.</h2>
+      <p class="lead">Analysis turns the text of a work into structured interpretations. They are not detached summaries: each one records its type, its source and the excerpt that supports it.</p>
+    </div>
+
+    <div class="guide-grid reveal">
+      <article class="card lit guide-card">
+        <h3>Typed ideas</h3>
+        <p>Every extracted unit is stored as a <b>claim, finding, construct, method or framework</b>. Keeping those apart matters — a method borrowed from one field is a different kind of object from a contested empirical finding, and a corpus that flattens them loses the distinction you most need.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Evidence that stays attached</h3>
+        <p>An idea keeps the passage behind it and, where the source supplies one, the page. Nodus records whether the evidence is quoted explicitly or paraphrased, so you always know how far the wording in front of you is the author's.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Typed relations</h3>
+        <p>Ideas are joined by relations with a meaning: one <b>supports</b>, <b>contradicts</b>, <b>refines</b>, <b>extends</b> or <b>applies to</b> another, shares its method, or is a precondition for it. Each edge records whether it was stated in the source or inferred during analysis.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Themes</h3>
+        <p>Related ideas gather into themes, which is what turns a few hundred extracted units into a readable map of a literature rather than a longer list.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>The knowledge graph</h3>
+        <p>Themes, ideas and authors appear as an interactive research map with presets and filters, so you can move from an overview of the whole corpus down to one contested question.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>The argument map</h3>
+        <p>A separate view arranges claims and evidence into an explicit structure for a paper or chapter — thesis, support, objection, reply, evidence — and lets you reorganise it as the argument develops.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Author profiles</h3>
+        <p>An author view aggregates only what the active corpus actually supports. It is deliberately narrower than a reputation: it shows the documented position of an author in <em>your</em> material.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Immersion</h3>
+        <p>A guided, audio-capable route through a central research question, sequencing evidence stations and commentary. It is built for orientation in unfamiliar material, not as a substitute for reading the sources.</p>
+      </article>
+    </div>
+
+    <div class="guide-note reveal">
+      <p><b>Extraction is a first pass, not a verdict.</b> Automatically extracted text, metadata and ideas can be wrong, and Nodus is designed on that assumption: the excerpt and the preserved original are always one click away so a claim can be checked against the page it came from. How the AI side of this works, and where its limits are, is covered on <a href="../ai-research/">AI for academic research</a>.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ search -->
+<section id="search" class="section-line" data-accent="#22d3ee" data-second="#a78bfa" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">03 · Search</span>
+      <h2 class="title" data-split>Semantic search across your own corpus.</h2>
+      <p class="lead">Nodus searches works, ideas, passages and authors with both exact and semantic retrieval, and results keep the entity type and the source context they came from.</p>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>Exact search is the right tool when you remember the wording. Semantic search matters in the common case where you do not: when the corpus says <em>desirable difficulty</em> and you are asking about effortful practice, or when half your sources are in another language. Nodus builds embeddings for that, and you decide which model computes them.</p>
+      <p>Embeddings can be produced by an external provider — OpenAI, Google Gemini or OpenRouter — or entirely on your machine through <b>Ollama</b>, <b>LM Studio</b> or a small multilingual model that Nodus manages itself. The indexes live on your computer either way.</p>
+      <p>Searching is also how the rest of the workspace is wired together: a search result opens the idea, the idea opens its passage, and the passage opens the preserved original at the page it came from.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ questions -->
+<section id="questions" class="section-line" data-accent="#fbbf24" data-second="#f87171" data-energy="0.32">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">04 · Gaps and debates</span>
+      <h2 class="title" data-split>Questions a corpus can be asked about itself.</h2>
+      <p class="lead">Once a body of literature is stored as anchored ideas and typed relations, some genuinely useful questions become answerable inside the corpus.</p>
+    </div>
+
+    <div class="guide-grid two reveal">
+      <article class="card lit guide-card">
+        <h3>Research gaps</h3>
+        <p>A gap records the evidence that exists, what is missing, and candidate directions. Nodus distinguishes the kinds that matter: <b>future work</b> flagged by authors, acknowledged <b>limitations</b>, <b>open questions</b>, and <b>unresolved contradictions</b> between sources.</p>
+        <p>The strength of a gap depends entirely on how well the corpus covers its area, which is why coverage sits next to it rather than in a different menu.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Debates</h3>
+        <p>Debate views group opposed or qualified positions by stance and show the works standing behind each one. The point is not a pro-and-con tally: boundary conditions, sample differences and methodological disagreements usually carry more information than the headline split.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Coverage analysis</h3>
+        <p>Coverage measures how well the corpus supports the themes and questions you care about, highlighting both overrepresented areas and thin ones. It is the honest way to state the boundary of a literature review — and a reading list for what to add next.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Hypotheses</h3>
+        <p>A hypothesis in Nodus combines a statement, the ideas that support it, the risks against it and a proposed test. Those fields are kept separate on purpose, so that a plausible speculation cannot quietly present itself as an established result.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Reading paths</h3>
+        <p>A reading path orders sources and ideas into a route with a purpose: foundations first, then a debate, then the open questions. Every stop carries a reason for being there rather than a rank.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Deep Research</h3>
+        <p>Deep Research runs as a queued job over the scoped corpus and produces a long-form, citation-rich report whose citations open the source they refer to. It is best treated as an auditable draft: useful because you can check it, not because it is finished.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ writing -->
+<section id="writing" class="section-line" data-accent="#34d399" data-second="#a78bfa" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">05 · Writing</span>
+      <h2 class="title" data-split>Writing with citations you can open.</h2>
+      <p class="lead">Research notes are worth little if the manuscript loses their provenance. Nodus keeps projects, notes and drafts in the same workspace as the corpus they draw on.</p>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>The Workspace holds projects, drafts and source-linked notes. Early observations start close to the passage that prompted them, and mature material moves into a structured manuscript without losing where it came from.</p>
+      <h3>Citations</h3>
+      <p>The citation manager uses real CSL styles, including custom <code>.csl</code> files copied over from Zotero, and formats them locally on your machine after installation.</p>
+      <h3>Word and LibreOffice</h3>
+      <p>Companions for Microsoft Word and LibreOffice bring selected Nodus context into a manuscript you are already writing, so the corpus is reachable from the document rather than only from the app.</p>
+      <h3>Other applications, through MCP</h3>
+      <p>Nodus ships an MCP server, which lets an MCP-capable assistant read approved parts of the active vault — works, ideas, notes, reports — and work with them under your control.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ private -->
+<section id="private" class="section-line band" data-accent="#34d399" data-second="#22d3ee" data-energy="0.24">
+  <div class="wrap">
+    <div class="reveal">
+      <span class="kicker" style="justify-content:center">06 · What stays on your machine</span>
+      <h2 class="title" data-split>Local-first, and open about it.</h2>
+      <p class="lead">Your vaults, the cross-vault Library and every search index live on your own computer and in the backup folder you choose. There are no accounts, no subscriptions and no telemetry, and model-assisted features stay switched off until you configure a provider or a local model. Nodus is open source under the AGPL-3.0-only licence, and every build links to its corresponding source.</p>
+      <div class="pills">
+        <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>100% local storage</span>
+        <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>Offline AI (Ollama · LM Studio)</span>
+        <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>Encrypted auto-backups</span>
+        <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>Audit ledger</span>
+        <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>Free forever (AGPL-3.0-only)</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ next -->
+<section class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.26">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">Keep going</span>
+      <h2 class="title" data-split>Where to go from here.</h2>
+    </div>
+    <div class="next-grid">
+      <a class="card lit next-card reveal" href="../zotero/">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14Z"/><path d="M9 7h6M9 11h6"/></svg></span>
+        <h3>Nodus and Zotero</h3>
+        <p>How the Zotero connection works, what it does and does not touch, and the standalone Nodus plugin that lives inside Zotero itself.</p>
+        <span class="arrow-link">Read about the Zotero integration
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../ai-research/" style="--delay:70ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M18.4 5.6l-2.1 2.1M7.7 16.3l-2.1 2.1"/></svg></span>
+        <h3>AI for academic research</h3>
+        <p>What the models are actually asked to do inside Nodus, how to run them locally, and where their output has to be checked.</p>
+        <span class="arrow-link">Read about AI-assisted research
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../wiki/" style="--delay:140ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14Z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg></span>
+        <h3>The manual</h3>
+        <p>Every view and setting of the academic vault documented in full, with a downloadable PDF manual for the research workflow.</p>
+        <span class="arrow-link">Open the wiki
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../faq/" style="--delay:210ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9.5 9a2.5 2.5 0 1 1 3.7 2.2c-.7.4-1.2 1-1.2 1.8v.5M12 17h.01"/></svg></span>
+        <h3>Questions before you begin</h3>
+        <p>What to expect and what not to, how the AI setup works, and what Nodus does about academic rigour.</p>
+        <span class="arrow-link">Read the FAQ
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<footer class="site-foot">
+  <div class="wrap">
+    <div class="foot-grid">
+      <div class="foot-brand">
+        <span class="logo"><img src="../assets/nodus-logo.svg" alt=""/> Nodus</span>
+        <p>A free, open-source, local-first research workspace for connecting sources, ideas and evidence. Your corpus stays on your machine.</p>
+      </div>
+      <div class="foot-col">
+        <h4>Research</h4>
+        <a href="./">Academic research</a>
+        <a href="../zotero/">Nodus and Zotero</a>
+        <a href="../ai-research/">AI for research</a>
+        <a href="../demo/index.html">Live demos</a>
+      </div>
+      <div class="foot-col">
+        <h4>Learn</h4>
+        <a href="../wiki/">Wiki</a>
+        <a href="../blog/">Blog</a>
+        <a href="../faq/">FAQ</a>
+      </div>
+      <div class="foot-col">
+        <h4>Project</h4>
+        <a href="../contribute/">Contribute</a>
+        <a href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/Drakonis96/nodus/releases" target="_blank" rel="noopener">Releases</a>
+      </div>
+    </div>
+    <div class="foot-base">
+      <span>© 2026 Jorge Pérez Burgueño and Nodus contributors.</span>
+      <a href="https://github.com/Drakonis96/nodus/blob/main/LICENSE" target="_blank" rel="noopener">AGPL-3.0-only</a>
+    </div>
+  </div>
+</footer>
+
+<script src="../assets/js/organism.js?v=20260815"></script>
+<script src="../assets/js/site.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
+</body>
+</html>

--- a/site/research/index.html
+++ b/site/research/index.html
@@ -288,7 +288,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="reveal">
       <span class="kicker" style="justify-content:center">06 · What stays on your machine</span>
       <h2 class="title" data-split>Local-first, and open about it.</h2>
-      <p class="lead">Your vaults, the cross-vault Library and every search index live on your own computer and in the backup folder you choose. There are no accounts, no subscriptions and no telemetry, and model-assisted features stay switched off until you configure a provider or a local model. Nodus is open source under the AGPL-3.0-only licence, and every build links to its corresponding source.</p>
+      <p class="lead">Your vaults, the cross-vault Library and every search index live on your own computer and in the backup folder you choose. There are no accounts, no subscriptions and no telemetry, and model-assisted features stay switched off until you configure a provider or a local model. Nodus is open source under the AGPL-3.0-only licence, and every build links to its corresponding source. <a href="../open-source/">What the licence gives you, and what leaves your machine</a>.</p>
       <div class="pills">
         <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>100% local storage</span>
         <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>Offline AI (Ollama · LM Studio)</span>
@@ -354,7 +354,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a href="./">Academic research</a>
         <a href="../zotero/">Nodus and Zotero</a>
         <a href="../ai-research/">AI for research</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../open-source/">Open source</a>
       </div>
       <div class="foot-col">
         <h4>Learn</h4>

--- a/site/research/index.html
+++ b/site/research/index.html
@@ -62,7 +62,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </nav>
       <span class="kicker">Academic research</span>
       <h1 class="display" data-split>Nodus for Academic Research</h1>
-      <p class="lead">Nodus is a free, open source, local-first workspace for academic research. It sits between your reference manager and your manuscript: you bring in the papers, books and documents you already work with, and Nodus turns them into a corpus of ideas, relations and evidence that you can search, question and cite — without any of it leaving your computer.</p>
+      <p class="lead">Nodus is a free, open source, local-first workspace for academic research. It sits between your reference manager and your manuscript. You bring in the papers, books and documents you already work with, and Nodus turns them into a corpus of ideas, relations and evidence that you can search, question and cite, without any of it leaving your computer.</p>
       <div class="guide-actions">
         <a class="btn primary" href="../demo/index.html">
           <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
@@ -87,18 +87,18 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="section-head scrim reveal">
       <span class="kicker">The shape of the tool</span>
-      <h2 class="title" data-split>A research application, not a general note app.</h2>
+      <h2 class="title" data-split>Built for research, not for notes in general.</h2>
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
-      <p>Most tools that hold research material are either bibliographies or notebooks. A bibliography knows what you have read; a notebook knows what you thought. Neither of them knows <b>which passage of which work supports which claim</b>, and that link is the one scholarly work actually runs on.</p>
-      <p>Nodus is built around that link. Every interpretation it stores — a claim, a finding, a construct, a method, a framework — carries the work it came from and the excerpt that supports it, with its page where the source provides one. Everything else in the application is a way of moving through those anchored units: a graph of how they relate, a map of an argument, a list of the questions your corpus cannot yet answer, a report whose citations you can open and check.</p>
-      <p>Nodus organises work into <b>vaults</b>, and the academic vault is the one described on this page. Other vaults reuse the same engine for <a href="../index.html#more-vaults">teaching, study, structured databases, genealogy and more</a>, but the research vault is the one designed for literature reviews, theses and research projects.</p>
+      <p>Most tools that hold research material are either bibliographies or notebooks. A bibliography knows what you have read. A notebook knows what you thought about it. What neither of them knows is <b>which passage of which work supports which claim</b>, and that is the link your writing rests on.</p>
+      <p>Nodus is built around that link. Every interpretation it stores is one of five kinds, a claim, a finding, a construct, a method or a framework, and each one carries the work it came from and the excerpt that supports it. If the source gives a page number, that travels with it too. Everything else in the application is a way of moving through those anchored units. There is a graph of how they relate to each other, a map of an argument you are putting together, a list of the questions your corpus cannot answer yet, and a report whose citations you can open and check for yourself.</p>
+      <p>Nodus organises work into <b>vaults</b>, and this page describes the academic one. The same engine also runs the vaults for <a href="../index.html#more-vaults">teaching, study, structured databases, genealogy and more</a>, but the academic vault is the one designed for literature reviews, theses and research projects.</p>
     </div>
 
     <div class="guide-grid reveal">
       <article class="card lit guide-card">
         <h3>Who it is for</h3>
-        <p>Doctoral candidates, postdocs and academics working through a literature review or a thesis chapter; students building a serious reading base; and anyone whose writing has to stand on sources rather than recollection.</p>
+        <p>Doctoral candidates, postdocs and academics working through a literature review or a thesis chapter. Students putting together a serious reading base. Anyone whose writing has to stand on sources rather than on memory.</p>
       </article>
       <article class="card lit guide-card">
         <h3>What it costs</h3>
@@ -106,7 +106,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </article>
       <article class="card lit guide-card">
         <h3>What it does not do</h3>
-        <p>It does not replace your reference manager, it does not read for you, and it does not decide whether an argument is sound. It records interpretations with their evidence so that <em>you</em> can judge them.</p>
+        <p>It does not replace your reference manager, it does not read for you, and it does not decide whether an argument is sound. What it does is keep every interpretation next to its evidence, so that judging it is quick for <em>you</em>.</p>
       </article>
     </div>
   </div>
@@ -126,7 +126,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <em>01</em>
         <div>
           <h3>Connect the research library you already have</h3>
-          <p>Nodus can mirror a complete <a href="../zotero/">Zotero library</a> — its collection hierarchy, stable item keys, attachments and child notes — from the Zotero application running on the same computer. It can also import <b>RIS, BibTeX and CSL JSON</b> exported from Mendeley or another manager, or take local documents directly.</p>
+          <p>Nodus can mirror a complete <a href="../zotero/">Zotero library</a> from the Zotero application running on the same computer, keeping its collection hierarchy, stable item keys, attachments and child notes. It can also import <b>RIS, BibTeX and CSL JSON</b> exported from Mendeley or another manager, or take local documents directly.</p>
           <p>The optional Nodus Connector for Chrome captures the academic page or document you are looking at into the Library, detecting embedded bibliographic metadata, DOI or ISBN and any available file.</p>
         </div>
       </div>
@@ -163,21 +163,21 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">02 · Ideas and evidence</span>
       <h2 class="title" data-split>From what you read to what it claims.</h2>
-      <p class="lead">Analysis turns the text of a work into structured interpretations. They are not detached summaries: each one records its type, its source and the excerpt that supports it.</p>
+      <p class="lead">Analysis turns the text of a work into structured interpretations. These are not loose summaries. Each one records what kind of interpretation it is, which source it came from, and the excerpt that supports it.</p>
     </div>
 
     <div class="guide-grid reveal">
       <article class="card lit guide-card">
         <h3>Typed ideas</h3>
-        <p>Every extracted unit is stored as a <b>claim, finding, construct, method or framework</b>. Keeping those apart matters — a method borrowed from one field is a different kind of object from a contested empirical finding, and a corpus that flattens them loses the distinction you most need.</p>
+        <p>Every extracted unit is stored as a <b>claim, finding, construct, method or framework</b>. Keeping those apart matters. A method borrowed from one field is a very different kind of thing from a contested empirical finding, and a corpus that lumps them together loses exactly the distinction you need.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Evidence that stays attached</h3>
-        <p>An idea keeps the passage behind it and, where the source supplies one, the page. Nodus records whether the evidence is quoted explicitly or paraphrased, so you always know how far the wording in front of you is the author's.</p>
+        <p>An idea keeps the passage behind it, plus the page when the source supplies one. Nodus also records whether the evidence is quoted directly or paraphrased, so you always know how much of the wording in front of you is the author's.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Typed relations</h3>
-        <p>Ideas are joined by relations with a meaning: one <b>supports</b>, <b>contradicts</b>, <b>refines</b>, <b>extends</b> or <b>applies to</b> another, shares its method, or is a precondition for it. Each edge records whether it was stated in the source or inferred during analysis.</p>
+        <p>Ideas are joined by relations that mean something. One idea <b>supports</b>, <b>contradicts</b>, <b>refines</b>, <b>extends</b> or <b>applies to</b> another, shares its method, or is a precondition for it. Each connection also records whether the source said so, or whether the analysis inferred it.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Themes</h3>
@@ -189,20 +189,20 @@ SPDX-License-Identifier: AGPL-3.0-only
       </article>
       <article class="card lit guide-card">
         <h3>The argument map</h3>
-        <p>A separate view arranges claims and evidence into an explicit structure for a paper or chapter — thesis, support, objection, reply, evidence — and lets you reorganise it as the argument develops.</p>
+        <p>A separate view arranges claims and evidence into the structure of a paper or chapter, with each piece marked as thesis, support, objection, reply or evidence. You can reorganise it as the argument develops.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Author profiles</h3>
-        <p>An author view aggregates only what the active corpus actually supports. It is deliberately narrower than a reputation: it shows the documented position of an author in <em>your</em> material.</p>
+        <p>An author view only gathers what the active corpus supports. That is narrower than a reputation on purpose, because what it shows you is the documented position of an author inside <em>your</em> material.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Immersion</h3>
-        <p>A guided, audio-capable route through a central research question, sequencing evidence stations and commentary. It is built for orientation in unfamiliar material, not as a substitute for reading the sources.</p>
+        <p>A guided route through a central research question, with audio if you want it, taking you through evidence stations and commentary in order. It is there to help you get your bearings in unfamiliar material, and it does not stand in for reading the sources.</p>
       </article>
     </div>
 
     <div class="guide-note reveal">
-      <p><b>Extraction is a first pass, not a verdict.</b> Automatically extracted text, metadata and ideas can be wrong, and Nodus is designed on that assumption: the excerpt and the preserved original are always one click away so a claim can be checked against the page it came from. How the AI side of this works, and where its limits are, is covered on <a href="../ai-research/">AI for academic research</a>.</p>
+      <p><b>Extraction is a first pass, not a verdict.</b> Automatically extracted text, metadata and ideas can be wrong, and Nodus is built on that assumption, which is why the excerpt and the preserved original are always one click away and a claim can be checked against the page it came from. For how the AI side of this works and where its limits are, see <a href="../ai-research/">AI for academic research</a>.</p>
     </div>
   </div>
 </section>
@@ -217,7 +217,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
       <p>Exact search is the right tool when you remember the wording. Semantic search matters in the common case where you do not: when the corpus says <em>desirable difficulty</em> and you are asking about effortful practice, or when half your sources are in another language. Nodus builds embeddings for that, and you decide which model computes them.</p>
-      <p>Embeddings can be produced by an external provider — OpenAI, Google Gemini or OpenRouter — or entirely on your machine through <b>Ollama</b>, <b>LM Studio</b> or a small multilingual model that Nodus manages itself. The indexes live on your computer either way.</p>
+      <p>Embeddings can be produced by an external provider such as OpenAI, Google Gemini or OpenRouter. They can also be produced entirely on your machine through <b>Ollama</b>, <b>LM Studio</b> or a small multilingual model that Nodus manages itself. The indexes live on your computer either way.</p>
       <p>Searching is also how the rest of the workspace is wired together: a search result opens the idea, the idea opens its passage, and the passage opens the preserved original at the page it came from.</p>
     </div>
   </div>
@@ -229,22 +229,22 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">04 · Gaps and debates</span>
       <h2 class="title" data-split>Questions a corpus can be asked about itself.</h2>
-      <p class="lead">Once a body of literature is stored as anchored ideas and typed relations, some genuinely useful questions become answerable inside the corpus.</p>
+      <p class="lead">Once a body of literature is stored as anchored ideas and typed relations, you can put some very useful questions to the corpus itself.</p>
     </div>
 
     <div class="guide-grid two reveal">
       <article class="card lit guide-card">
         <h3>Research gaps</h3>
-        <p>A gap records the evidence that exists, what is missing, and candidate directions. Nodus distinguishes the kinds that matter: <b>future work</b> flagged by authors, acknowledged <b>limitations</b>, <b>open questions</b>, and <b>unresolved contradictions</b> between sources.</p>
+        <p>A gap records the evidence that exists, what is missing, and candidate directions. Nodus keeps four kinds apart, because they call for different responses. There is <b>future work</b> flagged by the authors, there are acknowledged <b>limitations</b>, there are <b>open questions</b>, and there are <b>unresolved contradictions</b> between sources.</p>
         <p>The strength of a gap depends entirely on how well the corpus covers its area, which is why coverage sits next to it rather than in a different menu.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Debates</h3>
-        <p>Debate views group opposed or qualified positions by stance and show the works standing behind each one. The point is not a pro-and-con tally: boundary conditions, sample differences and methodological disagreements usually carry more information than the headline split.</p>
+        <p>Debate views group opposed or qualified positions by stance and show the works standing behind each one. The point is not to end up with a pro and con tally. Boundary conditions, sample differences and methodological disagreements usually tell you far more than the headline split does.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Coverage analysis</h3>
-        <p>Coverage measures how well the corpus supports the themes and questions you care about, highlighting both overrepresented areas and thin ones. It is the honest way to state the boundary of a literature review — and a reading list for what to add next.</p>
+        <p>Coverage measures how well the corpus supports the themes and questions you care about, highlighting both overrepresented areas and thin ones. It is the honest way to state the boundary of a literature review, and it doubles as a reading list for what to add next.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Hypotheses</h3>
@@ -252,11 +252,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       </article>
       <article class="card lit guide-card">
         <h3>Reading paths</h3>
-        <p>A reading path orders sources and ideas into a route with a purpose: foundations first, then a debate, then the open questions. Every stop carries a reason for being there rather than a rank.</p>
+        <p>A reading path puts sources and ideas into a route with a purpose, say foundations first, then a debate, then the open questions. Every stop carries a reason for being there rather than a rank.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Deep Research</h3>
-        <p>Deep Research runs as a queued job over the scoped corpus and produces a long-form, citation-rich report whose citations open the source they refer to. It is best treated as an auditable draft: useful because you can check it, not because it is finished.</p>
+        <p>Deep Research runs as a queued job over the scoped corpus and produces a long-form, citation-rich report whose citations open the source they refer to. Treat it as a draft you can audit. It is useful because you can check it, not because it is finished.</p>
       </article>
     </div>
   </div>
@@ -268,16 +268,16 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">05 · Writing</span>
       <h2 class="title" data-split>Writing with citations you can open.</h2>
-      <p class="lead">Research notes are worth little if the manuscript loses their provenance. Nodus keeps projects, notes and drafts in the same workspace as the corpus they draw on.</p>
+      <p class="lead">Research notes lose most of their value if the manuscript forgets where they came from. Nodus keeps projects, notes and drafts in the same workspace as the corpus they draw on.</p>
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
-      <p>The Workspace holds projects, drafts and source-linked notes. Early observations start close to the passage that prompted them, and mature material moves into a structured manuscript without losing where it came from.</p>
+      <p>The Workspace holds projects, drafts and source-linked notes. Early observations start out close to the passage that prompted them, and as they mature they move into a structured manuscript without losing that trail.</p>
       <h3>Citations</h3>
       <p>The citation manager uses real CSL styles, including custom <code>.csl</code> files copied over from Zotero, and formats them locally on your machine after installation.</p>
       <h3>Word and LibreOffice</h3>
       <p>Companions for Microsoft Word and LibreOffice bring selected Nodus context into a manuscript you are already writing, so the corpus is reachable from the document rather than only from the app.</p>
       <h3>Other applications, through MCP</h3>
-      <p>Nodus ships an MCP server, which lets an MCP-capable assistant read approved parts of the active vault — works, ideas, notes, reports — and work with them under your control.</p>
+      <p>Nodus ships an MCP server. It lets an MCP-capable assistant read approved parts of the active vault, such as works, ideas, notes and reports, and work with them under your control.</p>
     </div>
   </div>
 </section>
@@ -287,7 +287,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="reveal">
       <span class="kicker" style="justify-content:center">06 · What stays on your machine</span>
-      <h2 class="title" data-split>Local-first, and open about it.</h2>
+      <h2 class="title" data-split>Local-first and open source.</h2>
       <p class="lead">Your vaults, the cross-vault Library and every search index live on your own computer and in the backup folder you choose. There are no accounts, no subscriptions and no telemetry, and model-assisted features stay switched off until you configure a provider or a local model. Nodus is open source under the AGPL-3.0-only licence, and every build links to its corresponding source. <a href="../open-source/">What the licence gives you, and what leaves your machine</a>.</p>
       <div class="pills">
         <span class="pill"><svg viewBox="0 0 24 24"><path d="m4 12.5 5 5L20 6.5"/></svg>100% local storage</span>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -5,6 +5,18 @@
     <lastmod>2026-08-16</lastmod>
   </url>
   <url>
+    <loc>https://nodusresearch.com/research/</loc>
+    <lastmod>2026-08-16</lastmod>
+  </url>
+  <url>
+    <loc>https://nodusresearch.com/zotero/</loc>
+    <lastmod>2026-08-16</lastmod>
+  </url>
+  <url>
+    <loc>https://nodusresearch.com/ai-research/</loc>
+    <lastmod>2026-08-16</lastmod>
+  </url>
+  <url>
     <loc>https://nodusresearch.com/demo/</loc>
     <lastmod>2026-08-16</lastmod>
   </url>
@@ -50,6 +62,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/blog/post.html?p=how-to-organize-a-large-academic-research-library</loc>
+    <lastmod>2026-08-16</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/blog/post.html?p=nodus-open-source-research-workspace</loc>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -17,6 +17,9 @@
     <lastmod>2026-08-16</lastmod>
   </url>
   <url>
+    <loc>https://nodusresearch.com/open-source/</loc>
+  </url>
+  <url>
     <loc>https://nodusresearch.com/demo/</loc>
     <lastmod>2026-08-16</lastmod>
   </url>

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260817c"/>
+  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
   <link rel="stylesheet" href="wiki.css?v=20260817"/>
 </head>
 <body class="wiki-page" data-quiet>

--- a/site/zotero/index.html
+++ b/site/zotero/index.html
@@ -91,7 +91,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="guide-body prose reveal" style="margin-top:26px">
       <p>A reference manager and a research workspace answer different questions. Zotero answers <em>what do I have, and how do I cite it</em>. It collects items from the web, holds attachments, syncs across your machines, manages groups and drives citations in your word processor. Nodus does not do any of that better, and it does not try to.</p>
       <p>What Nodus answers is <em>what does this material say, and how do the pieces relate</em>. It reads the works in your library, records typed ideas with the passage and page that support them, connects those ideas with relations that have a meaning, and gives you a corpus you can search semantically, argue with and write from.</p>
-      <p>The practical consequence is that <b>you keep your Zotero workflow intact</b>. Keep saving with the Zotero Connector, keep organising in collections, keep syncing to zotero.org. Nodus reads what is there.</p>
+      <p>The practical consequence is that <b>you keep your Zotero workflow intact</b>. Keep saving with the Zotero Connector, keep organising in collections, keep syncing to zotero.org. Nodus reads what is there — and, being <a href="../open-source/">open source and local-first</a>, it reads it on your own machine.</p>
     </div>
 
     <div class="guide-note reveal">
@@ -320,7 +320,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a href="../research/">Academic research</a>
         <a href="./">Nodus and Zotero</a>
         <a href="../ai-research/">AI for research</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../open-source/">Open source</a>
       </div>
       <div class="foot-col">
         <h4>Learn</h4>

--- a/site/zotero/index.html
+++ b/site/zotero/index.html
@@ -1,0 +1,349 @@
+<!--
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Nodus + Zotero | Open Source Research Workspace</title>
+<meta name="description" content="How Nodus connects to Zotero: a read-only link to your local Zotero library that turns your references into a research workspace, plus the standalone Nodus plugin that adds semantic search and cited answers inside Zotero itself."/>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
+<meta property="og:title" content="Nodus + Zotero | Open Source Research Workspace"/>
+<meta property="og:description" content="Nodus does not replace Zotero. Connect your Zotero library, keep collecting and citing where you already do, and use Nodus as the research workspace around your sources."/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://nodusresearch.com/zotero/"/>
+<meta property="og:site_name" content="Nodus"/>
+<meta property="og:locale" content="en_GB"/>
+<meta property="og:image" content="https://nodusresearch.com/favicon.png"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="Nodus and Zotero"/>
+<meta name="twitter:description" content="A read-only connection to your local Zotero library, and a research workspace built around it."/>
+<meta name="twitter:image" content="https://nodusresearch.com/favicon.png"/>
+<link rel="canonical" href="https://nodusresearch.com/zotero/"/>
+<link rel="icon" href="../favicon.ico" sizes="any"/>
+  <link rel="icon" type="image/png" href="../favicon.png" sizes="512x512"/>
+  <link rel="icon" type="image/svg+xml" href="../assets/nodus-logo.svg"/>
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260818"/>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Nodus", "item": "https://nodusresearch.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Zotero integration", "item": "https://nodusresearch.com/zotero/" }
+  ]
+}
+</script>
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+<canvas id="organism" aria-hidden="true"></canvas>
+
+<div data-nodus-site-header data-base="../" data-page="zotero"></div>
+<script src="../site-header.js?v=20260817"></script>
+
+<main id="main">
+
+<header class="page-hero guide-hero" data-accent="#f87171" data-second="#a78bfa" data-energy="0.32">
+  <div class="wrap">
+    <div class="scrim" style="max-width:820px">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="../index.html">Nodus</a>
+        <span class="sep" aria-hidden="true">/</span>
+        <span aria-current="page">Zotero</span>
+      </nav>
+      <span class="kicker">Zotero integration</span>
+      <h1 class="display" data-split>Nodus and Zotero</h1>
+      <p class="lead">Zotero is where a great many researchers keep their library, and Nodus is not trying to take that job away from it. Nodus connects to the Zotero library you already maintain and becomes the workspace around it: a place where the sources you have collected turn into ideas, relations and evidence you can search, question and cite.</p>
+      <div class="guide-actions">
+        <a class="btn primary" href="https://github.com/Drakonis96/nodus/releases/latest" target="_blank" rel="noopener">
+          <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5"/><path d="M4 19h16"/></svg>
+          Download Nodus
+        </a>
+        <a class="btn" href="../research/">Nodus for academic research</a>
+      </div>
+      <nav class="guide-jump" aria-label="On this page">
+        <a href="#not-a-replacement"><em>01</em> Not a replacement</a>
+        <a href="#connect"><em>02</em> Connecting a library</a>
+        <a href="#workspace"><em>03</em> The workspace around it</a>
+        <a href="#plugin"><em>04</em> The Zotero plugin</a>
+        <a href="#which"><em>05</em> Which one to use</a>
+      </nav>
+    </div>
+  </div>
+</header>
+
+<!-- ============================================================ not a replacement -->
+<section id="not-a-replacement" class="section-line" data-accent="#a78bfa" data-second="#f87171" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">01 · The relationship</span>
+      <h2 class="title" data-split>Nodus does not replace Zotero.</h2>
+    </div>
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>A reference manager and a research workspace answer different questions. Zotero answers <em>what do I have, and how do I cite it</em>. It collects items from the web, holds attachments, syncs across your machines, manages groups and drives citations in your word processor. Nodus does not do any of that better, and it does not try to.</p>
+      <p>What Nodus answers is <em>what does this material say, and how do the pieces relate</em>. It reads the works in your library, records typed ideas with the passage and page that support them, connects those ideas with relations that have a meaning, and gives you a corpus you can search semantically, argue with and write from.</p>
+      <p>The practical consequence is that <b>you keep your Zotero workflow intact</b>. Keep saving with the Zotero Connector, keep organising in collections, keep syncing to zotero.org. Nodus reads what is there.</p>
+    </div>
+
+    <div class="guide-note reveal">
+      <p><b>The connection is read-only, by design.</b> Nodus talks to Zotero through the local API that the Zotero desktop application exposes, and never writes to it. It does not modify your items, does not create collections in Zotero, and never opens <code>zotero.sqlite</code> directly. Attachments are copied into the Nodus Library; the files in your Zotero storage are only ever read.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ connecting -->
+<section id="connect" class="section-line" data-accent="#818cf8" data-second="#22d3ee" data-energy="0.32">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">02 · Connecting a library</span>
+      <h2 class="title" data-split>Mirroring your research library into Nodus.</h2>
+      <p class="lead">Nodus keeps one cross-vault Library, and a Zotero library can be mirrored into it with its structure intact. Both applications run on the same computer, and nothing is routed through an external service.</p>
+    </div>
+
+    <div class="guide-steps reveal">
+      <div class="guide-step">
+        <em>01</em>
+        <div>
+          <h3>Have Zotero open</h3>
+          <p>Nodus reads from the local API served by the Zotero desktop application, which means <b>Zotero 7 or newer running on the same machine</b>. There is no API key to paste and no round-trip through zotero.org: the connection is a local one between two applications on your own computer.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>02</em>
+        <div>
+          <h3>Choose the library and what to bring</h3>
+          <p>Your personal library and any <b>group libraries</b> you belong to are both available, and Nodus previews a library before importing it so you can see what a sync would bring in. Collections keep their hierarchy, and items keep their stable Zotero keys, which is what lets a later sync recognise the same item rather than duplicating it.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>03</em>
+        <div>
+          <h3>Metadata, attachments and notes</h3>
+          <p>An import carries bibliographic metadata, attachments and the child notes attached to your items. Nodus preserves each original attachment and builds a clean reading copy beside it, along with extracted figures, tables and page mappings, so a claim can always be checked against the page it came from.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>04</em>
+        <div>
+          <h3>Keep it up to date</h3>
+          <p>Later syncs are incremental: Nodus asks Zotero what has changed since the version it last saw, and picks up new and edited items along with the ones you deleted, rather than re-reading the whole library each time.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>05</em>
+        <div>
+          <h3>Decide what belongs to which project</h3>
+          <p>A mirrored Zotero library sits in the shared Library, not inside one project. Linking an item into a vault is what places it in that project's corpus, so the same paper can support a thesis and a course without being stored twice. Unlinking it leaves the global source untouched.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="guide-note reveal">
+      <p>Zotero is not the only route in. The same Library accepts <b>RIS, BibTeX and CSL JSON</b> exported from Mendeley or another manager, plain local documents, and pages captured by the Nodus Connector for Chrome. If you do not use Zotero, nothing on <a href="../research/">the research page</a> becomes unavailable to you.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ workspace -->
+<section id="workspace" class="section-line" data-accent="#34d399" data-second="#818cf8" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">03 · The workspace around your sources</span>
+      <h2 class="title" data-split>What happens to a Zotero library once it is in Nodus.</h2>
+      <p class="lead">This is the part Zotero was never meant to do, and the reason the two tools sit well together.</p>
+    </div>
+
+    <div class="guide-grid reveal">
+      <article class="card lit guide-card">
+        <h3>Ideas with their evidence</h3>
+        <p>Works are analysed into typed units — claim, finding, construct, method, framework — each keeping the excerpt that supports it and, where the source provides one, the page.</p>
+        <a class="arrow-link" href="../research/#ideas">How ideas and evidence work
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+      <article class="card lit guide-card">
+        <h3>A graph of your reading</h3>
+        <p>Ideas are joined by relations that mean something — supports, contradicts, refines, extends, applies to — and gather into themes you can browse as an interactive research map.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Semantic search over the library</h3>
+        <p>Exact and semantic retrieval across works, ideas, passages and authors, including across languages, with the embeddings computed by a provider you choose or entirely on your own machine.</p>
+        <a class="arrow-link" href="../research/#search">More on searching a corpus
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Debates, gaps and coverage</h3>
+        <p>Where your sources disagree, which questions they leave open, and how well the collection you have actually covers the themes your work depends on.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Deep Research reports</h3>
+        <p>A queued job that synthesises the scoped corpus into a long-form report whose citations open the source behind them — an auditable draft rather than a finished text.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Citations in your own style</h3>
+        <p>The citation manager uses real CSL styles and will format with custom <code>.csl</code> files copied over from Zotero, locally on your machine.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Writing beside the sources</h3>
+        <p>Projects, drafts and source-linked notes live in the same workspace, with companions for Microsoft Word and LibreOffice for the manuscript itself.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Translating attachments</h3>
+        <p>Nodus Translate works with text, files and Zotero attachments using the model you choose, preserving DOCX and EPUB structure and offering a facsimile PDF mode that keeps the original layout.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ plugin -->
+<section id="plugin" class="section-line" data-accent="#fbbf24" data-second="#f87171" data-energy="0.34">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">04 · The plugin</span>
+      <h2 class="title" data-split>Nodus for Zotero, inside Zotero.</h2>
+      <p class="lead">Some work never leaves the reference manager. For that, Nodus ships a separate Zotero plugin — a standalone add-on that runs entirely within Zotero and does not need the Nodus desktop application at all.</p>
+    </div>
+
+    <div class="guide-body prose reveal" style="margin-top:26px">
+      <p>The plugin indexes the <b>PDF, EPUB and HTML attachments</b> in your library and adds a research sidebar that answers questions across them. Answers come back with the exact passages they rest on and the pages those passages sit on, so a reply is something you can check rather than something you have to trust.</p>
+      <p>Retrieval combines keyword and semantic search and works across languages. The embeddings can be produced by a managed local model that runs on your own machine inside the Zotero profile, or by a provider you configure yourself — Anthropic, OpenAI, OpenRouter, Groq, Cerebras, DeepSeek, Google Gemini and others are supported, alongside local <b>Ollama</b> and <b>LM Studio</b> endpoints.</p>
+      <h3>Reading what a scan does not say in text</h3>
+      <p>Vision-capable models can read document pages as images, transcribing scanned text and describing figures, tables and formulas so that material a plain text layer misses still enters the index.</p>
+      <h3>Auditing your own claims</h3>
+      <p>An evidence audit takes claims and checks them against the indexed library, highlighting the ones whose support is thin. It is a prompt to go back to the sources, not a verdict on whether a claim is true.</p>
+      <h3>Installing it</h3>
+      <p>Download <code>nodus-zotero.xpi</code> from the <a href="https://github.com/Drakonis96/nodus/releases/latest" target="_blank" rel="noopener">latest Nodus release</a>. In Zotero, open <b>Tools → Add-ons</b>, choose <b>Install Add-on From File</b> and select the downloaded file. The index it builds stays in your Zotero profile.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ which -->
+<section id="which" class="section-line" data-accent="#a78bfa" data-second="#34d399" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">05 · Choosing</span>
+      <h2 class="title" data-split>Which one do you actually need?</h2>
+      <p class="lead">The three pieces do different jobs, and most people end up using more than one.</p>
+    </div>
+
+    <div class="guide-table-scroll reveal">
+      <table class="guide-table">
+        <thead>
+          <tr><th scope="col">You want to…</th><th scope="col">Use</th><th scope="col">Why</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Collect references, store PDFs, sync and cite in a word processor</th>
+            <td>Zotero</td>
+            <td>That is what a reference manager is for, and Nodus is built on the assumption that you keep doing it there.</td>
+          </tr>
+          <tr>
+            <th scope="row">Search your library's full text and get answers with page citations, without leaving Zotero</th>
+            <td>The Nodus plugin for Zotero</td>
+            <td>It runs inside Zotero, indexes your attachments in your own profile and needs no separate application.</td>
+          </tr>
+          <tr>
+            <th scope="row">Turn a body of literature into ideas, relations, debates, gaps and a cited draft</th>
+            <td>The Nodus desktop app</td>
+            <td>That analysis needs a corpus with its own structure, which is what the academic vault is.</td>
+          </tr>
+          <tr>
+            <th scope="row">Do all of it</th>
+            <td>All three</td>
+            <td>Collect in Zotero, mirror into Nodus for the analysis and writing, and keep the plugin for quick retrieval while you are reading.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ next -->
+<section class="section-line" data-accent="#a78bfa" data-second="#818cf8" data-energy="0.26">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">Keep going</span>
+      <h2 class="title" data-split>Where to go from here.</h2>
+    </div>
+    <div class="next-grid">
+      <a class="card lit next-card reveal" href="../research/">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="7" r="2.4"/><circle cx="11" cy="18" r="2.4"/><path d="M8 7l7.6.6M7.2 8.2l3 7.4M16.6 9.2l-4.4 6.6"/></svg></span>
+        <h3>Nodus for academic research</h3>
+        <p>The full picture: sources, typed ideas with their evidence, semantic search, research gaps and writing with citations you can open.</p>
+        <span class="arrow-link">Read the research guide
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../ai-research/" style="--delay:70ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M18.4 5.6l-2.1 2.1M7.7 16.3l-2.1 2.1"/></svg></span>
+        <h3>AI for academic research</h3>
+        <p>Which models Nodus and the Zotero plugin can use, how to keep everything local, and where the output still has to be checked.</p>
+        <span class="arrow-link">Read about AI-assisted research
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../demo/index.html" style="--delay:140ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7-11-7Z"/></svg></span>
+        <h3>The live demo</h3>
+        <p>A sample academic corpus you can explore in this browser, with no installation and nothing to import.</p>
+        <span class="arrow-link">Try the demo
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+      <a class="card lit next-card reveal" href="../faq/" style="--delay:210ms">
+        <span class="pic"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9.5 9a2.5 2.5 0 1 1 3.7 2.2c-.7.4-1.2 1-1.2 1.8v.5M12 17h.01"/></svg></span>
+        <h3>Questions before you begin</h3>
+        <p>Setup, providers, citations and the honest limits of what an application like this can do for your research.</p>
+        <span class="arrow-link">Read the FAQ
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+      </a>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<footer class="site-foot">
+  <div class="wrap">
+    <div class="foot-grid">
+      <div class="foot-brand">
+        <span class="logo"><img src="../assets/nodus-logo.svg" alt=""/> Nodus</span>
+        <p>A free, open-source, local-first research workspace for connecting sources, ideas and evidence. Your corpus stays on your machine.</p>
+      </div>
+      <div class="foot-col">
+        <h4>Research</h4>
+        <a href="../research/">Academic research</a>
+        <a href="./">Nodus and Zotero</a>
+        <a href="../ai-research/">AI for research</a>
+        <a href="../demo/index.html">Live demos</a>
+      </div>
+      <div class="foot-col">
+        <h4>Learn</h4>
+        <a href="../wiki/">Wiki</a>
+        <a href="../blog/">Blog</a>
+        <a href="../faq/">FAQ</a>
+      </div>
+      <div class="foot-col">
+        <h4>Project</h4>
+        <a href="../contribute/">Contribute</a>
+        <a href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/Drakonis96/nodus/releases" target="_blank" rel="noopener">Releases</a>
+      </div>
+    </div>
+    <div class="foot-base">
+      <span>© 2026 Jorge Pérez Burgueño and Nodus contributors.</span>
+      <a href="https://github.com/Drakonis96/nodus/blob/main/LICENSE" target="_blank" rel="noopener">AGPL-3.0-only</a>
+    </div>
+  </div>
+</footer>
+
+<script src="../assets/js/organism.js?v=20260815"></script>
+<script src="../assets/js/site.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
+</body>
+</html>

--- a/site/zotero/index.html
+++ b/site/zotero/index.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Nodus + Zotero | Open Source Research Workspace</title>
-<meta name="description" content="How Nodus connects to Zotero: a read-only link to your local Zotero library that turns your references into a research workspace, plus the standalone Nodus plugin that adds semantic search and cited answers inside Zotero itself."/>
+<meta name="description" content="How Nodus connects to Zotero. A read-only link to your local Zotero library turns your references into a research workspace, and a standalone Nodus plugin adds semantic search and cited answers inside Zotero itself."/>
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
 <meta property="og:title" content="Nodus + Zotero | Open Source Research Workspace"/>
 <meta property="og:description" content="Nodus does not replace Zotero. Connect your Zotero library, keep collecting and citing where you already do, and use Nodus as the research workspace around your sources."/>
@@ -62,7 +62,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </nav>
       <span class="kicker">Zotero integration</span>
       <h1 class="display" data-split>Nodus and Zotero</h1>
-      <p class="lead">Zotero is where a great many researchers keep their library, and Nodus is not trying to take that job away from it. Nodus connects to the Zotero library you already maintain and becomes the workspace around it: a place where the sources you have collected turn into ideas, relations and evidence you can search, question and cite.</p>
+      <p class="lead">Zotero is where a great many researchers keep their library, and Nodus is not trying to take that job away from it. Nodus connects to the library you already maintain and becomes the workspace around it, a place where the sources you have collected turn into ideas, relations and evidence you can search, question and cite.</p>
       <div class="guide-actions">
         <a class="btn primary" href="https://github.com/Drakonis96/nodus/releases/latest" target="_blank" rel="noopener">
           <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5"/><path d="M4 19h16"/></svg>
@@ -90,12 +90,12 @@ SPDX-License-Identifier: AGPL-3.0-only
     </div>
     <div class="guide-body prose reveal" style="margin-top:26px">
       <p>A reference manager and a research workspace answer different questions. Zotero answers <em>what do I have, and how do I cite it</em>. It collects items from the web, holds attachments, syncs across your machines, manages groups and drives citations in your word processor. Nodus does not do any of that better, and it does not try to.</p>
-      <p>What Nodus answers is <em>what does this material say, and how do the pieces relate</em>. It reads the works in your library, records typed ideas with the passage and page that support them, connects those ideas with relations that have a meaning, and gives you a corpus you can search semantically, argue with and write from.</p>
-      <p>The practical consequence is that <b>you keep your Zotero workflow intact</b>. Keep saving with the Zotero Connector, keep organising in collections, keep syncing to zotero.org. Nodus reads what is there — and, being <a href="../open-source/">open source and local-first</a>, it reads it on your own machine.</p>
+      <p>What Nodus answers is <em>what does this material say, and how do the pieces relate to each other</em>. It reads the works in your library, records ideas with the passage and page that support them, connects those ideas with relations that mean something, and gives you a corpus you can search semantically, argue with and write from.</p>
+      <p>In practice this means <b>you keep your Zotero workflow exactly as it is</b>. Keep saving with the Zotero Connector, keep organising in collections, keep syncing to zotero.org. Nodus reads what is already there, and because it is <a href="../open-source/">open source and local-first</a>, it reads it on your own machine.</p>
     </div>
 
     <div class="guide-note reveal">
-      <p><b>The connection is read-only, by design.</b> Nodus talks to Zotero through the local API that the Zotero desktop application exposes, and never writes to it. It does not modify your items, does not create collections in Zotero, and never opens <code>zotero.sqlite</code> directly. Attachments are copied into the Nodus Library; the files in your Zotero storage are only ever read.</p>
+      <p><b>The connection is read-only, by design.</b> Nodus talks to Zotero through the local API that the Zotero desktop application exposes, and never writes to it. It does not modify your items, does not create collections in Zotero, and never opens <code>zotero.sqlite</code> directly. Attachments are copied into the Nodus Library, and the files in your Zotero storage are only ever read.</p>
     </div>
   </div>
 </section>
@@ -114,7 +114,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <em>01</em>
         <div>
           <h3>Have Zotero open</h3>
-          <p>Nodus reads from the local API served by the Zotero desktop application, which means <b>Zotero 7 or newer running on the same machine</b>. There is no API key to paste and no round-trip through zotero.org: the connection is a local one between two applications on your own computer.</p>
+          <p>Nodus reads from the local API served by the Zotero desktop application, which means <b>Zotero 7 or newer running on the same machine</b>. There is no API key to paste and no round trip through zotero.org, because the connection is a local one between two applications on your own computer.</p>
         </div>
       </div>
       <div class="guide-step">
@@ -165,13 +165,13 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="guide-grid reveal">
       <article class="card lit guide-card">
         <h3>Ideas with their evidence</h3>
-        <p>Works are analysed into typed units — claim, finding, construct, method, framework — each keeping the excerpt that supports it and, where the source provides one, the page.</p>
+        <p>Works are analysed into five kinds of unit, a claim, a finding, a construct, a method or a framework. Each one keeps the excerpt that supports it, plus the page when the source provides one.</p>
         <a class="arrow-link" href="../research/#ideas">How ideas and evidence work
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
       </article>
       <article class="card lit guide-card">
         <h3>A graph of your reading</h3>
-        <p>Ideas are joined by relations that mean something — supports, contradicts, refines, extends, applies to — and gather into themes you can browse as an interactive research map.</p>
+        <p>Ideas are joined by relations that mean something, such as supports, contradicts, refines, extends or applies to. They gather into themes you can browse as an interactive research map.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Semantic search over the library</h3>
@@ -185,7 +185,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </article>
       <article class="card lit guide-card">
         <h3>Deep Research reports</h3>
-        <p>A queued job that synthesises the scoped corpus into a long-form report whose citations open the source behind them — an auditable draft rather than a finished text.</p>
+        <p>A queued job that pulls the scoped corpus into a long-form report whose citations open the source behind them. Treat it as a draft you can audit rather than a finished text.</p>
       </article>
       <article class="card lit guide-card">
         <h3>Citations in your own style</h3>
@@ -209,16 +209,16 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="section-head scrim reveal">
       <span class="kicker">04 · The plugin</span>
       <h2 class="title" data-split>Nodus for Zotero, inside Zotero.</h2>
-      <p class="lead">Some work never leaves the reference manager. For that, Nodus ships a separate Zotero plugin — a standalone add-on that runs entirely within Zotero and does not need the Nodus desktop application at all.</p>
+      <p class="lead">Some work never leaves the reference manager. For that, Nodus ships a separate Zotero plugin. It is a standalone add-on that runs entirely inside Zotero and does not need the Nodus desktop application at all.</p>
     </div>
 
     <div class="guide-body prose reveal" style="margin-top:26px">
-      <p>The plugin indexes the <b>PDF, EPUB and HTML attachments</b> in your library and adds a research sidebar that answers questions across them. Answers come back with the exact passages they rest on and the pages those passages sit on, so a reply is something you can check rather than something you have to trust.</p>
-      <p>Retrieval combines keyword and semantic search and works across languages. The embeddings can be produced by a managed local model that runs on your own machine inside the Zotero profile, or by a provider you configure yourself — Anthropic, OpenAI, OpenRouter, Groq, Cerebras, DeepSeek, Google Gemini and others are supported, alongside local <b>Ollama</b> and <b>LM Studio</b> endpoints.</p>
+      <p>The plugin indexes the <b>PDF, EPUB and HTML attachments</b> in your library and adds a research sidebar that answers questions across them. Answers come back with the exact passages they rest on and the pages those passages sit on, so you can check a reply instead of having to take it on trust.</p>
+      <p>Retrieval combines keyword and semantic search and works across languages. The embeddings can be produced by a managed local model that runs on your own machine inside the Zotero profile, or by a provider you configure yourself. Anthropic, OpenAI, OpenRouter, Groq, Cerebras, DeepSeek and Google Gemini are all supported, among others, alongside local <b>Ollama</b> and <b>LM Studio</b> endpoints.</p>
       <h3>Reading what a scan does not say in text</h3>
       <p>Vision-capable models can read document pages as images, transcribing scanned text and describing figures, tables and formulas so that material a plain text layer misses still enters the index.</p>
       <h3>Auditing your own claims</h3>
-      <p>An evidence audit takes claims and checks them against the indexed library, highlighting the ones whose support is thin. It is a prompt to go back to the sources, not a verdict on whether a claim is true.</p>
+      <p>An evidence audit takes claims and checks them against the indexed library, highlighting the ones whose support looks thin. Read it as a nudge to go back to the sources, not as a verdict on whether a claim is true.</p>
       <h3>Installing it</h3>
       <p>Download <code>nodus-zotero.xpi</code> from the <a href="https://github.com/Drakonis96/nodus/releases/latest" target="_blank" rel="noopener">latest Nodus release</a>. In Zotero, open <b>Tools → Add-ons</b>, choose <b>Install Add-on From File</b> and select the downloaded file. The index it builds stays in your Zotero profile.</p>
     </div>
@@ -277,7 +277,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <a class="card lit next-card reveal" href="../research/">
         <span class="pic"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="7" r="2.4"/><circle cx="11" cy="18" r="2.4"/><path d="M8 7l7.6.6M7.2 8.2l3 7.4M16.6 9.2l-4.4 6.6"/></svg></span>
         <h3>Nodus for academic research</h3>
-        <p>The full picture: sources, typed ideas with their evidence, semantic search, research gaps and writing with citations you can open.</p>
+        <p>The whole picture. Sources, ideas with the evidence behind them, semantic search, research gaps and writing with citations you can open.</p>
         <span class="arrow-link">Read the research guide
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>


### PR DESCRIPTION
The website looked good but never said, in words a search engine or a first-time visitor could act on, that Nodus is a research application. This adds four topic pages, rewrites the home page around that idea, and puts the SEO plumbing in place.

## Pages created

| URL | Covers |
| --- | --- |
| `/research/` | The academic vault end to end: sources, ideas with their evidence, semantic search, gaps and debates, writing, what stays local |
| `/zotero/` | A read-only connection to the local Zotero library, and the standalone Nodus plugin that runs inside Zotero |
| `/ai-research/` | What models are actually asked to do over your own corpus, per-task model choice, local models, and the limits |
| `/open-source/` | The AGPL licence, where vaults and indexes are stored, and every outgoing request with what triggers it |

They share one new stylesheet, `assets/css/guide.css`, built on the existing design tokens, so they read as sections of the same site rather than landing pages.

## Home page

The motto keeps the hero. The sentence that names what Nodus is, an open source research workspace for connecting sources, ideas and evidence, heads the opening section instead, followed by a short prose case and four cards into the topic pages. Title, meta description, Open Graph, Twitter card and WebSite plus SoftwareApplication structured data all now describe a research workspace.

## SEO

Every new page has a unique title and description, exactly one h1, an h2/h3 hierarchy, a canonical URL, Open Graph and Twitter metadata, and a BreadcrumbList. Internal linking runs home to all four, and each topic page to the others where the subject genuinely comes up, with descriptive anchor text. The sitemap builder emits the new URLs. `robots.txt` is unchanged and still permissive.

## Content accuracy

Nothing here was written from the marketing copy. Every claim was checked against the code, `PRIVACY.md`, `SOURCE_CODE.md`, `CITATION.cff` and the wiki content file. The load-bearing ones: the Zotero link is read-only through the local API on port 23119 and never opens `zotero.sqlite`; idea and edge types come from `shared/types.ts`; provider lists come from `shared/providers.ts`; update downloads are not automatic, per `electron/main.ts`.

## Copy style

The prose carries no long dashes and no semicolons, and favours short sentences and second person. The two long dashes left in `index.html` are placeholders in the sample gradebook, where the character means no mark.

## Tests

`scripts/test-site-pages.mjs` and `scripts/test-site-shared-header.mjs` now hold the new pages to the same standard as the rest, and add checks for canonical URLs, unique titles and descriptions, valid JSON-LD, absence of noindex, the internal link structure, and the sitemap and robots configuration. 35/35 site tests pass.

## Verified

Crawled the served site, 58 URLs, no broken links, no dead anchors, no duplicate titles or descriptions among distinct pages. Checked in headless Chrome at 1440x900 and 390x844: no console errors, no failed requests, no horizontal overflow, one h1 per page. The opening sequence still plays, the download modal opens and closes, and every home card lands on the right page.

## Worth your attention

- The header nav is unchanged. Adding the topic pages there would be a strong signal but the bar already carries five items, two badges and a CTA before its 1080px breakpoint.
- There is no wide Open Graph image, so `og:image` points at the 512x512 favicon and the Twitter card is `summary` rather than `summary_large_image`. A 1200x630 card would be worth making.
- Pre-existing and out of scope: `/wiki/` and the six `/demo/` pages have no `h1`, since their content is rendered by JavaScript.
- The blog was left untouched, including its `nodus.css` cache-buster.