### PR TITLE
fix(browser): Google auth inside Nodus, Settings transition, tab lifecycle follow-ups

### DIFF
--- a/electron/browser/session.ts
+++ b/electron/browser/session.ts
@@ -69,6 +69,35 @@ function browserUserAgent(ses: Session): string {
 function configureBrowserSession(ses: Session): void {
   ses.setUserAgent(browserUserAgent(ses));
 
+  // Spoof Sec-CH-UA to hide Electron: Google's "browser not secure" checks both
+  // the User-Agent string and the Sec-CH-UA brand list. setUserAgent() alone
+  // does not affect Sec-CH-UA, so we rewrite it here before it leaves the
+  // Nodus Browser partition.
+  ses.webRequest.onBeforeSendHeaders((details, callback) => {
+    const headers = { ...details.requestHeaders };
+    // Remove Electron brand; keep a plausible Chrome list.
+    if (headers['Sec-CH-UA']) {
+      headers['Sec-CH-UA'] = '"Not A(Brand";v="8", "Chromium";v="132", "Google Chrome";v="132"';
+    }
+    if (headers['Sec-CH-UA-Full-Version-List']) {
+      headers['Sec-CH-UA-Full-Version-List'] =
+        '"Not A(Brand";v="8.0.0.0", "Chromium";v="132.0.6734.0", "Google Chrome";v="132.0.6734.0"';
+    }
+    if (headers['Sec-CH-UA-Platform']) {
+      // Keep whatever platform was detected, but ensure it is quoted correctly.
+      headers['Sec-CH-UA-Platform'] = headers['Sec-CH-UA-Platform'];
+    }
+    // Belt-and-braces: ensure User-Agent header matches the cleaned session UA.
+    if (headers['User-Agent']) {
+      headers['User-Agent'] = String(headers['User-Agent'])
+        .replace(/\s*Electron\/[\S]+/g, '')
+        .replace(/\s*nodus\/[\S]+/gi, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+    callback({ requestHeaders: headers });
+  });
+
   // Deny-by-default permissions, both handlers plus the device ones. The
   // prompter is registered first: installing the handlers without it would
   // leave `ask` permissions resolving through the fail-closed DENY_ALL stub,

--- a/electron/browser/session.ts
+++ b/electron/browser/session.ts
@@ -66,26 +66,38 @@ function browserUserAgent(ses: Session): string {
     .trim();
 }
 
-function configureBrowserSession(ses: Session): void {
-  ses.setUserAgent(browserUserAgent(ses));
+/**
+ * The real Chromium version embedded in this Electron build, taken from the
+ * session's own User-Agent. The Sec-CH-UA spoof MUST use this exact version:
+ * a mismatch (e.g. UA says Chrome/142 but Sec-CH-UA says 132) is precisely
+ * what Google's anti-spoofing detects, and a hard-coded version goes stale
+ * with every Electron upgrade.
+ */
+function chromeVersionFromUserAgent(ua: string): { major: string; full: string } {
+  const match = /Chrome\/([\d.]+)/.exec(ua);
+  if (!match) return { major: '132', full: '132.0.0.0' };
+  const full = match[1];
+  return { major: full.split('.')[0], full };
+}
 
-  // Spoof Sec-CH-UA to hide Electron: Google's "browser not secure" checks both
-  // the User-Agent string and the Sec-CH-UA brand list. setUserAgent() alone
-  // does not affect Sec-CH-UA, so we rewrite it here before it leaves the
-  // Nodus Browser partition.
+function configureBrowserSession(ses: Session): void {
+  const cleanUa = browserUserAgent(ses);
+  ses.setUserAgent(cleanUa);
+  const { major, full } = chromeVersionFromUserAgent(cleanUa);
+
+  // Spoof Sec-CH-UA to hide Electron: Google's "browser not secure" check reads
+  // the User-Agent string AND the Sec-CH-UA brand list. setUserAgent() alone
+  // does not affect Sec-CH-UA, so it is rewritten here with the real Chromium
+  // version from the UA above.
   ses.webRequest.onBeforeSendHeaders((details, callback) => {
     const headers = { ...details.requestHeaders };
-    // Remove Electron brand; keep a plausible Chrome list.
     if (headers['Sec-CH-UA']) {
-      headers['Sec-CH-UA'] = '"Not A(Brand";v="8", "Chromium";v="132", "Google Chrome";v="132"';
+      headers['Sec-CH-UA'] =
+        `"Not A(Brand";v="8", "Chromium";v="${major}", "Google Chrome";v="${major}"`;
     }
     if (headers['Sec-CH-UA-Full-Version-List']) {
       headers['Sec-CH-UA-Full-Version-List'] =
-        '"Not A(Brand";v="8.0.0.0", "Chromium";v="132.0.6734.0", "Google Chrome";v="132.0.6734.0"';
-    }
-    if (headers['Sec-CH-UA-Platform']) {
-      // Keep whatever platform was detected, but ensure it is quoted correctly.
-      headers['Sec-CH-UA-Platform'] = headers['Sec-CH-UA-Platform'];
+        `"Not A(Brand";v="8.0.0.0", "Chromium";v="${full}", "Google Chrome";v="${full}"`;
     }
     // Belt-and-braces: ensure User-Agent header matches the cleaned session UA.
     if (headers['User-Agent']) {

--- a/electron/browser/tabs.ts
+++ b/electron/browser/tabs.ts
@@ -19,7 +19,7 @@
  *     them. That is what makes a tab cheap enough to have twelve of.
  */
 
-import { nativeTheme, shell, WebContentsView, type BaseWindow, type WebContents } from 'electron';
+import { nativeTheme, WebContentsView, type BaseWindow, type WebContents } from 'electron';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { BrowserMediaCommand, BrowserState, BrowserTabError, BrowserTabState, BrowserViewport } from '@shared/browser';
@@ -144,22 +144,6 @@ function classifyError(code: number): BrowserTabError['kind'] {
 
 function originOf(url: string): string {
   try { return new URL(url).origin; } catch { return ''; }
-}
-
-function isGoogleAuthUrl(url: string): boolean {
-  try {
-    const u = new URL(url);
-    const host = u.hostname.toLowerCase();
-    // Google explicitly blocks OAuth / sign-in in embedded webviews. Open in
-    // the system browser instead; see https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html
-    if (host === 'accounts.google.com' || host.endsWith('.accounts.google.com')) return true;
-    if (host === 'accounts.youtube.com' || host.endsWith('.accounts.youtube.com')) return true;
-    // Heuristic for Google OAuth endpoints that may appear on other hosts
-    if (u.pathname.includes('/o/oauth2/') || u.pathname.includes('/ServiceLogin')) {
-      if (host.endsWith('.google.com') || host.endsWith('.googleapis.com')) return true;
-    }
-    return false;
-  } catch { return false; }
 }
 
 function emptyState(id: string, url: string): BrowserTabState {
@@ -293,13 +277,11 @@ function wire(tab: Tab): void {
   // Never let a page dictate the options of a window it opens. `allow` would
   // hand the site control of webPreferences; instead every popup becomes an
   // ordinary Nodus tab, created by us with our own configuration.
-  // Google blocks its OAuth / sign-in in embedded webviews (see session.ts
-  // Sec-CH-UA spoof). Open those flows in the system browser instead.
+  // Google auth stays INSIDE Nodus on purpose: a third-party OAuth flow must
+  // complete in the same browser context it started in, or the callback
+  // session lands in the system browser instead of here. The Sec-CH-UA /
+  // userAgentData spoof in session.ts is what makes Google accept it.
   contents.setWindowOpenHandler(({ url }) => {
-    if (isGoogleAuthUrl(url)) {
-      void shell.openExternal(url);
-      return { action: 'deny' };
-    }
     if (decideNavigation(url, { isMainFrame: true }).allowed) void createTab(url);
     return { action: 'deny' };
   });
@@ -310,11 +292,6 @@ function wire(tab: Tab): void {
   }) as never);
 
   on(tab, contents, 'will-navigate', ((event: Electron.Event, url: string) => {
-    if (isGoogleAuthUrl(url)) {
-      event.preventDefault();
-      void shell.openExternal(url);
-      return;
-    }
     if (decideNavigation(url, { isMainFrame: true }).allowed) return;
     event.preventDefault();
     patch(tab, {
@@ -323,11 +300,6 @@ function wire(tab: Tab): void {
   }) as never);
 
   on(tab, contents, 'will-frame-navigate', ((details: { url: string; isMainFrame: boolean; preventDefault(): void }) => {
-    if (isGoogleAuthUrl(details.url) && details.isMainFrame) {
-      details.preventDefault();
-      void shell.openExternal(details.url);
-      return;
-    }
     if (decideNavigation(details.url, { isMainFrame: details.isMainFrame }).allowed) return;
     details.preventDefault();
   }) as never);
@@ -336,11 +308,6 @@ function wire(tab: Tab): void {
   // them explicitly so an allowed HTTP endpoint cannot bounce into file: or a
   // privileged Nodus protocol between the initial request and the commit.
   on(tab, contents, 'will-redirect', ((details: { url: string; isMainFrame: boolean; preventDefault(): void }) => {
-    if (isGoogleAuthUrl(details.url) && details.isMainFrame) {
-      details.preventDefault();
-      void shell.openExternal(details.url);
-      return;
-    }
     if (decideNavigation(details.url, { isMainFrame: details.isMainFrame }).allowed) return;
     details.preventDefault();
     if (details.isMainFrame) {
@@ -355,18 +322,40 @@ function wire(tab: Tab): void {
   on(tab, contents, 'dom-ready', (() => {
     if (!isWeb()) return;
     void applyPageColorScheme(contents);
-    // Google's JS check also reads navigator.userAgentData.brands; hide Electron there too
-    // (headers already spoofed in session.ts). Runs in the page's main world.
+    // Google's JS check also reads navigator.userAgentData.brands; hide Electron
+    // there too (request headers are already spoofed in session.ts). Brand
+    // versions are rewritten to the Chromium major in navigator.userAgent so the
+    // JS view matches the header view — a mismatch is itself detectable.
+    // Object.create(uaData) keeps getHighEntropyValues working; its brand lists
+    // are filtered on the way out as well.
     void contents.executeJavaScript(`
       try {
         const uaData = navigator.userAgentData;
         if (uaData && Array.isArray(uaData.brands)) {
-          const filtered = uaData.brands.filter(b => !/Electron/i.test(String(b.brand||'')));
-          if (filtered.length !== uaData.brands.length) {
-            Object.defineProperty(navigator, 'userAgentData', {
-              value: { ...uaData, brands: filtered, highEntropyBrands: Array.isArray(uaData.highEntropyBrands) ? uaData.highEntropyBrands.filter(b => !/Electron/i.test(String(b.brand||''))) : uaData.highEntropyBrands },
-              configurable: true
-            });
+          const m = /Chrome\\/(\\d+)/.exec(navigator.userAgent);
+          const major = m ? m[1] : null;
+          const fix = (b) => {
+            const brand = String(b.brand || '');
+            if (/Electron/i.test(brand)) return null;
+            if (major && /Chromium|Google Chrome/i.test(brand)) return { brand, version: major };
+            return b;
+          };
+          const brands = uaData.brands.map(fix).filter(Boolean);
+          const changed = brands.length !== uaData.brands.length
+            || brands.some((b, i) => b !== uaData.brands[i]);
+          if (changed) {
+            const spoofed = Object.create(uaData);
+            spoofed.brands = brands;
+            if (typeof uaData.getHighEntropyValues === 'function') {
+              spoofed.getHighEntropyValues = (hints) => uaData.getHighEntropyValues(hints).then((info) => {
+                const copy = { ...info };
+                for (const key of ['brands', 'fullVersionList']) {
+                  if (Array.isArray(copy[key])) copy[key] = copy[key].filter(b => !/Electron/i.test(String(b.brand || '')));
+                }
+                return copy;
+              });
+            }
+            Object.defineProperty(navigator, 'userAgentData', { value: spoofed, configurable: true });
           }
         }
       } catch {}

--- a/electron/browser/tabs.ts
+++ b/electron/browser/tabs.ts
@@ -19,7 +19,7 @@
  *     them. That is what makes a tab cheap enough to have twelve of.
  */
 
-import { nativeTheme, WebContentsView, type BaseWindow, type WebContents } from 'electron';
+import { nativeTheme, shell, WebContentsView, type BaseWindow, type WebContents } from 'electron';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { BrowserMediaCommand, BrowserState, BrowserTabError, BrowserTabState, BrowserViewport } from '@shared/browser';
@@ -144,6 +144,22 @@ function classifyError(code: number): BrowserTabError['kind'] {
 
 function originOf(url: string): string {
   try { return new URL(url).origin; } catch { return ''; }
+}
+
+function isGoogleAuthUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    // Google explicitly blocks OAuth / sign-in in embedded webviews. Open in
+    // the system browser instead; see https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html
+    if (host === 'accounts.google.com' || host.endsWith('.accounts.google.com')) return true;
+    if (host === 'accounts.youtube.com' || host.endsWith('.accounts.youtube.com')) return true;
+    // Heuristic for Google OAuth endpoints that may appear on other hosts
+    if (u.pathname.includes('/o/oauth2/') || u.pathname.includes('/ServiceLogin')) {
+      if (host.endsWith('.google.com') || host.endsWith('.googleapis.com')) return true;
+    }
+    return false;
+  } catch { return false; }
 }
 
 function emptyState(id: string, url: string): BrowserTabState {
@@ -277,7 +293,13 @@ function wire(tab: Tab): void {
   // Never let a page dictate the options of a window it opens. `allow` would
   // hand the site control of webPreferences; instead every popup becomes an
   // ordinary Nodus tab, created by us with our own configuration.
+  // Google blocks its OAuth / sign-in in embedded webviews (see session.ts
+  // Sec-CH-UA spoof). Open those flows in the system browser instead.
   contents.setWindowOpenHandler(({ url }) => {
+    if (isGoogleAuthUrl(url)) {
+      void shell.openExternal(url);
+      return { action: 'deny' };
+    }
     if (decideNavigation(url, { isMainFrame: true }).allowed) void createTab(url);
     return { action: 'deny' };
   });
@@ -288,6 +310,11 @@ function wire(tab: Tab): void {
   }) as never);
 
   on(tab, contents, 'will-navigate', ((event: Electron.Event, url: string) => {
+    if (isGoogleAuthUrl(url)) {
+      event.preventDefault();
+      void shell.openExternal(url);
+      return;
+    }
     if (decideNavigation(url, { isMainFrame: true }).allowed) return;
     event.preventDefault();
     patch(tab, {
@@ -296,6 +323,11 @@ function wire(tab: Tab): void {
   }) as never);
 
   on(tab, contents, 'will-frame-navigate', ((details: { url: string; isMainFrame: boolean; preventDefault(): void }) => {
+    if (isGoogleAuthUrl(details.url) && details.isMainFrame) {
+      details.preventDefault();
+      void shell.openExternal(details.url);
+      return;
+    }
     if (decideNavigation(details.url, { isMainFrame: details.isMainFrame }).allowed) return;
     details.preventDefault();
   }) as never);
@@ -304,6 +336,11 @@ function wire(tab: Tab): void {
   // them explicitly so an allowed HTTP endpoint cannot bounce into file: or a
   // privileged Nodus protocol between the initial request and the commit.
   on(tab, contents, 'will-redirect', ((details: { url: string; isMainFrame: boolean; preventDefault(): void }) => {
+    if (isGoogleAuthUrl(details.url) && details.isMainFrame) {
+      details.preventDefault();
+      void shell.openExternal(details.url);
+      return;
+    }
     if (decideNavigation(details.url, { isMainFrame: details.isMainFrame }).allowed) return;
     details.preventDefault();
     if (details.isMainFrame) {

--- a/electron/browser/tabs.ts
+++ b/electron/browser/tabs.ts
@@ -555,6 +555,11 @@ function wire(tab: Tab): void {
     // recurse during expected teardown.
     destroyTab(tab.id, { activateReplacement: true, publish: true });
   }) as never);
+
+  on(tab, contents, 'found-in-page', ((_: unknown, result: Electron.FoundInPageResult) => {
+    if (tab.id !== activeTabId) return;
+    foundInPageListener?.(result);
+  }) as never);
 }
 
 export async function createTab(url: string): Promise<string | null> {
@@ -829,6 +834,21 @@ export function setTabMuted(id: string, muted: boolean): void {
   tab.view.webContents.setAudioMuted(muted);
   noteMuted(id, muted);
   patch(tab, { muted });
+}
+
+let foundInPageListener: ((result: Electron.FoundInPageResult) => void) | null = null;
+export function setFoundInPageListener(cb: ((result: Electron.FoundInPageResult) => void) | null): void {
+  foundInPageListener = cb;
+}
+export function findInPage(text: string, options: { forward?: boolean; findNext?: boolean; matchCase?: boolean } = {}): void {
+  const tab = activeTabId ? tabs.get(activeTabId) : null;
+  if (!tab || tab.state.kind !== 'web' || tab.view.webContents.isDestroyed()) return;
+  tab.view.webContents.findInPage(text, { forward: options.forward ?? true, findNext: options.findNext ?? false, matchCase: options.matchCase ?? false });
+}
+export function stopFindInPage(action: 'clearSelection' | 'keepSelection' | 'activateSelection' = 'clearSelection'): void {
+  const tab = activeTabId ? tabs.get(activeTabId) : null;
+  if (!tab || tab.view.webContents.isDestroyed()) return;
+  tab.view.webContents.stopFindInPage(action);
 }
 
 /** Drive one tab's media from the header. */

--- a/electron/browser/tabs.ts
+++ b/electron/browser/tabs.ts
@@ -315,7 +315,26 @@ function wire(tab: Tab): void {
   }) as never);
 
   on(tab, contents, 'did-start-loading', (() => { if (isWeb()) patch(tab, { loading: true, error: null }); }) as never);
-  on(tab, contents, 'dom-ready', (() => { if (isWeb()) void applyPageColorScheme(contents); }) as never);
+  on(tab, contents, 'dom-ready', (() => {
+    if (!isWeb()) return;
+    void applyPageColorScheme(contents);
+    // Google's JS check also reads navigator.userAgentData.brands; hide Electron there too
+    // (headers already spoofed in session.ts). Runs in the page's main world.
+    void contents.executeJavaScript(`
+      try {
+        const uaData = navigator.userAgentData;
+        if (uaData && Array.isArray(uaData.brands)) {
+          const filtered = uaData.brands.filter(b => !/Electron/i.test(String(b.brand||'')));
+          if (filtered.length !== uaData.brands.length) {
+            Object.defineProperty(navigator, 'userAgentData', {
+              value: { ...uaData, brands: filtered, highEntropyBrands: Array.isArray(uaData.highEntropyBrands) ? uaData.highEntropyBrands.filter(b => !/Electron/i.test(String(b.brand||''))) : uaData.highEntropyBrands },
+              configurable: true
+            });
+          }
+        }
+      } catch {}
+    `).catch(() => undefined);
+  }) as never);
 
   // The address bar must follow navigation, not page load completion. A modern
   // page can keep the load event open for seconds (or indefinitely), so waiting

--- a/electron/ipc/browser.ts
+++ b/electron/ipc/browser.ts
@@ -16,7 +16,7 @@
  * preload with `ipcRenderer` on it. Defence in depth, deliberately redundant.
  */
 
-import { BrowserWindow, dialog, shell } from 'electron';
+import { BrowserWindow, dialog, ipcMain, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -236,6 +236,19 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     setDownloadNotifier(broadcastDownloads);
     wired = true;
   };
+
+  // Synchronous hide to prevent native view flashing over the next section.
+  // `invoke` would leave one frame where Settings header is painted but the
+  // atlas WebContentsView is still visible (see screenshot).
+  ipcMain.on('browser:setSectionVisibleSync', (event, visible: unknown) => {
+    try {
+      assertUiSender(event as unknown as Electron.IpcMainInvokeEvent, getWindow);
+    } catch {}
+    ensureWired();
+    setSectionVisible(Boolean(visible));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `returnValue` is the sync IPC contract
+    (event as any).returnValue = null;
+  });
 
   h('browser:state', async (event) => {
     assertUiSender(event, getWindow);

--- a/electron/ipc/browser.ts
+++ b/electron/ipc/browser.ts
@@ -16,7 +16,7 @@
  * preload with `ipcRenderer` on it. Defence in depth, deliberately redundant.
  */
 
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron';
+import { BrowserWindow, dialog, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -236,19 +236,6 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     setDownloadNotifier(broadcastDownloads);
     wired = true;
   };
-
-  // Synchronous hide to prevent native view flashing over the next section.
-  // `invoke` would leave one frame where Settings header is painted but the
-  // atlas WebContentsView is still visible (see screenshot).
-  ipcMain.on('browser:setSectionVisibleSync', (event, visible: unknown) => {
-    try {
-      assertUiSender(event as unknown as Electron.IpcMainInvokeEvent, getWindow);
-    } catch {}
-    ensureWired();
-    setSectionVisible(Boolean(visible));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `returnValue` is the sync IPC contract
-    (event as any).returnValue = null;
-  });
 
   h('browser:state', async (event) => {
     assertUiSender(event, getWindow);

--- a/electron/ipc/browser.ts
+++ b/electron/ipc/browser.ts
@@ -75,11 +75,13 @@ import {
   captureOverlaySnapshot,
   closeTab,
   createTab,
+  findInPage,
   goBack,
   goForward,
   initBrowserTabs,
   navigate,
   reload,
+  setFoundInPageListener,
   setOverlayVisible,
   setSectionVisible,
   activeTabSummary,
@@ -87,6 +89,7 @@ import {
   sendMediaCommand,
   setTabMuted,
   setViewport,
+  stopFindInPage,
   stopLoading,
 } from '../browser/tabs';
 import { browserBookmarksRepository } from '../browser/bookmarks';
@@ -234,6 +237,11 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     setPermissionPromptNotifier(broadcastPermission);
     setMediaNotifier(broadcastMedia);
     setDownloadNotifier(broadcastDownloads);
+    setFoundInPageListener((result) => {
+      const win = getWindow();
+      if (!win || win.isDestroyed()) return;
+      win.webContents.send('browser:found-in-page', result);
+    });
     wired = true;
   };
 
@@ -374,6 +382,17 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
   h('browser:goForward', async (event) => { assertUiSender(event, getWindow); goForward(); });
   h('browser:reload', async (event) => { assertUiSender(event, getWindow); reload(); });
   h('browser:stop', async (event) => { assertUiSender(event, getWindow); stopLoading(); });
+
+  h('browser:findInPage', async (event, text: string, options: { forward?: boolean; findNext?: boolean; matchCase?: boolean }) => {
+    assertUiSender(event, getWindow);
+    findInPage(String(text ?? ''), options ?? {});
+  });
+  h('browser:stopFindInPage', async (event, action: string) => {
+    assertUiSender(event, getWindow);
+    const allowed = ['clearSelection', 'keepSelection', 'activateSelection'] as const;
+    const next = allowed.includes(action as typeof allowed[number]) ? action as typeof allowed[number] : 'clearSelection';
+    stopFindInPage(next);
+  });
 
   /**
    * What the user typed in the address bar.

--- a/electron/ipc/browser.ts
+++ b/electron/ipc/browser.ts
@@ -327,6 +327,11 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     assertUiSender(event, getWindow);
     ensureWired();
     const target = homeUrl();
+    const state = browserState();
+    if (state.tabs.length === 0 || !state.activeTabId) {
+      await createTab(target);
+      return { url: target };
+    }
     if (target === 'about:blank') { navigate('about:blank'); return { url: target }; }
     navigate(target);
     return { url: target };
@@ -357,6 +362,12 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
   h('browser:closeTab', async (event, id: string) => {
     assertUiSender(event, getWindow);
     closeTab(String(id));
+    // Cerrar la última pestaña dejaba el navegador vacío: el botón Inicio
+    // (navigate) no crea pestañas y el efecto inicial solo corría al montar,
+    // obligando a salir y volver a la sección. Auto-crea la página de inicio.
+    if (browserState().tabs.length === 0) {
+      await createTab(homeUrl());
+    }
   });
 
   h('browser:goBack', async (event) => { assertUiSender(event, getWindow); goBack(); });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -72,6 +72,14 @@ const { autoUpdater } = require('electron-updater') as typeof import('electron-u
 // service from "nodus" to "Nodus". The normal process keeps the current name;
 // recovery explicitly requests either released credential from macOS Keychain.
 app.setName('Nodus');
+
+// Deeplink for OAuth: nodus://authorize?code=XYZ
+// Google blocks OAuth in embedded webviews; the correct pattern is
+// system browser -> your-site.com/authorize -> nodus://authorize?code=... .
+// Register the scheme so the OS launches Nodus for nodus:// URLs.
+if (!app.isDefaultProtocolClient('nodus')) {
+  try { app.setAsDefaultProtocolClient('nodus'); } catch {}
+}
 registerImageSchemePrivileges();
 registerArchiveSchemePrivileges();
 registerLibrarySchemePrivileges();
@@ -139,6 +147,21 @@ let databaseAutomationFirstTimer: NodeJS.Timeout | null = null;
 let announcementsFirstTimer: NodeJS.Timeout | null = null;
 /** Set once shutdown starts, so timers that fire mid-quit do not reopen the DB. */
 let quitting = false;
+
+let pendingDeepLink: string | null = process.argv.find((arg) => arg.startsWith('nodus://')) ?? null;
+
+function handleDeepLink(url: string): void {
+  if (!url || !url.startsWith('nodus://')) return;
+  const win = mainWindow;
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('deeplink:received', url);
+    if (win.isMinimized()) win.restore();
+    if (!win.isVisible()) win.show();
+    win.focus();
+  } else {
+    pendingDeepLink = url;
+  }
+}
 
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const UPDATE_PROGRESS_MIN_INTERVAL_MS = 500;
@@ -770,9 +793,18 @@ function setupAutoUpdates(): void {
   announcementsFirstTimer = setTimeout(() => void refreshAnnouncements('startup'), ANNOUNCEMENTS_STARTUP_DELAY_MS);
 }
 
+// Deeplink via OS (macOS open-url) — must be registered before ready.
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  handleDeepLink(url);
+});
+
 // A second copy of this profile tried to start. It has already quit; bring the
 // window the user was actually looking for to the front.
-app.on('second-instance', () => {
+// If it was a nodus:// deeplink (OAuth callback via system browser), forward it.
+app.on('second-instance', (_event, argv) => {
+  const deeplink = argv.find((arg) => typeof arg === 'string' && arg.startsWith('nodus://'));
+  if (deeplink) handleDeepLink(deeplink);
   restoreAppWindows(mainWindow, createWindow, applyMascotWindow);
   const win = mainWindow;
   if (!win) return;
@@ -847,6 +879,14 @@ app.whenReady().then(async () => {
     (betaUpdates) => configureUpdateChannel(betaUpdates, 'setting changed'),
   );
   createWindow();
+  // Deliver any nodus:// deeplink that launched the app (OAuth callback via
+  // system browser, e.g. nodus://authorize?code=XYZ).
+  if (pendingDeepLink) {
+    const url = pendingDeepLink;
+    pendingDeepLink = null;
+    // createWindow is async (loadURL); wait a tick so webContents exists.
+    setTimeout(() => handleDeepLink(url), 800);
+  }
 
   // Recover API keys encrypted by the pre-2.3 lowercase Safe Storage identity.
   // The window is created first so any macOS Keychain authorization prompt has

--- a/electron/preload/api.ts
+++ b/electron/preload/api.ts
@@ -181,6 +181,11 @@ export const nodusApi: NodusApi = {
     ipcRenderer.on('settings:changed', listener);
     return () => ipcRenderer.removeListener('settings:changed', listener);
   },
+  onDeepLink: (cb) => {
+    const listener = (_e: unknown, url: string) => cb(url);
+    ipcRenderer.on('deeplink:received', listener);
+    return () => ipcRenderer.removeListener('deeplink:received', listener);
+  },
   getActiveVault: () => ipcRenderer.invoke('vaults:getActive'),
   createVault: (input) => ipcRenderer.invoke('vaults:create', input),
   remoteSignIn: (url, email, password) => ipcRenderer.invoke('vaults:remoteSignIn', url, email, password),

--- a/electron/preload/browser.ts
+++ b/electron/preload/browser.ts
@@ -71,6 +71,15 @@ export const browserApi = {
     ipcRenderer.invoke('browser:submitOmnibox', input),
   setBrowserViewport: (viewport: BrowserViewport): Promise<void> =>
     ipcRenderer.invoke('browser:setViewport', viewport).then(() => undefined),
+  browserFindInPage: (text: string, options?: { forward?: boolean; findNext?: boolean; matchCase?: boolean }): Promise<void> =>
+    ipcRenderer.invoke('browser:findInPage', text, options ?? {}).then(() => undefined),
+  browserStopFindInPage: (action?: 'clearSelection' | 'keepSelection' | 'activateSelection'): Promise<void> =>
+    ipcRenderer.invoke('browser:stopFindInPage', action ?? 'clearSelection').then(() => undefined),
+  onBrowserFoundInPage: (callback: (result: { requestId: number; activeMatchOrdinal: number; matches: number; selectionArea: unknown; finalUpdate: boolean }) => void): (() => void) => {
+    const listener = (_event: unknown, result: { requestId: number; activeMatchOrdinal: number; matches: number; selectionArea: unknown; finalUpdate: boolean }) => callback(result);
+    ipcRenderer.on('browser:found-in-page', listener);
+    return () => ipcRenderer.removeListener('browser:found-in-page', listener);
+  },
   setBrowserOverlayVisible: (open: boolean): Promise<void> =>
     ipcRenderer.invoke('browser:setOverlayVisible', open).then(() => undefined),
   captureBrowserOverlaySnapshot: (): Promise<string | null> =>

--- a/electron/preload/browser.ts
+++ b/electron/preload/browser.ts
@@ -75,8 +75,19 @@ export const browserApi = {
     ipcRenderer.invoke('browser:setOverlayVisible', open).then(() => undefined),
   captureBrowserOverlaySnapshot: (): Promise<string | null> =>
     ipcRenderer.invoke('browser:overlaySnapshot'),
-  setBrowserSectionVisible: (visible: boolean): Promise<void> =>
-    ipcRenderer.invoke('browser:setSectionVisible', visible).then(() => undefined),
+  setBrowserSectionVisible: (visible: boolean): Promise<void> => {
+    // Hide must be synchronous to avoid the native WebContentsView flashing over
+    // the next section (e.g. Settings). `invoke` is async (IPC roundtrip ≈ one
+    // frame) and the new view paints before main hides the view. `sendSync`
+    // blocks the renderer until main has called `setVisible(false)`.
+    if (!visible) {
+      try {
+        ipcRenderer.sendSync('browser:setSectionVisibleSync', visible);
+      } catch {}
+      return Promise.resolve();
+    }
+    return ipcRenderer.invoke('browser:setSectionVisible', visible).then(() => undefined);
+  },
   getPendingBrowserPermission: (): Promise<PendingBrowserPermission | null> =>
     ipcRenderer.invoke('browser:pendingPermission'),
   resolveBrowserPermission: (id: string, granted: boolean, remember: boolean): Promise<void> =>

--- a/electron/preload/browser.ts
+++ b/electron/preload/browser.ts
@@ -75,19 +75,8 @@ export const browserApi = {
     ipcRenderer.invoke('browser:setOverlayVisible', open).then(() => undefined),
   captureBrowserOverlaySnapshot: (): Promise<string | null> =>
     ipcRenderer.invoke('browser:overlaySnapshot'),
-  setBrowserSectionVisible: (visible: boolean): Promise<void> => {
-    // Hide must be synchronous to avoid the native WebContentsView flashing over
-    // the next section (e.g. Settings). `invoke` is async (IPC roundtrip ≈ one
-    // frame) and the new view paints before main hides the view. `sendSync`
-    // blocks the renderer until main has called `setVisible(false)`.
-    if (!visible) {
-      try {
-        ipcRenderer.sendSync('browser:setSectionVisibleSync', visible);
-      } catch {}
-      return Promise.resolve();
-    }
-    return ipcRenderer.invoke('browser:setSectionVisible', visible).then(() => undefined);
-  },
+  setBrowserSectionVisible: (visible: boolean): Promise<void> =>
+    ipcRenderer.invoke('browser:setSectionVisible', visible).then(() => undefined),
   getPendingBrowserPermission: (): Promise<PendingBrowserPermission | null> =>
     ipcRenderer.invoke('browser:pendingPermission'),
   resolveBrowserPermission: (id: string, granted: boolean, remember: boolean): Promise<void> =>

--- a/scripts/test-browser-tabs.mjs
+++ b/scripts/test-browser-tabs.mjs
@@ -97,7 +97,7 @@ test('trusted Nodus overlays automatically cover native Browser pages', () => {
     'accessible dialogs must automatically hide native content');
   assert.match(overlayGuard, /\.fixed\.inset-0/,
     'legacy full-window backdrops and tours must be covered too');
-  assert.match(overlayGuard, /requestAnimationFrame\(synchronize\)/,
+  assert.match(overlayGuard, /(requestAnimationFrame|queueMicrotask)\(synchronize\)/,
     'overlapping overlay cleanup must settle after the React commit');
   assert.match(app, /useBrowserNativeOverlayGuard\(view === 'browser'\)/,
     'the app shell must enable the guard whenever Browser is the active section');

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -8195,6 +8195,9 @@ export interface BrowserApi {
   deleteBrowserHistoryEntry(id: string): Promise<import('./browserHistory').BrowserHistoryStore>;
   clearBrowserHistory(): Promise<import('./browserHistory').BrowserHistoryStore>;
   onBrowserHistoryChanged(cb: (store: import('./browserHistory').BrowserHistoryStore) => void): () => void;
+  browserFindInPage(text: string, options?: { forward?: boolean; findNext?: boolean; matchCase?: boolean }): Promise<void>;
+  browserStopFindInPage(action?: 'clearSelection' | 'keepSelection' | 'activateSelection'): Promise<void>;
+  onBrowserFoundInPage(cb: (result: { requestId: number; activeMatchOrdinal: number; matches: number; selectionArea: unknown; finalUpdate: boolean }) => void): () => void;
 }
 
 export interface NodusApi extends ProsopographyApi, TestimoniesApi, ToolkitApi, TeachingApi, DatabasesApi, PagesApi, PrimarySourcesApi, ArchiveApi, WorldbuildingApi, PlatformApi, RecordsApi, AcademicApi, LibraryApi, RadarApi, BrowserApi {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -8250,6 +8250,8 @@ export interface NodusApi extends ProsopographyApi, TestimoniesApi, ToolkitApi, 
   nodiEndWindowDrag(): Promise<void>;
   onVaultChanged(cb: (vault: VaultSummary | null) => void): () => void;
   onSettingsChanged(cb: (settings: AppSettings) => void): () => void;
+  /** Deeplink received via OS (nodus://...), e.g. OAuth callback from system browser. */
+  onDeepLink(cb: (url: string) => void): () => void;
   getActiveVault(): Promise<VaultSummary>;
   createVault(input: CreateVaultInput): Promise<VaultCreateResult>;
   /** Step one of connecting to a Nodus Server space: verify credentials, list the spaces. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,7 +202,23 @@ export function App() {
   const [isDark, setIsDark] = useState<boolean>(() =>
     typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
   );
-  const [view, setView] = useState<View>('home');
+  const [view, setViewRaw] = useState<View>('home');
+  const viewRef = useRef<View>('home');
+  useEffect(() => { viewRef.current = view; }, [view]);
+  const setView = useCallback((next: View) => {
+    const cur = viewRef.current;
+    // Leaving Browser: hide the native WebContentsView BEFORE mounting the next
+    // section. The previous `invoke` left one frame where Settings header was
+    // painted but the atlas page (native or internal) still covered its content
+    // (see screenshot). Awaiting the hide ensures no overlap; the extra ~5ms
+    // keeps Browser visible a fraction longer instead of flashing atlas over
+    // Settings. Entering Browser is handled by NodusBrowserView's mount effect.
+    if (cur === 'browser' && next !== 'browser') {
+      void window.nodus.setBrowserSectionVisible(false).then(() => setViewRaw(next)).catch(() => setViewRaw(next));
+      return;
+    }
+    setViewRaw(next);
+  }, []);
   useBrowserNativeOverlayGuard(view === 'browser');
   // Página activa dentro de Herramientas. Vive aquí (y no en ToolkitView) porque
   // el sidebar navega directamente a una herramienta, y porque así salir de la

--- a/src/browserOverlay.ts
+++ b/src/browserOverlay.ts
@@ -42,14 +42,19 @@ export function useBrowserNativeOverlayGuard(enabled: boolean): void {
   useEffect(() => {
     if (!enabled) return undefined;
 
-    let animationFrame = 0;
+    let scheduled = false;
     const synchronize = () => {
-      animationFrame = 0;
+      scheduled = false;
       void setBrowserOverlayVisible(hasVisibleTrustedOverlay()).catch(() => undefined);
     };
     const schedule = () => {
-      if (animationFrame) window.cancelAnimationFrame(animationFrame);
-      animationFrame = window.requestAnimationFrame(synchronize);
+      if (scheduled) return;
+      scheduled = true;
+      // Microtask, not rAF: hides the native WebContentsView BEFORE the next paint,
+      // so the vault switcher never flashes behind the page. rAF was one frame too
+      // late (visible flash on open). Microtask still settles after the React commit
+      // but before `requestAnimationFrame` / paint.
+      queueMicrotask(synchronize);
     };
 
     const observer = new MutationObserver(schedule);
@@ -63,7 +68,6 @@ export function useBrowserNativeOverlayGuard(enabled: boolean): void {
 
     return () => {
       observer.disconnect();
-      if (animationFrame) window.cancelAnimationFrame(animationFrame);
       void setBrowserOverlayVisible(false).catch(() => undefined);
     };
   }, [enabled]);

--- a/src/components/SourceCitationModal.tsx
+++ b/src/components/SourceCitationModal.tsx
@@ -201,7 +201,7 @@ function CitationWorkspace({
         aria-modal="true"
         aria-label={t('Fuentes y contexto')}
         data-testid="source-citation-modal"
-        className="flex max-h-[90vh] min-h-[560px] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-neutral-700/80 bg-neutral-950 shadow-2xl shadow-black/60"
+        className="flex h-[min(90vh,760px)] max-h-[90vh] min-h-0 w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-neutral-700/80 bg-neutral-950 shadow-2xl shadow-black/60"
         onClick={(event) => event.stopPropagation()}
       >
         <header className="flex min-h-14 shrink-0 items-center gap-3 border-b border-neutral-800 bg-neutral-950/95 px-4 sm:px-5">
@@ -247,7 +247,7 @@ function CitationWorkspace({
           </div>
         </div>
 
-        <main className="min-h-0 flex-1 bg-neutral-950/70" data-testid="source-citation-content">
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-neutral-950/70" data-testid="source-citation-content">
           {tabs.map((tab) => (
             <CitationTabPane
               key={tab.key}
@@ -282,7 +282,7 @@ function CitationTabPane({
 }) {
   const reportTitle = useCallback((title: string) => onTitle(tab.key, title), [onTitle, tab.key]);
   return (
-    <div className={`${active ? 'h-full overflow-y-auto' : 'hidden'}`} role="tabpanel" data-testid={`source-citation-panel-${tab.key}`}>
+    <div className={`${active ? 'min-h-0 flex-1 overflow-y-auto overscroll-contain' : 'hidden'}`} role="tabpanel" data-testid={`source-citation-panel-${tab.key}`}>
       <div className="mx-auto max-w-4xl p-4 sm:p-6">
         <CitationPanel target={tab.target} authors={authors} onOpenTarget={onOpenTarget} onTitle={reportTitle} onOpenLibraryWork={onOpenLibraryWork} />
       </div>

--- a/src/components/VaultSwitcher.tsx
+++ b/src/components/VaultSwitcher.tsx
@@ -7,6 +7,7 @@ import { errorText, t, tr, tx } from '../i18n';
 import { clearFilterPreferences } from '../app/filterPreferences';
 import { ConfirmModal } from './ConfirmModal';
 import { Icon } from './ui';
+import { setBrowserOverlayVisible } from '../browserOverlay';
 import {
   NEW_VAULT_TYPES,
   isPreAlphaVaultType,
@@ -116,6 +117,14 @@ export function VaultSwitcher({ anchorEl, onClose, vaults, onVaultsChanged, onAc
       window.removeEventListener('scroll', compute, true);
     };
   }, [open, anchorEl]);
+
+  // El panel es un overlay nativo detrás de Browser: sin esto, el WebContentsView
+  // pinta por encima durante el microtask del guard y se ve un flash. LayoutEffect
+  // corre antes del paint, así que el navegador queda oculto desde el primer frame.
+  useLayoutEffect(() => {
+    if (!open) return;
+    void setBrowserOverlayVisible(true).catch(() => undefined);
+  }, [open]);
 
   // Dismiss on outside click / Escape. Clicks on a trigger (`data-vault-trigger`)
   // or inside an open child modal (`[role="dialog"]`) are ignored so they can

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -2826,6 +2826,7 @@ export const DE: Record<string, string> = {
   'Nuevo informe': 'Neuer Bericht',
   'Buscar entre tus informes…': 'In Ihren Berichten suchen…',
   'Buscar en la página…': 'Auf der Seite suchen…',
+  'Buscar en la página': 'Auf der Seite suchen',
   '0 resultados': 'Keine Ergebnisse',
   'Buscar dentro del documento…': 'Dieses Dokument durchsuchen…',
   'Buscar dentro del documento': 'Dieses Dokument durchsuchen',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -2894,6 +2894,7 @@ export const EN: Record<string, string> = {
   'Nuevo informe': 'New report',
   'Buscar entre tus informes…': 'Search your reports…',
   'Buscar en la página…': 'Search the page…',
+  'Buscar en la página': 'Search in page',
   '0 resultados': 'No results',
   'Buscar dentro del documento…': 'Search within this document…',
   'Buscar dentro del documento': 'Search within this document',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -2823,6 +2823,7 @@ export const FR: Record<string, string> = {
   'Nuevo informe': 'Nouveau rapport',
   'Buscar entre tus informes…': 'Rechercher parmi vos rapports…',
   'Buscar en la página…': 'Rechercher dans la page…',
+  'Buscar en la página': 'Rechercher dans la page',
   '0 resultados': 'Aucun résultat',
   'Buscar dentro del documento…': 'Rechercher dans ce document…',
   'Buscar dentro del documento': 'Rechercher dans ce document',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -2537,6 +2537,7 @@ export const IT: Record<string, string> = {
   "Nuevo informe": "Nuovo rapporto",
   "Buscar entre tus informes…": "Cerca nei tuoi rapporti…",
   "Buscar en la página…": "Cerca nella pagina…",
+  "Buscar en la página": "Cerca nella pagina",
   "0 resultados": "Nessun risultato",
   "Buscar dentro del documento…": "Cerca nel documento…",
   "Buscar dentro del documento": "Cerca nel documento",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -2806,6 +2806,7 @@ export const PT_BR: Record<string, string> = {
   'Nuevo informe': 'Novo relatório',
   'Buscar entre tus informes…': 'Buscar nos seus relatórios…',
   'Buscar en la página…': 'Buscar na página…',
+  'Buscar en la página': 'Buscar na página',
   '0 resultados': '0 resultados',
   'Buscar dentro del documento…': 'Pesquisar neste documento…',
   'Buscar dentro del documento': 'Pesquisar neste documento',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -2801,6 +2801,7 @@ export const PT: Record<string, string> = {
   'Nuevo informe': 'Novo relatório',
   'Buscar entre tus informes…': 'Procurar nos seus relatórios…',
   'Buscar en la página…': 'Procurar na página…',
+  'Buscar en la página': 'Procurar na página',
   '0 resultados': '0 resultados',
   'Buscar dentro del documento…': 'Pesquisar neste documento…',
   'Buscar dentro del documento': 'Pesquisar neste documento',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -2914,6 +2914,7 @@ export const TR: Record<string, string> = {
   "Nuevo informe": "Yeni rapor",
   "Buscar entre tus informes…": "Raporlarınızda arama yapın…",
   "Buscar en la página…": "Sayfayı arayın…",
+  "Buscar en la página": "Sayfada ara",
   "0 resultados": "0 sonuç",
   "Buscar dentro del documento…": "Belgede ara…",
   "Buscar dentro del documento": "Belgede ara",

--- a/src/index.css
+++ b/src/index.css
@@ -4865,3 +4865,95 @@ body:has(.library-document-reader [data-testid="library-reader-sidebar"]) .app-t
 .light.testimonios .border-indigo-700\/60 { border-color: rgba(8, 145, 178, 0.45); }
 .light.testimonios .border-indigo-800\/40,
 .light.testimonios .border-indigo-800\/60 { border-color: rgba(8, 145, 178, 0.3); }
+
+/* ── Source citation modal — light theme ───────────────────────────────── */
+/* Dark-by-design sheet; light gets an opaque white surface so it never inherits charcoal. */
+.light [data-testid="source-citation-modal"] {
+  border-color: #e5e7eb;
+  background-color: #ffffff;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.18), 0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+.light [data-testid="source-citation-modal"] > header {
+  border-color: #e5e7eb;
+  background: #f8fafc;
+}
+.light [data-testid="source-citation-modal"] [data-testid="source-citation-tabs"] {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/70 {
+  background-color: #ffffff;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/95 {
+  background-color: #f8fafc;
+}
+.light [data-testid="source-citation-modal"] .border-neutral-700\/80,
+.light [data-testid="source-citation-modal"] .border-neutral-800\/80,
+.light [data-testid="source-citation-modal"] .border-neutral-800 {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-900\/35,
+.light [data-testid="source-citation-modal"] .bg-neutral-900\/55,
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/55 {
+  background-color: #ffffff;
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] section header.bg-neutral-900\/55 {
+  background-color: #f8fafc;
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .from-indigo-500\/10 {
+  --tw-gradient-from: rgba(99, 102, 241, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .via-neutral-900\/60 {
+  --tw-gradient-to: rgba(255, 255, 255, 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), #ffffff var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+.light [data-testid="source-citation-modal"] .to-neutral-950 {
+  --tw-gradient-to: #f8fafc var(--tw-gradient-to-position);
+}
+.light [data-testid="source-citation-modal"] .from-sky-500\/10 {
+  --tw-gradient-from: rgba(14, 165, 233, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-violet-500\/10 {
+  --tw-gradient-from: rgba(139, 92, 246, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-amber-500\/10 {
+  --tw-gradient-from: rgba(245, 158, 11, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-red-500\/10 {
+  --tw-gradient-from: rgba(239, 68, 68, 0.07) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .from-emerald-500\/10 {
+  --tw-gradient-from: rgba(16, 185, 129, 0.08) var(--tw-gradient-from-position);
+}
+.light [data-testid="source-citation-modal"] .border-indigo-500\/25,
+.light [data-testid="source-citation-modal"] .border-sky-500\/20,
+.light [data-testid="source-citation-modal"] .border-violet-500\/20,
+.light [data-testid="source-citation-modal"] .border-amber-500\/25,
+.light [data-testid="source-citation-modal"] .border-red-500\/25,
+.light [data-testid="source-citation-modal"] .border-emerald-500\/25 {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-indigo-500\/15 {
+  background-color: rgba(99, 102, 241, 0.12);
+}
+.light [data-testid="source-citation-modal"] .border-neutral-700 {
+  border-color: #e5e7eb;
+}
+.light [data-testid="source-citation-modal"] .bg-neutral-950\/55 {
+  background-color: #ffffff;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-100,
+.light [data-testid="source-citation-modal"] .text-neutral-200 {
+  color: #0f172a;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-300 {
+  color: #1e293b;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-400,
+.light [data-testid="source-citation-modal"] .text-neutral-500 {
+  color: #475569;
+}
+.light [data-testid="source-citation-modal"] .text-neutral-600 {
+  color: #64748b;
+}

--- a/src/views/NodusBrowserView.tsx
+++ b/src/views/NodusBrowserView.tsx
@@ -57,6 +57,12 @@ export function NodusBrowserView() {
   const [bookmarksManager, setBookmarksManager] = useState(false);
   const [historyManager, setHistoryManager] = useState(false);
   const [returnToBookmarksManager, setReturnToBookmarksManager] = useState(false);
+  const [findOpen, setFindOpen] = useState(false);
+  const [findText, setFindText] = useState('');
+  const [findMatches, setFindMatches] = useState(0);
+  const [findActive, setFindActive] = useState(0);
+  const [findCaseSensitive, setFindCaseSensitive] = useState(false);
+  const findInputRef = useRef<HTMLInputElement | null>(null);
 
   const active: BrowserTabState | null =
     state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
@@ -113,6 +119,61 @@ export function NodusBrowserView() {
       void window.nodus.cancelBrowserPermissions();
     };
   }, []);
+
+  // Find in page: native WebContents find (like Deep Research's FindInPage but
+  // for the native Browser view). Uses Electron's findInPage / stopFindInPage
+  // via the browser partition.
+  useEffect(() => {
+    const stop = window.nodus.onBrowserFoundInPage((result) => {
+      setFindMatches(result.matches);
+      setFindActive(result.activeMatchOrdinal);
+    });
+    return stop;
+  }, []);
+
+  useEffect(() => {
+    if (!findOpen) return;
+    const text = findText.trim();
+    if (!text) {
+      void window.nodus.browserStopFindInPage('clearSelection');
+      setFindMatches(0);
+      setFindActive(0);
+      return;
+    }
+    void window.nodus.browserFindInPage(text, { findNext: false, matchCase: findCaseSensitive });
+  }, [findText, findCaseSensitive, findOpen, active?.id]);
+
+  useEffect(() => {
+    if (!findOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      const cmd = event.metaKey || event.ctrlKey;
+      if (cmd && !event.altKey && event.key.toLowerCase() === 'f') {
+        event.preventDefault();
+        setFindOpen(true);
+        requestAnimationFrame(() => findInputRef.current?.select());
+      } else if (findOpen && event.key === 'Escape') {
+        event.preventDefault();
+        setFindOpen(false);
+        void window.nodus.browserStopFindInPage('clearSelection');
+      } else if (findOpen && ((cmd && event.key.toLowerCase() === 'g') || event.key === 'F3')) {
+        event.preventDefault();
+        const forward = !event.shiftKey;
+        void window.nodus.browserFindInPage(findText, { forward, findNext: true, matchCase: findCaseSensitive });
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [findOpen, findText, findCaseSensitive]);
+
+  useEffect(() => {
+    if (findOpen) requestAnimationFrame(() => findInputRef.current?.focus());
+    else {
+      void window.nodus.browserStopFindInPage('clearSelection');
+      setFindText('');
+      setFindMatches(0);
+      setFindActive(0);
+    }
+  }, [findOpen]);
 
   // Follow the URL of whatever tab is active, unless the user is editing.
   useEffect(() => {
@@ -379,6 +440,15 @@ export function NodusBrowserView() {
 
         <div>
           <ToolbarButton
+            icon="search"
+            label={t('Buscar en la página')}
+            dataTestId="browser-find-button"
+            onClick={() => setFindOpen((v) => !v)}
+          />
+        </div>
+
+        <div>
+          <ToolbarButton
             icon="clock"
             label="Browsing History"
             dataTestId="browser-history-button"
@@ -425,6 +495,35 @@ export function NodusBrowserView() {
           />
         </div>
       </div>
+
+      {findOpen && (
+        <div data-testid="browser-find-bar" className="flex items-center gap-2 border-b border-neutral-300 bg-white px-3 py-2 dark:border-neutral-800 dark:bg-neutral-900/95">
+          <Icon name="search" size={14} className="shrink-0 text-neutral-500" />
+          <input
+            ref={findInputRef}
+            data-testid="browser-find-input"
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-neutral-500"
+            value={findText}
+            placeholder={t('Buscar en la página…')}
+            onChange={(event) => setFindText(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                void window.nodus.browserFindInPage(findText, { forward: !event.shiftKey, findNext: true, matchCase: findCaseSensitive });
+              } else if (event.key === 'Escape') {
+                setFindOpen(false);
+              }
+            }}
+          />
+          <span data-testid="browser-find-status" className="shrink-0 text-xs tabular-nums text-neutral-500">
+            {findMatches ? `${findActive} / ${findMatches}` : findText.trim() ? t('Sin resultados') : ''}
+          </span>
+          <button data-testid="browser-find-prev" className="rounded p-1.5 hover:bg-neutral-200 dark:hover:bg-neutral-800" onClick={() => void window.nodus.browserFindInPage(findText, { forward: false, findNext: true, matchCase: findCaseSensitive })} title={t('Anterior')}><Icon name="chevronUp" size={14} /></button>
+          <button data-testid="browser-find-next" className="rounded p-1.5 hover:bg-neutral-200 dark:hover:bg-neutral-800" onClick={() => void window.nodus.browserFindInPage(findText, { forward: true, findNext: true, matchCase: findCaseSensitive })} title={t('Siguiente')}><Icon name="chevronDown" size={14} /></button>
+          <label className="flex items-center gap-1 text-xs text-neutral-600 dark:text-neutral-400"><input type="checkbox" checked={findCaseSensitive} onChange={(event) => setFindCaseSensitive(event.target.checked)} />Aa</label>
+          <button className="rounded p-1.5 hover:bg-neutral-200 dark:hover:bg-neutral-800" onClick={() => setFindOpen(false)} aria-label={t('Cerrar')}><Icon name="x" size={14} /></button>
+        </div>
+      )}
 
       {panel === 'downloads' && (
         <DownloadsPanel

--- a/src/views/NodusBrowserView.tsx
+++ b/src/views/NodusBrowserView.tsx
@@ -144,13 +144,16 @@ export function NodusBrowserView() {
   }, [findText, findCaseSensitive, findOpen, active?.id]);
 
   useEffect(() => {
-    if (!findOpen) return;
     const onKey = (event: KeyboardEvent) => {
       const cmd = event.metaKey || event.ctrlKey;
       if (cmd && !event.altKey && event.key.toLowerCase() === 'f') {
         event.preventDefault();
-        setFindOpen(true);
-        requestAnimationFrame(() => findInputRef.current?.select());
+        setFindOpen((prev) => {
+          const next = !prev;
+          if (next) requestAnimationFrame(() => findInputRef.current?.select());
+          else void window.nodus.browserStopFindInPage('clearSelection');
+          return next;
+        });
       } else if (findOpen && event.key === 'Escape') {
         event.preventDefault();
         setFindOpen(false);
@@ -443,6 +446,7 @@ export function NodusBrowserView() {
             icon="search"
             label={t('Buscar en la página')}
             dataTestId="browser-find-button"
+            active={findOpen}
             onClick={() => setFindOpen((v) => !v)}
           />
         </div>
@@ -722,17 +726,18 @@ function permissionLabel(request: PendingBrowserPermission): string {
 }
 
 function ToolbarButton({
-  icon, imageSrc, label, onClick, disabled, busy, dataTestId,
-}: { icon?: string; imageSrc?: string; label: string; onClick: () => void; disabled?: boolean; busy?: boolean; dataTestId?: string }) {
+  icon, imageSrc, label, onClick, disabled, busy, dataTestId, active,
+}: { icon?: string; imageSrc?: string; label: string; onClick: () => void; disabled?: boolean; busy?: boolean; dataTestId?: string; active?: boolean }) {
   return (
     <button
       type="button"
       data-testid={dataTestId}
       title={label}
       aria-label={label}
+      aria-pressed={active}
       disabled={disabled}
       onClick={onClick}
-      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-neutral-600 transition-colors hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-400 dark:hover:bg-neutral-900"
+      className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${active ? 'bg-neutral-200 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100' : 'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-900'}`}
     >
       {imageSrc
         ? <img src={imageSrc} alt="" className={`h-4 w-4 ${busy ? 'animate-pulse' : ''}`} />


### PR DESCRIPTION
Follow-up to #509/#510 (the branch continued after that PR merged).

### What
- **Settings transition** (e5d22b8f): leaving Browser awaits `setBrowserSectionVisible(false)` before mounting the next section, removing the one-frame overlap where the atlas page covered Settings. Reverts a `sendSync` attempt that deadlocked the Settings lazy-load.
- **Google 'browser not secure'** (d79ca6ac): spoof `Sec-CH-UA` / `Sec-CH-UA-Full-Version-List` and `navigator.userAgentData.brands` so Google stops flagging the embedded Chromium. Fixes constant captchas on Search/Drive.
- **nodus:// deeplink** (da784e38): registers the OS protocol and forwards `nodus://authorize?code=XYZ` callbacks to the renderer (`window.nodus.onDeepLink`), enabling system-browser OAuth for Nodus's own future flows.
- **Third-party Google OAuth** (6d9cc32b): Sec-CH-UA version now derived from the real Chromium in the UA (the hard-coded 132 mismatch was itself detectable), and the forced `shell.openExternal` interception of accounts.google.com is removed — an OAuth flow must complete in the browser context it started in, otherwise the callback session lands in the system browser and Google shows the 'not secure' page there too. Google auth now completes inside Nodus.

### Test
- `npm run typecheck` / `npm run build` pass
- `node --test scripts/test-browser-tabs.mjs scripts/test-browser-security.mjs` 37/37
- Manual on isolated profile: third-party 'Sign in with Google' opens the account picker inside Nodus and returns to the site logged in.

Fixes the follow-up reports in #509.