### PR TITLE
Add independent entity tabs and null-safe searches

### DIFF
--- a/electron/ai/argumentMap.ts
+++ b/electron/ai/argumentMap.ts
@@ -73,6 +73,25 @@ interface IdeaRow {
   statement: string;
 }
 
+type RawIdeaRow = Omit<IdeaRow, 'type' | 'label' | 'statement'> & {
+  type: IdeaType | null;
+  label: string | null;
+  statement: string | null;
+};
+
+/** SQLite's original ideas table allowed nullable text; renderer contracts do not. */
+function listArgumentIdeas(): IdeaRow[] {
+  const rows = getDb()
+    .prepare('SELECT global_id, type, label, statement FROM ideas')
+    .all() as RawIdeaRow[];
+  return rows.map((row) => ({
+    global_id: row.global_id,
+    type: row.type ?? 'claim',
+    label: row.label ?? row.global_id,
+    statement: row.statement ?? '',
+  }));
+}
+
 interface EdgeRow {
   id: string;
   from_id: string;
@@ -104,9 +123,7 @@ function isDebateEdge(type: string): boolean {
 
 /** BFS the real idea↔idea edges from a seed, returning the focused subgraph. */
 function buildLocalSubgraph(seedId: string, maxIdeas = AI_MAX_IDEAS, maxEdges = AI_MAX_EDGES): LocalSubgraph {
-  const allIdeas = getDb()
-    .prepare('SELECT global_id, type, label, statement FROM ideas')
-    .all() as IdeaRow[];
+  const allIdeas = listArgumentIdeas();
   const ideaById = new Map(allIdeas.map((i) => [i.global_id, i]));
   if (!ideaById.has(seedId)) {
     throw new Error('La idea indicada no existe en el grafo.');
@@ -434,9 +451,7 @@ function pickBranches(candidates: AdjEntry[], cap: number): AdjEntry[] {
 
 /** Rank idea hubs by weighted connectivity for the automatic route picker. */
 export function discoverArgumentRoutes(): ArgumentRouteSuggestion[] {
-  const allIdeas = getDb()
-    .prepare('SELECT global_id, type, label, statement FROM ideas')
-    .all() as IdeaRow[];
+  const allIdeas = listArgumentIdeas();
   const ideaById = new Map(allIdeas.map((i) => [i.global_id, i]));
   if (allIdeas.length === 0) return [];
 

--- a/electron/db/ideasRepo.ts
+++ b/electron/db/ideasRepo.ts
@@ -232,10 +232,21 @@ export function clearAllEmbeddings(): void {
 export function getIdea(globalId: string): Idea | null {
   const db = getDb();
   const row = db.prepare('SELECT * FROM ideas WHERE global_id = ?').get(globalId) as
-    | (Omit<Idea, 'embedding'> & { embedding: Buffer | null })
+    | (Omit<Idea, 'type' | 'label' | 'statement' | 'embedding'> & {
+        type: IdeaType | null;
+        label: string | null;
+        statement: string | null;
+        embedding: Buffer | null;
+      })
     | undefined;
   if (!row) return null;
-  return { ...row, embedding: row.embedding ? decodeEmbedding(row.embedding) : null };
+  return {
+    ...row,
+    type: row.type ?? 'claim',
+    label: row.label ?? row.global_id,
+    statement: row.statement ?? '',
+    embedding: row.embedding ? decodeEmbedding(row.embedding) : null,
+  };
 }
 
 /**
@@ -248,9 +259,19 @@ export function getIdeaSummary(globalId: string): Idea | null {
   const db = getDb();
   const row = db
     .prepare('SELECT global_id, type, label, statement, created_at FROM ideas WHERE global_id = ?')
-    .get(globalId) as Omit<Idea, 'embedding'> | undefined;
+    .get(globalId) as (Omit<Idea, 'type' | 'label' | 'statement' | 'embedding'> & {
+      type: IdeaType | null;
+      label: string | null;
+      statement: string | null;
+    }) | undefined;
   if (!row) return null;
-  return { ...row, embedding: null };
+  return {
+    ...row,
+    type: row.type ?? 'claim',
+    label: row.label ?? row.global_id,
+    statement: row.statement ?? '',
+    embedding: null,
+  };
 }
 
 /**
@@ -799,7 +820,7 @@ export function getIdeaDetail(globalId: string, worksCache?: Map<string, WorkVie
  * join plus DISTINCT, so no statement text has to be sorted to deduplicate.
  */
 export function listPickerIdeas(): IdeaPickerItem[] {
-  return getDb()
+  const rows = getDb()
     .prepare(
       `SELECT i.global_id, i.type, i.label, i.statement
          FROM ideas i
@@ -812,7 +833,17 @@ export function listPickerIdeas(): IdeaPickerItem[] {
              AND w.deep_status = 'done'
         )`
     )
-    .all() as IdeaPickerItem[];
+    .all() as Array<Omit<IdeaPickerItem, 'type' | 'label' | 'statement'> & {
+      type: IdeaType | null;
+      label: string | null;
+      statement: string | null;
+    }>;
+  return rows.map((row) => ({
+    ...row,
+    type: row.type ?? 'claim',
+    label: row.label ?? row.global_id,
+    statement: row.statement ?? '',
+  }));
 }
 
 export function listIdeasPage(request: IdeaPageRequest): IdeaPage {
@@ -863,9 +894,9 @@ export function listIdeasPage(request: IdeaPageRequest): IdeaPage {
     )
     .all(params) as Array<{
       id: string;
-      label: string;
-      type: IdeaType;
-      statement: string;
+      label: string | null;
+      type: IdeaType | null;
+      statement: string | null;
       work_count: number;
       max_confidence: number | null;
       connection_count: number;
@@ -890,9 +921,9 @@ export function listIdeasPage(request: IdeaPageRequest): IdeaPage {
   }
   const items: IdeaListItem[] = rows.map((row) => ({
     id: row.id,
-    label: row.label,
-    type: row.type,
-    statement: row.statement,
+    label: row.label ?? row.id,
+    type: row.type ?? 'claim',
+    statement: row.statement ?? '',
     workCount: Number(row.work_count),
     themes: themes.get(row.id) ?? [],
     maxConfidence: Number(row.max_confidence ?? 0),
@@ -925,9 +956,9 @@ export function listIdeaConnections(globalId: string): IdeaConnection[] {
       basis: EdgeBasis;
       confidence: number;
       other_id: string;
-      label: string;
-      idea_type: IdeaType;
-      statement: string;
+      label: string | null;
+      idea_type: IdeaType | null;
+      statement: string | null;
       work_count: number;
       max_confidence: number | null;
       connection_count: number;
@@ -943,9 +974,9 @@ export function listIdeaConnections(globalId: string): IdeaConnection[] {
     } satisfies GraphEdge,
     node: {
       id: row.other_id,
-      label: row.label,
-      type: row.idea_type,
-      statement: row.statement,
+      label: row.label ?? row.other_id,
+      type: row.idea_type ?? 'claim',
+      statement: row.statement ?? '',
       workCount: Number(row.work_count),
       themes: [],
       maxConfidence: Number(row.max_confidence ?? 0),

--- a/electron/graph/graphService.ts
+++ b/electron/graph/graphService.ts
@@ -87,9 +87,9 @@ const STOPWORDS = new Set([
 
 interface IdeaRow {
   global_id: string;
-  type: IdeaType;
-  label: string;
-  statement: string;
+  type: IdeaType | null;
+  label: string | null;
+  statement: string | null;
   created_at: string;
 }
 
@@ -184,10 +184,10 @@ export async function buildIdeaGraph(): Promise<GraphData> {
     const agg = ideaAggById.get(idea.global_id);
     return {
       id: idea.global_id,
-      label: idea.label,
-      type: idea.type,
+      label: idea.label ?? idea.global_id,
+      type: idea.type ?? 'claim',
       createdAt: idea.created_at,
-      statement: idea.statement,
+      statement: idea.statement ?? '',
       workCount: agg?.works.size ?? 0,
       workIds: agg ? Array.from(agg.works) : [],
       read: agg ? agg.works.size > 0 && !agg.unread : false,
@@ -426,10 +426,10 @@ function loadBoundedIdeaNodes(ideaIds: string[], memberships: ThemeMembership): 
     const aggregate = aggregates.get(idea.global_id);
     return {
       id: idea.global_id,
-      label: idea.label,
-      type: idea.type,
+      label: idea.label ?? idea.global_id,
+      type: idea.type ?? 'claim',
       createdAt: idea.created_at,
-      statement: idea.statement,
+      statement: idea.statement ?? '',
       workCount: aggregate?.works.size ?? 0,
       workIds: aggregate ? [...aggregate.works] : [],
       read: Boolean(aggregate?.works.size) && !aggregate?.unread,

--- a/scripts/test-argument-map-graph.mjs
+++ b/scripts/test-argument-map-graph.mjs
@@ -125,7 +125,9 @@ try {
     addIdea.run(HUB, 'claim', 'idea central', 'La idea semilla del recorrido.', '2026-01-01');
     insertionOrder.forEach(({ link, i }) => {
       const id = `g-n${i}`;
-      addIdea.run(id, 'claim', `vecina ${i}`, `Enunciado de la vecina ${i}.`, '2026-01-01');
+      // The original ideas schema allows a missing statement. This reproduces the
+      // renderer crash that used to call null.toLowerCase() in the route search.
+      addIdea.run(id, 'claim', `vecina ${i}`, i === 0 ? null : `Enunciado de la vecina ${i}.`, '2026-01-01');
       addEdge.run(`e-hub-${i}`, HUB, id, link.type, 'basis', link.confidence);
       for (let k = 0; k < OUTER_PER_NEIGHBOUR; k++) {
         const outer = `g-o${i}-${k}`;
@@ -148,6 +150,10 @@ try {
   const route = discoverArgumentRoutes().find((r) => r.ideaId === HUB);
   assert.equal(route.degree, HUB_DEGREE, 'the fixture reproduces the reported hub');
   assert.equal(route.debateCount, HUB_DEBATES);
+  assert.equal(discoverArgumentRoutes().find((r) => r.ideaId === 'g-n0').statement, '',
+    'nullable SQLite statements are normalized before any view can search them');
+  assert.equal(nodes.find((node) => node.block.ideaId === 'g-n0')?.block.statement, '',
+    'the map tab receives the same safe text contract as the route catalogue');
   // The header used to quote the post-cap figures (79 / 9 for the real route),
   // so the map appeared to have lost connections the list had just promised.
   assert.equal(map.root.summary, `${HUB_DEGREE} conexiones · ${HUB_DEBATES} debate(s)`,

--- a/scripts/test-argument-map-tree.mjs
+++ b/scripts/test-argument-map-tree.mjs
@@ -111,7 +111,7 @@ test('a manual toggle takes over from the automatic unfold', () => {
   );
 });
 
-test('the catalogue and current idea are persistent workspace tabs', () => {
+test('the catalogue and open maps are persistent workspace tabs', () => {
   assert.match(view, /data-testid="argument-map-tabs"/, 'the argument workspace exposes a tab strip');
   assert.match(view, /data-testid="argument-tab-catalog"/, 'the catalogue is always reachable as the first tab');
   assert.match(view, /data-testid="argument-tab-map"/, 'the selected idea owns a named map tab');
@@ -122,7 +122,7 @@ test('the catalogue and current idea are persistent workspace tabs', () => {
   );
   assert.match(
     view,
-    /className=\{surface === 'map' \? 'flex h-full min-h-0' : 'hidden'\}/,
-    'the nested map stays mounted when the reader returns to the catalogue',
+    /<ArgumentMapTab key=\{tab\.key\} tab=\{tab\} active=\{surface === 'map' && activeMapKey === tab\.key\}/,
+    'every nested map stays mounted when the reader switches tabs or returns to the catalogue',
   );
 });

--- a/scripts/test-argument-map-ui.mjs
+++ b/scripts/test-argument-map-ui.mjs
@@ -19,17 +19,21 @@ test('argument map opens as a library-style metadata catalogue', () => {
 
 test('catalogue metadata can be searched, filtered and sorted', () => {
   assert.match(source, /data-testid="argument-routes-search"/);
+  assert.match(source, /\(s\.statement \?\? ''\)\.toLowerCase\(\)/, 'a route with no statement remains searchable instead of crashing the section');
+  assert.doesNotMatch(source, /s\.statement\.toLowerCase\(\)/);
   assert.match(source, /setMinConnections/);
   for (const sort of ['label', 'type', 'connections', 'debates', 'confidence']) {
     assert.match(source, new RegExp(`routeSort === '${sort}'|sort="${sort}"`), `catalogue supports ${sort} sorting`);
   }
 });
 
-test('clicking a row opens a persistent idea tab around the existing tree', () => {
-  assert.match(source, /setOpenArgumentMap\(\{ ideaId: sid, label, mode \}\);\s*setSurface\('map'\);/);
+test('clicking rows opens independent persistent map tabs around each tree', () => {
+  assert.match(source, /setOpenArgumentMaps\(\(current\) => existing[\s\S]*\[\.\.\.current, tab\][\s\S]*setActiveMapKey\(key\);\s*setSurface\('map'\);/);
+  assert.match(source, /openArgumentMaps\.find\(\(tab\) => tab\.key === key\)[\s\S]*if \(existing && !existing\.error\)/, 'an already-open successful map is focused instead of rebuilt');
   assert.match(source, /onClick=\{\(\) => build\(s\.ideaId\)\}/);
   assert.match(source, /data-testid="argument-tab-map"/);
-  assert.match(source, /<BlockTree block=\{map\.root\}/, 'the tab renders the established nested idea tree');
+  assert.match(source, /openArgumentMaps\.map\(\(tab\) =>/, 'all map tabs remain mounted independently');
+  assert.match(source, /<BlockTree block=\{tab\.map\.root\}/, 'each tab renders its own established nested idea tree');
 });
 
 test('catalogue and tabs explicitly support light and dark themes', () => {

--- a/scripts/test-authors-ui.mjs
+++ b/scripts/test-authors-ui.mjs
@@ -25,10 +25,11 @@ test('Authors is a library-style catalogue with real metadata and saved authors 
 
 test('author and synthesis-matrix clicks open persistent internal tabs', async () => {
   const view = await readSource('src/views/AuthorsView.tsx');
-  assert.match(view, /setOpenAuthor\(author\);[\s\S]*setSurface\('author'\)/);
+  assert.match(view, /setOpenAuthors\(\(current\) => \([\s\S]*current\.some\(\(open\) => open\.id === author\.id\)[\s\S]*\[\.\.\.current, author\][\s\S]*setActiveAuthorId\(author\.id\);[\s\S]*setSurface\('author'\)/, 'a new author gets its own tab and an already-open author is focused');
+  assert.match(view, /openAuthors\.map\(\(author\) =>/, 'all open author dossiers remain mounted independently');
   assert.match(view, /setMatrixOpen\(true\);[\s\S]*setSurface\('matrix'\)/);
   assert.match(view, /surface === 'catalog' \? 'h-full' : 'hidden'/, 'the catalogue remains mounted behind other tabs');
-  assert.match(view, /surface === 'author' \? 'h-full' : 'hidden'/, 'author detail remains mounted as a tab');
+  assert.match(view, /surface === 'author' && activeAuthorId === author\.id \? 'h-full' : 'hidden'/, 'each author detail remains mounted in its own tab');
   assert.match(view, /surface === 'matrix' \? 'h-full p-5' : 'hidden'/, 'the synthesis matrix remains mounted as a tab');
 });
 

--- a/scripts/test-ideas-ui.mjs
+++ b/scripts/test-ideas-ui.mjs
@@ -34,13 +34,14 @@ test('Ideas catalogue can be searched, filtered and sorted', async () => {
   }
 });
 
-test('clicking an idea opens a persistent detail tab', async () => {
+test('clicking ideas opens independent persistent detail tabs', async () => {
   const view = await readSource('src/views/IdeasView.tsx');
-  assert.match(view, /setSelectedId\(idea\.id\);[\s\S]*setOpenIdea\(idea\);[\s\S]*setSurface\('idea'\)/);
+  assert.match(view, /setOpenIdeas\(\(current\) => \([\s\S]*current\.some\(\(open\) => open\.id === idea\.id\)[\s\S]*\[\.\.\.current, idea\][\s\S]*setActiveIdeaId\(idea\.id\);[\s\S]*setSurface\('idea'\)/, 'a new idea gets its own tab and an existing one is focused');
   assert.match(view, /data-testid="ideas-tab-catalog"/);
   assert.match(view, /data-testid="ideas-tab-idea"/);
+  assert.match(view, /openIdeas\.map\(\(idea\) =>/, 'all open idea details remain mounted');
   assert.match(view, /surface === 'catalog' \? 'flex h-full min-h-0 flex-col' : 'hidden'/, 'catalogue stays mounted behind the detail tab');
-  assert.match(view, /surface === 'idea' \? 'h-full overflow-y-auto p-5' : 'hidden'/, 'idea detail is rendered as a workspace tab');
+  assert.match(view, /surface === 'idea' && activeIdeaId === idea\.id \? 'h-full' : 'hidden'/, 'each idea detail is rendered as its own workspace tab');
 });
 
 test('idea detail keeps evidence, works and expandable connected ideas', async () => {

--- a/scripts/test-null-safe-view-search.mjs
+++ b/scripts/test-null-safe-view-search.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readSource } from './ipc-channel-census.mjs';
+
+const SEARCH_VIEWS = [
+  'src/views/ArgumentMapView.tsx',
+  'src/views/GraphView.tsx',
+  'src/views/graph/model.ts',
+  'src/views/NotesView.tsx',
+  'src/components/nodi/NodiCompanion.tsx',
+  'src/views/DeepResearchView.tsx',
+  'src/views/ImmersionView.tsx',
+  'src/views/ProjectsView.tsx',
+  'src/views/RubricsView.tsx',
+  'src/components/VaultSwitcher.tsx',
+  'src/components/dbGrid.tsx',
+  'src/components/ArchiveFilterBar.tsx',
+  'src/components/world/WorldFilterBar.tsx',
+  'src/views/CollectionsModal.tsx',
+  'src/components/world/mapTimeline.tsx',
+  'src/views/MapView.tsx',
+  'src/components/PersonLinkPicker.tsx',
+  'src/views/ManualIdeaEditor.tsx',
+  'src/views/AudioGenerationSettings.tsx',
+  'src/views/DatabasesView.tsx',
+  'src/views/ProvidersSettings.tsx',
+];
+
+test('view searches never lowercase nullable payload fields directly', async () => {
+  const unsafe = /\.(?:statement|label|title|content|name|personName|displayName|objective|id)\.toLowerCase\(\)/;
+  for (const file of SEARCH_VIEWS) {
+    const source = await readSource(file);
+    assert.doesNotMatch(source, unsafe, `${file} must normalize persisted or imported text before searching it`);
+  }
+});
+
+test('search result ordering never compares nullable payload fields directly', async () => {
+  const unsafe = /\.(?:label|title|name|personName|displayName|provider|updatedAt)\.localeCompare\(/;
+  for (const file of SEARCH_VIEWS) {
+    const source = await readSource(file);
+    assert.doesNotMatch(source, unsafe, `${file} must normalize persisted or imported text before sorting it`);
+  }
+});

--- a/scripts/test-performance-pagination.mjs
+++ b/scripts/test-performance-pagination.mjs
@@ -27,7 +27,7 @@ assert.match(worksRepo, /Math\.min\(250,/, 'works endpoint must enforce a server
 
 assert.match(ideas, /listIdeasPage\(/, 'Ideas must use its compact list endpoint');
 assert.equal(ideas.includes("getGraph('ideas')"), false, 'Ideas list must not transfer the full graph');
-assert.match(ideas, /listIdeaConnections\(selectedId\)/, 'connections must load only for the selected idea');
+assert.match(ideas, /listIdeaConnections\(idea\.id\)/, 'connections must load only for each opened idea');
 assert.match(ideasRepo, /LIMIT @limit OFFSET @offset/, 'ideas must be paginated inside SQLite');
 
 assert.match(gaps, /getGapsPage\(/, 'Gaps must request a bounded page');

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -75,12 +75,13 @@ test('the two halves of a section merge instead of overwriting each other', () =
   // In Autores the tab strip lives in AuthorsView and the filters in its catalogue
   // child. Each reports only what it owns, and neither may erase the other's half.
   store.patchViewSnapshot('vault-a', 'authors', AUTHORS_CUT);
-  store.patchViewSnapshot('vault-a', 'authors', { surface: 'author', openAuthor: { id: 'A1', label: 'Ricoeur' }, matrixOpen: false });
+  store.patchViewSnapshot('vault-a', 'authors', { surface: 'author', openAuthors: [{ id: 'A1', label: 'Ricoeur' }], activeAuthorId: 'A1', matrixOpen: false });
 
   assert.deepEqual(store.readViewSnapshot('vault-a', 'authors'), {
     ...AUTHORS_CUT,
     surface: 'author',
-    openAuthor: { id: 'A1', label: 'Ricoeur' },
+    openAuthors: [{ id: 'A1', label: 'Ricoeur' }],
+    activeAuthorId: 'A1',
     matrixOpen: false,
   });
 });
@@ -311,7 +312,7 @@ test('a snapshot is an initial value, never a reactive prop', async () => {
   }
 });
 
-test('Autores restores its filters, its ordering and its open tab', async () => {
+test('Autores restores its filters, its ordering and its open tabs', async () => {
   const view = await readSource('src/views/AuthorsView.tsx');
   for (const restored of ['sortBy', 'synthFilter', 'savedOnly', 'filtersOpen', 'query']) {
     assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
@@ -321,16 +322,16 @@ test('Autores restores its filters, its ordering and its open tab', async () => 
   assert.match(view, /const \[query, setQuery\] = useState\(\(\) => snapshot\?\.query \?\? ''\)/);
   assert.match(view, /const \[queryFilter, setQueryFilter\] = useState\(\(\) => snapshot\?\.query \?\? ''\)/);
   // A tab that is no longer open cannot be the active one.
-  assert.match(view, /surface === 'author' && !snapshot\?\.openAuthor\) return 'catalog'/);
+  assert.match(view, /surface === 'author' && !snapshot\?\.openAuthors\?\.some\(\(author\) => author\.id === snapshot\.activeAuthorId\)\) return 'catalog'/);
   assert.match(view, /surface === 'matrix' && !snapshot\?\.matrixOpen\) return 'catalog'/);
 });
 
-test('Ideas restores its filters and its open idea together with the selection behind it', async () => {
+test('Ideas restores its filters and its open idea tabs together with the active one', async () => {
   const view = await readSource('src/views/IdeasView.tsx');
-  for (const restored of ['search', 'typeFilter', 'sortKey', 'filtersOpen', 'openIdea']) {
+  for (const restored of ['search', 'typeFilter', 'sortKey', 'filtersOpen', 'openIdeas']) {
     assert.match(view, new RegExp(`useState[^\\n]*\\(\\) => snapshot\\?\\.${restored}`), `${restored} survives leaving the section`);
   }
-  assert.match(view, /setSelectedId[\s\S]{0,120}snapshot\?\.openIdea\?\.id/, 'the open tab and the detail it shows are restored as a pair');
+  assert.match(view, /snapshot\?\.openIdeas\?\.some\(\(idea\) => idea\.id === snapshot\.activeIdeaId\)/, 'only an open idea can be restored as the active tab');
 });
 
 test('Biblioteca keeps a cut per scope, and only what nothing else already persists', async () => {

--- a/src/app/viewSnapshots.ts
+++ b/src/app/viewSnapshots.ts
@@ -91,9 +91,10 @@ export interface ListPlacement {
 }
 
 export interface AuthorsSnapshot {
-  /** 'author' is only reachable with `openAuthor` set; the pair travels together. */
+  /** 'author' is only reachable with an id present in `openAuthors`. */
   surface: 'catalog' | 'author' | 'matrix';
-  openAuthor: OpenEntityTab | null;
+  openAuthors: OpenEntityTab[];
+  activeAuthorId: string | null;
   matrixOpen: boolean;
   query: string;
   sortBy: AuthorsSortKey;
@@ -105,7 +106,8 @@ export interface AuthorsSnapshot {
 
 export interface IdeasSnapshot {
   surface: 'catalog' | 'idea';
-  openIdea: OpenEntityTab | null;
+  openIdeas: OpenEntityTab[];
+  activeIdeaId: string | null;
   search: string;
   typeFilter: IdeaType | '';
   sortKey: IdeasSortKey;

--- a/src/components/ArchiveFilterBar.tsx
+++ b/src/components/ArchiveFilterBar.tsx
@@ -309,7 +309,7 @@ function SimpleFilterDropdown({
   const [q, setQ] = useState('');
   const ref = useDismissableLayer<HTMLDivElement>({ open, onDismiss: () => setOpen(false) });
 
-  const filtered = searchable && q.trim() ? options.filter((o) => o.label.toLowerCase().includes(q.trim().toLowerCase())) : options;
+  const filtered = searchable && q.trim() ? options.filter((o) => (o.label ?? '').toLowerCase().includes(q.trim().toLowerCase())) : options;
 
   const toggle = (value: string) => {
     onChange(selected.includes(value) ? selected.filter((v) => v !== value) : [...selected, value]);

--- a/src/components/PersonLinkPicker.tsx
+++ b/src/components/PersonLinkPicker.tsx
@@ -45,7 +45,7 @@ export function PersonLinkPicker({
   const results = useMemo(() => {
     const query = q.trim().toLowerCase();
     return persons
-      .filter((p) => !linkedIds.has(p.personId) && (!query || p.displayName.toLowerCase().includes(query)))
+      .filter((p) => !linkedIds.has(p.personId) && (!query || (p.displayName ?? '').toLowerCase().includes(query)))
       .slice(0, 8);
   }, [persons, linkedIds, q]);
 

--- a/src/components/VaultSwitcher.tsx
+++ b/src/components/VaultSwitcher.tsx
@@ -156,11 +156,11 @@ export function VaultSwitcher({ anchorEl, onClose, vaults, onVaultsChanged, onAc
   const shownVaults = useMemo(() => {
     const q = query.trim().toLowerCase();
     const filtered = vaults.filter(
-      (v) => (typeFilter === 'all' || v.type === typeFilter) && (!q || v.name.toLowerCase().includes(q))
+      (v) => (typeFilter === 'all' || v.type === typeFilter) && (!q || (v.name ?? '').toLowerCase().includes(q))
     );
     const byRecent = (a: VaultSummary, b: VaultSummary) => (b.lastOpenedAt || '').localeCompare(a.lastOpenedAt || '');
     const byCreated = (a: VaultSummary, b: VaultSummary) => (b.createdAt || '').localeCompare(a.createdAt || '');
-    const byName = (a: VaultSummary, b: VaultSummary) => a.name.localeCompare(b.name);
+    const byName = (a: VaultSummary, b: VaultSummary) => (a.name ?? '').localeCompare(b.name ?? '');
     return [...filtered].sort(sortKey === 'created' ? byCreated : sortKey === 'name' ? byName : byRecent);
   }, [vaults, query, typeFilter, sortKey]);
 

--- a/src/components/dbGrid.tsx
+++ b/src/components/dbGrid.tsx
@@ -368,8 +368,8 @@ export function ChipSelectCell({
 
   const byId = new Map(options.map((o) => [o.id, o]));
   const query = q.trim().toLowerCase();
-  const filtered = options.filter((o) => !query || o.label.toLowerCase().includes(query));
-  const exact = options.some((o) => o.label.toLowerCase() === query);
+  const filtered = options.filter((o) => !query || (o.label ?? '').toLowerCase().includes(query));
+  const exact = options.some((o) => (o.label ?? '').toLowerCase() === query);
 
   const toggle = (id: string) => {
     if (values.includes(id)) onChange(values.filter((v) => v !== id));

--- a/src/components/nodi/NodiCompanion.tsx
+++ b/src/components/nodi/NodiCompanion.tsx
@@ -404,7 +404,7 @@ export function NodiCompanion({ context, costumes }: { context: Ctx; costumes?: 
   const filteredNotes = useMemo(() => {
     const q = noteSearch.trim().toLowerCase();
     if (!q) return notes;
-    return notes.filter((n) => n.title.toLowerCase().includes(q) || n.content.toLowerCase().includes(q));
+    return notes.filter((n) => (n.title ?? '').toLowerCase().includes(q) || (n.content ?? '').toLowerCase().includes(q));
   }, [notes, noteSearch]);
 
   // Markdown formatting acting on the textarea's current selection.

--- a/src/components/world/WorldFilterBar.tsx
+++ b/src/components/world/WorldFilterBar.tsx
@@ -92,7 +92,7 @@ function FacetChip({
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
     if (!needle) return options;
-    return options.filter((option) => option.label.toLowerCase().includes(needle));
+    return options.filter((option) => (option.label ?? '').toLowerCase().includes(needle));
   }, [options, query]);
 
   const ref = useDismissableLayer<HTMLDivElement>({

--- a/src/components/world/mapTimeline.tsx
+++ b/src/components/world/mapTimeline.tsx
@@ -348,7 +348,7 @@ export function CastPicker({
   const [query, setQuery] = useState('');
   const anchorRef = useRef<HTMLDivElement>(null);
   const shown = query.trim()
-    ? tracks.filter((track) => track.personName.toLowerCase().includes(query.trim().toLowerCase()))
+    ? tracks.filter((track) => (track.personName ?? '').toLowerCase().includes(query.trim().toLowerCase()))
     : tracks;
 
   const label = selected.size === 0

--- a/src/views/ArgumentMapView.tsx
+++ b/src/views/ArgumentMapView.tsx
@@ -61,7 +61,12 @@ const ROUTES_PAGE_SIZE = 40;
 type ArgumentMapSurface = 'catalog' | 'map';
 /** Exported because the section's snapshot stores it. */
 export type RouteSortKey = 'label' | 'type' | 'connections' | 'debates' | 'confidence';
-type OpenArgumentMap = { ideaId: string; label: string; mode: 'auto' | 'ai' };
+type OpenArgumentMap = { key: string; ideaId: string; label: string; mode: 'auto' | 'ai' };
+type ArgumentMapTabState = OpenArgumentMap & {
+  map: ArgumentMap | null;
+  building: boolean;
+  error: string | null;
+};
 
 export function ArgumentMapView({
   settings,
@@ -77,7 +82,8 @@ export function ArgumentMapView({
   // data of its own — redrawing it means rebuilding it, and in AI mode that would
   // spend a model call on the act of walking back into the section.
   const [surface, setSurface] = useState<ArgumentMapSurface>('catalog');
-  const [openArgumentMap, setOpenArgumentMap] = useState<OpenArgumentMap | null>(null);
+  const [openArgumentMaps, setOpenArgumentMaps] = useState<ArgumentMapTabState[]>([]);
+  const [activeMapKey, setActiveMapKey] = useState<string | null>(null);
   const [ideaNodes, setIdeaNodes] = useState<IdeaPickerItem[]>([]);
   const [graphLoaded, setGraphLoaded] = useState(false);
   const [mode, setMode] = useState<'auto' | 'ai'>(() => snapshot?.mode ?? 'auto');
@@ -103,22 +109,7 @@ export function ArgumentMapView({
     report.current?.({ mode, seedId, suggestionSearch, minConnections, routeSort });
   }, [minConnections, mode, routeSort, seedId, suggestionSearch]);
   const [model, setModel] = useFeatureModel(settings, 'argumentMapModel');
-  const [map, setMap] = useState<ArgumentMap | null>(null);
-  const [building, setBuilding] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Progressive unfold: the map opens one level per tick after it is built. The
-  // expanded set is the single source of truth, so a manual toggle and the
-  // automatic unfold can never disagree about what is on screen.
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const revealTimerRef = useRef<number | null>(null);
-
-  const [ideaDetail, setIdeaDetail] = useState<IdeaDetail | null>(null);
-  const [edgeDetail, setEdgeDetail] = useState<EdgeDetail | null>(null);
-  const [detailLoading, setDetailLoading] = useState<DetailLoading | null>(null);
-  const detailSeqRef = useRef(0);
-  const [detailWidth, setDetailWidth] = useState(() => loadNumber(DETAIL_WIDTH_KEY, DETAIL_DEFAULT_WIDTH, DETAIL_MIN_WIDTH, DETAIL_MAX_WIDTH));
-  const [detailFontSize, setDetailFontSize] = useState(() => loadNumber(DETAIL_FONT_KEY, DETAIL_DEFAULT_FONT, DETAIL_MIN_FONT, DETAIL_MAX_FONT));
+  const [catalogError, setCatalogError] = useState<string | null>(null);
   const seedSearchRef = useDismissableLayer<HTMLDivElement>({
     open: seedSearchOpen,
     onDismiss: () => setSeedSearchOpen(false),
@@ -147,12 +138,12 @@ export function ArgumentMapView({
   const discoverRoutes = useCallback(async (manual = false) => {
     setSuggestionsLoading(true);
     if (manual) setRefreshing(true);
-    setError(null);
+    setCatalogError(null);
     try {
       const raw = await window.nodus.discoverArgumentRoutes();
       setSuggestions([...raw].sort((a, b) => b.degree - a.degree));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setCatalogError(e instanceof Error ? e.message : String(e));
     } finally {
       setSuggestionsLoading(false);
       setRefreshing(false);
@@ -170,22 +161,15 @@ export function ArgumentMapView({
   const switchMode = (next: 'auto' | 'ai') => {
     if (next === mode) return;
     setMode(next);
-    setError(null);
+    setCatalogError(null);
     setSeedId('');
     setSearch('');
   };
 
-  useEffect(() => {
-    localStorage.setItem(DETAIL_WIDTH_KEY, String(detailWidth));
-  }, [detailWidth]);
-  useEffect(() => {
-    localStorage.setItem(DETAIL_FONT_KEY, String(detailFontSize));
-  }, [detailFontSize]);
-
   const filteredIdeas = useMemo(() => {
     const q = search.trim().toLowerCase();
     const base = q
-      ? ideaNodes.filter((n) => n.label.toLowerCase().includes(q) || (n.statement ?? '').toLowerCase().includes(q))
+      ? ideaNodes.filter((n) => (n.label ?? '').toLowerCase().includes(q) || (n.statement ?? '').toLowerCase().includes(q))
       : ideaNodes;
     return base.slice(0, 60);
   }, [ideaNodes, search]);
@@ -193,11 +177,11 @@ export function ArgumentMapView({
   const filteredSuggestions = useMemo(() => {
     const q = suggestionSearch.trim().toLowerCase();
     let base = suggestions;
-    if (q) base = base.filter((s) => s.label.toLowerCase().includes(q) || s.statement.toLowerCase().includes(q));
+    if (q) base = base.filter((s) => (s.label ?? '').toLowerCase().includes(q) || (s.statement ?? '').toLowerCase().includes(q));
     if (minConnections > 1) base = base.filter((s) => s.degree >= minConnections);
     return [...base].sort((a, b) => {
-      if (routeSort === 'label') return a.label.localeCompare(b.label);
-      if (routeSort === 'type') return a.type.localeCompare(b.type) || a.label.localeCompare(b.label);
+      if (routeSort === 'label') return (a.label ?? '').localeCompare(b.label ?? '');
+      if (routeSort === 'type') return (a.type ?? '').localeCompare(b.type ?? '') || (a.label ?? '').localeCompare(b.label ?? '');
       if (routeSort === 'debates') return b.debateCount - a.debateCount || b.degree - a.degree;
       if (routeSort === 'confidence') return b.avgConfidence - a.avgConfidence || b.degree - a.degree;
       return b.degree - a.degree || b.debateCount - a.debateCount;
@@ -226,119 +210,56 @@ export function ArgumentMapView({
     onCapture: (topId) => report.current?.({ placement: topId ? { anchorId: topId } : null }),
   });
 
-  const stopReveal = useCallback(() => {
-    if (revealTimerRef.current != null) {
-      window.clearInterval(revealTimerRef.current);
-      revealTimerRef.current = null;
-    }
-  }, []);
-
-  // Drive the progressive unfold once a map is built: open the root, then one
-  // deeper level per tick. Stops as soon as the last level is open.
-  useEffect(() => {
-    stopReveal();
-    if (!map) {
-      setExpanded(new Set());
-      return;
-    }
-    const levels = expandableIdsByDepth(map.root);
-    setExpanded(new Set(levels[0] ?? []));
-    if (levels.length <= 1) return;
-    let level = 1;
-    revealTimerRef.current = window.setInterval(() => {
-      const ids = levels[level++] ?? [];
-      setExpanded((cur) => {
-        const next = new Set(cur);
-        for (const id of ids) next.add(id);
-        return next;
-      });
-      if (level >= levels.length) stopReveal();
-    }, 260);
-    return stopReveal;
-  }, [map, stopReveal]);
-
   const build = useCallback(async (explicitSeed?: string) => {
     const sid = explicitSeed ?? seedId;
     if (!sid) return;
     const candidate = suggestions.find((entry) => entry.ideaId === sid);
     const pickerIdea = ideaNodes.find((entry) => entry.global_id === sid);
     const label = (candidate?.label ?? pickerIdea?.label ?? search.trim()) || t('Idea');
-    setOpenArgumentMap({ ideaId: sid, label, mode });
+    const key = `${mode}:${sid}`;
+    const existing = openArgumentMaps.find((tab) => tab.key === key);
+    if (existing && !existing.error) {
+      setActiveMapKey(key);
+      setSurface('map');
+      return;
+    }
+    const tab: ArgumentMapTabState = { key, ideaId: sid, label, mode, map: null, building: true, error: null };
+    setOpenArgumentMaps((current) => existing
+      ? current.map((open) => open.key === key ? tab : open)
+      : [...current, tab]
+    );
+    setActiveMapKey(key);
     setSurface('map');
-    setBuilding(true);
-    setError(null);
-    setMap(null);
-    setIdeaDetail(null);
-    setEdgeDetail(null);
-    setDetailLoading(null);
     try {
       const result = await window.nodus.buildArgumentMap({ seedIdeaId: sid, model, mode });
-      // The unfold effect seeds `expanded` from the new map.
-      setMap(result);
+      setOpenArgumentMaps((current) => current.map((open) => (
+        open.key === key ? { ...open, map: result, building: false } : open
+      )));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBuilding(false);
+      const message = e instanceof Error ? e.message : String(e);
+      setOpenArgumentMaps((current) => current.map((open) => (
+        open.key === key ? { ...open, building: false, error: message } : open
+      )));
     }
-  }, [ideaNodes, mode, model, search, seedId, suggestions]);
+  }, [ideaNodes, mode, model, openArgumentMaps, search, seedId, suggestions]);
 
-  const closeMapTab = useCallback(() => {
-    stopReveal();
-    setSurface('catalog');
-    setOpenArgumentMap(null);
-    setMap(null);
-    setError(null);
-    detailSeqRef.current++;
-    setIdeaDetail(null);
-    setEdgeDetail(null);
-    setDetailLoading(null);
-  }, [stopReveal]);
+  const closeMapTab = useCallback((key: string) => {
+    const closingIndex = openArgumentMaps.findIndex((tab) => tab.key === key);
+    if (closingIndex < 0) return;
+    const remaining = openArgumentMaps.filter((tab) => tab.key !== key);
+    setOpenArgumentMaps(remaining);
+    if (activeMapKey !== key) return;
 
-  const selectBlock = useCallback((block: ArgumentBlock) => {
-    if (!block.ideaId) return;
-    detailSeqRef.current++;
-    setIdeaDetail(null);
-    setEdgeDetail(null);
-    setDetailLoading({ kind: 'idea', id: block.ideaId, label: block.label, type: block.type });
-    const seq = detailSeqRef.current;
-    void window.nodus.getIdeaDetail(block.ideaId).then(
-      (d) => {
-        if (seq !== detailSeqRef.current) return;
-        setIdeaDetail(d);
-        setDetailLoading(null);
-      },
-      () => {
-        if (seq !== detailSeqRef.current) return;
-        setDetailLoading(null);
-      }
-    );
-  }, []);
-
-  // A manual toggle hands control to the user: the automatic unfold stops so it
-  // cannot reopen a branch the user just collapsed.
-  const toggleExpand = useCallback((id: string) => {
-    stopReveal();
-    setExpanded((cur) => {
-      const next = new Set(cur);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, [stopReveal]);
-
-  const closeDetail = () => {
-    detailSeqRef.current++;
-    setIdeaDetail(null);
-    setEdgeDetail(null);
-    setDetailLoading(null);
-  };
-
-  const changeDetailFont = (delta: number) => {
-    setDetailFontSize((v) => Math.min(DETAIL_MAX_FONT, Math.max(DETAIL_MIN_FONT, v + delta)));
-  };
+    const nextActive = remaining[Math.min(closingIndex, remaining.length - 1)] ?? null;
+    setActiveMapKey(nextActive?.key ?? null);
+    if (surface === 'map' && !nextActive) setSurface('catalog');
+  }, [activeMapKey, openArgumentMaps, surface]);
 
   const hasModel = !!model;
   const isAuto = mode === 'auto';
+  const selectedMapBuilding = seedId
+    ? openArgumentMaps.some((tab) => tab.key === `${mode}:${seedId}` && tab.building)
+    : false;
 
   return (
     <div data-testid="argument-map-workspace" className="flex h-full min-h-0 flex-col bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
@@ -363,16 +284,19 @@ export function ArgumentMapView({
           >
             <Icon name="list" size={13} /> {t('Ideas')}
           </button>
-          {openArgumentMap && (
-            <div className={`flex h-9 min-w-0 shrink-0 items-center rounded-t-lg border border-b-0 ${surface === 'map' ? 'border-neutral-300 bg-neutral-50 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100' : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-300'}`}>
-              <button data-testid="argument-tab-map" className="flex h-full max-w-72 min-w-0 items-center gap-2 px-3 text-xs" onClick={() => setSurface('map')}>
-                <Icon name="layers" size={13} /><span className="truncate">{openArgumentMap.label}</span>
-              </button>
-              <button className="mr-1 grid h-6 w-6 shrink-0 place-items-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-800" aria-label={t('Cerrar')} onClick={closeMapTab}>
-                <Icon name="x" size={11} />
-              </button>
-            </div>
-          )}
+          {openArgumentMaps.map((tab) => {
+            const active = surface === 'map' && activeMapKey === tab.key;
+            return (
+              <div key={tab.key} className={`flex h-9 min-w-0 shrink-0 items-center rounded-t-lg border border-b-0 ${active ? 'border-neutral-300 bg-neutral-50 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100' : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-300'}`}>
+                <button data-testid="argument-tab-map" data-map-key={tab.key} className="flex h-full max-w-72 min-w-0 items-center gap-2 px-3 text-xs" onClick={() => { setActiveMapKey(tab.key); setSurface('map'); }}>
+                  <Icon name="layers" size={13} /><span className="truncate">{tab.label}</span>
+                </button>
+                <button className="mr-1 grid h-6 w-6 shrink-0 place-items-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-800" aria-label={`${t('Cerrar')}: ${tab.label}`} onClick={() => closeMapTab(tab.key)}>
+                  <Icon name="x" size={11} />
+                </button>
+              </div>
+            );
+          })}
         </div>
       </header>
 
@@ -470,8 +394,8 @@ export function ArgumentMapView({
                     <label className="uppercase tracking-wide text-neutral-500">{t('Modelo')}</label>
                     <ModelPicker settings={settings} value={model} onChange={setModel} compact />
                   </div>
-                  <button className="btn btn-primary gap-1.5" onClick={() => build()} disabled={!seedId || building || !hasModel} title={!hasModel ? t('Configura un modelo de IA en Ajustes') : t('Trazar el mapa de argumentos')}>
-                    <Icon name="map" /> {building ? t('Trazando…') : t('Trazar mapa')}
+                  <button className="btn btn-primary gap-1.5" onClick={() => build()} disabled={!seedId || selectedMapBuilding || !hasModel} title={!hasModel ? t('Configura un modelo de IA en Ajustes') : t('Trazar el mapa de argumentos')}>
+                    <Icon name="map" /> {selectedMapBuilding ? t('Trazando…') : t('Trazar mapa')}
                   </button>
                 </>
               )}
@@ -489,10 +413,10 @@ export function ArgumentMapView({
             </div>
           ) : (
             <div ref={routesScrollerRef} data-testid="argument-routes-table" className="min-h-0 flex-1 overflow-auto">
-              {error && <div className="m-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-400"><Icon name="alert" /> <span>{error}</span></div>}
+              {catalogError && <div className="m-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-400"><Icon name="alert" /> <span>{catalogError}</span></div>}
               {suggestionsLoading && suggestions.length === 0 ? (
                 <div className="grid h-48 place-items-center text-neutral-500"><Spinner label={t('Detectando recorridos…')} /></div>
-              ) : suggestions.length === 0 && !error ? (
+              ) : suggestions.length === 0 && !catalogError ? (
                 <div className="grid h-48 place-items-center p-8 text-center text-sm text-neutral-500"><div><Icon name="map" size={32} className="mx-auto text-neutral-300 dark:text-neutral-700" /><p className="mt-3">{t('No hay ideas conectadas todavía. Analiza tus obras (escaneo profundo) para que el grafo genere conexiones entre ideas.')}</p></div></div>
               ) : (
                 <div className="min-w-[1120px]">
@@ -540,31 +464,128 @@ export function ArgumentMapView({
           )}
         </section>
 
-        {openArgumentMap && (
-          <section className={surface === 'map' ? 'flex h-full min-h-0' : 'hidden'}>
-            <div className="min-w-0 flex-1 overflow-y-auto p-4">
-              {error && <div className="card flex items-start gap-2 p-4 text-sm text-red-400"><Icon name="alert" /> <span>{error}</span></div>}
-              {building && !map && <div className="flex h-full flex-col items-center justify-center gap-3 text-neutral-500"><Spinner label={openArgumentMap.mode === 'auto' ? t('Construyendo el esquema…') : t('El modelo está trazando el esquema de argumentos…')} /></div>}
-              {map && (
-                <div className="mx-auto max-w-4xl">
-                  <div className="card mb-4 bg-neutral-900/60 p-4">
-                    <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-neutral-500">
-                      <Icon name="map" size={14} /> {t('Mapa desde')} <span className="text-neutral-300">{map.seedLabel}</span>
-                      <span>· {tx('{n} ideas', { n: map.ideaCount })}</span>
-                      {map.truncated && <span className="text-amber-500">· {t('subgrafo recortado')}</span>}
-                      <span className="text-neutral-600">· {openArgumentMap.mode === 'auto' ? t('modo automático') : t('modo IA')}</span>
-                    </div>
-                    {map.overview && <p className="text-sm leading-relaxed text-neutral-300">{map.overview}</p>}
-                  </div>
-                  <BlockTree block={map.root} depth={0} expanded={expanded} onToggle={toggleExpand} onSelect={selectBlock} />
-                </div>
-              )}
-            </div>
-            {(ideaDetail || edgeDetail || detailLoading) && <NodeDetailPanel ideaDetail={ideaDetail} edgeDetail={edgeDetail} loading={detailLoading} width={detailWidth} fontSize={detailFontSize} onWidthChange={setDetailWidth} onFontChange={changeDetailFont} onClose={closeDetail} />}
-          </section>
-        )}
+        {openArgumentMaps.map((tab) => (
+          <ArgumentMapTab key={tab.key} tab={tab} active={surface === 'map' && activeMapKey === tab.key} />
+        ))}
       </main>
     </div>
+  );
+}
+
+function ArgumentMapTab({ tab, active }: { tab: ArgumentMapTabState; active: boolean }) {
+  // Every open map owns its reveal and detail state. Keeping this inside the tab is
+  // what makes switching maps preserve the exact branches and side panel the reader
+  // was using in each one.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const revealTimerRef = useRef<number | null>(null);
+  const [ideaDetail, setIdeaDetail] = useState<IdeaDetail | null>(null);
+  const [edgeDetail, setEdgeDetail] = useState<EdgeDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState<DetailLoading | null>(null);
+  const detailSeqRef = useRef(0);
+  const [detailWidth, setDetailWidth] = useState(() => loadNumber(DETAIL_WIDTH_KEY, DETAIL_DEFAULT_WIDTH, DETAIL_MIN_WIDTH, DETAIL_MAX_WIDTH));
+  const [detailFontSize, setDetailFontSize] = useState(() => loadNumber(DETAIL_FONT_KEY, DETAIL_DEFAULT_FONT, DETAIL_MIN_FONT, DETAIL_MAX_FONT));
+
+  const stopReveal = useCallback(() => {
+    if (revealTimerRef.current != null) {
+      window.clearInterval(revealTimerRef.current);
+      revealTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(DETAIL_WIDTH_KEY, String(detailWidth));
+  }, [detailWidth]);
+  useEffect(() => {
+    localStorage.setItem(DETAIL_FONT_KEY, String(detailFontSize));
+  }, [detailFontSize]);
+
+  // Drive the progressive unfold once this map is built: open the root, then one
+  // deeper level per tick. A different tab has a different timer and expanded set.
+  useEffect(() => {
+    stopReveal();
+    if (!tab.map) {
+      setExpanded(new Set());
+      return;
+    }
+    const levels = expandableIdsByDepth(tab.map.root);
+    setExpanded(new Set(levels[0] ?? []));
+    if (levels.length <= 1) return;
+    let level = 1;
+    revealTimerRef.current = window.setInterval(() => {
+      const ids = levels[level++] ?? [];
+      setExpanded((current) => {
+        const next = new Set(current);
+        for (const id of ids) next.add(id);
+        return next;
+      });
+      if (level >= levels.length) stopReveal();
+    }, 260);
+    return stopReveal;
+  }, [stopReveal, tab.map]);
+
+  const selectBlock = useCallback((block: ArgumentBlock) => {
+    if (!block.ideaId) return;
+    detailSeqRef.current++;
+    setIdeaDetail(null);
+    setEdgeDetail(null);
+    setDetailLoading({ kind: 'idea', id: block.ideaId, label: block.label, type: block.type });
+    const seq = detailSeqRef.current;
+    void window.nodus.getIdeaDetail(block.ideaId).then(
+      (detail) => {
+        if (seq !== detailSeqRef.current) return;
+        setIdeaDetail(detail);
+        setDetailLoading(null);
+      },
+      () => {
+        if (seq !== detailSeqRef.current) return;
+        setDetailLoading(null);
+      }
+    );
+  }, []);
+
+  const toggleExpand = useCallback((id: string) => {
+    stopReveal();
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, [stopReveal]);
+
+  const closeDetail = () => {
+    detailSeqRef.current++;
+    setIdeaDetail(null);
+    setEdgeDetail(null);
+    setDetailLoading(null);
+  };
+
+  const changeDetailFont = (delta: number) => {
+    setDetailFontSize((value) => Math.min(DETAIL_MAX_FONT, Math.max(DETAIL_MIN_FONT, value + delta)));
+  };
+
+  return (
+    <section className={active ? 'flex h-full min-h-0' : 'hidden'}>
+      <div className="min-w-0 flex-1 overflow-y-auto p-4">
+        {tab.error && <div className="card flex items-start gap-2 p-4 text-sm text-red-400"><Icon name="alert" /> <span>{tab.error}</span></div>}
+        {tab.building && !tab.map && <div className="flex h-full flex-col items-center justify-center gap-3 text-neutral-500"><Spinner label={tab.mode === 'auto' ? t('Construyendo el esquema…') : t('El modelo está trazando el esquema de argumentos…')} /></div>}
+        {tab.map && (
+          <div className="mx-auto max-w-4xl">
+            <div className="card mb-4 bg-neutral-900/60 p-4">
+              <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+                <Icon name="map" size={14} /> {t('Mapa desde')} <span className="text-neutral-300">{tab.map.seedLabel}</span>
+                <span>· {tx('{n} ideas', { n: tab.map.ideaCount })}</span>
+                {tab.map.truncated && <span className="text-amber-500">· {t('subgrafo recortado')}</span>}
+                <span className="text-neutral-600">· {tab.mode === 'auto' ? t('modo automático') : t('modo IA')}</span>
+              </div>
+              {tab.map.overview && <p className="text-sm leading-relaxed text-neutral-300">{tab.map.overview}</p>}
+            </div>
+            <BlockTree block={tab.map.root} depth={0} expanded={expanded} onToggle={toggleExpand} onSelect={selectBlock} />
+          </div>
+        )}
+      </div>
+      {(ideaDetail || edgeDetail || detailLoading) && <NodeDetailPanel ideaDetail={ideaDetail} edgeDetail={edgeDetail} loading={detailLoading} width={detailWidth} fontSize={detailFontSize} onWidthChange={setDetailWidth} onFontChange={changeDetailFont} onClose={closeDetail} />}
+    </section>
   );
 }
 

--- a/src/views/AudioGenerationSettings.tsx
+++ b/src/views/AudioGenerationSettings.tsx
@@ -90,7 +90,7 @@ export function AudioGenerationSettings({
   const voices = useMemo(() => {
     const q = query.trim().toLowerCase();
     return baseVoices.filter((v) => {
-      if (q && !v.name.toLowerCase().includes(q)) return false;
+      if (q && !(v.name ?? '').toLowerCase().includes(q)) return false;
       // Local providers filter language client-side (Hume did it server-side).
       if (!isCloud && langFilter && v.languageLabel !== langFilter) return false;
       if (isCloud && humeLibrary !== 'all' && v.humeProvider !== humeLibrary) return false;

--- a/src/views/AuthorsView.tsx
+++ b/src/views/AuthorsView.tsx
@@ -74,13 +74,14 @@ const SYNTH_FILTER_LABELS: Record<SynthFilter, string> = {
 };
 
 /**
- * A tab can only be the active one if it is still open. The pair is written to the
- * snapshot together, but a closed author with `surface: 'author'` would render an
- * empty pane, so the surface answers to what actually exists.
+ * An author surface can only be active if its tab is still open. The collection and
+ * active id are written to the snapshot together, but a closed author with
+ * `surface: 'author'` would render an empty pane, so the surface answers to what
+ * actually exists.
  */
 function restoredSurface(snapshot?: AuthorsSnapshot): AuthorsSurface {
   const surface = snapshot?.surface ?? 'catalog';
-  if (surface === 'author' && !snapshot?.openAuthor) return 'catalog';
+  if (surface === 'author' && !snapshot?.openAuthors?.some((author) => author.id === snapshot.activeAuthorId)) return 'catalog';
   if (surface === 'matrix' && !snapshot?.matrixOpen) return 'catalog';
   return surface;
 }
@@ -101,7 +102,12 @@ export function AuthorsView({
 }) {
   // Restored as initial values only. A reactive `snapshot` prop would fight the
   // reader for control of their own tabs on every re-render of the shell.
-  const [openAuthor, setOpenAuthor] = useState<OpenAuthor | null>(() => snapshot?.openAuthor ?? null);
+  const [openAuthors, setOpenAuthors] = useState<OpenAuthor[]>(() => snapshot?.openAuthors ?? []);
+  const [activeAuthorId, setActiveAuthorId] = useState<string | null>(() => (
+    snapshot?.openAuthors?.some((author) => author.id === snapshot.activeAuthorId)
+      ? snapshot.activeAuthorId
+      : null
+  ));
   const [matrixOpen, setMatrixOpen] = useState(() => snapshot?.matrixOpen ?? false);
   const [surface, setSurface] = useState<AuthorsSurface>(() => restoredSurface(snapshot));
   const [catalogRevision, setCatalogRevision] = useState(0);
@@ -117,14 +123,32 @@ export function AuthorsView({
     report.current?.({
       surface,
       matrixOpen,
-      openAuthor: openAuthor ? { id: openAuthor.id, label: openAuthor.label } : null,
+      openAuthors: openAuthors.map(({ id, label }) => ({ id, label })),
+      activeAuthorId,
     });
-  }, [matrixOpen, openAuthor, surface]);
+  }, [activeAuthorId, matrixOpen, openAuthors, surface]);
 
   const showAuthor = useCallback((author: OpenAuthor) => {
-    setOpenAuthor(author);
+    setOpenAuthors((current) => (
+      current.some((open) => open.id === author.id)
+        ? current
+        : [...current, author]
+    ));
+    setActiveAuthorId(author.id);
     setSurface('author');
   }, []);
+
+  const closeAuthor = useCallback((authorId: string) => {
+    const closingIndex = openAuthors.findIndex((author) => author.id === authorId);
+    if (closingIndex < 0) return;
+    const remaining = openAuthors.filter((author) => author.id !== authorId);
+    setOpenAuthors(remaining);
+    if (activeAuthorId !== authorId) return;
+
+    const nextActive = remaining[Math.min(closingIndex, remaining.length - 1)] ?? null;
+    setActiveAuthorId(nextActive?.id ?? null);
+    if (surface === 'author' && !nextActive) setSurface('catalog');
+  }, [activeAuthorId, openAuthors, surface]);
 
   const showMatrix = useCallback(() => {
     setMatrixOpen(true);
@@ -159,16 +183,19 @@ export function AuthorsView({
           >
             <Icon name="list" size={13} /> {t('Autores')}
           </button>
-          {openAuthor && (
-            <div className={`flex h-9 shrink-0 items-center rounded-t-lg border border-b-0 ${surface === 'author' ? 'border-neutral-300 bg-white text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100' : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-300'}`}>
-              <button data-testid="authors-tab-author" className="flex h-full max-w-64 items-center gap-2 px-3 text-xs" onClick={() => setSurface('author')}>
-                <Icon name="user" size={13} /><span className="truncate">{openAuthor.label}</span>
-              </button>
-              <button className="mr-1 grid h-6 w-6 place-items-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-800" aria-label={t('Cerrar')} onClick={() => { setOpenAuthor(null); if (surface === 'author') setSurface('catalog'); }}>
-                <Icon name="x" size={11} />
-              </button>
-            </div>
-          )}
+          {openAuthors.map((author) => {
+            const active = surface === 'author' && activeAuthorId === author.id;
+            return (
+              <div key={author.id} className={`flex h-9 shrink-0 items-center rounded-t-lg border border-b-0 ${active ? 'border-neutral-300 bg-white text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100' : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-300'}`}>
+                <button data-testid="authors-tab-author" data-author-id={author.id} className="flex h-full max-w-64 items-center gap-2 px-3 text-xs" onClick={() => { setActiveAuthorId(author.id); setSurface('author'); }}>
+                  <Icon name="user" size={13} /><span className="truncate">{author.label}</span>
+                </button>
+                <button className="mr-1 grid h-6 w-6 place-items-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-800" aria-label={`${t('Cerrar')}: ${author.label}`} onClick={() => closeAuthor(author.id)}>
+                  <Icon name="x" size={11} />
+                </button>
+              </div>
+            );
+          })}
           {matrixOpen && (
             <div className={`flex h-9 shrink-0 items-center rounded-t-lg border border-b-0 ${surface === 'matrix' ? 'border-neutral-300 bg-white text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100' : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-300'}`}>
               <button data-testid="authors-tab-matrix" className="flex h-full items-center gap-2 px-3 text-xs" onClick={() => setSurface('matrix')}>
@@ -184,7 +211,11 @@ export function AuthorsView({
 
       <main className="min-h-0 flex-1">
         <div className={surface === 'catalog' ? 'h-full' : 'hidden'}><AuthorsCatalog vaultId={vaultId} refreshKey={catalogRevision} snapshot={snapshot} onSnapshotChange={onSnapshotChange} onOpenAuthor={showAuthor} onOpenMatrix={showMatrix} /></div>
-        {openAuthor && <div className={surface === 'author' ? 'h-full' : 'hidden'}><AuthorDetailTab key={openAuthor.id} author={openAuthor} vaultId={vaultId} model={model} onOpenAuthor={showAuthor} onOpenGraph={onOpenGraph} onSavedChange={() => setCatalogRevision((value) => value + 1)} /></div>}
+        {openAuthors.map((author) => (
+          <div key={author.id} className={surface === 'author' && activeAuthorId === author.id ? 'h-full' : 'hidden'}>
+            <AuthorDetailTab author={author} vaultId={vaultId} model={model} onOpenAuthor={showAuthor} onOpenGraph={onOpenGraph} onSavedChange={() => setCatalogRevision((value) => value + 1)} />
+          </div>
+        ))}
         {matrixOpen && <div className={surface === 'matrix' ? 'h-full p-5' : 'hidden'}><MatrixTab onOpenGraph={onOpenGraph} model={model} /></div>}
       </main>
     </div>

--- a/src/views/CollectionsModal.tsx
+++ b/src/views/CollectionsModal.tsx
@@ -221,7 +221,7 @@ export function CollectionsModal({
     return items.filter((it) => {
       if (q) {
         const hit =
-          it.title.toLowerCase().includes(q) ||
+          (it.title ?? '').toLowerCase().includes(q) ||
           it.creators.some((c) => (c.lastName ?? c.name ?? '').toLowerCase().includes(q)) ||
           String(it.year ?? '').includes(q) ||
           (it.abstract ?? '').toLowerCase().includes(q);
@@ -230,7 +230,7 @@ export function CollectionsModal({
       if (types.size && !types.has(it.itemType)) return false;
       if (min != null && (it.year ?? 0) < min) return false;
       if (max != null && (it.year ?? 9999) > max) return false;
-      if (onlyTag && !it.tags.some((t) => t.toLowerCase() === readTagLower)) return false;
+      if (onlyTag && !it.tags.some((tag) => (tag ?? '').toLowerCase() === readTagLower)) return false;
       if (statusFilter === 'summary' && worksByKey.get(it.key)?.summary_status !== 'done') return false;
       if (statusFilter !== 'all' && statusFilter !== 'summary' && statusOf(it.key) !== statusFilter) return false;
       return true;

--- a/src/views/DatabasesView.tsx
+++ b/src/views/DatabasesView.tsx
@@ -165,11 +165,11 @@ function clipboardInputForColumn(column: DatabaseColumn, value: string): string 
   const trimmed = value.trim();
   if (!trimmed) return null;
   if (column.type === 'select' || column.type === 'status') {
-    return column.options.find((option) => option.label.localeCompare(trimmed, undefined, { sensitivity: 'accent' }) === 0)?.id ?? trimmed;
+    return column.options.find((option) => (option.label ?? '').localeCompare(trimmed, undefined, { sensitivity: 'accent' }) === 0)?.id ?? trimmed;
   }
   if (column.type === 'multi_select') {
     const ids = trimmed.split(/[,;]\s*/).filter(Boolean).map((label) =>
-      column.options.find((option) => option.label.localeCompare(label, undefined, { sensitivity: 'accent' }) === 0)?.id ?? label,
+      column.options.find((option) => (option.label ?? '').localeCompare(label, undefined, { sensitivity: 'accent' }) === 0)?.id ?? label,
     );
     return encodeMultiSelect(ids);
   }
@@ -3643,8 +3643,8 @@ function SelectCell({
   const selected = selectedIds.map((id) => optionById.get(id)).filter((o): o is DatabaseSelectOption => Boolean(o));
 
   const qLower = query.trim().toLowerCase();
-  const filtered = qLower ? column.options.filter((o) => o.label.toLowerCase().includes(qLower)) : column.options;
-  const exactMatch = column.options.some((o) => o.label.toLowerCase() === qLower);
+  const filtered = qLower ? column.options.filter((o) => (o.label ?? '').toLowerCase().includes(qLower)) : column.options;
+  const exactMatch = column.options.some((o) => (o.label ?? '').toLowerCase() === qLower);
   const nextColor = OPTION_COLORS[column.options.length % OPTION_COLORS.length];
 
   const setValue = (ids: string[]) => onChange(multi ? encodeMultiSelect(ids) : ids[0] ?? null);

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -400,7 +400,7 @@ export function DeepResearchView({
     if (!composerOpen || !isGenealogy) return;
     let cancelled = false;
     void window.nodus.listPersons().then((list) => {
-      if (!cancelled) setPersonsList([...list].sort((a, b) => a.displayName.localeCompare(b.displayName)));
+      if (!cancelled) setPersonsList([...list].sort((a, b) => (a.displayName ?? '').localeCompare(b.displayName ?? '')));
     });
     return () => {
       cancelled = true;
@@ -706,16 +706,16 @@ export function DeepResearchView({
     const q = search.trim().toLowerCase();
     const filtered = savedDrafts.filter((draft) => {
       const matchesSearch = !q
-        || draft.title.toLowerCase().includes(q)
-        || draft.brief.objective.toLowerCase().includes(q);
+        || (draft.title ?? '').toLowerCase().includes(q)
+        || (draft.brief.objective ?? '').toLowerCase().includes(q);
       const matchesReadState = readFilter === 'all'
         || (readFilter === 'read' ? !!draft.readAt : !draft.readAt);
       return matchesSearch && matchesReadState;
     });
     const sorted = [...filtered];
-    if (sortKey === 'title') sorted.sort((a, b) => a.title.localeCompare(b.title));
-    else if (sortKey === 'oldest') sorted.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
-    else sorted.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    if (sortKey === 'title') sorted.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''));
+    else if (sortKey === 'oldest') sorted.sort((a, b) => (a.updatedAt ?? '').localeCompare(b.updatedAt ?? ''));
+    else sorted.sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
     return sorted;
   }, [savedDrafts, search, readFilter, sortKey]);
 

--- a/src/views/GraphView.tsx
+++ b/src/views/GraphView.tsx
@@ -1738,7 +1738,7 @@ export function GraphView({
       if (f.authors.length && !n.authors.some((a) => f.authors.includes(a))) return false;
       if (f.yearMin != null && !n.years.some((y) => y >= f.yearMin!)) return false;
       if (f.yearMax != null && !n.years.some((y) => y <= f.yearMax!)) return false;
-      if (q && !(n.label.toLowerCase().includes(q) || (n.statement ?? '').toLowerCase().includes(q) || n.authors.some((a) => a.toLowerCase().includes(q)))) {
+      if (q && !((n.label ?? '').toLowerCase().includes(q) || (n.statement ?? '').toLowerCase().includes(q) || n.authors.some((a) => (a ?? '').toLowerCase().includes(q)))) {
         return false;
       }
       return true;
@@ -1859,7 +1859,7 @@ export function GraphView({
   const activeThemeTotal = useMemo(() => {
     if (!activeThemeLabel || !constellationModel) return 0;
     const key = activeThemeLabel.trim().toLowerCase();
-    return constellationModel.nodes.find((n) => n.label.trim().toLowerCase() === key)?.workCount ?? 0;
+    return constellationModel.nodes.find((n) => (n.label ?? '').trim().toLowerCase() === key)?.workCount ?? 0;
   }, [activeThemeLabel, constellationModel]);
   const backboneShown = backboneModel?.nodes.filter((node) => !node.bridge).length ?? 0;
   const maximumThemeIdeas = Math.min(250, activeThemeTotal);

--- a/src/views/IdeasView.tsx
+++ b/src/views/IdeasView.tsx
@@ -62,20 +62,19 @@ export function IdeasView({
   const [searchQuery, setSearchQuery] = useState(() => snapshot?.search ?? '');
   const [typeFilter, setTypeFilter] = useState<IdeaType | ''>(() => snapshot?.typeFilter ?? '');
   const [sortKey, setSortKey] = useState<SortKey>(() => snapshot?.sortKey ?? 'label');
-  const [openIdea, setOpenIdea] = useState<OpenIdea | null>(() => snapshot?.openIdea ?? null);
+  const [openIdeas, setOpenIdeas] = useState<OpenIdea[]>(() => snapshot?.openIdeas ?? []);
+  const [activeIdeaId, setActiveIdeaId] = useState<string | null>(() => (
+    snapshot?.openIdeas?.some((idea) => idea.id === snapshot.activeIdeaId)
+      ? snapshot.activeIdeaId
+      : null
+  ));
   // An idea tab that is no longer open cannot be the active surface.
-  const [surface, setSurface] = useState<IdeasSurface>(() => (snapshot?.surface === 'idea' && snapshot.openIdea ? 'idea' : 'catalog'));
+  const [surface, setSurface] = useState<IdeasSurface>(() => (
+    snapshot?.surface === 'idea' && snapshot.openIdeas?.some((idea) => idea.id === snapshot.activeIdeaId)
+      ? 'idea'
+      : 'catalog'
+  ));
   const [filtersOpen, setFiltersOpen] = useState(() => snapshot?.filtersOpen ?? false);
-  // Paired with `openIdea` by `showIdea`; restoring one without the other would draw
-  // a tab with an empty pane behind it.
-  const [selectedId, setSelectedId] = useState<string | null>(() => snapshot?.openIdea?.id ?? null);
-  const [detail, setDetail] = useState<IdeaDetail | null>(null);
-  const [connections, setConnections] = useState<IdeaConnection[]>([]);
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [savingIdeaToNotes, setSavingIdeaToNotes] = useState(false);
-  const [savingIdea, setSavingIdea] = useState(false);
-  const [deletingIdea, setDeletingIdea] = useState(false);
-  const [confirmDeleteIdea, setConfirmDeleteIdea] = useState(false);
   // A cached page is useful while the reader changes pages or returns to a previous
   // sort during the same visit. It must not survive leaving and re-entering Ideas,
   // though: deep scans can finish while the view is unmounted, so the queue-idle
@@ -83,9 +82,31 @@ export function IdeasView({
   const initialListLoad = useRef(true);
 
   const showIdea = useCallback((idea: OpenIdea) => {
-    setSelectedId(idea.id);
-    setOpenIdea(idea);
+    setOpenIdeas((current) => (
+      current.some((open) => open.id === idea.id)
+        ? current
+        : [...current, idea]
+    ));
+    setActiveIdeaId(idea.id);
     setSurface('idea');
+  }, []);
+
+  const closeIdea = useCallback((ideaId: string) => {
+    const closingIndex = openIdeas.findIndex((idea) => idea.id === ideaId);
+    if (closingIndex < 0) return;
+    const remaining = openIdeas.filter((idea) => idea.id !== ideaId);
+    setOpenIdeas(remaining);
+    if (activeIdeaId !== ideaId) return;
+
+    const nextActive = remaining[Math.min(closingIndex, remaining.length - 1)] ?? null;
+    setActiveIdeaId(nextActive?.id ?? null);
+    if (surface === 'idea' && !nextActive) setSurface('catalog');
+  }, [activeIdeaId, openIdeas, surface]);
+
+  const updateIdeaLabel = useCallback((ideaId: string, label: string) => {
+    setOpenIdeas((current) => current.map((idea) => (
+      idea.id === ideaId && idea.label !== label ? { ...idea, label } : idea
+    )));
   }, []);
 
   useEffect(() => {
@@ -136,8 +157,16 @@ export function IdeasView({
   const report = useRef(onSnapshotChange);
   report.current = onSnapshotChange;
   useEffect(() => {
-    report.current?.({ surface, openIdea, search: searchQuery, typeFilter, sortKey, filtersOpen });
-  }, [filtersOpen, openIdea, searchQuery, sortKey, surface, typeFilter]);
+    report.current?.({
+      surface,
+      openIdeas: openIdeas.map(({ id, label }) => ({ id, label })),
+      activeIdeaId,
+      search: searchQuery,
+      typeFilter,
+      sortKey,
+      filtersOpen,
+    });
+  }, [activeIdeaId, filtersOpen, openIdeas, searchQuery, sortKey, surface, typeFilter]);
 
   // Changing the cut throws the place away with it: a row that was at the top of one
   // filter means nothing under another. It must skip its own first run, though, or
@@ -175,64 +204,7 @@ export function IdeasView({
   useDataRefresh(reload);
   useScanComplete(reload);
 
-  useEffect(() => {
-    if (!selectedId) {
-      setDetail(null);
-      setConnections([]);
-      return;
-    }
-    setDetailLoading(true);
-    let on = true;
-    const cacheKey = `${dataSource.key}:idea-detail:${selectedId}`;
-    const cached = getVaultQueryCache<{ detail: IdeaDetail | null; connections: IdeaConnection[] }>(vaultId, cacheKey);
-    if (cached) {
-      setDetail(cached.detail);
-      setConnections(cached.connections);
-      if (cached.detail) {
-        setOpenIdea((current) => current?.id === selectedId ? { id: selectedId, label: cached.detail!.idea.label } : current);
-      }
-      setDetailLoading(false);
-      return;
-    }
-    void Promise.all([dataSource.getIdeaDetail(selectedId), dataSource.listIdeaConnections(selectedId)]).then(([d, linked]) => {
-      if (on) {
-        setDetail(d);
-        setConnections(linked);
-        if (d) setOpenIdea((current) => current?.id === selectedId ? { id: selectedId, label: d.idea.label } : current);
-        setVaultQueryCache(vaultId, cacheKey, { detail: d, connections: linked });
-        setDetailLoading(false);
-      }
-    });
-    return () => {
-      on = false;
-    };
-  }, [dataSource, selectedId, vaultId]);
-
   useEffect(() => dataSource.subscribe?.(() => reload(true)), [dataSource, reload]);
-
-  const selectedNode = selectedId ? ideas.find((idea) => idea.id === selectedId) : null;
-
-  const deleteSelectedIdea = async () => {
-    if (!selectedId || deletingIdea) return;
-    setDeletingIdea(true);
-    try {
-      await dataSource.deleteIdea(selectedId);
-      setConfirmDeleteIdea(false);
-      setSelectedId(null);
-      setOpenIdea(null);
-      setSurface('catalog');
-      setDetail(null);
-      setConnections([]);
-      notifyDataChanged();
-      reload(true);
-    } finally {
-      setDeletingIdea(false);
-    }
-  };
-
-  const detailWorkCount = detail ? new Set(detail.occurrences.map((occurrence) => occurrence.nodus_id)).size : 0;
-  const detailConfidence = selectedNode?.maxConfidence
-    ?? (detail?.occurrences.length ? Math.max(...detail.occurrences.map((occurrence) => occurrence.confidence)) : 0);
 
   return (
     <div data-testid={testId ?? 'ideas-workspace'} className="flex h-full min-h-0 flex-col bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
@@ -255,20 +227,23 @@ export function IdeasView({
           >
             <Icon name="list" size={13} /> {t('Ideas')}
           </button>
-          {openIdea && (
-            <div className={`flex h-9 min-w-0 shrink-0 items-center rounded-t-lg border border-b-0 ${surface === 'idea' ? 'border-neutral-300 bg-white text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100' : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-300'}`}>
-              <button data-testid="ideas-tab-idea" className="flex h-full max-w-80 min-w-0 items-center gap-2 px-3 text-xs" onClick={() => setSurface('idea')}>
-                <Icon name="bulb" size={13} /><span className="truncate">{openIdea.label}</span>
-              </button>
-              <button
-                className="mr-1 grid h-6 w-6 shrink-0 place-items-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-800"
-                aria-label={t('Cerrar')}
-                onClick={() => { setOpenIdea(null); setSelectedId(null); setDetail(null); setConnections([]); setSurface('catalog'); }}
-              >
-                <Icon name="x" size={11} />
-              </button>
-            </div>
-          )}
+          {openIdeas.map((idea) => {
+            const active = surface === 'idea' && activeIdeaId === idea.id;
+            return (
+              <div key={idea.id} className={`flex h-9 min-w-0 shrink-0 items-center rounded-t-lg border border-b-0 ${active ? 'border-neutral-300 bg-white text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100' : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-300'}`}>
+                <button data-testid="ideas-tab-idea" data-idea-id={idea.id} className="flex h-full max-w-80 min-w-0 items-center gap-2 px-3 text-xs" onClick={() => { setActiveIdeaId(idea.id); setSurface('idea'); }}>
+                  <Icon name="bulb" size={13} /><span className="truncate">{idea.label}</span>
+                </button>
+                <button
+                  className="mr-1 grid h-6 w-6 shrink-0 place-items-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-800"
+                  aria-label={`${t('Cerrar')}: ${idea.label}`}
+                  onClick={() => closeIdea(idea.id)}
+                >
+                  <Icon name="x" size={11} />
+                </button>
+              </div>
+            );
+          })}
         </div>
       </header>
 
@@ -370,78 +345,174 @@ export function IdeasView({
           </footer>
         </div>
 
-        {selectedId && (
-          <div data-testid={testId ? 'study-idea-detail' : 'idea-detail-tab'} className={surface === 'idea' ? 'h-full overflow-y-auto p-5' : 'hidden'}>
-            {detailLoading && !detail && <div className="grid h-64 place-items-center"><Spinner label={t('Cargando detalle…')} /></div>}
-            {detail && (
-              <div className="mx-auto max-w-[1480px] space-y-4">
-                <section className="rounded-2xl border border-indigo-100 bg-indigo-50/80 p-5 dark:border-neutral-800 dark:bg-neutral-900/35">
-                  <div className="flex flex-wrap items-start gap-4">
-                    <span className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-indigo-100 text-indigo-600 dark:bg-indigo-500/15 dark:text-indigo-300"><Icon name="bulb" size={22} /></span>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2"><Badge color="indigo">{t(NODE_LABELS[detail.idea.type as IdeaType]) ?? detail.idea.type}</Badge></div>
-                      <h2 className="mt-2 text-xl font-semibold">{detail.idea.label}</h2>
-                      <p className="mt-1 max-w-5xl text-sm leading-6 text-neutral-600 dark:text-neutral-400">{detail.idea.statement}</p>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        <Badge>{tx('{n} obra(s)', { n: detailWorkCount })}</Badge>
-                        <Badge>{tx('{n} conexión(es)', { n: connections.length })}</Badge>
-                        <Badge>{t('Confianza')} {detailConfidence.toFixed(2)}</Badge>
-                        {selectedNode?.themes.map((theme) => <Badge key={theme} color="amber">{theme}</Badge>)}
-                      </div>
-                    </div>
-                    <div className="flex max-w-lg flex-wrap justify-end gap-2">
-                      <button className="btn btn-ghost border border-neutral-300 text-xs gap-1.5 dark:border-neutral-700" onClick={() => onOpenGraph({ preset: 'overview', nodeId: detail.idea.global_id, label: `${t('Idea:')} ${detail.idea.label}` })}><Icon name="layers" size={13} /> {t('Grafo')}</button>
-                      <button className="btn btn-ghost border border-neutral-300 text-xs gap-1.5 dark:border-neutral-700" onClick={() => onOpenAssistant({ title: `${t('Idea:')} ${detail.idea.label}`, selection: ASSISTANT_CONTEXTS.idea, prompt: `${t('Analiza esta idea dentro del corpus y resume sus conexiones, tensiones y lecturas prioritarias.')}\n\n${t('Idea:')} ${detail.idea.label}\n${detail.idea.statement}` })}><Icon name="chat" size={13} /> {t('Asistente')}</button>
-                      <button className="btn btn-ghost border border-neutral-300 text-xs gap-1.5 dark:border-neutral-700" disabled={savingIdea} onClick={() => { if (!dataSource.saveIdea) { setSavingIdeaToNotes(true); return; } setSavingIdea(true); void dataSource.saveIdea(detail).finally(() => setSavingIdea(false)); }}><Icon name="notebook" size={13} /> {t(savingIdea ? 'Guardando…' : 'Guardar en notas')}</button>
-                      <button className="btn btn-ghost border border-red-200 text-xs text-red-600 gap-1.5 dark:border-red-900/70 dark:text-red-400" disabled={deletingIdea} onClick={() => setConfirmDeleteIdea(true)}><Icon name="trash" size={13} /> {t('Eliminar idea')}</button>
-                    </div>
+        {openIdeas.map((idea) => (
+          <div key={idea.id} className={surface === 'idea' && activeIdeaId === idea.id ? 'h-full' : 'hidden'}>
+            <IdeaDetailTab
+              idea={idea}
+              summary={ideas.find((candidate) => candidate.id === idea.id) ?? null}
+              vaultId={vaultId}
+              dataSource={dataSource}
+              onOpenIdea={showIdea}
+              onOpenGraph={onOpenGraph}
+              onOpenAssistant={onOpenAssistant}
+              onLabelChange={updateIdeaLabel}
+              onDeleted={() => {
+                closeIdea(idea.id);
+                notifyDataChanged();
+                reload(true);
+              }}
+              testId={testId}
+            />
+          </div>
+        ))}
+      </main>
+    </div>
+  );
+}
+
+function IdeaDetailTab({
+  idea,
+  summary,
+  vaultId,
+  dataSource,
+  onOpenIdea,
+  onOpenGraph,
+  onOpenAssistant,
+  onLabelChange,
+  onDeleted,
+  testId,
+}: {
+  idea: OpenIdea;
+  summary: IdeaListItem | null;
+  vaultId: string | null;
+  dataSource: KnowledgeViewSource;
+  onOpenIdea: (idea: OpenIdea) => void;
+  onOpenGraph: (target: PendingGraphNavigationTarget) => void;
+  onOpenAssistant: (target?: PendingAssistantNavigationTarget) => void;
+  onLabelChange: (ideaId: string, label: string) => void;
+  onDeleted: () => void;
+  testId?: string;
+}) {
+  const [detail, setDetail] = useState<IdeaDetail | null>(null);
+  const [connections, setConnections] = useState<IdeaConnection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [savingToNotes, setSavingToNotes] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    const cacheKey = `${dataSource.key}:idea-detail:${idea.id}`;
+    const cached = getVaultQueryCache<{ detail: IdeaDetail | null; connections: IdeaConnection[] }>(vaultId, cacheKey);
+    if (cached) {
+      setDetail(cached.detail);
+      setConnections(cached.connections);
+      if (cached.detail) onLabelChange(idea.id, cached.detail.idea.label);
+      setLoading(false);
+      return;
+    }
+    void Promise.all([dataSource.getIdeaDetail(idea.id), dataSource.listIdeaConnections(idea.id)]).then(([nextDetail, linked]) => {
+      if (!mounted) return;
+      setDetail(nextDetail);
+      setConnections(linked);
+      if (nextDetail) onLabelChange(idea.id, nextDetail.idea.label);
+      setVaultQueryCache(vaultId, cacheKey, { detail: nextDetail, connections: linked });
+      setLoading(false);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [dataSource, idea.id, onLabelChange, vaultId]);
+
+  const deleteIdea = async () => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      await dataSource.deleteIdea(idea.id);
+      setConfirmDelete(false);
+      onDeleted();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const workCount = detail ? new Set(detail.occurrences.map((occurrence) => occurrence.nodus_id)).size : 0;
+  const confidence = summary?.maxConfidence
+    ?? (detail?.occurrences.length ? Math.max(...detail.occurrences.map((occurrence) => occurrence.confidence)) : 0);
+
+  return (
+    <>
+      <div data-testid={testId ? 'study-idea-detail' : 'idea-detail-tab'} className="h-full overflow-y-auto p-5">
+        {loading && !detail && <div className="grid h-64 place-items-center"><Spinner label={t('Cargando detalle…')} /></div>}
+        {detail && (
+          <div className="mx-auto max-w-[1480px] space-y-4">
+            <section className="rounded-2xl border border-indigo-100 bg-indigo-50/80 p-5 dark:border-neutral-800 dark:bg-neutral-900/35">
+              <div className="flex flex-wrap items-start gap-4">
+                <span className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-indigo-100 text-indigo-600 dark:bg-indigo-500/15 dark:text-indigo-300"><Icon name="bulb" size={22} /></span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2"><Badge color="indigo">{t(NODE_LABELS[detail.idea.type as IdeaType]) ?? detail.idea.type}</Badge></div>
+                  <h2 className="mt-2 text-xl font-semibold">{detail.idea.label}</h2>
+                  <p className="mt-1 max-w-5xl text-sm leading-6 text-neutral-600 dark:text-neutral-400">{detail.idea.statement}</p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Badge>{tx('{n} obra(s)', { n: workCount })}</Badge>
+                    <Badge>{tx('{n} conexión(es)', { n: connections.length })}</Badge>
+                    <Badge>{t('Confianza')} {confidence.toFixed(2)}</Badge>
+                    {summary?.themes.map((theme) => <Badge key={theme} color="amber">{theme}</Badge>)}
                   </div>
-                </section>
-
-                <div className="grid items-start gap-4 xl:grid-cols-12">
-                  <div className="space-y-4 xl:col-span-7">
-                    <section className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/70">
-                      <div className="mb-3 flex items-center gap-2"><Icon name="book" size={15} className="text-indigo-500" /><h3 className="font-semibold">{t('Obras que la desarrollan')}</h3><span className="text-xs text-neutral-500">{detail.occurrences.length}</span></div>
-                      {detail.occurrences.length > 0 ? <div className="space-y-2">{detail.occurrences.map((occurrence) => <OccurrenceCard key={occurrence.nodus_id} occurrence={occurrence} />)}</div> : <p className="text-sm text-neutral-500">—</p>}
-                    </section>
-
-                    <section className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/70">
-                      <div className="mb-3 flex items-center gap-2"><Icon name="quote" size={15} className="text-indigo-500" /><h3 className="font-semibold">{t('Evidencia anclada')}</h3><span className="text-xs text-neutral-500">{detail.evidence.length}</span></div>
-                      {detail.evidence.length > 0 ? <div className="space-y-2">{detail.evidence.map((evidence) => <blockquote key={evidence.id} className="rounded-r-lg border-l-2 border-indigo-500 bg-neutral-50 px-3 py-2 text-sm italic leading-6 text-neutral-600 dark:bg-neutral-900/45 dark:text-neutral-300">“{evidence.quote}” <EvidenceLocationLink nodusId={evidence.nodus_id} location={evidence.location} suffix={` · ${evidence.kind}`} onOpen={dataSource.openEvidence} /></blockquote>)}</div> : <p className="text-sm text-neutral-500">—</p>}
-                    </section>
-                  </div>
-
-                  <section data-testid="idea-connections" className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/70 xl:col-span-5">
-                    <div className="mb-3 flex items-center gap-2"><Icon name="share" size={15} className="text-indigo-500" /><h3 className="font-semibold">{tx('Ideas conectadas ({n})', { n: connections.length })}</h3></div>
-                    {connections.length > 0 ? <div className="space-y-2">{connections.map(({ edge, node }) => <ConnectedIdeaRow key={edge.id} edge={edge} node={node} onSelectIdea={(id) => showIdea({ id, label: node.label })} onOpenGraph={onOpenGraph} dataSource={dataSource} />)}</div> : <p className="text-sm text-neutral-500">{t('Esta idea aún no tiene conexiones con otras ideas.')}</p>}
-                  </section>
+                </div>
+                <div className="flex max-w-lg flex-wrap justify-end gap-2">
+                  <button className="btn btn-ghost border border-neutral-300 text-xs gap-1.5 dark:border-neutral-700" onClick={() => onOpenGraph({ preset: 'overview', nodeId: detail.idea.global_id, label: `${t('Idea:')} ${detail.idea.label}` })}><Icon name="layers" size={13} /> {t('Grafo')}</button>
+                  <button className="btn btn-ghost border border-neutral-300 text-xs gap-1.5 dark:border-neutral-700" onClick={() => onOpenAssistant({ title: `${t('Idea:')} ${detail.idea.label}`, selection: ASSISTANT_CONTEXTS.idea, prompt: `${t('Analiza esta idea dentro del corpus y resume sus conexiones, tensiones y lecturas prioritarias.')}\n\n${t('Idea:')} ${detail.idea.label}\n${detail.idea.statement}` })}><Icon name="chat" size={13} /> {t('Asistente')}</button>
+                  <button className="btn btn-ghost border border-neutral-300 text-xs gap-1.5 dark:border-neutral-700" disabled={saving} onClick={() => { if (!dataSource.saveIdea) { setSavingToNotes(true); return; } setSaving(true); void dataSource.saveIdea(detail).finally(() => setSaving(false)); }}><Icon name="notebook" size={13} /> {t(saving ? 'Guardando…' : 'Guardar en notas')}</button>
+                  <button className="btn btn-ghost border border-red-200 text-xs text-red-600 gap-1.5 dark:border-red-900/70 dark:text-red-400" disabled={deleting} onClick={() => setConfirmDelete(true)}><Icon name="trash" size={13} /> {t('Eliminar idea')}</button>
                 </div>
               </div>
-            )}
+            </section>
+
+            <div className="grid items-start gap-4 xl:grid-cols-12">
+              <div className="space-y-4 xl:col-span-7">
+                <section className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/70">
+                  <div className="mb-3 flex items-center gap-2"><Icon name="book" size={15} className="text-indigo-500" /><h3 className="font-semibold">{t('Obras que la desarrollan')}</h3><span className="text-xs text-neutral-500">{detail.occurrences.length}</span></div>
+                  {detail.occurrences.length > 0 ? <div className="space-y-2">{detail.occurrences.map((occurrence) => <OccurrenceCard key={occurrence.nodus_id} occurrence={occurrence} />)}</div> : <p className="text-sm text-neutral-500">—</p>}
+                </section>
+
+                <section className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/70">
+                  <div className="mb-3 flex items-center gap-2"><Icon name="quote" size={15} className="text-indigo-500" /><h3 className="font-semibold">{t('Evidencia anclada')}</h3><span className="text-xs text-neutral-500">{detail.evidence.length}</span></div>
+                  {detail.evidence.length > 0 ? <div className="space-y-2">{detail.evidence.map((evidence) => <blockquote key={evidence.id} className="rounded-r-lg border-l-2 border-indigo-500 bg-neutral-50 px-3 py-2 text-sm italic leading-6 text-neutral-600 dark:bg-neutral-900/45 dark:text-neutral-300">“{evidence.quote}” <EvidenceLocationLink nodusId={evidence.nodus_id} location={evidence.location} suffix={` · ${evidence.kind}`} onOpen={dataSource.openEvidence} /></blockquote>)}</div> : <p className="text-sm text-neutral-500">—</p>}
+                </section>
+              </div>
+
+              <section data-testid="idea-connections" className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/70 xl:col-span-5">
+                <div className="mb-3 flex items-center gap-2"><Icon name="share" size={15} className="text-indigo-500" /><h3 className="font-semibold">{tx('Ideas conectadas ({n})', { n: connections.length })}</h3></div>
+                {connections.length > 0 ? <div className="space-y-2">{connections.map(({ edge, node }) => <ConnectedIdeaRow key={edge.id} edge={edge} node={node} onSelectIdea={(id) => onOpenIdea({ id, label: node.label })} onOpenGraph={onOpenGraph} dataSource={dataSource} />)}</div> : <p className="text-sm text-neutral-500">{t('Esta idea aún no tiene conexiones con otras ideas.')}</p>}
+              </section>
+            </div>
           </div>
         )}
-      </main>
+      </div>
 
-      {savingIdeaToNotes && detail && !dataSource.saveIdea && (
+      {savingToNotes && detail && !dataSource.saveIdea && (
         <SaveToNotesModal
           content={buildIdeaNote(detail)}
           defaultTitle={detail.idea.label}
           kind="idea"
           source={{ origin: 'idea', ref: detail.idea.global_id }}
-          onClose={() => setSavingIdeaToNotes(false)}
+          onClose={() => setSavingToNotes(false)}
         />
       )}
-      {confirmDeleteIdea && detail && (
+      {confirmDelete && detail && (
         <ConfirmModal
           title={t('Eliminar idea')}
           message={tx('Se eliminará «{name}» junto con su embedding, evidencia y conexiones. Esta acción no se puede deshacer.', { name: detail.idea.label })}
           confirmLabel={t('Eliminar idea')}
           danger
-          onCancel={() => setConfirmDeleteIdea(false)}
-          onConfirm={() => void deleteSelectedIdea()}
+          onCancel={() => setConfirmDelete(false)}
+          onConfirm={() => void deleteIdea()}
         />
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/views/ImmersionView.tsx
+++ b/src/views/ImmersionView.tsx
@@ -568,11 +568,11 @@ function ImmersionHome({
 
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();
-    const filtered = q ? sessions.filter((s) => s.title.toLowerCase().includes(q)) : sessions;
+    const filtered = q ? sessions.filter((s) => (s.title ?? '').toLowerCase().includes(q)) : sessions;
     const sorted = [...filtered];
-    if (sortKey === 'title') sorted.sort((a, b) => a.title.localeCompare(b.title));
-    else if (sortKey === 'oldest') sorted.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
-    else sorted.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    if (sortKey === 'title') sorted.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''));
+    else if (sortKey === 'oldest') sorted.sort((a, b) => (a.updatedAt ?? '').localeCompare(b.updatedAt ?? ''));
+    else sorted.sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
     return sorted;
   }, [sessions, search, sortKey]);
 

--- a/src/views/ManualIdeaEditor.tsx
+++ b/src/views/ManualIdeaEditor.tsx
@@ -488,7 +488,7 @@ function WorkPicker({ onAdd, existing }: { onAdd: (w: WorkView) => void; existin
     return all
       .filter((w) => !exclude.has(w.nodus_id))
       .filter(
-        (w) => w.title.toLowerCase().includes(q) || w.authors.some((a) => a.toLowerCase().includes(q))
+        (w) => (w.title ?? '').toLowerCase().includes(q) || w.authors.some((a) => (a ?? '').toLowerCase().includes(q))
       )
       .slice(0, 12);
   }, [all, query, existing]);

--- a/src/views/MapView.tsx
+++ b/src/views/MapView.tsx
@@ -35,7 +35,7 @@ export function MapView() {
   const personOptions = useMemo<PersonOption[]>(() => {
     const byId = new Map<string, PersonOption>();
     for (const p of allPoints) if (!byId.has(p.personId)) byId.set(p.personId, { personId: p.personId, personName: p.personName });
-    return [...byId.values()].sort((a, b) => a.personName.localeCompare(b.personName));
+    return [...byId.values()].sort((a, b) => (a.personName ?? '').localeCompare(b.personName ?? ''));
   }, [allPoints]);
 
   const personFiltered = useMemo(
@@ -163,7 +163,7 @@ function PersonFilter({
         ? options.find((o) => selected.has(o.personId))?.personName ?? tx('{n} seleccionadas', { n: 1 })
         : tx('{n} seleccionadas', { n: selected.size });
 
-  const filtered = q.trim() ? options.filter((o) => o.personName.toLowerCase().includes(q.trim().toLowerCase())) : options;
+  const filtered = q.trim() ? options.filter((o) => (o.personName ?? '').toLowerCase().includes(q.trim().toLowerCase())) : options;
 
   return (
     <div className="relative" ref={ref} data-testid="map-person-filter">

--- a/src/views/NotesView.tsx
+++ b/src/views/NotesView.tsx
@@ -446,11 +446,11 @@ export function NotesView({
     else if (scope.kind === 'unfiled') list = notes.filter((n) => !n.folderId);
     else list = notes.filter((n) => n.folderId === scope.id);
     const q = search.trim().toLowerCase();
-    if (q) list = list.filter((n) => n.title.toLowerCase().includes(q) || n.content.toLowerCase().includes(q));
+    if (q) list = list.filter((n) => (n.title ?? '').toLowerCase().includes(q) || (n.content ?? '').toLowerCase().includes(q));
     const sorted = [...list];
     switch (sortMode) {
       case 'alpha':
-        sorted.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+        sorted.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? '', undefined, { sensitivity: 'base' }));
         break;
       case 'created-desc':
         sorted.sort((a, b) => (a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0));

--- a/src/views/ProjectsView.tsx
+++ b/src/views/ProjectsView.tsx
@@ -74,7 +74,7 @@ export function ProjectsView({ settings }: { settings: AppSettings }) {
 
   const filteredProjects = useMemo(() => {
     const q = search.trim().toLowerCase();
-    return q ? projects.filter((p) => p.title.toLowerCase().includes(q)) : projects;
+    return q ? projects.filter((p) => (p.title ?? '').toLowerCase().includes(q)) : projects;
   }, [projects, search]);
 
   const selectedChapter = useMemo(

--- a/src/views/ProvidersSettings.tsx
+++ b/src/views/ProvidersSettings.tsx
@@ -241,7 +241,7 @@ function ChatGptSubscriptionRow({
 
   const filtered = (models ?? []).filter((model) => {
     const query = search.toLowerCase();
-    return !query || model.id.toLowerCase().includes(query) || (model.name ?? '').toLowerCase().includes(query);
+    return !query || (model.id ?? '').toLowerCase().includes(query) || (model.name ?? '').toLowerCase().includes(query);
   });
 
   return (
@@ -422,7 +422,7 @@ function GitHubCopilotSubscriptionRow({
 
   const filtered = (models ?? []).filter((model) => {
     const query = search.toLowerCase();
-    return !query || model.id.toLowerCase().includes(query) || (model.name ?? '').toLowerCase().includes(query);
+    return !query || (model.id ?? '').toLowerCase().includes(query) || (model.name ?? '').toLowerCase().includes(query);
   });
 
   return (
@@ -559,15 +559,15 @@ export function ImageGenerationSettings({ settings, onChange }: { settings: AppS
       !q || `${model.provider} ${model.name} ${model.id}`.toLowerCase().includes(q)
     );
     return [...filtered].sort((a, b) => {
-      if (sort === 'provider') return a.provider.localeCompare(b.provider) || a.name.localeCompare(b.name);
-      if (sort === 'alpha') return a.name.localeCompare(b.name) || a.provider.localeCompare(b.provider);
+      if (sort === 'provider') return (a.provider ?? '').localeCompare(b.provider ?? '') || (a.name ?? '').localeCompare(b.name ?? '');
+      if (sort === 'alpha') return (a.name ?? '').localeCompare(b.name ?? '') || (a.provider ?? '').localeCompare(b.provider ?? '');
       // Providers publish unlike sizes/units. Price order is therefore scoped
       // to one provider and never implies a false cross-provider comparison.
-      const providerOrder = a.provider.localeCompare(b.provider);
+      const providerOrder = (a.provider ?? '').localeCompare(b.provider ?? '');
       if (providerOrder !== 0) return providerOrder;
       const aPrice = a.imagePriceUsd;
       const bPrice = b.imagePriceUsd;
-      if (aPrice == null && bPrice == null) return a.name.localeCompare(b.name);
+      if (aPrice == null && bPrice == null) return (a.name ?? '').localeCompare(b.name ?? '');
       if (aPrice == null) return 1;
       if (bPrice == null) return -1;
       return sort === 'price_asc' ? aPrice - bPrice : bPrice - aPrice;
@@ -719,7 +719,7 @@ function ProviderRow({
 
   const filtered = (models ?? []).filter((m) => {
     const q = search.toLowerCase();
-    return !q || m.id.toLowerCase().includes(q) || (m.name ?? '').toLowerCase().includes(q);
+    return !q || (m.id ?? '').toLowerCase().includes(q) || (m.name ?? '').toLowerCase().includes(q);
   });
   const shown = filtered.slice(0, 300);
 
@@ -942,7 +942,7 @@ function LocalProviderRow({
 
   const filtered = (models ?? []).filter((m) => {
     const q = search.toLowerCase();
-    return !q || m.id.toLowerCase().includes(q) || (m.name ?? '').toLowerCase().includes(q);
+    return !q || (m.id ?? '').toLowerCase().includes(q) || (m.name ?? '').toLowerCase().includes(q);
   });
   const shown = filtered.slice(0, 300);
 

--- a/src/views/RubricsView.tsx
+++ b/src/views/RubricsView.tsx
@@ -118,7 +118,7 @@ export function RubricsView() {
 
   /* ------------------------------------------------ history (database list) --- */
   if (!rubric) {
-    const filtered = rubrics.filter((entry) => !search.trim() || entry.title.toLowerCase().includes(search.toLowerCase()));
+    const filtered = rubrics.filter((entry) => !search.trim() || (entry.title ?? '').toLowerCase().includes(search.toLowerCase()));
     return (
       <div className="flex h-full min-h-0 flex-col bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100" data-testid="rubrics-list">
         <header className="border-b border-neutral-200 bg-white px-5 py-4 dark:border-neutral-800 dark:bg-neutral-950">

--- a/src/views/graph/model.ts
+++ b/src/views/graph/model.ts
@@ -238,7 +238,7 @@ export function buildGraphModel(
     if (f.authors.length && !n.authors.some((a) => f.authors.includes(a))) return false;
     if (f.yearMin != null && !n.years.some((y) => y >= f.yearMin!)) return false;
     if (f.yearMax != null && !n.years.some((y) => y <= f.yearMax!)) return false;
-    if (includeSearch && q && !(n.label.toLowerCase().includes(q) || (n.statement ?? '').toLowerCase().includes(q) || n.authors.some((a) => a.toLowerCase().includes(q)))) {
+    if (includeSearch && q && !((n.label ?? '').toLowerCase().includes(q) || (n.statement ?? '').toLowerCase().includes(q) || n.authors.some((a) => (a ?? '').toLowerCase().includes(q)))) {
       return false;
     }
     return true;
@@ -531,11 +531,11 @@ function buildIdeaPresetAtlas(
         // the corpus has the least connective tissue — the useful gap signal the
         // legacy preset was trying to expose with edge filters alone.
         return a.degree - b.degree || Number(a.read) - Number(b.read)
-          || b.labelRank - a.labelRank || a.label.localeCompare(b.label);
+          || b.labelRank - a.labelRank || (a.label ?? '').localeCompare(b.label ?? '');
       }
       // Reading atlases lead with the ideas that best connect their territory.
       return b.degree - a.degree || b.workCount - a.workCount
-        || b.labelRank - a.labelRank || a.label.localeCompare(b.label);
+        || b.labelRank - a.labelRank || (a.label ?? '').localeCompare(b.label ?? '');
     });
     const room = Math.max(0, globalCap - selected.length);
     if (room === 0) break;
@@ -575,8 +575,8 @@ function buildIdeaPresetAtlas(
   }
 
   const rankedSelected = [...selected].sort((a, b) => {
-    if (preset === 'gaps') return a.degree - b.degree || a.label.localeCompare(b.label);
-    return b.degree - a.degree || a.label.localeCompare(b.label);
+    if (preset === 'gaps') return a.degree - b.degree || (a.label ?? '').localeCompare(b.label ?? '');
+    return b.degree - a.degree || (a.label ?? '').localeCompare(b.label ?? '');
   });
   const selectedNodes = rankedSelected.map((node, index) => ({
     ...node,
@@ -681,7 +681,7 @@ function buildContradictionPresetAtlas(data: GraphData, base: GraphModel): Graph
     .map((id) => candidateById.get(id)!)
     .sort((a, b) => (degreeById.get(b.id) ?? 0) - (degreeById.get(a.id) ?? 0)
       || b.labelRank - a.labelRank
-      || a.label.localeCompare(b.label));
+      || (a.label ?? '').localeCompare(b.label ?? ''));
   const selectedNodes: NodeModel[] = rankedSelected.map((node, index) => {
     const degree = degreeById.get(node.id) ?? 0;
     return {
@@ -748,7 +748,7 @@ function buildContradictionPresetAtlas(data: GraphData, base: GraphModel): Graph
 function buildAuthorPresetAtlas(base: GraphModel): GraphModel {
   const ranked = base.nodes
     .filter((node) => node.type === 'author')
-    .sort((a, b) => b.degree - a.degree || b.workCount - a.workCount || a.label.localeCompare(b.label))
+    .sort((a, b) => b.degree - a.degree || b.workCount - a.workCount || (a.label ?? '').localeCompare(b.label ?? ''))
     .slice(0, AUTHOR_ATLAS_CAP);
   if (ranked.length === 0) return { nodes: [], edges: [] };
 


### PR DESCRIPTION
Closes #487

## What changed

- open authors, ideas, and argument maps in independent persistent tabs so multiple records can remain available for comparison
- persist and restore the active/open tab state for the affected views
- normalize nullable idea and graph metadata at the database/service boundary
- make searches and result sorting null-safe across the affected persisted-data views
- add regression coverage for independent tabs, snapshots, pagination, and nullable search payloads

## Root cause

Argument Map treated nullable SQLite idea fields as non-null strings. Searching then called `toLowerCase()` directly on a null statement. Several other views used the same unsafe pattern for persisted or imported metadata.

## User impact

Users can compare multiple authors, ideas, and argument maps without one selection replacing another, and malformed or incomplete metadata no longer crashes search views.

## Validation

- ESLint on all changed TypeScript/TSX files
- 69 targeted Node tests
- pagination regression checks
- Argument Map structural regression using a real SQLite `NULL` fixture
- `git diff --check`

## Local environment note

The full workspace typecheck could not be completed locally because the shared dependency installation is missing `yjs` and `archiver`; the targeted checks above pass.