### PR TITLE
Fix site intro timing and canonical navigation

### DIFF
--- a/scripts/build-blog-pages.mjs
+++ b/scripts/build-blog-pages.mjs
@@ -97,7 +97,7 @@ ${image ? `<meta name="twitter:image" content="${escapeHtml(image)}"/>` : ''}
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">
@@ -135,9 +135,9 @@ ${next ? `        <a class="btn" href="${encodeURIComponent(next.slug)}/">${esca
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -159,7 +159,7 @@ ${next ? `        <a class="btn" href="${encodeURIComponent(next.slug)}/">${esca
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/scripts/test-site-pages.mjs
+++ b/scripts/test-site-pages.mjs
@@ -43,7 +43,8 @@ test('the home page presents the four main vaults, the rest, and the toolkit', (
   assert.doesNotMatch(home, /at no extra cost/, 'the toolkit no longer needs the price disclaimer');
   // the vault demos advertised on the home page must exist
   for (const demo of ['index', 'teaching', 'study', 'databases', 'genealogy', 'worldbuilding']) {
-    assert.ok(home.includes(`demo/${demo}.html`), `the home page links the ${demo} demo`);
+    const href = demo === 'index' ? 'demo/' : `demo/${demo}.html`;
+    assert.ok(home.includes(href), `the home page links the ${demo} demo`);
     assert.ok(fs.existsSync(path.join(siteRoot, 'demo', `${demo}.html`)), `site/demo/${demo}.html exists`);
   }
 });
@@ -228,12 +229,15 @@ test('the home page opens with the mark forming, and can never strand a visitor'
 
   // armed before the first paint, so the page never flashes and then hides
   assert.match(home, /classList\.add\('intro-armed'\)/, 'the opening is armed inline in <head>');
+  assert.match(home, /min-width: 701px/, 'the opening is never armed in a mobile viewport');
   assert.match(home, /prefers-reduced-motion: reduce/, 'reduced motion never arms the opening');
   // the same inline script owns a watchdog, so a missing home.js cannot leave a blank page
   assert.match(home, /setTimeout\(function \(\) \{[\s\S]*?intro-done[\s\S]*?\}, 6000\)/, 'the inline watchdog reveals the page on its own');
   assert.match(css, /body \{[\s\S]*?radial-gradient[\s\S]*?background-attachment: fixed;/, 'a finished-looking background exists before WebGL starts');
   assert.match(css, /#organism \{ transition-duration: 0\.3s; \}/, 'the live field replaces the static paint quickly');
   assert.match(script, /const HOLD = 1200;/, 'the opening releases promptly instead of holding an empty hero');
+  assert.match(script, /organism-assembled/, 'the hold starts only after the field has finished assembling the mark');
+  assert.match(read('assets/js/organism.js'), /dataset\.formation === 'on' && openingIsArmed/, 'mobile and unarmed visits never assemble a hidden N');
   assert.match(css, /\.hero \{[\s\S]*?-webkit-user-select: none;[\s\S]*?user-select: none;/, 'visible hero copy cannot be accidentally selected');
 
   // three separately masked lines, one per beat of the motto
@@ -313,8 +317,33 @@ test('the topic pages are linked from the home page and to each other', () => {
     for (const href of required) {
       assert.ok(html.includes(`href="${href}"`), `${page} links to ${href}`);
     }
-    assert.ok(html.includes('href="../index.html"'), `${page} links back to the home page`);
+    assert.ok(html.includes('href="../"'), `${page} links back to the canonical home page`);
   }
+});
+
+test('internal navigation only advertises canonical directory URLs', () => {
+  const publishedSources = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (/\.(?:html|js)$/.test(entry.name)) publishedSources.push(fs.readFileSync(absolute, 'utf8'));
+    }
+  };
+  visit(siteRoot);
+  publishedSources.push(fs.readFileSync(path.join(repoRoot, 'scripts', 'build-blog-pages.mjs'), 'utf8'));
+
+  for (const source of publishedSources) {
+    assert.doesNotMatch(source, /href\s*=\s*["'][^"']*index\.html/i, 'no rendered or generated link points to an index filename');
+  }
+
+  const header = read('site-header.js');
+  assert.match(header, /href: \(base\) => base \|\| '\.\/'/, 'the shared Home link resolves to the canonical directory');
+  assert.match(header, /pathname\.endsWith\('\/index\.html'\)[\s\S]*?location\.replace/, 'GitHub Pages index aliases are replaced client-side');
+
+  const demoSwitcher = read('demo/vault-switcher.js');
+  assert.match(demoSwitcher, /\{ page: 'index\.html', href: '\.\/'/, 'the academic demo advertises its directory URL');
+  assert.match(demoSwitcher, /href="\$\{vault\.href \|\| vault\.page\}"/, 'the demo switcher uses a canonical override when one exists');
 });
 
 test('the sitemap lists every static page of the site', () => {

--- a/site/ai-research/index.html
+++ b/site/ai-research/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="ai-research"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main">
 
@@ -55,7 +55,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="scrim" style="max-width:820px">
       <nav class="breadcrumb" aria-label="Breadcrumb">
-        <a href="../index.html">Nodus</a>
+        <a href="../">Nodus</a>
         <span class="sep" aria-hidden="true">/</span>
         <span aria-current="page">AI for academic research</span>
       </nav>
@@ -63,7 +63,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <h1 class="display" data-split>AI for Academic Research</h1>
       <p class="lead">A general chatbot answers from whatever it absorbed during training. Nodus asks a model to work on something much narrower and far more useful, namely the documents, sources and notes <em>you</em> brought in. Every interpretation it produces is stored with the passage behind it, so you can check the output against the page instead of taking it on faith.</p>
       <div class="guide-actions">
-        <a class="btn primary" href="../demo/index.html">
+        <a class="btn primary" href="../demo/">
           <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
           See it on a sample corpus
         </a>
@@ -316,7 +316,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -76,7 +76,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="app"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main">
 
@@ -84,7 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="scrim" style="max-width:840px">
       <nav class="breadcrumb" aria-label="Breadcrumb">
-        <a href="../index.html">Nodus Research</a>
+        <a href="../">Nodus Research</a>
         <span class="sep" aria-hidden="true">/</span>
         <span aria-current="page">App</span>
       </nav>
@@ -220,7 +220,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     </div>
 
     <div class="guide-note reveal">
-      <p>Five specialised vaults also ship in the application: <b>Genealogy</b>, <b>Worldbuilding</b>, <b>Primary Sources</b>, <b>Testimony</b> and <b>Prosopography</b>. See the <a href="../index.html#vaults">main vaults</a> and <a href="../index.html#more-vaults">specialised vaults</a> on the home page for a brief picture of each.</p>
+      <p>Five specialised vaults also ship in the application: <b>Genealogy</b>, <b>Worldbuilding</b>, <b>Primary Sources</b>, <b>Testimony</b> and <b>Prosopography</b>. See the <a href="../#vaults">main vaults</a> and <a href="../#more-vaults">specialised vaults</a> on the home page for a brief picture of each.</p>
     </div>
   </div>
 </section>
@@ -423,7 +423,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <h3>Learn</h3>
         <a href="../wiki/">Wiki</a>
         <a href="../faq/">FAQ</a>
-        <a href="../index.html">Nodus Research</a>
+        <a href="../">Nodus Research</a>
       </div>
       <div class="foot-col">
         <h3>Project</h3>
@@ -440,7 +440,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/assets/js/home.js
+++ b/site/assets/js/home.js
@@ -16,15 +16,18 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
      moves the page between the three states, drives the organism's handoff, and
      makes sure the sequence can always be skipped or recovered from. */
 
-  const HOLD = 1200;   // enough to read the assembled N without delaying the page
-  const TAIL = 2750;   // the CSS timeline that runs after the release
+  const HOLD = 1200;              // time to read the N after it is fully assembled
+  const ASSEMBLY_TIMEOUT = 3600;  // recovery path if the renderer never settles
+  const TAIL = 2750;              // the CSS timeline that runs after the release
 
   function opening() {
     const root = document.documentElement;
     if (!root.classList.contains('intro-armed')) return; // reduced motion, or JS-off markup
 
     let finished = false;
+    let released = false;
     let timers = [];
+    const canvas = document.getElementById('organism');
 
     const finish = () => {
       if (finished) return;
@@ -33,6 +36,7 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
       timers = [];
       root.classList.remove('intro-armed', 'intro-run');
       root.classList.add('intro-done');
+      if (canvas) canvas.removeEventListener('organism-assembled', onAssembled);
       const engine = window.NodusOrganism;
       if (engine) engine.assemble(false);
       skip.remove();
@@ -40,7 +44,11 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
     };
 
     const release = () => {
-      if (finished) return;
+      if (finished || released) return;
+      // The organism can stand down while we wait (WebGL loss or frame-budget
+      // governor). In that case it already revealed the page; never re-arm it.
+      if (!root.classList.contains('intro-armed')) { finish(); return; }
+      released = true;
       root.classList.remove('intro-armed');
       root.classList.add('intro-run');
       const engine = window.NodusOrganism;
@@ -50,6 +58,11 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
         engine.pulse(innerWidth / 2, innerHeight * 0.46, 2.4);
       }
       timers.push(setTimeout(finish, TAIL));
+    };
+
+    const onAssembled = () => {
+      if (finished) return;
+      timers.push(setTimeout(release, HOLD));
     };
 
     // anyone who has seen it can leave early
@@ -76,9 +89,18 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
     // back to a title sequence.
     if (scrollY > 40 || location.hash) { finish(); return; }
 
-    timers.push(setTimeout(release, HOLD));
+    if (!canvas || !window.NodusOrganism) {
+      finish();
+      return;
+    }
+    if (canvas.dataset.organismAssembled === 'true') onAssembled();
+    else canvas.addEventListener('organism-assembled', onAssembled, { once: true });
+
+    // The visual signal normally wins. This timeout exists only so a context
+    // that keeps drawing but never converges cannot hold the page indefinitely.
+    timers.push(setTimeout(release, ASSEMBLY_TIMEOUT + HOLD));
     // last-resort guard: the page can never stay stuck in its opening state
-    timers.push(setTimeout(finish, HOLD + TAIL + 1500));
+    timers.push(setTimeout(finish, ASSEMBLY_TIMEOUT + HOLD + TAIL + 700));
   }
 
   /* ------------------------------------------------------------ presenter stage */

--- a/site/assets/js/organism.js
+++ b/site/assets/js/organism.js
@@ -377,6 +377,8 @@ for reduced motion.
       formation: 0,        // 0 = free drift, 1 = assembled into the N
       markScale: 1,        // how large the assembled mark is, relative to a phone
       formationTarget: 0,
+      formationSettledFrames: 0,
+      formationAnnounced: false,
       waves: [],           // click shockwaves
       time: 0,
       running: false,
@@ -497,6 +499,7 @@ for reduced motion.
       const form = state.formation;
       const energy = state.energy;
 
+      let formationError = 0;
       for (let i = 0; i < count; i++) {
         const s = seed[i];
         const m = mass[i];
@@ -553,11 +556,34 @@ for reduced motion.
         px[i] += vx[i] * dt * (1 + energy * 0.5);
         py[i] += vy[i] * dt * (1 + energy * 0.5);
 
+        if (state.formationTarget === 1) {
+          formationError += Math.hypot(px[i] - fx[i], py[i] - fy[i]);
+        }
+
         // wrap the drift anchors so the field never drains off one edge
         if (hx[i] < -80) hx[i] += state.width + 160;
         else if (hx[i] > state.width + 80) hx[i] -= state.width + 160;
         if (hy[i] < -80) hy[i] += state.height + 160;
         else if (hy[i] > state.height + 80) hy[i] -= state.height + 160;
+      }
+
+      /* Do not time the title shot from DOMContentLoaded: on a large viewport
+         the nodes need longer to travel than on a small one. Announce the mark
+         only after the formation blend is effectively complete and the nodes
+         themselves have settled close to their targets for several frames. */
+      if (state.formationTarget === 1 && !state.formationAnnounced) {
+        const averageError = formationError / Math.max(1, count);
+        const settledDistance = Math.max(9, 14 * state.markScale);
+        if (state.formation >= 0.985 && averageError <= settledDistance) {
+          state.formationSettledFrames++;
+          if (state.formationSettledFrames >= 6) {
+            state.formationAnnounced = true;
+            canvas.dataset.organismAssembled = 'true';
+            canvas.dispatchEvent(new CustomEvent('organism-assembled'));
+          }
+        } else {
+          state.formationSettledFrames = 0;
+        }
       }
     }
 
@@ -802,7 +828,14 @@ for reduced motion.
       scrolled(velocity) {
         state.scrollBoost = Math.min(0.8, state.scrollBoost + Math.min(0.34, Math.abs(velocity) * 0.0016));
       },
-      assemble(on) { state.formationTarget = on ? 1 : 0; },
+      assemble(on) {
+        state.formationTarget = on ? 1 : 0;
+        if (on) {
+          state.formationSettledFrames = 0;
+          state.formationAnnounced = false;
+          delete canvas.dataset.organismAssembled;
+        }
+      },
     };
   }
 
@@ -860,7 +893,8 @@ for reduced motion.
     // The field draws the Nodus N on arrival and holds it: on the home page that
     // is the whole opening shot, with the rest of the page still hidden. The
     // sequence in home.js decides when it bursts and the page arrives.
-    if (document.body.dataset.formation === 'on') {
+    const openingIsArmed = document.documentElement.classList.contains('intro-armed');
+    if (document.body.dataset.formation === 'on' && openingIsArmed) {
       organism.assemble(true);
       // home.js drives the actual release; this only stops the field being stuck
       // in the mark if that script never runs.

--- a/site/blog/how-nodus-can-support-research-in-the-humanities/index.html
+++ b/site/blog/how-nodus-can-support-research-in-the-humanities/index.html
@@ -41,7 +41,7 @@ Generated from posts/how-nodus-can-support-research-in-the-humanities.md by scri
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">
@@ -109,9 +109,9 @@ Generated from posts/how-nodus-can-support-research-in-the-humanities.md by scri
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -133,7 +133,7 @@ Generated from posts/how-nodus-can-support-research-in-the-humanities.md by scri
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/blog/how-to-organize-a-large-academic-research-library/index.html
+++ b/site/blog/how-to-organize-a-large-academic-research-library/index.html
@@ -41,7 +41,7 @@ Generated from posts/how-to-organize-a-large-academic-research-library.md by scr
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">
@@ -108,9 +108,9 @@ Generated from posts/how-to-organize-a-large-academic-research-library.md by scr
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -132,7 +132,7 @@ Generated from posts/how-to-organize-a-large-academic-research-library.md by scr
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -29,7 +29,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#22d3ee" data-energy="0.28">
   <header class="page-hero">
@@ -98,9 +98,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -145,7 +145,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </section>
 </div>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="blog.js?v=20260820"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>

--- a/site/blog/nodus-open-source-research-workspace/index.html
+++ b/site/blog/nodus-open-source-research-workspace/index.html
@@ -41,7 +41,7 @@ Generated from posts/nodus-open-source-research-workspace.md by scripts/build-bl
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">
@@ -103,9 +103,9 @@ Generated from posts/nodus-open-source-research-workspace.md by scripts/build-bl
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -127,7 +127,7 @@ Generated from posts/nodus-open-source-research-workspace.md by scripts/build-bl
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/blog/post.html
+++ b/site/blog/post.html
@@ -32,7 +32,7 @@ Compatibility redirect for the former /blog/post.html?p=<slug> URLs.
 <a class="skip-link" href="#main">Skip to the message</a>
 <canvas id="organism" aria-hidden="true"></canvas>
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.18">
   <section class="page-hero">
@@ -45,7 +45,7 @@ Compatibility redirect for the former /blog/post.html?p=<slug> URLs.
   </section>
 </main>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 </body>
 </html>

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="contribute"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main">
 
@@ -202,9 +202,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -226,7 +226,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="contribute.js?v=20260817f"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>

--- a/site/demo/databases.html
+++ b/site/demo/databases.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page db">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script defer src="../site-header.js?v=20260820a"></script>
+  <script defer src="../site-header.js?v=20260820b"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>
@@ -38,7 +38,7 @@
   <div id="modal-root"></div>
   <div id="toast" role="status"></div>
   <script src="databases-data.js?v=db1"></script>
-  <script src="vault-switcher.js?v=20260820b"></script>
+  <script src="vault-switcher.js?v=20260820c"></script>
   <script src="databases-app.js?v=db1"></script>
   <script src="mobile.js?v=20260801-responsive"></script>
   <script src="../nodi.js?v=20260720-menu1"></script>

--- a/site/demo/genealogy.html
+++ b/site/demo/genealogy.html
@@ -19,7 +19,7 @@
 </head>
 <body class="demo-page gen">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script defer src="../site-header.js?v=20260820a"></script>
+  <script defer src="../site-header.js?v=20260820b"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>
@@ -41,7 +41,7 @@
   <div id="toast" role="status"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="genealogy-data.js?v=204"></script>
-  <script src="vault-switcher.js?v=20260820b"></script>
+  <script src="vault-switcher.js?v=20260820c"></script>
   <script src="genealogy-app.js?v=204"></script>
   <script src="mobile.js?v=20260801-responsive"></script>
   <script src="../nodi.js?v=20260720-menu1"></script>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script defer src="../site-header.js?v=20260820a"></script>
+  <script defer src="../site-header.js?v=20260820b"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>
@@ -40,7 +40,7 @@
   <div id="bottom-player"></div>
   <div id="toast" role="status"></div>
   <script src="data.js?v=201"></script>
-  <script src="vault-switcher.js?v=20260820b"></script>
+  <script src="vault-switcher.js?v=20260820c"></script>
   <script src="app.js?v=20260820c"></script>
   <script src="mobile.js?v=20260801-responsive"></script>
   <script src="../nodi.js?v=20260720-menu1"></script>

--- a/site/demo/study.html
+++ b/site/demo/study.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page st">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script defer src="../site-header.js?v=20260820a"></script>
+  <script defer src="../site-header.js?v=20260820b"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>
@@ -38,7 +38,7 @@
   <div id="modal-root"></div>
   <div id="toast" role="status"></div>
   <script src="study-data.js?v=20260717"></script>
-  <script src="vault-switcher.js?v=20260820b"></script>
+  <script src="vault-switcher.js?v=20260820c"></script>
   <script src="study-app.js?v=20260717b"></script>
   <script src="mobile.js?v=20260801-responsive"></script>
   <script src="../nodi.js?v=20260720-menu1"></script>

--- a/site/demo/teaching.html
+++ b/site/demo/teaching.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page teach">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script defer src="../site-header.js?v=20260820a"></script>
+  <script defer src="../site-header.js?v=20260820b"></script>
   <div class="demo-frame">
     <div class="mac-titlebar"><span class="mac-dots"><i></i><i></i><i></i></span><span class="mac-title">Nodus — Teaching demo</span></div>
     <div class="shell teach">
@@ -28,7 +28,7 @@
   </div>
   <div id="modal-root"></div><div id="toast" role="status"></div>
   <script src="teaching-data.js?v=20260719"></script>
-  <script src="vault-switcher.js?v=20260820b"></script>
+  <script src="vault-switcher.js?v=20260820c"></script>
   <script src="teaching-app.js?v=20260719"></script>
   <script src="mobile.js?v=20260801-responsive"></script>
   <script src="../nodi.js?v=20260720-menu1"></script>

--- a/site/demo/vault-switcher.js
+++ b/site/demo/vault-switcher.js
@@ -23,7 +23,7 @@ corresponding static demo instead of loading a local database.
   const appIcon = (name) => `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${appIconPaths[name]}</svg>`;
 
   const vaults = [
-    { page: 'index.html', name: 'Learning science', type: 'Academic', tone: 'academic', icon: 'network' },
+    { page: 'index.html', href: './', name: 'Learning science', type: 'Academic', tone: 'academic', icon: 'network' },
     { page: 'teaching.html', name: 'Year 9 History', type: 'Teaching', tone: 'teaching', icon: 'presentation', phase: 'BETA' },
     { page: 'study.html', name: 'General Biology', type: 'Study', tone: 'study', icon: 'graduation', phase: 'BETA' },
     { page: 'databases.html', name: 'Field research', type: 'Databases', tone: 'databases', icon: 'table', phase: 'BETA' },
@@ -39,7 +39,7 @@ corresponding static demo instead of loading a local database.
   const bar = document.createElement('header');
   bar.className = 'demo-appbar';
   bar.innerHTML = `
-    <a class="demo-app-brand" href="../index.html" aria-label="Nodus home">
+    <a class="demo-app-brand" href="../" aria-label="Nodus home">
       <img src="../assets/nodus-logo.svg" alt=""/><span>Nodus</span>
     </a>
     <button class="demo-vault-trigger ${active.tone}" type="button" data-demo-vault-trigger
@@ -58,7 +58,7 @@ corresponding static demo instead of loading a local database.
       <div class="demo-vault-list">
         ${vaults.map((vault) => {
           const current = vault.page === active.page;
-          return `<a class="demo-vault-option ${vault.tone}${current ? ' active' : ''}" href="${vault.page}" role="menuitem"${current ? ' aria-current="page"' : ''}>
+          return `<a class="demo-vault-option ${vault.tone}${current ? ' active' : ''}" href="${vault.href || vault.page}" role="menuitem"${current ? ' aria-current="page"' : ''}>
             <span class="demo-vault-option-icon">${appIcon(vault.icon)}</span>
             <span class="demo-vault-copy"><b>${vault.name}</b><span>${vault.type}${vault.phase ? ` <em>${vault.phase}</em>` : ''}</span></span>
             ${current ? '<span class="demo-vault-active">Active</span><span class="demo-vault-check" aria-hidden="true">✓</span>' : '<span class="demo-vault-load">Open</span><span class="demo-vault-arrow" aria-hidden="true">›</span>'}

--- a/site/demo/worldbuilding.html
+++ b/site/demo/worldbuilding.html
@@ -19,7 +19,7 @@
 </head>
 <body class="demo-page worldbuilding">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-  <script defer src="../site-header.js?v=20260820a"></script>
+  <script defer src="../site-header.js?v=20260820b"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>
@@ -39,7 +39,7 @@
   <div id="modal-root"></div>
   <div id="toast" role="status"></div>
   <script src="worldbuilding-data.js?v=20260731-worldbuilding"></script>
-  <script src="vault-switcher.js?v=20260820b"></script>
+  <script src="vault-switcher.js?v=20260820c"></script>
   <script src="worldbuilding-app.js?v=20260731-worldbuilding"></script>
   <script src="mobile.js?v=20260801-responsive"></script>
   <script src="../nodi.js?v=20260720-menu1"></script>

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="faq"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" data-accent="#22d3ee" data-second="#a78bfa" data-energy="0.26">
   <header class="page-hero">
@@ -81,9 +81,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -105,7 +105,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="faq-data.js?v=20260815"></script>
 <script src="faq.js?v=20260815"></script>

--- a/site/index.html
+++ b/site/index.html
@@ -37,7 +37,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     /* Only on a pointer that hovers. On a phone the title sequence holds the
        whole page back for five seconds on the smallest screen and the slowest
        connection, which costs a visitor far more than the shot is worth. */
-    if (matchMedia('(pointer: fine)').matches
+    if (matchMedia('(min-width: 701px) and (hover: hover) and (pointer: fine)').matches
         && !matchMedia('(prefers-reduced-motion: reduce)').matches) {
       var root = document.documentElement;
       root.classList.add('intro-armed');
@@ -91,7 +91,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="" data-page="home"></div>
-<script defer src="site-header.js?v=20260820a"></script>
+<script defer src="site-header.js?v=20260820b"></script>
 
 <main id="main">
 
@@ -113,7 +113,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     </h1>
     <p class="sub">Nodus is a free desktop app for academic research. Connect your Zotero library or your own documents, and turn what you read into ideas, notes and evidence you can search, question and cite. Every claim stays anchored to the passage it came from. Built for scholars, students and teachers.</p>
     <div class="ctas">
-      <a class="btn primary" href="demo/index.html" data-magnet="0.16">
+      <a class="btn primary" href="demo/" data-magnet="0.16">
         <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
         Try the live demo
       </a>
@@ -199,7 +199,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <div class="cap"><em>02</em><p><b>Surface debates, contradictions and research gaps</b>, then explore them through semantic search, coverage analysis and reading paths.</p></div>
         <div class="cap"><em>03</em><p><b>Research and write with verifiable citations</b> through Deep Research, the writing workshop and copilots for Word and LibreOffice.</p></div>
       </div>
-      <a class="arrow-link" href="demo/index.html">Open the academic demo
+      <a class="arrow-link" href="demo/">Open the academic demo
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
     </div>
     <div class="scene-visual reveal" style="--delay:120ms">
@@ -565,7 +565,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <h2 class="title" data-split>Ready to meet your library?</h2>
     <p class="lead">Try the demo right here in your browser, or download the app and point it at your own material. <b style="color:#6ee7b7">Free and open source, forever.</b></p>
     <div class="ctas">
-      <a class="btn primary" href="demo/index.html" data-magnet="0.16">
+      <a class="btn primary" href="demo/" data-magnet="0.16">
         <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
         Try the live demo</a>
       <button class="btn" type="button" data-download data-magnet="0.12">
@@ -598,7 +598,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a href="#vaults">The four vaults</a>
         <a href="#more-vaults">Other vaults</a>
         <a href="#tools">Nodus Toolkit</a>
-        <a href="demo/index.html">Live demos</a>
+        <a href="demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -648,9 +648,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 </div>
 
 
-<script src="assets/js/organism.js?v=20260818c"></script>
+<script src="assets/js/organism.js?v=20260820a"></script>
 <script src="assets/js/site.js?v=20260815"></script>
-<script src="assets/js/home.js?v=20260820b"></script>
+<script src="assets/js/home.js?v=20260820d"></script>
 <script src="assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>

--- a/site/open-source/index.html
+++ b/site/open-source/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="open-source"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main">
 
@@ -55,7 +55,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="scrim" style="max-width:820px">
       <nav class="breadcrumb" aria-label="Breadcrumb">
-        <a href="../index.html">Nodus</a>
+        <a href="../">Nodus</a>
         <span class="sep" aria-hidden="true">/</span>
         <span aria-current="page">Open source</span>
       </nav>
@@ -307,7 +307,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/research-atlas/index.html
+++ b/site/research-atlas/index.html
@@ -30,7 +30,7 @@
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="atlas"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main" class="atlas-main" data-accent="#a78bfa" data-second="#22d3ee" data-energy="0.30">
   <div class="atlas-shell">
@@ -184,10 +184,10 @@
       </div>
       <div class="foot-col">
         <h3>Product</h3>
-        <a href="../index.html#vaults">The four vaults</a>
-        <a href="../index.html#more-vaults">Other vaults</a>
-        <a href="../index.html#tools">Nodus Toolkit</a>
-        <a href="../demo/index.html">Live demos</a>
+        <a href="../#vaults">The four vaults</a>
+        <a href="../#more-vaults">Other vaults</a>
+        <a href="../#tools">Nodus Toolkit</a>
+        <a href="../demo/">Live demos</a>
       </div>
       <div class="foot-col">
         <h3>Learn</h3>
@@ -214,7 +214,7 @@
 </footer>
 
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/research-atlas.js?v=20260819"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>

--- a/site/research/index.html
+++ b/site/research/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="research"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main">
 
@@ -55,7 +55,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="scrim" style="max-width:820px">
       <nav class="breadcrumb" aria-label="Breadcrumb">
-        <a href="../index.html">Nodus</a>
+        <a href="../">Nodus</a>
         <span class="sep" aria-hidden="true">/</span>
         <span aria-current="page">Academic research</span>
       </nav>
@@ -63,7 +63,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <h1 class="display" data-split>Nodus for Academic Research</h1>
       <p class="lead">Nodus is a free, open source, local-first workspace for academic research. It sits between your reference manager and your manuscript. You bring in the papers, books and documents you already work with, and Nodus turns them into a corpus of ideas, relations and evidence that you can search, question and cite, without any of it leaving your computer.</p>
       <div class="guide-actions">
-        <a class="btn primary" href="../demo/index.html">
+        <a class="btn primary" href="../demo/">
           <svg class="ic" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7-11-7Z"/></svg>
           Open the academic demo
         </a>
@@ -91,7 +91,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="guide-body prose reveal" style="margin-top:26px">
       <p>Most tools that hold research material are either bibliographies or notebooks. A bibliography knows what you have read. A notebook knows what you thought about it. What neither of them knows is <b>which passage of which work supports which claim</b>, and that is the link your writing rests on.</p>
       <p>Nodus is built around that link. Every interpretation it stores is one of five kinds, a claim, a finding, a construct, a method or a framework, and each one carries the work it came from and the excerpt that supports it. If the source gives a page number, that travels with it too. Everything else in the application is a way of moving through those anchored units. There is a graph of how they relate to each other, a map of an argument you are putting together, a list of the questions your corpus cannot answer yet, and a report whose citations you can open and check for yourself.</p>
-      <p>Nodus organises work into <b>vaults</b>, and this page describes the academic one. The same engine also runs the vaults for <a href="../index.html#more-vaults">teaching, study, structured databases, genealogy and more</a>, but the academic vault is the one designed for literature reviews, theses and research projects.</p>
+      <p>Nodus organises work into <b>vaults</b>, and this page describes the academic one. The same engine also runs the vaults for <a href="../#more-vaults">teaching, study, structured databases, genealogy and more</a>, but the academic vault is the one designed for literature reviews, theses and research projects.</p>
     </div>
 
     <div class="guide-grid reveal">
@@ -375,7 +375,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/site-header.js
+++ b/site/site-header.js
@@ -15,13 +15,22 @@ Hosts opt in with a placeholder element:
 (function () {
   'use strict';
 
+  /* GitHub Pages serves both /section/ and /section/index.html with a 200 and
+     offers no repository-level redirect rules. Keep explicit index requests
+     from lingering as duplicate browser/search URLs until the custom domain is
+     fronted by a service that can issue the preferred HTTP 301/308. */
+  if (/^https?:$/.test(location.protocol) && location.pathname.endsWith('/index.html')) {
+    location.replace(`${location.pathname.slice(0, -'index.html'.length)}${location.search}${location.hash}`);
+    return;
+  }
+
   const REPO = 'https://github.com/Drakonis96/nodus';
 
   const LOGO_STAR = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .67.42l1.88 3.8 4.2.62c.61.09.86.84.41 1.28l-3.04 2.96.72 4.18a.75.75 0 0 1-1.09.79L8 12.35l-3.76 1.97a.75.75 0 0 1-1.08-.79l.72-4.18L.83 6.37a.75.75 0 0 1 .41-1.28l4.2-.61L7.32.67A.75.75 0 0 1 8 .25Z"/></svg>';
   const LOGO_GH = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>';
 
   const PAGES = [
-    { id: 'home', label: 'Home', href: (base) => `${base}index.html` },
+    { id: 'home', label: 'Home', href: (base) => base || './' },
     { id: 'atlas', label: 'Atlas', href: (base) => `${base}research-atlas/` },
     // Nodus Browser reveals this prepared slot from its isolated preload. It is
     // hidden everywhere else, so a normal web visitor never sees a local-only
@@ -48,7 +57,7 @@ Hosts opt in with a placeholder element:
           <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z"/>
         </svg>
       </button>` : ''}
-      <a class="logo" href="${base}index.html" aria-label="Nodus, home">
+      <a class="logo" href="${base || './'}" aria-label="Nodus, home">
         <img class="mark" src="${base}assets/nodus-logo.svg" alt=""/> Nodus
       </a>
       <button class="nav-toggle" id="site-nav-toggle" type="button" aria-label="Open menu" aria-controls="site-nav-links" aria-expanded="false">
@@ -67,7 +76,7 @@ Hosts opt in with a placeholder element:
           <span class="download-word">downloads</span>
           <span class="download-tooltip" id="release-downloads-tooltip" role="tooltip">Package downloads from GitHub Releases · updated daily</span>
         </a>
-        <a class="btn primary" href="${base}demo/index.html">Try the live demo</a>
+        <a class="btn primary" href="${base}demo/">Try the live demo</a>
       </div>
     </nav>`;
   }

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -38,8 +38,8 @@
     </main>
     <aside class="toc" aria-label="On this page"><b>On this page</b><nav id="page-toc"></nav></aside>
   </div>
-  <script src="../assets/js/organism.js?v=20260818c"></script>
-  <script defer src="../site-header.js?v=20260820a"></script>
+  <script src="../assets/js/organism.js?v=20260820a"></script>
+  <script defer src="../site-header.js?v=20260820b"></script>
   <script src="wiki.js?v=20260817" type="module"></script>
   <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/zotero/index.html
+++ b/site/zotero/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="zotero"></div>
-<script defer src="../site-header.js?v=20260820a"></script>
+<script defer src="../site-header.js?v=20260820b"></script>
 
 <main id="main">
 
@@ -55,7 +55,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <div class="wrap">
     <div class="scrim" style="max-width:820px">
       <nav class="breadcrumb" aria-label="Breadcrumb">
-        <a href="../index.html">Nodus</a>
+        <a href="../">Nodus</a>
         <span class="sep" aria-hidden="true">/</span>
         <span aria-current="page">Zotero</span>
       </nav>
@@ -287,7 +287,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <span class="arrow-link">Read about AI-assisted research
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
       </a>
-      <a class="card lit next-card reveal" href="../demo/index.html" style="--delay:140ms">
+      <a class="card lit next-card reveal" href="../demo/" style="--delay:140ms">
         <span class="pic"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7-11-7Z"/></svg></span>
         <h3>The live demo</h3>
         <p>A sample academic corpus you can explore in this browser, with no installation and nothing to import.</p>
@@ -341,7 +341,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   </div>
 </footer>
 
-<script src="../assets/js/organism.js?v=20260818c"></script>
+<script src="../assets/js/organism.js?v=20260820a"></script>
 <script src="../assets/js/site.js?v=20260815"></script>
 <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>


### PR DESCRIPTION
## Summary

- wait for the particle field to finish forming the N before releasing the homepage intro
- disable the intro effect on mobile and keep a recovery timeout for unsupported rendering contexts
- replace internal `index.html` links with canonical directory URLs across the site, demos, and generated blog pages
- normalize direct `index.html` visits client-side while GitHub Pages remains the origin
- add regression coverage for intro behavior and canonical internal navigation

## Testing

- `node --check site/site-header.js`
- `node --check site/demo/vault-switcher.js`
- `node --test scripts/test-site-pages.mjs scripts/test-site-blog.mjs` (28 passing)