### PR TITLE
Prepare Nodus 4.1.5 release

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -65,7 +65,7 @@ jobs:
           scripts/test-server-vectors.mjs
 
       - name: Build smoke-test image
-        run: docker build --build-arg NODUS_VERSION=4.1.4 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
+        run: docker build --build-arg NODUS_VERSION=4.1.5 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
 
       - name: Run image health smoke test
         shell: bash
@@ -115,7 +115,7 @@ jobs:
             org.opencontainers.image.description=Experimental self-hosted Nodus MCP server
             org.opencontainers.image.source=https://github.com/Drakonis96/nodus
             org.opencontainers.image.licenses=AGPL-3.0-only
-            org.opencontainers.image.version=4.1.4
+            org.opencontainers.image.version=4.1.5
             org.opencontainers.image.revision=${{ github.sha }}
             app.nodus.stability=experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 4.1.5 — 2026-08-17
+
+Nodus 4.1.5 puts the floating selection ribbon where the hand that made the selection
+left it, and removes the last two places where a search stopped the whole window while
+it thought.
+
+- The reader's selection ribbon and the workspace, study and teaching note toolbars wait
+  for the pointer to be released and are placed above it, or above the caret when the
+  selection was made with the keyboard.
+- Clicking a stored highlight reopens the full ribbon with colours, comment, copy,
+  bookmark and Nodi quote, with its current colour marked and deletion at the end, so a
+  highlight can be recoloured instead of only deleted.
+- The research chat and Nodi's active-vault context use the paged vector scans, so asking
+  a question no longer blocks the main process, and a new Nodi chat starts with the
+  current vault selected.
+- `nodus_search_ideas` and `nodus_search_passages` use the paged vector scans too, so an
+  MCP client searching from another application no longer freezes the Nodus window behind
+  it. `test-mcp.mjs` now refuses the blocking call sites outright.
+- The What's New modal presents this release in all eight interface languages.
+
 ## 4.1.4 — 2026-08-16
 
 Nodus 4.1.4 keeps the desktop responsive during automatic backups and connected-vault

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "4.1.4"
-date-released: "2026-08-16"
+version: "4.1.5"
+date-released: "2026-08-17"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://nodusresearch.com/"

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.1.4 is licensed exclusively under the GNU Affero General Public
+Nodus 4.1.5 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.1.4 release is available
+The preferred form for modifying the official Nodus 4.1.5 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.4
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.4
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.5
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.5
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.5.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.5.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.1.4 is free software distributed exclusively under the GNU Affero
+Nodus 4.1.5 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/electron/library/libraryCslStyles.ts
+++ b/electron/library/libraryCslStyles.ts
@@ -155,7 +155,7 @@ function repositoryStyleTitle(id: string): string {
 async function officialRepositoryIndex(): Promise<LibraryCitationStyleRepositoryEntry[]> {
   if (!repositoryIndexPromise) {
     repositoryIndexPromise = fetch(OFFICIAL_STYLES_TREE_URL, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.1.4' },
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.1.5' },
     }).then(async (response) => {
       if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
       const payload = await response.json() as { tree?: Array<{ path?: string; type?: string }>; truncated?: boolean };
@@ -246,7 +246,7 @@ export async function installRepositoryCitationStyle(rawId: string): Promise<Lib
   const id = repositoryIdFromUrl(rawId) ?? rawId.trim().toLowerCase().replace(/\.csl$/i, '');
   if (!/^[a-z0-9][a-z0-9._-]{1,199}$/.test(id)) throw new Error('Introduce el identificador de un estilo del repositorio oficial de CSL.');
   const response = await fetch(`${OFFICIAL_STYLES_RAW_URL}/${encodeURIComponent(id)}.csl`, {
-    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.1.4' },
+    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.1.5' },
   });
   if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
   const declaredLength = Number(response.headers.get('content-length') || 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "AGPL-3.0-only",

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '4.1.4';
+const VERSION = '4.1.5';
 
 test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 4.1.4 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 4.1.5 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -74,7 +74,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '4.1.4');
+      assert.equal(info.version, '4.1.5');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,14 +25,23 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '4.1.4');
-  assert.equal(currentRelease?.date, '2026-08-16');
+  assert.equal(currentRelease?.version, '4.1.5');
+  assert.equal(currentRelease?.date, '2026-08-17');
   assert.equal(currentRelease?.highlights.length, 4);
-  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['general', 'general', 'general', 'nodi']);
-  assert.ok(currentRelease?.highlights.some((highlight) => /new home at nodusresearch\.com/.test(highlight.en)));
-  assert.ok(currentRelease?.highlights.some((highlight) => /no longer block the app/.test(highlight.en)));
-  assert.ok(currentRelease?.highlights.some((highlight) => /first administrator account/.test(highlight.en)));
-  assert.ok(currentRelease?.highlights.some((highlight) => /notification centre now gives a clear answer/.test(highlight.en)));
+  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['general', 'academic', 'nodi', 'mcp']);
+  assert.ok(currentRelease?.highlights.some((highlight) => /where you released the pointer/.test(highlight.en)));
+  assert.ok(currentRelease?.highlights.some((highlight) => /reopens the whole ribbon/.test(highlight.en)));
+  assert.ok(currentRelease?.highlights.some((highlight) => /no longer freezes the window/.test(highlight.en)));
+  assert.ok(currentRelease?.highlights.some((highlight) => /MCP client no longer block the Nodus window/.test(highlight.en)));
+
+  // 4.1.4 keeps the four it shipped with. They are published history.
+  const newHomeRelease = RELEASE_NOTES.find((note) => note.version === '4.1.4');
+  assert.equal(newHomeRelease?.date, '2026-08-16');
+  assert.equal(newHomeRelease?.highlights.length, 4);
+  assert.ok(newHomeRelease?.highlights.some((highlight) => /new home at nodusresearch\.com/.test(highlight.en)));
+  assert.ok(newHomeRelease?.highlights.some((highlight) => /no longer block the app/.test(highlight.en)));
+  assert.ok(newHomeRelease?.highlights.some((highlight) => /first administrator account/.test(highlight.en)));
+  assert.ok(newHomeRelease?.highlights.some((highlight) => /notification centre now gives a clear answer/.test(highlight.en)));
 
   // 4.1.3 keeps the two it shipped with. They are published history.
   const readingPositionRelease = RELEASE_NOTES.find((note) => note.version === '4.1.3');

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '4.1.4');
+  assert.equal(pluginManifest.version, '4.1.5');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,10 +54,10 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '4\.1\.4'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '4\.1\.5'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.1\.4\.tar\.gz/);
-  assert.match(citation, /^date-released: "2026-08-16"$/m);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.1\.5\.tar\.gz/);
+  assert.match(citation, /^date-released: "2026-08-17"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);
   }

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1244,9 +1244,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '4.1.4', 'the add-on shares the Nodus 4 release version');
+  assert.equal(manifest.version, '4.1.5', 'the add-on shares the Nodus 4 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.1\.4/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.1\.5/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,13 +3,13 @@
 
 FROM node:22-alpine
 
-ARG NODUS_VERSION=4.1.4
+ARG NODUS_VERSION=4.1.5
 ARG NODUS_REVISION=unknown
 LABEL org.opencontainers.image.title="Nodus Server" \
       org.opencontainers.image.description="Experimental self-hosted Nodus MCP server" \
       org.opencontainers.image.source="https://github.com/Drakonis96/nodus" \
       org.opencontainers.image.url="https://github.com/Drakonis96/nodus" \
-      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.1.4/server/README.md" \
+      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.1.5/server/README.md" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.version="${NODUS_VERSION}" \
       org.opencontainers.image.revision="${NODUS_REVISION}" \
@@ -24,7 +24,7 @@ COPY LICENSE SOURCE_CODE.md THIRD_PARTY_NOTICES.md ./
 ENV NODUS_DATA_DIR=/data \
     NODUS_HOST=0.0.0.0 \
     NODUS_PORT=7443 \
-    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.1.4
+    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.1.5
 
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.1.4 is licensed exclusively under the GNU Affero General Public
+Nodus 4.1.5 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.1.4 release is available
+The preferred form for modifying the official Nodus 4.1.5 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.4
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.4
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.4.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.1.5
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.1.5
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.5.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.1.5.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.1.4 is free software distributed exclusively under the GNU Affero
+Nodus 4.1.5 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -36,7 +36,7 @@ services:
       # With the pair, the account is created on first boot and its password is rotated
       # whenever you change the value here.
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.5}
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       # Optional ceilings. Unset they default to 8 MiB per image, 2 GiB of images per

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -21,7 +21,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.5}
       # Optional ceilings. Left unset they default to 8 MiB per image, 2 GiB of images per
       # space, and the snapshot limits documented in the README.
       NODUS_MAX_ASSET_BYTES: ${NODUS_MAX_ASSET_BYTES:-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.5}
     volumes:
       - nodus_data:/data
     ports:

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '4.1.4';
+export const NODUS_VERSION = '4.1.5';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/server/portainer-stack.yml
+++ b/server/portainer-stack.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.4}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.1.5}
     volumes:
       - nodus_data:/data
     expose:

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -155,6 +155,12 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "4.1.5": [
+    "Il nastro delle opzioni compare ora dove hai rilasciato il puntatore. Prima si posizionava sopra la prima riga della selezione, così trascinare un paragrafo dall'alto verso il basso lo lasciava lontano da dove stavi guardando. Aspetta inoltre che tu rilasci, invece di seguire la selezione mentre cresce. Una selezione fatta con la tastiera segue il cursore di testo. Vale sia per il lettore sia per gli editor di note dello spazio di lavoro, dello studio e dell'insegnamento.",
+    "Premendo un'evidenziazione salvata si riapre l'intero nastro. Prima offriva soltanto di cancellarla. Ora hai i colori, il commento, copia, il segnalibro e cita in Nodi, con il colore che ha già selezionato e il cestino alla fine. Cambiare colore a un'evidenziazione si fa ora da lì.",
+    "Chiedere a Nodi o alla chat di ricerca non blocca più la finestra. La ricerca per somiglianza percorreva tutto il corpus in una sola volta e lasciava l'applicazione ferma finché la risposta non iniziava ad arrivare. Ora lo percorre a tratti e restituisce esattamente gli stessi risultati. Inoltre una chat nuova parte con il vault attivo già selezionato, perché quasi sempre è quello di cui stai chiedendo. Tutti i vault resta a un clic di distanza.",
+    "Le ricerche fatte da un client MCP non bloccano più la finestra di Nodus. Cercare idee o passaggi da un'altra applicazione congelava Nodus sullo sfondo, senza nulla sullo schermo che lo spiegasse, e di nuovo a ogni ricerca del turno. Quelle due ricerche ora percorrono il corpus a tratti e restituiscono lo stesso ordine dei risultati.",
+  ],
   "4.1.4": [
     "Nodus ha una nuova casa su nodusresearch.com. Il nuovo sito riunisce wiki, manuali, demo interattive, domande frequenti, blog e una pagina per contribuire. È stato riprogettato per orientarti al primo sguardo e funziona meglio sugli schermi piccoli. L’applicazione ti avviserà una sola volta e il centro notifiche aprirà il nuovo indirizzo.",
     "I backup automatici e la pubblicazione dei vault connessi non bloccano più l’applicazione. Il lavoro pesante ora avviene fuori dalla finestra principale, usa una quantità di memoria limitata e si interrompe se un processo esterno si blocca. Puoi continuare a usare Nodus mentre un vault grande viene cifrato, compresso o inviato al server. Le pubblicazioni non riuscite attendono prima di riprovare e i dati invariati non vengono ricostruiti.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -95,6 +95,12 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "4.1.5": [
+    "Seçenekler şeridi artık işaretçiyi bıraktığınız yerde beliriyor. Önceden seçimin ilk satırının üzerinde duruyordu, bu yüzden bir paragrafı yukarıdan aşağıya sürüklemek onu baktığınız yerden uzağa bırakıyordu. Ayrıca seçim büyürken onu izlemek yerine bırakmanızı bekliyor. Klavyeyle yapılan bir seçimde şerit metin imlecini izliyor. Bu hem okuyucu için hem de çalışma alanı, çalışma ve öğretim not düzenleyicileri için geçerli.",
+    "Kayıtlı bir vurguya bastığınızda artık şeridin tamamı yeniden açılıyor. Önceden yalnızca silmeyi sunuyordu. Artık renkler, yorum, kopyalama, yer imi ve Nodi'de alıntılama elinizin altında, hâlihazırdaki rengi işaretli ve çöp kutusu en sonda. Bir vurgunun rengini değiştirmek artık oradan yapılıyor.",
+    "Nodi'ye ya da araştırma sohbetine soru sormak artık pencereyi dondurmuyor. Benzerlik araması bütün külliyatı tek seferde tarıyor ve yanıt gelmeye başlayana kadar uygulamayı kıpırdatmıyordu. Artık külliyatı bölümler hâlinde tarıyor ve tam olarak aynı sonuçları veriyor. Ayrıca yeni bir sohbet etkin kasa zaten seçili olarak başlıyor, çünkü sorduğunuz şey neredeyse her zaman odur. Tüm kasalar bir tık uzağınızda kalmayı sürdürüyor.",
+    "Bir MCP istemcisinin yaptığı aramalar artık Nodus penceresini engellemiyor. Başka bir uygulamadan fikir ya da pasaj aramak, ekranda bunu açıklayan hiçbir şey olmadan Nodus'u arkada donduruyordu, üstelik turdaki her arama için yeniden. Bu iki arama artık külliyatı bölümler hâlinde tarıyor ve aynı sıralamayı veriyor.",
+  ],
   "4.1.4": [
     "Nodus artık nodusresearch.com adresinde yeni bir eve sahip. Yeni site wiki’yi, kılavuzları, etkileşimli demoları, sık sorulan soruları, blogu ve katkıda bulunma sayfasını bir araya getiriyor. İlk bakışta yönünüzü bulmanız için yeniden tasarlandı ve küçük ekranlarda daha iyi çalışıyor. Uygulama size bunu yalnızca bir kez bildirecek ve bildirim merkezi yeni adresi açacak.",
     "Otomatik yedeklemeler ve bağlı kasaların yayımlanması artık uygulamayı engellemiyor. Ağır işler ana pencerenin dışında çalışıyor, sınırlı bellek kullanıyor ve harici bir süreç takılırsa durduruluyor. Büyük bir kasa şifrelenirken, sıkıştırılırken veya sunucuya gönderilirken Nodus’u kullanmaya devam edebilirsiniz. Başarısız yayımlar yeniden denemeden önce bekliyor ve değişmeyen veriler yeniden oluşturulmuyor.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1106,6 +1106,49 @@ const RELEASE_4_1_3_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+/**
+ * 4.1.5 — the selection ribbon lands where the hand left it, and the two remaining
+ * places that stopped the window while it thought stop doing it.
+ */
+const RELEASE_4_1_5_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'La cinta de opciones aparece ahora donde soltaste el ratón. Antes se colocaba sobre la primera línea de la selección, así que arrastrar un párrafo de arriba abajo la dejaba lejos de donde estabas mirando. También espera a que sueltes en lugar de seguir a la selección mientras crece. Si seleccionas con el teclado, la cinta sigue al cursor. Vale igual para el lector y para los editores de notas del espacio de trabajo, de estudio y de docencia.',
+    en: 'The options ribbon now appears where you released the pointer. It used to sit above the first line of the selection, so dragging a paragraph downwards left it far from where you were looking. It also waits for you to let go instead of following the selection as it grows. A selection made with the keyboard follows the caret instead. This applies to the reader and to the note editors in the workspace, study and teaching.',
+    fr: 'Le ruban d’options apparaît désormais là où vous avez relâché le pointeur. Il se plaçait avant au-dessus de la première ligne de la sélection, si bien que faire glisser un paragraphe vers le bas le laissait loin de votre regard. Il attend aussi que vous relâchiez au lieu de suivre la sélection pendant qu’elle grandit. Une sélection faite au clavier suit le curseur de texte. Cela vaut pour le lecteur comme pour les éditeurs de notes de l’espace de travail, des études et de l’enseignement.',
+    de: 'Das Optionsband erscheint jetzt dort, wo Sie den Zeiger losgelassen haben. Früher saß es über der ersten Zeile der Auswahl, sodass es beim Ziehen eines Absatzes nach unten weit weg von Ihrem Blick lag. Es wartet außerdem auf das Loslassen, statt der wachsenden Auswahl zu folgen. Eine mit der Tastatur getroffene Auswahl folgt stattdessen der Schreibmarke. Das gilt für den Reader ebenso wie für die Notizeditoren in Arbeitsbereich, Studium und Unterricht.',
+    pt: 'A fita de opções aparece agora onde largou o rato. Antes ficava sobre a primeira linha da seleção, por isso arrastar um parágrafo de cima para baixo deixava-a longe de onde estava a olhar. Também espera que largue, em vez de seguir a seleção enquanto ela cresce. Se selecionar com o teclado, a fita segue o cursor de texto. Vale tanto para o leitor como para os editores de notas do espaço de trabalho, do estudo e do ensino.',
+    'pt-BR': 'A faixa de opções aparece agora onde você soltou o mouse. Antes ela ficava sobre a primeira linha da seleção, então arrastar um parágrafo de cima para baixo a deixava longe de onde você estava olhando. Ela também espera você soltar, em vez de seguir a seleção enquanto cresce. Se você selecionar com o teclado, a faixa segue o cursor de texto. Vale tanto para o leitor quanto para os editores de notas do espaço de trabalho, do estudo e do ensino.',
+  },
+  {
+    scope: 'academic',
+    es: 'Al pulsar un subrayado guardado vuelve a abrirse la cinta completa. Antes solo ofrecía borrarlo. Ahora tienes los colores, el comentario, copiar, el marcador y citar en Nodi, con el color que ya tiene marcado y la papelera al final. Cambiar de color un subrayado ya funciona desde ahí.',
+    en: 'Clicking a stored highlight now reopens the whole ribbon. It used to offer deletion alone. You get the colours, the comment, copy, the bookmark and quoting in Nodi, with the colour it already has marked and the bin at the end. Recolouring a highlight now works from there.',
+    fr: 'Cliquer sur un surlignage enregistré rouvre désormais le ruban entier. Il ne proposait avant que la suppression. Vous retrouvez les couleurs, le commentaire, la copie, le signet et la citation dans Nodi, avec la couleur qu’il a déjà cochée et la corbeille à la fin. Changer la couleur d’un surlignage se fait maintenant de là.',
+    de: 'Ein Klick auf eine gespeicherte Markierung öffnet jetzt das ganze Band. Zuvor bot es nur das Löschen an. Sie erhalten die Farben, den Kommentar, Kopieren, das Lesezeichen und das Zitieren in Nodi, mit der bereits vorhandenen Farbe markiert und dem Papierkorb am Ende. Die Farbe einer Markierung lässt sich nun von dort ändern.',
+    pt: 'Ao carregar num sublinhado guardado, a fita completa volta a abrir. Antes só oferecia apagá-lo. Agora tem as cores, o comentário, copiar, o marcador e citar no Nodi, com a cor que já tem assinalada e o caixote no fim. Mudar a cor de um sublinhado passa a fazer-se a partir daí.',
+    'pt-BR': 'Ao clicar em um destaque salvo, a faixa completa volta a abrir. Antes ela só oferecia excluí-lo. Agora você tem as cores, o comentário, copiar, o marcador e citar no Nodi, com a cor que ele já tem assinalada e a lixeira no fim. Mudar a cor de um destaque passa a ser feito ali mesmo.',
+  },
+  {
+    scope: 'nodi',
+    es: 'Preguntar a Nodi o al chat de investigación ya no congela la ventana. La búsqueda por similitud recorría todo el corpus de una sola vez y dejaba la aplicación quieta hasta que empezaba a llegar la respuesta. Ahora lo recorre por tramos y devuelve exactamente los mismos resultados. Además, un chat nuevo empieza con la bóveda activa ya seleccionada, porque casi siempre preguntas por ella. Todas las bóvedas sigue estando a un clic.',
+    en: 'Asking Nodi or the research chat no longer freezes the window. The similarity search walked the whole corpus in one go and left the app still until the answer started arriving. It now walks it in stages and returns exactly the same results. A new chat also starts with the current vault already selected, because that is nearly always what you are asking about. All vaults stays one click away.',
+    fr: 'Poser une question à Nodi ou au chat de recherche ne fige plus la fenêtre. La recherche par similarité parcourait tout le corpus d’un seul coup et laissait l’application immobile jusqu’à l’arrivée de la réponse. Elle le parcourt désormais par tranches et renvoie exactement les mêmes résultats. Un nouveau chat démarre aussi avec le coffre actif déjà sélectionné, car c’est presque toujours celui dont vous parlez. Tous les coffres reste à un clic.',
+    de: 'Eine Frage an Nodi oder den Recherche-Chat friert das Fenster nicht mehr ein. Die Ähnlichkeitssuche durchlief das gesamte Korpus in einem Zug und ließ die App stillstehen, bis die Antwort einzutreffen begann. Jetzt durchläuft sie es in Abschnitten und liefert genau dieselben Ergebnisse. Ein neuer Chat startet außerdem mit dem aktiven Tresor bereits ausgewählt, denn fast immer geht es um diesen. Alle Tresore bleibt einen Klick entfernt.',
+    pt: 'Perguntar ao Nodi ou ao chat de investigação já não congela a janela. A pesquisa por semelhança percorria todo o corpus de uma só vez e deixava a aplicação parada até a resposta começar a chegar. Agora percorre-o por troços e devolve exatamente os mesmos resultados. Além disso, um chat novo começa com o cofre ativo já selecionado, porque é quase sempre sobre ele que pergunta. Todos os cofres continua a um clique.',
+    'pt-BR': 'Perguntar ao Nodi ou ao chat de pesquisa já não congela a janela. A busca por semelhança percorria todo o corpus de uma só vez e deixava o aplicativo parado até a resposta começar a chegar. Agora ele o percorre por trechos e devolve exatamente os mesmos resultados. Além disso, um chat novo começa com o cofre ativo já selecionado, porque é quase sempre sobre ele que você pergunta. Todos os cofres continua a um clique.',
+  },
+  {
+    scope: 'mcp',
+    es: 'Las búsquedas que hace un cliente MCP dejan de bloquear la ventana de Nodus. Buscar ideas o pasajes desde otra aplicación congelaba Nodus por detrás, sin nada en pantalla que lo explicara, y otra vez por cada búsqueda del turno. Ahora esas dos búsquedas recorren el corpus por tramos y devuelven el mismo orden de resultados.',
+    en: 'Searches made by an MCP client no longer block the Nodus window. Searching ideas or passages from another application froze Nodus behind it, with nothing on screen to explain it, and again for every search in a turn. Those two searches now walk the corpus in stages and return the same ranking.',
+    fr: 'Les recherches lancées par un client MCP ne bloquent plus la fenêtre de Nodus. Chercher des idées ou des passages depuis une autre application figeait Nodus à l’arrière-plan, sans rien à l’écran pour l’expliquer, et de nouveau à chaque recherche du tour. Ces deux recherches parcourent maintenant le corpus par tranches et renvoient le même classement.',
+    de: 'Suchen eines MCP-Clients blockieren das Nodus-Fenster nicht mehr. Das Suchen von Ideen oder Passagen aus einer anderen Anwendung ließ Nodus im Hintergrund einfrieren, ohne dass etwas auf dem Bildschirm es erklärte, und erneut bei jeder Suche im selben Zug. Diese beiden Suchen durchlaufen das Korpus nun in Abschnitten und liefern dieselbe Reihenfolge.',
+    pt: 'As pesquisas feitas por um cliente MCP deixam de bloquear a janela do Nodus. Procurar ideias ou passagens a partir de outra aplicação congelava o Nodus por trás, sem nada no ecrã que o explicasse, e outra vez a cada pesquisa do turno. Essas duas pesquisas percorrem agora o corpus por troços e devolvem a mesma ordem de resultados.',
+    'pt-BR': 'As buscas feitas por um cliente MCP deixam de bloquear a janela do Nodus. Procurar ideias ou passagens a partir de outro aplicativo congelava o Nodus por trás, sem nada na tela que explicasse, e de novo a cada busca do turno. Essas duas buscas percorrem agora o corpus por trechos e devolvem a mesma ordem de resultados.',
+  },
+];
+
 /** 4.1.4 — a new public home and a desktop that stays responsive during upkeep. */
 const RELEASE_4_1_4_HIGHLIGHTS: RawReleaseHighlight[] = [
   {
@@ -1435,6 +1478,11 @@ const RELEASE_4_0_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '4.1.5',
+    date: '2026-08-17',
+    highlights: RELEASE_4_1_5_HIGHLIGHTS,
+  },
   {
     version: '4.1.4',
     date: '2026-08-16',

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
Opens 4.1.5 across the desktop, the server, the extensions and the tests that pin the version, and writes the What's New notes for all eight interface languages.

What ships since 4.1.4:

- **The selection ribbon lands where the hand left it.** The reader's ribbon and the workspace, study and teaching note toolbars wait for the pointer to be released and appear above it, or above the caret when the selection came from the keyboard.
- **A stored highlight reopens the whole ribbon.** Colours, comment, copy, bookmark and Nodi quote, with the current colour marked and deletion at the end, so a highlight can be recoloured instead of only deleted.
- **Asking Nodi no longer freezes the window.** The research chat and Nodi's active-vault context moved to the paged vector scans, and a new chat starts with the current vault selected.
- **MCP searches no longer freeze the window either.** `nodus_search_ideas` and `nodus_search_passages` were the last foreground callers of the blocking similarity searches.

`npm run build` then `npm test`: 1949 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
