### PR TITLE
Retire the legacy graph renderer preference

### DIFF
--- a/scripts/test-graph-progressive.mjs
+++ b/scripts/test-graph-progressive.mjs
@@ -306,6 +306,9 @@ async function assertRendererContracts() {
   const preload = await Promise.resolve(readSource('@bridge'));
   const ipc = await Promise.resolve(readSource('@main'));
 
+  assert.match(graphView, /const USE_SIGMA = true;/, 'Sigma is the only selectable graph renderer');
+  assert.doesNotMatch(graphView, /localStorage\.getItem\(['"]nodus\.graph\.engine['"]\)/, 'retired renderer cannot be restored by persisted browser state');
+  assert.match(graphView, /localStorage\.removeItem\(['"]nodus\.graph\.engine['"]\)/, 'stale renderer preferences are removed from upgraded profiles');
   assert.match(graphView, /if \(USE_SIGMA\) return \[\];/, 'Sigma path skips legacy Cytoscape elements');
   assert.match(graphView, /getGraphOverview\(\)/, 'initial scene uses the compact overview endpoint');
   assert.match(graphView, /getGraphTheme\(/, 'theme drill-down uses the bounded endpoint');

--- a/src/views/GraphView.tsx
+++ b/src/views/GraphView.tsx
@@ -15,11 +15,10 @@ import type { GraphNavigationTarget, GraphPresetId } from '../navigation';
 import { t, tx } from '../i18n';
 import { academicKnowledgeViewSource, type KnowledgeViewSource } from './knowledgeViewSource';
 
-// The Sigma (WebGL) + worker-layout + LOD renderer is the default engine.
-// Fall back to the legacy Cytoscape canvas renderer by setting:
-//   localStorage.setItem('nodus.graph.engine', 'cytoscape')
-const enginePref = typeof localStorage !== 'undefined' ? localStorage.getItem('nodus.graph.engine') : null;
-const USE_SIGMA = enginePref !== 'cytoscape';
+// Sigma is the only supported graph renderer. This must not be user-selectable
+// through persistent browser state: old installations may still carry the
+// retired `nodus.graph.engine=cytoscape` preference.
+const USE_SIGMA = true;
 const EMPTY_GRAPH_DATA: GraphData = { nodes: [], edges: [] };
 
 const IDEA_TYPES: IdeaType[] = ['claim', 'finding', 'construct', 'method', 'framework'];
@@ -1496,6 +1495,10 @@ export function GraphView({
   const pendingGraphTransitionRef = useRef<{ first: number | null; second: number | null }>({ first: null, second: null });
 
   useEffect(() => { dataSourceRef.current = dataSource; }, [dataSource]);
+
+  useEffect(() => {
+    localStorage.removeItem('nodus.graph.engine');
+  }, []);
 
   useEffect(() => {
     localStorage.setItem(filterStorageKey, JSON.stringify(filters));


### PR DESCRIPTION
## Summary

- make Sigma the only selectable graph renderer
- remove stale `nodus.graph.engine` preferences from upgraded profiles
- add regression coverage for persisted renderer state

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- `node --test scripts/test-graph-progressive.mjs`

Closes #493