### PR TITLE
fix(authors): stop crediting volume editors with their chapters' ideas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ release/
 
 # esbuild smoke-test bundles (generated at repo root)
 .smoke-*.mjs
+.smoke-*.cjs
 # Bundles the perf benches build next to the sources they import (esbuild needs the
 # output inside the repo for --packages=external to resolve).
 .bench-*.cjs

--- a/electron/ai/authorDossier.ts
+++ b/electron/ai/authorDossier.ts
@@ -86,19 +86,25 @@ export function listAuthors(): AuthorSummary[] {
     .prepare('SELECT author_id, name, affiliation FROM authors')
     .all() as { author_id: string; name: string; affiliation: string | null }[];
 
-  // works per author (drives workCount + read)
+  // Works per author, counted separately by role: only the ones this person
+  // actually wrote are their body of work. Volumes they merely edited are shown
+  // as such and never folded into the footprint.
   const waRows = db
     .prepare(
-      `SELECT wa.author_id, w.read_tag
+      `SELECT wa.author_id, wa.role, w.read_tag
          FROM work_authors wa JOIN works w ON w.nodus_id = wa.nodus_id
         WHERE w.archived = 0`
     )
-    .all() as { author_id: string; read_tag: number }[];
-  const works = new Map<string, { total: number; read: number }>();
+    .all() as { author_id: string; role: string; read_tag: number }[];
+  const works = new Map<string, { total: number; read: number; edited: number }>();
   for (const r of waRows) {
-    const cur = works.get(r.author_id) ?? { total: 0, read: 0 };
-    cur.total += 1;
-    if (r.read_tag === 1) cur.read += 1;
+    const cur = works.get(r.author_id) ?? { total: 0, read: 0, edited: 0 };
+    if (r.role === 'editor') {
+      cur.edited += 1;
+    } else {
+      cur.total += 1;
+      if (r.read_tag === 1) cur.read += 1;
+    }
     works.set(r.author_id, cur);
   }
 
@@ -109,6 +115,7 @@ export function listAuthors(): AuthorSummary[] {
          FROM work_authors wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
+        WHERE wa.role = 'author'
         GROUP BY wa.author_id`
     )
     .all() as { id: string; n: number }[];
@@ -133,6 +140,7 @@ export function listAuthors(): AuthorSummary[] {
          FROM work_authors wa
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN themes t ON t.theme_id = itl.theme_id
+        WHERE wa.role = 'author'
         GROUP BY wa.author_id, t.theme_id
         ORDER BY n DESC`
     )
@@ -152,6 +160,7 @@ export function listAuthors(): AuthorSummary[] {
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN work_zotero_tags wzt ON wzt.nodus_id = wa.nodus_id
          JOIN zotero_tags zt ON zt.tag_id = wzt.tag_id
+        WHERE wa.role = 'author'
         GROUP BY wa.author_id, zt.tag_id
         ORDER BY n DESC, zt.label COLLATE NOCASE`
     )
@@ -169,7 +178,7 @@ export function listAuthors(): AuthorSummary[] {
 
   return authors
     .map((a): AuthorSummary => {
-      const w = works.get(a.author_id) ?? { total: 0, read: 0 };
+      const w = works.get(a.author_id) ?? { total: 0, read: 0, edited: 0 };
       const parts = splitName(a.name);
       return {
         author_id: a.author_id,
@@ -179,6 +188,7 @@ export function listAuthors(): AuthorSummary[] {
         fullName: parts.fullName,
         affiliation: a.affiliation,
         workCount: w.total,
+        editedCount: w.edited,
         ideaCount: ideaCount.get(a.author_id) ?? 0,
         relationCount: relationCount.get(a.author_id) ?? 0,
         topTags: tagsByAuthor.get(a.author_id) ?? [],
@@ -188,7 +198,9 @@ export function listAuthors(): AuthorSummary[] {
         saved: saved.has(a.author_id),
       };
     })
-    .filter((a) => a.workCount > 0)
+    // Someone who only ever edited volumes stays listed — that is a real
+    // bibliographic fact — but with an empty authored footprint.
+    .filter((a) => a.workCount > 0 || a.editedCount > 0)
     .sort((a, b) => b.ideaCount - a.ideaCount || a.name.localeCompare(b.name));
 }
 
@@ -229,7 +241,7 @@ function themesByIdeaForAuthor(authorId: string): Map<string, string[]> {
          FROM work_authors wa
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN themes t ON t.theme_id = itl.theme_id
-        WHERE wa.author_id = ?`
+        WHERE wa.author_id = ? AND wa.role = 'author'`
     )
     .all(authorId) as { gid: string; label: string }[];
   const map = new Map<string, string[]>();
@@ -263,7 +275,7 @@ function authorThemeSets(authorIds: string[]): Map<string, Set<string>> {
          FROM work_authors wa
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN themes t ON t.theme_id = itl.theme_id
-        WHERE wa.author_id IN (${authorIds.map(() => '?').join(',')})
+        WHERE wa.author_id IN (${authorIds.map(() => '?').join(',')}) AND wa.role = 'author'
         ORDER BY t.label`
     )
     .all(...authorIds) as { authorId: string; label: string }[];
@@ -286,7 +298,7 @@ function loadIdeas(authorId: string): AuthorDossierIdea[] {
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
          JOIN ideas i ON i.global_id = io.global_id
-        WHERE wa.author_id = ?
+        WHERE wa.author_id = ? AND wa.role = 'author'
         ORDER BY (io.role = 'principal') DESC, io.confidence DESC`
     )
     .all(authorId) as {
@@ -308,7 +320,7 @@ function loadIdeas(authorId: string): AuthorDossierIdea[] {
       `SELECT ev.id, ev.global_id, ev.nodus_id, ev.quote, ev.location, ev.kind
          FROM evidence ev
          JOIN work_authors wa ON wa.nodus_id = ev.nodus_id
-        WHERE wa.author_id = ?`
+        WHERE wa.author_id = ? AND wa.role = 'author'`
     )
     .all(authorId) as Evidence[];
   const evByKey = new Map<string, Evidence[]>();
@@ -383,6 +395,7 @@ function loadRelations(authorId: string): AuthorDossierRelation[] {
   return [...agg.values()].sort((a, b) => b.weight - a.weight);
 }
 
+/** Every work this person is credited on, whichever role Zotero gives them. */
 function loadWorks(authorId: string): AuthorDossierWork[] {
   return (
     getDb()
@@ -484,7 +497,11 @@ export function buildAuthorDossier(authorId: string): AuthorDossier | null {
 
   const ideas = loadIdeas(authorId);
   const relations = loadRelations(authorId);
-  const works = loadWorks(authorId);
+  // Authorship and editorship are shown apart: the ideas above come only from
+  // the works this person wrote, so the works list must not blur the two.
+  const credited = loadWorks(authorId);
+  const works = credited.filter((w) => w.role !== 'editor');
+  const editedWorks = credited.filter((w) => w.role === 'editor');
 
   // overall theme list ordered by how many of the author's ideas touch each
   const themeFreq = new Map<string, number>();
@@ -501,6 +518,7 @@ export function buildAuthorDossier(authorId: string): AuthorDossier | null {
     firstName: parts.firstName,
     lastName: parts.lastName,
     works,
+    editedWorks,
     ideas,
     relations,
     themes,

--- a/electron/ai/immersion.ts
+++ b/electron/ai/immersion.ts
@@ -13,6 +13,7 @@ import type {
   WritingWorkshopIdeaCandidate,
 } from '@shared/types';
 import { getDb } from '../db/database';
+import { parseBylineEntry } from '../db/authorsRepo';
 import { getSettings } from '../db/settingsRepo';
 import { getApiKey } from '../secrets/secretStore';
 import { buildIdeaGraph, getContradictions } from '../graph/graphService';
@@ -104,8 +105,15 @@ function buildAuthorResolver(): (name: string) => string | null {
   };
 }
 
+/** Who an idea can be attributed to: the authors of the works it occurs in, never
+ *  the editors of the volumes those works appear in. */
 function ideaAuthors(idea: WritingWorkshopIdeaCandidate): string[] {
-  return [...new Set(idea.works.flatMap((w) => w.authors))];
+  const names = idea.works
+    .flatMap((w) => w.authors)
+    .map((entry) => parseBylineEntry(entry))
+    .filter((entry) => entry.role === 'author')
+    .map((entry) => entry.display);
+  return [...new Set(names)];
 }
 
 /**

--- a/electron/ai/researchAssistant.ts
+++ b/electron/ai/researchAssistant.ts
@@ -921,7 +921,7 @@ function listAuthors(linkedWorkIds: Set<string>, scope: RelevanceScope) {
       const relevantAuthorIds = new Set(
         (
           db
-            .prepare(`SELECT DISTINCT author_id FROM work_authors WHERE nodus_id IN (${placeholders})`)
+            .prepare(`SELECT DISTINCT author_id FROM work_authors WHERE nodus_id IN (${placeholders}) AND role = 'author'`)
             .all(...workIds) as { author_id: string }[]
         ).map((row) => row.author_id)
       );
@@ -958,7 +958,7 @@ function listAuthors(linkedWorkIds: Set<string>, scope: RelevanceScope) {
             `SELECT w.nodus_id, w.zotero_key, w.title, w.authors_json, w.year, w.item_type, w.doi, w.source_type
              FROM work_authors wa
              JOIN works w ON w.nodus_id = wa.nodus_id
-             WHERE wa.author_id = ? AND w.archived = 0
+             WHERE wa.author_id = ? AND wa.role = 'author' AND w.archived = 0
              ORDER BY w.year DESC, w.title ASC`
           )
           .all(author.author_id) as Array<WorkRow & { authors_json: string }>
@@ -969,7 +969,7 @@ function listAuthors(linkedWorkIds: Set<string>, scope: RelevanceScope) {
            FROM work_authors wa
            JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
            JOIN ideas i ON i.global_id = io.global_id
-           WHERE wa.author_id = ?
+           WHERE wa.author_id = ? AND wa.role = 'author'
            ORDER BY i.label ASC`
         )
         .all(author.author_id) as Array<{ global_id: string; type: string; label: string; statement: string }>;
@@ -1300,7 +1300,9 @@ function addThemeWorkIds(themeId: string, out: Set<string>): void {
 }
 
 function addAuthorWorkIds(authorId: string, out: Set<string>): void {
-  const rows = getDb().prepare('SELECT nodus_id FROM work_authors WHERE author_id = ?').all(authorId) as { nodus_id: string }[];
+  const rows = getDb()
+    .prepare("SELECT nodus_id FROM work_authors WHERE author_id = ? AND role = 'author'")
+    .all(authorId) as { nodus_id: string }[];
   for (const row of rows) out.add(row.nodus_id);
 }
 

--- a/electron/ai/studyGuide.ts
+++ b/electron/ai/studyGuide.ts
@@ -75,7 +75,7 @@ async function semanticBoosts(objective: string | undefined, enabled: boolean): 
       .prepare(
         `SELECT DISTINCT wa.author_id, io.nodus_id
            FROM idea_occurrences io
-           JOIN work_authors wa ON wa.nodus_id = io.nodus_id
+           JOIN work_authors wa ON wa.nodus_id = io.nodus_id AND wa.role = 'author'
            JOIN works w ON w.nodus_id = io.nodus_id AND w.archived = 0
           WHERE io.global_id = ?`
       )
@@ -90,7 +90,7 @@ async function semanticBoosts(objective: string | undefined, enabled: boolean): 
   const passageHits = findSimilarPassages(vector, 0.2, 50);
   for (const passage of passageHits) {
     const rows = db
-      .prepare('SELECT author_id FROM work_authors WHERE nodus_id = ?')
+      .prepare("SELECT author_id FROM work_authors WHERE nodus_id = ? AND role = 'author'")
       .all(passage.nodus_id) as { author_id: string }[];
     for (const row of rows) addBoost(authorBoosts, row.author_id, passage.similarity * 0.8);
     addBoost(workBoosts, passage.nodus_id, passage.similarity * 1.1);
@@ -100,7 +100,7 @@ async function semanticBoosts(objective: string | undefined, enabled: boolean): 
   const workHits = findSimilarWorks(vector, 0.2, 40);
   for (const work of workHits) {
     const rows = db
-      .prepare('SELECT author_id FROM work_authors WHERE nodus_id = ?')
+      .prepare("SELECT author_id FROM work_authors WHERE nodus_id = ? AND role = 'author'")
       .all(work.nodus_id) as { author_id: string }[];
     for (const row of rows) addBoost(authorBoosts, row.author_id, work.similarity * 0.9);
     addBoost(workBoosts, work.nodus_id, work.similarity);
@@ -142,6 +142,7 @@ function loadWorkInputs(workBoosts: Map<string, number>): Map<string, StudyGuide
          LEFT JOIN idea_counts ic ON ic.nodus_id = w.nodus_id
          LEFT JOIN passage_counts pc ON pc.nodus_id = w.nodus_id
          LEFT JOIN work_summaries ws ON ws.nodus_id = w.nodus_id
+        WHERE wa.role = 'author'
         ORDER BY wa.author_id, ideaCount DESC, w.year DESC`
     )
     .all() as {
@@ -197,6 +198,7 @@ function loadKeyIdeas(): Map<string, StudyGuideIdeaInput[]> {
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = w.nodus_id
          JOIN ideas i ON i.global_id = io.global_id
+        WHERE wa.role = 'author'
         ORDER BY wa.author_id, (io.role = 'principal') DESC, io.confidence DESC, i.label`
     )
     .all() as {

--- a/electron/ai/synthesisMatrix.ts
+++ b/electron/ai/synthesisMatrix.ts
@@ -48,6 +48,7 @@ export function buildSynthesisMatrix(): SynthesisMatrix {
          JOIN authors a ON a.author_id = wa.author_id
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
+        WHERE wa.role = 'author'
         GROUP BY wa.author_id
         ORDER BY ideaCount DESC, name`
     )
@@ -84,7 +85,8 @@ export function buildSynthesisMatrix(): SynthesisMatrix {
          FROM work_authors wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
-         JOIN ideas i ON i.global_id = itl.global_id`
+         JOIN ideas i ON i.global_id = itl.global_id
+        WHERE wa.role = 'author'`
     )
     .all() as { authorId: string; themeId: string; gid: string; label: string; type: IdeaType }[];
 
@@ -149,7 +151,7 @@ export async function synthesizeMatrixCell(
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN ideas i ON i.global_id = itl.global_id
-        WHERE wa.author_id = ? AND itl.theme_id = ?`
+        WHERE wa.author_id = ? AND itl.theme_id = ? AND wa.role = 'author'`
     )
     .all(authorId, themeId) as { global_id: string; label: string; type: IdeaType; statement: string }[];
 

--- a/electron/db/authorsRepo.ts
+++ b/electron/db/authorsRepo.ts
@@ -111,12 +111,23 @@ function getOrCreateCanonicalAuthor(key: string, display: string, affiliation: s
   return authorId;
 }
 
+/**
+ * Link a work to a canonical author with the role Zotero credits them with.
+ *
+ * The role is written as given, including when it demotes an existing 'author'
+ * row to 'editor'. It used to be sticky the other way ("once an author, always
+ * an author"), which sounds protective but made the column unrepairable: every
+ * row that predates the role column was created with its DEFAULT 'author', so
+ * editors of edited volumes could never be corrected no matter how often the
+ * work was resynced. Callers resolve the author-beats-editor tie for a single
+ * work in memory before getting here (see linkZoteroAuthors), so nothing is lost
+ * by trusting the value passed in.
+ */
 export function linkWorkAuthor(nodusId: string, authorId: string, role: 'author' | 'editor' = 'author'): void {
   getDb()
     .prepare(
       `INSERT INTO work_authors (nodus_id, author_id, role) VALUES (?, ?, ?)
-       ON CONFLICT(nodus_id, author_id) DO UPDATE SET
-         role = CASE WHEN excluded.role = 'author' THEN 'author' ELSE work_authors.role END`
+       ON CONFLICT(nodus_id, author_id) DO UPDATE SET role = excluded.role`
     )
     .run(nodusId, authorId, role);
 }
@@ -132,6 +143,23 @@ function parseCreatorsJson(value: string | null): WorkCreator[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * How an editor is marked inside the stored byline (authors_json). The byline is
+ * a display string, so the role has to travel inside it; every reader that wants
+ * the role structurally should use creators_json instead.
+ */
+export const EDITOR_BYLINE_SUFFIX = ' (ed.)';
+
+/** Split a stored byline entry back into its display name and its Zotero role. */
+export function parseBylineEntry(entry: string): { display: string; role: 'author' | 'editor' } {
+  const clean = (entry || '').trim();
+  const marker = EDITOR_BYLINE_SUFFIX.trim();
+  if (clean.toLowerCase().endsWith(marker.toLowerCase())) {
+    return { display: clean.slice(0, clean.length - marker.length).trim(), role: 'editor' };
+  }
+  return { display: clean, role: 'author' };
 }
 
 function parseAuthorsJson(value: string | null): string[] {
@@ -154,7 +182,8 @@ interface CanonCreator {
 /**
  * Build one work's author links from its Zotero creators (the single source of
  * truth). Uses structured creators_json when available (carrying editor roles),
- * otherwise the legacy authors_json strings (all treated as authors). Links the
+ * otherwise the legacy authors_json byline strings (where an editor carries an
+ * "(ed.)" marker). Links the
  * canonical authors and drops any other author node previously linked to this
  * work — this is what removes the AI-extracted name variants.
  *
@@ -181,10 +210,11 @@ export function linkZoteroAuthors(
       raw.push({ key, display: structuredDisplay(c), role: c.role, affiliation: opts.affiliationByKey?.get(key) ?? null });
     }
   } else {
-    for (const name of parseAuthorsJson(work.authors_json)) {
-      const key = canonicalKey(parseDisplayName(name));
+    for (const entry of parseAuthorsJson(work.authors_json)) {
+      const { display, role } = parseBylineEntry(entry);
+      const key = canonicalKey(parseDisplayName(display));
       if (!key) continue;
-      raw.push({ key, display: name, role: 'author', affiliation: opts.affiliationByKey?.get(key) ?? null });
+      raw.push({ key, display, role, affiliation: opts.affiliationByKey?.get(key) ?? null });
     }
   }
 
@@ -297,6 +327,104 @@ export function reconcileAuthorLayerOnce(): void {
   run();
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Retroactive repair of the author/editor role (runs once on upgrade)
+//
+// work_authors.role arrived in migration 23 with DEFAULT 'author', which silently
+// credited every editor of an edited volume as one of its authors — and the old
+// sticky ON CONFLICT then made that unrepairable. Zotero's answer was never lost
+// though: it has been stored per work in creators_json all along, so the repair
+// is a pure recomputation with no network call and no re-analysis.
+//
+// This only rewrites the `role` column of existing links. It never creates a
+// link, never deletes one, and never touches ideas, works, edges, evidence,
+// themes or notes. Links whose author has no counterpart in creators_json (name
+// variants left over from AI extraction) are left exactly as they are.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ROLE_RECONCILE_FLAG = 'author_roles_reconciled';
+
+/** Zotero's role for each canonical identity credited on a work. Author wins a tie. */
+function rolesByCanonicalKey(creatorsJson: string | null): Map<string, 'author' | 'editor'> {
+  const roles = new Map<string, 'author' | 'editor'>();
+  for (const c of parseCreatorsJson(creatorsJson)) {
+    const key = canonicalKey(creatorParts(c));
+    if (!key) continue;
+    if (roles.get(key) === 'author') continue;
+    roles.set(key, c.role);
+  }
+  return roles;
+}
+
+/** Rewrite every work↔author role from creators_json. Returns the rows changed. */
+export function repairAuthorRoles(): number {
+  const db = getDb();
+  const links = db
+    .prepare(
+      `SELECT wa.nodus_id AS nodusId, wa.author_id AS authorId, wa.role AS role, a.canonical_key AS key
+         FROM work_authors wa
+         JOIN authors a ON a.author_id = wa.author_id
+        WHERE a.canonical_key IS NOT NULL
+          AND wa.nodus_id NOT LIKE 'demo-%'`
+    )
+    .all() as { nodusId: string; authorId: string; role: string; key: string }[];
+  if (links.length === 0) return 0;
+
+  const byWork = new Map<string, typeof links>();
+  for (const link of links) {
+    const list = byWork.get(link.nodusId) ?? [];
+    list.push(link);
+    byWork.set(link.nodusId, list);
+  }
+
+  const readCreators = db.prepare('SELECT creators_json FROM works WHERE nodus_id = ?');
+  const update = db.prepare('UPDATE work_authors SET role = ? WHERE nodus_id = ? AND author_id = ?');
+  let changed = 0;
+  for (const [nodusId, workLinks] of byWork) {
+    const row = readCreators.get(nodusId) as { creators_json: string | null } | undefined;
+    if (!row?.creators_json) continue;
+    const roles = rolesByCanonicalKey(row.creators_json);
+    if (roles.size === 0) continue;
+    for (const link of workLinks) {
+      const role = roles.get(link.key);
+      if (!role || role === link.role) continue;
+      update.run(role, nodusId, link.authorId);
+      changed += 1;
+    }
+  }
+  return changed;
+}
+
+/**
+ * One-time pass that repairs the stored roles and refreshes everything derived
+ * from them: the author-relations layer is rebuilt (it must no longer route a
+ * relation through an editor) and the cached AI syntheses are dropped, since
+ * they were written about a work list that included other people's chapters.
+ */
+export function reconcileAuthorRolesOnce(): void {
+  if (readFlag(ROLE_RECONCILE_FLAG) === '1') return;
+  const db = getDb();
+  const run = db.transaction(() => {
+    const changed = repairAuthorRoles();
+    // The derived layer is refreshed whenever the vault has any editor at all,
+    // not only when this pass moved a row. An everyday resync can land the right
+    // roles first, and then nothing here would change — but author_relations and
+    // the cached syntheses would still be the ones computed while editors counted
+    // as authors, which is the very thing this upgrade exists to undo.
+    const editors = (
+      db.prepare("SELECT COUNT(*) AS n FROM work_authors WHERE role = 'editor'").get() as { n: number }
+    ).n;
+    if (changed > 0 || editors > 0) {
+      db.prepare('DELETE FROM author_dossier_synthesis').run();
+      db.prepare('DELETE FROM synthesis_matrix_cell').run();
+      recomputeAuthorRelations();
+      console.log(`[authors] repaired ${changed} misfiled role(s); ${editors} editor link(s) no longer count as authorship`);
+    }
+    writeFlag(ROLE_RECONCILE_FLAG, '1');
+  });
+  run();
+}
+
 /**
  * Recompute the DERIVED author-relations layer from the idea graph.
  * Two authors are related when works they (co-)authored are connected by
@@ -341,7 +469,7 @@ function authorsForIdea(globalId: string): string[] {
     .prepare(
       `SELECT DISTINCT wa.author_id
        FROM idea_occurrences io
-       JOIN work_authors wa ON wa.nodus_id = io.nodus_id
+       JOIN work_authors wa ON wa.nodus_id = io.nodus_id AND wa.role = 'author'
        WHERE io.global_id = ?`
     )
     .all(globalId) as { author_id: string }[];

--- a/electron/db/searchRepo.ts
+++ b/electron/db/searchRepo.ts
@@ -468,13 +468,13 @@ export function getSearchResultDetail(kind: SearchResultKind, id: string): Searc
       const works = db
         .prepare(
           `SELECT w.title, w.year FROM work_authors a JOIN works w ON w.nodus_id = a.nodus_id
-           WHERE a.author_id = ? ORDER BY w.year DESC, w.title`
+           WHERE a.author_id = ? AND a.role = 'author' ORDER BY w.year DESC, w.title`
         )
         .all(id) as Array<{ title: string; year: number | null }>;
       const ideaCount = db
         .prepare(
           `SELECT COUNT(DISTINCT o.global_id) AS count FROM work_authors a
-           JOIN idea_occurrences o ON o.nodus_id = a.nodus_id WHERE a.author_id = ?`
+           JOIN idea_occurrences o ON o.nodus_id = a.nodus_id WHERE a.author_id = ? AND a.role = 'author'`
         )
         .get(id) as { count: number };
       return {

--- a/electron/graph/graphService.ts
+++ b/electron/graph/graphService.ts
@@ -776,7 +776,10 @@ export function buildAuthorGraph(): GraphData {
 
   // Batch-load all author→work mappings in one query instead of N+1.
   const waRows = db
-    .prepare(`SELECT wa.author_id, w.nodus_id, w.year, w.read_tag FROM work_authors wa JOIN works w ON w.nodus_id = wa.nodus_id WHERE w.archived = 0`)
+    .prepare(
+      `SELECT wa.author_id, w.nodus_id, w.year, w.read_tag FROM work_authors wa JOIN works w ON w.nodus_id = wa.nodus_id
+        WHERE w.archived = 0 AND wa.role = 'author'`
+    )
     .all() as { author_id: string; nodus_id: string; year: number | null; read_tag: number }[];
   const worksByAuthor = new Map<string, { nodus_id: string; year: number | null; read_tag: number }[]>();
   for (const row of waRows) {
@@ -1253,6 +1256,7 @@ function readPathRows(db: ReturnType<typeof getDb>): ReadingWorkRow[] {
           UNION ALL
           SELECT to_author AS author_id, type, weight FROM author_relations
         ) ar ON ar.author_id = wa.author_id
+        WHERE wa.role = 'author'
         GROUP BY wa.nodus_id
       ),
       dependency_stats AS (

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -96,7 +96,7 @@ import { onOpenCodeGoUsageStatusChanged } from './ai/openCodeGoUsage';
 import {
   interruptDecorativeImageGenerations,
 } from './ai/decorativeImages';
-import { reconcileAuthorLayerOnce } from './db/authorsRepo';
+import { reconcileAuthorLayerOnce, reconcileAuthorRolesOnce } from './db/authorsRepo';
 import { getSyncLog } from './db/syncRepo';
 import { fullSync, startRealtimeSync, stopRealtimeSync } from './sync/syncService';
 import {
@@ -312,6 +312,7 @@ export function registerIpc(
     upgradeWorldbuildingDemoNarrativeDepth();
     relocalizeWorldbuildingDemoData();
     reconcileAuthorLayerOnce();
+    reconcileAuthorRolesOnce();
 
     const settings = getSettings();
     if (settings.syncMode === 'realtime') startRealtimeSync();
@@ -669,6 +670,7 @@ export function registerIpc(
       const reset = resetVaultDatabase(id);
       getDb();
       reconcileAuthorLayerOnce();
+      reconcileAuthorRolesOnce();
       const settings = getSettings();
       if (settings.syncMode === 'realtime') startRealtimeSync();
       startNodusServerSync();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,7 +5,7 @@ import { constants as fsConstants, promises as fs } from 'node:fs';
 import os from 'node:os';
 import { spawn, spawnSync } from 'node:child_process';
 import { getDb, closeDb } from './db/database';
-import { reconcileAuthorLayerOnce } from './db/authorsRepo';
+import { reconcileAuthorLayerOnce, reconcileAuthorRolesOnce } from './db/authorsRepo';
 import { pruneDormantIdeas } from './db/ideasRepo';
 import {
   maybeRunAutoBackup,
@@ -865,6 +865,7 @@ app.whenReady().then(async () => {
   registerArchiveProtocol();
   registerLibraryProtocol();
   reconcileAuthorLayerOnce(); // one-time: collapse duplicate author nodes onto Zotero identity
+  reconcileAuthorRolesOnce(); // one-time: stop crediting volume editors as authors
   // Maintenance: drop ideas that have sat dormant (no occurrences) for >30 days.
   // Recent dormancy is kept — it lets fusion revive an idea with the same
   // global_id when its work is rescanned.

--- a/electron/sync/syncService.ts
+++ b/electron/sync/syncService.ts
@@ -17,17 +17,29 @@ import { collectionItemsRecursive, libraries as zoteroLibraries, libraryVersion,
 import type { ZoteroCollection, ZoteroLibrary } from '@shared/types';
 import { scanQueue } from '../pipeline/scanQueue';
 import type { SyncLogEntry, WorkCreator, ZoteroItem } from '@shared/types';
-import { linkZoteroAuthors } from '../db/authorsRepo';
+import { EDITOR_BYLINE_SUFFIX, linkZoteroAuthors } from '../db/authorsRepo';
 import { getDb } from '../db/database';
 import { probeWorkTextAvailability } from '../extraction/textExtractor';
 
+/** The stored byline. Only the creators that carry intellectual responsibility
+ *  for the item appear (translators, series editors, … are dropped), and an
+ *  editor is marked as such so the byline can never be read as authorship. */
 function authorsOf(item: ZoteroItem): string[] {
-  return item.creators.map((c) => {
-    if (c.name) return c.name;
+  const authors: string[] = [];
+  const editors: string[] = [];
+  for (const c of item.creators) {
+    const type = (c.creatorType ?? 'author').toLowerCase();
+    if (type !== 'author' && type !== 'editor') continue;
     const last = c.lastName ?? '';
     const initial = c.firstName ? `, ${c.firstName.charAt(0)}.` : '';
-    return `${last}${initial}`;
-  });
+    const display = c.name || `${last}${initial}`;
+    if (type === 'editor') editors.push(`${display}${EDITOR_BYLINE_SUFFIX}`);
+    else authors.push(display);
+  }
+  // Authors first, in Zotero's order, then the editors. Zotero lists the volume
+  // editor first on a book section, and everything that shortens a citation to
+  // "authors[0] (year)" would otherwise credit the chapter to the editor.
+  return [...authors, ...editors];
 }
 
 /** Structured creators kept for building canonical author identity. Only authors

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "test:e2e:browser-connector": "node scripts/e2e-browser-connector.mjs",
     "test:e2e:office-references": "node scripts/e2e-office-references.mjs",
     "test:e2e:local-server": "node scripts/e2e-local-server.mjs",
+    "smoke:author-roles": "node scripts/run-smoke.mjs smoke-author-roles",
+    "smoke:author-roles:realcopy": "node scripts/run-smoke.mjs smoke-author-roles-realcopy",
     "qa:notion-parity": "node scripts/notion-parity/cli.mjs",
     "test:database-storage": "node scripts/test-database-typed-storage.mjs",
     "test:database-properties": "node scripts/test-database-properties.mjs",

--- a/scripts/run-smoke.mjs
+++ b/scripts/run-smoke.mjs
@@ -1,0 +1,48 @@
+// Build and run one of the headless smoke scripts in scripts/smoke-*.ts.
+//
+// They need better-sqlite3's Electron ABI, so they run under `electron` with
+// ELECTRON_RUN_AS_NODE and the electron module stubbed. Native-only packages are
+// left external because esbuild cannot bundle a .node binary.
+//
+//   npm run smoke:author-roles
+//   NODUS_TEST_USERDATA=/path/to/vault-copy npm run smoke:author-roles:realcopy
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const name = process.argv[2];
+if (!name) {
+  console.error('usage: node scripts/run-smoke.mjs <smoke-script-name> [-- extra electron args]');
+  process.exit(2);
+}
+
+// The bundle lives in the repo root, not a temp dir: the native packages left
+// external are resolved relative to the bundle's own location.
+const bundle = path.join(root, `.${name}.cjs`);
+execFileSync(
+  path.join(root, 'node_modules/.bin/esbuild'),
+  [
+    path.join(root, 'scripts', `${name}.ts`),
+    '--bundle',
+    '--platform=node',
+    '--format=cjs',
+    `--outfile=${bundle}`,
+    '--external:better-sqlite3',
+    '--external:onnxruntime-node',
+    '--external:@napi-rs/canvas',
+    `--alias:electron=${path.join(root, 'scripts/stub-electron.mjs')}`,
+  ],
+  { cwd: root, stdio: 'inherit' }
+);
+
+// A smoke run must never touch the live vault: without an explicit directory it
+// gets a throwaway one.
+const userData = process.env.NODUS_TEST_USERDATA || mkdtempSync(path.join(os.tmpdir(), 'nodus-smoke-userdata-'));
+execFileSync(path.join(root, 'node_modules/.bin/electron'), [bundle], {
+  cwd: root,
+  env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', NODUS_TEST_USERDATA: userData },
+  stdio: 'inherit',
+});

--- a/scripts/smoke-author-roles-realcopy.ts
+++ b/scripts/smoke-author-roles-realcopy.ts
@@ -1,0 +1,94 @@
+// Runs the author/editor role repair against a COPY of a real corpus and proves
+// it corrects the attribution without touching any research data. Point
+// NODUS_TEST_USERDATA at a directory holding a COPY of nodus.sqlite — never the
+// live file.
+//
+// Build+run:
+//   npx esbuild scripts/smoke-author-roles-realcopy.ts --bundle --platform=node \
+//     --format=cjs --outfile=.smoke-roles-real.cjs --external:better-sqlite3 \
+//     --external:onnxruntime-node --external:@napi-rs/canvas \
+//     --alias:electron=./scripts/stub-electron.mjs
+//   ELECTRON_RUN_AS_NODE=1 NODUS_TEST_USERDATA=/path/to/copy npx electron .smoke-roles-real.cjs
+import { getDb } from '../electron/db/database';
+import { reconcileAuthorRolesOnce } from '../electron/db/authorsRepo';
+import { listAuthors } from '../electron/ai/authorDossier';
+
+const db = getDb();
+const c = (sql: string) => (db.prepare(sql).get() as { n: number }).n;
+
+// Everything that holds research. None of it may move.
+const RESEARCH_TABLES = [
+  'works', 'ideas', 'idea_occurrences', 'evidence', 'edges', 'gaps',
+  'external_refs', 'themes', 'idea_theme_links', 'notes', 'authors', 'work_authors',
+];
+const snap = () => Object.fromEntries(RESEARCH_TABLES.map((t) => [t, c(`SELECT COUNT(*) AS n FROM ${t}`)]));
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`ASSERT FAILED: ${msg}`);
+}
+
+const roleCounts = () =>
+  Object.fromEntries(
+    (db.prepare('SELECT role, COUNT(*) AS n FROM work_authors GROUP BY role').all() as { role: string; n: number }[]).map(
+      (r) => [r.role, r.n]
+    )
+  ) as Record<string, number>;
+
+const before = snap();
+const rolesBefore = roleCounts();
+const authorsBefore = listAuthors();
+const byIdBefore = new Map(authorsBefore.map((a) => [a.author_id, a] as const));
+console.log(`links before → author: ${rolesBefore.author ?? 0}, editor: ${rolesBefore.editor ?? 0}`);
+
+console.time('repair');
+reconcileAuthorRolesOnce();
+console.timeEnd('repair');
+
+const after = snap();
+const rolesAfter = roleCounts();
+const authorsAfter = listAuthors();
+console.log(`links after  → author: ${rolesAfter.author ?? 0}, editor: ${rolesAfter.editor ?? 0}`);
+
+for (const table of RESEARCH_TABLES) {
+  assert(after[table] === before[table], `${table} changed: ${before[table]} → ${after[table]}`);
+}
+console.log(`research tables identical (${RESEARCH_TABLES.length} checked) ✓`);
+
+// Who stopped being credited with other people's chapters, worst first.
+const drops = authorsAfter
+  .map((a) => {
+    const was = byIdBefore.get(a.author_id);
+    return {
+      name: a.name,
+      works: (was?.workCount ?? 0) - a.workCount,
+      ideas: (was?.ideaCount ?? 0) - a.ideaCount,
+      edited: a.editedCount,
+      keptWorks: a.workCount,
+      keptIdeas: a.ideaCount,
+    };
+  })
+  .filter((d) => d.ideas > 0 || d.works > 0)
+  .sort((a, b) => b.ideas - a.ideas);
+
+const totalIdeasDropped = drops.reduce((sum, d) => sum + d.ideas, 0);
+console.log(`\n${drops.length} people stopped being credited with ideas they did not write (${totalIdeasDropped} attributions):`);
+for (const d of drops.slice(0, 20)) {
+  console.log(
+    `  ${d.name.padEnd(38)} −${String(d.works).padStart(2)} works  −${String(d.ideas).padStart(3)} ideas` +
+      `   → keeps ${d.keptWorks} works / ${d.keptIdeas} ideas, edits ${d.edited} volumes`
+  );
+}
+
+// Nobody may gain attribution from a repair that only ever removes credit.
+const gains = authorsAfter.filter((a) => a.ideaCount > (byIdBefore.get(a.author_id)?.ideaCount ?? 0));
+assert(gains.length === 0, `${gains.length} authors gained ideas they did not have before`);
+
+// Every work that was credited to somebody still is: no work fell off the map.
+const orphans = c(
+  `SELECT COUNT(*) AS n FROM works w
+    WHERE w.nodus_id IN (SELECT nodus_id FROM work_authors)
+      AND NOT EXISTS (SELECT 1 FROM work_authors wa WHERE wa.nodus_id = w.nodus_id AND wa.role = 'author')`
+);
+console.log(`\nworks left with editors but no author: ${orphans}`);
+
+console.log('\nROLES REPAIRED · NO RESEARCH DATA TOUCHED ✓');

--- a/scripts/smoke-author-roles.ts
+++ b/scripts/smoke-author-roles.ts
@@ -1,0 +1,211 @@
+// Headless proof that a volume's EDITOR is never credited with the ideas of the
+// chapters inside it, and that a corpus already carrying the old mistake repairs
+// itself without losing anything.
+//
+// The bug this pins down: work_authors.role arrived with DEFAULT 'author', and
+// the old sticky ON CONFLICT ("once an author, always an author") made the column
+// unrepairable, so every editor stayed credited as an author of every chapter of
+// the volumes they edited — and every idea in those chapters was attributed to
+// them. Zotero's answer was never lost, only ignored: it sits in creators_json.
+//
+// Build+run (better-sqlite3 needs Electron's ABI, electron is stubbed):
+//   npx esbuild scripts/smoke-author-roles.ts --bundle --platform=node \
+//     --format=cjs --outfile=.smoke-roles.cjs --external:better-sqlite3 \
+//     --external:onnxruntime-node --external:@napi-rs/canvas \
+//     --alias:electron=./scripts/stub-electron.mjs
+//   ELECTRON_RUN_AS_NODE=1 NODUS_TEST_USERDATA=/tmp/x npx electron .smoke-roles.cjs
+import { getDb } from '../electron/db/database';
+import { linkZoteroAuthors, reconcileAuthorRolesOnce, recomputeAuthorRelations } from '../electron/db/authorsRepo';
+import { listAuthors, buildAuthorDossier } from '../electron/ai/authorDossier';
+import { ingestZoteroItem } from '../electron/sync/syncService';
+import type { ZoteroItem } from '@shared/types';
+
+const db = getDb();
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`ASSERT FAILED: ${msg}`);
+}
+function count(sql: string): number {
+  return (db.prepare(sql).get() as { n: number }).n;
+}
+function roleOf(work: string, key: string): string | null {
+  const row = db
+    .prepare(
+      `SELECT wa.role FROM work_authors wa JOIN authors a ON a.author_id = wa.author_id
+        WHERE wa.nodus_id = ? AND a.canonical_key = ?`
+    )
+    .get(work, key) as { role: string } | undefined;
+  return row?.role ?? null;
+}
+function authorIdFor(key: string): string {
+  return (db.prepare('SELECT author_id FROM authors WHERE canonical_key = ?').get(key) as { author_id: string }).author_id;
+}
+
+// ── Seed an edited volume in the SHAPE THE BUG LEFT BEHIND ───────────────────
+// creators_json is correct (Zotero always knew), work_authors.role is not: every
+// link says 'author', exactly as migration 23's DEFAULT wrote it.
+const chapters = [
+  { id: 'c1', title: 'Chapter one', author: { last: 'Arco Blanco', first: 'Miguel Ángel del', key: 'arco blanco::m' } },
+  { id: 'c2', title: 'Chapter two', author: { last: 'Martínez Martínez', first: 'Alba', key: 'martinez martinez::a' } },
+  { id: 'c3', title: 'Chapter three', author: { last: 'Cabezas Vega', first: 'Laura', key: 'cabezas vega::l' } },
+];
+const editor = { last: 'Román Ruiz', first: 'Gloria', key: 'roman ruiz::g' };
+
+const insWork = db.prepare(
+  `INSERT INTO works (nodus_id, zotero_key, title, authors_json, creators_json, year, item_type, archived, deep_status)
+   VALUES (?, ?, ?, ?, ?, 2024, 'bookSection', 0, 'done')`
+);
+const insAuthor = db.prepare('INSERT INTO authors (author_id, name, affiliation, canonical_key) VALUES (?, ?, NULL, ?)');
+const insLink = db.prepare("INSERT INTO work_authors (nodus_id, author_id, role) VALUES (?, ?, 'author')");
+
+insAuthor.run('a-editor', `${editor.last}, ${editor.first}`, editor.key);
+for (const ch of chapters) {
+  insAuthor.run(`a-${ch.id}`, `${ch.author.last}, ${ch.author.first}`, ch.author.key);
+  insWork.run(
+    ch.id,
+    `z-${ch.id}`,
+    ch.title,
+    // Zotero puts the volume editor first on a book section — which is exactly
+    // how a citation shortened to authors[0] ended up naming the editor.
+    JSON.stringify([`${editor.last}, ${editor.first.charAt(0)}.`, `${ch.author.last}, ${ch.author.first.charAt(0)}.`]),
+    JSON.stringify([
+      { lastName: editor.last, firstName: editor.first, name: null, role: 'editor' },
+      { lastName: ch.author.last, firstName: ch.author.first, name: null, role: 'author' },
+    ])
+  );
+  insLink.run(ch.id, 'a-editor'); // ← the misfiled link
+  insLink.run(ch.id, `a-${ch.id}`);
+}
+
+// A work the editor really did write, so the repair must not strip her whole footprint.
+insWork.run(
+  'own',
+  'z-own',
+  'Her own article',
+  JSON.stringify([`${editor.last}, ${editor.first.charAt(0)}.`]),
+  JSON.stringify([{ lastName: editor.last, firstName: editor.first, name: null, role: 'author' }])
+);
+insLink.run('own', 'a-editor');
+
+// Ideas + evidence + one cross-chapter edge, so attribution and relations are measurable.
+const insIdea = db.prepare("INSERT INTO ideas (global_id, type, label, statement, created_at) VALUES (?, 'claim', ?, ?, '2024-01-01')");
+const insOcc = db.prepare("INSERT INTO idea_occurrences (global_id, nodus_id, role, development, confidence) VALUES (?, ?, 'principal', '', 0.9)");
+const insEv = db.prepare("INSERT INTO evidence (id, global_id, nodus_id, quote, location, kind) VALUES (?, ?, ?, 'quote', 'p.1', 'explicit')");
+const insTheme = db.prepare("INSERT INTO themes (theme_id, label) VALUES (?, ?)");
+const insThemeLink = db.prepare("INSERT INTO idea_theme_links (global_id, nodus_id, theme_id, confidence, basis) VALUES (?, ?, ?, 0.9, 'explicit')");
+insTheme.run('t-infancia', 'infancia');
+for (const w of [...chapters.map((c) => c.id), 'own']) {
+  const gid = `i-${w}`;
+  insIdea.run(gid, `Idea ${w}`, `Statement ${w}`);
+  insOcc.run(gid, w);
+  insEv.run(`ev-${gid}`, gid, w);
+  insThemeLink.run(gid, w, 't-infancia');
+}
+db.prepare(
+  "INSERT INTO edges (id, from_id, to_id, type, basis, confidence) VALUES ('e1', 'i-c1', 'i-c2', 'contradicts', 'explicit', 0.8)"
+).run();
+recomputeAuthorRelations();
+
+// ── Before: the corpus as the bug left it ────────────────────────────────────
+const RESEARCH_TABLES = ['works', 'ideas', 'idea_occurrences', 'evidence', 'edges', 'themes', 'idea_theme_links'];
+const snap = () => Object.fromEntries(RESEARCH_TABLES.map((t) => [t, count(`SELECT COUNT(*) AS n FROM ${t}`)]));
+const researchBefore = snap();
+const linksBefore = count('SELECT COUNT(*) AS n FROM work_authors');
+const editorId = authorIdFor(editor.key);
+
+const summaryBefore = listAuthors().find((a) => a.author_id === editorId)!;
+console.log(`before → editor credited with ${summaryBefore.workCount} works, ${summaryBefore.ideaCount} ideas`);
+assert(summaryBefore.workCount === 4, 'seed did not reproduce the bug (works)');
+assert(summaryBefore.ideaCount === 4, 'seed did not reproduce the bug (ideas)');
+const relBefore = count(`SELECT COUNT(*) AS n FROM author_relations WHERE from_author='${editorId}' OR to_author='${editorId}'`);
+assert(relBefore > 0, 'seed did not reproduce the bug (relations routed through the editor)');
+
+const misfiledBefore = count("SELECT COUNT(*) AS n FROM work_authors WHERE author_id='a-editor' AND role='author'");
+assert(misfiledBefore === 4, 'seed did not reproduce the bug (stored roles)');
+
+// ── Repair ───────────────────────────────────────────────────────────────────
+reconcileAuthorRolesOnce();
+const misfiledAfter = count("SELECT COUNT(*) AS n FROM work_authors WHERE author_id='a-editor' AND role='author'");
+console.log(`roles → ${misfiledBefore} links credited to the editor as author, ${misfiledAfter} after the repair`);
+assert(misfiledAfter === 1, 'the repair did not rewrite exactly the three editor links');
+
+// ── After: roles, attribution and integrity ──────────────────────────────────
+for (const ch of chapters) {
+  assert(roleOf(ch.id, editor.key) === 'editor', `${ch.id}: editor still credited as author`);
+  assert(roleOf(ch.id, ch.author.key) === 'author', `${ch.id}: real author lost their role`);
+}
+assert(roleOf('own', editor.key) === 'author', 'the work she actually wrote was demoted');
+
+const summaryAfter = listAuthors().find((a) => a.author_id === editorId)!;
+console.log(`after  → editor: ${summaryAfter.workCount} works, ${summaryAfter.editedCount} edited, ${summaryAfter.ideaCount} ideas`);
+assert(summaryAfter.workCount === 1, 'authored count not corrected');
+assert(summaryAfter.editedCount === 3, 'edited volumes not counted apart');
+assert(summaryAfter.ideaCount === 1, 'ideas still attributed through editorship');
+assert(summaryAfter.topThemes.length === 1, 'themes still attributed through editorship');
+
+const dossier = buildAuthorDossier(editorId)!;
+assert(dossier.works.length === 1 && dossier.works[0].nodus_id === 'own', 'dossier works not restricted to authorship');
+assert(dossier.editedWorks.length === 3, 'edited volumes missing from the dossier');
+assert(dossier.ideas.length === 1 && dossier.ideas[0].workId === 'own', 'dossier ideas still borrowed from chapters');
+assert(dossier.ideas[0].evidence.length === 1, 'evidence lost for the work she wrote');
+
+const relAfter = count(`SELECT COUNT(*) AS n FROM author_relations WHERE from_author='${editorId}' OR to_author='${editorId}'`);
+assert(relAfter === 0, 'author relations still routed through the editor');
+const chapterRel = count(
+  `SELECT COUNT(*) AS n FROM author_relations WHERE from_author='${authorIdFor(chapters[0].author.key)}' AND to_author='${authorIdFor(chapters[1].author.key)}'`
+);
+assert(chapterRel === 1, 'the real authors lost the relation the edge proves');
+
+// Nothing was created, deleted or rewritten beyond the role column.
+const researchAfter = snap();
+for (const table of RESEARCH_TABLES) {
+  assert(researchAfter[table] === researchBefore[table], `${table} changed: ${researchBefore[table]} → ${researchAfter[table]}`);
+}
+assert(count('SELECT COUNT(*) AS n FROM work_authors') === linksBefore, 'work↔author links were added or dropped');
+
+// ── Idempotency: repairing twice changes nothing ─────────────────────────────
+db.prepare("DELETE FROM settings WHERE key='author_roles_reconciled'").run();
+reconcileAuthorRolesOnce();
+const summaryTwice = listAuthors().find((a) => a.author_id === editorId)!;
+assert(summaryTwice.workCount === 1 && summaryTwice.editedCount === 3, 'second repair changed the outcome');
+
+// ── The everyday path is self-healing on its own ─────────────────────────────
+// Put one chapter back into the broken shape and resync it the way ingest does:
+// the role must correct itself without the one-time pass running again.
+db.prepare("UPDATE work_authors SET role='author' WHERE nodus_id='c1' AND author_id='a-editor'").run();
+linkZoteroAuthors('c1', { createIfMissing: false });
+assert(roleOf('c1', editor.key) === 'editor', 'a plain resync cannot correct a misfiled editor');
+for (const ch of chapters) {
+  linkZoteroAuthors(ch.id, { createIfMissing: false });
+  assert(roleOf(ch.id, editor.key) === 'editor', `${ch.id}: resync re-credited the editor`);
+}
+
+// ── Ingest path: the byline marks editors and never leads with one ───────────
+const item = {
+  key: 'z-new',
+  itemKey: 'z-new',
+  library: { id: 'u1', type: 'user', name: 'Personal' },
+  version: 1,
+  title: 'A freshly synced chapter',
+  creators: [
+    { lastName: 'Román Ruiz', firstName: 'Gloria', creatorType: 'editor' },
+    { lastName: 'Jiménez Aguilar', firstName: 'Francisco', creatorType: 'author' },
+    { lastName: 'Translator', firstName: 'Tina', creatorType: 'translator' },
+  ],
+  year: 2024,
+  itemType: 'bookSection',
+  doi: null,
+  abstract: null,
+  tags: [],
+  collections: [],
+} as unknown as ZoteroItem;
+ingestZoteroItem(item, 'leído');
+const byline = JSON.parse(
+  (db.prepare("SELECT authors_json FROM works WHERE zotero_key='z-new'").get() as { authors_json: string }).authors_json
+) as string[];
+console.log(`byline → ${byline.join(' · ')}`);
+assert(byline.length === 2, 'the translator leaked into the byline');
+assert(byline[0] === 'Jiménez Aguilar, F.', 'the byline still leads with the editor');
+assert(byline[1] === 'Román Ruiz, G. (ed.)', 'the editor is not marked in the byline');
+
+console.log('\nEDITORS ARE NOT AUTHORS · CORPUS REPAIRED · NOTHING LOST ✓');

--- a/scripts/stub-electron.mjs
+++ b/scripts/stub-electron.mjs
@@ -2,7 +2,7 @@
 // Only what the DB/AI modules touch at import time is provided; safeStorage is
 // never actually invoked on the pure-assembly code path.
 const tmp = process.env.NODUS_TEST_USERDATA || '/tmp/nodus-smoke-userdata';
-export const app = { getPath: () => tmp };
+export const app = { getPath: () => tmp, getAppPath: () => process.cwd(), isPackaged: false };
 export const safeStorage = {
   isEncryptionAvailable: () => false,
   encryptString: (s) => Buffer.from(String(s)),

--- a/scripts/test-decorative-images.mjs
+++ b/scripts/test-decorative-images.mjs
@@ -404,7 +404,7 @@ try {
     CREATE TABLE passages (passage_id TEXT PRIMARY KEY, nodus_id TEXT, text TEXT, page_label TEXT, chunk_index INTEGER, char_len INTEGER, created_at TEXT);
     CREATE TABLE gaps (id TEXT PRIMARY KEY, kind TEXT, statement TEXT, confidence REAL, nodus_id TEXT, related_idea TEXT, evidence_id TEXT);
     CREATE TABLE authors (author_id TEXT PRIMARY KEY, name TEXT, affiliation TEXT, canonical_key TEXT);
-    CREATE TABLE work_authors (author_id TEXT, nodus_id TEXT);
+    CREATE TABLE work_authors (author_id TEXT, nodus_id TEXT, role TEXT NOT NULL DEFAULT 'author');
     CREATE TABLE note_folders (id TEXT PRIMARY KEY, name TEXT);
     CREATE TABLE notes (id TEXT PRIMARY KEY, title TEXT, kind TEXT, content TEXT, folder_id TEXT, created_at TEXT, updated_at TEXT, trashed_at TEXT);
     INSERT INTO ideas VALUES ('i1','claim','Idea de prueba','Enunciado completo','2026-01-01');
@@ -418,7 +418,7 @@ try {
     INSERT INTO passages VALUES ('p1','w1','Pasaje completo','4',0,15,'2026-01-01');
     INSERT INTO gaps VALUES ('g1','evidence','Hueco de prueba',0.8,'w1','i1','e1');
     INSERT INTO authors VALUES ('a1','Autora de prueba','Universidad','autora-prueba');
-    INSERT INTO work_authors VALUES ('a1','w1');
+    INSERT INTO work_authors VALUES ('a1','w1','author');
     INSERT INTO note_folders VALUES ('f1','Carpeta');
     INSERT INTO notes VALUES ('n1','Nota de prueba','markdown','Contenido completo','f1','2026-01-01','2026-01-02',NULL);
   `);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6781,7 +6781,10 @@ export interface AuthorSummary {
   /** Natural reading order ("Given Surname") for display. */
   fullName: string;
   affiliation: string | null;
+  /** Works this person actually wrote. Volumes they only edited are counted apart. */
   workCount: number;
+  /** Volumes this person edited without authoring — never part of their footprint. */
+  editedCount: number;
   ideaCount: number;
   relationCount: number;
   /** Most frequent Zotero tags across this author's live works. */
@@ -6882,7 +6885,10 @@ export interface AuthorDossier {
   fullName: string;
   firstName: string;
   lastName: string;
+  /** Works this person wrote — the only ones their ideas are drawn from. */
   works: AuthorDossierWork[];
+  /** Volumes they edited: listed as a bibliographic fact, never as authorship. */
+  editedWorks: AuthorDossierWork[];
   ideas: AuthorDossierIdea[];
   relations: AuthorDossierRelation[];
   themes: string[];

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -8206,4 +8206,7 @@ export const DE: Record<string, string> = {
   "Descifrando…": "Wird entschlüsselt…",
   "Finalizando…": "Wird abgeschlossen…",
   "Progreso de restauración": "Wiederherstellungsfortschritt",
+  "Volúmenes que edita": "Herausgegebene Bände",
+  "{n} volúmenes editados": "{n} herausgegebene Bände",
+  "Coordina la edición del volumen; las ideas no se le atribuyen.": "Diese Person gibt den Band heraus; dessen Ideen werden ihr nicht zugeschrieben.",
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -8433,4 +8433,7 @@ export const EN: Record<string, string> = {
   "Descifrando…": "Decrypting…",
   "Finalizando…": "Finalizing…",
   "Progreso de restauración": "Restore progress",
+  "Volúmenes que edita": "Volumes they edit",
+  "{n} volúmenes editados": "{n} edited volumes",
+  "Coordina la edición del volumen; las ideas no se le atribuyen.": "They edit the volume; its ideas are not attributed to them.",
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -8197,4 +8197,7 @@ export const FR: Record<string, string> = {
   "Descifrando…": "Déchiffrement…",
   "Finalizando…": "Finalisation…",
   "Progreso de restauración": "Progression de la restauration",
+  "Volúmenes que edita": "Volumes qu'iel dirige",
+  "{n} volúmenes editados": "{n} volumes dirigés",
+  "Coordina la edición del volumen; las ideas no se le atribuyen.": "Cette personne dirige le volume ; ses idées ne lui sont pas attribuées.",
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -7611,4 +7611,7 @@ export const IT: Record<string, string> = {
   "Descifrando…": "Decifratura…",
   "Finalizando…": "Finalizzazione…",
   "Progreso de restauración": "Avanzamento del ripristino",
+  "Volúmenes que edita": "Volumi che cura",
+  "{n} volúmenes editados": "{n} volumi curati",
+  "Coordina la edición del volumen; las ideas no se le atribuyen.": "Cura l'edizione del volume; le idee non le vengono attribuite.",
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -8156,4 +8156,7 @@ export const PT_BR: Record<string, string> = {
   "Descifrando…": "Descriptografando…",
   "Finalizando…": "Finalizando…",
   "Progreso de restauración": "Progresso da restauração",
+  "Volúmenes que edita": "Volumes que organiza",
+  "{n} volúmenes editados": "{n} volumes organizados",
+  "Coordina la edición del volumen; las ideas no se le atribuyen.": "Organiza a edição do volume; as ideias não são atribuídas a essa pessoa.",
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -8148,4 +8148,7 @@ export const PT: Record<string, string> = {
   "Descifrando…": "A desencriptar…",
   "Finalizando…": "A finalizar…",
   "Progreso de restauración": "Progresso da restauração",
+  "Volúmenes que edita": "Volumes que coordena",
+  "{n} volúmenes editados": "{n} volumes coordenados",
+  "Coordina la edición del volumen; las ideas no se le atribuyen.": "Coordena a edição do volume; as ideias não lhe são atribuídas.",
 };

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -7956,4 +7956,7 @@ export const TR: Record<string, string> = {
   "Descifrando…": "Şifre çözülüyor…",
   "Finalizando…": "Tamamlanıyor…",
   "Progreso de restauración": "Geri yükleme ilerlemesi",
+  "Volúmenes que edita": "Derlediği ciltler",
+  "{n} volúmenes editados": "{n} derlenen cilt",
+  "Coordina la edición del volumen; las ideas no se le atribuyen.": "Cildin editörlüğünü yapar; fikirler bu kişiye atfedilmez.",
 };

--- a/src/views/AuthorsView.tsx
+++ b/src/views/AuthorsView.tsx
@@ -483,7 +483,7 @@ function AuthorsCatalog({
               <input type="checkbox" checked={selected.has(author.author_id)} onChange={() => toggleSelect(author.author_id)} aria-label={t('Seleccionar para exportar')} />
               <button data-testid="author-name" className="min-w-0 pr-3 text-left font-medium text-neutral-200 hover:text-indigo-300" onClick={() => onOpenAuthor({ id: author.author_id, label: author.fullName || author.name, saved: author.saved })}><span className="block truncate">{author.firstName || author.fullName || author.name}</span>{author.affiliation && <span className="mt-1 block truncate text-[10px] font-normal text-neutral-600">{author.affiliation}</span>}</button>
               <button className="min-w-0 truncate pr-3 text-left text-neutral-400 hover:text-indigo-300" onClick={() => onOpenAuthor({ id: author.author_id, label: author.fullName || author.name, saved: author.saved })}>{author.lastName || author.name}</button>
-              <span className="tabular-nums text-neutral-400">{author.workCount}</span>
+              <span className="tabular-nums text-neutral-400">{author.workCount}{author.editedCount > 0 && <span className="ml-1 text-[10px] text-cyan-500/80" title={tx('{n} volúmenes editados', { n: author.editedCount })}>+{author.editedCount} {t('ed.')}</span>}</span>
               <span className="tabular-nums text-neutral-400">{author.ideaCount}</span>
               <span className="tabular-nums text-neutral-400">{author.relationCount}</span>
               <div className="flex min-w-0 flex-wrap gap-1 pr-3">{(author.topTags.length ? author.topTags : author.topThemes).slice(0, 4).map((tag) => <span key={tag} className="max-w-32 truncate rounded-full bg-neutral-900 px-2 py-1 text-[10px] text-neutral-500" title={tag}>{tag}</span>)}</div>
@@ -665,6 +665,11 @@ function AuthorDossierDetail({
             <Icon name="book" size={11} />
             {tx('{n} obras', { n: dossier.works.length })}
           </button>
+          {dossier.editedWorks.length > 0 && (
+            <Badge color="cyan" title={t('Coordina la edición del volumen; las ideas no se le atribuyen.')}>
+              {tx('{n} volúmenes editados', { n: dossier.editedWorks.length })}
+            </Badge>
+          )}
           <Badge>{tx('{n} ideas', { n: dossier.ideas.length })}</Badge>
           <Badge>{tx('{n} conexiones', { n: connectedAuthors.length })}</Badge>
           {dossier.themes.slice(0, 5).map((th) => (
@@ -755,6 +760,23 @@ function AuthorDossierDetail({
         </section>
       )}
 
+      {/* 2b. Volumes this person edited but did not write. Listed because it is a
+             real bibliographic fact, kept apart because none of the ideas above
+             come from them. */}
+      {dossier.editedWorks.length > 0 && (
+        <section data-testid="author-edited-works">
+          <h4 className="font-medium mb-1 flex items-center gap-2">
+            <Icon name="book" size={15} className="text-cyan-400" /> {t('Volúmenes que edita')}
+          </h4>
+          <p className="mb-2 text-xs text-neutral-500">{t('Coordina la edición del volumen; las ideas no se le atribuyen.')}</p>
+          <div className="space-y-1">
+            {dossier.editedWorks.map((w) => (
+              <AuthorWorkRow key={w.nodus_id} work={w} onOpenIdeas={(work) => setIdeasWork(work)} />
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* 3. Searchable idea list */}
       <AuthorIdeasSection ideas={dossier.ideas} onOpenIdea={setSelectedIdeaId} />
 
@@ -786,7 +808,7 @@ function AuthorDossierDetail({
       {worksOpen && (
         <AuthorWorksModal
           authorName={dossier.fullName || author.name}
-          works={dossier.works}
+          works={[...dossier.works, ...dossier.editedWorks]}
           onClose={() => setWorksOpen(false)}
           onOpenWorkIdeas={(work) => {
             setWorksOpen(false);


### PR DESCRIPTION
Closes #513.

A person listed in Zotero as the **editor** of an edited volume was treated as an **author** of every chapter in it, so every idea extracted from those chapters was attributed to them. On the 1,214-work corpus this was found in, that was **1,786 false attributions across 56 people**.

## The three defects

**1. The role was stored but unrepairable.** Zotero's answer was never lost — `works.creators_json` has carried `role` per creator since migration 23. But that migration added `work_authors.role` with `DEFAULT 'author'`, stamping every pre-existing link as authorship, and `linkWorkAuthor`'s `ON CONFLICT` was *"once an author, always an author"*: a link could be promoted to author but never demoted to editor. No amount of resyncing could fix a row. The role is now written as given; the author-beats-editor tie for one work is still resolved in memory by `linkZoteroAuthors` before the write, so nothing is lost by trusting it.

**2. Nothing downstream read the role.** Every query that attributes intellectual work joined `work_authors` unfiltered. They now filter to `role = 'author'`: the author list counts, the dossier's ideas/themes/evidence, `authorsForIdea` (which drives `author_relations`), the synthesis matrix, the study guide, the research assistant, the authors graph and global search. Immersion resolved an idea's authors from the byline, so it drops editors before attributing.

**3. The byline mixed roles.** `authorsOf` copied every Zotero creator into `works.authors_json`, translators included, in Zotero's own order — which leads with the volume editor on a book section, so anything shortening a citation to `authors[0]` named the editor. It now keeps only authors and editors, marks editors with `(ed.)`, and orders authors first.

## Retroactive repair

`reconcileAuthorRolesOnce()` runs once per vault at startup and on vault switch. It recomputes `work_authors.role` from `creators_json` — **no Zotero call, no re-analysis** — then rebuilds `author_relations` and drops the cached AI syntheses, which had been written about a work list containing other people's chapters.

It only rewrites the `role` column. It never adds or removes a link, and never touches ideas, works, edges, evidence, themes or notes. Links whose author has no counterpart in `creators_json` (name variants left over from AI extraction) are left exactly as they are.

## What the author page shows now

Volumes a person edits stay listed — that is a real bibliographic fact — in their own "Volumes they edit" section, counted apart from their own works and contributing no ideas, themes or relations. Someone who only ever edited stays in the author list with an empty authored footprint rather than disappearing.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` — clean.
- `npm test` — 2,105/2,106. The one failure, `test-prosopography-e2e.mjs`, fails identically on a clean checkout of `main` in this worktree and is unrelated. `test-decorative-images.mjs` did break: its hand-written fixture schema for `work_authors` was missing the `role` column the real table has; the fixture is fixed in this PR.
- `npm run smoke:author-roles` (new) — seeds an edited volume in the exact shape the bug left behind and proves the repair corrects the roles, that the ideas/themes/relations follow, that a resync no longer re-credits the editor, that the everyday `linkZoteroAuthors` path is self-healing on its own, that the repair is idempotent, and that no research table moves. Confirmed to **fail** against the old behaviour before being relied on.
- `npm run smoke:author-roles:realcopy` (new) — the same repair against a copy of a real 1,214-work vault:

```
links before → author: 970, editor: 70
[authors] repaired 159 misfiled role(s); 229 editor link(s) no longer count as authorship
repair: 252ms
links after  → author: 811, editor: 229
research tables identical (12 checked) ✓

56 people stopped being credited with ideas they did not write (1786 attributions):
  Burgos, Claudio Hernández     −15 works  −171 ideas  → keeps 1 works / 2 ideas, edits 16 volumes
  Nash, Mary                    −11 works  −119 ideas  → keeps 3 works / 177 ideas, edits 12 volumes
  Galant, Ivanne                − 9 works  −108 ideas  → keeps 8 works / 280 ideas, edits 10 volumes
  Román Ruiz, Gloria            − 8 works  − 91 ideas  → keeps 2 works / 14 ideas, edits 8 volumes
```

It also asserts that nobody *gains* attribution: a repair that only ever removes credit must never add any.

## Known follow-ups, not in this PR

- 20 works in that corpus are edited volumes whose Zotero record lists **only** editors. They now have no author link at all, so their ideas are attributed to nobody. That is the honest reading — the editor did not write them — but those chapters' real authors are only recoverable from richer metadata.
- Miguel Ángel del Arco Blanco exists as three author nodes (`arco blanco::m`, `blanco::m`, `del arco blanco::m`) because some Zotero records store the name in a single field. That is a pre-existing identity-splitting problem, independent of roles.
- Deep Research reports and immersions already generated are stored prose; they keep whatever they said. Only newly generated ones use the corrected attribution.