### PR TITLE
Fix large backup restore memory usage and show real progress

### DIFF
--- a/electron/export/backupCrypto.ts
+++ b/electron/export/backupCrypto.ts
@@ -1,6 +1,6 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes, scrypt, scryptSync } from 'node:crypto';
 import fs from 'node:fs';
-import { Transform } from 'node:stream';
+import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 const PASSWORD_BYTES = 24;
@@ -193,6 +193,62 @@ export async function encryptBackupPayloadFile(
     plaintextSha256: plaintextHash.digest('hex'),
     ciphertextSha256: ciphertextHash.digest('hex'),
   };
+}
+
+/** Decrypt an authenticated backup entry to a temporary file with bounded RAM.
+ * Plaintext is written before GCM's final authentication check, so callers must
+ * only use the file after this promise resolves; every failure removes it. */
+export async function decryptBackupPayloadStream(
+  ciphertext: Readable,
+  targetPath: string,
+  password: string,
+  metadata: BackupCipherMetadata,
+  onProgress?: (completedBytes: number) => void,
+): Promise<void> {
+  if (metadata.formatVersion !== 1 || metadata.algorithm !== 'aes-256-gcm' || metadata.kdf.name !== 'scrypt') {
+    throw new Error('Formato de cifrado no soportado.');
+  }
+  const salt = Buffer.from(metadata.kdf.salt, 'base64');
+  const iv = Buffer.from(metadata.iv, 'base64');
+  const authTag = Buffer.from(metadata.authTag, 'base64');
+  const key = await deriveKeyAsync(password, salt);
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  const ciphertextHash = createHash('sha256');
+  const plaintextHash = createHash('sha256');
+  let completedBytes = 0;
+  const hashCiphertext = new Transform({
+    transform(chunk, _encoding, callback) {
+      ciphertextHash.update(chunk);
+      completedBytes += Buffer.byteLength(chunk);
+      onProgress?.(completedBytes);
+      callback(null, chunk);
+    },
+  });
+  const hashPlaintext = new Transform({
+    transform(chunk, _encoding, callback) {
+      plaintextHash.update(chunk);
+      callback(null, chunk);
+    },
+  });
+  try {
+    await pipeline(
+      ciphertext,
+      hashCiphertext,
+      decipher,
+      hashPlaintext,
+      fs.createWriteStream(targetPath, { flags: 'wx', mode: 0o600 }),
+    );
+    if (ciphertextHash.digest('hex') !== metadata.ciphertextSha256) {
+      throw new Error('La copia de seguridad no supera la verificación de integridad.');
+    }
+    if (plaintextHash.digest('hex') !== metadata.plaintextSha256) {
+      throw new Error('El contenido descifrado no coincide con el hash esperado.');
+    }
+  } catch (error) {
+    await fs.promises.rm(targetPath, { force: true });
+    throw error;
+  }
 }
 
 function sealPayload(plaintext: Buffer, key: Buffer, salt: Buffer): { ciphertext: Buffer; metadata: BackupCipherMetadata } {

--- a/electron/export/backupUtilityWorker.ts
+++ b/electron/export/backupUtilityWorker.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { verifyBackupBytes } from './backupVerificationCore';
+import { verifyBackupFile } from './backupVerificationCore';
 import { backupVaultRevision } from './backupVaultRevision';
 import type { BackupUtilityRequest, BackupUtilityResponse } from './backupUtilityTypes';
 
@@ -116,8 +116,11 @@ async function snapshot(request: Extract<BackupUtilityRequest, { kind: 'snapshot
 
 export async function runBackupUtilityRequest(request: BackupUtilityRequest): Promise<BackupUtilityResponse> {
   if (request.kind === 'snapshot') return snapshot(request);
-  const archive = await fs.promises.readFile(request.archivePath);
-  return { kind: 'verify-done', id: request.id, result: verifyBackupBytes(archive, request.password, request.schemaVersion) };
+  return {
+    kind: 'verify-done',
+    id: request.id,
+    result: await verifyBackupFile(request.archivePath, request.password, request.schemaVersion),
+  };
 }
 
 process.parentPort?.on('message', (event) => {

--- a/electron/export/backupVerificationCore.ts
+++ b/electron/export/backupVerificationCore.ts
@@ -1,8 +1,60 @@
 import AdmZip from 'adm-zip';
-import { decryptBackupPayload, sha256Hex, type BackupCipherMetadata } from './backupCrypto';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  decryptBackupPayload,
+  decryptBackupPayloadStream,
+  sha256Hex,
+  type BackupCipherMetadata,
+} from './backupCrypto';
+import { ZipFileReader, type ZipFileEntry } from './zipFile';
 
-interface OuterManifest { format: string; formatVersion: number; schemaVersion: number; cipher: BackupCipherMetadata; recovery?: { wrappedKeyCipher: BackupCipherMetadata } }
-interface InnerManifest { schemaVersion: number; files: Record<string, { sha256: string; bytes: number }>; vaults?: Array<{ name: string; dbFile: string }>; globalLibrary?: { prefix: string; fileCount: number } }
+export interface StreamedOuterManifest {
+  format: string;
+  formatVersion: number;
+  schemaVersion: number;
+  appVersion?: string;
+  includesSecrets?: boolean;
+  cipher: BackupCipherMetadata;
+  recovery?: { wrappedKeyCipher: BackupCipherMetadata };
+}
+
+export interface StreamedVaultEntry {
+  id?: string;
+  name: string;
+  type?: string;
+  legacy?: boolean;
+  dbFile: string;
+  inventoryFile?: string;
+}
+
+export interface StreamedInnerManifest {
+  schemaVersion: number;
+  files: Record<string, { sha256: string; bytes: number }>;
+  activeVaultId?: string;
+  vaults?: StreamedVaultEntry[];
+  selection?: Record<string, unknown>;
+  globalLibrary?: { prefix: string; fileCount: number };
+}
+
+type OuterManifest = StreamedOuterManifest;
+type InnerManifest = StreamedInnerManifest;
+
+interface OpenedBackupFile {
+  ok: true;
+  manifest: StreamedOuterManifest;
+  payloadManifest: StreamedInnerManifest;
+  payload: ZipFileReader;
+  includesSecrets: boolean;
+  recoveredKey?: string;
+  usedRecoveryKey: boolean;
+  cleanup: () => Promise<void>;
+}
+
+export type OpenBackupFileResult = OpenedBackupFile | { ok: false; message: string };
+export type BackupFileProgress = (phase: 'decrypting' | 'verifying', completedBytes: number, totalBytes: number) => void;
 
 /** Full archive authentication with no Electron main-only imports. */
 export function verifyBackupBytes(archive: Buffer, password: string, currentSchema: number): { ok: boolean; message: string } {
@@ -44,4 +96,197 @@ export function verifyBackupBytes(archive: Buffer, password: string, currentSche
     }
     return { ok: true, message: `Copia verificada: ${inner.vaults.length} bóveda(s) descifrables.` };
   } catch { return { ok: false, message: 'No se pudo descifrar la copia. Revisa la contraseña o el archivo.' }; }
+}
+
+async function hashEntry(
+  payload: ZipFileReader,
+  entry: ZipFileEntry,
+  onChunk?: (chunkBytes: number) => void,
+): Promise<{ sha256: string; bytes: number }> {
+  const hash = createHash('sha256');
+  let bytes = 0;
+  for await (const raw of await payload.stream(entry)) {
+    const chunk = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+    hash.update(chunk);
+    bytes += chunk.byteLength;
+    onChunk?.(chunk.byteLength);
+  }
+  if (bytes !== entry.uncompressedSize) throw new Error(`La entrada ZIP ${entry.name} tiene un tamaño incoherente.`);
+  return { sha256: hash.digest('hex'), bytes };
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function decryptionMessage(error: unknown): string {
+  const message = errorText(error);
+  return /authenticat|unsupported state|contraseña no es válida/i.test(message)
+    ? 'No se pudo descifrar la copia. Revisa la contraseña o el archivo.'
+    : `No se pudo verificar la copia: ${message}`;
+}
+
+/**
+ * Open and fully authenticate a file-backed backup without retaining an archive,
+ * ciphertext, plaintext ZIP, or vault database in memory. The returned payload
+ * is temporary and must be released with `cleanup`.
+ */
+export async function openVerifiedBackupFile(
+  archivePath: string,
+  password: string,
+  currentSchema: number,
+  onProgress?: BackupFileProgress,
+): Promise<OpenBackupFileResult> {
+  if (!password.trim()) return { ok: false, message: 'Falta la contraseña para verificar la copia.' };
+
+  let outer: ZipFileReader;
+  let manifest: StreamedOuterManifest;
+  try {
+    outer = await ZipFileReader.open(archivePath);
+    const manifestEntry = outer.entry('manifest.json');
+    if (!manifestEntry || !outer.entry('backup.bin')) {
+      return { ok: false, message: 'Archivo .nodus inválido: faltan manifest o datos cifrados.' };
+    }
+    manifest = JSON.parse((await outer.read(manifestEntry, 1024 * 1024)).toString('utf8')) as StreamedOuterManifest;
+  } catch (error) {
+    return { ok: false, message: `Archivo .nodus inválido o dañado: ${errorText(error)}` };
+  }
+  if (!manifest || typeof manifest !== 'object') return { ok: false, message: 'Archivo .nodus inválido: su manifiesto no es legible.' };
+  if (manifest.format !== 'nodus.encrypted-backup' || ![1, 2, 3, 4, 5, 6].includes(manifest.formatVersion)) {
+    return { ok: false, message: 'Formato de copia de seguridad no soportado.' };
+  }
+  if (manifest.schemaVersion > currentSchema) {
+    return { ok: false, message: `El archivo usa un esquema más reciente (v${manifest.schemaVersion}) que esta versión de Nodus (v${currentSchema}). Actualiza la app.` };
+  }
+
+  const temporaryRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nodus-backup-verify-'));
+  const payloadPath = path.join(temporaryRoot, 'payload.zip');
+  const cleanup = () => fs.promises.rm(temporaryRoot, { recursive: true, force: true });
+  let credential = password;
+  let recoveredKey: string | undefined;
+  let usedRecoveryKey = false;
+  try {
+    if (manifest.formatVersion >= 6) {
+      const wrappedEntry = outer.entry('recovery-key.bin');
+      if (!wrappedEntry || !manifest.recovery?.wrappedKeyCipher) {
+        await cleanup();
+        return { ok: false, message: 'Copia inválida: falta la clave de recuperación cifrada.' };
+      }
+      try {
+        credential = decryptBackupPayload(
+          await outer.read(wrappedEntry, 1024 * 1024),
+          password,
+          manifest.recovery.wrappedKeyCipher,
+        ).toString('utf8');
+      } catch {
+        credential = password;
+        usedRecoveryKey = true;
+      }
+      recoveredKey = credential;
+    }
+    const encryptedEntry = outer.entry('backup.bin')!;
+    onProgress?.('decrypting', 0, encryptedEntry.uncompressedSize);
+    await decryptBackupPayloadStream(
+      await outer.stream(encryptedEntry),
+      payloadPath,
+      credential,
+      manifest.cipher,
+      (completedBytes) => onProgress?.('decrypting', completedBytes, encryptedEntry.uncompressedSize),
+    );
+  } catch (error) {
+    await cleanup();
+    return { ok: false, message: decryptionMessage(error) };
+  }
+
+  let payload: ZipFileReader;
+  let inner: StreamedInnerManifest;
+  try {
+    payload = await ZipFileReader.open(payloadPath);
+    const innerEntry = payload.entry('payload-manifest.json');
+    if (!innerEntry) {
+      await cleanup();
+      return { ok: false, message: 'Copia inválida: falta el manifiesto interno.' };
+    }
+    inner = JSON.parse((await payload.read(innerEntry, 16 * 1024 * 1024)).toString('utf8')) as StreamedInnerManifest;
+  } catch (error) {
+    await cleanup();
+    return { ok: false, message: `Copia inválida: no se pudo leer el contenido descifrado: ${errorText(error)}` };
+  }
+  if (!inner || typeof inner !== 'object' || !inner.files || typeof inner.files !== 'object') {
+    await cleanup();
+    return { ok: false, message: 'Copia inválida: el manifiesto interno no es legible.' };
+  }
+  if (inner.schemaVersion > currentSchema) {
+    await cleanup();
+    return { ok: false, message: 'La copia usa un esquema más reciente. Actualiza la app.' };
+  }
+  try {
+    const verificationTotal = Object.values(inner.files).reduce(
+      (total, file) => total + (file && Number.isSafeInteger(file.bytes) && file.bytes >= 0 ? file.bytes : 0),
+      0,
+    );
+    let verificationCompleted = 0;
+    onProgress?.('verifying', 0, verificationTotal);
+    for (const [name, expected] of Object.entries(inner.files)) {
+      const entry = payload.entry(name);
+      if (!entry || entry.isDirectory || !expected || typeof expected.sha256 !== 'string' || !Number.isSafeInteger(expected.bytes) || expected.bytes < 0) {
+        await cleanup();
+        return { ok: false, message: 'Copia inválida: los hashes internos no coinciden.' };
+      }
+      const actual = await hashEntry(payload, entry, (chunkBytes) => {
+        verificationCompleted += chunkBytes;
+        onProgress?.('verifying', verificationCompleted, verificationTotal);
+      });
+      if (actual.bytes !== expected.bytes || actual.sha256 !== expected.sha256) {
+        await cleanup();
+        return { ok: false, message: 'Copia inválida: los hashes internos no coinciden.' };
+      }
+    }
+  } catch (error) {
+    await cleanup();
+    return { ok: false, message: `No se pudo verificar el contenido de la copia: ${errorText(error)}` };
+  }
+  if (manifest.formatVersion >= 4 && !inner.vaults?.length) {
+    await cleanup();
+    return { ok: false, message: 'La copia verificada no contiene ninguna bóveda.' };
+  }
+  for (const vault of inner.vaults ?? []) {
+    if (!payload.entry(vault.dbFile)) {
+      await cleanup();
+      return { ok: false, message: `La copia verificada no contiene la bóveda «${vault.name}».` };
+    }
+  }
+  if (inner.globalLibrary) {
+    const prefix = `${inner.globalLibrary.prefix}/`;
+    const count = payload.entries.filter((entry) => !entry.isDirectory && entry.name.startsWith(prefix)).length;
+    if (count !== inner.globalLibrary.fileCount) {
+      await cleanup();
+      return { ok: false, message: 'La copia verificada no contiene todos los archivos de la Biblioteca global.' };
+    }
+  }
+  return {
+    ok: true,
+    manifest,
+    payloadManifest: inner,
+    payload,
+    includesSecrets: manifest.formatVersion < 3 || manifest.includesSecrets === true,
+    recoveredKey,
+    usedRecoveryKey,
+    cleanup,
+  };
+}
+
+/** Full, streaming authentication for the automatic-backup utility process. */
+export async function verifyBackupFile(
+  archivePath: string,
+  password: string,
+  currentSchema: number,
+): Promise<{ ok: boolean; message: string }> {
+  const opened = await openVerifiedBackupFile(archivePath, password, currentSchema);
+  if (!opened.ok) return opened;
+  try {
+    return { ok: true, message: `Copia verificada: ${opened.payloadManifest.vaults?.length ?? 1} bóveda(s) descifrables.` };
+  } finally {
+    await opened.cleanup();
+  }
 }

--- a/electron/export/exportImport.ts
+++ b/electron/export/exportImport.ts
@@ -5,8 +5,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { dialog, app } from 'electron';
 import { showImportOpenDialog } from '../privacy';
-import type { AiProvider, AppSettings, BackupSelection } from '@shared/types';
+import type { AiProvider, AppSettings, BackupSelection, RecoveryRestoreProgress, RecoveryRestoreProgressPhase } from '@shared/types';
 import { SECRET_PROVIDERS } from '@shared/providers';
+import { isVaultType } from '@shared/vaultTypes';
 import { closeDb, getDb, replaceDbFile, SCHEMA_VERSION } from '../db/database';
 import { testimonyBackupInventory } from './testimonyExport';
 import { getSettings } from '../db/settingsRepo';
@@ -24,6 +25,11 @@ import {
   type BackupCipherMetadata,
 } from './backupCrypto';
 import { snapshotVaultInUtility } from './backupUtilityHost';
+import {
+  openVerifiedBackupFile,
+  type StreamedInnerManifest,
+} from './backupVerificationCore';
+import type { ZipFileEntry, ZipFileReader } from './zipFile';
 import { StreamingZipWriter } from './streamingZip';
 import { browserBookmarksRepository } from '../browser/bookmarks';
 
@@ -459,7 +465,90 @@ export async function importData(password: string): Promise<{ ok: boolean; messa
     filters: [{ name: 'Nodus', extensions: ['nodus'] }],
   });
   if (canceled || filePaths.length === 0) return { ok: false, message: 'Cancelado' };
-  return restoreBackupArchiveSafely(fs.readFileSync(filePaths[0]), password, app.getVersion());
+  return restoreBackupArchiveFileSafely(filePaths[0], password, app.getVersion());
+}
+
+/** File-backed counterpart of {@link restoreBackupArchiveSafely}. Large recovery
+ * snapshots never pass through `readFileSync`, and the pre-restore escape hatch
+ * is also created directly on disk. */
+export async function restoreBackupArchiveFileSafely(
+  archivePath: string,
+  password: string,
+  appVersion: string,
+  onProgress?: (progress: RecoveryRestoreProgress) => void,
+): Promise<BackupRestoreResult> {
+  if (!password.trim()) return { ok: false, message: 'Importación cancelada: falta la contraseña de la copia.' };
+  const safetyPassword = getBackupPassword() || password;
+  const safetyDir = path.join(app.getPath('userData'), 'restore-safety');
+  const safetyPath = path.join(safetyDir, `pre-restore-${Date.now()}-${Math.random().toString(36).slice(2)}.nodus`);
+  const stagedSafety = `${safetyPath}.tmp`;
+  try {
+    emitRestoreProgress(onProgress, 'preparing', 0, 0);
+    await fs.promises.mkdir(safetyDir, { recursive: true });
+    await createBackupArchiveFile({ password: safetyPassword, appVersion }, stagedSafety);
+    await fs.promises.rename(stagedSafety, safetyPath);
+    emitRestoreProgress(onProgress, 'preparing', 1, 1);
+    const result = await restoreBackupArchiveFile(archivePath, password, onProgress);
+    if (!result.ok) {
+      await fs.promises.rm(safetyPath, { force: true });
+      return result;
+    }
+    emitRestoreProgress(onProgress, 'finalizing', 0, 0);
+    emitRestoreProgress(onProgress, 'complete', 1, 1);
+    return {
+      ...result,
+      message: `${result.message} Se ha conservado una copia de seguridad previa en ${safetyPath}.`,
+      safetyBackupPath: safetyPath,
+    };
+  } catch (error) {
+    await fs.promises.rm(stagedSafety, { force: true });
+    const failure = error instanceof Error ? error.message : String(error);
+    if (!fs.existsSync(safetyPath)) {
+      return { ok: false, message: `La restauración se canceló antes de modificar los datos: ${failure}` };
+    }
+    try {
+      const rollback = await restoreBackupArchiveFile(safetyPath, safetyPassword);
+      if (!rollback.ok) throw new Error(rollback.message);
+      return {
+        ok: false,
+        message: `La restauración falló (${failure}), pero Nodus recuperó automáticamente el estado anterior. Copia de seguridad: ${safetyPath}`,
+        safetyBackupPath: safetyPath,
+      };
+    } catch (rollbackError) {
+      return {
+        ok: false,
+        message: `La restauración falló (${failure}) y no se pudo completar la reversión automática (${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}). No borres la copia de emergencia: ${safetyPath}`,
+        safetyBackupPath: safetyPath,
+      };
+    }
+  }
+}
+
+const RESTORE_PHASE_RANGES: Record<RecoveryRestoreProgressPhase, readonly [number, number]> = {
+  preparing: [0, 0.08],
+  decrypting: [0.08, 0.33],
+  verifying: [0.33, 0.70],
+  restoring: [0.70, 0.97],
+  finalizing: [0.97, 0.99],
+  complete: [1, 1],
+};
+
+function emitRestoreProgress(
+  reporter: ((progress: RecoveryRestoreProgress) => void) | undefined,
+  phase: RecoveryRestoreProgressPhase,
+  completedBytes: number,
+  totalBytes: number,
+): void {
+  if (!reporter) return;
+  const [start, end] = RESTORE_PHASE_RANGES[phase];
+  const fraction = totalBytes > 0 ? Math.min(1, Math.max(0, completedBytes / totalBytes)) : 0;
+  const byteBacked = phase === 'decrypting' || phase === 'verifying' || phase === 'restoring';
+  reporter({
+    phase,
+    progress: phase === 'complete' ? 1 : start + (end - start) * fraction,
+    completedBytes: byteBacked ? Math.max(0, completedBytes) : 0,
+    totalBytes: byteBacked ? Math.max(0, totalBytes) : 0,
+  });
 }
 
 /**
@@ -769,6 +858,339 @@ export function restoreBackupArchive(archive: Buffer, password: string): BackupR
       ? 'Importación completa: biblioteca, texto extraído, embeddings, pasajes, modelos, grafo y claves API restaurados.'
       : 'Importación completa: biblioteca, texto extraído, embeddings, pasajes, modelos y grafo restaurados. Las claves API locales se han conservado (la copia automática no las incluye).',
   };
+}
+
+class RestoreByteTracker {
+  private completed = 0;
+  readonly total: number;
+
+  constructor(
+    payload: ZipFileReader,
+    names: ReadonlySet<string>,
+    private readonly reporter?: (progress: RecoveryRestoreProgress) => void,
+  ) {
+    this.total = payload.entries.reduce(
+      (total, entry) => total + (!entry.isDirectory && names.has(entry.name) ? entry.uncompressedSize : 0),
+      0,
+    );
+    emitRestoreProgress(this.reporter, 'restoring', 0, this.total);
+  }
+
+  readonly advance = (chunkBytes: number): void => {
+    this.completed = Math.min(this.total, this.completed + Math.max(0, chunkBytes));
+    emitRestoreProgress(this.reporter, 'restoring', this.completed, this.total);
+  };
+
+  finish(): void {
+    this.completed = this.total;
+    emitRestoreProgress(this.reporter, 'restoring', this.completed, this.total);
+  }
+}
+
+function plannedRestoreEntries(
+  payload: ZipFileReader,
+  payloadManifest: StreamedInnerManifest,
+  formatVersion: number,
+): Set<string> {
+  const names = new Set<string>();
+  const add = (name: string): void => { if (payload.entry(name)) names.add(name); };
+  add('api-keys.json');
+  add('audio-keys.json');
+  if (formatVersion < 4) {
+    add('database.sqlite');
+    add('settings.json');
+    add('backup-inventory.json');
+    return names;
+  }
+
+  for (const vault of streamedVaultEntries(payloadManifest) ?? []) {
+    add(vault.dbFile);
+    add(vault.inventoryFile);
+  }
+  if (payloadManifest.globalLibrary) {
+    const prefix = `${payloadManifest.globalLibrary.prefix}/`;
+    for (const entry of payload.entries) if (!entry.isDirectory && entry.name.startsWith(prefix)) names.add(entry.name);
+  }
+
+  const selection = normalizeBackupSelection(payloadManifest.selection as Partial<BackupSelection> | undefined, false);
+  if (selection.includePreferences) {
+    for (const name of GLOBAL_AUXILIARY_FILES) add(`aux/global/${name}`);
+  }
+  for (const vault of streamedVaultEntries(payloadManifest) ?? []) {
+    if (selection.includeHistories) {
+      for (const name of VAULT_HISTORY_FILES) add(`aux/vaults/${vault.id}/${name}`);
+    }
+    if (selection.includeGeneratedMedia) {
+      for (const name of VAULT_MEDIA_FILES) add(`aux/vaults/${vault.id}/${name}`);
+      const prefix = `aux/vaults/${vault.id}/audio/`;
+      for (const entry of payload.entries) if (!entry.isDirectory && entry.name.startsWith(prefix)) names.add(entry.name);
+    }
+  }
+  return names;
+}
+
+async function readStreamedJson<T>(payload: ZipFileReader, name: string, tracker?: RestoreByteTracker): Promise<T | null> {
+  const entry = payload.entry(name);
+  if (!entry) return null;
+  const value = JSON.parse((await payload.read(entry, 16 * 1024 * 1024)).toString('utf8')) as T;
+  tracker?.advance(entry.uncompressedSize);
+  return value;
+}
+
+async function extractAtomicEntry(payload: ZipFileReader, entry: ZipFileEntry, target: string, tracker?: RestoreByteTracker): Promise<void> {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const temporary = `${target}.restore-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    await payload.extract(entry, temporary, tracker?.advance);
+    await fs.promises.rename(temporary, target);
+  } catch (error) {
+    await fs.promises.rm(temporary, { force: true });
+    throw error;
+  }
+}
+
+function streamedVaultEntries(manifest: StreamedInnerManifest): BackupVaultEntry[] | null {
+  if (!manifest.vaults?.length) return null;
+  const vaults: BackupVaultEntry[] = [];
+  for (const candidate of manifest.vaults) {
+    if (
+      typeof candidate.id !== 'string' || !candidate.id
+      || typeof candidate.name !== 'string' || !candidate.name
+      || candidate.id === '.' || candidate.id === '..'
+      || candidate.id.includes('/') || candidate.id.includes('\\')
+      || !isVaultType(candidate.type)
+      || typeof candidate.dbFile !== 'string' || !candidate.dbFile
+      || typeof candidate.inventoryFile !== 'string' || !candidate.inventoryFile
+    ) return null;
+    vaults.push({
+      id: candidate.id,
+      name: candidate.name,
+      type: candidate.type,
+      legacy: candidate.legacy === true,
+      dbFile: candidate.dbFile,
+      inventoryFile: candidate.inventoryFile,
+    });
+  }
+  return vaults;
+}
+
+async function stageGlobalLibraryRestoreFromFile(
+  payload: ZipFileReader,
+  payloadManifest: StreamedInnerManifest,
+  tracker?: RestoreByteTracker,
+): Promise<StagedGlobalLibrary | null> {
+  const descriptor = payloadManifest.globalLibrary;
+  if (!descriptor) return null;
+  const root = configuredLibraryRoot();
+  if (!root) throw new Error('Configura una carpeta de copias antes de restaurar una copia que contiene la Biblioteca global.');
+  const parent = path.dirname(root);
+  fs.mkdirSync(parent, { recursive: true });
+  const staging = path.join(parent, `.nodus-library-restore-${process.pid}-${Math.random().toString(36).slice(2)}`);
+  fs.mkdirSync(staging, { recursive: false });
+  let written = 0;
+  try {
+    const prefix = `${descriptor.prefix}/`;
+    for (const entry of payload.entries) {
+      if (entry.isDirectory || !entry.name.startsWith(prefix)) continue;
+      const relative = safeArchiveRelative(entry.name.slice(prefix.length));
+      if (!relative) throw new Error(`La copia contiene una ruta de Biblioteca no válida: ${entry.name}`);
+      const target = path.resolve(staging, ...relative.split('/'));
+      if (!target.startsWith(`${path.resolve(staging)}${path.sep}`)) throw new Error('La copia intenta escribir fuera de la Biblioteca.');
+      await payload.extract(entry, target, tracker?.advance);
+      written += 1;
+    }
+    if (written !== descriptor.fileCount) throw new Error('La copia no contiene todos los archivos declarados de la Biblioteca global.');
+    return { root, staging };
+  } catch (error) {
+    fs.rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function restoreAllVaultsFromFile(
+  payload: ZipFileReader,
+  payloadManifest: StreamedInnerManifest,
+  tracker?: RestoreByteTracker,
+): Promise<{ ok: true; restored: number } | { ok: false; message: string }> {
+  const vaults = streamedVaultEntries(payloadManifest);
+  if (!vaults) return { ok: false, message: 'Copia inválida: el archivo no contiene bóvedas válidas.' };
+  const staged: { entry: BackupVaultEntry; tmp: string }[] = [];
+  const cleanup = () => staged.forEach((item) => fs.rmSync(item.tmp, { force: true }));
+  try {
+    for (const vault of vaults) {
+      const dbEntry = payload.entry(vault.dbFile);
+      if (!dbEntry) return { ok: false, message: `Copia inválida: falta la base de datos de la bóveda «${vault.name}».` };
+      const tmp = path.join(app.getPath('temp'), `nodus-import-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+      await payload.extract(dbEntry, tmp, tracker?.advance);
+      staged.push({ entry: vault, tmp });
+      const inventory = await readStreamedJson<BackupInventory>(payload, vault.inventoryFile, tracker);
+      if (inventory && !databaseMatchesInventory(tmp, inventory)) {
+        return { ok: false, message: `Copia inválida: faltan datos en la bóveda «${vault.name}».` };
+      }
+    }
+
+    const machineLocal = captureMachineLocalSettings();
+    closeDb();
+    for (const { entry, tmp } of staged) {
+      applyMachineLocalSettings(tmp, machineLocal.get(entry.id) ?? null);
+      restoreVaultDatabase(entry, tmp);
+    }
+    const activeId = payloadManifest.activeVaultId ?? vaults[0].id;
+    try { setActiveVault(activeId); } catch { /* keep the current vault if absent */ }
+    getDb();
+    return { ok: true, restored: staged.length };
+  } finally {
+    cleanup();
+  }
+}
+
+async function restoreAuxiliaryFilesFromFile(
+  payload: ZipFileReader,
+  payloadManifest: StreamedInnerManifest,
+  tracker?: RestoreByteTracker,
+): Promise<void> {
+  const selection = normalizeBackupSelection(payloadManifest.selection as Partial<BackupSelection> | undefined, false);
+  if (selection.includePreferences) {
+    let restoredBookmarks = false;
+    for (const name of GLOBAL_AUXILIARY_FILES) {
+      const entry = payload.entry(`aux/global/${name}`);
+      if (!entry) continue;
+      if (name === 'app-prefs.json') {
+        restoreGlobalPreferences(await payload.read(entry, 16 * 1024 * 1024));
+        tracker?.advance(entry.uncompressedSize);
+      } else await extractAtomicEntry(payload, entry, path.join(app.getPath('userData'), name), tracker);
+      if (name === 'browser-bookmarks.json') restoredBookmarks = true;
+    }
+    if (restoredBookmarks) browserBookmarksRepository().reloadFromDisk();
+  }
+
+  const restoredVaults = new Map(listVaults().map((vault) => [vault.id, vault]));
+  for (const vaultEntry of streamedVaultEntries(payloadManifest) ?? []) {
+    const vault = restoredVaults.get(vaultEntry.id);
+    if (!vault) continue;
+    const targetDir = path.dirname(vault.path);
+    if (selection.includeHistories) {
+      for (const name of VAULT_HISTORY_FILES) {
+        const entry = payload.entry(`aux/vaults/${vault.id}/${name}`);
+        if (entry) await extractAtomicEntry(payload, entry, path.join(targetDir, name), tracker);
+      }
+    }
+    if (selection.includeGeneratedMedia) {
+      for (const name of VAULT_MEDIA_FILES) {
+        const entry = payload.entry(`aux/vaults/${vault.id}/${name}`);
+        if (entry) await extractAtomicEntry(payload, entry, path.join(targetDir, name), tracker);
+      }
+      const prefix = `aux/vaults/${vault.id}/audio/`;
+      for (const entry of payload.entries) {
+        if (entry.isDirectory || !entry.name.startsWith(prefix)) continue;
+        const relative = safeArchiveRelative(entry.name.slice(prefix.length));
+        if (relative) await extractAtomicEntry(payload, entry, path.join(targetDir, 'audio', ...relative.split('/')), tracker);
+      }
+    }
+  }
+}
+
+/** Restore a fully authenticated file-backed archive while keeping large vaults
+ * and media entries on disk throughout the operation. */
+export async function restoreBackupArchiveFile(
+  archivePath: string,
+  password: string,
+  onProgress?: (progress: RecoveryRestoreProgress) => void,
+): Promise<BackupRestoreResult> {
+  if (!password.trim()) return { ok: false, message: 'Importación cancelada: falta la contraseña de la copia.' };
+  const opened = await openVerifiedBackupFile(archivePath, password, SCHEMA_VERSION, (phase, completedBytes, totalBytes) => {
+    emitRestoreProgress(onProgress, phase, completedBytes, totalBytes);
+  });
+  if (!opened.ok) return opened;
+  const { manifest, payload, payloadManifest, includesSecrets, recoveredKey, usedRecoveryKey } = opened;
+  const tracker = new RestoreByteTracker(payload, plannedRestoreEntries(payload, payloadManifest, manifest.formatVersion), onProgress);
+  try {
+    const importedKeys = await readStreamedJson<Partial<Record<AiProvider, string>>>(payload, 'api-keys.json', tracker) ?? {};
+    const importedAudioKeys = await readStreamedJson<Record<string, string>>(payload, 'audio-keys.json', tracker) ?? {};
+
+    if (manifest.formatVersion >= 4) {
+      const stagedLibrary = await stageGlobalLibraryRestoreFromFile(payload, payloadManifest, tracker);
+      try {
+        const result = await restoreAllVaultsFromFile(payload, payloadManifest, tracker);
+        if (!result.ok) {
+          cleanupStagedGlobalLibrary(stagedLibrary);
+          return result;
+        }
+        if (manifest.formatVersion >= 5) await restoreAuxiliaryFilesFromFile(payload, payloadManifest, tracker);
+        applyStagedGlobalLibrary(stagedLibrary);
+        if (includesSecrets) {
+          restoreApiKeys(importedKeys);
+          restoreAudioKeys(importedAudioKeys);
+        }
+        tracker.finish();
+        return {
+          ok: true,
+          message: includesSecrets
+            ? `Importación completa: ${result.restored} bóveda(s) con su biblioteca, embeddings, grafo y claves API restauradas.`
+            : `Importación completa: ${result.restored} bóveda(s) restauradas (biblioteca, embeddings y grafo). Las claves API locales se han conservado (la copia automática no las incluye).`,
+          recoveryKey: recoveredKey,
+          usedRecoveryKey,
+        };
+      } catch (error) {
+        cleanupStagedGlobalLibrary(stagedLibrary);
+        throw error;
+      }
+    }
+
+    const dbEntry = payload.entry('database.sqlite');
+    if (!dbEntry) return { ok: false, message: 'Copia inválida: falta la base de datos.' };
+    const importedSettings = await readStreamedJson<BackupSettings>(payload, 'settings.json', tracker);
+    const inventory = await readStreamedJson<BackupInventory>(payload, 'backup-inventory.json', tracker);
+    if (manifest.formatVersion >= 2 && !inventory) return { ok: false, message: 'Copia inválida: falta el inventario de datos.' };
+    if (inventory && !settingsMatchInventory(importedSettings, importedKeys, inventory)) {
+      return { ok: false, message: 'Copia inválida: la configuración de modelos o claves no coincide con su inventario.' };
+    }
+    const tmp = path.join(app.getPath('temp'), `nodus-import-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    try {
+      await payload.extract(dbEntry, tmp, tracker.advance);
+      if (inventory && !databaseMatchesInventory(tmp, inventory)) {
+        return { ok: false, message: 'Copia inválida: faltan datos o embeddings en la instantánea de base de datos.' };
+      }
+      const localPaths = captureMachineLocalSettings().get(getActiveVault().id) ?? null;
+      closeDb();
+      replaceDbFile(tmp);
+      if (importedSettings) {
+        const restoredSettings = {
+          ...importedSettings,
+          mcpEnabled: false,
+          mcpToken: '',
+          nodusServerEnabled: false,
+          nodusServerKind: 'classic',
+          nodusServerUrl: '',
+          nodusServerSpaceId: '',
+          nodusServerSpaceName: '',
+        } as Record<string, unknown>;
+        for (const key of MACHINE_LOCAL_SETTING_KEYS) {
+          if (localPaths && localPaths[key] !== undefined) restoredSettings[key] = localPaths[key];
+          else delete restoredSettings[key];
+        }
+        getDb().prepare('INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value')
+          .run('app', JSON.stringify(restoredSettings));
+      }
+      if (includesSecrets) {
+        restoreApiKeys(importedKeys);
+        restoreAudioKeys(importedAudioKeys);
+      }
+      tracker.finish();
+      return {
+        ok: true,
+        message: includesSecrets
+          ? 'Importación completa: biblioteca, texto extraído, embeddings, pasajes, modelos, grafo y claves API restaurados.'
+          : 'Importación completa: biblioteca, texto extraído, embeddings, pasajes, modelos y grafo restaurados. Las claves API locales se han conservado (la copia automática no las incluye).',
+        recoveryKey: recoveredKey,
+        usedRecoveryKey,
+      };
+    } finally {
+      fs.rmSync(tmp, { force: true });
+    }
+  } finally {
+    await opened.cleanup();
+  }
 }
 
 interface StagedGlobalLibrary {

--- a/electron/export/zipFile.ts
+++ b/electron/export/zipFile.ts
@@ -1,0 +1,302 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createInflateRaw, inflateRawSync } from 'node:zlib';
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_SIGNATURE = 0x02014b50;
+const LOCAL_SIGNATURE = 0x04034b50;
+const MAX_COMMENT_BYTES = 0xffff;
+const MAX_CENTRAL_DIRECTORY_BYTES = 64 * 1024 * 1024;
+
+export interface ZipFileEntry {
+  name: string;
+  method: 0 | 8;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+  isDirectory: boolean;
+}
+
+async function readExactly(file: fs.promises.FileHandle, length: number, position: number): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(length);
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await file.read(buffer, offset, length - offset, position + offset);
+    if (bytesRead === 0) throw new Error('ZIP truncado.');
+    offset += bytesRead;
+  }
+  return buffer;
+}
+
+function readExactlySync(fd: number, length: number, position: number): Buffer {
+  const buffer = Buffer.allocUnsafe(length);
+  let offset = 0;
+  while (offset < length) {
+    const bytesRead = fs.readSync(fd, buffer, offset, length - offset, position + offset);
+    if (bytesRead === 0) throw new Error('ZIP truncado.');
+    offset += bytesRead;
+  }
+  return buffer;
+}
+
+/**
+ * Read one deliberately small entry without loading the archive around it. Recovery
+ * folder inspection is synchronous, and used to instantiate AdmZip for every
+ * snapshot merely to read manifest.json. With multi-gigabyte snapshots that alone
+ * could exhaust memory before restore had even started.
+ */
+export function readZipEntrySync(
+  filePath: string,
+  entryName: string,
+  maxBytes = 16 * 1024 * 1024,
+): Buffer | null {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const stat = fs.fstatSync(fd);
+    const tailLength = Math.min(stat.size, MAX_COMMENT_BYTES + 22);
+    if (tailLength < 22) throw new Error('ZIP truncado.');
+    const tail = readExactlySync(fd, tailLength, stat.size - tailLength);
+    let eocd = -1;
+    for (let offset = tail.length - 22; offset >= 0; offset -= 1) {
+      if (tail.readUInt32LE(offset) !== EOCD_SIGNATURE) continue;
+      const commentLength = tail.readUInt16LE(offset + 20);
+      if (offset + 22 + commentLength === tail.length) { eocd = offset; break; }
+    }
+    if (eocd < 0) throw new Error('No se encontró el directorio ZIP.');
+    const disk = tail.readUInt16LE(eocd + 4);
+    const centralDisk = tail.readUInt16LE(eocd + 6);
+    const entriesOnDisk = tail.readUInt16LE(eocd + 8);
+    const entryCount = tail.readUInt16LE(eocd + 10);
+    const centralSize = tail.readUInt32LE(eocd + 12);
+    const centralOffset = tail.readUInt32LE(eocd + 16);
+    if (disk !== 0 || centralDisk !== 0 || entriesOnDisk !== entryCount) {
+      throw new Error('Los ZIP multidisco no están soportados.');
+    }
+    if (entryCount === 0xffff || centralSize === 0xffffffff || centralOffset === 0xffffffff) {
+      throw new Error('El formato ZIP64 no está soportado por esta versión de Nodus.');
+    }
+    if (centralSize > MAX_CENTRAL_DIRECTORY_BYTES || centralOffset + centralSize > stat.size) {
+      throw new Error('Directorio ZIP inválido.');
+    }
+
+    const central = readExactlySync(fd, centralSize, centralOffset);
+    let cursor = 0;
+    let selected: ZipFileEntry | null = null;
+    const names = new Set<string>();
+    for (let index = 0; index < entryCount; index += 1) {
+      if (cursor + 46 > central.length || central.readUInt32LE(cursor) !== CENTRAL_SIGNATURE) {
+        throw new Error('Directorio ZIP dañado.');
+      }
+      const flags = central.readUInt16LE(cursor + 8);
+      const method = central.readUInt16LE(cursor + 10);
+      const compressedSize = central.readUInt32LE(cursor + 20);
+      const uncompressedSize = central.readUInt32LE(cursor + 24);
+      const nameLength = central.readUInt16LE(cursor + 28);
+      const extraLength = central.readUInt16LE(cursor + 30);
+      const commentLength = central.readUInt16LE(cursor + 32);
+      const localHeaderOffset = central.readUInt32LE(cursor + 42);
+      const next = cursor + 46 + nameLength + extraLength + commentLength;
+      if (next > central.length) throw new Error('Directorio ZIP truncado.');
+      if ((flags & 0x1) !== 0) throw new Error('Las entradas ZIP cifradas externamente no están soportadas.');
+      if (method !== 0 && method !== 8) throw new Error(`Método ZIP no soportado: ${method}.`);
+      if (compressedSize === 0xffffffff || uncompressedSize === 0xffffffff || localHeaderOffset === 0xffffffff) {
+        throw new Error('El formato ZIP64 no está soportado por esta versión de Nodus.');
+      }
+      const name = central.subarray(cursor + 46, cursor + 46 + nameLength)
+        .toString((flags & 0x800) !== 0 ? 'utf8' : 'latin1');
+      if (!name || names.has(name)) throw new Error('El ZIP contiene nombres vacíos o duplicados.');
+      names.add(name);
+      if (name === entryName) {
+        if (compressedSize > maxBytes || uncompressedSize > maxBytes) {
+          throw new Error(`La entrada ${name} supera el límite seguro de lectura.`);
+        }
+        selected = {
+          name,
+          method: method as 0 | 8,
+          compressedSize,
+          uncompressedSize,
+          localHeaderOffset,
+          isDirectory: name.endsWith('/'),
+        };
+      }
+      cursor = next;
+    }
+    if (cursor !== central.length) throw new Error('El directorio ZIP contiene datos inesperados.');
+    if (!selected) return null;
+    if (selected.isDirectory) return Buffer.alloc(0);
+
+    const header = readExactlySync(fd, 30, selected.localHeaderOffset);
+    if (header.readUInt32LE(0) !== LOCAL_SIGNATURE) {
+      throw new Error(`Cabecera ZIP inválida: ${selected.name}.`);
+    }
+    const localFlags = header.readUInt16LE(6);
+    const localMethod = header.readUInt16LE(8);
+    if ((localFlags & 0x1) !== 0 || localMethod !== selected.method) {
+      throw new Error(`Cabecera ZIP incoherente: ${selected.name}.`);
+    }
+    const dataOffset = selected.localHeaderOffset + 30 + header.readUInt16LE(26) + header.readUInt16LE(28);
+    if (dataOffset + selected.compressedSize > stat.size) {
+      throw new Error(`Entrada ZIP truncada: ${selected.name}.`);
+    }
+    const compressed = readExactlySync(fd, selected.compressedSize, dataOffset);
+    const result = selected.method === 0
+      ? compressed
+      : inflateRawSync(compressed, { maxOutputLength: maxBytes });
+    if (result.byteLength !== selected.uncompressedSize) {
+      throw new Error(`La entrada ZIP ${selected.name} tiene un tamaño incoherente.`);
+    }
+    return result;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * A deliberately small ZIP32 reader for Nodus backups. Unlike AdmZip it never
+ * materialises an entry in memory unless the caller explicitly asks for a
+ * bounded small entry (the two JSON manifests and the wrapped recovery key).
+ */
+export class ZipFileReader {
+  private constructor(
+    readonly path: string,
+    readonly entries: ZipFileEntry[],
+    private readonly byName: Map<string, ZipFileEntry>,
+  ) {}
+
+  static async open(filePath: string): Promise<ZipFileReader> {
+    const handle = await fs.promises.open(filePath, 'r');
+    try {
+      const stat = await handle.stat();
+      const tailLength = Math.min(stat.size, MAX_COMMENT_BYTES + 22);
+      if (tailLength < 22) throw new Error('ZIP truncado.');
+      const tail = await readExactly(handle, tailLength, stat.size - tailLength);
+      let eocd = -1;
+      for (let offset = tail.length - 22; offset >= 0; offset -= 1) {
+        if (tail.readUInt32LE(offset) !== EOCD_SIGNATURE) continue;
+        const commentLength = tail.readUInt16LE(offset + 20);
+        if (offset + 22 + commentLength === tail.length) { eocd = offset; break; }
+      }
+      if (eocd < 0) throw new Error('No se encontró el directorio ZIP.');
+      const disk = tail.readUInt16LE(eocd + 4);
+      const centralDisk = tail.readUInt16LE(eocd + 6);
+      const entriesOnDisk = tail.readUInt16LE(eocd + 8);
+      const entryCount = tail.readUInt16LE(eocd + 10);
+      const centralSize = tail.readUInt32LE(eocd + 12);
+      const centralOffset = tail.readUInt32LE(eocd + 16);
+      if (disk !== 0 || centralDisk !== 0 || entriesOnDisk !== entryCount) throw new Error('Los ZIP multidisco no están soportados.');
+      if (entryCount === 0xffff || centralSize === 0xffffffff || centralOffset === 0xffffffff) {
+        throw new Error('El formato ZIP64 no está soportado por esta versión de Nodus.');
+      }
+      if (centralSize > MAX_CENTRAL_DIRECTORY_BYTES || centralOffset + centralSize > stat.size) {
+        throw new Error('Directorio ZIP inválido.');
+      }
+      const central = await readExactly(handle, centralSize, centralOffset);
+      const entries: ZipFileEntry[] = [];
+      const byName = new Map<string, ZipFileEntry>();
+      let cursor = 0;
+      for (let index = 0; index < entryCount; index += 1) {
+        if (cursor + 46 > central.length || central.readUInt32LE(cursor) !== CENTRAL_SIGNATURE) {
+          throw new Error('Directorio ZIP dañado.');
+        }
+        const flags = central.readUInt16LE(cursor + 8);
+        const method = central.readUInt16LE(cursor + 10);
+        const compressedSize = central.readUInt32LE(cursor + 20);
+        const uncompressedSize = central.readUInt32LE(cursor + 24);
+        const nameLength = central.readUInt16LE(cursor + 28);
+        const extraLength = central.readUInt16LE(cursor + 30);
+        const commentLength = central.readUInt16LE(cursor + 32);
+        const localHeaderOffset = central.readUInt32LE(cursor + 42);
+        const next = cursor + 46 + nameLength + extraLength + commentLength;
+        if (next > central.length) throw new Error('Directorio ZIP truncado.');
+        if ((flags & 0x1) !== 0) throw new Error('Las entradas ZIP cifradas externamente no están soportadas.');
+        if (method !== 0 && method !== 8) throw new Error(`Método ZIP no soportado: ${method}.`);
+        if (compressedSize === 0xffffffff || uncompressedSize === 0xffffffff || localHeaderOffset === 0xffffffff) {
+          throw new Error('El formato ZIP64 no está soportado por esta versión de Nodus.');
+        }
+        const name = central.subarray(cursor + 46, cursor + 46 + nameLength).toString((flags & 0x800) !== 0 ? 'utf8' : 'latin1');
+        if (!name || byName.has(name)) throw new Error('El ZIP contiene nombres vacíos o duplicados.');
+        const entry: ZipFileEntry = {
+          name,
+          method: method as 0 | 8,
+          compressedSize,
+          uncompressedSize,
+          localHeaderOffset,
+          isDirectory: name.endsWith('/'),
+        };
+        entries.push(entry);
+        byName.set(name, entry);
+        cursor = next;
+      }
+      if (cursor !== central.length) throw new Error('El directorio ZIP contiene datos inesperados.');
+      return new ZipFileReader(filePath, entries, byName);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  entry(name: string): ZipFileEntry | undefined { return this.byName.get(name); }
+
+  private async dataOffset(entry: ZipFileEntry): Promise<number> {
+    const handle = await fs.promises.open(this.path, 'r');
+    try {
+      const header = await readExactly(handle, 30, entry.localHeaderOffset);
+      if (header.readUInt32LE(0) !== LOCAL_SIGNATURE) throw new Error(`Cabecera ZIP inválida: ${entry.name}.`);
+      const localFlags = header.readUInt16LE(6);
+      const localMethod = header.readUInt16LE(8);
+      if ((localFlags & 0x1) !== 0 || localMethod !== entry.method) {
+        throw new Error(`Cabecera ZIP incoherente: ${entry.name}.`);
+      }
+      const offset = entry.localHeaderOffset + 30 + header.readUInt16LE(26) + header.readUInt16LE(28);
+      const size = (await handle.stat()).size;
+      if (offset + entry.compressedSize > size) throw new Error(`Entrada ZIP truncada: ${entry.name}.`);
+      return offset;
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async stream(entry: ZipFileEntry): Promise<Readable> {
+    if (entry.isDirectory || entry.compressedSize === 0) return Readable.from([]);
+    const start = await this.dataOffset(entry);
+    const raw = fs.createReadStream(this.path, { start, end: start + entry.compressedSize - 1 });
+    return entry.method === 0 ? raw : raw.pipe(createInflateRaw());
+  }
+
+  async read(entry: ZipFileEntry, maxBytes = 16 * 1024 * 1024): Promise<Buffer> {
+    if (entry.uncompressedSize > maxBytes) throw new Error(`La entrada ${entry.name} supera el límite seguro de lectura.`);
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    for await (const raw of await this.stream(entry)) {
+      const chunk = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+      bytes += chunk.byteLength;
+      if (bytes > maxBytes) throw new Error(`La entrada ${entry.name} supera el límite seguro de lectura.`);
+      chunks.push(chunk);
+    }
+    if (bytes !== entry.uncompressedSize) throw new Error(`La entrada ZIP ${entry.name} tiene un tamaño incoherente.`);
+    return Buffer.concat(chunks, bytes);
+  }
+
+  async extract(entry: ZipFileEntry, target: string, onProgress?: (chunkBytes: number) => void): Promise<void> {
+    await fs.promises.mkdir(path.dirname(target), { recursive: true });
+    let bytes = 0;
+    const meter = new Transform({
+      transform(chunk, _encoding, callback) {
+        const chunkBytes = Buffer.byteLength(chunk);
+        bytes += chunkBytes;
+        onProgress?.(chunkBytes);
+        callback(null, chunk);
+      },
+    });
+    try {
+      await pipeline(await this.stream(entry), meter, fs.createWriteStream(target, { flags: 'wx', mode: 0o600 }));
+      if (bytes !== entry.uncompressedSize) {
+        throw new Error(`La entrada ZIP ${entry.name} tiene un tamaño incoherente.`);
+      }
+    } catch (error) {
+      await fs.promises.rm(target, { force: true });
+      throw error;
+    }
+  }
+}

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -8,6 +8,7 @@ import {
 import type {
   AppLanguage,
   AppSettings,
+  RecoveryRestoreProgress,
   UpdateCheckResponse,
   CreateVaultInput,
   VaultSummary,
@@ -805,8 +806,20 @@ export function registerIpc(
   h('recovery:initialize', async (_e, folder: string, password: string, language: AppLanguage = 'es') =>
     initializeRecoveryFolder(folder, password, app.getVersion(), language)
   );
-  h('recovery:restore', async (_e, root: string, fileName: string, password: string, language: AppLanguage = 'es') => {
-    const result = await restoreRecoverySnapshot(root, fileName, password, app.getVersion(), language);
+  h('recovery:restore', async (event, root: string, fileName: string, password: string, language: AppLanguage = 'es', requestId = '') => {
+    let lastSentAt = 0;
+    let lastPhase: RecoveryRestoreProgress['phase'] | null = null;
+    const report = (progress: RecoveryRestoreProgress) => {
+      if (!requestId || event.sender.isDestroyed()) return;
+      const now = Date.now();
+      const phaseChanged = progress.phase !== lastPhase;
+      const phaseComplete = progress.totalBytes > 0 && progress.completedBytes >= progress.totalBytes;
+      if (!phaseChanged && !phaseComplete && now - lastSentAt < 80) return;
+      lastSentAt = now;
+      lastPhase = progress.phase;
+      event.sender.send('recovery:restore:progress', requestId, progress);
+    };
+    const result = await restoreRecoverySnapshot(root, fileName, password, app.getVersion(), language, report);
     if (result.ok) {
       stopNodusServerSync();
       stopInboxPolling();

--- a/electron/preload/api.ts
+++ b/electron/preload/api.ts
@@ -11,6 +11,7 @@ import { ipcRenderer, webUtils } from 'electron';
 import type {
   NodusApi,
   NodiOverlayPlacement,
+  RecoveryRestoreProgress,
   UpdateProgressEvent,
 } from '@shared/types';
 import { prosopographyApi } from './prosopography';
@@ -226,7 +227,15 @@ export const nodusApi: NodusApi = {
   getRecoveryStatus: () => ipcRenderer.invoke('recovery:status'),
   chooseRecoveryFolder: (mode, language) => ipcRenderer.invoke('recovery:chooseFolder', mode, language),
   initializeRecoveryFolder: (folder, password, language) => ipcRenderer.invoke('recovery:initialize', folder, password, language),
-  restoreRecoverySnapshot: (root, fileName, password, language) => ipcRenderer.invoke('recovery:restore', root, fileName, password, language),
+  restoreRecoverySnapshot: (root, fileName, password, language, onProgress) => {
+    const requestId = `recovery-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const listener = (_event: unknown, id: string, progress: RecoveryRestoreProgress) => {
+      if (id === requestId) onProgress?.(progress);
+    };
+    ipcRenderer.on('recovery:restore:progress', listener);
+    return ipcRenderer.invoke('recovery:restore', root, fileName, password, language, requestId)
+      .finally(() => ipcRenderer.removeListener('recovery:restore:progress', listener));
+  },
 
   // Dropped-file paths come from webUtils, not from a channel, so this one lives
   // wherever the bridge itself lives rather than with any domain slice.

--- a/electron/recovery/recoveryManager.ts
+++ b/electron/recovery/recoveryManager.ts
@@ -1,4 +1,3 @@
-import AdmZip from 'adm-zip';
 import fs from 'node:fs';
 import path from 'node:path';
 import type {
@@ -6,11 +5,12 @@ import type {
   RecoveryFolderInspection,
   RecoveryHealth,
   RecoverySetupResult,
+  RecoveryRestoreProgress,
   RecoverySnapshotSummary,
   RecoveryStatus,
 } from '@shared/types';
 import { getSettings, updateSettings } from '../db/settingsRepo';
-import { restoreBackupArchiveSafely } from '../export/exportImport';
+import { restoreBackupArchiveFileSafely } from '../export/exportImport';
 import { runAutoBackupNow } from '../export/autoBackup';
 import {
   clearBackupPassword,
@@ -22,6 +22,7 @@ import {
   setBackupRecoveryKey,
 } from '../secrets/secretStore';
 import { generateBackupPassword } from '../export/backupCrypto';
+import { readZipEntrySync } from '../export/zipFile';
 import { listVaults } from '../vaults/vaultRegistry';
 import {
   createRecoveryManifest,
@@ -48,10 +49,9 @@ function snapshotSummary(filePath: string): RecoverySnapshotSummary | null {
   try {
     const stat = fs.statSync(filePath);
     if (!stat.isFile()) return null;
-    const zip = new AdmZip(filePath);
-    const entry = zip.getEntry('manifest.json');
-    if (!entry) return null;
-    const manifest = JSON.parse(zip.readAsText(entry)) as OuterBackupManifest;
+    const manifestBytes = readZipEntrySync(filePath, 'manifest.json', 1024 * 1024);
+    if (!manifestBytes) return null;
+    const manifest = JSON.parse(manifestBytes.toString('utf8')) as OuterBackupManifest;
     if (manifest.format !== 'nodus.encrypted-backup' || !Number.isFinite(manifest.formatVersion)) return null;
     return {
       fileName: path.basename(filePath),
@@ -266,19 +266,14 @@ export async function restoreRecoverySnapshot(
   fileName: string,
   password: string,
   appVersion: string,
-  language: AppLanguage = 'es'
+  language: AppLanguage = 'es',
+  onProgress?: (progress: RecoveryRestoreProgress) => void,
 ): Promise<RecoverySetupResult> {
   const inspection = inspectRecoveryFolder(root, language);
   if (inspection.kind !== 'recovery') return { ok: false, message: inspection.message };
   const snapshot = inspection.snapshots.find((candidate) => candidate.fileName === path.basename(fileName));
   if (!snapshot) return { ok: false, message: tr(language, { es: 'La copia seleccionada no pertenece a esta carpeta de recuperación.', en: 'The selected snapshot does not belong to this recovery folder.', fr: "La sauvegarde sélectionnée n'appartient pas à ce dossier de récupération.", de: 'Die ausgewählte Sicherung gehört nicht zu diesem Wiederherstellungsordner.', pt: 'A cópia de segurança selecionada não pertence a esta pasta de recuperação.', 'pt-BR': 'O backup selecionado não pertence a esta pasta de recuperação.', it: 'La copia selezionata non appartiene a questa cartella di ripristino.', tr: 'Seçilen anlık görüntü bu kurtarma klasörüne ait değil.' }) };
-  let archive: Buffer;
-  try {
-    archive = fs.readFileSync(snapshot.path);
-  } catch (error) {
-    return { ok: false, message: error instanceof Error ? error.message : String(error) };
-  }
-  const result = await restoreBackupArchiveSafely(archive, password, appVersion);
+  const result = await restoreBackupArchiveFileSafely(snapshot.path, password, appVersion, onProgress);
   if (!result.ok) return { ...result, message: localizeRestoreMessage(result.message, language) };
   if (result.recoveryKey) setBackupRecoveryKey(result.recoveryKey);
   // A restore with the recovery key must not make both credentials identical.

--- a/scripts/test-backup-file-streaming.mjs
+++ b/scripts/test-backup-file-streaming.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { createHash, randomFillSync } from 'node:crypto';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks } from './lib/tsRuntimeHooks.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+installRuntimeHooks(repoRoot);
+
+test('large backup manifests and payloads are verified from file streams', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-backup-streaming-'));
+  const sourcePath = path.join(root, 'large.sqlite');
+  const payloadPath = path.join(root, 'payload.zip');
+  const ciphertextPath = path.join(root, 'backup.bin');
+  const archivePath = path.join(root, 'large.nodus');
+  const password = 'streaming-regression-password';
+  const sourceBytes = 32 * 1024 * 1024;
+
+  try {
+    const source = fs.openSync(sourcePath, 'wx', 0o600);
+    const chunk = Buffer.allocUnsafe(1024 * 1024);
+    const hash = createHash('sha256');
+    try {
+      for (let offset = 0; offset < sourceBytes; offset += chunk.byteLength) {
+        randomFillSync(chunk);
+        hash.update(chunk);
+        fs.writeSync(source, chunk);
+      }
+    } finally {
+      fs.closeSync(source);
+    }
+
+    const { StreamingZipWriter } = require(path.join(repoRoot, 'electron/export/streamingZip.ts'));
+    const { encryptBackupPayloadFile } = require(path.join(repoRoot, 'electron/export/backupCrypto.ts'));
+    const { readZipEntrySync } = require(path.join(repoRoot, 'electron/export/zipFile.ts'));
+    const { verifyBackupFile } = require(path.join(repoRoot, 'electron/export/backupVerificationCore.ts'));
+
+    const payload = new StreamingZipWriter(payloadPath, 6);
+    await payload.addFile('vaults/v1/database.sqlite', sourcePath);
+    await payload.addBuffer('payload-manifest.json', Buffer.from(JSON.stringify({
+      schemaVersion: 153,
+      files: {
+        'vaults/v1/database.sqlite': { sha256: hash.digest('hex'), bytes: sourceBytes },
+      },
+      vaults: [{ id: 'v1', name: 'Streaming regression vault', dbFile: 'vaults/v1/database.sqlite' }],
+    })));
+    await payload.finalize();
+
+    const cipher = await encryptBackupPayloadFile(payloadPath, ciphertextPath, password);
+    const outerManifest = {
+      format: 'nodus.encrypted-backup',
+      formatVersion: 5,
+      schemaVersion: 153,
+      appVersion: 'test',
+      date: new Date(0).toISOString(),
+      cipher,
+      vaultCount: 1,
+      includesSecrets: false,
+    };
+    const outer = new StreamingZipWriter(archivePath, 0);
+    await outer.addBuffer('manifest.json', Buffer.from(JSON.stringify(outerManifest)), true);
+    await outer.addFile('backup.bin', ciphertextPath, true);
+    await outer.finalize();
+    assert.ok(fs.statSync(archivePath).size > 30 * 1024 * 1024, 'fixture must remain large enough to expose whole-file reads');
+
+    const originalReadFileSync = fs.readFileSync;
+    const originalReadFile = fs.promises.readFile;
+    const forbidden = (file) => {
+      const name = typeof file === 'string' ? file : file instanceof URL ? fileURLToPath(file) : '';
+      return path.resolve(name) === archivePath || path.basename(name) === 'payload.zip';
+    };
+    fs.readFileSync = function patchedReadFileSync(file, ...args) {
+      if (forbidden(file)) throw new Error(`whole-file sync read forbidden: ${file}`);
+      return originalReadFileSync.call(this, file, ...args);
+    };
+    fs.promises.readFile = async function patchedReadFile(file, ...args) {
+      if (forbidden(file)) throw new Error(`whole-file async read forbidden: ${file}`);
+      return originalReadFile.call(this, file, ...args);
+    };
+    try {
+      const manifest = readZipEntrySync(archivePath, 'manifest.json', 1024 * 1024);
+      assert.deepEqual(JSON.parse(manifest.toString('utf8')), outerManifest);
+      const verified = await verifyBackupFile(archivePath, password, 153);
+      assert.equal(verified.ok, true, verified.message);
+    } finally {
+      fs.readFileSync = originalReadFileSync;
+      fs.promises.readFile = originalReadFile;
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/test-backup-utility-process.mjs
+++ b/scripts/test-backup-utility-process.mjs
@@ -53,8 +53,16 @@ test('production backup contains no sqlite backup or synchronous auto verificati
   const automatic = fs.readFileSync(path.join(repoRoot, 'electron/export/autoBackup.ts'), 'utf8');
   assert.match(host, /utilityProcess\.fork\(/);
   assert.match(worker, /VACUUM INTO/);
+  assert.match(worker, /await verifyBackupFile\(/);
+  assert.doesNotMatch(worker, /readFile\(request\.archivePath\)/);
   assert.doesNotMatch(writer, /\.backup\(/);
   assert.match(writer, /await zip\.addFile\('backup\.bin', ciphertextPath, true\)/);
+  assert.match(writer, /restoreBackupArchiveFileSafely/);
   assert.match(automatic, /await verifyBackupFileInUtility\(target, password\)/);
   assert.doesNotMatch(automatic, /verifyBackupArchive\(|readFile\(target\)/);
+
+  const recovery = fs.readFileSync(path.join(repoRoot, 'electron/recovery/recoveryManager.ts'), 'utf8');
+  assert.match(recovery, /readZipEntrySync\(filePath, 'manifest\.json'/);
+  assert.match(recovery, /restoreBackupArchiveFileSafely\(snapshot\.path/);
+  assert.doesNotMatch(recovery, /new AdmZip\(filePath\)|readFileSync\(snapshot\.path\)/);
 });

--- a/scripts/test-recovery-folder.mjs
+++ b/scripts/test-recovery-folder.mjs
@@ -62,11 +62,29 @@ try {
   fs.rmSync(path.join(vaultDir, 'study-chat-history.json'), { force: true });
   fs.rmSync(path.join(vaultDir, 'audio'), { recursive: true, force: true });
 
-  const wrong = await recovery.restoreRecoverySnapshot(recoveryRoot, initialized.snapshot.fileName, 'contraseña-errónea', '9.9.9-test');
+  const rejectedProgress = [];
+  const wrong = await recovery.restoreRecoverySnapshot(
+    recoveryRoot,
+    initialized.snapshot.fileName,
+    'contraseña-errónea',
+    '9.9.9-test',
+    'es',
+    (progress) => rejectedProgress.push(progress),
+  );
   assert.equal(wrong.ok, false, 'wrong password is rejected');
   assert.equal(entities.getPerson(alice.personId), null, 'wrong password does not mutate live data');
+  assert.ok(rejectedProgress.some((progress) => progress.phase === 'decrypting'), 'rejected restore reports real decryption work');
+  assert.ok(!rejectedProgress.some((progress) => progress.phase === 'complete'), 'rejected restore never reports completion');
 
-  const restored = await recovery.restoreRecoverySnapshot(recoveryRoot, initialized.snapshot.fileName, initialized.recoveryKey, '9.9.9-test', 'en');
+  const restoreProgress = [];
+  const restored = await recovery.restoreRecoverySnapshot(
+    recoveryRoot,
+    initialized.snapshot.fileName,
+    initialized.recoveryKey,
+    '9.9.9-test',
+    'en',
+    (progress) => restoreProgress.push(progress),
+  );
   assert.equal(restored.ok, true, restored.message);
   assert.match(restored.message, /recovery key/i, 'recovery flow reports which independent credential succeeded in English');
   assert.ok(entities.getPerson(alice.personId), 'vault database restored');
@@ -75,6 +93,26 @@ try {
   assert.equal(fs.readFileSync(path.join(vaultDir, 'audio', 'voz.wav'), 'utf8'), 'WAVE-DATA', 'generated media restored');
   const safetyFiles = fs.readdirSync(path.join(userData, 'restore-safety')).filter((name) => name.endsWith('.nodus'));
   assert.equal(safetyFiles.length, 1, 'successful restore retains a pre-restore encrypted safety snapshot');
+  assert.deepEqual(
+    [...new Set(restoreProgress.map((progress) => progress.phase))],
+    ['preparing', 'decrypting', 'verifying', 'restoring', 'finalizing', 'complete'],
+    'restore exposes every user-visible phase in order',
+  );
+  assert.ok(
+    restoreProgress.every((progress, index) => index === 0 || progress.progress >= restoreProgress[index - 1].progress),
+    'overall restore progress is monotonic',
+  );
+  for (const phase of ['decrypting', 'verifying', 'restoring']) {
+    const byteEvents = restoreProgress.filter((progress) => progress.phase === phase && progress.totalBytes > 0);
+    assert.ok(byteEvents.length > 0, `${phase} reports byte-backed progress`);
+    assert.ok(byteEvents.every((progress) => progress.completedBytes <= progress.totalBytes), `${phase} never exceeds its byte total`);
+    assert.equal(byteEvents.at(-1).completedBytes, byteEvents.at(-1).totalBytes, `${phase} reaches its real byte total`);
+  }
+  for (const phase of ['preparing', 'finalizing', 'complete']) {
+    const milestones = restoreProgress.filter((progress) => progress.phase === phase);
+    assert.ok(milestones.every((progress) => progress.completedBytes === 0 && progress.totalBytes === 0), `${phase} does not invent byte counters`);
+  }
+  assert.equal(restoreProgress.at(-1).progress, 1, 'successful restore reaches 100%');
 
   // ── Backup health must state the truth, not the last happy status ───────────
   // Every one of these used to be invisible: a broken schedule left `lastAutoBackupAt`

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1969,6 +1969,24 @@ export interface RecoverySetupResult {
   recoveryKey?: string;
 }
 
+export type RecoveryRestoreProgressPhase =
+  | 'preparing'
+  | 'decrypting'
+  | 'verifying'
+  | 'restoring'
+  | 'finalizing'
+  | 'complete';
+
+/** Live, monotonic restore progress. `progress` is the overall 0..1 value shown
+ * by the UI; byte counters describe the real work completed in the current
+ * streaming phase. Milestone-only phases intentionally report zero bytes. */
+export interface RecoveryRestoreProgress {
+  phase: RecoveryRestoreProgressPhase;
+  progress: number;
+  completedBytes: number;
+  totalBytes: number;
+}
+
 /**
  * Where a vault's canonical data lives.
  *
@@ -8292,7 +8310,13 @@ export interface NodusApi extends ProsopographyApi, TestimoniesApi, ToolkitApi, 
   /** Create a recovery root and commit its first verified full-state snapshot. */
   initializeRecoveryFolder(path: string, password: string, language?: AppLanguage): Promise<RecoverySetupResult>;
   /** Restore a selected snapshot from an existing recovery root. */
-  restoreRecoverySnapshot(root: string, fileName: string, password: string, language?: AppLanguage): Promise<RecoverySetupResult>;
+  restoreRecoverySnapshot(
+    root: string,
+    fileName: string,
+    password: string,
+    language?: AppLanguage,
+    onProgress?: (progress: RecoveryRestoreProgress) => void,
+  ): Promise<RecoverySetupResult>;
   /** The absolute path of a file dropped on the window. webUtils, not a channel. */
   getPathForDroppedFile(file: unknown): string;
 

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -8200,4 +8200,7 @@ export const DE: Record<string, string> = {
   "La copia previa se abrió como un vault separado.": "Die Kopie vor der Migration wurde als separater Vault geöffnet.",
   "Abriendo…": "Wird geöffnet…",
   "Abrir como vault separado": "Als separaten Vault öffnen",
+  "Descifrando…": "Wird entschlüsselt…",
+  "Finalizando…": "Wird abgeschlossen…",
+  "Progreso de restauración": "Wiederherstellungsfortschritt",
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -8427,4 +8427,7 @@ export const EN: Record<string, string> = {
   "La copia previa se abrió como un vault separado.": "The pre-migration copy was opened as a separate vault.",
   "Abriendo…": "Opening…",
   "Abrir como vault separado": "Open as a separate vault",
+  "Descifrando…": "Decrypting…",
+  "Finalizando…": "Finalizing…",
+  "Progreso de restauración": "Restore progress",
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -8191,4 +8191,7 @@ export const FR: Record<string, string> = {
   "La copia previa se abrió como un vault separado.": "La copie antérieure à la migration a été ouverte comme coffre séparé.",
   "Abriendo…": "Ouverture…",
   "Abrir como vault separado": "Ouvrir comme coffre séparé",
+  "Descifrando…": "Déchiffrement…",
+  "Finalizando…": "Finalisation…",
+  "Progreso de restauración": "Progression de la restauration",
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -7605,4 +7605,7 @@ export const IT: Record<string, string> = {
   "La copia previa se abrió como un vault separado.": "La copia precedente alla migrazione è stata aperta come vault separato.",
   "Abriendo…": "Apertura…",
   "Abrir como vault separado": "Apri come vault separato",
+  "Descifrando…": "Decifratura…",
+  "Finalizando…": "Finalizzazione…",
+  "Progreso de restauración": "Avanzamento del ripristino",
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -8150,4 +8150,7 @@ export const PT_BR: Record<string, string> = {
   "La copia previa se abrió como un vault separado.": "A cópia anterior à migração foi aberta como um cofre separado.",
   "Abriendo…": "Abrindo…",
   "Abrir como vault separado": "Abrir como cofre separado",
+  "Descifrando…": "Descriptografando…",
+  "Finalizando…": "Finalizando…",
+  "Progreso de restauración": "Progresso da restauração",
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -8142,4 +8142,7 @@ export const PT: Record<string, string> = {
   "La copia previa se abrió como un vault separado.": "A cópia anterior à migração foi aberta como um cofre separado.",
   "Abriendo…": "A abrir…",
   "Abrir como vault separado": "Abrir como cofre separado",
+  "Descifrando…": "A desencriptar…",
+  "Finalizando…": "A finalizar…",
+  "Progreso de restauración": "Progresso da restauração",
 };

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -7950,4 +7950,7 @@ export const TR: Record<string, string> = {
   "Antes de cambiar el esquema, Nodus conserva una copia inmutable y verificada. Puedes abrirla como un vault separado sin sustituir el actual.": "Nodus, şemayı değiştirmeden önce değiştirilemez ve doğrulanmış bir kopya saklar. Geçerli kasanın yerine koymadan ayrı bir kasa olarak açabilirsiniz.",
   "La copia previa se abrió como un vault separado.": "Geçiş öncesi kopya ayrı bir kasa olarak açıldı.",
   "Abrir como vault separado": "Ayrı kasa olarak aç",
+  "Descifrando…": "Şifre çözülüyor…",
+  "Finalizando…": "Tamamlanıyor…",
+  "Progreso de restauración": "Geri yükleme ilerlemesi",
 };

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,12 @@
 .recovery-vault-grid b, .recovery-vault-grid small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .recovery-vault-grid small { margin-top: 2px; color: #686a79; }
 .recovery-error { display: flex; gap: 8px; margin-top: 14px; padding: 11px; border: 1px solid rgba(239,68,68,.4); border-radius: 10px; background: rgba(127,29,29,.2); color: #fca5a5; font-size: 12px; }
+.recovery-restore-progress { display: grid; gap: 8px; margin-top: 14px; padding: 13px 14px; border: 1px solid rgba(99,102,241,.35); border-radius: 12px; background: rgba(49,46,129,.14); }
+.recovery-restore-progress-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; color: #c7d2fe; font-size: 12px; }
+.recovery-restore-progress-heading b { color: #fff; font-variant-numeric: tabular-nums; }
+.recovery-restore-progress-track { height: 8px; overflow: hidden; border-radius: 999px; background: rgba(99,102,241,.2); }
+.recovery-restore-progress-track span { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #2dd4bf, #818cf8); box-shadow: 0 0 14px rgba(45,212,191,.35); transition: width 120ms linear; }
+.recovery-restore-progress small { color: #77798b; font-size: 10px; font-variant-numeric: tabular-nums; }
 .recovery-password-field { position: relative; }
 .recovery-password-field .input { padding-right: 42px; }
 .recovery-password-field button { position: absolute; top: 50%; right: 7px; display: grid; width: 30px; height: 30px; place-items: center; transform: translateY(-50%); border-radius: 7px; color: #a3a3b3; }
@@ -122,6 +128,11 @@
 .light .recovery-vault-grid small { color: #64748b; }
 .light .recovery-password-field button { color: #64748b; }
 .light .recovery-password-field button:hover { background: #e8edf4; color: #111827; }
+.light .recovery-restore-progress { border-color: #c7d2fe; background: #eef2ff; }
+.light .recovery-restore-progress-heading { color: #4338ca; }
+.light .recovery-restore-progress-heading b { color: #312e81; }
+.light .recovery-restore-progress-track { background: #dbeafe; }
+.light .recovery-restore-progress small { color: #64748b; }
 .light .recovery-footer > span { color: #64748b; }
 .light .recovery-summary { background: #ecfdf5; color: #047857; }
 .light .recovery-key { border-color: #99f6e4; background: #f0fdfa; }

--- a/src/views/RecoverySetupWizard.tsx
+++ b/src/views/RecoverySetupWizard.tsx
@@ -4,6 +4,7 @@ import { t } from '../i18n';
 import type {
   AppLanguage,
   RecoveryFolderInspection,
+  RecoveryRestoreProgress,
   RecoverySetupResult,
   RecoveryStatus,
 } from '@shared/types';
@@ -30,6 +31,7 @@ export function RecoverySetupWizard({
   const [selectedSnapshot, setSelectedSnapshot] = useState('');
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<RecoverySetupResult | null>(null);
+  const [restoreProgress, setRestoreProgress] = useState<RecoveryRestoreProgress | null>(null);
 
   const snapshots = folder?.snapshots ?? [];
   const effectiveSnapshot = selectedSnapshot || snapshots[0]?.fileName || '';
@@ -43,17 +45,20 @@ export function RecoverySetupWizard({
     setFolder(picked);
     setSelectedSnapshot(picked.snapshots[0]?.fileName ?? '');
     setResult(null);
+    setRestoreProgress(null);
   };
 
   const submit = async () => {
     if (!folder || !canSubmit) return;
     setBusy(true);
     setResult(null);
+    if (mode === 'restore') setRestoreProgress({ phase: 'preparing', progress: 0, completedBytes: 0, totalBytes: 0 });
     try {
       const next = mode === 'create'
         ? await window.nodus.initializeRecoveryFolder(folder.path, password, language)
-        : await window.nodus.restoreRecoverySnapshot(folder.path, effectiveSnapshot, password, language);
+        : await window.nodus.restoreRecoverySnapshot(folder.path, effectiveSnapshot, password, language, setRestoreProgress);
       setResult(next);
+      if (!next.ok) setRestoreProgress(null);
     } finally {
       setBusy(false);
     }
@@ -107,8 +112,8 @@ export function RecoverySetupWizard({
 
         <section className="recovery-form">
           <div className="recovery-mode-tabs">
-            <button className={mode === 'create' ? 'active' : ''} onClick={() => { setMode('create'); setFolder(null); setResult(null); }}><Icon name="lock" />{status.previousInstallation ? (t('Migrar y proteger este equipo')) : (t('Crear carpeta segura'))}</button>
-            <button className={mode === 'restore' ? 'active' : ''} onClick={() => { setMode('restore'); setFolder(null); setResult(null); }}><Icon name="upload" />{t('Recuperar otro equipo')}</button>
+            <button className={mode === 'create' ? 'active' : ''} onClick={() => { setMode('create'); setFolder(null); setResult(null); setRestoreProgress(null); }}><Icon name="lock" />{status.previousInstallation ? (t('Migrar y proteger este equipo')) : (t('Crear carpeta segura'))}</button>
+            <button className={mode === 'restore' ? 'active' : ''} onClick={() => { setMode('restore'); setFolder(null); setResult(null); setRestoreProgress(null); }}><Icon name="upload" />{t('Recuperar otro equipo')}</button>
           </div>
 
           <div className="recovery-block">
@@ -145,11 +150,44 @@ export function RecoverySetupWizard({
           </div>
 
           {result && !result.ok && <div className="recovery-error"><Icon name="alert" />{result.message}</div>}
-          <footer className="recovery-footer"><span><Icon name="lock" />{t('AES-256-GCM · instantáneas SQLite consistentes · hashes de integridad')}</span><button className="btn btn-primary" disabled={!canSubmit || busy} onClick={() => void submit()}>{busy ? (t('Verificando y guardando…')) : mode === 'create' ? (t('Crear primera copia segura')) : (t('Verificar y recuperar'))}<Icon name={busy ? 'sync' : 'chevronRight'} className={busy ? 'animate-spin' : ''} /></button></footer>
+          {mode === 'restore' && busy && restoreProgress && (
+            <div
+              className="recovery-restore-progress"
+              data-testid="recovery-restore-progress"
+              data-phase={restoreProgress.phase}
+              role="progressbar"
+              aria-live="polite"
+              aria-label={t('Progreso de restauración')}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(restoreProgress.progress * 100)}
+            >
+              <div className="recovery-restore-progress-heading">
+                <span>{restoreProgressLabel(restoreProgress.phase)}</span>
+                <b>{Math.round(restoreProgress.progress * 100)}%</b>
+              </div>
+              <div className="recovery-restore-progress-track" aria-hidden="true">
+                <span style={{ width: `${Math.max(0, Math.min(100, restoreProgress.progress * 100))}%` }} />
+              </div>
+              {restoreProgress.totalBytes > 0 && (
+                <small>{formatBytes(restoreProgress.completedBytes)} / {formatBytes(restoreProgress.totalBytes)}</small>
+              )}
+            </div>
+          )}
+          <footer className="recovery-footer"><span><Icon name="lock" />{t('AES-256-GCM · instantáneas SQLite consistentes · hashes de integridad')}</span><button className="btn btn-primary" disabled={!canSubmit || busy} onClick={() => void submit()}>{busy ? (mode === 'restore' && restoreProgress ? restoreProgressLabel(restoreProgress.phase) : t('Verificando y guardando…')) : mode === 'create' ? (t('Crear primera copia segura')) : (t('Verificar y recuperar'))}<Icon name={busy ? 'sync' : 'chevronRight'} className={busy ? 'animate-spin' : ''} /></button></footer>
         </section>
       </motion.main>
     </div>
   );
+}
+
+function restoreProgressLabel(phase: RecoveryRestoreProgress['phase']): string {
+  if (phase === 'preparing') return t('Preparando…');
+  if (phase === 'decrypting') return t('Descifrando…');
+  if (phase === 'verifying') return t('Verificando…');
+  if (phase === 'restoring') return t('Restaurando…');
+  if (phase === 'finalizing' || phase === 'complete') return t('Finalizando…');
+  return t('Restaurando…');
 }
 
 function PasswordField({ value, onChange, visible, onToggle, placeholder, language }: {


### PR DESCRIPTION
## Summary

- replace whole-file `.nodus` verification and restore reads with bounded, file-backed ZIP streaming
- stream AES-GCM decryption, integrity hashing, vault extraction, auxiliary files, and recovery-folder manifest inspection
- show monotonic restore progress for preparation, decryption, verification, extraction, finalization, and completion
- report real phase byte counts in the UI, throttle IPC updates, and provide accessible/localized labels
- retain the pre-restore safety snapshot and existing rollback behavior

## Reproduction and validation

The previous path reached 2.84 GB RSS while verifying a valid 768 MiB synthetic backup. The streaming path verified the same fixture at about 342 MB RSS.

Visual verification used an isolated 512.8 MiB recovery snapshot. The production UI showed live decryption progress (`482.2 MB / 512.8 MB`, 32%), completed the restore, produced a 518 MiB restored SQLite database, and retained the encrypted pre-restore safety snapshot.

## Tests

- `npm run build`
- renderer and Electron TypeScript checks
- scoped ESLint
- backup streaming and utility-process regression tests
- recovery-folder integration, including wrong credentials, all progress phases, real byte totals, monotonicity, and successful completion
- i18n coverage for every supported language
- full test suite excluding the independently hanging `test-prosopography-e2e.mjs`: 2,089 passed, 0 failed

Closes #498