### PR TITLE
Fix macOS packaging for Nodus 4.2.0

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # npm can omit Rollup's platform package when a lockfile was generated on
+      # another OS. Repair only that build-time optional dependency without
+      # changing package.json or package-lock.json on the runner.
+      - name: Ensure native Rollup binary
+        run: node scripts/ensure-rollup-native.mjs
+
       - name: Build renderer + main
         env:
           NODE_OPTIONS: --max-old-space-size=4096

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -43,7 +43,11 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - os: macos-latest
+          # The release targets arm64, but packaging remains pinned to the Intel
+          # image: electron-builder cross-builds the arm64 app there and the
+          # Electron npm distribution includes the legal bundle required by
+          # beforePack. macos-latest is now an arm64 image and omits that bundle.
+          - os: macos-15-intel
             platform: '--mac'
           - os: windows-latest
             platform: '--win'
@@ -80,7 +84,7 @@ jobs:
         run: npx electron-builder ${{ matrix.platform }} --publish always --config build/electron-builder.release.cjs
 
       - name: Build and publish signed macOS installer
-        if: matrix.os == 'macos-latest' && env.HAS_MACOS_SIGNING == 'true'
+        if: matrix.os == 'macos-15-intel' && env.HAS_MACOS_SIGNING == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MACOS_CERTIFICATE }}
@@ -92,7 +96,7 @@ jobs:
         run: npx electron-builder ${{ matrix.platform }} --publish always --config build/electron-builder.release.cjs
 
       - name: Build and publish ad-hoc macOS installer
-        if: matrix.os == 'macos-latest' && env.HAS_MACOS_SIGNING != 'true'
+        if: matrix.os == 'macos-15-intel' && env.HAS_MACOS_SIGNING != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false

--- a/scripts/ensure-rollup-native.mjs
+++ b/scripts/ensure-rollup-native.mjs
@@ -1,0 +1,36 @@
+// npm may omit Rollup's platform-specific optional package when package-lock.json
+// was generated on another operating system. Release builds need a deterministic,
+// cross-platform repair that does not rewrite either dependency manifest.
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const targets = new Map([
+  ['darwin-arm64', '@rollup/rollup-darwin-arm64'],
+  ['darwin-x64', '@rollup/rollup-darwin-x64'],
+  ['linux-x64', '@rollup/rollup-linux-x64-gnu'],
+  ['win32-x64', '@rollup/rollup-win32-x64-msvc'],
+]);
+const target = targets.get(`${process.platform}-${process.arch}`);
+if (!target) throw new Error(`Unsupported Rollup release platform: ${process.platform}-${process.arch}`);
+
+const targetRoot = path.join(root, 'node_modules', ...target.split('/'));
+if (existsSync(path.join(targetRoot, 'package.json'))) {
+  console.log(`Rollup native package is present: ${target}`);
+  process.exit(0);
+}
+
+const rollup = JSON.parse(readFileSync(path.join(root, 'node_modules', 'rollup', 'package.json'), 'utf8'));
+const spec = `${target}@${rollup.version}`;
+console.log(`Installing missing Rollup native package: ${spec}`);
+execFileSync('npm', ['install', '--no-save', '--package-lock=false', '--ignore-scripts', spec], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+if (!existsSync(path.join(targetRoot, 'package.json'))) {
+  throw new Error(`npm did not install the required Rollup native package: ${spec}`);
+}

--- a/scripts/test-update-channels.mjs
+++ b/scripts/test-update-channels.mjs
@@ -106,6 +106,7 @@ test('stable and beta publication have isolated entry points and shared build lo
   assert.match(shared, /--prerelease --latest=false/);
   assert.match(shared, /os: macos-15-intel/, 'macOS packaging stays on the Intel runner that carries the Electron legal bundle');
   assert.doesNotMatch(shared, /- os: macos-latest/, 'macos-latest is arm64 and cannot package the verified legal bundle');
+  assert.match(shared, /node scripts\/ensure-rollup-native\.mjs/, 'release runners repair npm optional Rollup binaries before building');
 
   const configPath = require.resolve(path.join(repoRoot, 'build/electron-builder.release.cjs'));
   const previousChannel = process.env.NODUS_RELEASE_CHANNEL;

--- a/scripts/test-update-channels.mjs
+++ b/scripts/test-update-channels.mjs
@@ -104,6 +104,8 @@ test('stable and beta publication have isolated entry points and shared build lo
   assert.match(shared, /beta-mac\.yml beta\.yml beta-linux\.yml/);
   assert.match(shared, /Beta release contains stable update manifest/);
   assert.match(shared, /--prerelease --latest=false/);
+  assert.match(shared, /os: macos-15-intel/, 'macOS packaging stays on the Intel runner that carries the Electron legal bundle');
+  assert.doesNotMatch(shared, /- os: macos-latest/, 'macos-latest is arm64 and cannot package the verified legal bundle');
 
   const configPath = require.resolve(path.join(repoRoot, 'build/electron-builder.release.cjs'));
   const previousChannel = process.env.NODUS_RELEASE_CHANNEL;


### PR DESCRIPTION
## Resumen

- fija el empaquetado de macOS en macos-15-intel después de que macos-latest pasara a ARM64
- conserva la salida arm64 mediante el cross-build ya configurado
- añade una regresión para impedir volver al runner que no incluye el bundle legal esperado por beforePack

## Validación

- 73 pruebas de canales y Zotero
- npm run lint
- git diff --check

Desbloquea el instalador macOS de v4.2.0; la release permanece en borrador.