### PR TITLE
Release the homepage intro immediately after formation

### DIFF
--- a/scripts/test-site-pages.mjs
+++ b/scripts/test-site-pages.mjs
@@ -235,8 +235,9 @@ test('the home page opens with the mark forming, and can never strand a visitor'
   assert.match(home, /setTimeout\(function \(\) \{[\s\S]*?intro-done[\s\S]*?\}, 6000\)/, 'the inline watchdog reveals the page on its own');
   assert.match(css, /body \{[\s\S]*?radial-gradient[\s\S]*?background-attachment: fixed;/, 'a finished-looking background exists before WebGL starts');
   assert.match(css, /#organism \{ transition-duration: 0\.3s; \}/, 'the live field replaces the static paint quickly');
-  assert.match(script, /const HOLD = 1200;/, 'the opening releases promptly instead of holding an empty hero');
-  assert.match(script, /organism-assembled/, 'the hold starts only after the field has finished assembling the mark');
+  assert.match(script, /organism-assembled/, 'the release starts only after the field has finished assembling the mark');
+  assert.match(script, /const onAssembled = \(\) => \{\s*if \(finished\) return;\s*release\(\);\s*\};/, 'the completed mark returns to the node flow immediately');
+  assert.doesNotMatch(script, /engine\.pulse\(innerWidth/, 'the completed mark flows away instead of exploding outward');
   assert.match(read('assets/js/organism.js'), /dataset\.formation === 'on' && openingIsArmed/, 'mobile and unarmed visits never assemble a hidden N');
   assert.match(css, /\.hero \{[\s\S]*?-webkit-user-select: none;[\s\S]*?user-select: none;/, 'visible hero copy cannot be accidentally selected');
 

--- a/site/assets/css/home.css
+++ b/site/assets/css/home.css
@@ -470,8 +470,8 @@ body {
 
 /* ============================================================ the opening
    The visitor arrives to an empty field. The nodes gather into the Nodus N,
-   hold, then burst apart as the mark lands and the three lines of the motto
-   rise one after another. Everything else follows.
+   then flow straight back into the field as the mark lands and the three lines
+   of the motto rise one after another. Everything else follows.
 
    `intro-armed` is set on <html> before the first paint by a tiny inline
    script, so nothing ever flashes. `intro-run` starts the choreography;

--- a/site/assets/js/home.js
+++ b/site/assets/js/home.js
@@ -9,14 +9,13 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
   'use strict';
 
   /* ------------------------------------------------------------ the opening */
-  /* The page arrives empty. The field gathers into the Nodus N, holds, then
-     bursts apart as the mark lands and the motto rises line by line.
+  /* The page arrives empty. The field gathers into the Nodus N, then flows
+     straight back into the organism as the mark lands and the motto rises.
 
      The CSS owns the choreography (see the opening block in home.css); this only
      moves the page between the three states, drives the organism's handoff, and
      makes sure the sequence can always be skipped or recovered from. */
 
-  const HOLD = 1200;              // time to read the N after it is fully assembled
   const ASSEMBLY_TIMEOUT = 3600;  // recovery path if the renderer never settles
   const TAIL = 2750;              // the CSS timeline that runs after the release
 
@@ -53,16 +52,16 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
       root.classList.add('intro-run');
       const engine = window.NodusOrganism;
       if (engine) {
+        // Formation itself is the reveal: return immediately and smoothly to
+        // the field's normal anchors instead of pausing or exploding outward.
         engine.assemble(false);
-        // the letter blows apart from its own centre
-        engine.pulse(innerWidth / 2, innerHeight * 0.46, 2.4);
       }
       timers.push(setTimeout(finish, TAIL));
     };
 
     const onAssembled = () => {
       if (finished) return;
-      timers.push(setTimeout(release, HOLD));
+      release();
     };
 
     // anyone who has seen it can leave early
@@ -98,9 +97,9 @@ actually draw on. The video gallery lives in the wiki (site/wiki/wiki.js).
 
     // The visual signal normally wins. This timeout exists only so a context
     // that keeps drawing but never converges cannot hold the page indefinitely.
-    timers.push(setTimeout(release, ASSEMBLY_TIMEOUT + HOLD));
+    timers.push(setTimeout(release, ASSEMBLY_TIMEOUT));
     // last-resort guard: the page can never stay stuck in its opening state
-    timers.push(setTimeout(finish, ASSEMBLY_TIMEOUT + HOLD + TAIL + 700));
+    timers.push(setTimeout(finish, ASSEMBLY_TIMEOUT + TAIL + 700));
   }
 
   /* ------------------------------------------------------------ presenter stage */

--- a/site/assets/js/organism.js
+++ b/site/assets/js/organism.js
@@ -847,7 +847,7 @@ for reduced motion.
   /* ------------------------------------------------------------ boot */
 
   /* The opening sequence on the home page is a title shot for the field: the
-     nodes gather into the Nodus N, hold, and burst as the page arrives. With no
+     nodes gather into the Nodus N, then flow back as the page arrives. With no
      field there is no N, and holding a blank page for five seconds shows the
      visitor nothing at all. So every path that stands the field down also hands
      the page straight back, and home.js finds the sequence already over. */
@@ -890,9 +890,9 @@ for reduced motion.
     organism.start();
     requestAnimationFrame(() => canvas.classList.add('awake'));
 
-    // The field draws the Nodus N on arrival and holds it: on the home page that
-    // is the whole opening shot, with the rest of the page still hidden. The
-    // sequence in home.js decides when it bursts and the page arrives.
+    // The field draws the Nodus N on arrival: on the home page that is the whole
+    // opening shot, with the rest of the page still hidden. The sequence in
+    // home.js releases it into the normal flow as soon as the mark is complete.
     const openingIsArmed = document.documentElement.classList.contains('intro-armed');
     if (document.body.dataset.formation === 'on' && openingIsArmed) {
       organism.assemble(true);

--- a/site/index.html
+++ b/site/index.html
@@ -650,7 +650,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script src="assets/js/organism.js?v=20260820a"></script>
 <script src="assets/js/site.js?v=20260815"></script>
-<script src="assets/js/home.js?v=20260820d"></script>
+<script src="assets/js/home.js?v=20260820e"></script>
 <script src="assets/js/back-to-top.js?v=20260817b"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- release the homepage intro as soon as the particle field finishes forming the N
- remove the extra 1.2-second hold
- return the formed nodes smoothly to their normal flow instead of applying an explosive pulse
- update the cache key and regression coverage

## Validation

- verified the desktop transition locally at a 1280px viewport: formation immediately enters `intro-run`
- no browser console errors
- `node --check site/assets/js/home.js`
- `node --check site/assets/js/organism.js`
- `node --test scripts/test-site-pages.mjs scripts/test-site-blog.mjs` (28 passing)