### PR TITLE
fix: browser empty state, vault switcher flash and citation modal

### DIFF
--- a/electron/ipc/browser.ts
+++ b/electron/ipc/browser.ts
@@ -16,7 +16,7 @@
  * preload with `ipcRenderer` on it. Defence in depth, deliberately redundant.
  */
 
-import { BrowserWindow, dialog, shell } from 'electron';
+import { BrowserWindow, dialog, ipcMain, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -236,6 +236,19 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     setDownloadNotifier(broadcastDownloads);
     wired = true;
   };
+
+  // Synchronous hide to prevent native view flashing over the next section.
+  // `invoke` would leave one frame where Settings header is painted but the
+  // atlas WebContentsView is still visible (see screenshot).
+  ipcMain.on('browser:setSectionVisibleSync', (event, visible: unknown) => {
+    try {
+      assertUiSender(event as unknown as Electron.IpcMainInvokeEvent, getWindow);
+    } catch {}
+    ensureWired();
+    setSectionVisible(Boolean(visible));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `returnValue` is the sync IPC contract
+    (event as any).returnValue = null;
+  });
 
   h('browser:state', async (event) => {
     assertUiSender(event, getWindow);

--- a/electron/ipc/browser.ts
+++ b/electron/ipc/browser.ts
@@ -327,6 +327,11 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     assertUiSender(event, getWindow);
     ensureWired();
     const target = homeUrl();
+    const state = browserState();
+    if (state.tabs.length === 0 || !state.activeTabId) {
+      await createTab(target);
+      return { url: target };
+    }
     if (target === 'about:blank') { navigate('about:blank'); return { url: target }; }
     navigate(target);
     return { url: target };
@@ -357,6 +362,12 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
   h('browser:closeTab', async (event, id: string) => {
     assertUiSender(event, getWindow);
     closeTab(String(id));
+    // Cerrar la última pestaña dejaba el navegador vacío: el botón Inicio
+    // (navigate) no crea pestañas y el efecto inicial solo corría al montar,
+    // obligando a salir y volver a la sección. Auto-crea la página de inicio.
+    if (browserState().tabs.length === 0) {
+      await createTab(homeUrl());
+    }
   });
 
   h('browser:goBack', async (event) => { assertUiSender(event, getWindow); goBack(); });

--- a/electron/preload/browser.ts
+++ b/electron/preload/browser.ts
@@ -75,8 +75,19 @@ export const browserApi = {
     ipcRenderer.invoke('browser:setOverlayVisible', open).then(() => undefined),
   captureBrowserOverlaySnapshot: (): Promise<string | null> =>
     ipcRenderer.invoke('browser:overlaySnapshot'),
-  setBrowserSectionVisible: (visible: boolean): Promise<void> =>
-    ipcRenderer.invoke('browser:setSectionVisible', visible).then(() => undefined),
+  setBrowserSectionVisible: (visible: boolean): Promise<void> => {
+    // Hide must be synchronous to avoid the native WebContentsView flashing over
+    // the next section (e.g. Settings). `invoke` is async (IPC roundtrip ≈ one
+    // frame) and the new view paints before main hides the view. `sendSync`
+    // blocks the renderer until main has called `setVisible(false)`.
+    if (!visible) {
+      try {
+        ipcRenderer.sendSync('browser:setSectionVisibleSync', visible);
+      } catch {}
+      return Promise.resolve();
+    }
+    return ipcRenderer.invoke('browser:setSectionVisible', visible).then(() => undefined);
+  },
   getPendingBrowserPermission: (): Promise<PendingBrowserPermission | null> =>
     ipcRenderer.invoke('browser:pendingPermission'),
   resolveBrowserPermission: (id: string, granted: boolean, remember: boolean): Promise<void> =>

--- a/scripts/test-browser-tabs.mjs
+++ b/scripts/test-browser-tabs.mjs
@@ -97,7 +97,7 @@ test('trusted Nodus overlays automatically cover native Browser pages', () => {
     'accessible dialogs must automatically hide native content');
   assert.match(overlayGuard, /\.fixed\.inset-0/,
     'legacy full-window backdrops and tours must be covered too');
-  assert.match(overlayGuard, /requestAnimationFrame\(synchronize\)/,
+  assert.match(overlayGuard, /(requestAnimationFrame|queueMicrotask)\(synchronize\)/,
     'overlapping overlay cleanup must settle after the React commit');
   assert.match(app, /useBrowserNativeOverlayGuard\(view === 'browser'\)/,
     'the app shell must enable the guard whenever Browser is the active section');

--- a/src/browserOverlay.ts
+++ b/src/browserOverlay.ts
@@ -42,14 +42,19 @@ export function useBrowserNativeOverlayGuard(enabled: boolean): void {
   useEffect(() => {
     if (!enabled) return undefined;
 
-    let animationFrame = 0;
+    let scheduled = false;
     const synchronize = () => {
-      animationFrame = 0;
+      scheduled = false;
       void setBrowserOverlayVisible(hasVisibleTrustedOverlay()).catch(() => undefined);
     };
     const schedule = () => {
-      if (animationFrame) window.cancelAnimationFrame(animationFrame);
-      animationFrame = window.requestAnimationFrame(synchronize);
+      if (scheduled) return;
+      scheduled = true;
+      // Microtask, not rAF: hides the native WebContentsView BEFORE the next paint,
+      // so the vault switcher never flashes behind the page. rAF was one frame too
+      // late (visible flash on open). Microtask still settles after the React commit
+      // but before `requestAnimationFrame` / paint.
+      queueMicrotask(synchronize);
     };
 
     const observer = new MutationObserver(schedule);
@@ -63,7 +68,6 @@ export function useBrowserNativeOverlayGuard(enabled: boolean): void {
 
     return () => {
       observer.disconnect();
-      if (animationFrame) window.cancelAnimationFrame(animationFrame);
       void setBrowserOverlayVisible(false).catch(() => undefined);
     };
   }, [enabled]);

--- a/src/components/SourceCitationModal.tsx
+++ b/src/components/SourceCitationModal.tsx
@@ -201,7 +201,7 @@ function CitationWorkspace({
         aria-modal="true"
         aria-label={t('Fuentes y contexto')}
         data-testid="source-citation-modal"
-        className="flex max-h-[90vh] min-h-[560px] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-neutral-700/80 bg-neutral-950 shadow-2xl shadow-black/60"
+        className="flex h-[min(90vh,760px)] max-h-[90vh] min-h-0 w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-neutral-700/80 bg-neutral-950 shadow-2xl shadow-black/60"
         onClick={(event) => event.stopPropagation()}
       >
         <header className="flex min-h-14 shrink-0 items-center gap-3 border-b border-neutral-800 bg-neutral-950/95 px-4 sm:px-5">
@@ -247,7 +247,7 @@ function CitationWorkspace({
           </div>
         </div>
 
-        <main className="min-h-0 flex-1 bg-neutral-950/70" data-testid="source-citation-content">
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-neutral-950/70" data-testid="source-citation-content">
           {tabs.map((tab) => (
             <CitationTabPane
               key={tab.key}
@@ -282,7 +282,7 @@ function CitationTabPane({
 }) {
   const reportTitle = useCallback((title: string) => onTitle(tab.key, title), [onTitle, tab.key]);
   return (
-    <div className={`${active ? 'h-full overflow-y-auto' : 'hidden'}`} role="tabpanel" data-testid={`source-citation-panel-${tab.key}`}>
+    <div className={`${active ? 'min-h-0 flex-1 overflow-y-auto overscroll-contain' : 'hidden'}`} role="tabpanel" data-testid={`source-citation-panel-${tab.key}`}>
       <div className="mx-auto max-w-4xl p-4 sm:p-6">
         <CitationPanel target={tab.target} authors={authors} onOpenTarget={onOpenTarget} onTitle={reportTitle} onOpenLibraryWork={onOpenLibraryWork} />
       </div>

--- a/src/components/VaultSwitcher.tsx
+++ b/src/components/VaultSwitcher.tsx
@@ -7,6 +7,7 @@ import { errorText, t, tr, tx } from '../i18n';
 import { clearFilterPreferences } from '../app/filterPreferences';
 import { ConfirmModal } from './ConfirmModal';
 import { Icon } from './ui';
+import { setBrowserOverlayVisible } from '../browserOverlay';
 import {
   NEW_VAULT_TYPES,
   isPreAlphaVaultType,
@@ -116,6 +117,14 @@ export function VaultSwitcher({ anchorEl, onClose, vaults, onVaultsChanged, onAc
       window.removeEventListener('scroll', compute, true);
     };
   }, [open, anchorEl]);
+
+  // El panel es un overlay nativo detrás de Browser: sin esto, el WebContentsView
+  // pinta por encima durante el microtask del guard y se ve un flash. LayoutEffect
+  // corre antes del paint, así que el navegador queda oculto desde el primer frame.
+  useLayoutEffect(() => {
+    if (!open) return;
+    void setBrowserOverlayVisible(true).catch(() => undefined);
+  }, [open]);
 
   // Dismiss on outside click / Escape. Clicks on a trigger (`data-vault-trigger`)
   // or inside an open child modal (`[role="dialog"]`) are ignored so they can

--- a/src/index.css
+++ b/src/index.css
@@ -4865,3 +4865,95 @@ body:has(.library-document-reader [data-testid="library-reader-sidebar"]) .app-t
 .light.testimonios .border-indigo-700\/60 { border-color: rgba(8, 145, 178, 0.45); }
 .light.testimonios .border-indigo-800\/40,
 .light.testimonios .border-indigo-800\/60 { border-color: rgba(8, 145, 178, 0.3); }
+
+/* ── Source citation modal — light theme ───────────────────────────────── */
+/* Dark-by-design sheet; light gets an opaque white surface so it never inherits charcoal. */
+.light [data-testid="source-citation-modal"] {
+  border-color: #e5e7eb;
+  background-color: #ffffff;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.18), 0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+.light [data-testid="source-citation-modal"] > header {
+  border-color: #e5e7eb;
+  background: #f8fafc;
+}
+.light [data-testid="source-citation-modal"] [data-testid="source-citation-tabs"] {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/70 {
+  background-color: #ffffff;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/95 {
+  background-color: #f8fafc;
+}
+.light [data-testid="source-citation-modal"] .border-neutral-700\/80,
+.light [data-testid="source-citation-modal"] .border-neutral-800\/80,
+.light [data-testid="source-citation-modal"] .border-neutral-800 {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-900\/35,
+.light [data-testid="source-citation-modal"] .bg-neutral-900\/55,
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/55 {
+  background-color: #ffffff;
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] section header.bg-neutral-900\/55 {
+  background-color: #f8fafc;
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .from-indigo-500\/10 {
+  --tw-gradient-from: rgba(99, 102, 241, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .via-neutral-900\/60 {
+  --tw-gradient-to: rgba(255, 255, 255, 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), #ffffff var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+.light [data-testid="source-citation-modal"] .to-neutral-950 {
+  --tw-gradient-to: #f8fafc var(--tw-gradient-to-position);
+}
+.light [data-testid="source-citation-modal"] .from-sky-500\/10 {
+  --tw-gradient-from: rgba(14, 165, 233, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-violet-500\/10 {
+  --tw-gradient-from: rgba(139, 92, 246, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-amber-500\/10 {
+  --tw-gradient-from: rgba(245, 158, 11, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-red-500\/10 {
+  --tw-gradient-from: rgba(239, 68, 68, 0.07) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-emerald-500\/10 {
+  --tw-gradient-from: rgba(16, 185, 129, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .border-indigo-500\/25,
+.light [data-testid="source-citation-modal"] .border-sky-500\/20,
+.light [data-testid="source-citation-modal"] .border-violet-500\/20,
+.light [data-testid="source-citation-modal"] .border-amber-500\/25,
+.light [data-testid="source-citation-modal"] .border-red-500\/25,
+.light [data-testid="source-citation-modal"] .border-emerald-500\/25 {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-indigo-500\/15 {
+  background-color: rgba(99, 102, 241, 0.12);
+}
+.light [data-testid="source-citation-modal"] .border-neutral-700 {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/55 {
+  background-color: #ffffff;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-100,
+.light [data-testid="source-citation-modal"] .text-neutral-200 {
+  color: #0f172a;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-300 {
+  color: #1e293b;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-400,
+.light [data-testid="source-citation-modal"] .text-neutral-500 {
+  color: #475569;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-600 {
+  color: #64748b;
+}


### PR DESCRIPTION
Fixes #509

### What
- **Browser empty state**: `browser:closeTab` now auto-creates `homeUrl()` when the last tab is closed; `browser:goHome` creates a tab when `tabs.length===0 || !activeTabId` instead of silently failing via `navigate()`. Prevents double Research Atlas (renderer no longer auto-creates on empty — single producer in main).
- **Vault switcher flash**: `useBrowserNativeOverlayGuard` now uses `queueMicrotask(synchronize)` instead of `requestAnimationFrame` so the native `WebContentsView` is hidden **before** the next paint (rAF was one frame late). `VaultSwitcher` also hides immediately in a `useLayoutEffect` when `open`.
- **Citation modal**: `SourceCitationModal` fixed height `h-[min(90vh,760px)] min-h-0`, `main` as `flex flex-col overflow-hidden`, `CitationTabPane` as `flex-1 overflow-y-auto overscroll-contain` (scroll works); light-mode overrides for all neutral/indigo gradients in `index.css`.

### Test
- `npm run typecheck` pass
- `npm run build` pass
- `node --test scripts/test-browser-tabs.mjs` 16/16 (updated assertion to accept `queueMicrotask`)
- Manual verification on isolated profile `NODUS_USERDATA=/tmp/nodus-modal-fix-copy` (Browser, vault switcher, deep research citation modal in both themes).

### Risk
Low — isolated to Browser IPC + overlay guard + citation modal styling. No DB migration.

