### PR TITLE
Stop the MCP searches from freezing a window nobody is watching

### DIFF
--- a/electron/mcp/tools.ts
+++ b/electron/mcp/tools.ts
@@ -1231,7 +1231,7 @@ export function registerTools(server: McpServer): void {
           );
         }
         return {
-          ideas: ideas.findSimilarIdeas(vector, -1, limit),
+          ideas: await ideas.findSimilarIdeasPaged(vector, -1, limit),
           ...searchCoverage(ideas.embeddedIdeaCount(), count('ideas'), 'ideas'),
         };
       })()
@@ -1689,7 +1689,12 @@ export function registerTools(server: McpServer): void {
             'No embeddings available. Configure the embedding provider and key in Nodus Settings.'
           );
         }
-        const hits = passages.findSimilarPassages(vector, minSimilarity, limit, nodusId ? { nodusIds: [nodusId] } : {});
+        const hits = await passages.findSimilarPassagesPaged(
+          vector,
+          minSimilarity,
+          limit,
+          nodusId ? { nodusIds: [nodusId] } : {}
+        );
         return {
           ...searchCoverage(passages.embeddedPassageCount(), count('passages'), 'full-text passages'),
           passages: hits.map((hit) => ({

--- a/scripts/test-mcp.mjs
+++ b/scripts/test-mcp.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
@@ -1103,6 +1103,22 @@ try {
   const missing = await callTool(server, 'nodus_get_deep_research_job', { jobId: 'drj-does-not-exist' });
   assert.equal(missing.job, null);
   assert.match(missing.error, /nodus_list_deep_research_reports/, 'a dropped job points the client at the persistent gallery');
+
+  // The two semantic searches must never hold the main process for a whole scan.
+  // MCP calls arrive while the user is working in another application with Nodus
+  // open behind it, so a blocking scan freezes a window nobody is even looking at:
+  // one statement running vec_cosine() over every embedded row is, on a real corpus
+  // (13,799 ideas, 44,138 passages), 95 ms per idea scan and 366 ms per passage
+  // scan of dead UI. The paged scans (electron/db/vectorScan.ts) return the same
+  // rows in the same order and yield between rowid windows.
+  const toolsSource = await readFile(path.join(repoRoot, 'electron/mcp/tools.ts'), 'utf8');
+  for (const blocking of ['findSimilarIdeas', 'findSimilarPassages']) {
+    assert.doesNotMatch(
+      toolsSource,
+      new RegExp(`\\.${blocking}\\(`),
+      `${blocking}() blocks the event loop for the whole scan — use ${blocking}Paged()`
+    );
+  }
 
   // Semantic passage search: unconfigured provider must fail cleanly…
   const passageAiError = await callToolRaw(server, 'nodus_search_passages', {


### PR DESCRIPTION
Closes #474.

`nodus_search_ideas` and `nodus_search_passages` were the last foreground callers of the blocking similarity searches. Each ran one SQL statement that evaluates the JS `vec_cosine()` function over every embedded row, on the single thread that also services every IPC call and paints the window: 95 ms per idea scan and 366 ms per passage scan on the active academic vault (13,799 embedded ideas, 44,138 embedded passages).

MCP is where that hurts most, for a reason unrelated to the numbers. The calls arrive while the user is working in another application, with Nodus open behind it — no button was pressed, no spinner is being watched, and the window simply beachballs, repeatedly if the client searches more than once in a turn.

Both now go through the paged scans in `electron/db/vectorScan.ts`, which walk the same rows in rowid windows and yield the event loop between them. The paged variants are drop-in apart from being async, and both handlers already were.

Same swap as #473 did for the research chat and Nodi, on the same two functions.

## Verification

- `npm run typecheck` and `npm test` (1949 tests) both clean.
- `scripts/test-mcp.mjs` already drives both tools through the real handlers under Electron, so the cosine ranking, the `workId` scoping, the `minSimilarity` floor and the index-coverage warnings are covered exactly as before.
- What it lacked was anything stopping the call sites from reverting, which is how these two survived every earlier pass. It now reads `electron/mcp/tools.ts` and rejects the blocking names. Both halves were checked by making them fail — restoring `findSimilarIdeas(` reports `findSimilarIdeas() blocks the event loop for the whole scan — use findSimilarIdeasPaged()`, and likewise for passages.
- Row-for-row equivalence of the paged scans is already established by `npm run verify:vector-scan` and `scripts/test-vector-scan.mjs`; it was not re-run here, as nothing in this PR touches those functions.

The scans inside long background jobs (`fusion.ts`, `chapterIdeas.ts`, `manuscriptVerifier.ts`) are deliberately untouched — separate call.
