### PR TITLE
feat(authors): attribute author-less volumes to their editors, marked provisional

### DIFF
--- a/electron/ai/authorDossier.ts
+++ b/electron/ai/authorDossier.ts
@@ -112,10 +112,9 @@ export function listAuthors(): AuthorSummary[] {
   const ideaRows = db
     .prepare(
       `SELECT wa.author_id AS id, COUNT(DISTINCT io.global_id) AS n
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
-        WHERE wa.role = 'author'
         GROUP BY wa.author_id`
     )
     .all() as { id: string; n: number }[];
@@ -137,10 +136,9 @@ export function listAuthors(): AuthorSummary[] {
   const themeRows = db
     .prepare(
       `SELECT wa.author_id AS id, t.label AS label, COUNT(*) AS n
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN themes t ON t.theme_id = itl.theme_id
-        WHERE wa.role = 'author'
         GROUP BY wa.author_id, t.theme_id
         ORDER BY n DESC`
     )
@@ -156,11 +154,10 @@ export function listAuthors(): AuthorSummary[] {
   const tagRows = db
     .prepare(
       `SELECT wa.author_id AS id, zt.label AS label, COUNT(DISTINCT wzt.nodus_id) AS n
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN work_zotero_tags wzt ON wzt.nodus_id = wa.nodus_id
          JOIN zotero_tags zt ON zt.tag_id = wzt.tag_id
-        WHERE wa.role = 'author'
         GROUP BY wa.author_id, zt.tag_id
         ORDER BY n DESC, zt.label COLLATE NOCASE`
     )
@@ -238,10 +235,10 @@ function themesByIdeaForAuthor(authorId: string): Map<string, string[]> {
   const rows = getDb()
     .prepare(
       `SELECT DISTINCT itl.global_id AS gid, t.label AS label
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN themes t ON t.theme_id = itl.theme_id
-        WHERE wa.author_id = ? AND wa.role = 'author'`
+        WHERE wa.author_id = ?`
     )
     .all(authorId) as { gid: string; label: string }[];
   const map = new Map<string, string[]>();
@@ -272,10 +269,10 @@ function authorThemeSets(authorIds: string[]): Map<string, Set<string>> {
   const rows = getDb()
     .prepare(
       `SELECT DISTINCT wa.author_id AS authorId, t.label AS label
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN themes t ON t.theme_id = itl.theme_id
-        WHERE wa.author_id IN (${authorIds.map(() => '?').join(',')}) AND wa.role = 'author'
+        WHERE wa.author_id IN (${authorIds.map(() => '?').join(',')})
         ORDER BY t.label`
     )
     .all(...authorIds) as { authorId: string; label: string }[];
@@ -293,12 +290,13 @@ function loadIdeas(authorId: string): AuthorDossierIdea[] {
     .prepare(
       `SELECT io.global_id AS global_id, i.type AS type, i.label AS label, i.statement AS statement,
               io.role AS role, io.development AS development, io.confidence AS confidence,
-              io.nodus_id AS workId, w.title AS workTitle, w.year AS year
-         FROM work_authors wa
+              io.nodus_id AS workId, w.title AS workTitle, w.year AS year,
+              wa.basis AS basis
+         FROM work_attributions wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
          JOIN ideas i ON i.global_id = io.global_id
-        WHERE wa.author_id = ? AND wa.role = 'author'
+        WHERE wa.author_id = ?
         ORDER BY (io.role = 'principal') DESC, io.confidence DESC`
     )
     .all(authorId) as {
@@ -312,6 +310,7 @@ function loadIdeas(authorId: string): AuthorDossierIdea[] {
     workId: string;
     workTitle: string;
     year: number | null;
+    basis: 'author' | 'editor_only';
   }[];
 
   // evidence for the author's works, grouped by idea+work
@@ -319,8 +318,8 @@ function loadIdeas(authorId: string): AuthorDossierIdea[] {
     .prepare(
       `SELECT ev.id, ev.global_id, ev.nodus_id, ev.quote, ev.location, ev.kind
          FROM evidence ev
-         JOIN work_authors wa ON wa.nodus_id = ev.nodus_id
-        WHERE wa.author_id = ? AND wa.role = 'author'`
+         JOIN work_attributions wa ON wa.nodus_id = ev.nodus_id
+        WHERE wa.author_id = ?`
     )
     .all(authorId) as Evidence[];
   const evByKey = new Map<string, Evidence[]>();
@@ -350,6 +349,9 @@ function loadIdeas(authorId: string): AuthorDossierIdea[] {
       workId: r.workId,
       workTitle: r.workTitle,
       year: r.year,
+      // The volume has no author on record, so this idea is shown here only
+      // because somebody has to hold it. Marked, never presented as authorship.
+      provisional: r.basis === 'editor_only',
       themes: themesByIdea.get(r.global_id) ?? [],
       evidence: evByKey.get(`${r.global_id}::${r.workId}`) ?? [],
     });
@@ -403,8 +405,12 @@ function loadWorks(authorId: string): AuthorDossierWork[] {
         `SELECT w.nodus_id, w.title, w.authors_json AS authorsJson, w.year, w.item_type AS itemType,
                 w.doi, w.zotero_key AS zoteroKey, w.source_type AS sourceType,
                 w.light_status AS lightStatus, w.deep_status AS deepStatus, w.summary_status AS summaryStatus,
-                w.notes, w.read_tag AS readTag, wa.role AS role
-           FROM work_authors wa JOIN works w ON w.nodus_id = wa.nodus_id
+                w.notes, w.read_tag AS readTag, wa.role AS role,
+                (att.author_id IS NOT NULL) AS attributed
+           FROM work_authors wa
+           JOIN works w ON w.nodus_id = wa.nodus_id
+           LEFT JOIN work_attributions att
+                  ON att.nodus_id = wa.nodus_id AND att.author_id = wa.author_id
           WHERE wa.author_id = ? AND w.archived = 0
           ORDER BY w.year DESC, w.title`
       )
@@ -423,6 +429,7 @@ function loadWorks(authorId: string): AuthorDossierWork[] {
       notes: string | null;
       readTag: number;
       role: string | null;
+      attributed: number;
     }[]
   ).map((w) => ({
     nodus_id: w.nodus_id,
@@ -439,6 +446,7 @@ function loadWorks(authorId: string): AuthorDossierWork[] {
     notes: w.notes,
     read: w.readTag === 1,
     role: w.role === 'editor' ? ('editor' as const) : ('author' as const),
+    attributed: w.attributed === 1,
   }));
 }
 

--- a/electron/ai/researchAssistant.ts
+++ b/electron/ai/researchAssistant.ts
@@ -921,7 +921,7 @@ function listAuthors(linkedWorkIds: Set<string>, scope: RelevanceScope) {
       const relevantAuthorIds = new Set(
         (
           db
-            .prepare(`SELECT DISTINCT author_id FROM work_authors WHERE nodus_id IN (${placeholders}) AND role = 'author'`)
+            .prepare(`SELECT DISTINCT author_id FROM work_attributions WHERE nodus_id IN (${placeholders})`)
             .all(...workIds) as { author_id: string }[]
         ).map((row) => row.author_id)
       );
@@ -956,9 +956,9 @@ function listAuthors(linkedWorkIds: Set<string>, scope: RelevanceScope) {
         db
           .prepare(
             `SELECT w.nodus_id, w.zotero_key, w.title, w.authors_json, w.year, w.item_type, w.doi, w.source_type
-             FROM work_authors wa
+             FROM work_attributions wa
              JOIN works w ON w.nodus_id = wa.nodus_id
-             WHERE wa.author_id = ? AND wa.role = 'author' AND w.archived = 0
+             WHERE wa.author_id = ? AND w.archived = 0
              ORDER BY w.year DESC, w.title ASC`
           )
           .all(author.author_id) as Array<WorkRow & { authors_json: string }>
@@ -966,10 +966,10 @@ function listAuthors(linkedWorkIds: Set<string>, scope: RelevanceScope) {
       const allIdeas = db
         .prepare(
           `SELECT DISTINCT i.global_id, i.type, i.label, i.statement
-           FROM work_authors wa
+           FROM work_attributions wa
            JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
            JOIN ideas i ON i.global_id = io.global_id
-           WHERE wa.author_id = ? AND wa.role = 'author'
+           WHERE wa.author_id = ?
            ORDER BY i.label ASC`
         )
         .all(author.author_id) as Array<{ global_id: string; type: string; label: string; statement: string }>;
@@ -1301,7 +1301,7 @@ function addThemeWorkIds(themeId: string, out: Set<string>): void {
 
 function addAuthorWorkIds(authorId: string, out: Set<string>): void {
   const rows = getDb()
-    .prepare("SELECT nodus_id FROM work_authors WHERE author_id = ? AND role = 'author'")
+    .prepare('SELECT nodus_id FROM work_attributions WHERE author_id = ?')
     .all(authorId) as { nodus_id: string }[];
   for (const row of rows) out.add(row.nodus_id);
 }

--- a/electron/ai/studyGuide.ts
+++ b/electron/ai/studyGuide.ts
@@ -75,7 +75,7 @@ async function semanticBoosts(objective: string | undefined, enabled: boolean): 
       .prepare(
         `SELECT DISTINCT wa.author_id, io.nodus_id
            FROM idea_occurrences io
-           JOIN work_authors wa ON wa.nodus_id = io.nodus_id AND wa.role = 'author'
+           JOIN work_attributions wa ON wa.nodus_id = io.nodus_id
            JOIN works w ON w.nodus_id = io.nodus_id AND w.archived = 0
           WHERE io.global_id = ?`
       )
@@ -137,12 +137,11 @@ function loadWorkInputs(workBoosts: Map<string, number>): Map<string, StudyGuide
               COALESCE(ic.ideaCount, 0) AS ideaCount,
               COALESCE(ic.principalIdeaCount, 0) AS principalIdeaCount,
               COALESCE(pc.passageCount, 0) AS passageCount
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          LEFT JOIN idea_counts ic ON ic.nodus_id = w.nodus_id
          LEFT JOIN passage_counts pc ON pc.nodus_id = w.nodus_id
          LEFT JOIN work_summaries ws ON ws.nodus_id = w.nodus_id
-        WHERE wa.role = 'author'
         ORDER BY wa.author_id, ideaCount DESC, w.year DESC`
     )
     .all() as {
@@ -194,11 +193,10 @@ function loadKeyIdeas(): Map<string, StudyGuideIdeaInput[]> {
     .prepare(
       `SELECT wa.author_id, i.global_id, i.type, i.label, i.statement,
               io.nodus_id AS workId, w.title AS workTitle, io.role, io.confidence
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = w.nodus_id
          JOIN ideas i ON i.global_id = io.global_id
-        WHERE wa.role = 'author'
         ORDER BY wa.author_id, (io.role = 'principal') DESC, io.confidence DESC, i.label`
     )
     .all() as {

--- a/electron/ai/synthesisMatrix.ts
+++ b/electron/ai/synthesisMatrix.ts
@@ -44,11 +44,10 @@ export function buildSynthesisMatrix(): SynthesisMatrix {
       `SELECT wa.author_id AS id, a.name AS name,
               COUNT(DISTINCT wa.nodus_id) AS workCount,
               COUNT(DISTINCT io.global_id) AS ideaCount
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN authors a ON a.author_id = wa.author_id
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_occurrences io ON io.nodus_id = wa.nodus_id
-        WHERE wa.role = 'author'
         GROUP BY wa.author_id
         ORDER BY ideaCount DESC, name`
     )
@@ -82,11 +81,10 @@ export function buildSynthesisMatrix(): SynthesisMatrix {
     .prepare(
       `SELECT DISTINCT wa.author_id AS authorId, itl.theme_id AS themeId,
               i.global_id AS gid, i.label AS label, i.type AS type
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
-         JOIN ideas i ON i.global_id = itl.global_id
-        WHERE wa.role = 'author'`
+         JOIN ideas i ON i.global_id = itl.global_id`
     )
     .all() as { authorId: string; themeId: string; gid: string; label: string; type: IdeaType }[];
 
@@ -147,11 +145,11 @@ export async function synthesizeMatrixCell(
   const ideaRows = db
     .prepare(
       `SELECT DISTINCT i.global_id AS global_id, i.label AS label, i.type AS type, i.statement AS statement
-         FROM work_authors wa
+         FROM work_attributions wa
          JOIN works w ON w.nodus_id = wa.nodus_id AND w.archived = 0
          JOIN idea_theme_links itl ON itl.nodus_id = wa.nodus_id
          JOIN ideas i ON i.global_id = itl.global_id
-        WHERE wa.author_id = ? AND itl.theme_id = ? AND wa.role = 'author'`
+        WHERE wa.author_id = ? AND itl.theme_id = ?`
     )
     .all(authorId, themeId) as { global_id: string; label: string; type: IdeaType; statement: string }[];
 

--- a/electron/db/authorsRepo.ts
+++ b/electron/db/authorsRepo.ts
@@ -547,7 +547,7 @@ function authorsForIdea(globalId: string): string[] {
     .prepare(
       `SELECT DISTINCT wa.author_id
        FROM idea_occurrences io
-       JOIN work_authors wa ON wa.nodus_id = io.nodus_id AND wa.role = 'author'
+       JOIN work_attributions wa ON wa.nodus_id = io.nodus_id
        WHERE io.global_id = ?`
     )
     .all(globalId) as { author_id: string }[];

--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -15,7 +15,7 @@ export interface Migration {
 
 // Versioned, append-only migrations. Never edit an existing migration's SQL once
 // shipped — add a new one. The current schema version is the highest applied.
-export const SCHEMA_VERSION = 153;
+export const SCHEMA_VERSION = 154;
 
 export const migrations: Migration[] = [
   {
@@ -8256,6 +8256,35 @@ export const migrations: Migration[] = [
         WHERE new.state='active' AND new.row_id IS NULL;
       END;
       CREATE TRIGGER pages_search_ad AFTER DELETE ON pages BEGIN DELETE FROM db_search_fts WHERE rowid=4611686018427387904+old.rowid; END;
+    `,
+  },
+  {
+    version: 154,
+    up: /* sql */ `
+      -- Single source of truth for "who may be credited with this work's ideas".
+      -- Normally that is its authors, and only its authors: crediting the editor of
+      -- an edited volume with the chapters inside it is what this whole layer exists
+      -- to prevent.
+      --
+      -- The one exception, and it is deliberate: a work Zotero credits to editors
+      -- ONLY has no author on record, so filtering editors out would leave its ideas
+      -- attributed to nobody and invisible in every author view. Until the real
+      -- chapter authors can be recovered from richer metadata, those ideas are shown
+      -- under the editors, marked in the interface as a provisional attribution.
+      --
+      -- 'basis' says which of the two cases a row is, so a reader never has to guess:
+      -- 'author' is authorship, 'editor_only' is the exception.
+      CREATE VIEW work_attributions AS
+        SELECT wa.nodus_id,
+               wa.author_id,
+               wa.role,
+               CASE WHEN wa.role = 'author' THEN 'author' ELSE 'editor_only' END AS basis
+        FROM work_authors wa
+        WHERE wa.role = 'author'
+           OR NOT EXISTS (
+                SELECT 1 FROM work_authors peer
+                 WHERE peer.nodus_id = wa.nodus_id AND peer.role = 'author'
+              );
     `,
   },
 ];

--- a/electron/db/searchRepo.ts
+++ b/electron/db/searchRepo.ts
@@ -467,14 +467,14 @@ export function getSearchResultDetail(kind: SearchResultKind, id: string): Searc
       if (!row) return null;
       const works = db
         .prepare(
-          `SELECT w.title, w.year FROM work_authors a JOIN works w ON w.nodus_id = a.nodus_id
-           WHERE a.author_id = ? AND a.role = 'author' ORDER BY w.year DESC, w.title`
+          `SELECT w.title, w.year FROM work_attributions a JOIN works w ON w.nodus_id = a.nodus_id
+           WHERE a.author_id = ? ORDER BY w.year DESC, w.title`
         )
         .all(id) as Array<{ title: string; year: number | null }>;
       const ideaCount = db
         .prepare(
-          `SELECT COUNT(DISTINCT o.global_id) AS count FROM work_authors a
-           JOIN idea_occurrences o ON o.nodus_id = a.nodus_id WHERE a.author_id = ? AND a.role = 'author'`
+          `SELECT COUNT(DISTINCT o.global_id) AS count FROM work_attributions a
+           JOIN idea_occurrences o ON o.nodus_id = a.nodus_id WHERE a.author_id = ?`
         )
         .get(id) as { count: number };
       return {

--- a/electron/graph/graphService.ts
+++ b/electron/graph/graphService.ts
@@ -777,8 +777,8 @@ export function buildAuthorGraph(): GraphData {
   // Batch-load all author→work mappings in one query instead of N+1.
   const waRows = db
     .prepare(
-      `SELECT wa.author_id, w.nodus_id, w.year, w.read_tag FROM work_authors wa JOIN works w ON w.nodus_id = wa.nodus_id
-        WHERE w.archived = 0 AND wa.role = 'author'`
+      `SELECT wa.author_id, w.nodus_id, w.year, w.read_tag FROM work_attributions wa JOIN works w ON w.nodus_id = wa.nodus_id
+        WHERE w.archived = 0`
     )
     .all() as { author_id: string; nodus_id: string; year: number | null; read_tag: number }[];
   const worksByAuthor = new Map<string, { nodus_id: string; year: number | null; read_tag: number }[]>();
@@ -1250,13 +1250,12 @@ function readPathRows(db: ReturnType<typeof getDb>): ReadingWorkRow[] {
         SELECT wa.nodus_id,
                COUNT(ar.type) AS author_relation_count,
                COALESCE(SUM(ar.weight), 0) AS author_weight
-        FROM work_authors wa
+        FROM work_attributions wa
         LEFT JOIN (
           SELECT from_author AS author_id, type, weight FROM author_relations
           UNION ALL
           SELECT to_author AS author_id, type, weight FROM author_relations
         ) ar ON ar.author_id = wa.author_id
-        WHERE wa.role = 'author'
         GROUP BY wa.nodus_id
       ),
       dependency_stats AS (

--- a/scripts/smoke-author-roles-realcopy.ts
+++ b/scripts/smoke-author-roles-realcopy.ts
@@ -107,12 +107,29 @@ for (const d of drops.slice(0, 20)) {
 const gains = authorsAfter.filter((a) => a.ideaCount > (byIdBefore.get(a.author_id)?.ideaCount ?? 0));
 assert(gains.length === 0, `${gains.length} authors gained ideas they did not have before`);
 
-// Every work that was credited to somebody still is: no work fell off the map.
-const orphans = c(
+// No work loses its voice. A volume Zotero credits to editors only keeps its ideas
+// under those editors, marked provisional; everything else is attributed to authors.
+const editorsOnlyWorks = c(
   `SELECT COUNT(*) AS n FROM works w
     WHERE w.nodus_id IN (SELECT nodus_id FROM work_authors)
       AND NOT EXISTS (SELECT 1 FROM work_authors wa WHERE wa.nodus_id = w.nodus_id AND wa.role = 'author')`
 );
-console.log(`\nworks left with editors but no author: ${orphans}`);
+const unattributed = c(
+  `SELECT COUNT(*) AS n FROM works w
+    WHERE w.nodus_id IN (SELECT nodus_id FROM work_authors)
+      AND NOT EXISTS (SELECT 1 FROM work_attributions att WHERE att.nodus_id = w.nodus_id)`
+);
+const provisional = c("SELECT COUNT(*) AS n FROM work_attributions WHERE basis = 'editor_only'");
+console.log(`\nworks Zotero credits to editors only: ${editorsOnlyWorks} (${provisional} provisional attributions)`);
+console.log(`works left with nobody to attribute their ideas to: ${unattributed}`);
+assert(unattributed === 0, 'some credited works ended up with no attribution at all');
+
+// The exception must not leak: a work that HAS an author never attributes to its editor.
+const leaked = c(
+  `SELECT COUNT(*) AS n FROM work_attributions att
+    WHERE att.basis = 'editor_only'
+      AND EXISTS (SELECT 1 FROM work_authors wa WHERE wa.nodus_id = att.nodus_id AND wa.role = 'author')`
+);
+assert(leaked === 0, 'the editors-only exception leaked to works that do have an author');
 
 console.log('\nROLES REPAIRED · NO RESEARCH DATA TOUCHED ✓');

--- a/scripts/smoke-author-roles.ts
+++ b/scripts/smoke-author-roles.ts
@@ -87,6 +87,17 @@ insWork.run(
 );
 insLink.run('own', 'a-editor');
 
+// The exception: a volume Zotero credits to EDITORS ONLY. Nobody wrote it on
+// record, so its ideas would belong to no one at all if editors were filtered out.
+insWork.run(
+  'vol',
+  'z-vol',
+  'The volume itself',
+  JSON.stringify([`${editor.last}, ${editor.first.charAt(0)}. (ed.)`]),
+  JSON.stringify([{ lastName: editor.last, firstName: editor.first, name: null, role: 'editor' }])
+);
+insLink.run('vol', 'a-editor');
+
 // Ideas + evidence + one cross-chapter edge, so attribution and relations are measurable.
 const insIdea = db.prepare("INSERT INTO ideas (global_id, type, label, statement, created_at) VALUES (?, 'claim', ?, ?, '2024-01-01')");
 const insOcc = db.prepare("INSERT INTO idea_occurrences (global_id, nodus_id, role, development, confidence) VALUES (?, ?, 'principal', '', 0.9)");
@@ -94,7 +105,7 @@ const insEv = db.prepare("INSERT INTO evidence (id, global_id, nodus_id, quote, 
 const insTheme = db.prepare("INSERT INTO themes (theme_id, label) VALUES (?, ?)");
 const insThemeLink = db.prepare("INSERT INTO idea_theme_links (global_id, nodus_id, theme_id, confidence, basis) VALUES (?, ?, ?, 0.9, 'explicit')");
 insTheme.run('t-infancia', 'infancia');
-for (const w of [...chapters.map((c) => c.id), 'own']) {
+for (const w of [...chapters.map((c) => c.id), 'own', 'vol']) {
   const gid = `i-${w}`;
   insIdea.run(gid, `Idea ${w}`, `Statement ${w}`);
   insOcc.run(gid, w);
@@ -115,13 +126,13 @@ const editorId = authorIdFor(editor.key);
 
 const summaryBefore = listAuthors().find((a) => a.author_id === editorId)!;
 console.log(`before → editor credited with ${summaryBefore.workCount} works, ${summaryBefore.ideaCount} ideas`);
-assert(summaryBefore.workCount === 4, 'seed did not reproduce the bug (works)');
-assert(summaryBefore.ideaCount === 4, 'seed did not reproduce the bug (ideas)');
+assert(summaryBefore.workCount === 5, 'seed did not reproduce the bug (works)');
+assert(summaryBefore.ideaCount === 5, 'seed did not reproduce the bug (ideas)');
 const relBefore = count(`SELECT COUNT(*) AS n FROM author_relations WHERE from_author='${editorId}' OR to_author='${editorId}'`);
 assert(relBefore > 0, 'seed did not reproduce the bug (relations routed through the editor)');
 
 const misfiledBefore = count("SELECT COUNT(*) AS n FROM work_authors WHERE author_id='a-editor' AND role='author'");
-assert(misfiledBefore === 4, 'seed did not reproduce the bug (stored roles)');
+assert(misfiledBefore === 5, 'seed did not reproduce the bug (stored roles)');
 
 // The byline is what a citation is shortened from, and the seed has it in the
 // broken shape too: editor first, unmarked.
@@ -140,7 +151,7 @@ assert(c1Byline[0] === 'Arco Blanco, M.', 'the repaired byline still leads with 
 assert(c1Byline[1] === 'Román Ruiz, G. (ed.)', 'the repaired byline does not mark the editor');
 assert(bylineOf('own')[0] === 'Román Ruiz, G.', 'the byline of the work she wrote was altered');
 console.log(`roles → ${misfiledBefore} links credited to the editor as author, ${misfiledAfter} after the repair`);
-assert(misfiledAfter === 1, 'the repair did not rewrite exactly the three editor links');
+assert(misfiledAfter === 1, 'the repair did not rewrite exactly the four editor links');
 
 // ── After: roles, attribution and integrity ──────────────────────────────────
 for (const ch of chapters) {
@@ -148,19 +159,31 @@ for (const ch of chapters) {
   assert(roleOf(ch.id, ch.author.key) === 'author', `${ch.id}: real author lost their role`);
 }
 assert(roleOf('own', editor.key) === 'author', 'the work she actually wrote was demoted');
+assert(roleOf('vol', editor.key) === 'editor', 'the editors-only volume lost its editor role');
 
 const summaryAfter = listAuthors().find((a) => a.author_id === editorId)!;
 console.log(`after  → editor: ${summaryAfter.workCount} works, ${summaryAfter.editedCount} edited, ${summaryAfter.ideaCount} ideas`);
 assert(summaryAfter.workCount === 1, 'authored count not corrected');
-assert(summaryAfter.editedCount === 3, 'edited volumes not counted apart');
-assert(summaryAfter.ideaCount === 1, 'ideas still attributed through editorship');
+assert(summaryAfter.editedCount === 4, 'edited volumes not counted apart');
+// One idea from the work she wrote, plus the one from the volume nobody is
+// recorded as writing — the deliberate exception, never a chapter of someone else's.
+assert(summaryAfter.ideaCount === 2, 'ideas still attributed through editorship');
 assert(summaryAfter.topThemes.length === 1, 'themes still attributed through editorship');
 
 const dossier = buildAuthorDossier(editorId)!;
 assert(dossier.works.length === 1 && dossier.works[0].nodus_id === 'own', 'dossier works not restricted to authorship');
-assert(dossier.editedWorks.length === 3, 'edited volumes missing from the dossier');
-assert(dossier.ideas.length === 1 && dossier.ideas[0].workId === 'own', 'dossier ideas still borrowed from chapters');
-assert(dossier.ideas[0].evidence.length === 1, 'evidence lost for the work she wrote');
+assert(dossier.editedWorks.length === 4, 'edited volumes missing from the dossier');
+const ownIdea = dossier.ideas.find((i) => i.workId === 'own');
+const volIdea = dossier.ideas.find((i) => i.workId === 'vol');
+assert(dossier.ideas.length === 2, 'dossier ideas still borrowed from chapters');
+assert(ownIdea !== undefined && !ownIdea.provisional, 'her own idea was marked provisional');
+assert(volIdea !== undefined && volIdea.provisional, 'the author-less volume\'s idea is not marked provisional');
+assert(ownIdea.evidence.length === 1, 'evidence lost for the work she wrote');
+
+// The chapters stay unattributed to her; only the author-less volume is flagged.
+const attributedEdited = dossier.editedWorks.filter((w) => w.attributed).map((w) => w.nodus_id);
+console.log(`edited volumes whose ideas she provisionally holds → ${attributedEdited.join(', ') || 'none'}`);
+assert(attributedEdited.length === 1 && attributedEdited[0] === 'vol', 'the exception leaked to chapters that do have an author');
 
 const relAfter = count(`SELECT COUNT(*) AS n FROM author_relations WHERE from_author='${editorId}' OR to_author='${editorId}'`);
 assert(relAfter === 0, 'author relations still routed through the editor');
@@ -180,7 +203,7 @@ assert(count('SELECT COUNT(*) AS n FROM work_authors') === linksBefore, 'work↔
 db.prepare("DELETE FROM settings WHERE key='author_roles_reconciled'").run();
 reconcileAuthorRolesOnce();
 const summaryTwice = listAuthors().find((a) => a.author_id === editorId)!;
-assert(summaryTwice.workCount === 1 && summaryTwice.editedCount === 3, 'second repair changed the outcome');
+assert(summaryTwice.workCount === 1 && summaryTwice.editedCount === 4, 'second repair changed the outcome');
 
 // ── The everyday path is self-healing on its own ─────────────────────────────
 // Put one chapter back into the broken shape and resync it the way ingest does:

--- a/scripts/test-decorative-images.mjs
+++ b/scripts/test-decorative-images.mjs
@@ -419,6 +419,12 @@ try {
     INSERT INTO gaps VALUES ('g1','evidence','Hueco de prueba',0.8,'w1','i1','e1');
     INSERT INTO authors VALUES ('a1','Autora de prueba','Universidad','autora-prueba');
     INSERT INTO work_authors VALUES ('a1','w1','author');
+    CREATE VIEW work_attributions AS
+      SELECT wa.nodus_id, wa.author_id, wa.role,
+             CASE WHEN wa.role = 'author' THEN 'author' ELSE 'editor_only' END AS basis
+      FROM work_authors wa
+      WHERE wa.role = 'author'
+         OR NOT EXISTS (SELECT 1 FROM work_authors peer WHERE peer.nodus_id = wa.nodus_id AND peer.role = 'author');
     INSERT INTO note_folders VALUES ('f1','Carpeta');
     INSERT INTO notes VALUES ('n1','Nota de prueba','markdown','Contenido completo','f1','2026-01-01','2026-01-02',NULL);
   `);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6828,6 +6828,13 @@ export interface AuthorDossierWork {
   read: boolean;
   /** How this person is credited on the work (from Zotero). */
   role: 'author' | 'editor';
+  /**
+   * Whether this work's ideas count towards this person. True for everything they
+   * wrote, and — as the one deliberate exception — for a volume they edited that
+   * Zotero credits to no author at all, whose ideas would otherwise belong to
+   * nobody. The interface marks that second case as provisional.
+   */
+  attributed: boolean;
 }
 
 export interface AuthorDossierIdea {
@@ -6841,6 +6848,8 @@ export interface AuthorDossierIdea {
   workId: string;
   workTitle: string;
   year: number | null;
+  /** Attributed here only because the volume records no author. Shown as provisional. */
+  provisional: boolean;
   themes: string[];
   evidence: Evidence[];
 }

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -8209,4 +8209,8 @@ export const DE: Record<string, string> = {
   "Volúmenes que edita": "Herausgegebene Bände",
   "{n} volúmenes editados": "{n} herausgegebene Bände",
   "Coordina la edición del volumen; las ideas no se le atribuyen.": "Diese Person gibt den Band heraus; dessen Ideen werden ihr nicht zugeschrieben.",
+  "Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.": "Ausnahme: Die markierten Bände verzeichnen keinerlei Autor, ihre Ideen erscheinen hier daher vorläufig.",
+  "Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita": "Dieses Werk verzeichnet keinen Autor: Seine Ideen werden vorläufig der herausgebenden Person zugeschrieben",
+  "atribución provisional": "vorläufige Zuschreibung",
+  "provisional": "vorläufig",
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -8436,4 +8436,8 @@ export const EN: Record<string, string> = {
   "Volúmenes que edita": "Volumes they edit",
   "{n} volúmenes editados": "{n} edited volumes",
   "Coordina la edición del volumen; las ideas no se le atribuyen.": "They edit the volume; its ideas are not attributed to them.",
+  "Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.": "Exception: the marked ones record no author at all, so their ideas are shown here provisionally.",
+  "Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita": "This work records no author: its ideas are provisionally attributed to whoever edited it",
+  "atribución provisional": "provisional attribution",
+  "provisional": "provisional",
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -8200,4 +8200,8 @@ export const FR: Record<string, string> = {
   "Volúmenes que edita": "Volumes qu'iel dirige",
   "{n} volúmenes editados": "{n} volumes dirigés",
   "Coordina la edición del volumen; las ideas no se le atribuyen.": "Cette personne dirige le volume ; ses idées ne lui sont pas attribuées.",
+  "Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.": "Exception : les volumes signalés n'enregistrent aucun auteur, leurs idées sont donc affichées ici à titre provisoire.",
+  "Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita": "Cette œuvre n'enregistre aucun auteur : ses idées sont attribuées provisoirement à qui l'a dirigée",
+  "atribución provisional": "attribution provisoire",
+  "provisional": "provisoire",
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -7614,4 +7614,8 @@ export const IT: Record<string, string> = {
   "Volúmenes que edita": "Volumi che cura",
   "{n} volúmenes editados": "{n} volumi curati",
   "Coordina la edición del volumen; las ideas no se le atribuyen.": "Cura l'edizione del volume; le idee non le vengono attribuite.",
+  "Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.": "Eccezione: i volumi segnalati non registrano alcun autore, quindi le loro idee compaiono qui in via provvisoria.",
+  "Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita": "Quest'opera non registra alcun autore: le sue idee sono attribuite in via provvisoria a chi la cura",
+  "atribución provisional": "attribuzione provvisoria",
+  "provisional": "provvisoria",
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -8159,4 +8159,8 @@ export const PT_BR: Record<string, string> = {
   "Volúmenes que edita": "Volumes que organiza",
   "{n} volúmenes editados": "{n} volumes organizados",
   "Coordina la edición del volumen; las ideas no se le atribuyen.": "Organiza a edição do volume; as ideias não são atribuídas a essa pessoa.",
+  "Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.": "Exceção: os marcados não registram nenhum autor, então suas ideias aparecem aqui provisoriamente.",
+  "Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita": "Esta obra não registra nenhum autor: suas ideias são atribuídas provisoriamente a quem a organiza",
+  "atribución provisional": "atribuição provisória",
+  "provisional": "provisória",
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -8151,4 +8151,8 @@ export const PT: Record<string, string> = {
   "Volúmenes que edita": "Volumes que coordena",
   "{n} volúmenes editados": "{n} volumes coordenados",
   "Coordina la edición del volumen; las ideas no se le atribuyen.": "Coordena a edição do volume; as ideias não lhe são atribuídas.",
+  "Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.": "Exceção: os assinalados não registam qualquer autor, pelo que as suas ideias são mostradas aqui a título provisório.",
+  "Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita": "Esta obra não regista qualquer autor: as suas ideias são atribuídas provisoriamente a quem a coordena",
+  "atribución provisional": "atribuição provisória",
+  "provisional": "provisória",
 };

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -7959,4 +7959,8 @@ export const TR: Record<string, string> = {
   "Volúmenes que edita": "Derlediği ciltler",
   "{n} volúmenes editados": "{n} derlenen cilt",
   "Coordina la edición del volumen; las ideas no se le atribuyen.": "Cildin editörlüğünü yapar; fikirler bu kişiye atfedilmez.",
+  "Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.": "İstisna: İşaretli olanlar hiçbir yazar kaydetmiyor, bu yüzden fikirleri burada geçici olarak gösteriliyor.",
+  "Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita": "Bu eser hiçbir yazar kaydetmiyor: fikirleri geçici olarak derleyen kişiye atfediliyor",
+  "atribución provisional": "geçici atıf",
+  "provisional": "geçici",
 };

--- a/src/views/AuthorsView.tsx
+++ b/src/views/AuthorsView.tsx
@@ -769,6 +769,11 @@ function AuthorDossierDetail({
             <Icon name="book" size={15} className="text-cyan-400" /> {t('Volúmenes que edita')}
           </h4>
           <p className="mb-2 text-xs text-neutral-500">{t('Coordina la edición del volumen; las ideas no se le atribuyen.')}</p>
+          {dossier.editedWorks.some((w) => w.attributed) && (
+            <p className="mb-2 text-xs text-amber-400/80">
+              {t('Excepción: los marcados no registran ningún autor, así que sus ideas se muestran aquí de forma provisional.')}
+            </p>
+          )}
           <div className="space-y-1">
             {dossier.editedWorks.map((w) => (
               <AuthorWorkRow key={w.nodus_id} work={w} onOpenIdeas={(work) => setIdeasWork(work)} />
@@ -900,6 +905,14 @@ function AuthorIdeasSection({ ideas, onOpenIdea }: { ideas: AuthorDossierIdea[];
               <div className="mt-2 flex items-center gap-2 text-[10px] text-neutral-600">
                 <span className="truncate">{idea.workTitle || t('(sin título)')}</span>
                 {idea.year && <span className="shrink-0">{idea.year}</span>}
+                {idea.provisional && (
+                  <span
+                    className="shrink-0 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-amber-400/90"
+                    title={t('Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita')}
+                  >
+                    {t('provisional')}
+                  </span>
+                )}
                 <span className="ml-auto flex shrink-0 gap-1">{idea.themes.slice(0, 2).map((theme) => <span key={theme} className="rounded-full bg-neutral-950 px-1.5 py-0.5">{theme}</span>)}</span>
               </div>
             </button>
@@ -1148,6 +1161,11 @@ function AuthorWorkRow({
       {work.role === 'editor' && (
         <Badge color="cyan" title={t('Figura como editor/a de esta obra')}>
           {t('ed.')}
+        </Badge>
+      )}
+      {work.role === 'editor' && work.attributed && (
+        <Badge color="amber" title={t('Esta obra no registra ningún autor: sus ideas se atribuyen provisionalmente a quien la edita')}>
+          {t('atribución provisional')}
         </Badge>
       )}
       {work.read && (


### PR DESCRIPTION
Closes #517. Follow-up to #514 and #516.

After the role fix, a work Zotero credits to **editors only** had no `role = 'author'` link at all, so every attribution query left its ideas belonging to nobody. On a real corpus that hid the ideas of **20 works**. Filtering the editor out is right when a chapter has its own author; it is a net loss when nobody is recorded as having written the thing.

## One rule, one place

The exception lives in the `work_attributions` view (migration 154) rather than being repeated across the ten attribution queries, where it would drift:

```sql
CREATE VIEW work_attributions AS
  SELECT wa.nodus_id, wa.author_id, wa.role,
         CASE WHEN wa.role = 'author' THEN 'author' ELSE 'editor_only' END AS basis
  FROM work_authors wa
  WHERE wa.role = 'author'
     OR NOT EXISTS (SELECT 1 FROM work_authors peer
                     WHERE peer.nodus_id = wa.nodus_id AND peer.role = 'author');
```

Every attribution reader now selects from the view instead of filtering `role` itself: the author list counts, the dossier's ideas / themes / evidence / tags, `authorsForIdea` (which drives `author_relations`), the synthesis matrix, the study guide, the research assistant, the authors graph and global search.

`basis` travels all the way to the interface, so nothing has to guess which of the two cases a row is.

## The exception is visible, never silent

- An edited volume whose ideas count carries an **"atribución provisional"** badge.
- The edited-volumes section gains a line explaining why, in amber, only when such a volume exists.
- Each borrowed idea is marked **"provisional"** in the idea list, next to its work title.
- A chapter that *does* have an author is untouched: its editor still gets nothing.

Strings added in all seven translated languages.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` — clean.
- `npm test` — **2,106/2,106**. Two fixture repairs were needed and are included: `SCHEMA_VERSION` had to move to 154 (44 tests assert the DB migrates to the declared version — they caught the omission immediately), and `test-decorative-images.mjs` builds its own minimal schema by hand, so it now creates the view too.
- `npm run smoke:author-roles` — the seed gained a fourth work: a volume credited to editors only. The run asserts the editor holds exactly that volume's idea and none of the three chapters', that the borrowed idea is flagged `provisional` while her own is not, and that exactly one edited volume is marked `attributed`.
- `npm run smoke:author-roles:realcopy` against a copy of a real 1,214-work vault:

```
[authors] repaired 159 misfiled role(s); 229 editor link(s) no longer count as authorship
research tables identical (12 checked) ✓
bylines led by an editor: 0 burying an author, 41 on editor-only volumes
56 people stopped being credited with ideas they did not write (1425 attributions)
works Zotero credits to editors only: 20 (40 provisional attributions)
works left with nobody to attribute their ideas to: 0
```

Two invariants are asserted, not just printed: **no credited work ends up with zero attribution**, and **the exception never leaks** — a work that has an author never attributes to its editor. The removed-attribution count drops from 1,786 to 1,425 because 361 of them were the author-less volumes now handled by the exception.