### PR TITLE
Fix macOS ARM64 runtime packaging for v4.2.0

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,27 +30,50 @@ jobs:
       - name: Verify citation version
         run: npm run citation:check && npm run release:verify-source
 
-  release:
+  prepare-release:
     needs: validate-release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag }}
+    steps:
+      - name: Create or reuse the single draft release
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            draft="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
+            if [[ "$draft" != true ]]; then
+              echo "::error::Release $RELEASE_TAG already exists and is not a draft"
+              exit 1
+            fi
+          else
+            gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft \
+              --title "${RELEASE_TAG#v}"
+          fi
+
+  release:
+    needs: prepare-release
     env:
       HAS_MACOS_SIGNING: ${{ secrets.MACOS_CERTIFICATE != '' }}
       NODUS_RELEASE_CHANNEL: ${{ inputs.channel }}
       RELEASE_TAG: ${{ inputs.tag }}
     strategy:
       fail-fast: false
-      # electron-builder creates one shared draft. Serialising the native builds
-      # prevents simultaneous attempts to create that draft release.
-      max-parallel: 1
       matrix:
         include:
-          # The release targets arm64, but packaging remains pinned to Intel so
-          # electron-builder can cross-build the configured target consistently.
-          - os: macos-15-intel
+          # The application targets Apple Silicon. npm selects native optional
+          # dependencies from the host architecture, so this must be ARM64 too.
+          - os: macos-latest
             platform: '--mac'
+            asset-platform: mac
           - os: windows-latest
             platform: '--win'
+            asset-platform: win
           - os: ubuntu-latest
             platform: '--linux'
+            asset-platform: linux
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout release tag
@@ -81,36 +104,35 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
         run: npm run build
 
-      - name: Build and publish Windows installer
+      - name: Build Windows installer
         if: matrix.os == 'windows-latest'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx electron-builder ${{ matrix.platform }} --publish always --config build/electron-builder.release.cjs
+        run: npx electron-builder ${{ matrix.platform }} --publish never --config build/electron-builder.release.cjs
 
-      - name: Build and publish signed macOS installer
-        if: matrix.os == 'macos-15-intel' && env.HAS_MACOS_SIGNING == 'true'
+      - name: Build signed macOS installer
+        if: matrix.os == 'macos-latest' && env.HAS_MACOS_SIGNING == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MACOS_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
           CSC_IDENTITY_AUTO_DISCOVERY: true
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npx electron-builder ${{ matrix.platform }} --publish always --config build/electron-builder.release.cjs
+        run: npx electron-builder ${{ matrix.platform }} --publish never --config build/electron-builder.release.cjs
 
-      - name: Build and publish ad-hoc macOS installer
-        if: matrix.os == 'macos-15-intel' && env.HAS_MACOS_SIGNING != 'true'
+      - name: Build ad-hoc macOS installer
+        if: matrix.os == 'macos-latest' && env.HAS_MACOS_SIGNING != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
-        run: npx electron-builder ${{ matrix.platform }} --publish always --config build/electron-builder.release.cjs
+        run: npx electron-builder ${{ matrix.platform }} --publish never --config build/electron-builder.release.cjs
 
-      - name: Build and publish Linux installer
+      - name: Build Linux installer
         if: matrix.os == 'ubuntu-latest'
+        run: npx electron-builder ${{ matrix.platform }} --publish never --config build/electron-builder.release.cjs
+
+      - name: Upload platform assets to the single draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx electron-builder ${{ matrix.platform }} --publish always --config build/electron-builder.release.cjs
+        run: node scripts/upload-release-assets.mjs ${{ matrix.asset-platform }}
 
   build-zotero-plugin:
     # The fixed-name plugin assets remain stable-only: installed plugins resolve

--- a/build/afterPack.cjs
+++ b/build/afterPack.cjs
@@ -5,6 +5,7 @@
 const { execFileSync, spawnSync } = require('node:child_process');
 const { copyFileSync, existsSync, mkdirSync } = require('node:fs');
 const path = require('node:path');
+const { verifyPackagedNativeRuntime } = require('../scripts/verify-packaged-native-runtime.cjs');
 
 exports.default = async function afterPack(context) {
   const appName = context.packager.appInfo.productFilename; // "Nodus"
@@ -29,6 +30,11 @@ exports.default = async function afterPack(context) {
   copyFileSync(chromiumLicenses, path.join(resourcesPath, 'LICENSES.chromium.html'));
 
   if (context.electronPlatformName !== 'darwin') return;
+
+  // npm optional native packages follow the runner architecture. The macOS
+  // product is ARM64-only, so fail packaging before signing if an Intel runner
+  // (or a stale Intel dependency tree) ever slips back into the release path.
+  verifyPackagedNativeRuntime(appPath);
 
   const signature = spawnSync('codesign', ['-dv', '--verbose=4', appPath], { encoding: 'utf8' });
   const signatureInfo = `${signature.stdout || ''}\n${signature.stderr || ''}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1090,6 +1090,8 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
@@ -1232,6 +1234,8 @@
     },
     "node_modules/@github/copilot-darwin-arm64": {
       "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.71.tgz",
+      "integrity": "sha512-mEWzyqbqRAWgyU7i2uuSRoVPx/TwaFQX0nZmw0bc30aJ0BnO7cy2kYQyCHw8ykmf/tfxT0xauZ6k0BOFmWizzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1397,6 +1401,8 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -1417,6 +1423,8 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -1480,6 +1488,8 @@
     },
     "node_modules/@koromix/koffi-darwin-arm64": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.1.tgz",
+      "integrity": "sha512-+Dl0zQDh1Wb55AWOn9hp7K30qgkODvrvN+ZNkFOh81Q0oFX/rpJQtocgjAuYk2zFAcajSeVDumkcHMPwnKSXzA==",
       "cpu": [
         "arm64"
       ],
@@ -2125,6 +2135,8 @@
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
       "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
       "cpu": [
         "arm64"
       ],
@@ -2212,6 +2224,8 @@
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
       "version": "0.144.6-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-arm64.tgz",
+      "integrity": "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==",
       "cpu": [
         "arm64"
       ],
@@ -2328,6 +2342,8 @@
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],

--- a/scripts/test-packaged-native-runtime.mjs
+++ b/scripts/test-packaged-native-runtime.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { selectReleaseAssets } from './upload-release-assets.mjs';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  assertArm64Binary,
+  findIntelRuntimePaths,
+} = require(path.join(repoRoot, 'scripts/verify-packaged-native-runtime.cjs'));
+
+test('packaged runtime audit detects Intel-only optional dependencies', () => {
+  const paths = [
+    '/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node',
+    '/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex',
+    '/node_modules/@koromix/koffi-darwin_x64/darwin_x64/koffi.node',
+  ];
+  assert.deepEqual(findIntelRuntimePaths(paths), [paths[0], paths[2]]);
+});
+
+test('packaged runtime audit requires an ARM64 slice', () => {
+  assert.doesNotThrow(() => assertArm64Binary('fixture', import.meta.filename, () => ['arm64']));
+  assert.throws(
+    () => assertArm64Binary('fixture', import.meta.filename, () => ['x86_64']),
+    /is not ARM64/,
+  );
+});
+
+test('release uploader selects only one platform and its current channel manifest', () => {
+  const entries = [
+    'Nodus-mac-arm64.dmg',
+    'Nodus-mac-arm64.dmg.blockmap',
+    'Nodus-mac-arm64.zip',
+    'latest-mac.yml',
+    'beta-mac.yml',
+    'builder-debug.yml',
+  ];
+  assert.deepEqual(selectReleaseAssets('mac', 'latest', entries), [
+    'Nodus-mac-arm64.dmg',
+    'Nodus-mac-arm64.dmg.blockmap',
+    'Nodus-mac-arm64.zip',
+    'latest-mac.yml',
+  ]);
+  assert.throws(() => selectReleaseAssets('win', 'latest', entries), /Missing win release asset/);
+});

--- a/scripts/test-update-channels.mjs
+++ b/scripts/test-update-channels.mjs
@@ -104,39 +104,46 @@ test('stable and beta publication have isolated entry points and shared build lo
   assert.match(shared, /beta-mac\.yml beta\.yml beta-linux\.yml/);
   assert.match(shared, /Beta release contains stable update manifest/);
   assert.match(shared, /--prerelease --latest=false/);
-  assert.match(shared, /os: macos-15-intel/, 'macOS packaging stays on the explicit Intel runner used for cross-building');
-  assert.doesNotMatch(shared, /- os: macos-latest/, 'release packaging does not depend on the moving macOS runner alias');
+  assert.match(shared, /- os: macos-latest/, 'ARM64 macOS packaging runs on an ARM64 host for native optional dependencies');
+  assert.doesNotMatch(shared, /macos-15-intel/, 'the ARM64 application is never packaged from an Intel dependency tree');
   assert.match(shared, /node node_modules\/electron\/install\.js/, 'release runners install Electron legal files before packaging');
+  assert.match(shared, /gh release create[\s\S]*--draft/, 'the workflow creates one explicit draft before native builds');
+  assert.match(shared, /upload-release-assets\.mjs/, 'all platforms upload to the explicit shared draft');
+  assert.doesNotMatch(shared, /--publish always/, 'electron-builder cannot create competing draft releases');
 
   const lock = JSON.parse(await read('package-lock.json'));
   const nativePackages = [
-    '@esbuild/darwin-x64',
+    '@esbuild/darwin-arm64',
     '@esbuild/linux-x64',
     '@esbuild/win32-x64',
-    '@github/copilot-darwin-x64',
+    '@github/copilot-darwin-arm64',
     '@github/copilot-linux-x64',
     '@github/copilot-win32-x64',
-    '@img/sharp-darwin-x64',
+    '@img/sharp-darwin-arm64',
+    '@img/sharp-libvips-darwin-arm64',
     '@img/sharp-linux-x64',
     '@img/sharp-win32-x64',
-    '@koromix/koffi-darwin-x64',
+    '@koromix/koffi-darwin-arm64',
     '@koromix/koffi-linux-x64',
     '@koromix/koffi-win32-x64',
-    '@napi-rs/canvas-darwin-x64',
+    '@napi-rs/canvas-darwin-arm64',
     '@napi-rs/canvas-linux-x64-gnu',
     '@napi-rs/canvas-win32-x64-msvc',
-    '@openai/codex-darwin-x64',
+    '@openai/codex-darwin-arm64',
     '@openai/codex-linux-x64',
     '@openai/codex-win32-x64',
-    '@rollup/rollup-darwin-x64',
+    '@rollup/rollup-darwin-arm64',
     '@rollup/rollup-linux-x64-gnu',
     '@rollup/rollup-win32-x64-msvc',
   ];
   for (const packageName of nativePackages) {
-    assert.ok(lock.packages[`node_modules/${packageName}`], `${packageName} is locked for release runners`);
+    const entry = lock.packages[`node_modules/${packageName}`];
+    assert.ok(entry, `${packageName} is locked for release runners`);
+    assert.ok(entry.resolved, `${packageName} has a deterministic tarball URL`);
+    assert.ok(entry.integrity, `${packageName} has a deterministic integrity hash`);
   }
-  assert.equal(lock.packages['node_modules/@koromix/koffi-darwin-x64'].version, '3.1.1');
-  assert.equal(lock.packages['node_modules/@rollup/rollup-darwin-x64'].version, '4.62.0');
+  assert.equal(lock.packages['node_modules/@koromix/koffi-darwin-arm64'].version, '3.1.1');
+  assert.equal(lock.packages['node_modules/@rollup/rollup-darwin-arm64'].version, '4.62.0');
 
   const configPath = require.resolve(path.join(repoRoot, 'build/electron-builder.release.cjs'));
   const previousChannel = process.env.NODUS_RELEASE_CHANNEL;

--- a/scripts/upload-release-assets.mjs
+++ b/scripts/upload-release-assets.mjs
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const releaseDir = path.join(repoRoot, 'release');
+
+const expectedByPlatform = {
+  mac: ['Nodus-mac-arm64.dmg', 'Nodus-mac-arm64.zip'],
+  win: ['Nodus-win-x64.exe'],
+  linux: ['Nodus-linux-amd64.deb', 'Nodus-linux-x86_64.AppImage'],
+};
+
+const manifestByPlatform = {
+  mac: (channel) => `${channel}-mac.yml`,
+  win: (channel) => `${channel}.yml`,
+  linux: (channel) => `${channel}-linux.yml`,
+};
+
+export function selectReleaseAssets(platform, channel, entries) {
+  const expected = expectedByPlatform[platform];
+  if (!expected) throw new Error(`Unsupported release platform: ${platform}`);
+  if (channel !== 'latest' && channel !== 'beta') {
+    throw new Error(`Unsupported release channel: ${channel}`);
+  }
+
+  const manifest = manifestByPlatform[platform](channel);
+  for (const filename of [...expected, manifest]) {
+    if (!entries.includes(filename)) throw new Error(`Missing ${platform} release asset: ${filename}`);
+  }
+
+  const selected = entries
+    .filter((filename) => filename.startsWith('Nodus-') || filename === manifest)
+    .sort();
+  if (selected.length === 0) throw new Error(`No ${platform} release assets found`);
+  return selected;
+}
+
+export function uploadReleaseAssets({ platform, channel, tag, repository }) {
+  const entries = readdirSync(releaseDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name);
+  const assets = selectReleaseAssets(platform, channel, entries)
+    .map((filename) => path.join(releaseDir, filename));
+
+  execFileSync('gh', [
+    'release', 'upload', tag,
+    ...assets,
+    '--repo', repository,
+    '--clobber',
+  ], { cwd: repoRoot, stdio: 'inherit' });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  uploadReleaseAssets({
+    platform: process.argv[2],
+    channel: process.env.NODUS_RELEASE_CHANNEL,
+    tag: process.env.RELEASE_TAG,
+    repository: process.env.GITHUB_REPOSITORY,
+  });
+}

--- a/scripts/verify-packaged-native-runtime.cjs
+++ b/scripts/verify-packaged-native-runtime.cjs
@@ -1,0 +1,67 @@
+const { execFileSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const path = require('node:path');
+const asar = require('@electron/asar');
+
+const REQUIRED_ARM64_BINARIES = [
+  ['Canvas', '@napi-rs/canvas-darwin-arm64/skia.darwin-arm64.node'],
+  ['Sharp', '@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node'],
+  ['libvips', '@img/sharp-libvips-darwin-arm64/lib/libvips-cpp.8.17.3.dylib'],
+  ['Koffi', '@koromix/koffi-darwin-arm64/darwin_arm64/koffi.node'],
+  ['Codex', '@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex'],
+  ['Copilot', '@github/copilot-darwin-arm64/copilot'],
+  ['Copilot native runtime', '@github/copilot-darwin-arm64/prebuilds/darwin-arm64/runtime.node'],
+];
+
+const INTEL_PACKAGE_MARKERS = [
+  /darwin-x64/i,
+  /darwin_x64/i,
+  /x86_64-apple-darwin/i,
+];
+
+function findIntelRuntimePaths(entries) {
+  return entries.filter((entry) => INTEL_PACKAGE_MARKERS.some((marker) => marker.test(entry)));
+}
+
+function getArchitectures(filename) {
+  return execFileSync('lipo', ['-archs', filename], { encoding: 'utf8' }).trim().split(/\s+/);
+}
+
+function assertArm64Binary(label, filename, architectureReader = getArchitectures) {
+  if (!existsSync(filename)) throw new Error(`Missing packaged ARM64 ${label}: ${filename}`);
+  const architectures = architectureReader(filename);
+  if (!architectures.includes('arm64')) {
+    throw new Error(`Packaged ${label} is not ARM64 (${architectures.join(', ')}): ${filename}`);
+  }
+}
+
+function verifyPackagedNativeRuntime(appPath, options = {}) {
+  const resourcesPath = path.join(appPath, 'Contents', 'Resources');
+  const asarPath = path.join(resourcesPath, 'app.asar');
+  const unpackedModules = path.join(resourcesPath, 'app.asar.unpacked', 'node_modules');
+  if (!existsSync(asarPath)) throw new Error(`Missing packaged application archive: ${asarPath}`);
+
+  const archiveEntries = (options.listPackage || asar.listPackage)(asarPath);
+  const intelEntries = findIntelRuntimePaths(archiveEntries);
+  if (intelEntries.length > 0) {
+    throw new Error(`Intel-only macOS runtime packages were bundled:\n${intelEntries.slice(0, 20).join('\n')}`);
+  }
+
+  const appName = path.basename(appPath, '.app');
+  assertArm64Binary(
+    'Electron executable',
+    path.join(appPath, 'Contents', 'MacOS', appName),
+    options.getArchitectures,
+  );
+  for (const [label, relativePath] of REQUIRED_ARM64_BINARIES) {
+    assertArm64Binary(label, path.join(unpackedModules, relativePath), options.getArchitectures);
+  }
+  console.log(`[native-runtime] Verified ARM64 Electron, Canvas, Sharp, Koffi, Codex and Copilot in ${appPath}`);
+}
+
+module.exports = {
+  REQUIRED_ARM64_BINARIES,
+  assertArm64Binary,
+  findIntelRuntimePaths,
+  verifyPackagedNativeRuntime,
+};


### PR DESCRIPTION
Fixes the v4.2.0 startup crash caused by Intel-only optional native packages in the Apple Silicon build.\n\n- package macOS on the ARM64 runner\n- audit Electron, Canvas, Sharp, Koffi, Codex and Copilot before signing\n- lock the ARM64 optional tarballs and integrity hashes\n- create one release draft and upload every platform to it\n\nVerified locally with lint, build, 2,105 tests, a full DMG build, native architecture audit, and an app launch from the mounted DMG.