### PR TITLE
feat(citations): re-derive citation labels from the corpus when a report is read

### DIFF
--- a/electron/ai/deepResearchCore.ts
+++ b/electron/ai/deepResearchCore.ts
@@ -1,3 +1,10 @@
+// Citation naming lives in @shared/citationLabel so the reader that re-derives a
+// stored label at open time cannot drift from the writer that produced it.
+import {
+  authorYearLabel,
+  referenceEntry as sharedReferenceEntry,
+  sourceLabelFromWork,
+} from '@shared/citationLabel';
 import type {
   DeepResearchMeta,
   DeepResearchProgress,
@@ -1641,11 +1648,7 @@ export function buildReferences(workIds: Set<string>, maps: SnapshotMaps, langua
 }
 
 function referenceEntry(work: WorkInfo, L: Labels): string {
-  const authors = work.authors.length ? work.authors.join('; ') : L.unknownAuthor;
-  const year = work.year ? ` (${work.year})` : ` (${L.noDate})`;
-  const title = work.title ? `. ${work.title.replace(/\.\s*$/, '')}.` : '.';
-  const doi = work.doi?.trim() ? ` https://doi.org/${work.doi.trim().replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')}` : '';
-  return `${authors}${year}${title}${doi}`;
+  return sharedReferenceEntry(work, L);
 }
 
 function buildMatrix(coveredIdeaIds: Set<string>, maps: SnapshotMaps, L: Labels): WritingWorkshopMatrixRow[] {
@@ -1869,28 +1872,6 @@ export function buildCitationCatalog(snapshot: WritingWorkshopSnapshot): Citatio
   };
 }
 
-function sourceLabelFromWork(work: { authors: string[]; year: number | null; title?: string } | undefined): string {
-  if (!work) return '';
-  return authorYearLabel(work.authors[0], work.year, work.title);
-}
-
-/** Turn Nodus's stored `Apellido, I.` name into a readable inline citation. */
-function authorYearLabel(author: string | undefined, year: number | null | undefined, title?: string): string {
-  const raw = author?.replace(/\s+/g, ' ').trim();
-  if (!raw) {
-    // "Autor" reads as a placeholder in the middle of academic prose. A shortened
-    // title is a real citation for a source whose author the corpus never captured.
-    const short = clip((title ?? '').replace(/\s+/g, ' ').trim(), 42);
-    if (short) return year ? `${short} (${year})` : short;
-    return year ? `Obra sin autor (${year})` : 'Obra sin autor';
-  }
-  const comma = raw.indexOf(',');
-  const surname = (comma >= 0 ? raw.slice(0, comma) : raw.split(' ').slice(-1).join(' ')).trim() || raw;
-  const given = (comma >= 0 ? raw.slice(comma + 1) : raw.split(' ').slice(0, -1).join(' ')).trim();
-  const initial = given.match(/[\p{L}]/u)?.[0]?.toLocaleUpperCase('es-ES');
-  const name = initial ? `${surname}, ${initial}.` : surname;
-  return year ? `${name} (${year})` : name;
-}
 
 /**
  * A running synopsis of the report so far. The opening sentence of a section says

--- a/electron/audio/audioService.ts
+++ b/electron/audio/audioService.ts
@@ -21,6 +21,7 @@ import type {
   StudyPronunciationEntry,
 } from '@shared/types';
 import { getDb } from '../db/database';
+import { relabelCitations } from '../citations/liveCitations';
 import { deepResearchSegments, immersionSegments, studyNarrationSegments } from './speakable';
 import { activeVaultDir } from '../vaults/vaultRegistry';
 import { audioDir, audioFilePath } from './audioPaths';
@@ -51,7 +52,13 @@ export function getEntitySegments(kind: AudioEntityKind, id: string, request: Au
     } catch {
       /* fall back to the row title only */
     }
-    return deepResearchSegments({ title: draft.title || row.title, abstract: draft.abstract, draftMarkdown: draft.draftMarkdown });
+    // Narration reads this report aloud, so it must speak the names the report
+    // would show today, not the ones frozen into it when it was generated.
+    return deepResearchSegments({
+      title: draft.title || row.title,
+      abstract: draft.abstract,
+      draftMarkdown: relabelCitations(draft.draftMarkdown ?? ''),
+    });
   }
   const row = getDb().prepare('SELECT title, topic, plan_json FROM immersion_sessions WHERE id = ?').get(id) as
     | { title: string; topic: string; plan_json: string }

--- a/electron/citations/liveCitations.ts
+++ b/electron/citations/liveCitations.ts
@@ -1,0 +1,305 @@
+// Live citation labels.
+//
+// A saved report is prose plus a set of claims about the corpus. The prose is the
+// author's and must never change; the claims must stay true. Nodus writes every
+// inline citation as `[Apellido, I. (año)](nodus://idea/g-123)`, so the visible
+// label is the perishable part and the anchor is the durable one. When the corpus
+// corrects a work's byline — an editor who had been miscredited as its author —
+// the anchor still points at the right source while the label keeps naming the
+// wrong person.
+//
+// This module re-derives the label from the anchor at read time. It rewrites only
+// the text inside the brackets, never the anchor, never the surrounding sentence,
+// and only when the stored text is one this codebase generated (see
+// looksLikeGeneratedLabel). A label it cannot resolve is left exactly as it was:
+// a stale name is a smaller harm than an empty citation.
+import { getDb } from '../db/database';
+import {
+  NODUS_LINK_RE,
+  authorYearLabel,
+  looksLikeGeneratedLabel,
+  normalizeName,
+  referenceEntry,
+  splitPageSuffix,
+  surnameOfLabel,
+  yearOfLabel,
+} from '@shared/citationLabel';
+import type { PromptLanguage, WritingWorkshopDraft, WritingWorkshopSavedDraft } from '@shared/types';
+// The report generator's own label table. Imported rather than re-declared: it
+// falls back to English for languages with no table of their own, and a private
+// copy that guessed a French "Auteur inconnu" would rewrite entries that were
+// never wrong. deepResearchCore is a pure module — it imports nothing but types.
+import { labels as reportLabels } from '../ai/deepResearchCore';
+
+interface WorkFacts {
+  authors: string[];
+  year: number | null;
+  title: string;
+  doi: string | null;
+}
+
+function parseAuthors(json: string | null): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.filter((name): name is string => typeof name === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function workFacts(nodusId: string): WorkFacts | null {
+  const row = getDb()
+    .prepare('SELECT title, authors_json, year, doi FROM works WHERE nodus_id = ?')
+    .get(nodusId) as { title: string; authors_json: string | null; year: number | null; doi: string | null } | undefined;
+  if (!row) return null;
+  return { authors: parseAuthors(row.authors_json), year: row.year, title: row.title ?? '', doi: row.doi };
+}
+
+/**
+ * The works a cited idea occurs in, ranked exactly as the report generator ranked
+ * them (see ideaWorks in writingWorkshop). The ORDER BY is not cosmetic and must
+ * not be "improved".
+ */
+function ideaWorks(globalId: string): WorkFacts[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT w.title, w.authors_json, w.year, w.doi
+         FROM idea_occurrences io
+         JOIN works w ON w.nodus_id = io.nodus_id
+        WHERE io.global_id = ?
+        ORDER BY io.role = 'principal' DESC, io.confidence DESC, w.year DESC
+        LIMIT 5`
+    )
+    .all(globalId) as { title: string; authors_json: string | null; year: number | null; doi: string | null }[];
+  return rows.map((row) => ({
+    authors: parseAuthors(row.authors_json),
+    year: row.year,
+    title: row.title ?? '',
+    doi: row.doi,
+  }));
+}
+
+/**
+ * Which of an idea's works a stored citation was named after.
+ *
+ * An idea anchor names the idea, not the source: `nodus://idea/g-5293` says nothing
+ * about which of its five works the sentence was citing. The generator picked the
+ * top-ranked one, but that ranking moves — a rescan changes a confidence, a new
+ * occurrence appears — and g-5293's top two works are both `principal` at
+ * confidence 1.0, separated only by year. Re-deriving from the top work alone
+ * turned "Moreno Garrido, A. (2004)" into "Pack, S. (2009)": not a corrected name
+ * but a different source, silently substituted under a sentence written about the
+ * first one.
+ *
+ * So the stored label is treated as evidence of which work was meant. Its year
+ * must match, because a byline repair never moves a year; among the works that
+ * match, the one whose byline still contains the stored surname is preferred,
+ * since a miscredited editor is reordered and marked by the repair but never
+ * removed. No match means no confident answer, and the citation keeps the text it
+ * has: a stale name is a smaller harm than a citation pointing somewhere else.
+ */
+function ideaWorkForLabel(globalId: string, storedLabel: string): WorkFacts | null {
+  const works = ideaWorks(globalId);
+  if (works.length === 0) return null;
+  const year = yearOfLabel(storedLabel);
+  if (year === null) return null;
+  const sameYear = works.filter((work) => work.year === year);
+  if (sameYear.length === 0) return null;
+  if (sameYear.length === 1) return sameYear[0];
+  const surname = surnameOfLabel(storedLabel);
+  const named = sameYear.filter((work) =>
+    work.authors.some((author) => surnameOfLabel(author) === surname || normalizeName(author).includes(surname))
+  );
+  // Still ranked, so ties fall back to the generator's own order.
+  return named[0] ?? sameYear[0];
+}
+
+/** A gap belongs to exactly one work, so its label has no ambiguity to guard. */
+function gapWork(gapId: string): WorkFacts | null {
+  const row = getDb()
+    .prepare(
+      `SELECT w.title, w.authors_json, w.year, w.doi
+         FROM gaps g JOIN works w ON w.nodus_id = g.nodus_id
+        WHERE g.id = ?`
+    )
+    .get(gapId) as { title: string; authors_json: string | null; year: number | null; doi: string | null } | undefined;
+  if (!row) return null;
+  return { authors: parseAuthors(row.authors_json), year: row.year, title: row.title ?? '', doi: row.doi };
+}
+
+function passageWork(passageId: string): WorkFacts | null {
+  const row = getDb()
+    .prepare(
+      `SELECT w.title, w.authors_json, w.year, w.doi
+         FROM passages p JOIN works w ON w.nodus_id = p.nodus_id
+        WHERE p.passage_id = ?`
+    )
+    .get(passageId) as { title: string; authors_json: string | null; year: number | null; doi: string | null } | undefined;
+  if (!row) return null;
+  return { authors: parseAuthors(row.authors_json), year: row.year, title: row.title ?? '', doi: row.doi };
+}
+
+/**
+ * The label a citation would be given if the report were written today, or null
+ * when the anchor names something this module does not label by author and year
+ * (a gap or a contradiction), or a source the corpus no longer holds.
+ */
+export function resolveCitationLabel(kind: string, id: string, storedLabel = ''): string | null {
+  let facts: WorkFacts | null = null;
+  switch (kind) {
+    case 'idea':
+      // An idea can be cited from any of its works, so the stored label is needed
+      // to tell which one this citation meant. See ideaWorkForLabel.
+      facts = ideaWorkForLabel(id, storedLabel);
+      break;
+    case 'work':
+      facts = workFacts(id);
+      break;
+    case 'passage':
+      facts = passageWork(id);
+      break;
+    case 'gap':
+      facts = gapWork(id);
+      break;
+    // A contradiction links two ideas and its label names one of their works,
+    // with nothing recorded to say which. Re-deriving it would be the same guess
+    // that turned one source into another for idea anchors, so it is left alone.
+    default:
+      return null;
+  }
+  if (!facts) return null;
+  const label = authorYearLabel(facts.authors[0], facts.year, facts.title);
+  return label || null;
+}
+
+function decode(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+export interface RelabelResult {
+  markdown: string;
+  /** Citations whose visible name changed, for verification and reporting. */
+  changed: { kind: string; id: string; from: string; to: string }[];
+  /** Anchors left alone: unresolvable, hand-written, or already correct. */
+  kept: number;
+}
+
+/** Re-derive every generated citation label in a markdown body. */
+export function relabelCitationsDetailed(markdown: string): RelabelResult {
+  const changed: RelabelResult['changed'] = [];
+  let kept = 0;
+  const out = markdown.replace(NODUS_LINK_RE, (full, label: string, kind: string, rawId: string) => {
+    const stored = String(label);
+    if (!looksLikeGeneratedLabel(stored)) {
+      kept += 1;
+      return full;
+    }
+    const id = decode(rawId);
+    const fresh = resolveCitationLabel(kind, id, stored);
+    if (!fresh) {
+      kept += 1;
+      return full;
+    }
+    // A passage label carries a page locator after the author-year. That part came
+    // from the passage, not the byline, so it survives the relabel untouched.
+    const { suffix } = splitPageSuffix(stored);
+    const next = `${fresh}${suffix}`;
+    if (next === stored) {
+      kept += 1;
+      return full;
+    }
+    changed.push({ kind, id, from: stored, to: next });
+    return `[${next}](nodus://${kind}/${rawId})`;
+  });
+  return { markdown: out, changed, kept };
+}
+
+/** Re-derive every generated citation label in a markdown body. */
+export function relabelCitations(markdown: string): string {
+  return relabelCitationsDetailed(markdown).markdown;
+}
+
+/**
+ * Rebuild the reference list from the works the report actually cited.
+ *
+ * Reference lines carry no anchor, so they are matched to a work by title — the
+ * one part of an entry the byline repair cannot move. A line no work matches
+ * unambiguously is left alone, in both the array and the prose, so the two can
+ * never end up disagreeing with each other.
+ */
+function relabelBibliography(
+  bibliography: string[],
+  workIds: string[],
+  labels: { unknownAuthor: string; noDate: string }
+): { entries: string[]; replacements: Map<string, string> } {
+  const byTitle = new Map<string, WorkFacts[]>();
+  for (const id of workIds) {
+    const facts = workFacts(id);
+    if (!facts?.title) continue;
+    const key = facts.title.replace(/\s+/g, ' ').trim().toLowerCase();
+    byTitle.set(key, [...(byTitle.get(key) ?? []), facts]);
+  }
+
+  const replacements = new Map<string, string>();
+  const entries = bibliography.map((line) => {
+    const haystack = line.replace(/\s+/g, ' ').toLowerCase();
+    let match: WorkFacts | null = null;
+    let ambiguous = false;
+    for (const [title, works] of byTitle) {
+      if (!title || !haystack.includes(title)) continue;
+      if (works.length > 1) {
+        ambiguous = true;
+        break;
+      }
+      // Longest title wins: one work's title can be a prefix of another's.
+      if (!match || title.length > (match.title?.length ?? 0)) match = works[0];
+    }
+    if (ambiguous || !match) return line;
+    const next = referenceEntry(match, labels);
+    if (next === line) return line;
+    replacements.set(line, next);
+    return next;
+  });
+  return { entries, replacements };
+}
+
+/**
+ * Every perishable name in a stored report, refreshed against the corpus: the
+ * inline citations, the matrix's source column, and the reference list. Returns a
+ * new draft; the stored row is never written back, so the repair costs nothing if
+ * the corpus later changes again.
+ */
+export function relabelDraft(draft: WritingWorkshopDraft): WritingWorkshopDraft {
+  const labels = reportLabels((draft.brief?.language ?? 'es') as PromptLanguage);
+  const { entries, replacements } = relabelBibliography(
+    Array.isArray(draft.bibliography) ? draft.bibliography : [],
+    Array.isArray(draft.selection?.workIds) ? draft.selection.workIds : [],
+    labels
+  );
+
+  let markdown = relabelCitations(draft.draftMarkdown ?? '');
+  // The reference list is printed inside the prose as well as held in the array.
+  // Both are updated from the same replacement map so they stay identical.
+  for (const [from, to] of replacements) markdown = markdown.split(from).join(to);
+
+  const matrix = Array.isArray(draft.matrix)
+    ? draft.matrix.map((row) => {
+        const anchor = /^nodus:\/\/([a-z]+)\/(.+)$/.exec((row.citation ?? '').trim());
+        if (!anchor || !looksLikeGeneratedLabel(row.sourceLabel ?? '')) return row;
+        const fresh = resolveCitationLabel(anchor[1], decode(anchor[2]), row.sourceLabel ?? '');
+        return fresh && fresh !== row.sourceLabel ? { ...row, sourceLabel: fresh } : row;
+      })
+    : draft.matrix;
+
+  return { ...draft, draftMarkdown: markdown, bibliography: entries, matrix };
+}
+
+/** The same refresh, applied to a saved report as it leaves the database. */
+export function relabelSavedDraft(saved: WritingWorkshopSavedDraft): WritingWorkshopSavedDraft {
+  return { ...saved, draft: relabelDraft(saved.draft) };
+}

--- a/electron/db/authorsRepo.ts
+++ b/electron/db/authorsRepo.ts
@@ -1,6 +1,7 @@
 import { getDb } from './database';
 import { v4 as uuid } from 'uuid';
 import type { WorkCreator } from '@shared/types';
+import { EDITOR_BYLINE_SUFFIX } from '@shared/citationLabel';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Canonical author identity
@@ -148,9 +149,10 @@ function parseCreatorsJson(value: string | null): WorkCreator[] {
 /**
  * How an editor is marked inside the stored byline (authors_json). The byline is
  * a display string, so the role has to travel inside it; every reader that wants
- * the role structurally should use creators_json instead.
+ * the role structurally should use creators_json instead. Defined once in
+ * @shared/citationLabel, which is where citation labels read the marker back.
  */
-export const EDITOR_BYLINE_SUFFIX = ' (ed.)';
+export { EDITOR_BYLINE_SUFFIX } from '@shared/citationLabel';
 
 /**
  * The stored byline for a set of Zotero creators. Only the people who carry

--- a/electron/db/writingDraftsRepo.ts
+++ b/electron/db/writingDraftsRepo.ts
@@ -13,6 +13,7 @@ import { normalizeDeepResearchApproach } from '@shared/deepResearchApproaches';
 import { getDb } from './database';
 import { deleteDecorativeImageRow, getDecorativeImage } from './decorativeImagesRepo';
 import { deleteAnnotationsForWritingDraft } from './writingAnnotationsRepo';
+import { relabelSavedDraft } from '../citations/liveCitations';
 
 interface SavedWritingDraftRow {
   id: string;
@@ -76,9 +77,16 @@ const SELECT_DRAFTS =
   'SELECT d.*, r.updated_at AS read_at FROM writing_saved_drafts d ' +
   'LEFT JOIN writing_draft_reads r ON r.draft_id = d.id';
 
+/**
+ * Every read of a saved report goes through here, which is why the citation labels
+ * are refreshed here and nowhere else: the reader, the exports, the archive and the
+ * MCP tools all inherit it from this one place. The stored row is never written
+ * back — the report on disk stays exactly as it was written, and the names it shows
+ * are re-derived from the corpus each time it is opened.
+ */
 function toSavedDraft(row: SavedWritingDraftRow): WritingWorkshopSavedDraft | null {
   try {
-    return {
+    return relabelSavedDraft({
       id: row.id,
       title: row.title,
       brief: JSON.parse(row.brief_json) as WritingWorkshopBrief,
@@ -89,7 +97,7 @@ function toSavedDraft(row: SavedWritingDraftRow): WritingWorkshopSavedDraft | nu
       readAt: row.read_at ?? null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
-    };
+    });
   } catch {
     // One corrupt local record must not prevent opening the rest of the workshop.
     return null;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:e2e:local-server": "node scripts/e2e-local-server.mjs",
     "smoke:author-roles": "node scripts/run-smoke.mjs smoke-author-roles",
     "smoke:author-roles:realcopy": "node scripts/run-smoke.mjs smoke-author-roles-realcopy",
+    "smoke:live-citations": "node scripts/run-smoke.mjs smoke-live-citations-realcopy",
     "qa:notion-parity": "node scripts/notion-parity/cli.mjs",
     "test:database-storage": "node scripts/test-database-typed-storage.mjs",
     "test:database-properties": "node scripts/test-database-properties.mjs",

--- a/scripts/smoke-live-citations-realcopy.ts
+++ b/scripts/smoke-live-citations-realcopy.ts
@@ -1,0 +1,206 @@
+// Live citation labels, proved against a COPY of a real corpus.
+//
+// The change rewrites text inside saved reports. Two things must hold, and neither
+// is obvious from reading the code:
+//
+//   1. It works. Reports that named the editor of an edited volume now name the
+//      author of the chapter they are actually citing.
+//   2. It breaks nothing. Every anchor survives byte-for-byte, in the same order;
+//      the prose around the citations is untouched to the character; labels a
+//      person wrote are left alone; and no citation is left empty or dangling.
+//
+// Assertion (2) is checked structurally rather than by eye: each report is reduced
+// to a "skeleton" with every link label blanked out, and the skeletons before and
+// after must be identical. Anything that moved outside a label would show up there.
+//
+// Point NODUS_TEST_USERDATA at a directory holding a COPY of nodus.sqlite.
+//
+//   npm run smoke:live-citations   (see scripts/run-smoke.mjs)
+import { getDb } from '../electron/db/database';
+import { reconcileAuthorRolesOnce } from '../electron/db/authorsRepo';
+import { relabelCitationsDetailed, relabelDraft, resolveCitationLabel } from '../electron/citations/liveCitations';
+import { getWritingWorkshopDraft, listWritingWorkshopDrafts } from '../electron/db/writingDraftsRepo';
+import { NODUS_LINK_RE, looksLikeGeneratedLabel, yearOfLabel } from '@shared/citationLabel';
+import type { WritingWorkshopDraft } from '@shared/types';
+
+const db = getDb();
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`ASSERT FAILED: ${msg}`);
+}
+
+/** Every anchor in render order: what a citation points at, ignoring what it says. */
+function anchors(markdown: string): string[] {
+  return [...markdown.matchAll(new RegExp(NODUS_LINK_RE.source, 'g'))].map((m) => `${m[2]}:${m[3]}`);
+}
+
+/** The report with every link label blanked out — the part that must never move. */
+function skeleton(markdown: string): string {
+  return markdown.replace(new RegExp(NODUS_LINK_RE.source, 'g'), (_full, _label, kind, id) => `[⟦⟧](nodus://${kind}/${id})`);
+}
+
+function labelsOf(markdown: string): string[] {
+  return [...markdown.matchAll(new RegExp(NODUS_LINK_RE.source, 'g'))].map((m) => String(m[1]));
+}
+
+// ── The corpus must first be in its repaired state, or there is nothing to relabel.
+reconcileAuthorRolesOnce();
+
+const rows = db
+  .prepare('SELECT id, title, draft_json FROM writing_saved_drafts ORDER BY created_at')
+  .all() as { id: string; title: string; draft_json: string }[];
+assert(rows.length > 0, 'the copy holds no saved reports, so this proves nothing');
+console.log(`saved reports: ${rows.length}`);
+
+let totalAnchors = 0;
+let totalChanged = 0;
+let totalKeptHandwritten = 0;
+let totalUnresolvable = 0;
+const examples: string[] = [];
+const unresolvableByKind = new Map<string, number>();
+const bibliographyChanges: string[] = [];
+
+for (const row of rows) {
+  const draft = JSON.parse(row.draft_json) as WritingWorkshopDraft;
+  const before = draft.draftMarkdown ?? '';
+  const detail = relabelCitationsDetailed(before);
+  const after = detail.markdown;
+
+  // ── (2) Nothing outside a label moved ──────────────────────────────────────
+  assert(skeleton(before) === skeleton(after), `${row.id}: the prose or an anchor changed, not just a label`);
+  const anchorsBefore = anchors(before);
+  const anchorsAfter = anchors(after);
+  assert(
+    anchorsBefore.length === anchorsAfter.length && anchorsBefore.every((a, i) => a === anchorsAfter[i]),
+    `${row.id}: the anchors changed`
+  );
+  assert(!/\[\]\(nodus:\/\//.test(after), `${row.id}: a citation was left with no visible label`);
+  assert(
+    (before.match(/nodus:\/\//g) ?? []).length === (after.match(/nodus:\/\//g) ?? []).length,
+    `${row.id}: the number of citations changed`
+  );
+
+  // A label a person wrote must come out of the relabel untouched.
+  const beforeLabels = labelsOf(before);
+  const afterLabels = labelsOf(after);
+  beforeLabels.forEach((label, i) => {
+    if (!looksLikeGeneratedLabel(label)) {
+      assert(afterLabels[i] === label, `${row.id}: a hand-written label was rewritten ("${label}")`);
+      totalKeptHandwritten += 1;
+    }
+  });
+
+  // Every anchor that still resolves must end up carrying its current label, and
+  // — the load-bearing one — a relabelled citation must still name the SAME source.
+  // A byline repair never moves a year, so a year that changed means the citation
+  // was re-pointed at a different work, which is worse than the stale name it fixes.
+  beforeLabels.forEach((label, i) => {
+    const [kind, id] = anchorsBefore[i].split(/:(.+)/);
+    const fresh = resolveCitationLabel(kind, decodeURIComponent(id), label);
+    if (!fresh) {
+      totalUnresolvable += 1;
+      unresolvableByKind.set(kind, (unresolvableByKind.get(kind) ?? 0) + 1);
+      assert(afterLabels[i] === label, `${row.id}: an unresolvable citation lost its stored label`);
+      return;
+    }
+    if (!looksLikeGeneratedLabel(label)) return;
+    assert(afterLabels[i].startsWith(fresh), `${row.id}: label ${i} is not the current one ("${afterLabels[i]}" vs "${fresh}")`);
+    if (kind === 'idea') {
+      assert(
+        yearOfLabel(afterLabels[i]) === yearOfLabel(label),
+        `${row.id}: citation ${i} was re-pointed at another source ("${label}" → "${afterLabels[i]}")`
+      );
+    }
+  });
+
+  totalAnchors += anchorsBefore.length;
+  totalChanged += detail.changed.length;
+  for (const change of detail.changed.slice(0, 2)) {
+    if (examples.length < 12) examples.push(`  ${change.from}  →  ${change.to}`);
+  }
+
+  // ── The reference list and the prose must stay in agreement ────────────────
+  const relabelled = relabelDraft(draft);
+  const bib = relabelled.bibliography ?? [];
+  assert(bib.length === (draft.bibliography ?? []).length, `${row.id}: the reference list changed length`);
+  bib.forEach((entry, i) => {
+    const old = (draft.bibliography ?? [])[i];
+    if (entry === old) return;
+    // A rewritten entry must also appear rewritten inside the prose, or the report
+    // would print one bibliography and carry another. Testing that the new text is
+    // present is the real invariant: some rewrites are additive (a DOI the corpus
+    // has acquired since), so the old string legitimately survives inside the new.
+    assert(
+      !(draft.draftMarkdown ?? '').includes(old) || relabelled.draftMarkdown.includes(entry),
+      `${row.id}: reference "${old.slice(0, 50)}…" was updated in the list but not in the report body`
+    );
+    if (bibliographyChanges.length < 6) bibliographyChanges.push(`  ${old.slice(0, 78)}\n    →  ${entry.slice(0, 78)}`);
+  });
+
+  // Relabelling twice must produce the same text: the operation is a projection of
+  // the corpus, not an accumulating edit.
+  assert(relabelCitationsDetailed(after).markdown === after, `${row.id}: relabelling is not idempotent`);
+}
+
+const byKind = [...unresolvableByKind.entries()].sort((a, b) => b[1] - a[1]).map(([k, n]) => `${k} ${n}`).join(', ');
+console.log(`\ncitations: ${totalAnchors} anchors · ${totalChanged} labels refreshed · ${totalKeptHandwritten} hand-written left alone`);
+console.log(`not re-derivable, kept exactly as stored: ${totalUnresolvable} (${byKind || 'none'})`);
+if (examples.length) {
+  console.log('\nnames a report used to print, and what it prints now:');
+  for (const line of examples) console.log(line);
+}
+if (bibliographyChanges.length) {
+  console.log('\nreference entries rebuilt from the corpus:');
+  for (const line of bibliographyChanges) console.log(line);
+}
+
+assert(totalChanged > 0, 'no label changed at all — the repair is not reaching stored reports');
+
+// ── It reaches the real read path, not just the function under test ──────────
+// Everything above calls the relabeller directly. This reads the reports the way
+// the reader, the exports, the archive and the MCP tools do — through the repo —
+// and proves the text they receive is the refreshed one, while the row on disk is
+// untouched. Nothing else in the app would notice if the wiring were missing.
+const served = listWritingWorkshopDrafts();
+assert(served.length === rows.length, 'the repo did not return every saved report');
+let servedChanged = 0;
+for (const saved of served) {
+  const stored = rows.find((r) => r.id === saved.id);
+  assert(!!stored, `${saved.id}: served a report the table does not hold`);
+  const raw = JSON.parse(stored!.draft_json) as WritingWorkshopDraft;
+  assert(
+    saved.draft.draftMarkdown === relabelDraft(raw).draftMarkdown,
+    `${saved.id}: the repo served text that is not the refreshed one`
+  );
+  // Every line that differs must differ for one of exactly two sanctioned reasons:
+  // it carries a citation whose label was refreshed, or it is a reference entry
+  // rebuilt from the corpus. A line that changed for any other reason is prose
+  // Nodus had no business touching.
+  const storedLines = (raw.draftMarkdown ?? '').split('\n');
+  const servedLines = saved.draft.draftMarkdown.split('\n');
+  assert(storedLines.length === servedLines.length, `${saved.id}: the report gained or lost lines`);
+  const oldEntries = (raw.bibliography ?? []).filter((entry) => entry.trim().length > 0);
+  storedLines.forEach((line, i) => {
+    if (line === servedLines[i]) return;
+    const isCitationLine = line.includes('nodus://') && skeleton(line) === skeleton(servedLines[i]);
+    const isReferenceLine = oldEntries.some((entry) => line.includes(entry));
+    assert(isCitationLine || isReferenceLine, `${saved.id}: line ${i + 1} changed for no sanctioned reason:\n  ${line}\n  ${servedLines[i]}`);
+  });
+  if (saved.draft.draftMarkdown !== raw.draftMarkdown) servedChanged += 1;
+}
+// The archive and the MCP tools fetch one report at a time through the other
+// getter; it must refresh the same way, or an export would disagree with the reader.
+for (const saved of served) {
+  const single = getWritingWorkshopDraft(saved.id);
+  assert(!!single, `${saved.id}: the single-report getter returned nothing`);
+  assert(
+    single!.draft.draftMarkdown === saved.draft.draftMarkdown,
+    `${saved.id}: the single-report getter served different text from the list`
+  );
+}
+
+const onDisk = db.prepare('SELECT draft_json FROM writing_saved_drafts WHERE id = ?').get(rows[0].id) as { draft_json: string };
+assert(onDisk.draft_json === rows[0].draft_json, 'reading a report rewrote it on disk');
+console.log(`\nthrough the repo the reader actually uses: ${served.length} reports served, ${servedChanged} with refreshed names, 0 rows written back`);
+
+console.log('\nLABELS ARE LIVE · ANCHORS AND PROSE UNTOUCHED ✓');

--- a/scripts/test-deep-research.mjs
+++ b/scripts/test-deep-research.mjs
@@ -28,7 +28,11 @@ try {
     bundle: true,
     format: 'esm',
     platform: 'node',
-    external: ['@shared/*'],
+    // Types from @shared are erased at build time, but citation naming is a real
+    // value import — the writer and the reader that re-derives its labels share one
+    // implementation — so it has to be bundled in rather than left external.
+    external: ['@shared/types', '@shared/deepResearchApproaches'],
+    alias: { '@shared': path.join(repoRoot, 'shared') },
     logLevel: 'silent',
   });
   const mod = await import(pathToFileURL(outfile).href);

--- a/scripts/test-live-citation-labels.mjs
+++ b/scripts/test-live-citation-labels.mjs
@@ -1,0 +1,120 @@
+// The rule that decides which citation labels a stored report may have rewritten.
+//
+// Getting this wrong is not a cosmetic bug. Too permissive and Nodus edits prose a
+// person wrote; too strict and a report keeps naming the wrong author forever. The
+// cases below are the boundary, so they are pinned here rather than left to a
+// reviewer's memory of the regex.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const bundle = path.join(mkdtempSync(path.join(os.tmpdir(), 'nodus-citation-label-')), 'citationLabel.cjs');
+execFileSync(
+  path.join(repoRoot, 'node_modules/.bin/esbuild'),
+  [
+    path.join(repoRoot, 'shared/citationLabel.ts'),
+    '--bundle',
+    '--platform=node',
+    '--format=cjs',
+    `--outfile=${bundle}`,
+  ],
+  { cwd: repoRoot, stdio: 'inherit' }
+);
+const {
+  authorYearLabel,
+  looksLikeGeneratedLabel,
+  splitPageSuffix,
+  referenceEntry,
+  NODUS_LINK_RE,
+} = require(bundle);
+
+test('a generated author-year label is recognised, in every shape the writer emits', () => {
+  for (const label of [
+    'Arco Blanco, M. (2024)',
+    'Nash (1999)',
+    'Román Ruiz, G. (2024)',
+    'Obra sin autor (1978)',
+    'La España negra en color: el desarrollismo turístico… (2012)',
+    'Fuentes Vega, A. (2017), p. 44', // passage: author-year plus a page locator
+    'Lleó Cañal, V. (1984), pp. 20-31',
+  ]) {
+    assert.equal(looksLikeGeneratedLabel(label), true, label);
+  }
+});
+
+test('prose a person wrote is never treated as a generated label', () => {
+  for (const label of [
+    'esta idea',
+    'véase la discusión',
+    'the argument developed here',
+    'Arco Blanco', // no year: left alone rather than guessed at
+    'Obra sin autor',
+    'una obra de 2024', // a bare year is not a citation
+    '(2024) abre la sección', // the year must close the label
+  ]) {
+    assert.equal(looksLikeGeneratedLabel(label), false, label);
+  }
+});
+
+test('the page locator of a passage survives a relabel', () => {
+  assert.deepEqual(splitPageSuffix('Fuentes Vega, A. (2017), p. 44'), {
+    base: 'Fuentes Vega, A. (2017)',
+    suffix: ', p. 44',
+  });
+  assert.deepEqual(splitPageSuffix('Arco Blanco, M. (2024)'), {
+    base: 'Arco Blanco, M. (2024)',
+    suffix: '',
+  });
+});
+
+test('the label of a work is its first author, surname and initial, with the year', () => {
+  assert.equal(authorYearLabel('Arco Blanco, Miguel Ángel del', 2024), 'Arco Blanco, M. (2024)');
+  assert.equal(authorYearLabel('Miguel Ángel del Arco Blanco', 2024), 'Blanco, M. (2024)');
+  assert.equal(authorYearLabel(undefined, 2024, 'Los niños de Franco'), 'Los niños de Franco (2024)');
+  assert.equal(authorYearLabel(undefined, null, ''), 'Obra sin autor');
+});
+
+test('an editor marked in the byline is named as one, never silently as an author', () => {
+  // The byline repair marks editors with "(ed.)". A citation derived from one has
+  // to carry the marker: a reader seeing "Román Ruiz, G. (2024)" cannot tell she
+  // edited the volume rather than wrote it, which is the whole point of the repair.
+  assert.equal(authorYearLabel('Román Ruiz, G. (ed.)', 2024), 'Román Ruiz, G. (ed.) (2024)');
+  assert.equal(authorYearLabel('Román Ruiz, G. (ed.)', null), 'Román Ruiz, G. (ed.)');
+  // And the marker must not break the two rules that decide whether a label is
+  // rewritable and where its page locator starts.
+  assert.equal(looksLikeGeneratedLabel('Román Ruiz, G. (ed.) (2024)'), true);
+  assert.deepEqual(splitPageSuffix('Román Ruiz, G. (ed.) (2024), p. 12'), {
+    base: 'Román Ruiz, G. (ed.) (2024)',
+    suffix: ', p. 12',
+  });
+});
+
+test('the link pattern captures the label and the anchor, and stops at the bracket', () => {
+  const md = 'Como sostiene [Arco Blanco, M. (2024)](nodus://idea/g-1160) y también [Nash (1999)](nodus://work/w-2).';
+  const found = [...md.matchAll(new RegExp(NODUS_LINK_RE.source, 'g'))].map((m) => [m[1], m[2], m[3]]);
+  assert.deepEqual(found, [
+    ['Arco Blanco, M. (2024)', 'idea', 'g-1160'],
+    ['Nash (1999)', 'work', 'w-2'],
+  ]);
+});
+
+test('a reference entry joins every author, and an edited volume shows its editors', () => {
+  assert.equal(
+    referenceEntry(
+      { authors: ['Arco Blanco, M.', 'Román Ruiz, G. (ed.)'], year: 2024, title: 'Los niños de la derrota.', doi: null },
+      { unknownAuthor: 'Autor desconocido', noDate: 's.f.' }
+    ),
+    'Arco Blanco, M.; Román Ruiz, G. (ed.) (2024). Los niños de la derrota.'
+  );
+  assert.equal(
+    referenceEntry({ authors: [], year: null, title: 'Sin datos', doi: null }, { unknownAuthor: 'Autor desconocido', noDate: 's.f.' }),
+    'Autor desconocido (s.f.). Sin datos.'
+  );
+});

--- a/shared/citationLabel.ts
+++ b/shared/citationLabel.ts
@@ -1,0 +1,132 @@
+// How a source is named in a citation, in one place.
+//
+// These strings are written into a report once, at generation time, and then read
+// back for as long as the report exists. That makes them two things at once: prose
+// the writer produced, and a claim about the corpus that must still be true later.
+// When a work's byline is corrected — an editor who was miscredited as an author,
+// say — every stored label naming that person becomes a lie the report keeps
+// repeating.
+//
+// The fix is to re-derive the label from the corpus when the report is read. That
+// only works if the reader derives it *exactly* as the writer did, so both sides
+// import these functions instead of keeping their own copy.
+
+/**
+ * How an editor is marked inside a stored byline. Defined here, with the code that
+ * reads bylines, and re-exported by the repo that writes them, so the marker can
+ * never be spelled two ways.
+ */
+export const EDITOR_BYLINE_SUFFIX = ' (ed.)';
+
+/** Trim to `max` characters on a word-safe boundary, with an ellipsis. */
+export function clipLabel(text: string, max: number): string {
+  const clean = (text ?? '').replace(/\s+/g, ' ').trim();
+  return clean.length > max ? `${clean.slice(0, max - 1).trim()}…` : clean;
+}
+
+/** Turn Nodus's stored `Apellido, I.` name into a readable inline citation. */
+export function authorYearLabel(author: string | undefined, year: number | null | undefined, title?: string): string {
+  const trimmed = author?.replace(/\s+/g, ' ').trim();
+  // A work Zotero credits to editors only is cited under one of them, and the
+  // citation says so. Dropping the marker here would put the whole point of the
+  // byline back: a reader seeing "Román Ruiz, G. (2024)" has no way to tell that
+  // she edited the volume rather than wrote it.
+  const marker = EDITOR_BYLINE_SUFFIX.trim();
+  const isEditor = !!trimmed && trimmed.toLowerCase().endsWith(marker.toLowerCase());
+  const raw = isEditor ? trimmed.slice(0, trimmed.length - marker.length).trim() : trimmed;
+  if (!raw) {
+    // "Autor" reads as a placeholder in the middle of academic prose. A shortened
+    // title is a real citation for a source whose author the corpus never captured.
+    const short = clipLabel((title ?? '').replace(/\s+/g, ' ').trim(), 42);
+    if (short) return year ? `${short} (${year})` : short;
+    return year ? `Obra sin autor (${year})` : 'Obra sin autor';
+  }
+  const comma = raw.indexOf(',');
+  const surname = (comma >= 0 ? raw.slice(0, comma) : raw.split(' ').slice(-1).join(' ')).trim() || raw;
+  const given = (comma >= 0 ? raw.slice(comma + 1) : raw.split(' ').slice(0, -1).join(' ')).trim();
+  const initial = given.match(/[\p{L}]/u)?.[0]?.toLocaleUpperCase('es-ES');
+  const base = initial ? `${surname}, ${initial}.` : surname;
+  // The year keeps its own trailing parentheses so every label still ends the way
+  // looksLikeGeneratedLabel and splitPageSuffix expect.
+  const name = isEditor ? `${base}${EDITOR_BYLINE_SUFFIX}` : base;
+  return year ? `${name} (${year})` : name;
+}
+
+/** The inline citation for one work. */
+export function sourceLabelFromWork(
+  work: { authors: string[]; year: number | null; title?: string } | undefined
+): string {
+  if (!work) return '';
+  return authorYearLabel(work.authors[0], work.year, work.title);
+}
+
+/** One line of the reference list. */
+export function referenceEntry(
+  work: { authors: string[]; year: number | null; title?: string | null; doi?: string | null },
+  labels: { unknownAuthor: string; noDate: string }
+): string {
+  const authors = work.authors.length ? work.authors.join('; ') : labels.unknownAuthor;
+  const year = work.year ? ` (${work.year})` : ` (${labels.noDate})`;
+  const title = work.title ? `. ${work.title.replace(/\.\s*$/, '')}.` : '.';
+  const doi = work.doi?.trim() ? ` https://doi.org/${work.doi.trim().replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')}` : '';
+  return `${authors}${year}${title}${doi}`;
+}
+
+/**
+ * A markdown link to a Nodus source: `[label](nodus://kind/id)`. The label is
+ * captured lazily and forbidden from containing brackets so a nested link cannot
+ * swallow the one after it.
+ */
+export const NODUS_LINK_RE = /\[([^\]]*)\]\(nodus:\/\/([a-z]+)\/([^)\s]+)\)/g;
+
+/**
+ * Whether a stored link label is one this module produced, and may therefore be
+ * replaced by a freshly derived one.
+ *
+ * The test is deliberately narrow. A `nodus://` link can also be written by a
+ * person — in a note, or in a sentence like "[as discussed here](nodus://idea/x)"
+ * — and rewriting that would destroy their prose to fix a problem it never had.
+ * Every label this module generates for a dated source ends in a parenthesised
+ * year, optionally followed by a page locator for a passage; nothing else is
+ * touched. An undated source is left alone too: it is rare, and being conservative
+ * costs only a stale label, while being wrong costs the reader's own words.
+ */
+export function looksLikeGeneratedLabel(label: string): boolean {
+  return /\(\d{3,4}\)(?:,\s*[^,]{1,40})?\s*$/.test(label.trim());
+}
+
+/** Accent- and case-insensitive form, for comparing two spellings of a surname. */
+export function normalizeName(text: string): string {
+  return (text || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** The year a generated label ends with, or null when it carries none. */
+export function yearOfLabel(label: string): number | null {
+  const { base } = splitPageSuffix(label);
+  const match = /\((\d{3,4})\)\s*$/.exec(base);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * The surname a generated label names, normalized. Empty when the label falls back
+ * to a shortened title instead of a person.
+ */
+export function surnameOfLabel(label: string): string {
+  const { base } = splitPageSuffix(label);
+  const withoutYear = base.replace(/\s*\((\d{3,4})\)\s*$/, '').trim();
+  const withoutMarker = withoutYear.replace(new RegExp(`\\s*\\${EDITOR_BYLINE_SUFFIX.trim()}\\s*$`.replace('(', '\\('), 'i'), '').trim();
+  const comma = withoutMarker.indexOf(',');
+  return normalizeName(comma >= 0 ? withoutMarker.slice(0, comma) : withoutMarker);
+}
+
+/** The page locator a passage label carries after its author-year, if any. */
+export function splitPageSuffix(label: string): { base: string; suffix: string } {
+  const match = /^(.*\(\d{3,4}\))(,\s*.+)$/.exec(label.trim());
+  return match ? { base: match[1], suffix: match[2] } : { base: label.trim(), suffix: '' };
+}


### PR DESCRIPTION
Closes #519. Follow-up to #514, #516 and #518.

A saved report is prose plus a set of claims about the corpus. The prose is the author's and must not change; the claims must stay true. After the byline repair, reports kept printing the name they were written with — including the volume editor they had been miscrediting.

## How it works

Every inline citation is already a markdown link with a durable anchor, so the label is the only perishable part:

```
[Román Ruiz, G. (2024)](nodus://idea/g-1160)   →   [Jiménez Aguilar, F. (2024)](nodus://idea/g-1160)
```

`relabelDraft` re-derives the label from the anchor at read time, and `toSavedDraft` applies it — the one funnel every read goes through, so the reader, the exports, the ZIP archive and the MCP tools all inherit it from a single place. **The stored row is never written back**; the report on disk stays exactly as it was written and its names are re-derived each time it is opened.

Citation naming moved to `@shared/citationLabel`, imported by both the writer that emits a label and the reader that re-derives it, so the two cannot drift apart. A label built from an editor now carries the `(ed.)` marker — citing "Román Ruiz, G. (2024)" for a volume she edited was the original problem in miniature.

## What it refuses to do

**Only a label this codebase generated is rewritten**, recognised by the parenthesised year it ends with. A `nodus://` link a person wrote in a note keeps their words. An anchor that no longer resolves keeps the text it has: a stale name is a smaller harm than an empty citation. Contradictions are left alone — their label names one of two ideas' works with nothing recorded to say which.

**The load-bearing guard: a relabel may change a name, never the source.** An idea anchor names the idea, not the work, and an idea occurring in several works ranks them by confidence then year — a ranking that moves. Taking the top work alone turned `Moreno Garrido, A. (2004)` into `Pack, S. (2009)`: not a corrected name but a different source silently substituted under a sentence written about the first one. That case was caught by the verification, not by review.

The stored label is now read as evidence of which work was meant: its year must match (a byline repair never moves a year), and among same-year works the one whose byline still contains the stored surname wins, since the repair reorders and marks a miscredited editor but never removes them. On the real corpus this refuses **5 of 1,901** idea citations and prevents every substitution.

## Verification

`npm run typecheck`, `npm run lint`, `npm run build` — clean. `npm test` — **2,113/2,113**. `npm run test:e2e` — passes.

One fixture repair is included: `test-deep-research.mjs` bundles `deepResearchCore` with `@shared/*` external, which was fine while those were type-only imports and broke the moment citation naming became a real value import. It now aliases `@shared` to the real directory.

**`npm run test-live-citation-labels`** (new, in `npm test`) pins the rule that decides what may be rewritten — the boundary between a generated label and a person's prose — because getting it wrong either edits someone's writing or leaves a report lying forever.

**`npm run smoke:live-citations`** (new) runs against a copy of a real 1,214-work vault with 28 saved reports:

```
citations: 3455 anchors · 511 labels refreshed · 662 hand-written left alone
not re-derivable, kept exactly as stored: 804 (idea 574, contradiction 225, gap 5)
through the repo the reader actually uses: 28 reports served, 26 with refreshed names, 0 rows written back

names a report used to print, and what it prints now:
  Román Ruiz, G. (2024)      →  Jiménez Aguilar, F. (2024)
  Román Ruiz, G. (2024)      →  Ortega López, T. (2024)
  Sánchez Vigil, J. (2001)   →  Fontcuberta, J. (2001)
  Hulme, P. (2002)           →  Campbell, M. (2002)
  Olivera Zaldua, M. (2023)  →  Olivera Zaldua, M. (ed.) (2023)
  Cabornero Domingo, J. (2004) →  Carbonero Domingo, J. (2004)

reference entries rebuilt from the corpus:
  Arroyo, C.; Reviejo, M.; Ruiz Baudrihaye, J. (2014). De libros y viajeros…
    →  Ruiz Baudrihaye, J.; Arroyo, C. (ed.); Reviejo, M. (ed.) (2014). De libros y viajeros…
```

Every one of those was verified against the corpus by hand: each is the same single work, with the chapter's author replacing the volume's editor.

The smoke asserts, per report, that:

- every anchor survives with the same target, order and count;
- the prose outside citation labels does not move by a character (each report is reduced to a skeleton with labels blanked out, and the skeletons must match);
- no citation is left with an empty label;
- a hand-written label is returned byte-identical;
- an unresolvable anchor keeps its stored text;
- **an idea citation's year never changes** — the same-source guarantee;
- relabelling twice yields the same text (it is a projection of the corpus, not an accumulating edit);
- the reference array and the reference list printed in the prose always agree;
- reading a report through the repo the reader actually uses returns the refreshed text, the single-report getter agrees with the list getter, and **the row on disk is unchanged**;
- every line that differs does so for one of exactly two sanctioned reasons: a refreshed citation label, or a rebuilt reference entry.

Two assertions were wrong on their first run and were corrected rather than worked around — one treated an additive change (a DOI the corpus has since acquired) as a mismatch, the other forbade the reference-line rewrite it was meant to allow.

## Scope

Narration of a report now speaks the refreshed names too. Immersion sessions are not covered: their prose lives in a different shape, and the one session in the test corpus carries a single anchor. Reports exported to PDF or Markdown before this lands keep whatever they said — the files are already on disk.