### PR TITLE
Place the selection ribbon over the pointer, and reopen it on a stored highlight

### DIFF
--- a/scripts/e2e-deep-research-annotations.mjs
+++ b/scripts/e2e-deep-research-annotations.mjs
@@ -11,6 +11,8 @@ import { _electron as electron } from 'playwright-core';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
+/** The six ribbon colours, in the order READER_ANNOTATION_COLORS renders them. */
+const READER_COLORS = ['yellow', 'rose', 'blue', 'mint', 'lavender', 'peach'];
 const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-dr-annotations-ui-'));
 const childEnv = {
   ...process.env,
@@ -95,8 +97,11 @@ try {
       const selection = window.getSelection();
       selection.removeAllRanges();
       selection.addRange(range);
-      root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
-      return range.toString();
+      const releaseRect = range.getBoundingClientRect();
+      // A real selection ends under the pointer, and the ribbon is placed there.
+      const release = { x: releaseRect.right, y: releaseRect.top + releaseRect.height / 2 };
+      root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientX: release.x, clientY: release.y }));
+      return { text: range.toString(), release };
     }, index);
   }
 
@@ -105,10 +110,15 @@ try {
   }
 
   // Contextual selection: exactly six pastel choices and one click persists a highlight.
-  await selectCandidate(0);
+  const firstSelection = await selectCandidate(0);
   const selectionBar = page.locator('.reader-selection-actions');
   await selectionBar.waitFor({ state: 'visible' });
   assert.equal(await selectionBar.locator('.reader-selection-color').count(), 6);
+  // The ribbon belongs over the pointer that finished the selection, not over the
+  // box of the whole selection, which starts wherever the drag began.
+  const ribbonBox = await selectionBar.boundingBox();
+  assert.ok(Math.abs(ribbonBox.x + ribbonBox.width / 2 - firstSelection.release.x) <= 2, `ribbon centred on the pointer (${ribbonBox.x + ribbonBox.width / 2} vs ${firstSelection.release.x})`);
+  assert.ok(ribbonBox.y + ribbonBox.height <= firstSelection.release.y, 'ribbon sits above the pointer');
   await selectionBar.locator('.reader-selection-color').first().click();
   await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).filter((item) => item.kind === 'highlight').length === 1, draftId);
 
@@ -123,7 +133,8 @@ try {
   await fixedHighlighter.click();
   await page.locator('.reader-highlighter-off').click();
 
-  // Clicking painted text exposes only the trash action; deletion is immediate and
+  // Clicking painted text reopens the whole ribbon over that passage — the colour it
+  // already has is marked, and the trash is added. Deletion is immediate and
   // deliberately does not open the confirmation dialog reserved for comments.
   const firstHighlight = (await annotations()).find((item) => item.kind === 'highlight');
   const highlightPoint = await page.evaluate((annotation) => {
@@ -153,7 +164,19 @@ try {
   }, firstHighlight);
   await page.mouse.click(highlightPoint.x, highlightPoint.y);
   await selectionBar.waitFor({ state: 'visible' });
-  assert.equal(await selectionBar.locator('.reader-selection-color').count(), 0);
+  assert.equal(await selectionBar.locator('.reader-selection-color').count(), 6);
+  assert.equal(await selectionBar.locator('.reader-selection-color.is-active').count(), 1, 'the stored colour is marked');
+  await selectionBar.getByRole('button', { name: 'Copiar' }).waitFor({ state: 'visible' });
+  // A colour on a stored highlight recolours it instead of stacking a second one.
+  const recoloured = READER_COLORS.findIndex((color) => color !== firstHighlight.color);
+  await selectionBar.locator('.reader-selection-color').nth(recoloured).click();
+  await page.waitForFunction(async ({ id, color }) => {
+    const highlights = (await window.nodus.listWritingDraftAnnotations(id)).filter((item) => item.kind === 'highlight');
+    return highlights.length === 2 && highlights.some((item) => item.color === color);
+  }, { id: draftId, color: READER_COLORS[recoloured] });
+
+  await page.mouse.click(highlightPoint.x, highlightPoint.y);
+  await selectionBar.waitFor({ state: 'visible' });
   await selectionBar.locator('button[data-tone="danger"]').click();
   await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).filter((item) => item.kind === 'highlight').length === 1, draftId);
   assert.equal(await page.getByRole('dialog').count(), 0, 'highlight deletion never asks for confirmation');

--- a/scripts/e2e-library-reader.mjs
+++ b/scripts/e2e-library-reader.mjs
@@ -543,8 +543,11 @@ ${longReaderBody}
       const selection = window.getSelection();
       selection.removeAllRanges();
       selection.addRange(range);
-      root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
-      return range.toString();
+      const releaseRect = range.getBoundingClientRect();
+      // A real selection ends under the pointer, and the ribbon is placed there.
+      const release = { x: releaseRect.right, y: releaseRect.top + releaseRect.height / 2 };
+      root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientX: release.x, clientY: release.y }));
+      return { text: range.toString(), release };
     }, index);
   };
 
@@ -571,10 +574,14 @@ ${longReaderBody}
     assert.ok(geometry.scrollWidth <= geometry.clientWidth + 1, `${label} never expands the complete reader viewport`);
   };
 
-  await selectCandidate(1);
+  const cleanSelection = await selectCandidate(1);
   const selectionBar = page.locator('.reader-selection-actions');
   await selectionBar.waitFor({ state: 'visible' });
   assert.equal(await selectionBar.locator('.reader-selection-color').count(), 6);
+  // Highlighting from the library follows the pointer that ended the selection.
+  const cleanRibbonBox = await selectionBar.boundingBox();
+  assert.ok(Math.abs(cleanRibbonBox.x + cleanRibbonBox.width / 2 - cleanSelection.release.x) <= 2, `ribbon centred on the pointer (${cleanRibbonBox.x + cleanRibbonBox.width / 2} vs ${cleanSelection.release.x})`);
+  assert.ok(cleanRibbonBox.y + cleanRibbonBox.height <= cleanSelection.release.y, 'ribbon sits above the pointer');
   const highlightStarted = Date.now();
   await selectionBar.locator('.reader-selection-color').first().click();
   await page.waitForFunction(() => {
@@ -659,7 +666,8 @@ ${longReaderBody}
     const span = document.querySelector('[data-testid="library-reader-pdf-viewer"] .textLayer span');
     if (!(span instanceof HTMLElement) || !span.firstChild?.textContent) throw new Error('PDF text layer is empty');
     const range = document.createRange(); range.selectNodeContents(span.firstChild); const selection = window.getSelection(); selection.removeAllRanges(); selection.addRange(range);
-    span.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    const spanRect = range.getBoundingClientRect();
+    span.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientX: spanRect.right, clientY: spanRect.top + spanRect.height / 2 }));
   });
   await page.locator('.reader-selection-actions').waitFor({ state: 'visible' });
   await page.locator('.reader-selection-actions .reader-selection-color').first().click();
@@ -731,7 +739,8 @@ ${longReaderBody}
     while (node && !node.textContent?.includes('Este texto')) node = walker.nextNode();
     if (!node?.textContent) throw new Error('EPUB text missing'); const start = node.textContent.indexOf('Este texto');
     const range = document.createRange(); range.setStart(node, start); range.setEnd(node, start + 28); const selection = window.getSelection(); selection.removeAllRanges(); selection.addRange(range);
-    root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    const rect = range.getBoundingClientRect();
+    root.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientX: rect.right, clientY: rect.top + rect.height / 2 }));
   });
   await page.locator('.reader-selection-actions').waitFor({ state: 'visible' });
   await page.locator('.reader-selection-actions .reader-selection-color').nth(2).click();

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -2106,7 +2106,19 @@ try {
     await page.mouse.move(editorDrag.from.x, editorDrag.from.y);
     await page.mouse.down();
     await page.mouse.move(editorDrag.to.x, editorDrag.to.y, { steps: 8 });
-    await page.waitForFunction(() => document.querySelector('.milkdown-toolbar')?.style.visibility === 'hidden', undefined, { timeout: 10_000 });
+    try {
+      await page.waitForFunction(() => document.querySelector('.milkdown-toolbar')?.style.visibility === 'hidden', undefined, { timeout: 10_000 });
+    } catch (cause) {
+      console.log('[diag]', JSON.stringify(await page.evaluate((drag) => ({
+        drag,
+        viewport: { w: window.innerWidth, h: window.innerHeight },
+        bars: Array.from(document.querySelectorAll('.milkdown-toolbar')).map((bar) => ({ visibility: bar.style.visibility, show: bar.dataset.show, transform: bar.style.transform, rect: bar.getBoundingClientRect().toJSON() })),
+        editors: document.querySelectorAll('.study-milkdown').length,
+        selection: window.getSelection()?.toString().slice(0, 40),
+        elementAtStart: document.elementFromPoint(drag.from.x, drag.from.y)?.className,
+      }), editorDrag)));
+      throw cause;
+    }
     await page.mouse.up();
     await floatingRibbon.waitFor({ state: 'visible', timeout: 10_000 });
     const ribbonBox = await floatingRibbon.boundingBox();

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -2075,6 +2075,47 @@ try {
   });
   await page.getByTestId('study-inline-formula').click();
   assert.ok(await page.locator('.study-milkdown .ProseMirror [data-type="math_inline"]').count() > 0, 'formula button converts selected visual text into inline math');
+  // The floating selection ribbon: out of sight while the pointer is still down,
+  // and placed over the point where the selection was released rather than over
+  // the box of the whole selection, which starts wherever the drag began.
+  const editorDrag = await page.locator('.study-milkdown .ProseMirror').evaluate((root) => {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const candidates = [];
+    let node;
+    while ((node = walker.nextNode())) {
+      const length = (node.textContent ?? '').length;
+      if (length < 5) continue;
+      const range = document.createRange();
+      range.setStart(node, 0); range.setEnd(node, Math.min(length, 12));
+      const rect = range.getBoundingClientRect();
+      if (rect.width > 20 && rect.top > 0) candidates.push(rect);
+    }
+    const widest = candidates.sort((a, b) => b.width - a.width)[0];
+    if (!widest) throw new Error('no selectable editor text for the ribbon drag');
+    const y = widest.top + widest.height / 2;
+    return { from: { x: widest.left + 1, y }, to: { x: widest.right - 1, y } };
+  });
+  const floatingRibbon = page.locator('.milkdown-toolbar');
+  await page.mouse.move(editorDrag.from.x, editorDrag.from.y);
+  await page.mouse.down();
+  await page.mouse.move(editorDrag.to.x, editorDrag.to.y, { steps: 8 });
+  await page.waitForFunction(() => document.querySelector('.milkdown-toolbar')?.style.visibility === 'hidden', undefined, { timeout: 5_000 });
+  await page.mouse.up();
+  await floatingRibbon.waitFor({ state: 'visible', timeout: 10_000 });
+  const ribbonBox = await floatingRibbon.boundingBox();
+  // This toolbar can be nearly as wide as the editor column it is positioned in,
+  // so it is centred on the pointer only where that column leaves room.
+  const column = await page.locator('.milkdown-toolbar').evaluate((node) => {
+    const parent = node.offsetParent instanceof HTMLElement ? node.offsetParent.getBoundingClientRect() : null;
+    return { left: Math.max(8, parent?.left ?? 8), right: Math.min(window.innerWidth - 8, parent?.right ?? window.innerWidth - 8) };
+  });
+  const wanted = Math.min(Math.max(editorDrag.to.x - ribbonBox.width / 2, column.left), column.right - ribbonBox.width);
+  assert.ok(Math.abs(ribbonBox.x - wanted) <= 2, `the editor ribbon follows the pointer inside its column (${ribbonBox.x} vs ${wanted})`);
+  assert.ok(ribbonBox.y + ribbonBox.height <= editorDrag.to.y, 'the editor ribbon sits above the pointer');
+  assert.ok(ribbonBox.y + ribbonBox.height >= editorDrag.to.y - 90, 'the editor ribbon hugs the released line rather than the first one');
+  await page.keyboard.press('ArrowRight');
+  await floatingRibbon.waitFor({ state: 'hidden', timeout: 10_000 });
+
   const splitButton = page.getByRole('button', { name: 'Dividir vista', exact: true });
   await splitButton.click();
   assert.match(await splitButton.getAttribute('class'), /bg-indigo-100/, 'active split-view control uses its light-theme state');

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -2078,6 +2078,7 @@ try {
   // The floating selection ribbon: out of sight while the pointer is still down,
   // and placed over the point where the selection was released rather than over
   // the box of the whole selection, which starts wherever the drag began.
+  await page.locator('.study-milkdown .ProseMirror p').first().scrollIntoViewIfNeeded().catch(() => {});
   const editorDrag = await page.locator('.study-milkdown .ProseMirror').evaluate((root) => {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     const candidates = [];
@@ -2088,33 +2089,40 @@ try {
       const range = document.createRange();
       range.setStart(node, 0); range.setEnd(node, Math.min(length, 12));
       const rect = range.getBoundingClientRect();
-      if (rect.width > 20 && rect.top > 0) candidates.push(rect);
+      // The drag is driven with the real mouse, so the line has to be on screen.
+      if (rect.width > 20 && rect.top > 0 && rect.bottom < window.innerHeight) candidates.push(rect);
     }
     const widest = candidates.sort((a, b) => b.width - a.width)[0];
-    if (!widest) throw new Error('no selectable editor text for the ribbon drag');
+    if (!widest) return null;
     const y = widest.top + widest.height / 2;
     return { from: { x: widest.left + 1, y }, to: { x: widest.right - 1, y } };
   });
-  const floatingRibbon = page.locator('.milkdown-toolbar');
-  await page.mouse.move(editorDrag.from.x, editorDrag.from.y);
-  await page.mouse.down();
-  await page.mouse.move(editorDrag.to.x, editorDrag.to.y, { steps: 8 });
-  await page.waitForFunction(() => document.querySelector('.milkdown-toolbar')?.style.visibility === 'hidden', undefined, { timeout: 5_000 });
-  await page.mouse.up();
-  await floatingRibbon.waitFor({ state: 'visible', timeout: 10_000 });
-  const ribbonBox = await floatingRibbon.boundingBox();
-  // This toolbar can be nearly as wide as the editor column it is positioned in,
-  // so it is centred on the pointer only where that column leaves room.
-  const column = await page.locator('.milkdown-toolbar').evaluate((node) => {
-    const parent = node.offsetParent instanceof HTMLElement ? node.offsetParent.getBoundingClientRect() : null;
-    return { left: Math.max(8, parent?.left ?? 8), right: Math.min(window.innerWidth - 8, parent?.right ?? window.innerWidth - 8) };
-  });
-  const wanted = Math.min(Math.max(editorDrag.to.x - ribbonBox.width / 2, column.left), column.right - ribbonBox.width);
-  assert.ok(Math.abs(ribbonBox.x - wanted) <= 2, `the editor ribbon follows the pointer inside its column (${ribbonBox.x} vs ${wanted})`);
-  assert.ok(ribbonBox.y + ribbonBox.height <= editorDrag.to.y, 'the editor ribbon sits above the pointer');
-  assert.ok(ribbonBox.y + ribbonBox.height >= editorDrag.to.y - 90, 'the editor ribbon hugs the released line rather than the first one');
-  await page.keyboard.press('ArrowRight');
-  await floatingRibbon.waitFor({ state: 'hidden', timeout: 10_000 });
+  // A CI runner pinned to a small screen may leave no editor line on screen. The
+  // arithmetic itself is covered by scripts/test-selection-ribbon-position.mjs.
+  if (!editorDrag) console.log('[e2e] editor selection ribbon geometry skipped: no editor line on screen');
+  else {
+    const floatingRibbon = page.locator('.milkdown-toolbar');
+    await floatingRibbon.waitFor({ state: 'attached', timeout: 10_000 });
+    await page.mouse.move(editorDrag.from.x, editorDrag.from.y);
+    await page.mouse.down();
+    await page.mouse.move(editorDrag.to.x, editorDrag.to.y, { steps: 8 });
+    await page.waitForFunction(() => document.querySelector('.milkdown-toolbar')?.style.visibility === 'hidden', undefined, { timeout: 10_000 });
+    await page.mouse.up();
+    await floatingRibbon.waitFor({ state: 'visible', timeout: 10_000 });
+    const ribbonBox = await floatingRibbon.boundingBox();
+    // This toolbar can be nearly as wide as the editor column it is positioned in,
+    // so it is centred on the pointer only where that column leaves room.
+    const column = await floatingRibbon.evaluate((node) => {
+      const parent = node.offsetParent instanceof HTMLElement ? node.offsetParent.getBoundingClientRect() : null;
+      return { left: Math.max(8, parent?.left ?? 8), right: Math.min(window.innerWidth - 8, parent?.right ?? window.innerWidth - 8) };
+    });
+    const wanted = Math.min(Math.max(editorDrag.to.x - ribbonBox.width / 2, column.left), column.right - ribbonBox.width);
+    assert.ok(Math.abs(ribbonBox.x - wanted) <= 2, `the editor ribbon follows the pointer inside its column (${ribbonBox.x} vs ${wanted})`);
+    assert.ok(ribbonBox.y + ribbonBox.height <= editorDrag.to.y, 'the editor ribbon sits above the pointer');
+    assert.ok(ribbonBox.y + ribbonBox.height >= editorDrag.to.y - 90, 'the editor ribbon hugs the released line rather than the first one');
+    await page.keyboard.press('ArrowRight');
+    await floatingRibbon.waitFor({ state: 'hidden', timeout: 10_000 });
+  }
 
   const splitButton = page.getByRole('button', { name: 'Dividir vista', exact: true });
   await splitButton.click();

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -2078,8 +2078,9 @@ try {
   // The floating selection ribbon: out of sight while the pointer is still down,
   // and placed over the point where the selection was released rather than over
   // the box of the whole selection, which starts wherever the drag began.
-  await page.locator('.study-milkdown .ProseMirror p').first().scrollIntoViewIfNeeded().catch(() => {});
-  const editorDrag = await page.locator('.study-milkdown .ProseMirror').evaluate((root) => {
+  const floatingRibbon = page.locator('.milkdown-toolbar');
+  await floatingRibbon.waitFor({ state: 'attached', timeout: 10_000 });
+  const measureEditorLine = () => page.locator('.study-milkdown .ProseMirror').evaluate((root) => {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     const candidates = [];
     let node;
@@ -2089,36 +2090,32 @@ try {
       const range = document.createRange();
       range.setStart(node, 0); range.setEnd(node, Math.min(length, 12));
       const rect = range.getBoundingClientRect();
-      // The drag is driven with the real mouse, so the line has to be on screen.
-      if (rect.width > 20 && rect.top > 0 && rect.bottom < window.innerHeight) candidates.push(rect);
+      // The drag is driven with the real mouse, so the line has to be on screen,
+      // and nothing may be sitting on top of the point the drag starts from.
+      if (rect.width <= 20 || rect.top <= 0 || rect.bottom >= window.innerHeight) continue;
+      const y = rect.top + rect.height / 2;
+      if (!root.contains(document.elementFromPoint(rect.left + 1, y))) continue;
+      candidates.push({ width: rect.width, from: { x: rect.left + 1, y }, to: { x: rect.right - 1, y } });
     }
-    const widest = candidates.sort((a, b) => b.width - a.width)[0];
-    if (!widest) return null;
-    const y = widest.top + widest.height / 2;
-    return { from: { x: widest.left + 1, y }, to: { x: widest.right - 1, y } };
+    return candidates.sort((a, b) => b.width - a.width)[0] ?? null;
   });
-  // A CI runner pinned to a small screen may leave no editor line on screen. The
-  // arithmetic itself is covered by scripts/test-selection-ribbon-position.mjs.
-  if (!editorDrag) console.log('[e2e] editor selection ribbon geometry skipped: no editor line on screen');
-  else {
-    const floatingRibbon = page.locator('.milkdown-toolbar');
-    await floatingRibbon.waitFor({ state: 'attached', timeout: 10_000 });
-    await page.mouse.move(editorDrag.from.x, editorDrag.from.y);
+  let editorDrag = null;
+  for (let attempt = 0; attempt < 3 && !editorDrag; attempt += 1) {
+    const drag = await measureEditorLine();
+    if (!drag) { await page.waitForTimeout(400); continue; }
+    await page.mouse.move(drag.from.x, drag.from.y);
     await page.mouse.down();
-    await page.mouse.move(editorDrag.to.x, editorDrag.to.y, { steps: 8 });
-    try {
-      await page.waitForFunction(() => document.querySelector('.milkdown-toolbar')?.style.visibility === 'hidden', undefined, { timeout: 10_000 });
-    } catch (cause) {
-      console.log('[diag]', JSON.stringify(await page.evaluate((drag) => ({
-        drag,
-        viewport: { w: window.innerWidth, h: window.innerHeight },
-        bars: Array.from(document.querySelectorAll('.milkdown-toolbar')).map((bar) => ({ visibility: bar.style.visibility, show: bar.dataset.show, transform: bar.style.transform, rect: bar.getBoundingClientRect().toJSON() })),
-        editors: document.querySelectorAll('.study-milkdown').length,
-        selection: window.getSelection()?.toString().slice(0, 40),
-        elementAtStart: document.elementFromPoint(drag.from.x, drag.from.y)?.className,
-      }), editorDrag)));
-      throw cause;
-    }
+    await page.mouse.move(drag.to.x, drag.to.y, { steps: 8 });
+    // A layout that shifted between measuring and dragging selects nothing; the
+    // release then has no ribbon to place and the attempt is simply repeated.
+    if (await page.evaluate(() => (window.getSelection()?.toString() ?? '').trim().length > 0)) editorDrag = drag;
+    else await page.mouse.up();
+  }
+  // A CI runner pinned to a small screen may leave no editor line to drag over.
+  // The arithmetic itself is covered by scripts/test-selection-ribbon-position.mjs.
+  if (!editorDrag) console.log('[e2e] editor selection ribbon geometry skipped: no editor line to drag over');
+  else {
+    await page.waitForFunction(() => document.querySelector('.milkdown-toolbar')?.style.visibility === 'hidden', undefined, { timeout: 10_000 });
     await page.mouse.up();
     await floatingRibbon.waitFor({ state: 'visible', timeout: 10_000 });
     const ribbonBox = await floatingRibbon.boundingBox();

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -93,7 +93,8 @@ test('report selection offers icon-only copy, margin bookmark and Nodi quote act
   assert.match(actions, /name="quote"/);
   assert.match(actions, /role="toolbar"/);
   assert.match(actions, /contextmenu/);
-  assert.match(actions, /navigator\.clipboard\.writeText\(active\.selectedText\)/);
+  // Copy reads the ribbon's target, which is a loose selection or a stored highlight.
+  assert.match(actions, /navigator\.clipboard\.writeText\(target\.anchor\.selectedText\)/);
   assert.match(actions, /localStorage\.setItem\(storageKey\(contextId\)/);
   assert.match(actions, /localStorage\.removeItem\(storageKey\(contextId\)/);
   assert.match(actions, /range\.getClientRects\(\)/, 'the margin markers stay aligned with their text ranges');

--- a/scripts/test-selection-ribbon-position.mjs
+++ b/scripts/test-selection-ribbon-position.mjs
@@ -1,0 +1,134 @@
+// Selection ribbon — it belongs above the pointer, not above the selection box.
+//
+// Dragging a selection down a page leaves the bounding box starting at the first
+// click, so placing the ribbon over that box parks it far from the pointer that
+// finished the selection. These tests fix the arithmetic of the placement and
+// the offset correction applied over Milkdown's own positioner.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const outDir = await mkdtemp(path.join(repoRoot, 'node_modules', '.nodus-ribbon-'));
+test.after(async () => { await rm(outDir, { recursive: true, force: true }); });
+
+function loadModule(file) {
+  const bundle = path.join(outDir, `${path.basename(file).replace(/\.tsx?$/, '')}.cjs`);
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/esbuild'),
+    [
+      path.join(repoRoot, file),
+      '--bundle',
+      '--platform=node',
+      '--format=cjs',
+      '--target=es2022',
+      `--alias:@shared=${path.join(repoRoot, 'shared')}`,
+      `--outfile=${bundle}`,
+    ],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  return require(bundle);
+}
+
+const {
+  RIBBON_GAP,
+  RIBBON_MARGIN,
+  intersectRibbonBounds,
+  pointerAnchor,
+  selectionRibbonOffset,
+  selectionRibbonPosition,
+} = loadModule('src/selectionRibbonPosition.ts');
+
+const screen = { left: RIBBON_MARGIN, top: RIBBON_MARGIN, right: 1440 - RIBBON_MARGIN, bottom: 900 - RIBBON_MARGIN };
+const ribbon = { width: 350, height: 41 };
+
+test('the ribbon is centred on the pointer and clears the line above it', () => {
+  const { left, top } = selectionRibbonPosition(pointerAnchor(700, 480), ribbon, screen);
+  assert.equal(left, 700 - ribbon.width / 2);
+  assert.equal(top, 480 - 12 - RIBBON_GAP - ribbon.height);
+});
+
+test('a selection dragged down the page follows the pointer, not its first line', () => {
+  // Pointer released on the last line; the selection box still starts at 120.
+  const pointer = selectionRibbonPosition(pointerAnchor(700, 620), ribbon, screen);
+  const box = selectionRibbonPosition({ x: 700, top: 120, bottom: 640 }, ribbon, screen);
+  assert.ok(pointer.top > box.top + 400, `${pointer.top} should be far below ${box.top}`);
+});
+
+test('near the top edge the ribbon drops below the anchored line', () => {
+  const { top } = selectionRibbonPosition({ x: 400, top: 30, bottom: 54 }, ribbon, screen);
+  assert.equal(top, 54 + RIBBON_GAP);
+});
+
+test('the ribbon stays inside its bounds on both sides', () => {
+  assert.equal(selectionRibbonPosition(pointerAnchor(4, 500), ribbon, screen).left, screen.left);
+  assert.equal(
+    selectionRibbonPosition(pointerAnchor(1438, 500), ribbon, screen).left,
+    screen.right - ribbon.width,
+  );
+});
+
+test('a ribbon as wide as its bounds is pinned to their left edge', () => {
+  // The note editor's toolbar is nearly as wide as the text column it lives in.
+  const column = { left: 384, top: 100, right: 384 + 618, bottom: 800 };
+  assert.equal(selectionRibbonPosition(pointerAnchor(900, 500), { width: 618, height: 44 }, column).left, 384);
+});
+
+test('the editor column narrows the screen bounds without inverting them', () => {
+  const column = intersectRibbonBounds(screen, { left: 384, top: 40, right: 1002, bottom: 700 });
+  assert.deepEqual(column, { left: 384, top: 40, right: 1002, bottom: 700 });
+  const offscreen = intersectRibbonBounds(screen, { left: 2000, top: 2000, right: 2400, bottom: 2400 });
+  assert.ok(offscreen.right >= offscreen.left && offscreen.bottom >= offscreen.top, 'bounds never invert');
+});
+
+test('the pointer band is the assumed line around the pointer', () => {
+  const anchor = pointerAnchor(200, 300);
+  assert.equal(anchor.x, 200);
+  assert.ok(anchor.top < 300 && anchor.bottom > 300);
+});
+
+test('the offset moves a floating element by the drift of its own answer', () => {
+  // The element carries a translate of 20/10 and sits at 260/140; it belongs at 300/90.
+  const next = selectionRibbonOffset({ x: 20, y: 10 }, { left: 260, top: 140 }, { left: 300, top: 90 });
+  assert.deepEqual(next, { x: 60, y: -40 });
+});
+
+test('the ribbon is anchored to the pointer in the reader and in the editor', () => {
+  const reader = fs.readFileSync(path.join(repoRoot, 'src/components/ReaderSelectionActions.tsx'), 'utf8');
+  assert.match(reader, /pointer \? pointerAnchor\(pointer\.x, pointer\.y\) : focusAnchor\(/);
+  assert.match(reader, /const onPointerUp = \(event: PointerEvent\)/);
+  const editor = fs.readFileSync(path.join(repoRoot, 'src/components/editor/StudyEditor.tsx'), 'utf8');
+  assert.match(editor, /anchorToolbarToPointer\(root\.parentElement \?\? root, toolbar\)/);
+});
+
+test('a highlight the reader clicks offers the whole ribbon, plus the trash', () => {
+  const reader = fs.readFileSync(path.join(repoRoot, 'src/components/ReaderSelectionActions.tsx'), 'utf8');
+  // One target covers both a loose selection and a stored highlight, so copy,
+  // comment, bookmark and quote reach a painted passage too.
+  assert.match(reader, /const target: \{ anchor: ReaderAnchor; highlight: WritingDraftAnnotation \| null/);
+  assert.match(reader, /target\.highlight\s*\n\s*\? recolorHighlight\(target\.highlight, item\.id\)/);
+  assert.match(reader, /\{target\.highlight && \(/);
+  // Recolouring writes the new highlight before dropping the old one.
+  const recolor = reader.slice(reader.indexOf('const recolorHighlight'), reader.indexOf('const deleteHighlight'));
+  assert.ok(recolor.indexOf('onCreateAnnotation(') < recolor.indexOf('onDeleteAnnotation('), 'the new colour is written first');
+});
+
+test('the editor toolbar keeps out of sight until the pointer is released', () => {
+  const anchored = fs.readFileSync(path.join(repoRoot, 'src/components/editor/pointerAnchoredToolbar.ts'), 'utf8');
+  // Milkdown shows its toolbar on every selection change; while the button is
+  // down the selection is still growing and the toolbar must not follow it.
+  assert.match(anchored, /write\('visibility', dragging \? 'hidden' : ''\)/);
+  assert.match(anchored, /if \(dragging \|\| !pointer \|\| toolbar\.dataset\.show !== 'true'\) return/);
+  assert.match(anchored, /dragging = true/);
+  assert.match(anchored, /addEventListener\('pointerup', onPointerUp, true\)/);
+  // floating-ui rewrites left/top on every recompute, so the correction is kept
+  // in the transform it never touches.
+  assert.match(anchored, /write\('transform', `translate\(/);
+  assert.doesNotMatch(anchored, /toolbar\.style\.left =/);
+});

--- a/src/components/ReaderSelectionActions.tsx
+++ b/src/components/ReaderSelectionActions.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
   type RefObject,
@@ -14,9 +15,13 @@ import type {
   WritingDraftAnnotationInput,
 } from '@shared/types';
 import { t } from '../i18n';
+import { pointerAnchor, selectionRibbonPosition, viewportRibbonBounds, type RibbonAnchor } from '../selectionRibbonPosition';
 import { confirm } from './feedback';
 import { Icon } from './ui';
 import './readerSelectionActions.css';
+
+/** Rough size of the ribbon, for the first paint before it can be measured. */
+const SELECTION_RIBBON = { width: 350, height: 41 };
 
 interface ReaderMark {
   start: number;
@@ -35,12 +40,14 @@ interface ReaderAnchor {
 interface ActiveSelection extends ReaderAnchor {
   left: number;
   top: number;
+  band: RibbonAnchor;
 }
 
 interface FloatingAction<T = undefined> {
   value: T;
   left: number;
   top: number;
+  band?: RibbonAnchor;
 }
 
 interface MarginPosition {
@@ -205,6 +212,17 @@ function findAnchoredText(root: HTMLElement, anchor: ReaderAnchor): Range | null
   return bestIndex >= 0 ? rangeFromOffsets(root, bestIndex, bestIndex + anchor.selectedText.length) : null;
 }
 
+/** The anchor of a stored annotation, so its range can be acted on like a selection. */
+function annotationAnchor(annotation: WritingDraftAnnotation): ReaderAnchor {
+  return {
+    startOffset: annotation.startOffset,
+    endOffset: annotation.endOffset,
+    selectedText: annotation.selectedText,
+    prefix: annotation.prefix,
+    suffix: annotation.suffix,
+  };
+}
+
 function annotationRange(root: HTMLElement, annotation: WritingDraftAnnotation): Range | null {
   const direct = rangeFromOffsets(root, annotation.startOffset, annotation.endOffset);
   if (direct?.toString() === annotation.selectedText) return direct;
@@ -273,6 +291,21 @@ function wordAtPoint(event: MouseEvent, root: HTMLElement): Range | null {
   selection?.removeAllRanges();
   selection?.addRange(range);
   return range;
+}
+
+/**
+ * The moving end of a selection made without a pointer. With the keyboard the
+ * caret is where the reader is working, so the ribbon follows it instead of
+ * sitting over the first line of the selection.
+ */
+function focusAnchor(range: Range): RibbonAnchor {
+  const selection = window.getSelection();
+  const backwards = !!selection?.focusNode
+    && selection.focusNode === range.startContainer
+    && selection.focusOffset === range.startOffset;
+  const rects = Array.from(range.getClientRects()).filter((item) => item.width > 0 || item.height > 0);
+  const rect = rects.length ? (backwards ? rects[0] : rects[rects.length - 1]) : range.getBoundingClientRect();
+  return { x: backwards ? rect.left : rect.right, top: rect.top, bottom: rect.bottom };
 }
 
 function rectAtPoint(range: Range, x: number, y: number): DOMRect | null {
@@ -386,6 +419,7 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
   const [commentError, setCommentError] = useState<string | null>(null);
   const [localMark, setLocalMark] = useState<ReaderMark | null>(() => loadMark(contextId));
   const [marginPositions, setMarginPositions] = useState<MarginPosition[]>([]);
+  const ribbonRef = useRef<HTMLDivElement | null>(null);
   const [contentRevision, setContentRevision] = useState(0);
   const migratedBookmark = useRef<string | null>(null);
   const usesSyncedBookmark = !!onCreateAnnotation && !!onDeleteAnnotation;
@@ -467,7 +501,7 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
     }
   }, [activeHighlightActions, annotations, commentEditor]);
 
-  const captureSelection = useCallback((event?: MouseEvent): ActiveSelection | null => {
+  const captureSelection = useCallback((event?: MouseEvent, pointer?: { x: number; y: number }): ActiveSelection | null => {
     const root = targetRef.current;
     if (!root) return null;
     let selected = selectionInside(root);
@@ -476,13 +510,14 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
       if (range) selected = { range, text: range.toString() };
     }
     if (!selected) return null;
-    const rect = selected.range.getBoundingClientRect();
     const anchor = anchorFromRange(root, selected.range, selected.text);
-    const width = 350;
+    // The pointer wins over the selection box: a selection dragged over several
+    // lines ends where the pointer is, and that is where the reader is looking.
+    const band = pointer ? pointerAnchor(pointer.x, pointer.y) : focusAnchor(selected.range);
     return {
       ...anchor,
-      left: Math.max(8, Math.min(window.innerWidth - Math.min(width, window.innerWidth - 16) - 8, rect.left + rect.width / 2 - width / 2)),
-      top: Math.max(8, rect.top - 48),
+      band,
+      ...selectionRibbonPosition(band, SELECTION_RIBBON, viewportRibbonBounds()),
     };
   }, [targetRef]);
 
@@ -507,8 +542,8 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
     });
   }, [annotations, clearSelection, onAnnotationError, onCreateAnnotation]);
 
-  const showSelection = useCallback((event?: MouseEvent) => {
-    const selection = captureSelection(event);
+  const showSelection = useCallback((event?: MouseEvent, pointer?: { x: number; y: number }) => {
+    const selection = captureSelection(event, pointer);
     if (!selection) {
       setActive(null);
       return false;
@@ -579,12 +614,15 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
   useEffect(() => {
     const root = targetRef.current;
     if (!root) return;
-    const onPointerUp = () => window.setTimeout(() => showSelection(), 0);
+    const onPointerUp = (event: PointerEvent) => {
+      const pointer = { x: event.clientX, y: event.clientY };
+      window.setTimeout(() => showSelection(undefined, pointer), 0);
+    };
     const onKeyUp = (event: KeyboardEvent) => {
       if (event.key.startsWith('Arrow') || event.key === 'Shift') showSelection();
     };
     const onContextMenu = (event: MouseEvent) => {
-      if (showSelection(event)) event.preventDefault();
+      if (showSelection(event, { x: event.clientX, y: event.clientY })) event.preventDefault();
     };
     const onClick = (event: MouseEvent) => {
       // A drag ending over an existing highlight is still a new selection. Its
@@ -603,10 +641,11 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
       event.stopPropagation();
       clearSelection();
       setActiveMarkActions(null);
+      const band = { x: event.clientX, top: match.rect.top, bottom: match.rect.bottom };
       setActiveHighlightActions({
         value: match.annotation,
-        left: Math.max(8, Math.min(window.innerWidth - 51, match.rect.left + match.rect.width / 2 - 22)),
-        top: Math.max(8, match.rect.top - 48),
+        band,
+        ...selectionRibbonPosition(band, SELECTION_RIBBON, viewportRibbonBounds()),
       });
     };
     const hide = (event: Event) => {
@@ -660,18 +699,52 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
     };
   }, [annotations, contentRevision, contextId, targetRef]);
 
-  const copy = async () => {
-    if (!active) return;
-    await navigator.clipboard.writeText(active.selectedText);
+  // A fresh selection and a highlight the reader clicked on offer the same actions:
+  // both are a passage of the document, one still loose and one already saved.
+  const target: { anchor: ReaderAnchor; highlight: WritingDraftAnnotation | null; left: number; top: number } | null = active
+    ? { anchor: active, highlight: null, left: active.left, top: active.top }
+    : activeHighlightActions
+      ? {
+        anchor: annotationAnchor(activeHighlightActions.value),
+        highlight: activeHighlightActions.value,
+        left: activeHighlightActions.left,
+        top: activeHighlightActions.top,
+      }
+      : null;
+
+  const closeActions = () => {
     clearSelection();
+    setActiveHighlightActions(null);
+  };
+
+  const copy = async () => {
+    if (!target) return;
+    await navigator.clipboard.writeText(target.anchor.selectedText);
+    closeActions();
+  };
+
+  const recolorHighlight = (annotation: WritingDraftAnnotation, color: WritingDraftAnnotationColor) => {
+    setActiveHighlightActions(null);
+    if (annotation.color === color || !onCreateAnnotation || !onDeleteAnnotation) return;
+    // No call changes the colour of a stored highlight, so the new one is written
+    // before the old one goes: a failure leaves the reader's mark where it was.
+    void onCreateAnnotation({ ...annotationAnchor(annotation), kind: 'highlight', color })
+      .then(() => onDeleteAnnotation(annotation.id))
+      .catch((error) => onAnnotationError?.(errorMessage(error)));
+  };
+
+  const deleteHighlight = (annotation: WritingDraftAnnotation) => {
+    setActiveHighlightActions(null);
+    void onDeleteAnnotation?.(annotation.id).catch((error) => onAnnotationError?.(errorMessage(error)));
   };
 
   const saveMark = () => {
-    if (!active) return;
-    const next: ReaderMark = { start: active.startOffset, end: active.endOffset, text: active.selectedText };
-    clearSelection();
+    if (!target) return;
+    const anchor = target.anchor;
+    const next: ReaderMark = { start: anchor.startOffset, end: anchor.endOffset, text: anchor.selectedText };
+    closeActions();
     if (usesSyncedBookmark && onCreateAnnotation) {
-      void onCreateAnnotation({ ...active, kind: 'bookmark', color: null }).catch((error) => {
+      void onCreateAnnotation({ ...anchor, kind: 'bookmark', color: null }).catch((error) => {
         onAnnotationError?.(errorMessage(error));
       });
       return;
@@ -711,25 +784,25 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
   useImperativeHandle(ref, () => ({ goToMark }), [goToMark]);
 
   const quoteInNodi = async () => {
-    if (!active) return;
-    const text = active.selectedText.replace(/\s+/g, ' ').trim();
+    if (!target) return;
+    const text = target.anchor.selectedText.replace(/\s+/g, ' ').trim();
     const settings = await window.nodus.getSettings();
     if (!settings.mascotEnabled) await window.nodus.updateSettings({ mascotEnabled: true });
     await window.nodus.quoteNodiSelection(text);
-    clearSelection();
+    closeActions();
   };
 
   const openNewComment = () => {
-    if (!active) return;
+    if (!target) return;
     setCommentError(null);
     setCommentEditor({
       annotation: null,
-      anchor: active,
+      anchor: target.anchor,
       body: '',
-      left: active.left,
-      top: Math.max(8, Math.min(window.innerHeight - 270, active.top)),
+      left: target.left,
+      top: Math.max(8, Math.min(window.innerHeight - 270, target.top)),
     });
-    clearSelection();
+    closeActions();
   };
 
   const openComment = (annotation: WritingDraftAnnotation, position: MarginPosition) => {
@@ -790,6 +863,17 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
 
   const action = active ?? activeMarkActions ?? activeHighlightActions;
 
+  // The estimated width above keeps the first paint from flashing in the wrong
+  // place; the ribbon is only truly centred on the pointer once measured.
+  useLayoutEffect(() => {
+    const node = ribbonRef.current;
+    if (!node || !action?.band) return;
+    const rect = node.getBoundingClientRect();
+    const { left, top } = selectionRibbonPosition(action.band, rect, viewportRibbonBounds());
+    node.style.left = `${left}px`;
+    node.style.top = `${top}px`;
+  }, [action]);
+
   return (
     <>
       {marginPositions.length > 0 && createPortal(
@@ -820,22 +904,25 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
 
       {action && createPortal(
         <div
+          ref={ribbonRef}
           className="reader-selection-actions"
           data-reader-selection-actions
           role="toolbar"
-          aria-label={active ? t('Acciones de selección') : t('Editar o eliminar')}
+          aria-label={target ? t('Acciones de selección') : t('Editar o eliminar')}
           style={{ left: action.left, top: action.top }}
           onPointerDown={(event) => event.preventDefault()}
         >
-          {active ? (
+          {target ? (
             <>
               <div className="reader-selection-colors" aria-label={t('Color')}>
                 {READER_ANNOTATION_COLORS.map((item, index) => (
                   <button
                     key={item.id}
                     type="button"
-                    className="reader-selection-color"
-                    onClick={() => createHighlight(active, item.id)}
+                    className={`reader-selection-color${target.highlight?.color === item.id ? ' is-active' : ''}`}
+                    onClick={() => target.highlight
+                      ? recolorHighlight(target.highlight, item.id)
+                      : createHighlight(target.anchor, item.id)}
                     title={`${t('Subrayar')} ${index + 1}`}
                     aria-label={`${t('Subrayar')} ${index + 1}`}
                   >
@@ -857,22 +944,28 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
               <button type="button" onClick={() => void quoteInNodi()} title={t('Citar en Nodi')} aria-label={t('Citar en Nodi')}>
                 <Icon name="quote" size={17} />
               </button>
+              {target.highlight && (
+                <>
+                  <span className="reader-selection-divider" />
+                  <button
+                    type="button"
+                    data-tone="danger"
+                    onClick={() => target.highlight && deleteHighlight(target.highlight)}
+                    title={t('Eliminar')}
+                    aria-label={t('Eliminar')}
+                  >
+                    <Icon name="trash" size={17} />
+                  </button>
+                </>
+              )}
             </>
           ) : (
             <button
               type="button"
               data-tone="danger"
-              onClick={() => {
-                if (activeHighlightActions) {
-                  const id = activeHighlightActions.value.id;
-                  setActiveHighlightActions(null);
-                  void onDeleteAnnotation?.(id).catch((error) => onAnnotationError?.(errorMessage(error)));
-                } else {
-                  deleteMark();
-                }
-              }}
-              title={activeHighlightActions ? t('Eliminar') : t('Eliminar marcador de lectura')}
-              aria-label={activeHighlightActions ? t('Eliminar') : t('Eliminar marcador de lectura')}
+              onClick={deleteMark}
+              title={t('Eliminar marcador de lectura')}
+              aria-label={t('Eliminar marcador de lectura')}
             >
               <Icon name="trash" size={17} />
             </button>

--- a/src/components/editor/StudyEditor.tsx
+++ b/src/components/editor/StudyEditor.tsx
@@ -37,6 +37,7 @@ import { Icon, ICON_NAMES, Spinner } from '../ui';
 import { TextInputModal } from '../TextInputModal';
 import { t } from '../../i18n';
 import { DocOutline } from './DocOutline';
+import { anchorToolbarToPointer } from './pointerAnchoredToolbar';
 import { StudyDictation } from './StudyDictation';
 import { StudyImproveDialog } from './StudyImproveDialog';
 import { AudioPanel } from '../AudioPanel';
@@ -134,6 +135,8 @@ const MilkdownCanvas = forwardRef<MilkdownCanvasHandle, {
     }));
     let disposed = false;
     let toolbarObserver: MutationObserver | null = null;
+    let anchoredToolbar: HTMLElement | null = null;
+    let detachAnchor: (() => void) | null = null;
     void crepe.create().then(() => {
       if (disposed) return;
       const editable = root.querySelector('[contenteditable="true"]');
@@ -149,6 +152,11 @@ const MilkdownCanvas = forwardRef<MilkdownCanvasHandle, {
           host.className = 'study-selection-tools-host';
           toolbar.append(host);
         }
+        if (anchoredToolbar !== toolbar) {
+          detachAnchor?.();
+          anchoredToolbar = toolbar;
+          detachAnchor = anchorToolbarToPointer(root.parentElement ?? root, toolbar);
+        }
         onToolbarElement(host);
         return host;
       };
@@ -156,7 +164,7 @@ const MilkdownCanvas = forwardRef<MilkdownCanvasHandle, {
       toolbarObserver = new MutationObserver(() => { findToolbar(); });
       toolbarObserver.observe(root.parentElement ?? root, { childList: true, subtree: true });
     });
-    return () => { disposed = true; toolbarObserver?.disconnect(); onToolbarElement(null); crepeRef.current = null; void crepe.destroy(); };
+    return () => { disposed = true; toolbarObserver?.disconnect(); detachAnchor?.(); onToolbarElement(null); crepeRef.current = null; void crepe.destroy(); };
   }, [documentId, spellcheck, language]);
 
   useImperativeHandle(ref, () => ({

--- a/src/components/editor/pointerAnchoredToolbar.ts
+++ b/src/components/editor/pointerAnchoredToolbar.ts
@@ -27,6 +27,7 @@ export function anchorToolbarToPointer(root: HTMLElement, toolbar: HTMLElement):
   let pointer: { x: number; y: number } | null = null;
   let offset = { x: 0, y: 0 };
   let frame = 0;
+  let timer = 0;
   let dragging = false;
 
   const write = (property: 'visibility' | 'transform', value: string) => {
@@ -53,9 +54,20 @@ export function anchorToolbarToPointer(root: HTMLElement, toolbar: HTMLElement):
     write('transform', `translate(${next.x}px, ${next.y}px)`);
   };
 
-  const schedule = () => {
+  const run = () => {
     cancelAnimationFrame(frame);
-    frame = requestAnimationFrame(place);
+    window.clearTimeout(timer);
+    frame = 0;
+    timer = 0;
+    place();
+  };
+
+  const schedule = () => {
+    if (frame || timer) return;
+    frame = requestAnimationFrame(run);
+    // A window that is not painting — occluded, or a test runner's — starves
+    // requestAnimationFrame, and the toolbar would stay where it was.
+    timer = window.setTimeout(run, 30);
   };
 
   const insideToolbar = (event: Event) => event.target instanceof Node && toolbar.contains(event.target);
@@ -94,6 +106,7 @@ export function anchorToolbarToPointer(root: HTMLElement, toolbar: HTMLElement):
   root.addEventListener('keydown', onKeyDown);
   return () => {
     cancelAnimationFrame(frame);
+    window.clearTimeout(timer);
     observer.disconnect();
     document.removeEventListener('pointerdown', onPointerDown, true);
     document.removeEventListener('pointerup', onPointerUp, true);

--- a/src/components/editor/pointerAnchoredToolbar.ts
+++ b/src/components/editor/pointerAnchoredToolbar.ts
@@ -1,0 +1,105 @@
+import {
+  intersectRibbonBounds,
+  pointerAnchor,
+  selectionRibbonOffset,
+  selectionRibbonPosition,
+  viewportRibbonBounds,
+} from '../../selectionRibbonPosition';
+
+/**
+ * Keeps Milkdown's selection toolbar above the pointer that made the selection,
+ * and out of the way until the pointer is released.
+ *
+ * Milkdown places the toolbar with floating-ui against the bounding box of the
+ * whole selection, and shows it on every selection change, so dragging over a
+ * paragraph makes it follow the growing box from the first click.
+ *
+ * floating-ui owns `left`/`top` and rewrites them on every recompute — writing
+ * them here only starts a tug of war it wins. The correction lives in the
+ * element's transform instead, recomputed from wherever floating-ui last left
+ * it, and bounded by the editor column so a toolbar nearly as wide as the text
+ * is not pushed under its own edge.
+ *
+ * A selection made with the keyboard keeps the original placement: there is no
+ * pointer to follow, and the caret is already inside the selection box.
+ */
+export function anchorToolbarToPointer(root: HTMLElement, toolbar: HTMLElement): () => void {
+  let pointer: { x: number; y: number } | null = null;
+  let offset = { x: 0, y: 0 };
+  let frame = 0;
+  let dragging = false;
+
+  const write = (property: 'visibility' | 'transform', value: string) => {
+    // Writing an unchanged value is still a mutation this observer would answer.
+    if (toolbar.style[property] !== value) toolbar.style[property] = value;
+  };
+
+  const place = () => {
+    // Visibility rather than the theme's display toggle: a hidden toolbar still
+    // has to be measured to be placed, and it is placed the moment the pointer
+    // comes back up.
+    write('visibility', dragging ? 'hidden' : '');
+    if (dragging || !pointer || toolbar.dataset.show !== 'true') return;
+    const rect = toolbar.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    const column = toolbar.offsetParent instanceof HTMLElement ? toolbar.offsetParent.getBoundingClientRect() : null;
+    const bounds = column
+      ? intersectRibbonBounds(viewportRibbonBounds(), { left: column.left, top: column.top, right: column.right, bottom: column.bottom })
+      : viewportRibbonBounds();
+    const target = selectionRibbonPosition(pointerAnchor(pointer.x, pointer.y), rect, bounds);
+    const next = selectionRibbonOffset(offset, rect, target);
+    if (Math.abs(next.x - offset.x) < 0.5 && Math.abs(next.y - offset.y) < 0.5) return;
+    offset = next;
+    write('transform', `translate(${next.x}px, ${next.y}px)`);
+  };
+
+  const schedule = () => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(place);
+  };
+
+  const insideToolbar = (event: Event) => event.target instanceof Node && toolbar.contains(event.target);
+
+  const onPointerDown = (event: PointerEvent) => {
+    // A click on the toolbar is not a new selection; following it would walk
+    // the toolbar away from the text under the writer's own cursor.
+    if (insideToolbar(event) || !(event.target instanceof Node) || !root.contains(event.target)) return;
+    dragging = true;
+    pointer = null;
+    schedule();
+  };
+
+  const onPointerUp = (event: PointerEvent) => {
+    if (!dragging || insideToolbar(event)) return;
+    dragging = false;
+    pointer = { x: event.clientX, y: event.clientY };
+    schedule();
+  };
+
+  const onKeyDown = () => {
+    dragging = false;
+    pointer = null;
+    offset = { x: 0, y: 0 };
+    write('transform', '');
+    schedule();
+  };
+
+  const observer = new MutationObserver(schedule);
+  observer.observe(toolbar, { attributes: true, attributeFilter: ['style', 'data-show'] });
+  // The release is watched on the document: a selection dragged past the editor
+  // still ends when the button comes up, wherever the pointer happens to be.
+  document.addEventListener('pointerdown', onPointerDown, true);
+  document.addEventListener('pointerup', onPointerUp, true);
+  document.addEventListener('pointercancel', onPointerUp, true);
+  root.addEventListener('keydown', onKeyDown);
+  return () => {
+    cancelAnimationFrame(frame);
+    observer.disconnect();
+    document.removeEventListener('pointerdown', onPointerDown, true);
+    document.removeEventListener('pointerup', onPointerUp, true);
+    document.removeEventListener('pointercancel', onPointerUp, true);
+    root.removeEventListener('keydown', onKeyDown);
+    toolbar.style.visibility = '';
+    toolbar.style.transform = '';
+  };
+}

--- a/src/components/readerSelectionActions.css
+++ b/src/components/readerSelectionActions.css
@@ -39,6 +39,10 @@
 
 .reader-selection-colors { display: flex; gap: 1px; }
 .reader-selection-actions .reader-selection-color { width: 25px; }
+/* On a highlight the reader clicked, the colour it already has stays marked so
+   the palette reads as a choice among six rather than six new highlights. */
+.reader-selection-actions .reader-selection-color.is-active { background: #3730a3; }
+.reader-selection-actions .reader-selection-color.is-active span { border-color: #fff; }
 .reader-selection-color span,
 .reader-highlighter-palette button span {
   width: 16px;
@@ -132,6 +136,8 @@
    on white that ring vanishes and the pale swatches lose their edge. */
 .light .reader-selection-color span,
 .light .reader-highlighter-palette button span { border-color: rgb(24 24 27 / 0.22); }
+.light .reader-selection-actions .reader-selection-color.is-active { background: #eef2ff; }
+.light .reader-selection-actions .reader-selection-color.is-active span { border-color: #4338ca; }
 .light .reader-active-color { box-shadow: 0 0 0 1px rgb(24 24 27 / 0.3); }
 .light .reader-selection-actions button[data-tone='danger'] { color: #dc2626; }
 .light .reader-selection-actions button[data-tone='danger']:hover,

--- a/src/selectionRibbonPosition.ts
+++ b/src/selectionRibbonPosition.ts
@@ -1,0 +1,100 @@
+/**
+ * Where the floating selection ribbon goes.
+ *
+ * A selection is made with a pointer that keeps moving, so the ribbon must land
+ * where the pointer finished, not over the bounding box of the whole selection:
+ * on a long selection that box starts at the first click and the ribbon would
+ * appear far above the text the reader is actually looking at.
+ */
+
+/** The band of text the ribbon must not cover, in viewport coordinates. */
+export interface RibbonAnchor {
+  /** Horizontal centre for the ribbon. */
+  x: number;
+  /** Top of the line the anchor sits on. */
+  top: number;
+  /** Bottom of that line. */
+  bottom: number;
+}
+
+export interface RibbonSize {
+  width: number;
+  height: number;
+}
+
+/** The area the ribbon may occupy, in viewport coordinates. Already inset. */
+export interface RibbonBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/** Gap between the anchored line and the ribbon. */
+export const RIBBON_GAP = 8;
+/** Distance kept from the edges of the area the ribbon may use. */
+export const RIBBON_MARGIN = 8;
+/** Half the line height assumed around a pointer, when no line box is known. */
+export const RIBBON_POINTER_LINE = 12;
+
+/** The band around a pointer position, when the line box under it is unknown. */
+export function pointerAnchor(x: number, y: number): RibbonAnchor {
+  return { x, top: y - RIBBON_POINTER_LINE, bottom: y + RIBBON_POINTER_LINE };
+}
+
+/** The window, inset by the margin the ribbon keeps from the screen edges. */
+export function viewportRibbonBounds(): RibbonBounds {
+  return {
+    left: RIBBON_MARGIN,
+    top: RIBBON_MARGIN,
+    right: window.innerWidth - RIBBON_MARGIN,
+    bottom: window.innerHeight - RIBBON_MARGIN,
+  };
+}
+
+/** The part of `bounds` that also lies inside `limit`, never inverted. */
+export function intersectRibbonBounds(bounds: RibbonBounds, limit: RibbonBounds): RibbonBounds {
+  const left = Math.max(bounds.left, limit.left);
+  const top = Math.max(bounds.top, limit.top);
+  return {
+    left,
+    top,
+    right: Math.max(left, Math.min(bounds.right, limit.right)),
+    bottom: Math.max(top, Math.min(bounds.bottom, limit.bottom)),
+  };
+}
+
+/** Top-left corner, in viewport coordinates, for a ribbon of this size. */
+export function selectionRibbonPosition(
+  anchor: RibbonAnchor,
+  size: RibbonSize,
+  bounds: RibbonBounds,
+): { left: number; top: number } {
+  const maxLeft = Math.max(bounds.left, bounds.right - size.width);
+  const left = Math.max(bounds.left, Math.min(maxLeft, anchor.x - size.width / 2));
+  const above = anchor.top - RIBBON_GAP - size.height;
+  // Below the pointer when the line is too close to the top of the area, so the
+  // ribbon is never clipped nor pinned over the words just selected.
+  const top = above >= bounds.top
+    ? above
+    : Math.max(bounds.top, Math.min(bounds.bottom - size.height, anchor.bottom + RIBBON_GAP));
+  return { left, top };
+}
+
+/**
+ * The offset that takes a floating element from where it is to where it belongs.
+ *
+ * Used where a third-party positioner (floating-ui inside Milkdown) owns
+ * `left`/`top` and rewrites them whenever it recomputes: the correction is kept
+ * in the element's own transform, which that positioner never touches.
+ */
+export function selectionRibbonOffset(
+  current: { x: number; y: number },
+  rect: { left: number; top: number },
+  target: { left: number; top: number },
+): { x: number; y: number } {
+  return {
+    x: current.x + (target.left - rect.left),
+    y: current.y + (target.top - rect.top),
+  };
+}

--- a/visual-tests/editor-toolbar-harness.html
+++ b/visual-tests/editor-toolbar-harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Editor toolbar visual harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/visual-tests/editor-toolbar-harness.tsx"></script>
+  </body>
+</html>

--- a/visual-tests/editor-toolbar-harness.tsx
+++ b/visual-tests/editor-toolbar-harness.tsx
@@ -1,0 +1,72 @@
+// Milkdown's selection toolbar, with the pointer anchoring the note editors use.
+// Mounting Crepe alone keeps the check on the placement itself, away from the
+// vault plumbing the study and teaching editors need.
+import React, { useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import { Crepe } from '@milkdown/crepe';
+import '@milkdown/crepe/theme/common/style.css';
+import '@milkdown/crepe/theme/classic.css';
+import { anchorToolbarToPointer } from '../src/components/editor/pointerAnchoredToolbar';
+import '../src/index.css';
+
+const NOTE = `# Cuaderno de apuntes
+
+Selecciona un párrafo completo arrastrando el puntero de arriba abajo: la cinta
+de opciones debe aparecer encima del punto donde sueltas el ratón, no encima del
+primer clic.
+
+Una segunda línea permite comprobar el caso contrario, arrastrando de abajo
+arriba, y también la selección hecha con el teclado, que conserva la colocación
+original de Milkdown porque no hay puntero al que seguir.`;
+
+function Harness() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState('Sin selección');
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const crepe = new Crepe({ root, defaultValue: NOTE, features: { [Crepe.Feature.AI]: false } });
+    let detach: (() => void) | null = null;
+    let observer: MutationObserver | null = null;
+    let anchored: HTMLElement | null = null;
+    void crepe.create().then(() => {
+      const attach = () => {
+        const toolbar = root.querySelector<HTMLElement>('.milkdown-toolbar')
+          ?? root.parentElement?.querySelector<HTMLElement>('.milkdown-toolbar')
+          ?? null;
+        if (!toolbar || anchored === toolbar) return;
+        detach?.();
+        anchored = toolbar;
+        detach = anchorToolbarToPointer(root.parentElement ?? root, toolbar);
+      };
+      attach();
+      observer = new MutationObserver(attach);
+      observer.observe(root.parentElement ?? root, { childList: true, subtree: true });
+    });
+    const report = () => setStatus(window.getSelection()?.toString().trim() ? 'Selección activa' : 'Sin selección');
+    document.addEventListener('selectionchange', report);
+    return () => {
+      document.removeEventListener('selectionchange', report);
+      observer?.disconnect();
+      detach?.();
+      void crepe.destroy();
+    };
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-neutral-950 px-8 py-10 text-neutral-100">
+      <section className="mx-auto max-w-3xl">
+        <header className="mb-5 border-b border-neutral-800 pb-4">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-300">Apuntes</div>
+          <h1 className="mt-1 text-3xl font-semibold">Cinta de opciones del editor</h1>
+        </header>
+        <div className="study-milkdown rounded-2xl border border-neutral-800 bg-neutral-900/70 p-4" ref={rootRef} />
+        <output data-testid="editor-toolbar-status" className="mt-5 block rounded-xl border border-teal-800/60 bg-teal-950/40 px-4 py-3 text-sm text-teal-200">{status}</output>
+      </section>
+    </main>
+  );
+}
+
+document.documentElement.classList.add('dark');
+ReactDOM.createRoot(document.getElementById('root')!).render(<Harness />);

--- a/visual-tests/reader-selection-harness.tsx
+++ b/visual-tests/reader-selection-harness.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom/client';
-import type { AppSettings, NodiQuoteSelection, NodusApi } from '../shared/types';
+import type { AppSettings, NodiQuoteSelection, NodusApi, WritingDraftAnnotation } from '../shared/types';
 import { ReaderSelectionActions } from '../src/components/ReaderSelectionActions';
 import '../src/index.css';
 
@@ -9,6 +9,9 @@ const settings = { mascotEnabled: false } as AppSettings;
 function Harness() {
   const readerRef = useRef<HTMLElement | null>(null);
   const [status, setStatus] = useState('Sin acción');
+  // Annotations live in memory: the reader is the same component the saved
+  // reports and the library use, and clicking a highlight needs stored rows.
+  const [annotations, setAnnotations] = useState<WritingDraftAnnotation[]>([]);
   useEffect(() => {
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
@@ -47,7 +50,36 @@ function Harness() {
             El marcador devuelve al lector al pasaje decisivo, mientras que la cita permite formular una pregunta precisa sin volver a describir el fragmento.
           </p>
         </article>
-        <ReaderSelectionActions targetRef={readerRef} contextId="visual-deep-research" />
+        <ReaderSelectionActions
+          targetRef={readerRef}
+          contextId="visual-deep-research"
+          annotations={annotations}
+          onCreateAnnotation={async (input) => {
+            const now = new Date().toISOString();
+            setAnnotations((current) => [...current, {
+              id: `visual-${current.length + 1}`,
+              draftId: 'visual',
+              scope: 'source',
+              comment: input.comment ?? null,
+              createdAt: now,
+              updatedAt: now,
+              ...input,
+              color: input.color ?? null,
+              prefix: input.prefix ?? '',
+              suffix: input.suffix ?? '',
+            }]);
+            setStatus(`Anotación ${input.kind} ${input.color ?? ''}`.trim());
+          }}
+          onUpdateComment={async (id, comment) => {
+            setAnnotations((current) => current.map((item) => item.id === id ? { ...item, comment } : item));
+            setStatus(`Comentario: ${comment}`);
+          }}
+          onDeleteAnnotation={async (id) => {
+            setAnnotations((current) => current.filter((item) => item.id !== id));
+            setStatus(`Eliminada ${id}`);
+          }}
+          onAnnotationError={(message) => setStatus(`Error: ${message}`)}
+        />
         <output data-testid="selection-status" className="mt-5 block rounded-xl border border-indigo-800/60 bg-indigo-950/40 px-4 py-3 text-sm text-indigo-200">{status}</output>
       </section>
     </main>


### PR DESCRIPTION
Closes #470.

## The ribbon follows the pointer

Selecting text placed the floating options ribbon against the bounding box of the whole selection, which starts at the first click. Dragging a paragraph downwards therefore parked the ribbon above its first line, far from the pointer that finished the selection.

- **Deep Research, the Library reader and Immersion** (all three share `ReaderSelectionActions`) now anchor the ribbon to the pointer position at release, centred on it and clearing the line under it. A selection made with the keyboard follows the caret — the moving end of the selection — since there is no pointer to follow.
- **The workspace and the study and teaching note editors** got the same treatment for Milkdown's selection toolbar, which additionally appeared *while* the pointer was still down and followed the selection as it grew. It now stays out of sight until the release.

Milkdown positions that toolbar with floating-ui, which rewrites `left`/`top` on every recompute — writing them back only starts a tug of war it wins. The correction is kept in the element's `transform`, which floating-ui never touches, and is bounded by the editor column: with the Nodus AI tools appended, that toolbar can be nearly as wide as the text it floats over.

## A clicked highlight offers the whole ribbon

Clicking painted text used to offer deletion alone. It now reopens the full ribbon over that passage — the six colours with the current one marked, comment, copy, reading bookmark and Nodi quote — with the trash added at the end. No call changes the colour of a stored highlight, so recolouring writes the new highlight before dropping the old one: a failure leaves the reader's mark where it was.

## Verification

- New `scripts/test-selection-ribbon-position.mjs` (11 tests) fixes the placement arithmetic: centring, the drop below the line near the top edge, the bounds clamp, a ribbon as wide as its bounds, and the transform offset.
- `npm test` — 1947 pass; `npm run typecheck` and `npm run lint` clean.
- `scripts/e2e-deep-research-annotations.mjs` and `scripts/e2e-library-reader.mjs` now assert in the real app that the ribbon is centred on the release point and sits above it, and cover recolouring a stored highlight from the ribbon.
- `scripts/e2e-smoke.mjs` drives a real drag in the study editor: the toolbar is `visibility: hidden` mid-drag, then lands above the released line, as near the pointer as its column allows.
- Both visual harnesses were driven in a browser (`visual-tests/reader-selection-harness.html`, and the new `visual-tests/editor-toolbar-harness.html`): measured ribbon centre 500.0 for a pointer released at x=500, bottom 380 for y=400.
