### PR TITLE
feat(deep-research): full-screen reading, a wider report column and live reading progress

### DIFF
--- a/scripts/e2e-deep-research-annotations.mjs
+++ b/scripts/e2e-deep-research-annotations.mjs
@@ -70,6 +70,51 @@ try {
   ));
   assert.ok(draftId, 'the demo supplies a saved Deep Research report');
 
+  // Full-screen reading lifts the same reader out of the app shell and hands it the
+  // whole window; Escape and the toggle both put it back. The column has to grow with
+  // it, or the extra room would be spent on margins.
+  const readerShell = page.getByTestId('deep-research-reader-shell');
+  const columnWidth = () => documentRoot.evaluate((node) => Math.round(node.getBoundingClientRect().width));
+  const windowedWidth = await columnWidth();
+  assert.equal(await readerShell.getAttribute('data-fullscreen'), 'off', 'the reader opens inside the shell');
+  await page.getByTestId('deep-research-fullscreen-toggle').click();
+  await page.waitForFunction(() => document.querySelector('[data-testid="deep-research-reader-shell"]')?.getAttribute('data-fullscreen') === 'on');
+  const fullscreenBox = await readerShell.evaluate((node) => {
+    const box = node.getBoundingClientRect();
+    return { position: getComputedStyle(node).position, width: Math.round(box.width), height: Math.round(box.height), viewport: [window.innerWidth, window.innerHeight] };
+  });
+  assert.equal(fullscreenBox.position, 'fixed', 'full screen is a fixed layer over the window');
+  assert.deepEqual([fullscreenBox.width, fullscreenBox.height], fullscreenBox.viewport, 'it covers the whole window');
+  assert.ok(await columnWidth() > windowedWidth, 'full screen widens the reading column');
+  await page.keyboard.press('Escape');
+  await page.waitForFunction(() => document.querySelector('[data-testid="deep-research-reader-shell"]')?.getAttribute('data-fullscreen') === 'off');
+  assert.equal(await columnWidth(), windowedWidth, 'leaving full screen restores the reading column');
+
+  // The rail's percentage is how far the reader has come, not which section they are
+  // in: scrolling inside one section has to move it, or the bar sits still for pages
+  // and then jumps at a heading. The demo report fits on one screen, so the window is
+  // squeezed to give it something to scroll and put back afterwards.
+  const readingProgress = () => page.evaluate(() => Number(document.querySelector('[data-testid="deep-research-reading-progress"]')?.textContent?.replace('%', '')));
+  const activeHeading = () => page.evaluate(() => document.querySelector('[data-testid="deep-research-outline-rail"] [aria-current="location"]')?.textContent?.trim() ?? null);
+  const scrollReader = (top) => page.evaluate((value) => new Promise((resolve) => {
+    const scroller = document.querySelector('[data-testid="deep-research-reader-document"]').closest('main');
+    scroller.scrollTop = value;
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }), top);
+  assert.equal(await readingProgress(), 100, 'a report that fits on screen is already read');
+  await page.setViewportSize({ width: 1440, height: 420 });
+  await scrollReader(0);
+  await page.waitForFunction(() => Number(document.querySelector('[data-testid="deep-research-reading-progress"]')?.textContent?.replace('%', '')) === 0);
+  const headingAtTop = await activeHeading();
+  await scrollReader(60);
+  const partway = await readingProgress();
+  assert.ok(partway > 0 && partway < 100, `scrolling inside a section advances the percentage (${partway}%)`);
+  assert.equal(await activeHeading(), headingAtTop, 'and it advances without changing section');
+  await scrollReader(120);
+  assert.ok(await readingProgress() > partway, 'scrolling further advances it again');
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await scrollReader(0);
+
   async function selectCandidate(index, releaseInGutter = false, readerTestId = 'deep-research-reader-document') {
     return page.evaluate(({ candidateIndex, releaseInGutter, readerTestId }) => {
       const root = document.querySelector(`[data-testid="${readerTestId}"]`);

--- a/scripts/test-author-links.mjs
+++ b/scripts/test-author-links.mjs
@@ -1,0 +1,67 @@
+// The citation workspace turns the names printed under a linked work into links to
+// the author's own record. Bibliographies abbreviate the given name and the record
+// keeps it whole, so the match cannot be a string comparison — and it must refuse to
+// guess when two people would answer to the same abbreviation.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const temp = await mkdtemp(path.join(os.tmpdir(), 'nodus-author-links-'));
+test.after(() => rm(temp, { recursive: true, force: true }));
+
+const bundle = path.join(temp, 'author-links.cjs');
+execFileSync(path.join(root, 'node_modules/.bin/esbuild'), [
+  path.join(root, 'src/authorLinks.ts'), '--bundle', '--platform=node', '--format=cjs', '--target=es2022', `--outfile=${bundle}`,
+], { cwd: root, stdio: 'inherit' });
+const { buildAuthorIndex, lookupAuthor } = createRequire(import.meta.url)(bundle);
+
+function author(id, firstName, lastName) {
+  return { author_id: id, firstName, lastName, name: `${lastName}, ${firstName}`, fullName: `${firstName} ${lastName}` };
+}
+
+const corpus = [
+  author('a1', 'Luis', 'Alburquerque García'),
+  author('a2', 'Jesús', 'Cabornero Domingo'),
+  author('a3', 'Henry L.', 'Roediger'),
+  author('a4', 'Ana', 'Torres'),
+  author('a5', 'Alberto', 'Torres'),
+];
+const index = buildAuthorIndex(corpus);
+const id = (name) => lookupAuthor(index, name)?.author_id ?? null;
+
+test('a byline written out in full matches either stored form', () => {
+  assert.equal(id('Alburquerque García, Luis'), 'a1');
+  assert.equal(id('Luis Alburquerque García'), 'a1');
+});
+
+test('an abbreviated given name still finds the person', () => {
+  assert.equal(id('Alburquerque García, L.'), 'a1');
+  assert.equal(id('Cabornero Domingo, J.'), 'a2');
+  assert.equal(id('L. Alburquerque García'), 'a1');
+});
+
+test('accents and punctuation do not decide the match', () => {
+  assert.equal(id('Alburquerque Garcia, L'), 'a1');
+  assert.equal(id('CABORNERO DOMINGO, J.'), 'a2');
+});
+
+test('a record already stored with initials matches its own byline', () => {
+  assert.equal(id('Roediger, H. L.'), 'a3');
+});
+
+test('two people behind one abbreviation stay plain text', () => {
+  assert.equal(id('Torres, A.'), null);
+  assert.equal(id('Torres, Ana'), 'a4');
+});
+
+test('a stranger to the corpus is never linked', () => {
+  assert.equal(id('Martín, M.'), null);
+  assert.equal(id('Alburquerque'), null);
+  assert.equal(id(''), null);
+});

--- a/src/authorLinks.ts
+++ b/src/authorLinks.ts
@@ -1,0 +1,79 @@
+/**
+ * Matching bylines to author records.
+ *
+ * A work's byline and the author's own record rarely agree letter for letter: the
+ * bibliography abbreviates the given name, the record keeps it whole. This is the
+ * one place that reconciles the two, so the citation workspace can turn a printed
+ * name into a link to the person.
+ */
+import type { AuthorSummary } from '@shared/types';
+
+export interface AuthorIndex {
+  /** Exact matches on either stored form of the name. */
+  byName: Map<string, AuthorSummary>;
+  /**
+   * Surname plus the initial of the given name. Bibliographies abbreviate ("García
+   * Simón, A.") where the author record keeps the full given name, so the exact form
+   * never matches. Names that collapse onto the same key are dropped rather than
+   * guessed: sending a reader to the wrong author is worse than plain text.
+   */
+  byInitial: Map<string, AuthorSummary | null>;
+}
+
+export function buildAuthorIndex(authors: AuthorSummary[]): AuthorIndex {
+  const byName = new Map<string, AuthorSummary>();
+  const byInitial = new Map<string, AuthorSummary | null>();
+  for (const author of authors) {
+    byName.set(normalizeAuthorName(author.name), author);
+    byName.set(normalizeAuthorName(author.fullName), author);
+    for (const key of [initialKey(author.firstName, author.lastName), initialKeyFromDisplay(author.name), initialKeyFromDisplay(author.fullName)]) {
+      if (!key) continue;
+      const seen = byInitial.get(key);
+      if (seen === undefined) byInitial.set(key, author);
+      else if (seen && seen.author_id !== author.author_id) byInitial.set(key, null);
+    }
+  }
+  return { byName, byInitial };
+}
+
+export function lookupAuthor(index: AuthorIndex, name: string): AuthorSummary | null {
+  const exact = index.byName.get(normalizeAuthorName(name));
+  if (exact) return exact;
+  const key = initialKeyFromDisplay(name);
+  return key ? index.byInitial.get(key) ?? null : null;
+}
+
+/** "Jesús" + "Cabornero Domingo" → "j|cabornero domingo". */
+function initialKey(firstName: string | null | undefined, lastName: string | null | undefined): string | null {
+  const given = plainAuthorText(firstName ?? '');
+  const family = plainAuthorText(lastName ?? '');
+  if (!given || !family) return null;
+  return `${given[0]}|${family}`;
+}
+
+/**
+ * The same key from a byline as printed, where the split has to be guessed: the
+ * comma marks it when there is one, otherwise the first word is the given name.
+ */
+function initialKeyFromDisplay(value: string): string | null {
+  const plain = plainAuthorText(value.replace(/,/g, ' , '));
+  if (!plain) return null;
+  if (plain.includes(' , ')) {
+    const [family, given] = plain.split(' , ', 2).map((part) => part.trim());
+    return initialKey(given, family);
+  }
+  const parts = plain.split(' ');
+  if (parts.length < 2) return null;
+  return initialKey(parts[0], parts.slice(1).join(' '));
+}
+
+function plainAuthorText(value: string): string {
+  return value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLocaleLowerCase().replace(/[^a-z0-9, ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeAuthorName(value: string): string {
+  const plain = plainAuthorText(value);
+  if (!plain.includes(',')) return plain;
+  const [last, first] = plain.split(',', 2).map((part) => part.trim());
+  return `${first} ${last}`.trim();
+}

--- a/src/components/SourceCitationModal.tsx
+++ b/src/components/SourceCitationModal.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@shared/types';
 import type { LibraryItemRecord, LibraryScope } from '@shared/libraryTypes';
 import { Badge, EDGE_LABELS, Icon, NODE_LABELS } from './ui';
+import { buildAuthorIndex, lookupAuthor } from '../authorLinks';
 import { t, tx } from '../i18n';
 
 export type CitationTarget =
@@ -195,13 +196,13 @@ function CitationWorkspace({
   };
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 p-3 backdrop-blur-[2px] sm:p-6" onClick={onClose}>
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 p-2 backdrop-blur-[2px] sm:p-4" onClick={onClose}>
       <div
         role="dialog"
         aria-modal="true"
         aria-label={t('Fuentes y contexto')}
         data-testid="source-citation-modal"
-        className="flex h-[min(90vh,760px)] max-h-[90vh] min-h-0 w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-neutral-700/80 bg-neutral-950 shadow-2xl shadow-black/60"
+        className="flex h-[min(94vh,1100px)] max-h-[94vh] min-h-0 w-full max-w-[92rem] flex-col overflow-hidden rounded-2xl border border-neutral-700/80 bg-neutral-950 shadow-2xl shadow-black/60"
         onClick={(event) => event.stopPropagation()}
       >
         <header className="flex min-h-14 shrink-0 items-center gap-3 border-b border-neutral-800 bg-neutral-950/95 px-4 sm:px-5">
@@ -283,7 +284,7 @@ function CitationTabPane({
   const reportTitle = useCallback((title: string) => onTitle(tab.key, title), [onTitle, tab.key]);
   return (
     <div className={`${active ? 'min-h-0 flex-1 overflow-y-auto overscroll-contain' : 'hidden'}`} role="tabpanel" data-testid={`source-citation-panel-${tab.key}`}>
-      <div className="mx-auto max-w-4xl p-4 sm:p-6">
+      <div className="mx-auto max-w-6xl p-4 sm:p-6">
         <CitationPanel target={tab.target} authors={authors} onOpenTarget={onOpenTarget} onTitle={reportTitle} onOpenLibraryWork={onOpenLibraryWork} />
       </div>
     </div>
@@ -595,22 +596,11 @@ function useLocalWork(workId: string): { id: string; scope: LibraryScope } | nul
 }
 
 function AuthorLinks({ names, authors, onOpenTarget }: { names: string[]; authors: AuthorSummary[]; onOpenTarget: CitationPanelProps['onOpenTarget'] }) {
-  const index = useMemo(() => {
-    const map = new Map<string, AuthorSummary>();
-    for (const author of authors) { map.set(normalizeAuthorName(author.name), author); map.set(normalizeAuthorName(author.fullName), author); }
-    return map;
-  }, [authors]);
+  const index = useMemo(() => buildAuthorIndex(authors), [authors]);
   return <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-neutral-400">{names.map((name, indexInList) => {
-    const author = index.get(normalizeAuthorName(name));
-    return <span key={`${name}:${indexInList}`} className="inline-flex items-center gap-1.5">{indexInList > 0 && <span className="text-neutral-700">·</span>}{author ? <button className="rounded px-1 py-0.5 text-neutral-400 hover:bg-violet-500/10 hover:text-violet-200" onClick={() => onOpenTarget({ kind: 'author', id: author.author_id }, author.fullName || author.name)}>{name}</button> : <span>{name}</span>}</span>;
+    const author = lookupAuthor(index, name);
+    return <span key={`${name}:${indexInList}`} className="inline-flex items-center gap-1.5">{indexInList > 0 && <span className="text-neutral-700">·</span>}{author ? <button className="rounded px-1 py-0.5 text-neutral-400 hover:bg-violet-500/10 hover:text-violet-200" title={t('Abrir en una pestaña nueva')} onClick={() => onOpenTarget({ kind: 'author', id: author.author_id }, author.fullName || author.name)}>{name}</button> : <span>{name}</span>}</span>;
   })}</div>;
-}
-
-function normalizeAuthorName(value: string): string {
-  const plain = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLocaleLowerCase().replace(/[^a-z0-9, ]/g, ' ').replace(/\s+/g, ' ').trim();
-  if (!plain.includes(',')) return plain;
-  const [last, first] = plain.split(',', 2).map((part) => part.trim());
-  return `${first} ${last}`.trim();
 }
 
 function Subheading({ children }: { children: React.ReactNode }) { return <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">{children}</h4>; }

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -124,6 +124,9 @@ const ICON_PATHS: Record<string, string> = {
   bookmarkFill: '<path fill="currentColor" stroke="none" d="M6 2.25h12A1.75 1.75 0 0 1 19.75 4v18.3L12 17.87 4.25 22.3V4A1.75 1.75 0 0 1 6 2.25Z"/>',
   cursor: '<path d="M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z"/>',
   fit: '<path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/>',
+  // Corners pushed out (enter full screen) and pulled back in (leave it).
+  maximize: '<path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/>',
+  minimize: '<path d="M8 3v3a2 2 0 0 1-2 2H3"/><path d="M21 8h-3a2 2 0 0 1-2-2V3"/><path d="M3 16h3a2 2 0 0 1 2 2v3"/><path d="M16 21v-3a2 2 0 0 1 2-2h3"/>',
   plus: '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>',
   minus: '<line x1="5" y1="12" x2="19" y2="12"/>',
   search: '<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>',

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -2858,6 +2858,8 @@ export const DE: Record<string, string> = {
   'Quitar de la cola': 'Aus der Warteschlange entfernen',
   'Falló': 'Fehlgeschlagen',
   'Abrir a pantalla completa': 'Im Vollbild öffnen',
+  'Lectura a pantalla completa': 'Vollbildlesen',
+  'Salir de pantalla completa': 'Vollbild verlassen',
   'Leer': 'Lesen',
   'Reutilizar la idea para un informe nuevo': 'Idee für einen neuen Bericht wiederverwenden',
   'Volver a la galería': 'Zurück zur Galerie',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -2926,6 +2926,8 @@ export const EN: Record<string, string> = {
   'Quitar de la cola': 'Remove from queue',
   'Falló': 'Failed',
   'Abrir a pantalla completa': 'Open full-screen',
+  'Lectura a pantalla completa': 'Full-screen reading',
+  'Salir de pantalla completa': 'Leave full screen',
   'Leer': 'Read',
   'Reutilizar la idea para un informe nuevo': 'Reuse the idea for a new report',
   'Volver a la galería': 'Back to gallery',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -2855,6 +2855,8 @@ export const FR: Record<string, string> = {
   'Quitar de la cola': 'Retirer de la file',
   'Falló': 'Échoué',
   'Abrir a pantalla completa': 'Ouvrir en plein écran',
+  'Lectura a pantalla completa': 'Lecture en plein écran',
+  'Salir de pantalla completa': 'Quitter le plein écran',
   'Leer': 'Lire',
   'Reutilizar la idea para un informe nuevo': 'Réutiliser l\'idée pour un nouveau rapport',
   'Volver a la galería': 'Retour à la galerie',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -2568,6 +2568,8 @@ export const IT: Record<string, string> = {
   "Quitar de la cola": "Rimuovi dalla coda",
   "Falló": "Fallito",
   "Abrir a pantalla completa": "Apri a schermo intero",
+  "Lectura a pantalla completa": "Lettura a schermo intero",
+  "Salir de pantalla completa": "Esci dallo schermo intero",
   "Leer": "Leggi",
   "Reutilizar la idea para un informe nuevo": "Riutilizzare l'idea per un nuovo report",
   "Volver a la galería": "Torna alla galleria",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -2838,6 +2838,8 @@ export const PT_BR: Record<string, string> = {
   'Quitar de la cola': 'Remover da fila',
   'Falló': 'Falhou',
   'Abrir a pantalla completa': 'Abrir em tela cheia',
+  'Lectura a pantalla completa': 'Leitura em tela cheia',
+  'Salir de pantalla completa': 'Sair da tela cheia',
   'Leer': 'Ler',
   'Reutilizar la idea para un informe nuevo': 'Reaproveitar a ideia para um novo relatório',
   'Volver a la galería': 'Voltar à galeria',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -2833,6 +2833,8 @@ export const PT: Record<string, string> = {
   'Quitar de la cola': 'Remover da fila',
   'Falló': 'Falhou',
   'Abrir a pantalla completa': 'Abrir em ecrã inteiro',
+  'Lectura a pantalla completa': 'Leitura em ecrã inteiro',
+  'Salir de pantalla completa': 'Sair do ecrã inteiro',
   'Leer': 'Ler',
   'Reutilizar la idea para un informe nuevo': 'Reutilizar a ideia para um novo relatório',
   'Volver a la galería': 'Voltar à galeria',

--- a/src/i18n.sourceCitation.ts
+++ b/src/i18n.sourceCitation.ts
@@ -27,6 +27,7 @@ export const SOURCE_CITATION_TRANSLATIONS = {
     'No hay fragmentos de evidencia anclados.': 'There are no anchored evidence excerpts.',
     'Abrir en la biblioteca local': 'Open in local library',
     'Biblioteca local': 'Local library',
+    'Abrir en una pestaña nueva': 'Open in a new tab',
   },
   fr: {
     'Fuentes y contexto': 'Sources et contexte',
@@ -52,6 +53,7 @@ export const SOURCE_CITATION_TRANSLATIONS = {
     'No hay fragmentos de evidencia anclados.': 'Aucun extrait de preuve ancré.',
     'Abrir en la biblioteca local': 'Ouvrir dans la bibliothèque locale',
     'Biblioteca local': 'Bibliothèque locale',
+    'Abrir en una pestaña nueva': 'Ouvrir dans un nouvel onglet',
   },
   de: {
     'Fuentes y contexto': 'Quellen und Kontext',
@@ -77,6 +79,7 @@ export const SOURCE_CITATION_TRANSLATIONS = {
     'No hay fragmentos de evidencia anclados.': 'Es sind keine verankerten Belegauszüge vorhanden.',
     'Abrir en la biblioteca local': 'In der lokalen Bibliothek öffnen',
     'Biblioteca local': 'Lokale Bibliothek',
+    'Abrir en una pestaña nueva': 'In neuem Tab öffnen',
   },
   pt: {
     'Fuentes y contexto': 'Fontes e contexto',
@@ -102,6 +105,7 @@ export const SOURCE_CITATION_TRANSLATIONS = {
     'No hay fragmentos de evidencia anclados.': 'Não existem excertos de evidência ancorados.',
     'Abrir en la biblioteca local': 'Abrir na biblioteca local',
     'Biblioteca local': 'Biblioteca local',
+    'Abrir en una pestaña nueva': 'Abrir num separador novo',
   },
   'pt-BR': {
     'Fuentes y contexto': 'Fontes e contexto',
@@ -127,6 +131,7 @@ export const SOURCE_CITATION_TRANSLATIONS = {
     'No hay fragmentos de evidencia anclados.': 'Não há trechos de evidências ancorados.',
     'Abrir en la biblioteca local': 'Abrir na biblioteca local',
     'Biblioteca local': 'Biblioteca local',
+    'Abrir en una pestaña nueva': 'Abrir em uma nova aba',
   },
   it: {
     'Fuentes y contexto': 'Fonti e contesto',
@@ -152,6 +157,7 @@ export const SOURCE_CITATION_TRANSLATIONS = {
     'No hay fragmentos de evidencia anclados.': 'Non sono presenti estratti di prova ancorati.',
     'Abrir en la biblioteca local': 'Apri nella biblioteca locale',
     'Biblioteca local': 'Biblioteca locale',
+    'Abrir en una pestaña nueva': 'Apri in una nuova scheda',
   },
   tr: {
     'Fuentes y contexto': 'Kaynaklar ve bağlam',
@@ -177,5 +183,6 @@ export const SOURCE_CITATION_TRANSLATIONS = {
     'No hay fragmentos de evidencia anclados.': 'Bağlantılı kanıt alıntısı yok.',
     'Abrir en la biblioteca local': 'Yerel kitaplıkta aç',
     'Biblioteca local': 'Yerel kitaplık',
+    'Abrir en una pestaña nueva': 'Yeni sekmede aç',
   },
 } satisfies Record<string, Record<string, string>>;

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -2945,6 +2945,8 @@ export const TR: Record<string, string> = {
   "Quitar de la cola": "sıradan kaldır",
   "Falló": "Başarısız",
   "Abrir a pantalla completa": "Tam ekranı aç",
+  "Lectura a pantalla completa": "Tam ekran okuma",
+  "Salir de pantalla completa": "Tam ekrandan çık",
   "Leer": "Oku",
   "Reutilizar la idea para un informe nuevo": "Fikri yeni bir rapor için yeniden kullanın",
   "Volver a la galería": "Galeriye dön",

--- a/src/views/DeepResearchView.tsx
+++ b/src/views/DeepResearchView.tsx
@@ -343,6 +343,7 @@ export function DeepResearchView({
   // Reader + shared modals.
   const [openDraft, setOpenDraft] = useState<WritingWorkshopSavedDraft | null>(null);
   const [showMatrix, setShowMatrix] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
   const [citation, setCitation] = useState<CitationTarget>(null);
   const [savingToNotes, setSavingToNotes] = useState(false);
   const [translationOpen, setTranslationOpen] = useState(false);
@@ -532,6 +533,7 @@ export function DeepResearchView({
 
   const backToGallery = () => {
     setMode('gallery');
+    setFullscreen(false);
     setOpenDraft(null);
     restoredReading.current = null;
     report.current?.({ reading: null });
@@ -789,6 +791,25 @@ export function DeepResearchView({
     void window.nodus.clearFinishedDeepResearchJobs();
   };
 
+  /**
+   * Escape leaves full-screen reading — but only when it is the outermost thing on
+   * screen. A citation workspace, a translation dialog or the find panel each close
+   * on Escape too, and taking the reader out from under them would answer one key
+   * press twice.
+   */
+  useEffect(() => {
+    if (!fullscreen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      if (citation || translationOpen || savingToNotes) return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"], [data-testid="find-in-page"]')) return;
+      event.preventDefault();
+      setFullscreen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [citation, fullscreen, savingToNotes, translationOpen]);
+
   // A report that was left open is the section's first frame, never its second. The
   // gallery below is a screen full of cards; painting it for the frames the read of
   // the report takes is what makes returning to the section look like the app opening
@@ -799,30 +820,37 @@ export function DeepResearchView({
   if (mode === 'reader' && openDraft) {
     return (
       <>
-        <ReaderView
-          saved={openDraft}
-          settings={settings}
-          initialReading={restoredReading.current}
-          onReadingChange={(place) => report.current?.({ reading: place })}
-          showMatrix={showMatrix}
-          exporting={exporting}
-          message={message}
-          error={error}
-          appliedTranslation={appliedTranslation}
-          onToggleMatrix={() => setShowMatrix((v) => !v)}
-          onBack={backToGallery}
-          onCopy={() => void copyDraft()}
-          onCopyReading={() => void copyForListening()}
-          onSaveToNotes={() => setSavingToNotes(true)}
-          onToggleRead={() => void toggleRead(openDraft)}
-          onTranslate={() => setTranslationOpen(true)}
-          onExport={(format) => void exportDraft(format)}
-          onCitation={setCitation}
-          onImageChange={onImageChange}
-          onOpenStudyDocument={onOpenStudyDocument}
-          onOpenStudyMaterial={onOpenStudyMaterial}
-          onOpenStudyRecording={onOpenStudyRecording}
-        />
+        {/* Full screen is the same reader lifted out of the shell: a fixed layer over
+            the window, so the report and its own toolbar are all that is left on
+            screen. `display: contents` keeps the normal case exactly as it was. */}
+        <div className={fullscreen ? 'fixed inset-0 z-40 flex flex-col bg-neutral-950' : 'contents'} data-testid="deep-research-reader-shell" data-fullscreen={fullscreen ? 'on' : 'off'}>
+          <ReaderView
+            saved={openDraft}
+            settings={settings}
+            initialReading={restoredReading.current}
+            onReadingChange={(place) => report.current?.({ reading: place })}
+            showMatrix={showMatrix}
+            fullscreen={fullscreen}
+            exporting={exporting}
+            message={message}
+            error={error}
+            appliedTranslation={appliedTranslation}
+            onToggleMatrix={() => setShowMatrix((v) => !v)}
+            onToggleFullscreen={() => setFullscreen((v) => !v)}
+            onBack={backToGallery}
+            onCopy={() => void copyDraft()}
+            onCopyReading={() => void copyForListening()}
+            onSaveToNotes={() => setSavingToNotes(true)}
+            onToggleRead={() => void toggleRead(openDraft)}
+            onTranslate={() => setTranslationOpen(true)}
+            onExport={(format) => void exportDraft(format)}
+            onCitation={setCitation}
+            onImageChange={onImageChange}
+            onOpenStudyDocument={onOpenStudyDocument}
+            onOpenStudyMaterial={onOpenStudyMaterial}
+            onOpenStudyRecording={onOpenStudyRecording}
+          />
+        </div>
         {translationOpen && (
           <TranslationModal
             entityKind="deep_research"
@@ -1540,9 +1568,10 @@ function useReportOutline({
   scrollerRef: RefObject<HTMLElement | null>;
   documentRef: RefObject<HTMLDivElement | null>;
   revision: unknown;
-}): { headings: ReportOutlineHeading[]; activeIndex: number } {
+}): { headings: ReportOutlineHeading[]; activeIndex: number; progress: number } {
   const [headings, setHeadings] = useState<ReportOutlineHeading[]>([]);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [progress, setProgress] = useState(0);
 
   useEffect(() => {
     const scroller = scrollerRef.current;
@@ -1551,6 +1580,7 @@ function useReportOutline({
     if (!scroller || !root || !prose) {
       setHeadings([]);
       setActiveIndex(0);
+      setProgress(0);
       return;
     }
 
@@ -1559,6 +1589,12 @@ function useReportOutline({
 
     const locate = () => {
       frame = null;
+      // How far down the report the reader has actually come. Counting sections
+      // instead would sit still for pages at a time and then jump a fifth of the
+      // way at a heading, which reads as a broken bar rather than a coarse one.
+      const scrollable = scroller.scrollHeight - scroller.clientHeight;
+      const read = scrollable > 1 ? Math.min(100, Math.max(0, Math.round((scroller.scrollTop / scrollable) * 100))) : 100;
+      setProgress((current) => current === read ? current : read);
       if (nodes.length === 0) {
         setActiveIndex(0);
         return;
@@ -1603,8 +1639,12 @@ function useReportOutline({
     scan();
     const mutations = new MutationObserver(scan);
     mutations.observe(prose, { childList: true, subtree: true, characterData: true });
+    // Both boxes matter: the report grows as images land, and the window (or the
+    // support-matrix panel) changes how much of it fits on screen. Either one moves
+    // how much is left to read.
     const resize = new ResizeObserver(scheduleLocate);
     resize.observe(root);
+    resize.observe(scroller);
     scroller.addEventListener('scroll', scheduleLocate, { passive: true });
     return () => {
       mutations.disconnect();
@@ -1614,17 +1654,20 @@ function useReportOutline({
     };
   }, [documentRef, revision, scrollerRef]);
 
-  return { headings, activeIndex };
+  return { headings, activeIndex, progress };
 }
 
 function ReportOutlineRail({
   headings,
   activeIndex,
+  progress,
   deferUntilWide = false,
   onSelect,
 }: {
   headings: ReportOutlineHeading[];
   activeIndex: number;
+  /** Share of the report already scrolled past, 0–100. */
+  progress: number;
   deferUntilWide?: boolean;
   onSelect: (heading: ReportOutlineHeading) => void;
 }) {
@@ -1634,7 +1677,6 @@ function ReportOutlineRail({
   }, [activeIndex]);
   if (headings.length < 2) return null;
 
-  const progress = Math.round(((activeIndex + 1) / headings.length) * 100);
   return (
     <aside
       data-testid="deep-research-outline-rail"
@@ -1643,7 +1685,7 @@ function ReportOutlineRail({
     >
       <div className="mb-4 flex items-center justify-between gap-3 px-1">
         <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-neutral-500">{t('Contenido')}</span>
-        <span className="text-[10px] font-medium tabular-nums text-indigo-300">{progress}%</span>
+        <span data-testid="deep-research-reading-progress" className="text-[10px] font-medium tabular-nums text-indigo-300">{progress}%</span>
       </div>
       <div className="mb-4 h-1 overflow-hidden rounded-full bg-neutral-800" aria-hidden="true">
         <div className="h-full rounded-full bg-indigo-500 transition-[width] duration-200" style={{ width: `${progress}%` }} />
@@ -1789,11 +1831,13 @@ function ReaderView({
   initialReading,
   onReadingChange,
   showMatrix,
+  fullscreen,
   exporting,
   message,
   error,
   appliedTranslation,
   onToggleMatrix,
+  onToggleFullscreen,
   onBack,
   onCopy,
   onCopyReading,
@@ -1813,11 +1857,14 @@ function ReaderView({
   initialReading: ReadingPlace | null;
   onReadingChange: (place: ReadingPlace | null) => void;
   showMatrix: boolean;
+  /** Reading with the app shell out of the way; only the report's own tools remain. */
+  fullscreen: boolean;
   exporting: boolean;
   message: string | null;
   error: string | null;
   appliedTranslation: ContentTranslation | null;
   onToggleMatrix: () => void;
+  onToggleFullscreen: () => void;
   onBack: () => void;
   onCopy: () => void;
   onCopyReading: () => void;
@@ -1840,7 +1887,7 @@ function ReaderView({
   const [highlighterColor, setHighlighterColor] = useState<WritingDraftAnnotationColor | null>(null);
   const [annotationError, setAnnotationError] = useState<string | null>(null);
   const annotationScope = appliedTranslation ? `translation:${appliedTranslation.id}` : 'source';
-  const { headings, activeIndex } = useReportOutline({
+  const { headings, activeIndex, progress } = useReportOutline({
     scrollerRef: mainRef,
     documentRef,
     revision: appliedTranslation?.id ?? saved.id,
@@ -1967,6 +2014,17 @@ function ReaderView({
           showLabel={showMatrix}
           className={`btn-ghost h-9 min-h-9 border ${showMatrix ? 'border-indigo-700/60 text-indigo-200' : 'border-neutral-700'}`}
         />
+        {/* Clicked with the mouse, the button hands focus back: a focused toolbar
+            button keeps its label open, and a label that wide re-wraps the row under
+            whatever the reader reaches for next. Keyboard activation (detail 0) keeps
+            its focus, which is the whole point of having it there. */}
+        <HoverLabelButton
+          icon={fullscreen ? 'minimize' : 'maximize'}
+          label={fullscreen ? t('Salir de pantalla completa') : t('Lectura a pantalla completa')}
+          onClick={(event) => { if (event.detail > 0) event.currentTarget.blur(); onToggleFullscreen(); }}
+          data-testid="deep-research-fullscreen-toggle"
+          className={`btn-ghost h-9 min-h-9 border ${fullscreen ? 'border-indigo-700/60 text-indigo-200' : 'border-neutral-700'}`}
+        />
       </header>
 
       {(message || error || annotationError) && (
@@ -1976,9 +2034,9 @@ function ReaderView({
       )}
 
       <div className="min-h-0 flex-1 flex">
-        <ReportOutlineRail headings={headings} activeIndex={activeIndex} deferUntilWide={showMatrix} onSelect={goToHeading} />
-        <main ref={mainRef} className="min-w-0 flex-1 overflow-y-auto px-6 py-6 max-md:px-4">
-          <div className="mx-auto max-w-3xl space-y-6">
+        <ReportOutlineRail headings={headings} activeIndex={activeIndex} progress={progress} deferUntilWide={showMatrix} onSelect={goToHeading} />
+        <main ref={mainRef} className={`min-w-0 flex-1 overflow-y-auto py-6 max-md:px-4 ${fullscreen ? 'px-10 max-lg:px-6' : 'px-6'}`}>
+          <div className={`mx-auto space-y-6 ${fullscreen ? 'max-w-6xl' : 'max-w-5xl'}`}>
             <DecorativeImageCard
               entityKind="deep_research"
               entityId={saved.id}
@@ -2001,6 +2059,7 @@ function ReaderView({
                 draftSaved
                 hideActions
                 justify
+                wide
                 onCopy={onCopy}
                 onSaveToNotes={onSaveToNotes}
                 onExport={onExport}

--- a/src/views/writingShared.tsx
+++ b/src/views/writingShared.tsx
@@ -123,6 +123,7 @@ export function DraftResultMain({
   draftSaved = false,
   hideActions = false,
   justify = false,
+  wide = false,
   onCopy,
   onSaveDraft,
   onSaveToNotes,
@@ -141,6 +142,8 @@ export function DraftResultMain({
   hideActions?: boolean;
   /** Justify the rendered report body. */
   justify?: boolean;
+  /** Let the report use the full reading column instead of the workshop's measure. */
+  wide?: boolean;
   onCopy: () => void;
   onSaveDraft?: () => void;
   onSaveToNotes: () => void;
@@ -151,7 +154,7 @@ export function DraftResultMain({
   onStudyRecording?: (id: string, timestamp?: number | null) => void;
 }) {
   return (
-    <div className="max-w-4xl mx-auto space-y-5">
+    <div className={`mx-auto space-y-5 ${wide ? 'max-w-none' : 'max-w-4xl'}`}>
       <div className="space-y-3">
         <div className="min-w-0">
           <h2 className="text-xl font-semibold break-words">{draft.title}</h2>


### PR DESCRIPTION
Reading a Deep Research report happened in a narrow column inside the app shell, and the outline rail's percentage counted sections rather than reading.

## Full-screen reading

A new toggle in the reader toolbar lifts the report out of the shell as a fixed layer over the window: the report and its own tools, nothing else. The toggle or `Escape` brings the shell back. Escape stands down while a citation workspace, a translation dialog, the save-to-notes dialog or the find panel is open, so a single key press is never answered twice.

Clicked with the mouse, the toggle hands focus back. A focused toolbar button keeps its label open, and a label that wide re-wraps the row under whatever the reader reaches for next — which swallowed the following click. Keyboard activation keeps its focus.

## A wider report column

The report used the writing workshop's measure (`max-w-4xl`) inside a `max-w-3xl` column. It now takes the room the reader has — `max-w-5xl`, and `max-w-6xl` in full screen. `DraftResultMain` takes a `wide` prop so the workshop is untouched.

## Reading progress that follows the scroll

The rail showed `(activeIndex + 1) / headings.length`: with five sections it could only ever read 20, 40, 60, 80 or 100%. It now comes from the scroller's position, computed in the `requestAnimationFrame` pass that already tracked the active section, and it is recomputed when the window or the support-matrix panel changes how much fits on screen. A report that fits on one screen reads 100%.

## Sources workspace

The modal opens larger (`max-w-[92rem]`, 94vh), and an abbreviated byline in a work's linked-works list now links to the author. `Alburquerque García, L.` never matched the record that spells out `Luis Alburquerque García`, so those names were dead text; they now match on surname plus initial. Two people behind one abbreviation stay plain text rather than send the reader to the wrong person. The matching moved to `src/authorLinks.ts`.

## Verification

- `npm test` — 2119 passing, including the new `scripts/test-author-links.mjs`.
- `scripts/e2e-deep-research-annotations.mjs` — extended with the full-screen round trip (fixed layer covering the window, wider column, Escape) and with reading progress advancing inside a single section.
- `scripts/e2e-source-citation-modal.mjs`, `npm run build`, `npm run lint`, typecheck.
- Checked in the real app against an isolated copy of a live vault, in dark and light themes.

No version was opened and no What's New highlights were added — say the word if this should ship as a release.
