### PR TITLE
Improve Nodi sizing and streamed chat readability

### DIFF
--- a/electron/db/appPrefs.ts
+++ b/electron/db/appPrefs.ts
@@ -37,6 +37,7 @@ export const GLOBAL_PREF_KEYS = [
   'betaUpdates',
   'favorites',
   'mascotEnabled',
+  'mascotScale',
   'mascotAlwaysOnTop',
   'mascotVaultCostumes',
   'mascotStyle',

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -3,6 +3,7 @@ import type { AppSettings, ModelRef } from '@shared/types';
 import { DEFAULT_EMBEDDING_MODELS, DEFAULT_LOCAL_BASE_URLS, normalizeEmbeddingProvider } from '@shared/providers';
 import { isOpenAiStudySttModel } from '@shared/sttModels';
 import { NODI_ORB_DEFAULT_COLOR } from '@shared/nodiOrb';
+import { NODI_DEFAULT_SCALE, normalizeNodiScale } from '@shared/nodiSize';
 import { lockedApiKeyProviders, providerKeyMap } from '../secrets/secretStore';
 import { GRANULAR_MODEL_KEYS, migrateModelSettings } from '@shared/modelSettings';
 import { DEFAULT_NODUS_IMAGE_QUALITY, isNodusImageQuality } from '@shared/localImageModels';
@@ -125,6 +126,7 @@ const DEFAULTS: Omit<AppSettings, 'providerKeys' | 'lockedProviderKeys'> = {
   announcementsEnabled: true,
   betaUpdates: false,
   mascotEnabled: true,
+  mascotScale: NODI_DEFAULT_SCALE,
   mascotAlwaysOnTop: false,
   mascotVaultCostumes: true,
   // The classic Nodi stays the default: an existing install must never wake up with a
@@ -272,6 +274,7 @@ export function getSettings(): AppSettings {
     merged.libraryScopeOnboardingVersion = 0;
   }
   merged.codexReasoningEfforts = sanitizeCodexReasoningEfforts(parsed.codexReasoningEfforts);
+  merged.mascotScale = normalizeNodiScale(parsed.mascotScale);
   merged.studyImproveToolbarStyleIds = [...new Set((Array.isArray(merged.studyImproveToolbarStyleIds) ? merged.studyImproveToolbarStyleIds : [])
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0))].slice(0, 4);
   merged.customEventTypes = sanitizeCustomEventTypes(parsed.customEventTypes);
@@ -311,6 +314,9 @@ export function getSettings(): AppSettings {
     if (globalPrefs[key] === undefined) seed[key] = merged[key];
     else (merged as Record<string, unknown>)[key] = globalPrefs[key];
   }
+  // The global preferences file is user-editable, so validate the shared size again
+  // after it has overlaid the vault defaults.
+  merged.mascotScale = normalizeNodiScale(merged.mascotScale);
   // Global preferences are user-editable JSON on disk. Fail closed to the v3-safe
   // vault scope if those three values are missing or malformed.
   if (merged.libraryScope !== 'global' && merged.libraryScope !== 'vault') merged.libraryScope = 'vault';
@@ -415,6 +421,9 @@ export function getSettings(): AppSettings {
 }
 
 export function updateSettings(patch: Partial<AppSettings>): AppSettings {
+  if (patch.mascotScale !== undefined) {
+    patch = { ...patch, mascotScale: normalizeNodiScale(patch.mascotScale) };
+  }
   if (patch.customEventTypes !== undefined) {
     patch = { ...patch, customEventTypes: sanitizeCustomEventTypes(patch.customEventTypes) };
   }

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -398,7 +398,7 @@ export function registerIpc(
       if (next.zoteroPluginEnabled || next.browserConnectorEnabled) await restartZoteroPluginServer();
       else await stopZoteroPluginServer();
     }
-    if (patch.mascotEnabled !== undefined || patch.mascotAlwaysOnTop !== undefined) {
+    if (patch.mascotEnabled !== undefined || patch.mascotAlwaysOnTop !== undefined || patch.mascotScale !== undefined) {
       applyMascotWindow();
     }
     // Turning announcements back on asks straight away. The alternative is a panel that

--- a/electron/mascotWindow.ts
+++ b/electron/mascotWindow.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, screen } from 'electron';
 import path from 'node:path';
 import type { NodiOverlayPlacement } from '@shared/types';
+import { normalizeNodiScale } from '@shared/nodiSize';
 import { getSettings } from './db/settingsRepo';
 
 // Standalone always-on-top desktop window that hosts the Nodi mascot (mascot.html).
@@ -16,8 +17,8 @@ const RENDERER_DIST = path.join(__dirname, '../dist');
 // exact transient is the diagonal jump seen when Nodi opens outside the main app.
 const EXPANDED_WIDTH = 600;
 const EXPANDED_HEIGHT = 520;
-const FIGURE_WIDTH = 180;
-const FIGURE_HEIGHT = 200;
+const BASE_FIGURE_WIDTH = 180;
+const BASE_FIGURE_HEIGHT = 200;
 const MARGIN = 16;
 
 let mascotWindow: BrowserWindow | null = null;
@@ -25,23 +26,31 @@ let tutorialVisible = false;
 let placement: NodiOverlayPlacement = { x: MARGIN, y: MARGIN, horizontal: 'left', vertical: 'up' };
 let windowDrag: { cursorX: number; cursorY: number; nodiX: number; nodiY: number } | null = null;
 let requestedBounds: { x: number; y: number; width: number; height: number } | null = null;
+let figureWidth = BASE_FIGURE_WIDTH;
+let figureHeight = BASE_FIGURE_HEIGHT;
+
+function syncFigureSize(): void {
+  const scale = normalizeNodiScale(getSettings().mascotScale);
+  figureWidth = Math.round(BASE_FIGURE_WIDTH * scale);
+  figureHeight = Math.round(BASE_FIGURE_HEIGHT * scale);
+}
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(min, value), Math.max(min, max));
 
 function placeWindowAroundNodi(win: BrowserWindow, desiredX: number, desiredY: number): NodiOverlayPlacement {
   const display = screen.getDisplayNearestPoint({
-    x: Math.round(desiredX + FIGURE_WIDTH / 2),
-    y: Math.round(desiredY + FIGURE_HEIGHT / 2),
+    x: Math.round(desiredX + figureWidth / 2),
+    y: Math.round(desiredY + figureHeight / 2),
   });
   const { workArea } = display;
-  const nodiX = clamp(desiredX, workArea.x, workArea.x + workArea.width - FIGURE_WIDTH);
-  const nodiY = clamp(desiredY, workArea.y, workArea.y + workArea.height - FIGURE_HEIGHT);
-  const horizontal: NodiOverlayPlacement['horizontal'] = nodiX + FIGURE_WIDTH / 2 >= workArea.x + workArea.width / 2 ? 'left' : 'right';
-  const vertical: NodiOverlayPlacement['vertical'] = nodiY + FIGURE_HEIGHT / 2 >= workArea.y + workArea.height / 2 ? 'up' : 'down';
+  const nodiX = clamp(desiredX, workArea.x, workArea.x + workArea.width - figureWidth);
+  const nodiY = clamp(desiredY, workArea.y, workArea.y + workArea.height - figureHeight);
+  const horizontal: NodiOverlayPlacement['horizontal'] = nodiX + figureWidth / 2 >= workArea.x + workArea.width / 2 ? 'left' : 'right';
+  const vertical: NodiOverlayPlacement['vertical'] = nodiY + figureHeight / 2 >= workArea.y + workArea.height / 2 ? 'up' : 'down';
   const width = Math.min(EXPANDED_WIDTH, workArea.width);
   const height = Math.min(EXPANDED_HEIGHT, workArea.height);
-  const idealX = horizontal === 'left' ? nodiX - (width - FIGURE_WIDTH - MARGIN) : nodiX - MARGIN;
-  const idealY = vertical === 'up' ? nodiY - (height - FIGURE_HEIGHT - MARGIN) : nodiY - MARGIN;
+  const idealX = horizontal === 'left' ? nodiX - (width - figureWidth - MARGIN) : nodiX - MARGIN;
+  const idealY = vertical === 'up' ? nodiY - (height - figureHeight - MARGIN) : nodiY - MARGIN;
   const x = clamp(idealX, workArea.x, workArea.x + workArea.width - width);
   const y = clamp(idealY, workArea.y, workArea.y + workArea.height - height);
 
@@ -71,8 +80,8 @@ function placeWindowAroundNodi(win: BrowserWindow, desiredX: number, desiredY: n
   // host window to be, or the next pointer event feeds that error back as a bounce.
   const appliedBounds = win.getBounds();
   placement = {
-    x: Math.round(clamp(nodiX - appliedBounds.x, 0, appliedBounds.width - FIGURE_WIDTH)),
-    y: Math.round(clamp(nodiY - appliedBounds.y, 0, appliedBounds.height - FIGURE_HEIGHT)),
+    x: Math.round(clamp(nodiX - appliedBounds.x, 0, appliedBounds.width - figureWidth)),
+    y: Math.round(clamp(nodiY - appliedBounds.y, 0, appliedBounds.height - figureHeight)),
     horizontal,
     vertical,
   };
@@ -88,9 +97,9 @@ function cursorIsOverNodi(win: BrowserWindow): boolean {
   const cursor = screen.getCursorScreenPoint();
   const nodi = currentNodiPosition(win);
   return cursor.x >= nodi.x
-    && cursor.x < nodi.x + FIGURE_WIDTH
+    && cursor.x < nodi.x + figureWidth
     && cursor.y >= nodi.y
-    && cursor.y < nodi.y + FIGURE_HEIGHT;
+    && cursor.y < nodi.y + figureHeight;
 }
 
 function applyClosedMousePassthrough(win: BrowserWindow): void {
@@ -104,12 +113,13 @@ function positionBottomRight(win: BrowserWindow): void {
   const { workArea } = screen.getPrimaryDisplay();
   placeWindowAroundNodi(
     win,
-    workArea.x + workArea.width - FIGURE_WIDTH - MARGIN,
-    workArea.y + workArea.height - FIGURE_HEIGHT - MARGIN
+    workArea.x + workArea.width - figureWidth - MARGIN,
+    workArea.y + workArea.height - figureHeight - MARGIN
   );
 }
 
 function createMascotWindow(): BrowserWindow {
+  syncFigureSize();
   const isMac = process.platform === 'darwin';
   const win = new BrowserWindow({
     width: EXPANDED_WIDTH,
@@ -254,6 +264,9 @@ export function applyMascotWindow(): void {
     if (!mascotWindow || mascotWindow.isDestroyed()) {
       mascotWindow = createMascotWindow();
     } else {
+      const nodi = currentNodiPosition(mascotWindow);
+      syncFigureSize();
+      placeWindowAroundNodi(mascotWindow, nodi.x, nodi.y);
       mascotWindow.showInactive();
     }
   } else if (tutorialVisible && mascotWindow && !mascotWindow.isDestroyed()) {

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -473,6 +473,15 @@ test('a new Nodi chat starts on documentation, the current view and the current 
   assert.doesNotMatch(types, /NODI_DEFAULT_CONTEXTS[^\n]*all_vaults/);
 });
 
+test('Nodi keeps the reading position stable while an answer is streaming', async () => {
+  const companion = await read('src/components/nodi/NodiCompanion.tsx');
+  assert.match(companion, /const scrollChatToBottom = useCallback/);
+  assert.match(companion, /if \(panel === 'chat'\) scrollChatToBottom\(\);\s*\}, \[panel, scrollChatToBottom\]\);/s);
+  assert.doesNotMatch(companion, /\[messages,\s*panel\]/, 'message deltas must not drive the scroll position');
+  const deltaHandler = companion.match(/onDelta: \(delta\) => \{([\s\S]*?)\n\s*\},/)?.[1] ?? '';
+  assert.doesNotMatch(deltaHandler, /scrollChatToBottom|scrollTop|scrollIntoView/);
+});
+
 test('the chat retrieval never holds the main process for a whole similarity scan', async () => {
   const assistant = await read('electron/ai/researchAssistant.ts');
   // researchAssistant builds the context for the research chat AND for Nodi's

--- a/scripts/verify-nodi-overlay.mjs
+++ b/scripts/verify-nodi-overlay.mjs
@@ -100,6 +100,27 @@ try {
   await nativeOverlay.evaluate((win) => win.focus());
   const figure = overlay.locator('.nodi-figure');
   await figure.waitFor({ timeout: 30_000 });
+  const verifyFigureSize = async (scale, expected) => {
+    await page.evaluate((mascotScale) => window.nodus.updateSettings({ mascotScale }), scale);
+    await overlay.waitForFunction(([width, height]) => {
+      const rect = document.querySelector('.nodi-figure')?.getBoundingClientRect();
+      return Math.round(rect?.width ?? 0) === width && Math.round(rect?.height ?? 0) === height;
+    }, expected);
+    const rect = await figure.boundingBox();
+    assert.deepEqual(
+      [Math.round(rect?.width ?? 0), Math.round(rect?.height ?? 0)],
+      expected,
+      `Nodi scale ${scale} did not reach the overlay figure`,
+    );
+    assert.deepEqual(
+      await nativeOverlay.evaluate((win) => [win.getBounds().width, win.getBounds().height]),
+      [600, 520],
+      `Nodi scale ${scale} resized the stable native host`,
+    );
+  };
+  await verifyFigureSize(0.6, [108, 120]);
+  await verifyFigureSize(1.4, [252, 280]);
+  await verifyFigureSize(1, [180, 200]);
   const figureScreenPosition = async () => {
     const [bounds, box] = await Promise.all([
       nativeOverlay.evaluate((win) => win.getBounds()),

--- a/shared/nodiSize.ts
+++ b/shared/nodiSize.ts
@@ -1,0 +1,12 @@
+/** Nine discrete Nodi sizes. The centre value preserves the pre-setting size. */
+export const NODI_SIZE_SCALES = [0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4] as const;
+
+export const NODI_DEFAULT_SCALE = 1;
+
+/** Keep persisted or hand-edited values on one of the supported slider stops. */
+export function normalizeNodiScale(value: unknown): number {
+  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : NODI_DEFAULT_SCALE;
+  return NODI_SIZE_SCALES.reduce((nearest, scale) => (
+    Math.abs(scale - numeric) < Math.abs(nearest - numeric) ? scale : nearest
+  ), NODI_DEFAULT_SCALE as number);
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1575,6 +1575,9 @@ export interface AppSettings {
   // Nodi mascot: show the floating companion (visual/animation only for now — no wired
   // behaviour yet). App-wide preference, on by default.
   mascotEnabled: boolean;
+  // Discrete scale shared by the in-app and always-on-top companions. The default 1
+  // preserves the size used before this setting was introduced.
+  mascotScale: number;
   // Keep Nodi pinned on top of every application in a floating desktop window, on the
   // operating systems that allow it. When off, Nodi lives inside the app window only.
   mascotAlwaysOnTop: boolean;

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -3,6 +3,7 @@ import { deriveNodiNoteTitle } from '@shared/nodiNotes';
 import { announcementCopyFor, type AnnouncementRefreshResult } from '@shared/announcements';
 import { NODI_DEFAULT_CONTEXTS } from '@shared/types';
 import type { AppSettings, ModelRef, NodiChatMessage, NodiContextKind, NodiConversation, NodiNote, NodiNotification, NodiOverlayPlacement, NodiQuoteSelection, VaultType } from '@shared/types';
+import { normalizeNodiScale } from '@shared/nodiSize';
 import { vaultTypeColor } from '@shared/vaultTypes';
 import { type NodiRole, type NodiState } from './Nodi';
 import { NodiAvatar } from './NodiAvatar';
@@ -133,11 +134,13 @@ const NOTE_AUTOSAVE_DELAY_MS = 600;
 
 export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: boolean }) {
   const isOverlay = context === 'overlay';
-  const figureH = isOverlay ? 200 : 168;
+  const [settings, setSettings] = useState<AppSettings | null>(null);
+  const sizeScale = normalizeNodiScale(settings?.mascotScale);
+  const figureH = Math.round((isOverlay ? 200 : 168) * sizeScale);
   const figureW = Math.round((figureH * 270) / 300);
   const anchorR = Math.round(figureW * 0.52);
   const anchorB = Math.round(figureH * 0.533);
-  const R = isOverlay ? 104 : 92;
+  const R = Math.round((isOverlay ? 104 : 92) * sizeScale);
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [panel, setPanel] = useState<'none' | 'notifications' | 'chat' | 'notes'>('none');
@@ -170,7 +173,6 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(null);
   // The source detail opened from an inline citation in an answer (idea/work/passage/…).
   const [citation, setCitation] = useState<MarkdownCitation | null>(null);
-  const [settings, setSettings] = useState<AppSettings | null>(null);
   const [nodiModel, setNodiModel] = useState<ModelRef | null>(null);
   const [deleteConfirmation, setDeleteConfirmation] = useState<{ kind: 'conversation'; conversation: NodiConversation } | { kind: 'all' } | null>(null);
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
@@ -539,10 +541,18 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     };
   }, [hasOpenSurface, isOverlay]);
 
-  // ── Auto-scroll chat ──────────────────────────────────────────────────────
+  // Scroll only at deliberate navigation points. Following every `messages`
+  // update used to pin the viewport to the bottom while Nodi streamed a reply,
+  // making the beginning impossible to read until the answer had finished.
+  const scrollChatToBottom = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      if (msgsRef.current) msgsRef.current.scrollTop = msgsRef.current.scrollHeight;
+    });
+  }, []);
+
   useEffect(() => {
-    if (panel === 'chat' && msgsRef.current) msgsRef.current.scrollTop = msgsRef.current.scrollHeight;
-  }, [messages, panel]);
+    if (panel === 'chat') scrollChatToBottom();
+  }, [panel, scrollChatToBottom]);
 
   // Leaving the chat panel dismisses any open source card so it never lingers behind.
   useEffect(() => {
@@ -772,6 +782,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
     setCopiedMessageIndex(null);
     setChatTool('none');
     setCitation(null);
+    scrollChatToBottom();
   };
 
   const copyMessage = async (content: string, index: number) => {
@@ -820,6 +831,9 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
       : question;
     const next: NodiChatMessage[] = [...messages, { role: 'user', content: text }];
     setMessages([...next, { role: 'assistant', content: '' }]);
+    // Bring the new question and the beginning of Nodi's answer into view once.
+    // From here on the scroll position stays fixed while streaming deltas arrive.
+    scrollChatToBottom();
     // A starter chip passes its text explicitly; don't wipe a draft the user may be typing.
     if (!explicit) setInput('');
     setQuotedSelection(null);

--- a/src/components/nodi/NodiOrb.tsx
+++ b/src/components/nodi/NodiOrb.tsx
@@ -250,11 +250,6 @@ export function NodiOrb({
           <stop offset="60%" className="st-ped2" stopOpacity=".14" />
           <stop offset="100%" className="st-ped2" stopOpacity="0" />
         </radialGradient>
-        <radialGradient id={u('pedShadowG')} cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stopColor="#26314a" stopOpacity=".38" />
-          <stop offset="70%" stopColor="#26314a" stopOpacity=".12" />
-          <stop offset="100%" stopColor="#26314a" stopOpacity="0" />
-        </radialGradient>
         <radialGradient id={u('satHaloGold')} cx="50%" cy="50%" r="50%">
           <stop offset="0%" stopColor="#ffe9a8" stopOpacity=".9" />
           <stop offset="40%" stopColor="#f7c95e" stopOpacity=".35" />
@@ -308,10 +303,6 @@ export function NodiOrb({
           <ellipse className="ped-pulse ped-ln1" cx="160" cy="297" rx="80" ry="12" fill="none" strokeWidth="1.2" filter={ref('b1')} />
           <ellipse className="ped-ln2" cx="160" cy="299" rx="48" ry="7" fill="none" strokeWidth="1" filter={ref('b1')} />
         </g>
-        <g className="ped-shadow">
-          <ellipse cx="160" cy="292" rx="72" ry="13" fill={ref('pedShadowG')} />
-        </g>
-
         {/* Orbits: a soft blurred underlay carries the light, a crisp line the shape. */}
         <g transform="rotate(-16 160 160)">
           <ellipse className="ring ring-glow add" cx="160" cy="160" rx="130" ry="42" stroke="rgba(232,198,106,.35)" strokeWidth="3.2" filter={ref('b4')} fill="none" />

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -14,7 +14,6 @@
   -webkit-user-select: none;
   user-select: none;
   touch-action: none;
-  filter: drop-shadow(0 6px 18px rgba(10, 14, 26, 0.28));
 }
 .nodi-figure.dragging { cursor: grabbing; }
 .nodi-figure.closing { cursor: default; }

--- a/src/components/nodi/nodiOrb.css
+++ b/src/components/nodi/nodiOrb.css
@@ -103,11 +103,9 @@
   50%     { transform: translateY(-7px); }
 }
 
-/* Pedestal: a light pool in the dark, a contact shadow in the light. */
+/* Pedestal: a restrained light pool, without a contact shadow below Nodi. */
 .nodi-orb .ped-glow   { transition: opacity .5s ease; }
-.nodi-orb .ped-shadow { transition: opacity .5s ease; opacity: 0; }
 .light .nodi-orb .ped-glow   { opacity: .25; }
-.light .nodi-orb .ped-shadow { opacity: 1; }
 .nodi-orb .ped-pulse { transform-box: view-box; transform-origin: 160px 298px; animation: nodiorb-ped 4.6s ease-in-out infinite; }
 @keyframes nodiorb-ped {
   0%,100% { opacity: .5; transform: scaleX(1); }

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -43,6 +43,9 @@ import { NOTION_IMPORT_TRANSLATIONS } from './i18n.notionImport';
 import { LIBRARY_ONBOARDING_TRANSLATIONS } from './i18n.libraryOnboarding';
 
 export const DE: Record<string, string> = {
+  'Tamaño de Nodi': 'Nodi-Größe',
+  'El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.': 'Die mittlere Markierung behält die Standardgröße bei. Wähle eine der neun verfügbaren Größen.',
+  'Tamaños predeterminados': 'Voreingestellte Größen',
   ...PAGE_TRANSLATIONS.de,
   ...DATABASE_PROPERTY_TRANSLATIONS.de,
   ...DATABASE_RELATION_FORMULA_TRANSLATIONS.de,

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -42,6 +42,9 @@ import { LIBRARY_ONBOARDING_TRANSLATIONS } from './i18n.libraryOnboarding';
  * every non-Spanish interface language.
  */
 export const EN: Record<string, string> = {
+  'Tamaño de Nodi': 'Nodi size',
+  'El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.': 'The centre marker keeps the default size. Choose one of the nine available sizes.',
+  'Tamaños predeterminados': 'Preset sizes',
   ...PAGE_TRANSLATIONS.en,
   ...DATABASE_PROPERTY_TRANSLATIONS.en,
   ...DATABASE_RELATION_FORMULA_TRANSLATIONS.en,

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -43,6 +43,9 @@ import { NOTION_IMPORT_TRANSLATIONS } from './i18n.notionImport';
 import { LIBRARY_ONBOARDING_TRANSLATIONS } from './i18n.libraryOnboarding';
 
 export const FR: Record<string, string> = {
+  'Tamaño de Nodi': 'Taille de Nodi',
+  'El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.': 'Le repère central conserve la taille par défaut. Choisissez l’une des neuf tailles disponibles.',
+  'Tamaños predeterminados': 'Tailles prédéfinies',
   ...PAGE_TRANSLATIONS.fr,
   ...DATABASE_PROPERTY_TRANSLATIONS.fr,
   ...DATABASE_RELATION_FORMULA_TRANSLATIONS.fr,

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -38,6 +38,9 @@ import { LIBRARY_ONBOARDING_TRANSLATIONS } from './i18n.libraryOnboarding';
 
 /** Complete static Italian interface table; coverage prohibits runtime fallbacks. */
 export const IT: Record<string, string> = {
+  'Tamaño de Nodi': 'Dimensione di Nodi',
+  'El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.': "L'indicatore centrale mantiene la dimensione predefinita. Scegli una delle nove dimensioni disponibili.",
+  'Tamaños predeterminados': 'Dimensioni predefinite',
   ...PAGE_TRANSLATIONS.it,
   ...DATABASE_PROPERTY_TRANSLATIONS.it,
   ...DATABASE_RELATION_FORMULA_TRANSLATIONS.it,

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -43,6 +43,9 @@ import { NOTION_IMPORT_TRANSLATIONS } from './i18n.notionImport';
 import { LIBRARY_ONBOARDING_TRANSLATIONS } from './i18n.libraryOnboarding';
 
 export const PT_BR: Record<string, string> = {
+  'Tamaño de Nodi': 'Tamanho do Nodi',
+  'El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.': 'O marcador central mantém o tamanho padrão. Escolha um dos nove tamanhos disponíveis.',
+  'Tamaños predeterminados': 'Tamanhos predefinidos',
   ...PAGE_TRANSLATIONS['pt-BR'],
   ...DATABASE_PROPERTY_TRANSLATIONS['pt-BR'],
   ...DATABASE_RELATION_FORMULA_TRANSLATIONS['pt-BR'],

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -43,6 +43,9 @@ import { NOTION_IMPORT_TRANSLATIONS } from './i18n.notionImport';
 import { LIBRARY_ONBOARDING_TRANSLATIONS } from './i18n.libraryOnboarding';
 
 export const PT: Record<string, string> = {
+  'Tamaño de Nodi': 'Tamanho do Nodi',
+  'El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.': 'O marcador central mantém o tamanho predefinido. Escolha um dos nove tamanhos disponíveis.',
+  'Tamaños predeterminados': 'Tamanhos predefinidos',
   ...PAGE_TRANSLATIONS.pt,
   ...DATABASE_PROPERTY_TRANSLATIONS.pt,
   ...DATABASE_RELATION_FORMULA_TRANSLATIONS.pt,

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -38,6 +38,9 @@ import { LIBRARY_ONBOARDING_TRANSLATIONS } from './i18n.libraryOnboarding';
 
 /** Complete static Turkish interface table; coverage prohibits runtime fallbacks. */
 export const TR: Record<string, string> = {
+  'Tamaño de Nodi': 'Nodi boyutu',
+  'El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.': 'Ortadaki işaretçi varsayılan boyutu korur. Kullanılabilir dokuz boyuttan birini seçin.',
+  'Tamaños predeterminados': 'Önceden ayarlanmış boyutlar',
   ...PAGE_TRANSLATIONS.tr,
   ...DATABASE_PROPERTY_TRANSLATIONS.tr,
   ...DATABASE_RELATION_FORMULA_TRANSLATIONS.tr,

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -57,6 +57,7 @@ import { errorText, t, tx } from '../i18n';
 import { updateStatusMessage } from '../updateStatus';
 import { DEFAULT_EMBEDDING_MODELS, EMBEDDING_PROVIDERS } from '@shared/providers';
 import { ORB_COLOR_CHOICES, orbHue } from '@shared/nodiOrb';
+import { NODI_DEFAULT_SCALE, NODI_SIZE_SCALES } from '@shared/nodiSize';
 import { effectiveSidebarHidden, isViewAllowedForVaultType } from '@shared/vaultTypes';
 import chromeWebStoreLogo from '../assets/brands/chrome-web-store.svg';
 
@@ -996,6 +997,50 @@ export function Settings({
             <div className="flex items-center justify-between gap-4">
               <label className="text-sm text-neutral-300">{t('Mostrar a Nodi')}</label>
               <input type="checkbox" checked={settings.mascotEnabled} onChange={(e) => void patch({ mascotEnabled: e.target.checked })} />
+            </div>
+            <div data-testid="nodi-size-setting">
+              <label className="text-sm text-neutral-300" htmlFor="nodi-size-slider">{t('Tamaño de Nodi')}</label>
+              <p className="mt-0.5 text-xs text-neutral-500">
+                {t('El marcador central conserva el tamaño predeterminado. Elige uno de los nueve tamaños disponibles.')}
+              </p>
+              <div className="mt-2 flex w-full max-w-md items-start gap-3">
+                <div className="min-w-0 flex-1">
+                  <input
+                    id="nodi-size-slider"
+                    className="block w-full"
+                    type="range"
+                    min={NODI_SIZE_SCALES[0]}
+                    max={NODI_SIZE_SCALES[NODI_SIZE_SCALES.length - 1]}
+                    step={0.1}
+                    value={settings.mascotScale}
+                    aria-label={t('Tamaño de Nodi')}
+                    onChange={(e) => void patch({ mascotScale: Number(e.target.value) })}
+                  />
+                  <div className="mt-1 flex justify-between px-1" aria-label={t('Tamaños predeterminados')}>
+                    {NODI_SIZE_SCALES.map((scale) => {
+                      const selected = settings.mascotScale === scale;
+                      const isDefault = scale === NODI_DEFAULT_SCALE;
+                      const label = isDefault
+                        ? `${Math.round(scale * 100)}% · ${t('Predeterminado')}`
+                        : `${Math.round(scale * 100)}%`;
+                      return (
+                        <button
+                          key={scale}
+                          type="button"
+                          className={`h-3 w-3 rounded-full border transition-colors ${selected ? 'border-amber-300 bg-amber-300' : isDefault ? 'border-neutral-300 bg-neutral-500' : 'border-neutral-600 bg-neutral-800 hover:border-neutral-400'}`}
+                          aria-label={label}
+                          aria-pressed={selected}
+                          title={label}
+                          onClick={() => void patch({ mascotScale: scale })}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+                <output className="w-12 pt-0.5 text-right text-xs text-neutral-400" htmlFor="nodi-size-slider">
+                  {Math.round(settings.mascotScale * 100)}%
+                </output>
+              </div>
             </div>
             <div>
               <label className="text-sm text-neutral-300">{t('Aspecto de Nodi')}</label>


### PR DESCRIPTION
Closes #485

## Summary

- remove Nodi's lower drop shadow and the orb's light-theme contact shadow
- add nine persisted size presets from 60% to 140%, with the existing 100% size at the center
- keep overlay placement, hit testing, drag bounds, and radial controls synchronized with the selected size
- stop streamed response deltas from forcing the chat viewport to the bottom
- add translations for every supported UI language and regression coverage for overlay sizing and chat scroll behavior

## Root cause

The companion container applied a downward drop shadow, while the orb also rendered a separate contact-shadow ellipse. Nodi's dimensions were hard-coded independently in the renderer and native overlay geometry. The chat scroll effect depended on the entire `messages` array, so every streaming delta reset `scrollTop` to `scrollHeight`.

## User impact

Users can now select a comfortable Nodi size without clipping or invisible hit areas. Incoming answers remain readable from the beginning instead of dragging the viewport down as text arrives.

## Validation

- `npm run typecheck`
- `node --test scripts/test-nodi-assistant.mjs`
- `node --test scripts/test-i18n-coverage.mjs`
- `npm run verify:nodi-overlay` (includes the production build and min/default/max overlay size checks)