### PR TITLE
fix(authors): repair stored bylines so citations name the author, not the editor

### DIFF
--- a/electron/db/authorsRepo.ts
+++ b/electron/db/authorsRepo.ts
@@ -152,6 +152,34 @@ function parseCreatorsJson(value: string | null): WorkCreator[] {
  */
 export const EDITOR_BYLINE_SUFFIX = ' (ed.)';
 
+/**
+ * The stored byline for a set of Zotero creators. Only the people who carry
+ * intellectual responsibility appear (translators and the rest are already out of
+ * creators_json), an editor is marked so the byline can never be read as
+ * authorship, and authors come first in Zotero's own order.
+ *
+ * Zotero lists the volume editor first on a book section, so anything that
+ * shortens a citation to the first name in the byline — Deep Research, the
+ * writing workshop — would otherwise credit the chapter to its editor.
+ *
+ * Shared by the sync path and the retroactive repair so both produce byte-identical
+ * bylines; a corpus that never resyncs must end up with exactly what a resync writes.
+ */
+export function bylineFromCreators(creators: WorkCreator[]): string[] {
+  const authors: string[] = [];
+  const editors: string[] = [];
+  for (const c of creators) {
+    const last = (c.lastName ?? '').trim();
+    const first = (c.firstName ?? '').trim();
+    const initial = first ? `, ${first.charAt(0)}.` : '';
+    const display = (c.name ?? '').trim() || `${last}${initial}`;
+    if (!display) continue;
+    if (c.role === 'editor') editors.push(`${display}${EDITOR_BYLINE_SUFFIX}`);
+    else authors.push(display);
+  }
+  return [...authors, ...editors];
+}
+
 /** Split a stored byline entry back into its display name and its Zotero role. */
 export function parseBylineEntry(entry: string): { display: string; role: 'author' | 'editor' } {
   const clean = (entry || '').trim();
@@ -395,6 +423,39 @@ export function repairAuthorRoles(): number {
   return changed;
 }
 
+const BYLINE_RECONCILE_FLAG = 'author_bylines_reconciled';
+
+/**
+ * Rewrite every Zotero-synced work's byline from its structured creators, so a
+ * corpus that has not been resynced still cites the author of a chapter rather
+ * than the editor of the volume it sits in. Returns the rows changed.
+ *
+ * Only works that carry creators_json are touched — that is what makes them
+ * Zotero-owned. A manually created work, or one whose byline came from anywhere
+ * but a sync, is left alone.
+ */
+export function repairAuthorBylines(): number {
+  const db = getDb();
+  const works = db
+    .prepare(
+      `SELECT nodus_id AS nodusId, authors_json AS authorsJson, creators_json AS creatorsJson
+         FROM works
+        WHERE creators_json IS NOT NULL AND nodus_id NOT LIKE 'demo-%'`
+    )
+    .all() as { nodusId: string; authorsJson: string | null; creatorsJson: string }[];
+  const update = db.prepare('UPDATE works SET authors_json = ? WHERE nodus_id = ?');
+  let changed = 0;
+  for (const work of works) {
+    const creators = parseCreatorsJson(work.creatorsJson);
+    if (creators.length === 0) continue;
+    const byline = JSON.stringify(bylineFromCreators(creators));
+    if (byline === work.authorsJson) continue;
+    update.run(byline, work.nodusId);
+    changed += 1;
+  }
+  return changed;
+}
+
 /**
  * One-time pass that repairs the stored roles and refreshes everything derived
  * from them: the author-relations layer is rebuilt (it must no longer route a
@@ -402,6 +463,7 @@ export function repairAuthorRoles(): number {
  * they were written about a work list that included other people's chapters.
  */
 export function reconcileAuthorRolesOnce(): void {
+  reconcileAuthorBylinesOnce();
   if (readFlag(ROLE_RECONCILE_FLAG) === '1') return;
   const db = getDb();
   const run = db.transaction(() => {
@@ -421,6 +483,22 @@ export function reconcileAuthorRolesOnce(): void {
       console.log(`[authors] repaired ${changed} misfiled role(s); ${editors} editor link(s) no longer count as authorship`);
     }
     writeFlag(ROLE_RECONCILE_FLAG, '1');
+  });
+  run();
+}
+
+/**
+ * One-time byline repair. Kept on its own flag rather than folded into the role
+ * pass: the two shipped one after the other, and a vault that already ran the role
+ * pass must still get its bylines fixed.
+ */
+export function reconcileAuthorBylinesOnce(): void {
+  if (readFlag(BYLINE_RECONCILE_FLAG) === '1') return;
+  const db = getDb();
+  const run = db.transaction(() => {
+    const changed = repairAuthorBylines();
+    if (changed > 0) console.log(`[authors] rewrote ${changed} byline(s) so editors are marked and never lead`);
+    writeFlag(BYLINE_RECONCILE_FLAG, '1');
   });
   run();
 }

--- a/electron/sync/syncService.ts
+++ b/electron/sync/syncService.ts
@@ -17,30 +17,10 @@ import { collectionItemsRecursive, libraries as zoteroLibraries, libraryVersion,
 import type { ZoteroCollection, ZoteroLibrary } from '@shared/types';
 import { scanQueue } from '../pipeline/scanQueue';
 import type { SyncLogEntry, WorkCreator, ZoteroItem } from '@shared/types';
-import { EDITOR_BYLINE_SUFFIX, linkZoteroAuthors } from '../db/authorsRepo';
+import { bylineFromCreators, linkZoteroAuthors } from '../db/authorsRepo';
 import { getDb } from '../db/database';
 import { probeWorkTextAvailability } from '../extraction/textExtractor';
 
-/** The stored byline. Only the creators that carry intellectual responsibility
- *  for the item appear (translators, series editors, … are dropped), and an
- *  editor is marked as such so the byline can never be read as authorship. */
-function authorsOf(item: ZoteroItem): string[] {
-  const authors: string[] = [];
-  const editors: string[] = [];
-  for (const c of item.creators) {
-    const type = (c.creatorType ?? 'author').toLowerCase();
-    if (type !== 'author' && type !== 'editor') continue;
-    const last = c.lastName ?? '';
-    const initial = c.firstName ? `, ${c.firstName.charAt(0)}.` : '';
-    const display = c.name || `${last}${initial}`;
-    if (type === 'editor') editors.push(`${display}${EDITOR_BYLINE_SUFFIX}`);
-    else authors.push(display);
-  }
-  // Authors first, in Zotero's order, then the editors. Zotero lists the volume
-  // editor first on a book section, and everything that shortens a citation to
-  // "authors[0] (year)" would otherwise credit the chapter to the editor.
-  return [...authors, ...editors];
-}
 
 /** Structured creators kept for building canonical author identity. Only authors
  *  and editors feed the author layer (translators, series editors, … are ignored). */
@@ -95,7 +75,9 @@ export function ingestZoteroItem(item: ZoteroItem, readTagName: string): { nodus
     zotero_key: item.key,
     zotero_version: item.version,
     title: item.title,
-    authors: authorsOf(item),
+    // Byline and structured creators are derived from the same filtered list, so
+    // the display string can never disagree with the roles stored beside it.
+    authors: bylineFromCreators(creatorsOf(item)),
     creators: creatorsOf(item),
     year: item.year,
     item_type: item.itemType,

--- a/scripts/smoke-author-roles-realcopy.ts
+++ b/scripts/smoke-author-roles-realcopy.ts
@@ -54,6 +54,30 @@ for (const table of RESEARCH_TABLES) {
 }
 console.log(`research tables identical (${RESEARCH_TABLES.length} checked) ✓`);
 
+// The byline is what a Deep Research citation is shortened from: a report written
+// after the repair but before any Zotero resync must already name the author.
+const bylines = db
+  .prepare("SELECT title, authors_json FROM works WHERE creators_json IS NOT NULL AND authors_json IS NOT NULL")
+  .all() as { title: string; authors_json: string }[];
+const isEditor = (name: string) => name.trim().toLowerCase().endsWith('(ed.)');
+let ledByEditor = 0;
+let editorsOnly = 0;
+for (const row of bylines) {
+  let names: string[] = [];
+  try {
+    names = JSON.parse(row.authors_json) as string[];
+  } catch {
+    continue;
+  }
+  if (names.length === 0 || !isEditor(names[0])) continue;
+  // A volume Zotero credits to editors only is legitimately led by one — there is
+  // no author to lead with. The defect is a byline that buries an author behind one.
+  if (names.some((name) => !isEditor(name))) ledByEditor += 1;
+  else editorsOnly += 1;
+}
+console.log(`\nbylines led by an editor: ${ledByEditor} burying an author, ${editorsOnly} on editor-only volumes`);
+assert(ledByEditor === 0, 'some citations would still be shortened to the volume editor');
+
 // Who stopped being credited with other people's chapters, worst first.
 const drops = authorsAfter
   .map((a) => {

--- a/scripts/smoke-author-roles.ts
+++ b/scripts/smoke-author-roles.ts
@@ -123,9 +123,22 @@ assert(relBefore > 0, 'seed did not reproduce the bug (relations routed through 
 const misfiledBefore = count("SELECT COUNT(*) AS n FROM work_authors WHERE author_id='a-editor' AND role='author'");
 assert(misfiledBefore === 4, 'seed did not reproduce the bug (stored roles)');
 
+// The byline is what a citation is shortened from, and the seed has it in the
+// broken shape too: editor first, unmarked.
+const bylineOf = (work: string) =>
+  JSON.parse((db.prepare('SELECT authors_json FROM works WHERE nodus_id = ?').get(work) as { authors_json: string }).authors_json) as string[];
+assert(bylineOf('c1')[0] === 'Román Ruiz, G.', 'seed did not reproduce the bug (byline leads with the editor)');
+
 // ── Repair ───────────────────────────────────────────────────────────────────
 reconcileAuthorRolesOnce();
 const misfiledAfter = count("SELECT COUNT(*) AS n FROM work_authors WHERE author_id='a-editor' AND role='author'");
+// A report generated after the repair but before any Zotero resync must already
+// cite the chapter's author, so the stored byline has to be repaired too.
+const c1Byline = bylineOf('c1');
+console.log(`byline of c1 after the repair → ${c1Byline.join(' · ')}`);
+assert(c1Byline[0] === 'Arco Blanco, M.', 'the repaired byline still leads with the editor');
+assert(c1Byline[1] === 'Román Ruiz, G. (ed.)', 'the repaired byline does not mark the editor');
+assert(bylineOf('own')[0] === 'Román Ruiz, G.', 'the byline of the work she wrote was altered');
 console.log(`roles → ${misfiledBefore} links credited to the editor as author, ${misfiledAfter} after the repair`);
 assert(misfiledAfter === 1, 'the repair did not rewrite exactly the three editor links');
 


### PR DESCRIPTION
Closes #515. Follow-up to #514.

That PR fixed **who owns an idea**. It did not fix **whose name a citation carries**, and those are two different columns.

Deep Research and the writing workshop shorten a source to `authors[0]` of `works.authors_json`. `authorsOf` was corrected in #514, but it only runs when a work is ingested from Zotero — so on a corpus that has not been resynced, the byline still held Zotero's own order, which puts the volume editor first on a book section:

```
before  ["Román Ruiz, G.","Arco Blanco, M.","Pulpillo Chiclana, M.","Martínez Martínez, A."]
after   ["Arco Blanco, M.","Pulpillo Chiclana, M.","Martínez Martínez, A.","Román Ruiz, G. (ed.)"]
```

A report generated after #514 but before a resync would still have cited *(Román Ruiz, 2024)* for Arco Blanco's chapter.

## The change

- `bylineFromCreators` is now the single builder, shared by the sync path and the repair, so a corpus that never resyncs ends up with **byte-identical** bylines to one that does. `authorsOf` is gone; `ingestZoteroItem` derives the byline and the structured creators from the same filtered list, so the display string can never disagree with the roles stored beside it.
- `reconcileAuthorBylinesOnce()` rewrites every Zotero-synced work's byline from `creators_json`. It runs on its own flag rather than folded into the role pass, so a vault that already ran #514 still gets its bylines fixed.
- Works without `creators_json` — manual entries, anything whose byline did not come from a sync — are left alone.

## Verification

- `npm run typecheck`, `npm run lint` — clean.
- `npm test` — **2,106/2,106**. (`test-prosopography-e2e.mjs`, which failed on `main` in this worktree during #514, passed here; it is the known flaky one.)
- `npm run smoke:author-roles` — extended: the seed now also reproduces the broken byline, and the run asserts that after the repair the chapter's byline leads with its author and marks the editor, while the byline of the work the editor actually wrote is untouched.
- `npm run smoke:author-roles:realcopy` against a copy of a real 1,214-work vault:

```
[authors] rewrote 332 byline(s) so editors are marked and never lead
[authors] repaired 159 misfiled role(s); 229 editor link(s) no longer count as authorship
repair: 255ms
research tables identical (12 checked) ✓
bylines led by an editor: 0 burying an author, 41 on editor-only volumes
```

The realcopy invariant was wrong on its first run and was corrected, not worked around: it flagged 29 volumes that Zotero credits to **editors only**. Those legitimately lead with an editor — there is no author to lead with. The invariant now flags only a byline that buries an author behind one, and that count is zero.

## Still true, and unchanged by this PR

Deep Research reports and immersions already generated are stored prose (`writing_saved_drafts`, `immersion_sessions`). They keep whatever they said. Only newly generated ones use the corrected byline — but now they do so immediately, without waiting for a Zotero resync.