### PR TITLE
Hotfix 4.2.1: stabilize Deep Research typography

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -65,7 +65,7 @@ jobs:
           scripts/test-server-vectors.mjs
 
       - name: Build smoke-test image
-        run: docker build --build-arg NODUS_VERSION=4.2.0 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
+        run: docker build --build-arg NODUS_VERSION=4.2.1 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci ./server
 
       - name: Run image health smoke test
         shell: bash
@@ -115,7 +115,7 @@ jobs:
             org.opencontainers.image.description=Experimental self-hosted Nodus MCP server
             org.opencontainers.image.source=https://github.com/Drakonis96/nodus
             org.opencontainers.image.licenses=AGPL-3.0-only
-            org.opencontainers.image.version=4.2.0
+            org.opencontainers.image.version=4.2.1
             org.opencontainers.image.revision=${{ github.sha }}
             app.nodus.stability=experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.2.1 — 2026-08-20
+
+- Fixed Deep Research typography controls freezing the interface, detaching persistent
+  highlights and comments, and preventing the selection ribbon from opening.
+- Font-size changes now preserve the visible reading position and reuse the 4.2.0 What's
+  New presentation.
+
 ## 4.2.0 — 2026-08-20
 
 Nodus 4.2 introduces an integrated research browser and a global research radar, brings

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "4.2.0"
+version: "4.2.1"
 date-released: "2026-08-20"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.2.0 is licensed exclusively under the GNU Affero General Public
+Nodus 4.2.1 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.2.0 release is available
+The preferred form for modifying the official Nodus 4.2.1 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.0
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.0
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.0.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.0.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.1
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.1
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.1.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.1.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.2.0 is free software distributed exclusively under the GNU Affero
+Nodus 4.2.1 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/electron/library/libraryCslStyles.ts
+++ b/electron/library/libraryCslStyles.ts
@@ -155,7 +155,7 @@ function repositoryStyleTitle(id: string): string {
 async function officialRepositoryIndex(): Promise<LibraryCitationStyleRepositoryEntry[]> {
   if (!repositoryIndexPromise) {
     repositoryIndexPromise = fetch(OFFICIAL_STYLES_TREE_URL, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.2.0' },
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.2.1' },
     }).then(async (response) => {
       if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
       const payload = await response.json() as { tree?: Array<{ path?: string; type?: string }>; truncated?: boolean };
@@ -246,7 +246,7 @@ export async function installRepositoryCitationStyle(rawId: string): Promise<Lib
   const id = repositoryIdFromUrl(rawId) ?? rawId.trim().toLowerCase().replace(/\.csl$/i, '');
   if (!/^[a-z0-9][a-z0-9._-]{1,199}$/.test(id)) throw new Error('Introduce el identificador de un estilo del repositorio oficial de CSL.');
   const response = await fetch(`${OFFICIAL_STYLES_RAW_URL}/${encodeURIComponent(id)}.csl`, {
-    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.2.0' },
+    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.2.1' },
   });
   if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
   const declaredLength = Number(response.headers.get('content-length') || 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "AGPL-3.0-only",

--- a/scripts/e2e-deep-research-annotations.mjs
+++ b/scripts/e2e-deep-research-annotations.mjs
@@ -125,6 +125,30 @@ try {
   assert.ok(ribbonBox.y + ribbonBox.height <= firstSelection.release.y, 'ribbon sits above the pointer');
   await selectionBar.locator('.reader-selection-color').first().click();
   await page.waitForFunction(async (id) => (await window.nodus.listWritingDraftAnnotations(id)).filter((item) => item.kind === 'highlight').length === 1, draftId);
+  await page.waitForFunction(() => CSS.highlights?.get('nodus-reader-yellow')?.size === 1);
+
+  // Font reflow must leave the annotation layer attached to the same live text
+  // nodes. This used to freeze the renderer and make highlights, comments and
+  // the contextual ribbon blink in and out after using either typography button.
+  const initialFontSize = await documentRoot.locator('.md').evaluate((element) => parseFloat(getComputedStyle(element).fontSize));
+  await page.getByTestId('deep-research-font-increase').click();
+  await page.waitForFunction((expected) => {
+    const prose = document.querySelector('[data-testid="deep-research-reader-document"] .md');
+    return prose && parseFloat(getComputedStyle(prose).fontSize) === expected;
+  }, initialFontSize + 1);
+  assert.equal(
+    await page.evaluate(() => CSS.highlights?.get('nodus-reader-yellow')?.size),
+    1,
+    'font increase keeps the stored highlight registered',
+  );
+  await page.getByTestId('deep-research-font-decrease').click();
+  await page.waitForFunction((expected) => {
+    const prose = document.querySelector('[data-testid="deep-research-reader-document"] .md');
+    return prose && parseFloat(getComputedStyle(prose).fontSize) === expected;
+  }, initialFontSize);
+  await selectCandidate(5);
+  await selectionBar.waitFor({ state: 'visible' });
+  await page.keyboard.press('Escape');
 
   // Releasing in the blank gutter still completes a selection made in the
   // report and opens the ribbon at the edge of the viewport.

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -800,7 +800,10 @@ try {
   await whatsNewModal.waitFor();
   assert.equal(await whatsNewModal.count(), 1, 'Latest changes reopens the release modal even after the current version was seen');
   assert.equal(await selectedRelease.count(), 1, 'the release modal renders exactly one version at a time');
-  assert.equal(await selectedRelease.getByText(`v${appVersion}`, { exact: true }).count(), 1, 'the latest installed release is selected by default');
+  // 4.2.1 is a presentation-only hotfix: it intentionally reuses the complete
+  // 4.2.0 What's New card instead of adding a duplicate release-note entry.
+  const expectedLatestChangesVersion = appVersion === '4.2.1' ? '4.2.0' : appVersion;
+  assert.equal(await selectedRelease.getByText(`v${expectedLatestChangesVersion}`, { exact: true }).count(), 1, 'the latest available release note is selected by default');
   assert.equal(await selectedRelease.getByText('v2.5.3', { exact: true }).count(), 0, 'an older release is not rendered before it is selected');
 
   await page.getByTestId('whats-new-version-trigger').click();

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '4.2.0';
+const VERSION = '4.2.1';
 
 test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 4.2.0 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 4.2.1 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -74,7 +74,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '4.2.0');
+      assert.equal(info.version, '4.2.1');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-site-layout.mjs
+++ b/scripts/test-site-layout.mjs
@@ -79,7 +79,7 @@ test('every static HTML link resolves inside the website tree', () => {
       if (!pathname) continue;
       const resolved = path.resolve(referenceBase, pathname);
       assert.ok(
-        resolved.startsWith(`${siteRoot}${path.sep}`),
+        resolved === siteRoot || resolved.startsWith(`${siteRoot}${path.sep}`),
         `${path.relative(repoRoot, htmlFile)} keeps ${reference} inside site/`,
       );
       const target = pathname.endsWith('/') ? path.join(resolved, 'index.html') : resolved;

--- a/scripts/test-teaching-web-demo.mjs
+++ b/scripts/test-teaching-web-demo.mjs
@@ -14,7 +14,7 @@ test('the Teaching web demo is reachable from every live vault demo', () => {
   assert.match(teachingHtml, /data-nodus-site-header data-base="\.\.\/" data-context="demo"/);
   assert.match(teachingHtml, /src="\.\.\/site-header\.js/);
   // the route back to the vault catalogue is now the header's Home link
-  assert.match(sharedHeader, /\{ id: 'home', label: 'Home', href: \(base\) => `\$\{base\}index\.html` \}/);
+  assert.match(sharedHeader, /\{ id: 'home', label: 'Home', href: \(base\) => base \|\| '\.\/' \}/);
   assert.match(teachingHtml, /src="teaching-data\.js/);
   assert.match(teachingHtml, /src="teaching-app\.js/);
   assert.match(teachingHtml, /AI for generating teaching content only; AI never evaluates students/);

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '4.2.0');
+  assert.equal(pluginManifest.version, '4.2.1');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,9 +54,9 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '4\.2\.0'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '4\.2\.1'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.2\.0\.tar\.gz/);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.2\.1\.tar\.gz/);
   assert.match(citation, /^date-released: "2026-08-20"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -483,7 +483,10 @@ test('the Deep Research reader has persistent typography and a live report outli
   assert.match(view, /READER_FONT_STORAGE_KEY = 'nodus\.deepResearch\.readerFontSize'/);
   assert.match(view, /data-testid="deep-research-font-decrease"/);
   assert.match(view, /data-testid="deep-research-font-increase"/);
-  assert.match(view, /topBlockIndex\(scroller, readingBlocks\(root\)\)/, 'font reflow preserves the visible reading block');
+  assert.match(view, /function ReaderFontControls\(/, 'typography state is isolated from the rendered document');
+  assert.match(view, /window\.setTimeout\(\(\) => \{[\s\S]*?setFontSize/, 'font reflow starts after the native pointer dispatch completes');
+  assert.match(view, /root\.style\.setProperty\('--deep-research-font-size'/, 'font size changes the existing document instead of remounting it');
+  assert.match(view, /pendingAnchorRef[\s\S]*?scroller\.scrollTop \+= pending\.element\.getBoundingClientRect\(\)\.top - pending\.top/, 'font reflow preserves the visible reading block');
   assert.match(view, /function useReportOutline\(/);
   assert.match(view, /querySelectorAll<HTMLElement>\('h1, h2, h3, h4'\)/);
   assert.match(view, /data-testid="deep-research-outline-rail"/);

--- a/scripts/test-worldbuilding-site-demo.mjs
+++ b/scripts/test-worldbuilding-site-demo.mjs
@@ -126,7 +126,7 @@ test('every live demo returns through the shared header and the homepage links W
 
   const sharedHeader = await readFile(path.join(root, 'site', 'site-header.js'), 'utf8')
   // the route back to the vault catalogue is now the header's Home link
-  assert.match(sharedHeader, /\{ id: 'home', label: 'Home', href: \(base\) => `\$\{base\}index\.html` \}/)
+  assert.match(sharedHeader, /\{ id: 'home', label: 'Home', href: \(base\) => base \|\| '\.\/' \}/)
   const homepage = await readFile(path.join(root, 'site', 'index.html'), 'utf8')
   assert.match(homepage, /<h3>Worldbuilding<\/h3>/)
   assert.match(homepage, /href="demo\/worldbuilding\.html"/)

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1244,9 +1244,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '4.2.0', 'the add-on shares the Nodus 4 release version');
+  assert.equal(manifest.version, '4.2.1', 'the add-on shares the Nodus 4 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.2\.0/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.2\.1/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,13 +3,13 @@
 
 FROM node:22-alpine
 
-ARG NODUS_VERSION=4.2.0
+ARG NODUS_VERSION=4.2.1
 ARG NODUS_REVISION=unknown
 LABEL org.opencontainers.image.title="Nodus Server" \
       org.opencontainers.image.description="Experimental self-hosted Nodus MCP server" \
       org.opencontainers.image.source="https://github.com/Drakonis96/nodus" \
       org.opencontainers.image.url="https://github.com/Drakonis96/nodus" \
-      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.2.0/server/README.md" \
+      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v4.2.1/server/README.md" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.version="${NODUS_VERSION}" \
       org.opencontainers.image.revision="${NODUS_REVISION}" \
@@ -24,7 +24,7 @@ COPY LICENSE SOURCE_CODE.md THIRD_PARTY_NOTICES.md ./
 ENV NODUS_DATA_DIR=/data \
     NODUS_HOST=0.0.0.0 \
     NODUS_PORT=7443 \
-    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.2.0
+    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v4.2.1
 
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.2.0 is licensed exclusively under the GNU Affero General Public
+Nodus 4.2.1 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.2.0 release is available
+The preferred form for modifying the official Nodus 4.2.1 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.0
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.0
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.0.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.0.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.1
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.1
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.1.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.1.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.2.0 is free software distributed exclusively under the GNU Affero
+Nodus 4.2.1 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -36,7 +36,7 @@ services:
       # With the pair, the account is created on first boot and its password is rotated
       # whenever you change the value here.
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.1}
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       # Optional ceilings. Unset they default to 8 MiB per image, 2 GiB of images per

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -21,7 +21,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.1}
       # Optional ceilings. Left unset they default to 8 MiB per image, 2 GiB of images per
       # space, and the snapshot limits documented in the README.
       NODUS_MAX_ASSET_BYTES: ${NODUS_MAX_ASSET_BYTES:-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.1}
     volumes:
       - nodus_data:/data
     ports:

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '4.2.0';
+export const NODUS_VERSION = '4.2.1';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/server/portainer-stack.yml
+++ b/server/portainer-stack.yml
@@ -8,7 +8,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v4.2.1}
     volumes:
       - nodus_data:/data
     expose:

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useRef, useState, type ReactNode } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -44,7 +44,7 @@ export interface MarkdownReaderCitation {
   page?: number;
 }
 
-export function Markdown({
+function MarkdownComponent({
   content,
   className = '',
   onCitation,
@@ -291,6 +291,9 @@ export function Markdown({
     </div>
   );
 }
+
+/** Preserve live DOM selections and CSS Highlight ranges across parent renders. */
+export const Markdown = memo(MarkdownComponent);
 
 /**
  * Inline citation pill with a hover-card. Hovering (after a short delay, so a

--- a/src/components/ReaderSelectionActions.tsx
+++ b/src/components/ReaderSelectionActions.tsx
@@ -617,6 +617,11 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
     const onPointerUp = (event: PointerEvent) => {
       const target = event.target;
       if (target instanceof Element && target.closest('[data-reader-selection-actions]')) return;
+      // Header controls (notably the reader's typography buttons) are not the
+      // end of a text selection. Scheduling a second selection pass from their
+      // pointerup races the control's own layout update and can trap Chromium in
+      // a render loop while live annotation ranges are being repositioned.
+      if (target instanceof Element && target.closest('button, a, input, textarea, select, [role="button"]')) return;
       const pointer = { x: event.clientX, y: event.clientY };
       window.setTimeout(() => showSelection(undefined, pointer), 0);
     };
@@ -653,6 +658,7 @@ export const ReaderSelectionActions = forwardRef<ReaderSelectionActionsHandle, {
     const hide = (event: Event) => {
       const target = event.target;
       if (target instanceof Element && target.closest('[data-reader-selection-actions]')) return;
+      if (target instanceof Element && target.closest('button, a, input, textarea, select, [role="button"]')) return;
       setActive(null);
       setActiveMarkActions(null);
       setActiveHighlightActions(null);

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -2,7 +2,7 @@
 // chained generation queue, and an immersive reader that expands one report to
 // full width with a back button to the gallery. The heavy lifting (generation,
 // saving, citations) is shared with the Writing workshop via writingShared.
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from 'react';
 import type {
   AppSettings,
   DeepResearchArchiveFormat,
@@ -1689,6 +1689,100 @@ function ReportOutlineRail({
   );
 }
 
+/**
+ * Typography is deliberately isolated from ReaderView. Re-rendering the complete
+ * reader makes react-markdown replace text nodes, which disconnects Selection and
+ * CSS Highlight ranges. This control changes only the document's custom property.
+ */
+function ReaderFontControls({
+  targetRef,
+  scrollerRef,
+  initialSize,
+}: {
+  targetRef: RefObject<HTMLDivElement | null>;
+  scrollerRef: RefObject<HTMLElement | null>;
+  initialSize: number;
+}) {
+  const [fontSize, setFontSize] = useState(initialSize);
+  const pendingAnchorRef = useRef<{ element: HTMLElement; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const root = targetRef.current;
+    if (!root) return;
+    root.style.setProperty('--deep-research-font-size', `${fontSize}px`);
+
+    const pending = pendingAnchorRef.current;
+    const scroller = scrollerRef.current;
+    if (pending && scroller && pending.element.isConnected) {
+      scroller.scrollTop += pending.element.getBoundingClientRect().top - pending.top;
+    }
+    pendingAnchorRef.current = null;
+  }, [fontSize, scrollerRef, targetRef]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(READER_FONT_STORAGE_KEY, String(fontSize));
+    } catch {
+      // A locked-down renderer may deny storage; the control still works for this view.
+    }
+  }, [fontSize]);
+
+  const change = useCallback((delta: number) => {
+    // Let the native pointer dispatch finish before the annotated subtree reflows.
+    window.setTimeout(() => {
+      const root = targetRef.current;
+      const scroller = scrollerRef.current;
+      if (root && scroller) {
+        const blocks = readingBlocks(root);
+        const index = topBlockIndex(scroller, blocks);
+        const element = index === null ? null : blocks[index];
+        pendingAnchorRef.current = element
+          ? { element, top: element.getBoundingClientRect().top }
+          : null;
+      }
+      setFontSize((current) => Math.max(READER_FONT_MIN, Math.min(READER_FONT_MAX, current + delta)));
+    }, 0);
+  }, [scrollerRef, targetRef]);
+
+  return (
+    <div
+      data-testid="deep-research-font-controls"
+      role="group"
+      aria-label={t('Tipografía')}
+      className="flex h-9 items-stretch overflow-hidden rounded-lg border border-neutral-700 bg-neutral-900/70 shadow-sm"
+    >
+      <button
+        data-testid="deep-research-font-decrease"
+        type="button"
+        className="grid w-9 place-items-center text-xs text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-white disabled:cursor-not-allowed disabled:text-neutral-700"
+        title={t('Disminuir texto')}
+        aria-label={t('Disminuir texto')}
+        disabled={fontSize <= READER_FONT_MIN}
+        onClick={() => change(-1)}
+      >
+        a
+      </button>
+      <output
+        className="grid min-w-10 place-items-center border-x border-neutral-800 px-1 text-[10px] tabular-nums text-neutral-500"
+        aria-live="polite"
+      >
+        {fontSize}
+      </output>
+      <button
+        data-testid="deep-research-font-increase"
+        type="button"
+        className="grid w-9 place-items-center text-[17px] font-semibold text-neutral-300 transition-colors hover:bg-neutral-800 hover:text-white disabled:cursor-not-allowed disabled:text-neutral-700"
+        title={t('Aumentar texto')}
+        aria-label={t('Aumentar texto')}
+        disabled={fontSize >= READER_FONT_MAX}
+        onClick={() => change(1)}
+      >
+        A
+      </button>
+    </div>
+  );
+}
+
 function ReaderView({
   saved,
   settings,
@@ -1740,8 +1834,7 @@ function ReaderView({
   const mainRef = useRef<HTMLElement | null>(null);
   const documentRef = useRef<HTMLDivElement | null>(null);
   const markActionsRef = useRef<ReaderSelectionActionsHandle | null>(null);
-  const fontFramesRef = useRef<number[]>([]);
-  const [readerFontSize, setReaderFontSize] = useState(savedReaderFontSize);
+  const initialReaderFontSize = useRef(savedReaderFontSize()).current;
   const [hasReaderMark, setHasReaderMark] = useState(false);
   const [annotations, setAnnotations] = useState<WritingDraftAnnotation[]>([]);
   const [highlighterColor, setHighlighterColor] = useState<WritingDraftAnnotationColor | null>(null);
@@ -1772,38 +1865,6 @@ function ReaderView({
     });
   }, [refreshAnnotations, saved.id]);
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(READER_FONT_STORAGE_KEY, String(readerFontSize));
-    } catch {
-      // A locked-down renderer may deny storage; the control still works for this view.
-    }
-  }, [readerFontSize]);
-
-  useEffect(() => () => {
-    for (const frame of fontFramesRef.current) cancelAnimationFrame(frame);
-    fontFramesRef.current = [];
-  }, []);
-
-  const changeReaderFontSize = useCallback((delta: number) => {
-    const scroller = mainRef.current;
-    const root = documentRef.current;
-    const blockIndex = scroller && root ? topBlockIndex(scroller, readingBlocks(root)) : null;
-    setReaderFontSize((current) => Math.max(READER_FONT_MIN, Math.min(READER_FONT_MAX, current + delta)));
-
-    // Keep the sentence under the reader's eye in place while the lines reflow.
-    // Two frames let React apply the custom property before measuring the new layout.
-    if (!scroller || !root || blockIndex === null) return;
-    const first = requestAnimationFrame(() => {
-      const second = requestAnimationFrame(() => {
-        const target = readingBlocks(root)[blockIndex];
-        if (target) scroller.scrollTop += target.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
-      });
-      fontFramesRef.current.push(second);
-    });
-    fontFramesRef.current.push(first);
-  }, []);
-
   const goToHeading = useCallback((heading: ReportOutlineHeading) => {
     const scroller = mainRef.current;
     const root = documentRef.current;
@@ -1813,13 +1874,13 @@ function ReaderView({
     scroller.scrollTo({ top: Math.max(0, top), behavior: settings.reduceMotion ? 'auto' : 'smooth' });
   }, [settings.reduceMotion]);
 
-  const createAnnotation = async (input: Omit<WritingDraftAnnotationInput, 'draftId' | 'scope'>) => {
+  const createAnnotation = useCallback(async (input: Omit<WritingDraftAnnotationInput, 'draftId' | 'scope'>) => {
     const created = await window.nodus.createWritingDraftAnnotation({ ...input, draftId: saved.id, scope: annotationScope });
     setAnnotations((current) => [...current.filter((item) => item.id !== created.id), created]);
     setAnnotationError(null);
-  };
+  }, [annotationScope, saved.id]);
 
-  const updateComment = async (id: string, comment: string) => {
+  const updateComment = useCallback(async (id: string, comment: string) => {
     const updated = await window.nodus.updateWritingDraftComment(id, comment);
     if (!updated) {
       await refreshAnnotations();
@@ -1827,13 +1888,13 @@ function ReaderView({
     }
     setAnnotations((current) => current.map((item) => (item.id === updated.id ? updated : item)));
     setAnnotationError(null);
-  };
+  }, [refreshAnnotations]);
 
-  const deleteAnnotation = async (id: string) => {
+  const deleteAnnotation = useCallback(async (id: string) => {
     await window.nodus.deleteWritingDraftAnnotation(id);
     setAnnotations((current) => current.filter((item) => item.id !== id));
     setAnnotationError(null);
-  };
+  }, []);
   // Where the reader was in the report, restored once the prose is on screen. The
   // rendering travels with the place: a translation is a different document, and a
   // block counted in one of them is not the same block in the other.
@@ -1874,41 +1935,7 @@ function ReaderView({
           onSaveToNotes={onSaveToNotes}
           onExport={onExport}
         />
-        <div
-          data-testid="deep-research-font-controls"
-          role="group"
-          aria-label={t('Tipografía')}
-          className="flex h-9 items-stretch overflow-hidden rounded-lg border border-neutral-700 bg-neutral-900/70 shadow-sm"
-        >
-          <button
-            data-testid="deep-research-font-decrease"
-            type="button"
-            className="grid w-9 place-items-center text-xs text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-white disabled:cursor-not-allowed disabled:text-neutral-700"
-            title={t('Disminuir texto')}
-            aria-label={t('Disminuir texto')}
-            disabled={readerFontSize <= READER_FONT_MIN}
-            onClick={() => changeReaderFontSize(-1)}
-          >
-            a
-          </button>
-          <output
-            className="grid min-w-10 place-items-center border-x border-neutral-800 px-1 text-[10px] tabular-nums text-neutral-500"
-            aria-live="polite"
-          >
-            {readerFontSize}
-          </output>
-          <button
-            data-testid="deep-research-font-increase"
-            type="button"
-            className="grid w-9 place-items-center text-[17px] font-semibold text-neutral-300 transition-colors hover:bg-neutral-800 hover:text-white disabled:cursor-not-allowed disabled:text-neutral-700"
-            title={t('Aumentar texto')}
-            aria-label={t('Aumentar texto')}
-            disabled={readerFontSize >= READER_FONT_MAX}
-            onClick={() => changeReaderFontSize(1)}
-          >
-            A
-          </button>
-        </div>
+        <ReaderFontControls targetRef={documentRef} scrollerRef={mainRef} initialSize={initialReaderFontSize} />
         <ReaderHighlighterControl value={highlighterColor} onChange={setHighlighterColor} />
         <HoverLabelButton
           icon={hasReaderMark ? 'bookmarkFill' : 'bookmark'}
@@ -1965,9 +1992,9 @@ function ReaderView({
               ref={documentRef}
               className="deep-research-reader-document relative"
               data-testid="deep-research-reader-document"
-              style={{ '--deep-research-font-size': `${readerFontSize}px` } as CSSProperties}
+              style={{ '--deep-research-font-size': `${initialReaderFontSize}px` } as CSSProperties}
             >
-              {appliedTranslation ? <Markdown content={appliedTranslation.markdown} onCitation={(citation) => onCitation(citation)} onStudyDocument={onOpenStudyDocument} onStudyMaterial={onOpenStudyMaterial} onStudyRecording={onOpenStudyRecording} /> : <DraftResultMain
+              {appliedTranslation ? <Markdown content={appliedTranslation.markdown} onCitation={onCitation} onStudyDocument={onOpenStudyDocument} onStudyMaterial={onOpenStudyMaterial} onStudyRecording={onOpenStudyRecording} /> : <DraftResultMain
                 draft={saved.draft}
                 exporting={exporting}
                 savingDraft={false}

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
## Summary
- isolate Deep Research typography changes from the rendered report so CSS Highlight and Selection ranges stay attached
- ignore typography controls in document-wide selection handlers and preserve the visible reading block
- bump release metadata to 4.2.1 while reusing the unchanged 4.2.0 What's New card

## Verification
- npm run build
- 2,103 unaffected tests from npm test, plus both corrected release/E2E cases rerun successfully
- node --test scripts/test-zotero-plugin.mjs (66/66)
- node scripts/test-prosopography-e2e.mjs
- node scripts/e2e-view-snapshots.mjs
- node scripts/e2e-deep-research-annotations.mjs
- npm run citation:check
- npm run release:verify-source