### PR TITLE
Answer Nodi questions without freezing the window

### DIFF
--- a/electron/ai/researchAssistant.ts
+++ b/electron/ai/researchAssistant.ts
@@ -23,9 +23,9 @@ import { resolveWorkText } from '../extraction/textExtractor';
 import { completeText, completeTextStream, resolveModelRef, localModelContextWindow } from './aiClient';
 import { embed } from './aiClient';
 import { enforceContextBudget, humanizeCitationLabels } from './researchContextFit';
-import { findSimilarWorks } from '../db/workSummariesRepo';
-import { findSimilarPassages } from '../db/passagesRepo';
-import { findSimilarIdeas } from '../db/ideasRepo';
+import { findSimilarWorksPaged } from '../db/workSummariesRepo';
+import { findSimilarPassagesPaged } from '../db/passagesRepo';
+import { findSimilarIdeasPaged } from '../db/ideasRepo';
 
 const MAX_HISTORY_MESSAGES = 12;
 const MAX_DOCUMENTS = 30;
@@ -42,10 +42,19 @@ const MAX_PASSAGE_CONTEXT_CHARS = 24_000;
 // ── Query-relevant retrieval ────────────────────────────────────────────────
 // The graph sections used to dump the whole corpus regardless of the question,
 // which overflowed the model's context window on large libraries. Instead we
-// retrieve a top-K slice ranked by the question's embedding (via findSimilarIdeas
-// / findSimilarWorks) and scope every derived section to that slice. When no
-// embedding provider is configured we fall back to a bounded, most-supported
-// slice so the payload is always capped.
+// retrieve a top-K slice ranked by the question's embedding (via the paged
+// findSimilarIdeasPaged / findSimilarWorksPaged scans) and scope every derived
+// section to that slice. When no embedding provider is configured we fall back
+// to a bounded, most-supported slice so the payload is always capped.
+//
+// Every similarity search here is the paged variant on purpose (see
+// db/vectorScan.ts). This module builds the context for the research chat AND
+// for Nodi's active-vault context, both of which run while the user is looking
+// at the window: on the reference corpus (13,799 ideas, 44,138 passages) the
+// blocking queries held the main process for 95 ms per idea scan and 366 ms per
+// passage scan — with two passage scans per question that is most of a second of
+// frozen UI, per message. The paged scans return the same rows in the same order
+// and never hold the loop for more than ~10 ms at a time.
 const IDEA_SIM_THRESHOLD = 0.28;
 const TOP_K_IDEAS = 60;
 const MAX_OCCURRENCES_PER_IDEA = 6;
@@ -499,7 +508,7 @@ async function buildRelevanceScope(selection: ResearchContextSelection, question
   // active provider) must fall back to the bounded default rather than filter
   // every section down to nothing — so an empty result becomes a null scope,
   // not an empty one. queryEmbedding is kept for documents/passages retrieval.
-  const similarIdeas = findSimilarIdeas(queryEmbedding, IDEA_SIM_THRESHOLD, TOP_K_IDEAS).map((row) => row.global_id);
+  const similarIdeas = (await findSimilarIdeasPaged(queryEmbedding, IDEA_SIM_THRESHOLD, TOP_K_IDEAS)).map((row) => row.global_id);
   const ideaIds = similarIdeas.length ? similarIdeas : null;
   const ideaIdSet = ideaIds ? new Set(ideaIds) : null;
 
@@ -511,7 +520,7 @@ async function buildRelevanceScope(selection: ResearchContextSelection, question
       .all(...ideaIds) as { nodus_id: string }[];
     for (const row of rows) workIds.add(row.nodus_id);
   }
-  for (const row of findSimilarWorks(queryEmbedding, WORK_SIM_THRESHOLD, TOP_K_SCOPE_WORKS)) {
+  for (const row of await findSimilarWorksPaged(queryEmbedding, WORK_SIM_THRESHOLD, TOP_K_SCOPE_WORKS)) {
     workIds.add(row.nodus_id);
   }
   const workIdSet = workIds.size ? workIds : null;
@@ -613,7 +622,7 @@ async function buildResearchContext(
   // Default to enabled for historic saved selections created before the passage
   // toggle existed. Explicit false still gives the reader full control.
   if (selection.passages !== false) {
-    const passages = listRelevantPassages(scope.queryEmbedding, passageScopeWorkIds, heavyCap);
+    const passages = await listRelevantPassages(scope.queryEmbedding, passageScopeWorkIds, heavyCap);
     context.pasajes_relevantes = passages;
     sections.push('Pasajes de texto completo');
   }
@@ -1066,7 +1075,7 @@ async function listDocuments(
   // (file reads, OCR) for documents that would just be pruned to fit the window.
   const docTotal = Math.min(MAX_DOCUMENT_TOTAL_CHARS, Math.max(0, budget));
   const perDoc = Math.min(MAX_DOCUMENT_CHARS, docTotal || MAX_DOCUMENT_CHARS);
-  const candidateWorks = selectDocumentWorks(linkedWorkIds, queryEmbedding);
+  const candidateWorks = await selectDocumentWorks(linkedWorkIds, queryEmbedding);
   const works = candidateWorks.slice(0, MAX_DOCUMENTS);
   const omitted = Math.max(0, candidateWorks.length - works.length);
   const settings = getSettings();
@@ -1113,7 +1122,7 @@ async function listDocuments(
   return { documents, summaries, omitted, truncated };
 }
 
-function selectDocumentWorks(linkedWorkIds: Set<string>, queryEmbedding: number[] | null): WorkRow[] {
+async function selectDocumentWorks(linkedWorkIds: Set<string>, queryEmbedding: number[] | null): Promise<WorkRow[]> {
   const db = getDb();
   let works: WorkRow[];
   if (linkedWorkIds.size > 0) {
@@ -1131,7 +1140,9 @@ function selectDocumentWorks(linkedWorkIds: Set<string>, queryEmbedding: number[
     (b.year ?? 0) - (a.year ?? 0) ||
     a.title.localeCompare(b.title);
   if (!queryEmbedding) return works.sort(fallback);
-  const similarities = new Map(findSimilarWorks(queryEmbedding, -1, Math.max(works.length, MAX_SUMMARIES)).map((row) => [row.nodus_id, row.similarity]));
+  const similarities = new Map(
+    (await findSimilarWorksPaged(queryEmbedding, -1, Math.max(works.length, MAX_SUMMARIES))).map((row) => [row.nodus_id, row.similarity])
+  );
   return works.sort((a, b) => {
     const aSimilarity = similarities.get(a.nodus_id);
     const bSimilarity = similarities.get(b.nodus_id);
@@ -1140,19 +1151,19 @@ function selectDocumentWorks(linkedWorkIds: Set<string>, queryEmbedding: number[
   });
 }
 
-function listRelevantPassages(
+async function listRelevantPassages(
   queryEmbedding: number[] | null,
   linkedWorkIds: Set<string>,
   budget = MAX_TOTAL_CONTEXT_CHARS
-): unknown[] {
+): Promise<unknown[]> {
   if (!queryEmbedding) return [];
   const passageTotal = Math.min(MAX_PASSAGE_CONTEXT_CHARS, Math.max(0, budget));
   const scoped = linkedWorkIds.size
-    ? findSimilarPassages(queryEmbedding, PASSAGE_SIM_THRESHOLD, TOP_K_SCOPED_PASSAGES, {
+    ? await findSimilarPassagesPaged(queryEmbedding, PASSAGE_SIM_THRESHOLD, TOP_K_SCOPED_PASSAGES, {
         nodusIds: [...linkedWorkIds],
       })
     : [];
-  const global = findSimilarPassages(queryEmbedding, PASSAGE_SIM_THRESHOLD, TOP_K_GLOBAL_PASSAGES);
+  const global = await findSimilarPassagesPaged(queryEmbedding, PASSAGE_SIM_THRESHOLD, TOP_K_GLOBAL_PASSAGES);
   const unique = new Map<string, (typeof global)[number]>();
   for (const passage of [...scoped, ...global]) {
     if (!unique.has(passage.passage_id)) unique.set(passage.passage_id, passage);

--- a/electron/nodiConversations.ts
+++ b/electron/nodiConversations.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
+import { NODI_DEFAULT_CONTEXTS } from '@shared/types';
 import type { NodiContextKind, NodiConversation, NodiConversationInput } from '@shared/types';
 import { getActiveVault } from './vaults/vaultRegistry';
 
@@ -19,7 +20,7 @@ function storePath(): string {
 }
 
 function normalizeContexts(value: unknown): NodiContextKind[] {
-  if (!Array.isArray(value)) return ['documentation', 'current_view'];
+  if (!Array.isArray(value)) return [...NODI_DEFAULT_CONTEXTS];
   return [...new Set(value.filter((item): item is NodiContextKind => ALLOWED_CONTEXTS.has(item as NodiContextKind)))];
 }
 

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -454,3 +454,46 @@ test('Nodi receives aggregated, rate-limited lifecycle notifications', async () 
   assert.match(component, /latestNotificationId/);
   assert.match(component, /setCelebrate\(true\)/);
 });
+
+test('a new Nodi chat starts on documentation, the current view and the current vault', async () => {
+  const [types, companion, store] = await Promise.all([
+    read('@api'),
+    read('src/components/nodi/NodiCompanion.tsx'),
+    read('electron/nodiConversations.ts'),
+  ]);
+  assert.match(
+    types,
+    /export const NODI_DEFAULT_CONTEXTS: NodiContextKind\[\] = \['documentation', 'current_view', 'vault'\];/,
+    'the current vault is selected by default, next to the documentation and the visible view'
+  );
+  // One definition: the panel and the stored history must open on the same set.
+  assert.match(companion, /useState<NodiContextKind\[\]>\(\[\.\.\.NODI_DEFAULT_CONTEXTS\]\)/);
+  assert.match(store, /return \[\.\.\.NODI_DEFAULT_CONTEXTS\]/);
+  // Reaching into every other vault stays a per-question decision.
+  assert.doesNotMatch(types, /NODI_DEFAULT_CONTEXTS[^\n]*all_vaults/);
+});
+
+test('the chat retrieval never holds the main process for a whole similarity scan', async () => {
+  const assistant = await read('electron/ai/researchAssistant.ts');
+  // researchAssistant builds the context for the research chat AND for Nodi's
+  // active-vault context, both while the user is looking at the window. The
+  // blocking queries scan every embedded row inside one statement: measured on a
+  // real corpus (13,799 ideas, 44,138 passages) that is 95 ms per idea scan and
+  // 366 ms per passage scan of frozen UI — the beachball. The paged scans
+  // (db/vectorScan.ts) return the same rows and yield between rowid windows.
+  for (const blocking of ['findSimilarIdeas', 'findSimilarWorks', 'findSimilarPassages']) {
+    assert.doesNotMatch(
+      assistant,
+      new RegExp(`${blocking}\\(`),
+      `${blocking}() blocks the event loop for the whole scan — use ${blocking}Paged()`
+    );
+  }
+  for (const paged of ['findSimilarIdeasPaged', 'findSimilarWorksPaged', 'findSimilarPassagesPaged']) {
+    assert.match(assistant, new RegExp(`await ${paged}\\(`), `${paged} is awaited`);
+  }
+  // The passage section is the largest scan of all and runs twice per question.
+  assert.match(assistant, /async function listRelevantPassages/);
+  assert.match(assistant, /await listRelevantPassages\(/);
+  assert.match(assistant, /async function selectDocumentWorks/);
+  assert.match(assistant, /await selectDocumentWorks\(/);
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -7293,6 +7293,14 @@ export interface NodiChatMessage {
 
 export type NodiContextKind = 'documentation' | 'current_view' | 'vault' | 'all_vaults';
 
+/**
+ * Contexts a Nodi chat starts with. A question asked from inside a vault is
+ * almost always a question about that vault, so its retrieval is on next to the
+ * product documentation and the visible view. `all_vaults` stays opt-in: it
+ * reaches into every other vault, which is a decision per question.
+ */
+export const NODI_DEFAULT_CONTEXTS: NodiContextKind[] = ['documentation', 'current_view', 'vault'];
+
 export interface NodiViewContext {
   viewId: string;
   title: string;

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { deriveNodiNoteTitle } from '@shared/nodiNotes';
 import { announcementCopyFor, type AnnouncementRefreshResult } from '@shared/announcements';
+import { NODI_DEFAULT_CONTEXTS } from '@shared/types';
 import type { AppSettings, ModelRef, NodiChatMessage, NodiContextKind, NodiConversation, NodiNote, NodiNotification, NodiOverlayPlacement, NodiQuoteSelection, VaultType } from '@shared/types';
 import { vaultTypeColor } from '@shared/vaultTypes';
 import { type NodiRole, type NodiState } from './Nodi';
@@ -159,7 +160,10 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const [input, setInput] = useState('');
   const [quotedSelection, setQuotedSelection] = useState<string | null>(null);
   const [streaming, setStreaming] = useState(false);
-  const [contexts, setContexts] = useState<NodiContextKind[]>(['documentation', 'current_view']);
+  // The current vault is on by default (see NODI_DEFAULT_CONTEXTS). Its retrieval
+  // is a bounded, paged semantic scan — never the whole corpus, and never a scan
+  // that holds the window (see electron/db/vectorScan.ts).
+  const [contexts, setContexts] = useState<NodiContextKind[]>([...NODI_DEFAULT_CONTEXTS]);
   const [conversations, setConversations] = useState<NodiConversation[]>([]);
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
   const [chatTool, setChatTool] = useState<'none' | 'history' | 'contexts' | 'settings'>('none');


### PR DESCRIPTION
Closes #472.

## Nodi no longer holds the window while it retrieves

`electron/ai/researchAssistant.ts` builds the context for the research chat **and** for Nodi's "Current vault" context. It still used the blocking similarity searches, each of which is one SQL statement running the JS `vec_cosine()` function over every embedded row in the table. The Electron main process is single-threaded and also services every IPC call, so the window is frozen — beachball — until the statement returns.

All four call sites now use the paged scans (`electron/db/vectorScan.ts`), which walk the same rows in rowid windows and yield the event loop between them:

- `buildRelevanceScope` → `findSimilarIdeasPaged`, `findSimilarWorksPaged`
- `selectDocumentWorks` → `findSimilarWorksPaged` (now async)
- `listRelevantPassages` → `findSimilarPassagesPaged` ×2 (now async)

Measured on a copy of the active academic vault — 645 MB, 13,799 embedded ideas, 44,138 embedded passages — with `npm run verify:vector-scan`:

| scan | before: longest block | after: longest block | ranking |
| --- | --- | --- | --- |
| ideas (top 120) | 95 ms | 8 ms | identical, 120 rows |
| passages (top 48) | 366 ms | 9 ms | identical, 48 rows |
| passages scoped to 8 works (top 8) | 1 ms | 1 ms | identical, 8 rows |

A question runs one idea scan, one work scan and two passage scans, so this took most of a second of frozen UI off every chat turn. Total scan time also drops (95 → 50 ms and 366 → 188 ms) because ranking now reads ids only and fetches payloads for the winners alone; the scoped passage case goes from 1 ms to 3 ms, which is the paging overhead on a search that was already fast.

The research assistant modal, which shares this module, gets the same fix.

## A new chat starts on the current vault

Nodi opened a new chat with "Nodus documentation" and "Current view" ticked; "Current vault" is now ticked as well. A question asked from inside a vault is nearly always a question about that vault, and this was friction before every first question.

"All vaults" stays opt-in: it reaches into every other vault, which is a decision per question.

The default moved to `NODI_DEFAULT_CONTEXTS` in `shared/types.ts`, so the panel and the conversation store can no longer drift apart (the store had its own copy of the old pair as its fallback for a record with no contexts).

Making vault retrieval a default is what makes the first half of this PR load-bearing: it now runs on every message.

## Verification

- `npm run typecheck`, `npm run lint` on the touched files, `npm run build` — clean.
- `npm test` — 1949 tests pass. (`test-prosopography-e2e.mjs` fails in a fresh worktree until `npm run build` has produced `dist-electron`; it passes after the build.)
- `npm run verify:vector-scan -- <copy of the vault>` — the numbers above, with the paged scans asserted to return the same rows in the same order.
- Two new tests in `scripts/test-nodi-assistant.mjs`: one pins the default context set to a single definition shared by the panel and the store, the other fails if any blocking `findSimilar*(` call comes back into the chat retrieval path.

## Still blocking, deliberately out of scope

`electron/mcp/tools.ts` (`search_ideas`, `search_passages`) runs the same blocking scans, which freezes the Nodus window when an MCP client queries it in the background. `fusion.ts`, `chapterIdeas.ts` and `manuscriptVerifier.ts` also do, from inside long background jobs. Separate changes.
