### PR TITLE
Fix Zotero import dying before it copies any attachment

### DIFF
--- a/electron/library/zoteroLibraryImport.ts
+++ b/electron/library/zoteroLibraryImport.ts
@@ -669,8 +669,15 @@ export async function importZoteroLibraries(options: {
     await new Promise<void>((resolve) => setImmediate(resolve));
     report.partial = report.partial || report.failures.length > 0 || report.librariesMissing.length > 0;
     const failed = report.failures.length > 0 && completedLibraries === 0;
+    // `failed` only means that no library reached the end; it says nothing about why.
+    // Reporting it as "Zotero no está disponible" made every cause look like a closed
+    // Zotero, so a failure with Zotero plainly running sent the reader hunting through
+    // connectivity, paths and permissions instead of reading the actual error. Lead
+    // with the first failure's own message and keep the reassurance after it.
+    const failureDetail = report.failures[0]?.message?.trim();
     emit(progress(requestId, failed ? 'failed' : 'complete', null, processedItems, totalItems, processedAttachments, totalAttachments,
-      failed ? 'Zotero no está disponible; los datos locales se conservan.'
+      failed
+        ? `${failureDetail || 'No se pudo completar la importación de Zotero.'} Los datos locales se conservan.`
         : report.partial ? 'Sincronización parcial completada; revisa el informe.' : 'Importación de Zotero completada.'));
     report.durationMs = Date.now() - started;
     sessions.finish(requestId, failed ? 'failed' : 'completed', report, failed ? report.failures[0]?.message ?? 'Sincronización fallida.' : null);

--- a/electron/zotero/zoteroClient.ts
+++ b/electron/zotero/zoteroClient.ts
@@ -263,6 +263,18 @@ export async function deletedSince(
 ): Promise<ZoteroDeletedObjects> {
   if (since <= 0) return { version: 0, items: [], collections: [] };
   const res = await zfetch(`${BASE}/${libraryPrefix(library)}/deleted?since=${encodeURIComponent(String(since))}`, signal);
+  // The local API does not implement /deleted: it answers 404 "No endpoint found" for
+  // every library, user id and `since` — unlike the Web API this endpoint only exists in.
+  // Read as a missing library that aborted the entire import on the *second* run, once a
+  // version had been recorded and `since` stopped being zero, which is why it stayed
+  // hidden while first syncs were failing for other reasons. A library that really is
+  // gone also fails on the items and collections endpoints, which are checked on their
+  // own, so answering "no tombstones" here cannot disguise one.
+  //
+  // The cost is that deletions made in Zotero are not mirrored: an item removed there
+  // stays in the local catalogue until a full refresh. That is the honest answer while
+  // the runtime cannot report tombstones, and it is preferable to refusing to sync.
+  if (res.status === 404) return { version: since, items: [], collections: [] };
   if (!res.ok) throw endpointError('Elementos eliminados de Zotero', res);
   const data = (await res.json().catch(() => ({}))) as { items?: string[]; collections?: string[] };
   return {

--- a/src/views/GlobalLibraryView.tsx
+++ b/src/views/GlobalLibraryView.tsx
@@ -455,7 +455,19 @@ function ZoteroImportDialog({ onClose, onFinished }: { onClose: () => void; onFi
     }
   };
   const start = () => run(crypto.randomUUID(), { libraryIds: [...selected], copyAttachments, includeUnfiled });
-  const resumable = sessions.find((session) => session.status === 'canceled' || session.status === 'failed');
+  // Only the newest session can be resumed. Searching the whole history instead meant
+  // that one old failure kept the "interrupted sync" banner up forever: a later run
+  // that completed cleanly still found the stale entry and reported itself as
+  // interrupted, which makes a healthy import look broken. A newer run supersedes an
+  // older failure, so the banner follows the latest attempt and nothing else. Picked by
+  // `updatedAt` rather than list order, so it does not depend on how the store sorts.
+  const latestSession = sessions.reduce<ZoteroSyncSession | null>(
+    (newest, session) => (!newest || session.updatedAt > newest.updatedAt ? session : newest),
+    null,
+  );
+  const resumable = latestSession && (latestSession.status === 'canceled' || latestSession.status === 'failed')
+    ? latestSession
+    : null;
 
   return (
     <div className="fixed inset-0 z-[80] grid place-items-center bg-black/65 p-6" onMouseDown={(event) => { if (event.target === event.currentTarget && !requestId) onClose(); }}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,14 @@ const mainExternals = [
   '@github/copilot-sdk',
   'openai',
   'electron-updater',
+  // Turndown picks its HTML parser at module-evaluation time: with no `window` — i.e.
+  // in the main process — it takes the Node branch, which is a bare
+  // `require('@mixmark-io/domino')`. Bundled into an ESM chunk that call throws
+  // "require is not defined in ES module scope" the moment the chunk is imported,
+  // which took down the whole Zotero note-mirroring step. Kept external so it loads
+  // as the real CommonJS package, where the require resolves normally.
+  'turndown',
+  '@mixmark-io/domino',
 ];
 
 /**


### PR DESCRIPTION
Two bugs that stop the Global Library Zotero import, plus the reporting change that made the second one findable.

## Symptom

The import catalogues every document and then stops, copying nothing:

```
2628/2628 documents · 0/— attachments
Partial sync: 2 issue(s); 0 missing source(s); 0 unavailable attachment(s)
Zotero no está disponible; los datos locales se conservan.
```

Deterministic, including via Resume. Zotero is running throughout, and the numbers contradict each other: `0 unavailable` means no attachment was ever *evaluated*.

## Bug 1 — turndown crashes the import before any attachment

Turndown chooses its HTML parser while the module is being evaluated:

```js
var L = typeof window < "u" ? window : {};   // main process → no window
var Q = q() ? L.DOMParser : z();             // so it takes the Node branch…
function z() { var r = require("@mixmark-io/domino"); }   // …a bare require()
```

Bundled into an ESM chunk, that `require` throws `require is not defined in ES module scope` as soon as the chunk loads, so `await import('turndown')` fails.

The import sits between the catalog phase and the attachment loop, and **outside any per-item try** ([`zoteroLibraryImport.ts:529`](https://github.com/Drakonis96/nodus/blob/main/electron/library/zoteroLibraryImport.ts#L529)), so one throw takes down the whole library: notes are never mirrored and no attachment is reached. One throw per library is exactly the "2 issue(s)"; with `completedLibraries === 0` the run is reported as failed.

Only the main process is affected — the renderer has a real `window`, so turndown resolves `DOMParser` there and every other caller keeps working. Hence it looks specific to the Zotero sync.

**Fix:** keep `turndown` and `@mixmark-io/domino` external so they load as the CommonJS packages they are.

## Bug 2 — the deleted-items endpoint aborts every later sync

`deletedSince()` returns early while `since` is zero, so it only runs once a *completed* import has recorded a library version. It therefore stayed hidden while first syncs were failing for the reason above, and appeared the moment they started working.

Zotero's local API does not implement `/deleted`:

```
users/0/deleted?since=40353       404  "No endpoint found"
groups/6613502/deleted?since=307  404
users/0/items?limit=1             200
users/0/collections?limit=1       200
```

That 404 was read as a missing library — fatal and non-retriable — so the second import aborted before reading a single item.

**Fix:** a 404 from this endpoint now means "no tombstones reported" rather than "library gone". A library that really is missing still fails on the items and collections endpoints, which are checked separately, so this cannot disguise one.

**Trade-off, stated plainly:** deletions made in Zotero are no longer mirrored incrementally — an item deleted there stays in the local catalogue until a full refresh. That seems the honest answer while the runtime cannot report tombstones, and better than refusing to sync. Happy to take a different approach if you would rather surface it as a warning.

## Reporting changes

These are why bug 2 was findable at all, and why the first report blamed connectivity for a week.

- **`zoteroLibraryImport.ts`** — `failed` only means that no library reached the end; it says nothing about why. Reporting it as "Zotero no está disponible" made every cause look like a closed Zotero and discarded the real error. Now leads with the first failure's own message — which is precisely how bug 2 identified itself.
- **`GlobalLibraryView.tsx`** — `resumable` searched the entire session history for anything canceled or failed, so one old failure kept the "Sincronización interrumpida — Reanudar" banner up permanently, and a later import that completed cleanly still presented itself as interrupted. Only the newest session is resumable now, picked by `updatedAt` so it does not depend on store ordering.

## Verification

Against a live library of 2678 attachments across a personal and a group library:

| | before | after |
|---|---|---|
| documents | 2628/2628 | 2628/2628 |
| attachments | **0/—** | **2544/2544** |
| issues | 2 | **0** |
| libraries completed | 0 | 2 |

1339 files copied. The 1205 reported unavailable are correct and accounted for: ~1139 `linked_url` bookmarks, which have no file by definition, and 70 `linked_file` entries pointing at a home directory that no longer exists on that machine.

A subsequent incremental run — the one that exposed bug 2 — now reports `Importación de Zotero completada` with zero failures.

On this branch: `npm run typecheck` clean, production build clean with turndown correctly externalised, `npm test` **1935/1935**.


Closes #477
