### PR TITLE
Persistent gallery filters in Deep Research and Inmersión, and no gallery flash when reopening an item

### DIFF
--- a/scripts/e2e-view-snapshots.mjs
+++ b/scripts/e2e-view-snapshots.mjs
@@ -37,6 +37,27 @@ const TOP_BLOCK = `(() => {
   return found ? (found.textContent ?? '').trim().slice(0, 80) : null;
 })()`;
 
+/**
+ * Samples what is painted on every frame until told to stop. A section walking back
+ * into a report or a session must never show its gallery on the way: the read of the
+ * thing to reopen takes a few frames, and painting the list in the meantime looks
+ * like the app opening the list and clicking the item by itself.
+ */
+const WATCH_SURFACES = (gallery) => `(() => {
+  window.__gen = (window.__gen ?? 0) + 1;
+  const mine = window.__gen;
+  window.__surfaces = [];
+  const started = performance.now();
+  const tick = () => {
+    if (window.__gen !== mine) return;
+    if (document.querySelector('${gallery}')) window.__surfaces.push(Math.round(performance.now() - started));
+    if (performance.now() - started < 3000) requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+})()`;
+const DEEP_GALLERY = 'input[placeholder^="Buscar entre tus informes"]';
+const IMMERSION_GALLERY = 'input[placeholder^="Buscar entre tus inmersiones"]';
+
 let app;
 try {
   app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
@@ -67,12 +88,14 @@ try {
   }, require(path.join(repoRoot, 'package.json')).version);
   await page.reload();
   await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
-  const updateModal = page.getByTestId('startup-update-modal');
-  if (await updateModal.count()) {
+  const dismissUpdateModal = async () => {
+    const updateModal = page.getByTestId('startup-update-modal');
+    if (!(await updateModal.count())) return;
     await page.waitForFunction(() => document.querySelector('[data-testid="startup-update-modal"]')?.getAttribute('data-update-status') === 'not-available');
     await updateModal.getByRole('button', { name: 'Entendido', exact: false }).click();
     await updateModal.waitFor({ state: 'detached' });
-  }
+  };
+  await dismissUpdateModal();
 
   // The demo's report is one screen long, and a place only means something in a
   // document that does not fit on one. This is the demo report with a long body: same
@@ -117,8 +140,14 @@ try {
   // ── Out of the section, and back in ─────────────────────────────────────────
   await page.locator('[data-tour="nav-ideas"]').click();
   await page.waitForSelector('[data-testid="deep-research-reader-document"]', { state: 'detached' });
+  await page.evaluate(WATCH_SURFACES(DEEP_GALLERY));
   await openDeepResearch();
   await readerDocument.waitFor({ state: 'visible' });
+  assert.deepEqual(
+    await page.evaluate(() => window.__surfaces),
+    [],
+    'the gallery is never painted on the way back to an open report',
+  );
 
   const backAt = await page.evaluate(TOP_BLOCK);
   assert.equal(backAt, leftAt, 'the report reopens at the paragraph it was left on');
@@ -157,8 +186,14 @@ try {
   const step = await page.locator('header .text-\\[11px\\]').first().innerText();
   await page.locator('[data-tour="nav-ideas"]').click();
   await immersionExit.waitFor({ state: 'detached' });
+  await page.evaluate(WATCH_SURFACES(IMMERSION_GALLERY));
   await page.locator('[data-tour="nav-immersion"]').click();
   await immersionExit.waitFor({ state: 'visible' });
+  assert.deepEqual(
+    await page.evaluate(() => window.__surfaces),
+    [],
+    'nor on the way back to an open session',
+  );
   assert.equal(await page.locator('header .text-\\[11px\\]').first().innerText(), step, 'the immersion reopens on the step it was left on');
 
   // And leaving the player is leaving it: the gallery does not reopen it by itself.
@@ -166,6 +201,48 @@ try {
   await page.locator('[data-tour="nav-ideas"]').click();
   await page.locator('[data-tour="nav-immersion"]').click();
   await immersionExit.waitFor({ state: 'detached' });
+
+  // ── A restart: what was a preference, and what was only a place ─────────────
+  //
+  // Reloading the window throws the entire renderer away, module-level snapshot store
+  // included, which is what the reader gets on the next launch. Everything above this
+  // line is remembered by that store; only the ordering, the read filter and the
+  // grid/list choice are expected to come back from disk.
+  const immersionSort = page.locator('select').filter({ hasText: 'Más recientes' });
+  await immersionSort.selectOption('title');
+  await page.getByTitle('Vista lista').click();
+
+  // A search and an open report, which are a question and a place: neither is a
+  // preference, and neither may come back a launch later to hide the gallery.
+  await openDeepResearch();
+  await page.locator('input[placeholder^="Buscar entre tus informes"]').fill('AAA informe largo');
+  await page.getByRole('button', { name: 'Leer', exact: true }).first().click();
+  await readerDocument.waitFor({ state: 'visible' });
+
+  await page.reload();
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+  await dismissUpdateModal();
+
+  await openDeepResearch();
+  await readerDocument.waitFor({ state: 'detached' });
+  assert.equal(await sortSelect.inputValue(), 'title', 'the ordering survives the restart');
+  assert.ok(
+    await page.evaluate(() => Boolean(document.querySelector('.space-y-2 [data-anchor-id]'))),
+    'and so does the list/grid choice',
+  );
+  assert.equal(
+    await page.locator('input[placeholder^="Buscar entre tus informes"]').inputValue(),
+    '',
+    'the search box does not come back with them',
+  );
+
+  await page.locator('[data-tour="nav-immersion"]').click();
+  await page.locator('[data-anchor-id]').first().waitFor({ state: 'visible' });
+  assert.equal(await immersionSort.inputValue(), 'title', 'Inmersión reopens on its own stored ordering');
+  assert.ok(
+    await page.evaluate(() => Boolean(document.querySelector('.space-y-2 [data-anchor-id]'))),
+    'and on its own stored layout',
+  );
 
   assert.deepEqual(pageErrors.map((error) => error.message), [], 'no renderer errors');
   console.log('View snapshots e2e passed.');

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -491,12 +491,35 @@ test('Inmersión restores its gallery and reopens the session it was left in', a
   // The session carries its own progress, so reopening it lands on the step it was
   // left on. Reporting waits for the reopen, or the empty state on the way in would
   // erase the very session being restored.
-  assert.match(view, /resuming = useRef<string \| null>\(snapshot\?\.openSession\?\.id \?\? null\)/);
+  // The target is chosen at mount, before the first paint: a dossier still being
+  // written wins over the session that was merely left open.
+  assert.match(view, /return fromDossier \|\| snapshot\?\.openSession\?\.id \|\| null;/);
+  assert.match(view, /const resuming = useRef<string \| null>\(resumeTarget\);/);
   assert.match(view, /if \(resuming\.current\) return;/);
-  assert.match(view, /const resume = fromDossier \|\| resuming\.current;/);
   // The scope screen is a pass over the corpus; redrawing it means paying for it again.
   const types = await readSource('src/app/viewSnapshots.ts');
   assert.doesNotMatch(types, /ImmersionScope|openScope/, 'the scope screen is not restored');
+});
+
+test('a section walking back into what it had open never paints its gallery on the way', async () => {
+  const [deep, immersion, ui] = await Promise.all([
+    readSource('src/views/DeepResearchView.tsx'),
+    readSource('src/views/ImmersionView.tsx'),
+    readSource('src/components/ui.tsx'),
+  ]);
+  // Reopening means reading the report or the session back, which takes frames. What
+  // is painted in those frames used to be the gallery, and a gallery that appears and
+  // is replaced by the item it lists looks like the app clicking that item itself.
+  assert.match(deep, /if \(mode === 'reader' && !openDraft\) return <RestoringPane \/>;/);
+  // Inmersión decides at mount, not in an effect: an effect runs after the first
+  // paint, and the first paint is the one that must not be the gallery.
+  assert.match(immersion, /useState<'home' \| 'scope' \| 'player'>\(\(\) => \(resumeTarget \? 'player' : 'home'\)\)/);
+  assert.match(immersion, /mode === 'player' && !session && <RestoringPane \/>/);
+  // The waiting pane has exactly one way out when the thing is gone.
+  assert.match(immersion, /if \(!opened\) setMode\('home'\)/);
+  assert.match(deep, /restoredReading\.current = null;\s*setMode\('gallery'\)/);
+  // A spinner that appears and vanishes inside 60ms is its own flicker.
+  assert.match(ui, /setTimeout\(\(\) => setSlow\(true\), delayMs\)/);
 });
 
 test('Biblioteca reopens the documents that were open, and the reader finds its own page', async () => {

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -33,7 +33,28 @@ const bundleOf = (source, name) => {
   );
   return require(outfile);
 };
+/**
+ * The renderer's `localStorage`, which `node --test` does not have. Defined before
+ * the store is bundled so the durable half of a cut can be exercised for real
+ * instead of described, and counting its writes because a gallery patches its
+ * snapshot on every keystroke in the search box.
+ */
+class FakeStorage {
+  #values = new Map();
+  writes = 0;
+  get length() { return this.#values.size; }
+  key(index) { return [...this.#values.keys()][index] ?? null; }
+  getItem(key) { return this.#values.has(key) ? this.#values.get(key) : null; }
+  setItem(key, value) { this.writes += 1; this.#values.set(key, String(value)); }
+  removeItem(key) { this.#values.delete(key); }
+  clear() { this.#values.clear(); }
+}
+globalThis.localStorage = new FakeStorage();
+
 const store = bundleOf('src/app/viewSnapshots.ts', 'viewSnapshots.cjs');
+// Bundled apart from the store on purpose: a second instance of the module shares
+// no memory with the first, so anything the two agree on came through the disk.
+const preferences = bundleOf('src/app/filterPreferences.ts', 'filterPreferences.cjs');
 const { topAnchorId } = bundleOf('src/listPlacement.ts', 'listPlacement.cjs');
 const { readingBlocks, topBlockIndex } = bundleOf('src/readingPlace.ts', 'readingPlace.cjs');
 
@@ -506,4 +527,185 @@ test('the three sections added here receive their snapshot the way the others do
   // The same surface under the three names the app gives it, each with its own cut.
   assert.match(study, /snapshots\.read\('studyDeepResearch'\)/);
   assert.match(teaching, /snapshots\.read\('teachingUnits'\)/);
+});
+
+// ── Phase four: the half of the cut that outlives the run ─────────────────────
+
+/** A fresh app start: the in-memory store is gone, the disk is not. */
+const restart = () => store.clearViewSnapshots();
+
+const forgetPreferences = () => {
+  preferences.clearFilterPreferences();
+  globalThis.localStorage.writes = 0;
+  store.clearViewSnapshots();
+};
+
+test('the galleries reopen on the ordering and the layout the reader chose, run after run', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', {
+    surface: 'gallery', openReport: null, search: 'mímesis', readFilter: 'unread', sortKey: 'title', viewMode: 'list',
+  });
+  store.patchViewSnapshot('vault-a', 'immersion', { search: 'ricoeur', sortKey: 'oldest', viewMode: 'list' });
+
+  restart();
+
+  const reports = store.readViewSnapshot('vault-a', 'deepResearch');
+  assert.equal(reports.readFilter, 'unread', 'the read filter is a preference, not a place');
+  assert.equal(reports.sortKey, 'title');
+  assert.equal(reports.viewMode, 'list');
+  const immersion = store.readViewSnapshot('vault-a', 'immersion');
+  assert.equal(immersion.sortKey, 'oldest');
+  assert.equal(immersion.viewMode, 'list');
+});
+
+test('a query and a place are not preferences, and do not come back with them', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', {
+    surface: 'reader',
+    openReport: { id: 'R1', label: 'La metáfora viva' },
+    search: 'mímesis',
+    sortKey: 'title',
+    viewMode: 'list',
+    placement: { anchorId: 'R7' },
+    reading: { blockIndex: 42, rendering: 'original' },
+  });
+  store.patchViewSnapshot('vault-a', 'immersion', {
+    openSession: { id: 'S1', label: 'Sesión' }, search: 'ricoeur', sortKey: 'oldest', placement: { anchorId: 'S9' },
+  });
+
+  restart();
+
+  const reports = store.readViewSnapshot('vault-a', 'deepResearch');
+  // A search restored a week later hides the gallery with no visible cause; a place
+  // and an open report point at rows that may not exist any more.
+  assert.equal(reports.search, '', 'the search box starts empty on a new run');
+  assert.equal(reports.surface, 'gallery', 'a new run opens on the gallery');
+  assert.equal(reports.openReport, null);
+  assert.equal(reports.placement, null);
+  assert.equal(reports.reading, null);
+  const immersion = store.readViewSnapshot('vault-a', 'immersion');
+  assert.equal(immersion.search, '');
+  assert.equal(immersion.openSession, null);
+  assert.equal(immersion.placement, null);
+});
+
+test('within a run the whole cut still wins over the stored preferences', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', { sortKey: 'title', viewMode: 'list' });
+  store.patchViewSnapshot('vault-a', 'deepResearch', { search: 'mímesis', placement: { anchorId: 'R7' } });
+
+  // Leaving the section and coming back is not a restart: the snapshot in memory is
+  // the whole answer, and the seed must not overwrite it with its emptier one.
+  const live = store.readViewSnapshot('vault-a', 'deepResearch');
+  assert.equal(live.search, 'mímesis');
+  assert.deepEqual(live.placement, { anchorId: 'R7' });
+  assert.equal(live.sortKey, 'title');
+});
+
+test('a gallery never visited has no preferences to restore', () => {
+  forgetPreferences();
+  assert.equal(store.readViewSnapshot('vault-a', 'deepResearch'), undefined);
+  assert.equal(store.readViewSnapshot('vault-a', 'immersion'), undefined);
+});
+
+test('wiping one vault leaves the others their preferences', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', { sortKey: 'title' });
+  store.patchViewSnapshot('vault-b', 'deepResearch', { sortKey: 'oldest' });
+
+  // Deleting a vault takes its preferences with it, and nobody else's.
+  preferences.clearFilterPreferences('vault-a');
+  store.clearViewSnapshots();
+  assert.equal(store.readViewSnapshot('vault-a', 'deepResearch'), undefined);
+  assert.equal(store.readViewSnapshot('vault-b', 'deepResearch').sortKey, 'oldest');
+});
+
+test('the three names of Deep Research keep three sets of preferences', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', { sortKey: 'title' });
+  store.patchViewSnapshot('vault-a', 'studyDeepResearch', { sortKey: 'oldest' });
+  store.patchViewSnapshot('vault-a', 'teachingUnits', { viewMode: 'list' });
+
+  restart();
+
+  assert.equal(store.readViewSnapshot('vault-a', 'deepResearch').sortKey, 'title');
+  assert.equal(store.readViewSnapshot('vault-a', 'studyDeepResearch').sortKey, 'oldest');
+  assert.equal(store.readViewSnapshot('vault-a', 'teachingUnits').viewMode, 'list');
+  assert.equal(store.readViewSnapshot('vault-a', 'teachingUnits').sortKey, 'recent', 'what was never chosen keeps its default');
+});
+
+test('a preference belongs to the vault it was chosen in', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', { sortKey: 'title', viewMode: 'list' });
+  restart();
+
+  // Two corpora are two different sets of reports; ordering one says nothing about
+  // the other, and the seed is read under the id being asked for, never carried over.
+  assert.equal(store.readViewSnapshot('vault-b', 'deepResearch'), undefined);
+  assert.equal(store.readViewSnapshot('vault-a', 'deepResearch').sortKey, 'title');
+});
+
+test('with no vault nothing is stored and nothing is seeded', () => {
+  forgetPreferences();
+  store.patchViewSnapshot(null, 'deepResearch', { sortKey: 'title' });
+  assert.equal(store.readViewSnapshot(null, 'deepResearch'), undefined);
+  assert.equal(store.readViewSnapshot('vault-a', 'deepResearch'), undefined, 'a vault-less write is not a write to whoever comes next');
+});
+
+test('a value that is not an option of its select is ignored, not restored', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', { sortKey: 'conexiones', viewMode: 'list', readFilter: 42 });
+  restart();
+
+  const reports = store.readViewSnapshot('vault-a', 'deepResearch');
+  // A select holding a value it has no option for renders visibly empty and cannot
+  // be put right except by choosing something else.
+  assert.equal(reports.sortKey, 'recent', 'an unknown ordering falls back to the default');
+  assert.equal(reports.readFilter, 'all');
+  assert.equal(reports.viewMode, 'list', 'the fields that were valid still survive');
+
+  // The same for a store written by hand or left behind by an older version.
+  globalThis.localStorage.setItem('nodus.galleryFilters.immersion.vault-a', '{ not json');
+  store.clearViewSnapshots();
+  assert.equal(store.readViewSnapshot('vault-a', 'immersion'), undefined, 'an unreadable entry is a missing entry');
+});
+
+test('typing in the search box does not write to disk once per keystroke', () => {
+  forgetPreferences();
+  store.patchViewSnapshot('vault-a', 'deepResearch', { sortKey: 'title', viewMode: 'list' });
+  const afterChoice = globalThis.localStorage.writes;
+  assert.ok(afterChoice > 0, 'choosing an ordering is written');
+
+  // The gallery reports its filters together with the search on every keystroke, and
+  // `setItem` is synchronous on the thread painting the list being typed into.
+  for (const search of ['m', 'mí', 'mím', 'míme', 'mímes', 'mímesi', 'mímesis']) {
+    store.patchViewSnapshot('vault-a', 'deepResearch', { search, sortKey: 'title', viewMode: 'list' });
+  }
+  assert.equal(globalThis.localStorage.writes, afterChoice, 'repeating the same preferences costs nothing');
+
+  store.patchViewSnapshot('vault-a', 'deepResearch', { search: 'mímesis', sortKey: 'oldest', viewMode: 'list' });
+  assert.equal(globalThis.localStorage.writes, afterChoice + 1, 'a changed preference is written once');
+});
+
+test('only the galleries opt in, and only for the three durable fields', async () => {
+  const [preferences, types] = await Promise.all([
+    readSource('src/app/filterPreferences.ts'),
+    readSource('src/app/viewSnapshots.ts'),
+  ]);
+  const opted = preferences.match(/export const PREFERENCE_VIEWS[^;]*;/s)?.[0] ?? '';
+  for (const view of ['deepResearch', 'studyDeepResearch', 'teachingUnits', 'immersion']) {
+    assert.match(opted, new RegExp(`'${view}'`), `${view} keeps its preferences between runs`);
+  }
+  for (const view of ['authors', 'ideas', 'library', 'workspace', 'notes', 'argument']) {
+    assert.doesNotMatch(opted, new RegExp(`'${view}'`), `${view} was not asked for and does not opt in`);
+  }
+  // The durable set is closed: anything else in a patch stops at the in-memory store.
+  const fields = preferences.match(/export interface GalleryFilterPreferences \{[^}]*\}/s)?.[0] ?? '';
+  assert.match(fields, /readFilter\?:/);
+  assert.match(fields, /sortKey\?:/);
+  assert.match(fields, /viewMode\?:/);
+  for (const ephemeral of ['search', 'placement', 'openReport', 'openSession', 'reading', 'surface']) {
+    assert.doesNotMatch(fields, new RegExp(`\\b${ephemeral}\\??:`), `${ephemeral} is a place, not a preference`);
+  }
+  assert.match(types, /if \(isPreferenceView\(view\)\) writeFilterPreferences\(vaultId, view, patch/, 'the write-through sits in the one place a cut is recorded');
 });

--- a/src/app/filterPreferences.ts
+++ b/src/app/filterPreferences.ts
@@ -1,0 +1,156 @@
+// The half of a gallery's cut that outlives the run.
+//
+// `viewSnapshots` keeps a section's whole shape in memory so that leaving it and
+// coming back lands on the same cut. That store dies with the process, which is
+// right for most of what it holds: a search term, an open report, a place in a
+// list are all answers to "where was I", and on the next run there is no "was".
+//
+// Ordering, the read filter and grid-vs-list are not that. They are not where the
+// reader was, they are how the reader wants the gallery to look — set once, kept
+// for good, and re-set by hand on every launch when nothing remembers them. So
+// those three, and only those three, are written to disk here and read back as the
+// seed of the snapshot the section mounts with.
+//
+// What is deliberately not persisted:
+//
+//   * The search box. A query is asked once; restoring it a week later opens the
+//     section on a near-empty gallery with no visible cause, and the reader has to
+//     work out what is hiding their reports. It still survives inside a run, from
+//     the in-memory snapshot.
+//   * The place in a list and the open report. Both are a place, not a preference,
+//     and both point at rows that may not exist by the next launch.
+//   * Anything from the composer. An objective, a model and an outline are a draft
+//     of work not yet asked for.
+//
+// Preferences are stored per vault, like the snapshots they seed: the galleries of
+// two corpora are two different sets of reports, and a cut chosen for one is not a
+// statement about the other.
+
+/** The sections whose gallery preferences are remembered between runs. */
+export type PreferenceView = 'deepResearch' | 'studyDeepResearch' | 'teachingUnits' | 'immersion';
+
+export const PREFERENCE_VIEWS: readonly PreferenceView[] = [
+  'deepResearch',
+  'studyDeepResearch',
+  'teachingUnits',
+  'immersion',
+];
+
+/**
+ * The three durable controls, shared by both galleries. Deep Research has all of
+ * them; Inmersión has no read state and so never writes `readFilter`.
+ */
+export interface GalleryFilterPreferences {
+  readFilter?: 'all' | 'read' | 'unread';
+  sortKey?: 'recent' | 'oldest' | 'title';
+  viewMode?: 'grid' | 'list';
+}
+
+const READ_FILTERS = new Set(['all', 'read', 'unread']);
+const SORT_KEYS = new Set(['recent', 'oldest', 'title']);
+const VIEW_MODES = new Set(['grid', 'list']);
+
+const STORAGE_PREFIX = 'nodus.galleryFilters.';
+
+const keyFor = (vaultId: string, view: PreferenceView) => `${STORAGE_PREFIX}${view}.${vaultId}`;
+
+/**
+ * Absent under `node --test`, which is where the store is exercised for real, and
+ * unreachable in a renderer whose storage the user has disabled. Neither is an
+ * error worth propagating: a missing preference means the section opens on its
+ * defaults, which is exactly what it did before this file existed.
+ */
+function storage(): Storage | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every field is validated against its own union rather than trusted. What is on
+ * disk was written by an older version of this app, or by a hand editing the store,
+ * and a `sortKey` of `"conexiones"` would put a select in a state it has no option
+ * for — visibly empty, and unfixable except by choosing something else.
+ */
+function sanitize(raw: unknown): GalleryFilterPreferences {
+  if (!raw || typeof raw !== 'object') return {};
+  const value = raw as Record<string, unknown>;
+  const result: GalleryFilterPreferences = {};
+  if (typeof value.readFilter === 'string' && READ_FILTERS.has(value.readFilter)) {
+    result.readFilter = value.readFilter as GalleryFilterPreferences['readFilter'];
+  }
+  if (typeof value.sortKey === 'string' && SORT_KEYS.has(value.sortKey)) {
+    result.sortKey = value.sortKey as GalleryFilterPreferences['sortKey'];
+  }
+  if (typeof value.viewMode === 'string' && VIEW_MODES.has(value.viewMode)) {
+    result.viewMode = value.viewMode as GalleryFilterPreferences['viewMode'];
+  }
+  return result;
+}
+
+/** `{}` for a vault that has never set a preference, and for an unreadable store. */
+export function readFilterPreferences(
+  vaultId: string | null | undefined,
+  view: PreferenceView,
+): GalleryFilterPreferences {
+  const store = storage();
+  if (!vaultId || !store) return {};
+  try {
+    const raw = store.getItem(keyFor(vaultId, view));
+    return raw ? sanitize(JSON.parse(raw)) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Merges the durable fields of a snapshot patch into what is on disk.
+ *
+ * A patch is not a full cut — the galleries report their filters on every keystroke
+ * in the search box, and their placement separately — so a patch that mentions none
+ * of the three, or repeats the values already stored, must not cost a write. That
+ * is not only about I/O: `localStorage.setItem` is synchronous and lands on the same
+ * thread that is painting the list being typed into.
+ */
+export function writeFilterPreferences(
+  vaultId: string | null | undefined,
+  view: PreferenceView,
+  patch: GalleryFilterPreferences,
+): void {
+  const store = storage();
+  if (!vaultId || !store) return;
+  const incoming = sanitize(patch);
+  if (Object.keys(incoming).length === 0) return;
+  const current = readFilterPreferences(vaultId, view);
+  const next = { ...current, ...incoming };
+  if (
+    next.readFilter === current.readFilter
+    && next.sortKey === current.sortKey
+    && next.viewMode === current.viewMode
+  ) return;
+  try {
+    store.setItem(keyFor(vaultId, view), JSON.stringify(next));
+  } catch {
+    // A full or disabled store loses the preference, not the section.
+  }
+}
+
+/** Drop every stored preference. For tests and for wiping a vault. */
+export function clearFilterPreferences(vaultId?: string): void {
+  const store = storage();
+  if (!store) return;
+  try {
+    const doomed: string[] = [];
+    for (let index = 0; index < store.length; index += 1) {
+      const key = store.key(index);
+      if (!key || !key.startsWith(STORAGE_PREFIX)) continue;
+      if (vaultId && !key.endsWith(`.${vaultId}`)) continue;
+      doomed.push(key);
+    }
+    for (const key of doomed) store.removeItem(key);
+  } catch {
+    // Nothing to clear if the store cannot be walked.
+  }
+}

--- a/src/app/viewSnapshots.ts
+++ b/src/app/viewSnapshots.ts
@@ -28,7 +28,20 @@
 // The store is deliberately NOT React state. It is read once when a view mounts and
 // written on every filter change; as state it would re-render the whole shell on
 // every keystroke in a search box, and this repo has paid for that before.
+//
+// All of this dies with the window, which is right for a place: on the next launch
+// there is no "where was I". Three fields are not a place but a preference — the
+// ordering, the read filter and grid-vs-list of the two galleries, set once and
+// expected to hold — and those are written through to `filterPreferences` and read
+// back as the seed a section mounts with. That file says why only those three.
 import type { View } from '../navigation';
+import {
+  PREFERENCE_VIEWS,
+  readFilterPreferences,
+  writeFilterPreferences,
+  type GalleryFilterPreferences,
+  type PreferenceView,
+} from './filterPreferences';
 import type { LibraryCatalogItem, LibraryItemSource, LibraryItemType, LibraryScope } from '@shared/libraryTypes';
 // Type-only, so the lazy view chunks are not pulled in: the unions stay declared
 // once, where the selects that produce them live.
@@ -295,13 +308,59 @@ let slot: { vaultId: string; values: ViewSnapshots } | null = null;
  * Undefined for a different vault, and for no vault at all — same contract as
  * `getVaultQueryCache`. The vault check lives in the read, not in an effect, so a
  * view that mounts in the same commit as a vault change cannot see the old cut.
+ *
+ * The two galleries are the exception, and only for the three fields `filterPreferences`
+ * keeps: with nothing in memory they are seeded from that vault's stored preferences,
+ * so the ordering and the layout the reader chose survive a restart. The seed is still
+ * closed to its own vault — it is read under the id being asked for, never carried over
+ * from the one that was active a moment ago.
  */
 export function readViewSnapshot<K extends SnapshotView>(
   vaultId: string | null | undefined,
   view: K,
 ): ViewSnapshots[K] | undefined {
-  if (!vaultId || slot?.vaultId !== vaultId) return undefined;
-  return slot.values[view];
+  const live = !vaultId || slot?.vaultId !== vaultId ? undefined : slot?.values[view];
+  if (live || !vaultId || !isPreferenceView(view)) return live;
+  // Nothing in memory: either the first visit of the run, or the first after a
+  // vault change. Both are exactly when the preferences kept on disk are the only
+  // record of how the reader wants this gallery, so they become the seed.
+  return gallerySeed(vaultId, view) as ViewSnapshots[K] | undefined;
+}
+
+function isPreferenceView(view: SnapshotView): view is PreferenceView {
+  return (PREFERENCE_VIEWS as readonly SnapshotView[]).includes(view);
+}
+
+/**
+ * A snapshot holding nothing but the stored preferences: no open report, no search,
+ * no place. Every other field is its default, so the seed says only what the reader
+ * actually chose and never claims a place they were never at.
+ *
+ * Undefined when nothing was ever stored, so that "never visited" stays
+ * distinguishable from "visited and left on the defaults".
+ */
+function gallerySeed(vaultId: string, view: PreferenceView): DeepResearchSnapshot | ImmersionSnapshot | undefined {
+  const stored = readFilterPreferences(vaultId, view);
+  if (!stored.readFilter && !stored.sortKey && !stored.viewMode) return undefined;
+  if (view === 'immersion') {
+    return {
+      openSession: null,
+      search: '',
+      sortKey: stored.sortKey ?? 'recent',
+      viewMode: stored.viewMode ?? 'grid',
+      placement: null,
+    };
+  }
+  return {
+    surface: 'gallery',
+    openReport: null,
+    search: '',
+    readFilter: stored.readFilter ?? 'all',
+    sortKey: stored.sortKey ?? 'recent',
+    viewMode: stored.viewMode ?? 'grid',
+    placement: null,
+    reading: null,
+  };
 }
 
 /**
@@ -318,6 +377,10 @@ export function patchViewSnapshot<K extends SnapshotView>(
   if (slot?.vaultId !== vaultId) slot = { vaultId, values: {} };
   const current = slot.values[view];
   slot.values[view] = { ...(current ?? {}), ...patch } as ViewSnapshots[K];
+  // The galleries' ordering, read filter and grid-vs-list are preferences rather
+  // than places, so they go on through to disk. Everything else in the patch stops
+  // here, and a patch mentioning none of the three costs nothing.
+  if (isPreferenceView(view)) writeFilterPreferences(vaultId, view, patch as GalleryFilterPreferences);
 }
 
 /** Drop everything. For vault deletion, imports and tests. */

--- a/src/components/VaultSwitcher.tsx
+++ b/src/components/VaultSwitcher.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import type { RemoteSignIn, VaultSummary, VaultType } from '@shared/types';
 import { isPreviewVaultType } from '@shared/vaultTypes';
 import { errorText, t, tr, tx } from '../i18n';
+import { clearFilterPreferences } from '../app/filterPreferences';
 import { ConfirmModal } from './ConfirmModal';
 import { Icon } from './ui';
 import {
@@ -342,6 +343,9 @@ export function VaultSwitcher({ anchorEl, onClose, vaults, onVaultsChanged, onAc
     void run(async () => {
       if (action.kind === 'delete') {
         await window.nodus.deleteVault(action.vault.id, true);
+        // The gallery preferences of a vault that no longer exists are not a cut of
+        // anything; they would only sit in the store until a new vault reused the id.
+        clearFilterPreferences(action.vault.id);
         await onVaultsChanged();
         setMessage(t('Bóveda eliminada.'));
         return;

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { EdgeType, ModelRef, GraphNodeType } from '@shared/types';
 import { t } from '../i18n';
 
@@ -358,6 +358,32 @@ export function Spinner({ label }: { label?: string }) {
     <div className="flex items-center gap-2 text-neutral-400 text-sm">
       <span className="inline-block w-4 h-4 border-2 border-neutral-600 border-t-indigo-400 rounded-full animate-spin" />
       {label}
+    </div>
+  );
+}
+
+/**
+ * The pane of a section on its way back to what it had open.
+ *
+ * A section is unmounted when you leave it, so walking back into one that was left
+ * on a report or a session means reading that report back before it can be drawn.
+ * What must NOT be drawn in the meantime is the section's gallery: it is a screen
+ * full of content, and painting it for the two or three frames the read takes reads
+ * as the app opening the list and then clicking the item by itself.
+ *
+ * So the pane stays quiet instead. It is empty at first — a spinner that appears and
+ * vanishes inside 60ms is its own flicker — and only starts spinning if the read is
+ * slow enough that the reader would otherwise wonder whether anything is happening.
+ */
+export function RestoringPane({ delayMs = 250 }: { delayMs?: number }) {
+  const [slow, setSlow] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setSlow(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [delayMs]);
+  return (
+    <div className="flex h-full items-center justify-center" data-testid="section-restoring">
+      {slow && <Spinner />}
     </div>
   );
 }

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -28,7 +28,7 @@ import type { PendingGraphNavigationTarget } from '../navigation';
 import type { DeepResearchSnapshot } from '../app/viewSnapshots';
 import { useListPlacement } from '../listPlacement';
 import { useReadingPlace, type ReadingPlace } from '../readingPlace';
-import { HoverLabelButton, Icon, modelLabel } from '../components/ui';
+import { HoverLabelButton, Icon, RestoringPane, modelLabel } from '../components/ui';
 import { SectionHeader } from '../components/SectionHeader';
 import { ModelPicker } from '../components/ModelPicker';
 import { confirm } from '../components/feedback';
@@ -761,6 +761,13 @@ export function DeepResearchView({
     clearFinishedDeepResearch();
     void window.nodus.clearFinishedDeepResearchJobs();
   };
+
+  // A report that was left open is the section's first frame, never its second. The
+  // gallery below is a screen full of cards; painting it for the frames the read of
+  // the report takes is what makes returning to the section look like the app opening
+  // the list and clicking the report by itself. `mode` already says the reader was in
+  // a report — so wait here, quietly, until the report it names has landed.
+  if (mode === 'reader' && !openDraft) return <RestoringPane />;
 
   if (mode === 'reader' && openDraft) {
     return (

--- a/src/views/ImmersionView.tsx
+++ b/src/views/ImmersionView.tsx
@@ -32,7 +32,7 @@ import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
 import type { PendingGraphNavigationTarget } from '../navigation';
 import type { ImmersionSnapshot } from '../app/viewSnapshots';
 import { useListPlacement } from '../listPlacement';
-import { Badge, Icon, TypeDot } from '../components/ui';
+import { Badge, Icon, RestoringPane, TypeDot } from '../components/ui';
 import { SectionHeader } from '../components/SectionHeader';
 import { ModelPicker } from '../components/ModelPicker';
 import { Markdown, type MarkdownCitation } from '../components/Markdown';
@@ -178,7 +178,21 @@ export function ImmersionView({
   onSnapshotChange?: (patch: Partial<ImmersionSnapshot>) => void;
   onOpenGraph: (target: PendingGraphNavigationTarget) => void;
 }) {
-  const [mode, setMode] = useState<'home' | 'scope' | 'player'>('home');
+  /**
+   * The session this mount is walking back into, decided here rather than in an
+   * effect: the section has to know on its very first frame that it is going to the
+   * player, or it paints the gallery on the way there and the return looks like the
+   * app opening the list and clicking the session by itself.
+   *
+   * A dossier still being written wins over the session that was merely left open:
+   * it is the more recent thing, and it is the same section either way.
+   */
+  const [resumeTarget] = useState<string | null>(() => {
+    const dossier = findLatestBackgroundJob<unknown, unknown, unknown>(IMMERSION_DOSSIER_JOB_PREFIX);
+    const fromDossier = dossier ? dossier.key.slice(IMMERSION_DOSSIER_JOB_PREFIX.length) : '';
+    return fromDossier || snapshot?.openSession?.id || null;
+  });
+  const [mode, setMode] = useState<'home' | 'scope' | 'player'>(() => (resumeTarget ? 'player' : 'home'));
   const [sessions, setSessions] = useState<ImmersionSessionSummary[]>([]);
   const [loadingSessions, setLoadingSessions] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
@@ -322,29 +336,24 @@ export function ImmersionView({
   // render of the shell; a ref keeps that out of the effects' dependencies.
   const report = useRef(onSnapshotChange);
   report.current = onSnapshotChange;
-  /** The session to reopen, read once. Silences the report until it has landed. */
-  const resuming = useRef<string | null>(snapshot?.openSession?.id ?? null);
+  /** The session being reopened. Silences the report until it has landed. */
+  const resuming = useRef<string | null>(resumeTarget);
   useEffect(() => {
     if (resuming.current) return;
     report.current?.({ openSession: session ? { id: session.id, label: session.plan.title } : null });
   }, [session]);
 
   useEffect(() => {
-    const dossier = findLatestBackgroundJob<unknown, unknown, unknown>(IMMERSION_DOSSIER_JOB_PREFIX);
-    const fromDossier = dossier ? dossier.key.slice(IMMERSION_DOSSIER_JOB_PREFIX.length) : '';
-    // A dossier still being written wins over the session that was merely left open:
-    // it is the more recent thing, and it is the same section either way.
-    const resume = fromDossier || resuming.current;
-    if (!resume) {
-      resuming.current = null;
-      return;
-    }
+    const resume = resuming.current;
+    if (!resume) return;
     // Reconnect only when this view is mounted. The session itself persists its
     // current player step, so opening it returns directly to the step it was left on.
     // Reporting here rather than in the effect above, because the report has to say
-    // what actually loaded: a session deleted elsewhere leaves the section at home.
+    // what actually loaded: a session deleted elsewhere leaves the section at home —
+    // which is also the only way out of the waiting pane the mount opened on.
     void openSession(resume).then((opened) => {
       resuming.current = null;
+      if (!opened) setMode('home');
       report.current?.({ openSession: opened ? { id: opened.id, label: opened.plan.title } : null });
     });
   }, []);
@@ -448,6 +457,9 @@ export function ImmersionView({
           onCitation={setCitation}
         />
       )}
+
+      {/* The session is on its way back; the gallery is not what was asked for. */}
+      {mode === 'player' && !session && <RestoringPane />}
 
       {mode === 'player' && session && (
         <ImmersionPlayer


### PR DESCRIPTION
Closes #480.

Two changes to the two gallery sections — Deep Research (with its Study and Teaching variants) and Inmersión.

## 1. The gallery filters are remembered between runs

`viewSnapshots` keeps a section's cut in memory so leaving it and coming back lands on the same one, and that store dies with the process. Right for a place; wrong for a preference. The ordering, the read filter and the grid/list choice had to be set again by hand on every launch.

New `src/app/filterPreferences.ts` holds exactly those three fields, per vault and per section, and validates every value against its own union on read — a store written by an older version cannot leave a `<select>` on an option it does not have.

It is wired at the single seam where a cut is recorded, so neither view needed changing:

- `patchViewSnapshot` writes the three durable fields through; everything else stops in memory. A patch repeating what is already stored costs no write, because the galleries report their filters on every keystroke in the search box and `setItem` is synchronous on the painting thread.
- `readViewSnapshot` seeds the snapshot from disk when memory has nothing — the first visit of a run, or the first after a vault change. The seed stays closed to its own vault.

Deliberately **not** persisted: the search box (a query restored a week later opens the section on a near-empty gallery with no visible cause), the open report, the place inside a list, and anything from the composer. All of those still survive leaving and re-entering the section within a run, as before.

Deleting a vault now clears its stored preferences.

## 2. The gallery no longer flashes when reopening an item

Returning to a section left on a report or an immersion showed the gallery for a moment and then swapped to the item, as if the app had opened the list and clicked the entry itself.

- `DeepResearchView` renders the reader only under `mode === 'reader' && openDraft`; at mount `mode` was already `'reader'` while `openDraft` stayed null until `listWritingWorkshopDrafts()` resolved, so the render fell through to the gallery.
- `ImmersionView` started at `mode: 'home'` and reopened the session from a `useEffect` — which runs after the first paint, and that paint was the gallery.

Now Inmersión decides at mount which session it is going back to (a dossier still being written still wins over the session merely left open), and both sections hold a quiet `RestoringPane` until the item lands. The pane stays empty for 250ms before showing a spinner, since a spinner that appears and vanishes inside 60ms is its own flicker. A session that no longer exists lands on the gallery instead of stranding the pane.

Measured frame by frame in the running app, walking back into each section:

| | before | after |
|---|---|---|
| Deep Research | previous section → **gallery 44ms** → report 63ms | previous section → waiting 40ms → report 57ms |
| Inmersión | previous section → **gallery 41ms** → player 56ms | previous section → waiting 44ms → player 61ms |

One painted frame on the demo corpus; on a large corpus the gallery stays up for as long as the read takes.

## Verification

- `npm test` — 1961 pass, 0 fail (44 in `test-view-snapshots.mjs`, 10 of them new).
- `scripts/e2e-view-snapshots.mjs` — extended twice: it now reloads the window, which throws the whole renderer away, and asserts the ordering and layout come back while the search box and the open report do not; and it samples every frame of the walk back into both sections, asserting the gallery is never painted.
- Both new assertions were checked against a build without the fixes: the unit suite drops to 7 failures, and the e2e fails on `the ordering survives the restart` and on `the gallery is never painted on the way back to an open report`.
- `npm run typecheck` and `npm run lint` clean.

No version bump here: opening a version touches 22 files and is a separate call.
