### PR TITLE
Translate the study/teaching organization header title

### DIFF
--- a/scripts/test-i18n-coverage.mjs
+++ b/scripts/test-i18n-coverage.mjs
@@ -769,6 +769,23 @@ test('seeded Spanish data labels are translated on screen, not left raw', () => 
   }
 });
 
+test('the study/teaching organization header title is translated', () => {
+  // The <h1> of the organization browser (study AND docencia, which reuse the same view)
+  // is not a t() literal: it comes back from targetTitle(), which returns either the name
+  // the user typed or one of three interface fallbacks. Those fallbacks shipped bare, so
+  // an English interface showed "Cursos y asignaturas" under an "ORGANISATION" eyebrow.
+  const view = fs.readFileSync(path.join(repoRoot, 'src/views/StudyOrganizationView.tsx'), 'utf8');
+  const body = view.slice(view.indexOf('function targetTitle'));
+  const fn = body.slice(0, body.indexOf('\n}') + 2);
+  assert.ok(fn.includes('function targetTitle'), 'targetTitle must exist');
+  for (const key of ['Cursos y asignaturas', 'Documento', 'Selección actual']) {
+    assert.match(fn, new RegExp(`t\\('${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'\\)`), `targetTitle must return t('${key}'), not the bare literal`);
+    for (const { name, table } of TRANSLATIONS) {
+      assert.ok(table[key], `"${key}" must be translated into ${name}`);
+    }
+  }
+});
+
 test('genealogy vault-type + section labels are translated', () => {
   // Spot-check the surfaces the user reported: header vault label, tree, relations,
   // archive, tour welcome.

--- a/src/views/StudyOrganizationView.tsx
+++ b/src/views/StudyOrganizationView.tsx
@@ -256,11 +256,20 @@ function placementMatches(workspace: StudyWorkspace, documentId: string, target:
   ));
 }
 
+/**
+ * The header title. A course, subject, folder or topic carries the name the user typed,
+ * so it travels as-is; the three fallbacks are interface wording and must be translated
+ * HERE — this string is rendered raw into the <h1>, so a bare literal left the section
+ * heading in Spanish in every other language while the eyebrow and breadcrumb beside it
+ * were translated.
+ */
 function targetTitle(workspace: StudyWorkspace, target: StudyNavigationTarget | null): string {
-  if (!target) return 'Cursos y asignaturas';
-  if (target.kind === 'document') return workspace.documents.find((item) => item.id === target.id)?.title ?? 'Documento';
+  if (!target) return t('Cursos y asignaturas');
+  if (target.kind === 'document') return workspace.documents.find((item) => item.id === target.id)?.title ?? t('Documento');
   const list = target.kind === 'course' ? workspace.courses : target.kind === 'subject' ? workspace.subjects : target.kind === 'topic' ? workspace.topics : workspace.folders;
-  return list.find((item) => item.id === target.id)?.name ?? 'Selección';
+  // Not 'Selección': that key is the databases column type, translated as the verb
+  // ("Select" / "Seleziona"), which reads as an instruction rather than a heading.
+  return list.find((item) => item.id === target.id)?.name ?? t('Selección actual');
 }
 
 interface StudyBrowserItem {


### PR DESCRIPTION
Closes #478

## The bug

In the study and teaching vaults, the heading of the organization browser stayed in
Spanish in every interface language. With the app in English the eyebrow above it read
`ORGANISATION` and the breadcrumb below it read `Courses`, while the `<h1>` between them
still read `Cursos y asignaturas` — which is what made it look like a glitch rather than
a missing string.

## Cause

`targetTitle()` in `src/views/StudyOrganizationView.tsx` builds that heading, and its
value is rendered raw into the `<h1>`. A course, subject, folder or topic contributes the
name the user typed, so it travels as-is — but the three fallbacks are interface wording,
and they were bare Spanish literals rather than `t()` calls.

The Spanish keys already existed in all seven translation tables. Only the `t()` call was
missing, which is also why the suite stayed green: `test-i18n-coverage` verifies that
every key *reaching* `t()` has a translation, and this string never reached it.

Both vaults are affected by one defect: `docencia` reuses this same view behind
*Cursos, asignaturas y grupos*.

## Change

- Wrap the three fallbacks in `t()`.
- Use `'Selección actual'` for the not-found fallback instead of `'Selección'`. That key
  is the databases column type and is translated as a verb ("Select", "Seleziona"), which
  reads as an instruction rather than a heading; `'Selección actual'` ("Current selection")
  is already translated in all seven languages.
- Add a regression test that asserts each fallback still goes through `t()` and is
  translated everywhere. It was checked against the previous code and fails there.

## Audit

The report asked whether anything else was left untranslated. A sweep of the study and
teaching surfaces — sidebars, tours, home cards, question bank, materials, schedule,
calendar, search, review, exam builder, rubrics, assessment plan editor, gradebook —
found every other Spanish label already reaching `t()`, directly or through a label map.
Widening the same sweep to the rest of the app (every module-level Spanish literal whose
identifier never appears inside a `t()` call, plus every helper returning a bare Spanish
string, plus raw Spanish JSX text) turned up no other instance of this shape. Language
endonyms in the exam and rubric pickers (`Español`, `Français`, …) are intentionally not
translated.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean.
- `node --test scripts/test-i18n-coverage.mjs` — 24/24, including the new test.
- `npm test` — 1948/1950. The two failures are unrelated and reproduce without this
  change: `test-prosopography-e2e` fails to launch Electron in a worktree with no build
  (identical failure on the parent commit), and `test-library-scale` is a wall-clock
  budget that tripped under parallel load and passes when run on its own.
