### PR TITLE
Add a dedicated Nodus desktop app page

### DIFF
--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -10,6 +10,7 @@ const SITE = 'https://nodusresearch.com';
 
 const PAGES = [
   { file: 'index.html', url: '/' },
+  { file: 'app/index.html', url: '/app/' },
   { file: 'research/index.html', url: '/research/' },
   { file: 'zotero/index.html', url: '/zotero/' },
   { file: 'ai-research/index.html', url: '/ai-research/' },

--- a/scripts/test-site-pages.mjs
+++ b/scripts/test-site-pages.mjs
@@ -171,7 +171,7 @@ test('the organism degrades for visitors who cannot or do not want to run it', (
   assert.match(site, /matchMedia\('\(prefers-reduced-motion: reduce\)'\)/, 'reveals and the cursor respect reduced motion');
 
   // every page that paints the organism has to provide its canvas
-  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'wiki/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html', 'open-source/index.html']) {
+  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'wiki/index.html', 'app/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html', 'open-source/index.html']) {
     assert.ok(read(page).includes('<canvas id="organism" aria-hidden="true"></canvas>'), `${page} carries the organism canvas`);
   }
 });
@@ -205,8 +205,9 @@ test('the home page opens with the mark forming, and can never strand a visitor'
   assert.match(script, /addEventListener\('keydown', onKey\)/, 'any key ends it');
 });
 
-// The three long-form topic pages, and the URL each one is published at.
+// The long-form product and topic pages, and the URL each one is published at.
 const TOPIC_PAGES = [
+  ['app/index.html', 'https://nodusresearch.com/app/'],
   ['research/index.html', 'https://nodusresearch.com/research/'],
   ['zotero/index.html', 'https://nodusresearch.com/zotero/'],
   ['ai-research/index.html', 'https://nodusresearch.com/ai-research/'],
@@ -244,13 +245,14 @@ test('the topic pages are indexable, canonical and described only once each', ()
 
 test('the topic pages are linked from the home page and to each other', () => {
   const home = read('index.html');
-  for (const href of ['research/', 'zotero/', 'ai-research/', 'open-source/']) {
+  for (const href of ['app/', 'research/', 'zotero/', 'ai-research/', 'open-source/']) {
     assert.ok(home.includes(`href="${href}"`), `the home page links to /${href}`);
   }
   // descriptive anchors, not "click here" — the anchor text is the link's whole signal
   assert.match(home, /Nodus for academic research/, 'the home page names the research page');
 
   const links = {
+    'app/index.html': ['../research/', '../zotero/', '../ai-research/', '../open-source/', '../faq/', '../wiki/'],
     'research/index.html': ['../zotero/', '../ai-research/', '../open-source/'],
     'zotero/index.html': ['../research/', '../open-source/'],
     'ai-research/index.html': ['../research/', '../zotero/', '../open-source/'],
@@ -269,6 +271,7 @@ test('the sitemap lists every static page of the site', () => {
   const sitemap = read('sitemap.xml');
   for (const url of [
     'https://nodusresearch.com/',
+    'https://nodusresearch.com/app/',
     'https://nodusresearch.com/research/',
     'https://nodusresearch.com/zotero/',
     'https://nodusresearch.com/ai-research/',
@@ -287,8 +290,25 @@ test('the sitemap lists every static page of the site', () => {
   assert.match(robots, /Sitemap: https:\/\/nodusresearch\.com\/sitemap\.xml/);
 });
 
+test('the app page documents the current desktop builds and available vaults', () => {
+  const app = read('app/index.html');
+  for (const asset of [
+    'Nodus-mac-arm64.dmg',
+    'Nodus-win-x64.exe',
+    'Nodus-linux-x86_64.AppImage',
+    'Nodus-linux-amd64.deb',
+  ]) {
+    assert.match(app, new RegExp(`https://github\\.com/Drakonis96/nodus/releases/latest/download/${asset.replaceAll('.', '\\.')}`), `${asset} uses the stable release URL`);
+  }
+  for (const vault of ['Academic', 'Teaching', 'Study', 'Databases', 'Genealogy', 'Worldbuilding', 'Primary Sources', 'Testimony', 'Prosopography']) {
+    assert.match(app, new RegExp(`\\b${vault}\\b`), `${vault} is represented on the app page`);
+  }
+  assert.match(app, /"@type": "SoftwareApplication"/, 'the app page identifies the downloadable software');
+  assert.match(app, /"operatingSystem": "macOS, Windows, Linux"/, 'structured data names every supported platform');
+});
+
 test('every page is reachable by keyboard and readable by a screen reader', () => {
-  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html', 'open-source/index.html']) {
+  for (const page of ['index.html', 'faq/index.html', 'blog/index.html', 'blog/post.html', 'contribute/index.html', 'app/index.html', 'research/index.html', 'zotero/index.html', 'ai-research/index.html', 'open-source/index.html']) {
     const html = read(page);
     assert.match(html, /class="skip-link" href="#/, `${page} offers a skip link`);
     assert.match(html, /<html lang="en">/, `${page} declares its language`);

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -1,0 +1,448 @@
+<!--
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Nodus App | Open Source Research Software</title>
+<meta name="description" content="Download the Nodus app for macOS, Windows or Linux. Learn how this open source desktop research software brings sources, notes, vaults, semantic search and optional AI into one application."/>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1"/>
+<meta property="og:title" content="Nodus App | Open Source Research Software"/>
+<meta property="og:description" content="The desktop application behind Nodus Research: focused vaults for research, teaching, study and structured data, available for macOS, Windows and Linux."/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://nodusresearch.com/app/"/>
+<meta property="og:site_name" content="Nodus"/>
+<meta property="og:locale" content="en_GB"/>
+<meta property="og:image" content="https://nodusresearch.com/favicon.png"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="The Nodus App"/>
+<meta name="twitter:description" content="Open source research software for macOS, Windows and Linux, organised around focused vaults."/>
+<meta name="twitter:image" content="https://nodusresearch.com/favicon.png"/>
+<link rel="canonical" href="https://nodusresearch.com/app/"/>
+<link rel="icon" href="../favicon.ico" sizes="any"/>
+  <link rel="icon" type="image/png" href="../favicon.png" sizes="512x512"/>
+  <link rel="icon" type="image/svg+xml" href="../assets/nodus-logo.svg"/>
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<link rel="stylesheet" href="../assets/css/app.css?v=20260818"/>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Nodus Research", "item": "https://nodusresearch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Nodus App", "item": "https://nodusresearch.com/app/" }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://nodusresearch.com/app/#software",
+      "name": "Nodus",
+      "alternateName": ["Nodus App", "Nodus desktop app", "Nodus research software"],
+      "url": "https://nodusresearch.com/app/",
+      "mainEntityOfPage": "https://nodusresearch.com/app/",
+      "isPartOf": {
+        "@type": "WebSite",
+        "@id": "https://nodusresearch.com/#website",
+        "name": "Nodus Research",
+        "url": "https://nodusresearch.com/"
+      },
+      "applicationCategory": "EducationalApplication",
+      "applicationSubCategory": "Open source research software",
+      "operatingSystem": "macOS, Windows, Linux",
+      "description": "Nodus is an open source desktop application that organises research, teaching, study and structured data into focused vaults.",
+      "license": "https://github.com/Drakonis96/nodus/blob/main/LICENSE",
+      "isAccessibleForFree": true,
+      "downloadUrl": "https://github.com/Drakonis96/nodus/releases/latest",
+      "softwareHelp": "https://nodusresearch.com/wiki/",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "author": { "@type": "Person", "name": "Jorge Pérez Burgueño" }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+<canvas id="organism" aria-hidden="true"></canvas>
+
+<div data-nodus-site-header data-base="../" data-page="app"></div>
+<script src="../site-header.js?v=20260817"></script>
+
+<main id="main">
+
+<header class="page-hero guide-hero" data-accent="#a78bfa" data-second="#22d3ee" data-energy="0.36">
+  <div class="wrap">
+    <div class="scrim" style="max-width:840px">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="../index.html">Nodus Research</a>
+        <span class="sep" aria-hidden="true">/</span>
+        <span aria-current="page">App</span>
+      </nav>
+      <span class="kicker">Desktop application</span>
+      <h1 class="display" data-split>The Nodus App</h1>
+      <p class="lead"><b>An open source research app for scholars, researchers, students and teachers.</b> Nodus brings sources, documents, notes, data and the work you do with them into one desktop application, while giving different kinds of work a structure of their own.</p>
+      <div class="guide-actions">
+        <a class="btn primary" href="#download" data-magnet="0.14">
+          <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5"/><path d="M4 19h16"/></svg>
+          Download Nodus
+        </a>
+        <a class="btn" href="../wiki/">Read the documentation</a>
+      </div>
+      <nav class="guide-jump" aria-label="On this page">
+        <a href="#capabilities"><em>01</em> What you can do</a>
+        <a href="#vaults"><em>02</em> Vaults</a>
+        <a href="#download"><em>03</em> Download</a>
+        <a href="#ecosystem"><em>04</em> Ecosystem</a>
+        <a href="#local-first"><em>05</em> Local-first</a>
+        <a href="#who"><em>06</em> Who it is for</a>
+        <a href="#app-faq"><em>07</em> FAQ</a>
+      </nav>
+    </div>
+  </div>
+</header>
+
+<!-- ============================================================ introduction -->
+<section class="section-line" data-accent="#818cf8" data-second="#a78bfa" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">One application, clearly named</span>
+      <h2 class="title" data-split>Nodus is the app behind Nodus Research.</h2>
+      <p class="lead">The Nodus desktop app solves a practical problem: research material often ends up divided between a reference manager, folders, notes, spreadsheets and a manuscript. The Nodus software is built to give that material one local workspace, then separate the work into vaults so a literature review does not have to behave like a course, a study plan or a database.</p>
+    </div>
+
+    <dl class="app-identity reveal">
+      <div>
+        <dt>Nodus</dt>
+        <dd>The application itself.</dd>
+      </div>
+      <div>
+        <dt>Nodus Research</dt>
+        <dd>The project and this website, where the software, documentation and research guides are published.</dd>
+      </div>
+      <div>
+        <dt>Nodus App</dt>
+        <dd>The downloadable desktop application for macOS, Windows and Linux.</dd>
+      </div>
+      <div>
+        <dt>Open source research software</dt>
+        <dd>The category Nodus belongs to: academic research software whose source is published under AGPL-3.0-only.</dd>
+      </div>
+    </dl>
+  </div>
+</section>
+
+<!-- ============================================================ capabilities -->
+<section id="capabilities" class="section-line" data-accent="#22d3ee" data-second="#a78bfa" data-energy="0.32">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">01 · What you can do</span>
+      <h2 class="title" data-split>Work with material, not just a list of files.</h2>
+      <p class="lead">The Nodus app combines a shared Library with purpose-built workspaces. These are capabilities in the current desktop application; the linked guides explain the research-specific ones in more depth.</p>
+    </div>
+
+    <div class="capability-list reveal">
+      <article>
+        <em>01</em>
+        <div><h3>Organise sources and documents</h3><p>Bring in local files, RIS, BibTeX or CSL JSON, or mirror a Zotero library through a read-only local connection. <a href="../zotero/">How Nodus works with Zotero</a>.</p></div>
+      </article>
+      <article>
+        <em>02</em>
+        <div><h3>Read and annotate</h3><p>Open preserved originals or clean reading copies, highlight text or image regions, and keep notes and document chat attached to the source.</p></div>
+      </article>
+      <article>
+        <em>03</em>
+        <div><h3>Connect notes, ideas and evidence</h3><p>Build source-linked notes, an idea graph and writing projects while keeping interpretations close to the passage and page behind them. <a href="../research/#ideas">Ideas and evidence in the Academic vault</a>.</p></div>
+      </article>
+      <article>
+        <em>04</em>
+        <div><h3>Search your own material</h3><p>Use exact and semantic search across works, passages, ideas and authors, with indexes stored on your computer. <a href="../research/#search">How corpus search works</a>.</p></div>
+      </article>
+      <article>
+        <em>05</em>
+        <div><h3>Use AI with your own sources</h3><p>Choose models for bounded tasks such as extraction, relation finding, document chat and cited synthesis, or use Nodus without AI. <a href="../ai-research/">Read the AI research guide</a>.</p></div>
+      </article>
+      <article>
+        <em>06</em>
+        <div><h3>Manage study workflows</h3><p>Organise courses, subjects, materials, recordings and plans, then build question banks, flashcards, practice tests and spaced review from that work.</p></div>
+      </article>
+      <article>
+        <em>07</em>
+        <div><h3>Manage teaching workflows</h3><p>Plan courses and classes, keep groups and schedules, and work with gradebooks, exams, reusable rubrics and teaching units.</p></div>
+      </article>
+      <article>
+        <em>08</em>
+        <div><h3>Build structured databases</h3><p>Create typed tables with relations, formulas, rollups, filters and reusable views, then search, analyse or question the data.</p></div>
+      </article>
+    </div>
+
+    <div class="guide-note reveal">
+      <p>The complete academic workflow, from assembling a corpus to writing with citations you can open, belongs on the <a href="../research/">Nodus for Academic Research</a> page rather than being repeated here.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ vaults -->
+<section id="vaults" class="section-line" data-accent="#fbbf24" data-second="#a78bfa" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">02 · Vaults</span>
+      <h2 class="title" data-split>Each vault is a workspace with a purpose.</h2>
+      <p class="lead">A vault is not just a folder. Its purpose decides which sections, vocabulary and workflows the application presents, while the underlying engine, settings and Toolkit remain familiar. This keeps one app useful across different kinds of academic work without flattening them into the same template.</p>
+    </div>
+
+    <div class="vault-list reveal">
+      <article>
+        <span class="vault-index">01</span>
+        <div><h3>Academic</h3><p>For a research corpus, connected ideas and evidence, semantic search, literature questions and source-linked writing.</p></div>
+      </article>
+      <article>
+        <span class="vault-index">02</span>
+        <div><h3>Teaching</h3><p>For courses, groups, schedules, materials, assessment, gradebooks, rubrics and unit planning.</p></div>
+      </article>
+      <article>
+        <span class="vault-index">03</span>
+        <div><h3>Study</h3><p>For subjects, notes, recordings, deadlines, revision, practice questions, flashcards and study planning.</p></div>
+      </article>
+      <article>
+        <span class="vault-index">04</span>
+        <div><h3>Databases</h3><p>For structured records that need typed fields, linked tables, reusable views, analysis and data chat.</p></div>
+      </article>
+    </div>
+
+    <div class="guide-note reveal">
+      <p>Five specialised vaults also ship in the application: <b>Genealogy</b>, <b>Worldbuilding</b>, <b>Primary Sources</b>, <b>Testimony</b> and <b>Prosopography</b>. See the <a href="../index.html#vaults">main vaults</a> and <a href="../index.html#more-vaults">specialised vaults</a> on the home page for a brief picture of each.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ download -->
+<section id="download" class="section-line app-download" data-accent="#34d399" data-second="#22d3ee" data-energy="0.38">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">03 · Available platforms</span>
+      <h2 class="title" data-split>Download Nodus for your desktop.</h2>
+      <p class="lead">Nodus is a real desktop application, not a browser account. Choose the current installer for your operating system and open it to begin.</p>
+    </div>
+
+    <div class="platform-grid reveal">
+      <article class="platform-option">
+        <div class="platform-head">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17.05 12.54c-.03-2.68 2.19-3.97 2.29-4.03-1.25-1.82-3.19-2.07-3.87-2.1-1.63-.17-3.2.96-4.03.96-.84 0-2.12-.94-3.49-.91-1.79.03-3.45 1.04-4.37 2.65-1.87 3.24-.48 8.03 1.34 10.66.89 1.29 1.95 2.73 3.34 2.68 1.34-.05 1.85-.87 3.47-.87 1.61 0 2.08.87 3.49.84 1.44-.02 2.36-1.31 3.24-2.6 1.02-1.49 1.44-2.94 1.46-3.01-.03-.02-2.8-1.08-2.87-4.27ZM14.4 4.66c.74-.9 1.24-2.14 1.1-3.39-1.07.04-2.36.71-3.12 1.61-.69.79-1.29 2.06-1.13 3.28 1.19.09 2.41-.6 3.15-1.5Z"/></svg>
+          <div><h3>macOS</h3><p>Apple silicon · DMG</p></div>
+        </div>
+        <a class="btn primary" href="https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-mac-arm64.dmg">Download for macOS</a>
+      </article>
+
+      <article class="platform-option">
+        <div class="platform-head">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5.1 10.6 4v7.6H3V5.1Zm0 13.8 7.6 1.1v-7.5H3v6.4ZM11.4 3.9 21 2.5v9.1h-9.6V3.9Zm0 16.2 9.6 1.4v-9h-9.6v7.6Z"/></svg>
+          <div><h3>Windows</h3><p>Windows 10 or 11 · x64 EXE</p></div>
+        </div>
+        <a class="btn primary" href="https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-win-x64.exe">Download for Windows</a>
+      </article>
+
+      <article class="platform-option">
+        <div class="platform-head">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 1.7c-2 0-3.2 1.6-3.2 3.8 0 .8.1 1.4.1 2 0 .7-.5 1.1-1.1 1.9-.9 1.2-2.3 2.8-2.3 4.6 0 .5.1.9.2 1.3-.6.5-1.3 1.1-1.7 1.9-.4.7-.2 1.3.4 1.5.4.1.9 0 1.4.1.4.1.7.5 1.3.8 1.3.6 3.1.7 4.3.7s3-.1 4.3-.7c.6-.3.9-.7 1.3-.8.5-.1 1 0 1.4-.1.6-.2.8-.8.4-1.5-.4-.8-1.1-1.4-1.7-1.9.1-.4.2-.8.2-1.3 0-1.8-1.4-3.4-2.3-4.6-.6-.8-1.1-1.2-1.1-1.9 0-.6.1-1.2.1-2 0-2.2-1.2-3.8-3.2-3.8Z"/><path d="M9.8 7.1h.01M14.2 7.1h.01M10.4 10c1 .7 2.2.7 3.2 0"/></svg>
+          <div><h3>Linux</h3><p>x86_64 · AppImage or DEB</p></div>
+        </div>
+        <div class="platform-actions">
+          <a class="btn primary" href="https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-linux-x86_64.AppImage">AppImage</a>
+          <a class="btn" href="https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-linux-amd64.deb">Ubuntu / Debian</a>
+        </div>
+      </article>
+    </div>
+
+    <p class="release-route reveal">Release notes, checksums and previous versions are on the <a href="https://github.com/Drakonis96/nodus/releases/latest" target="_blank" rel="noopener">latest Nodus release page</a>.</p>
+  </div>
+</section>
+
+<!-- ============================================================ ecosystem -->
+<section id="ecosystem" class="section-line" data-accent="#f87171" data-second="#a78bfa" data-energy="0.3">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">04 · The Nodus ecosystem</span>
+      <h2 class="title" data-split>The desktop app sits at the centre of a broader workflow.</h2>
+      <p class="lead">These integrations extend Nodus into the places where sources are collected and manuscripts are written. They complement the app rather than turn it into a hosted service.</p>
+    </div>
+
+    <div class="guide-steps reveal">
+      <div class="guide-step">
+        <em>01</em>
+        <div>
+          <h3>Nodus Connector for Chrome</h3>
+          <p>Capture the academic page or document open in Chrome, review detected metadata and files, and save it into the local Nodus Library while the desktop app is running. <a href="https://chromewebstore.google.com/detail/nodus-connector/ilcclajjhofhieoljdjmikmfopfbamej" target="_blank" rel="noopener">Install it from the Chrome Web Store</a>.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>02</em>
+        <div>
+          <h3>Zotero connection and standalone plugin</h3>
+          <p>The app can mirror a Zotero library over Zotero's local API. A separate Nodus plugin runs inside Zotero for semantic search, cited answers and evidence review. <a href="../zotero/">See what each Zotero integration does</a>.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>03</em>
+        <div>
+          <h3>Microsoft Word and LibreOffice Writer</h3>
+          <p>Install the writing companions from Nodus to search the active Library, bring passages and ideas into a manuscript, and manage live citations and bibliographies. <a href="../research/#writing">Read about writing from a corpus</a>.</p>
+        </div>
+      </div>
+      <div class="guide-step">
+        <em>04</em>
+        <div>
+          <h3>MCP-compatible assistants</h3>
+          <p>The built-in MCP server can expose approved read and writing tools for the active vault to a compatible client. It is optional and configured from the desktop app.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ local first -->
+<section id="local-first" class="section-line band" data-accent="#34d399" data-second="#22d3ee" data-energy="0.24">
+  <div class="wrap">
+    <div class="reveal">
+      <span class="kicker" style="justify-content:center">05 · Local-first and user control</span>
+      <h2 class="title" data-split>Your workspace starts on your computer.</h2>
+      <p class="lead">The Nodus desktop app stores its vaults, shared Library and search indexes locally, and it does not require an account. It works without AI. If you enable model-assisted features, you can use compatible local models through Ollama or LM Studio, or configure an external provider for the tasks you choose. The <a href="../open-source/">open source and local-first page</a> explains the licence, storage model and outgoing requests in full.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ who -->
+<section id="who" class="section-line" data-accent="#818cf8" data-second="#fbbf24" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">06 · Who Nodus is for</span>
+      <h2 class="title" data-split>One app for three parts of academic life.</h2>
+    </div>
+
+    <div class="guide-grid audience-grid reveal">
+      <article class="card lit guide-card">
+        <h3>Researchers and scholars</h3>
+        <p>Assemble a corpus, connect interpretations to evidence, search across sources and write with citations that resolve to material in the Library.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Students</h3>
+        <p>Organise subjects and course materials, take source-linked notes, plan study time and turn known material into questions, flashcards and review.</p>
+      </article>
+      <article class="card lit guide-card">
+        <h3>Teachers</h3>
+        <p>Keep course planning, teaching materials, groups, schedules and assessment structures together in a dedicated teaching workspace.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ faq -->
+<section id="app-faq" class="section-line" data-accent="#22d3ee" data-second="#818cf8" data-energy="0.28">
+  <div class="wrap">
+    <div class="section-head scrim reveal">
+      <span class="kicker">07 · Before you download</span>
+      <h2 class="title" data-split>Short answers about the application.</h2>
+    </div>
+
+    <div class="app-faq reveal">
+      <details open>
+        <summary>What is Nodus?</summary>
+        <p>The Nodus research app is a downloadable desktop application for research, teaching, study and structured data. Nodus Research is the project and website around that application.</p>
+      </details>
+      <details>
+        <summary>Is Nodus free?</summary>
+        <p>Yes. Nodus is free and its current source is published under AGPL-3.0-only. Optional external AI providers may charge for their own services.</p>
+      </details>
+      <details>
+        <summary>Which platforms does Nodus support?</summary>
+        <p>The current release provides an Apple-silicon macOS DMG, a Windows 10/11 x64 installer, and Linux x86_64 builds as AppImage and DEB.</p>
+      </details>
+      <details>
+        <summary>Does Nodus require an account?</summary>
+        <p>No. You can install the application and create a local vault without signing up for a Nodus account.</p>
+      </details>
+      <details>
+        <summary>Can Nodus use local AI models?</summary>
+        <p>Yes. Compatible text and embedding models can run through Ollama or LM Studio. AI is optional, and local models still require the appropriate downloads and computer resources.</p>
+      </details>
+    </div>
+
+    <p class="faq-route reveal">For setup details, model guidance and questions about academic use, see the <a href="../faq/">complete Nodus FAQ</a>.</p>
+  </div>
+</section>
+
+<!-- ============================================================ final -->
+<section class="section-line app-final" data-accent="#a78bfa" data-second="#22d3ee" data-energy="0.4">
+  <div class="wrap reveal">
+    <span class="kicker" style="justify-content:center">Start with Nodus</span>
+    <h2 class="title" data-split>Download the research app for your desktop.</h2>
+    <p class="lead">Free and open source, with focused vaults for the work you actually need to do.</p>
+    <div class="guide-actions">
+      <a class="btn primary" href="#download">
+        <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5"/><path d="M4 19h16"/></svg>
+        Download Nodus
+      </a>
+      <a class="btn" href="../wiki/">Open the wiki</a>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<footer class="site-foot">
+  <div class="wrap">
+    <div class="foot-grid wide">
+      <div class="foot-brand">
+        <span class="logo"><img src="../assets/nodus-logo.svg" alt=""/> Nodus</span>
+        <p>An open source desktop research app organised around focused vaults. Available for macOS, Windows and Linux.</p>
+      </div>
+      <div class="foot-col">
+        <h4>App</h4>
+        <a href="./">The Nodus App</a>
+        <a href="#capabilities">What you can do</a>
+        <a href="#vaults">Vaults</a>
+        <a href="#download">Download</a>
+      </div>
+      <div class="foot-col">
+        <h4>Research</h4>
+        <a href="../research/">Academic research</a>
+        <a href="../zotero/">Nodus and Zotero</a>
+        <a href="../ai-research/">AI for research</a>
+        <a href="../open-source/">Open source</a>
+      </div>
+      <div class="foot-col">
+        <h4>Learn</h4>
+        <a href="../wiki/">Wiki</a>
+        <a href="../faq/">FAQ</a>
+        <a href="../index.html">Nodus Research</a>
+      </div>
+      <div class="foot-col">
+        <h4>Project</h4>
+        <a href="https://github.com/Drakonis96/nodus" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/Drakonis96/nodus/releases" target="_blank" rel="noopener">Releases</a>
+        <a href="https://github.com/Drakonis96/nodus/blob/main/LICENSE" target="_blank" rel="noopener">AGPL-3.0-only</a>
+      </div>
+    </div>
+    <div class="foot-base">
+      <span>© 2026 Jorge Pérez Burgueño and Nodus contributors.</span>
+      <a href="https://github.com/Drakonis96/nodus/blob/main/PRIVACY.md" target="_blank" rel="noopener">Privacy</a>
+      <a href="https://github.com/Drakonis96/nodus/blob/main/SECURITY.md" target="_blank" rel="noopener">Security</a>
+    </div>
+  </div>
+</footer>
+
+<script src="../assets/js/organism.js?v=20260815"></script>
+<script src="../assets/js/site.js?v=20260815"></script>
+<script src="../assets/js/back-to-top.js?v=20260817b"></script>
+</body>
+</html>

--- a/site/assets/css/app.css
+++ b/site/assets/css/app.css
@@ -1,0 +1,120 @@
+/*
+SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+SPDX-License-Identifier: AGPL-3.0-only
+
+Small additions for /app/. The page otherwise uses the same guide components as
+the research, Zotero, AI research and open-source pages.
+*/
+
+.guide-hero .lead b { color: var(--ink); font-weight: 650; }
+
+/* The naming block is deliberately plain: it clarifies the relationship between
+   project, site and application without turning it into four marketing cards. */
+.app-identity {
+  max-width: 900px; margin: 40px 0 0;
+  border-top: 1px solid var(--membrane);
+}
+.app-identity > div {
+  display: grid; grid-template-columns: minmax(180px, 0.38fr) minmax(0, 1fr);
+  gap: 28px; padding: 19px 0; border-bottom: 1px solid var(--membrane);
+}
+.app-identity dt { color: var(--ink); font-size: 14px; font-weight: 700; }
+.app-identity dd { margin: 0; color: var(--ink-2); font-size: 14.5px; line-height: 1.62; }
+
+/* Capabilities use an open list rather than a field of cards. */
+.capability-list {
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 34px; margin-top: 42px; border-top: 1px solid var(--membrane);
+}
+.capability-list article {
+  display: grid; grid-template-columns: 34px minmax(0, 1fr);
+  gap: 14px; padding: 23px 0; border-bottom: 1px solid var(--membrane);
+}
+.capability-list em, .vault-index {
+  padding-top: 3px; color: var(--accent); font-family: var(--mono);
+  font-size: 11px; font-style: normal;
+}
+.capability-list h3, .vault-list h3 { margin: 0 0 7px; font-size: 17px; }
+.capability-list p, .vault-list p {
+  margin: 0; color: var(--ink-2); font-size: 14px; line-height: 1.62;
+}
+
+.vault-list {
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px 36px; max-width: 940px; margin-top: 42px;
+}
+.vault-list article {
+  display: grid; grid-template-columns: 44px minmax(0, 1fr);
+  gap: 12px; padding: 22px 0; border-top: 1px solid var(--membrane);
+}
+
+/* Platform choices deserve stronger weight than the surrounding explanations:
+   downloading is the page's main task. */
+.app-download { background: linear-gradient(180deg, transparent, rgba(52, 211, 153, 0.025), transparent); }
+.platform-grid {
+  display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px; margin-top: 42px;
+}
+.platform-option {
+  display: flex; min-width: 0; min-height: 235px; flex-direction: column;
+  justify-content: space-between; gap: 28px; padding: 26px;
+  border: 1px solid var(--membrane); border-radius: var(--r-l);
+  background: var(--skin); box-shadow: var(--shadow);
+}
+.platform-head { display: flex; align-items: center; gap: 16px; }
+.platform-head > svg {
+  width: 38px; height: 38px; flex: 0 0 auto; padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius: 11px; color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent);
+  fill: currentColor; stroke: currentColor; stroke-width: 0.5;
+}
+.platform-head h3 { margin: 0 0 4px; font-size: 18px; }
+.platform-head p { margin: 0; color: var(--ink-3); font-size: 12.5px; line-height: 1.4; }
+.platform-option > .btn { width: 100%; justify-content: center; }
+.platform-actions { display: flex; flex-wrap: wrap; gap: 9px; }
+.platform-actions .btn { flex: 1 1 120px; justify-content: center; padding-inline: 14px; }
+.release-route, .faq-route {
+  max-width: 820px; margin: 28px 0 0; color: var(--ink-3);
+  font-size: 13.5px; line-height: 1.6;
+}
+
+.audience-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+.app-faq { max-width: 860px; margin-top: 40px; border-top: 1px solid var(--membrane); }
+.app-faq details { border-bottom: 1px solid var(--membrane); }
+.app-faq summary {
+  position: relative; padding: 21px 42px 21px 0; color: var(--ink);
+  cursor: pointer; list-style: none; font-size: 16px; font-weight: 650;
+}
+.app-faq summary::-webkit-details-marker { display: none; }
+.app-faq summary::after {
+  content: '+'; position: absolute; top: 18px; right: 8px;
+  color: var(--accent); font-family: var(--mono); font-size: 20px; font-weight: 400;
+}
+.app-faq details[open] summary::after { content: '−'; }
+.app-faq p {
+  max-width: 720px; margin: -4px 0 21px; color: var(--ink-2);
+  font-size: 14.5px; line-height: 1.65;
+}
+
+.app-final { text-align: center; }
+.app-final .title { max-width: 760px; margin-inline: auto; }
+.app-final .lead { max-width: 650px; margin-inline: auto; }
+.app-final .guide-actions { justify-content: center; }
+
+@media (max-width: 900px) {
+  .platform-grid { grid-template-columns: 1fr; }
+  .platform-option { min-height: 0; }
+  .audience-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 720px) {
+  .app-identity > div { grid-template-columns: 1fr; gap: 7px; }
+  .capability-list, .vault-list { grid-template-columns: 1fr; }
+  .capability-list { gap: 0; }
+  .platform-option { padding: 22px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-faq summary { scroll-behavior: auto; }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -124,7 +124,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </button>
     </div>
     <p class="meta"><b>Completely free and open source.</b> No accounts, no subscriptions, no telemetry, and your corpus never leaves your machine.</p>
-    <p class="hero-links">Read on: <a href="research/">Nodus for academic research</a> · <a href="zotero/">the Zotero integration</a> · <a href="ai-research/">AI for academic research</a> · <a href="open-source/">open source and local-first</a></p>
+    <p class="hero-links">Read on: <a href="app/">the Nodus app</a> · <a href="research/">Nodus for academic research</a> · <a href="zotero/">the Zotero integration</a> · <a href="ai-research/">AI for academic research</a> · <a href="open-source/">open source and local-first</a></p>
   </div>
   <div class="scroll-cue" aria-hidden="true"><span class="rail"></span>Scroll</div>
 </header>
@@ -583,6 +583,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </div>
       <div class="foot-col">
         <h4>Research</h4>
+        <a href="app/">The Nodus App</a>
         <a href="research/">Academic research</a>
         <a href="zotero/">Nodus and Zotero</a>
         <a href="ai-research/">AI for research</a>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -5,6 +5,9 @@
     <lastmod>2026-08-16</lastmod>
   </url>
   <url>
+    <loc>https://nodusresearch.com/app/</loc>
+  </url>
+  <url>
     <loc>https://nodusresearch.com/research/</loc>
     <lastmod>2026-08-16</lastmod>
   </url>
@@ -18,6 +21,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/open-source/</loc>
+    <lastmod>2026-08-16</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/demo/</loc>


### PR DESCRIPTION
## Summary

- add a dedicated `/app/` page explaining what the Nodus desktop application is
- document current capabilities, vaults, supported platforms, downloads, and integrations
- add canonical, Open Graph, and SoftwareApplication structured metadata
- link the page from the homepage and include it in the sitemap
- extend website tests to cover the new page, downloads, vaults, and metadata

## Verification

- `npm test` (1,936 tests passed)
- `npm run build`
- desktop and mobile browser checks at 1440px and 390px
- internal-link and installer URL validation