### PR TITLE
Fit inner page heroes so the first section is visible without scrolling

### DIFF
--- a/site/about/index.html
+++ b/site/about/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/site/ai-research/index.html
+++ b/site/ai-research/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <link rel="stylesheet" href="../assets/css/app.css?v=20260818"/>
 <script type="application/ld+json">
 {

--- a/site/apps/index.html
+++ b/site/apps/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/site/assets/css/guide.css
+++ b/site/assets/css/guide.css
@@ -10,7 +10,7 @@ those pages need that the home page does not already define.
 /* ============================================================ breadcrumb */
 .breadcrumb {
   display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
-  margin-bottom: 22px;
+  margin-bottom: clamp(12px, 2vh, 22px);
   font-size: 13px; color: var(--ink-3);
 }
 .breadcrumb a { color: var(--ink-3); }
@@ -20,19 +20,19 @@ those pages need that the home page does not already define.
 
 /* ============================================================ hero extras */
 .guide-hero .display { max-width: 18ch; }
-.guide-actions { display: flex; flex-wrap: wrap; gap: 13px; margin-top: 34px; }
+.guide-actions { display: flex; flex-wrap: wrap; gap: 13px; margin-top: clamp(18px, 3vh, 34px); }
 
 /* the anchor row under the hero: a plain, wrapping list of the page's sections */
 .guide-jump {
-  display: flex; flex-wrap: wrap; gap: 9px;
-  margin-top: 34px; padding-top: 26px;
+  display: flex; flex-wrap: wrap; gap: 7px;
+  margin-top: clamp(16px, 2.8vh, 34px); padding-top: clamp(13px, 2.2vh, 26px);
   border-top: 1px solid var(--membrane);
 }
 .guide-jump a {
   display: inline-flex; align-items: center; gap: 8px;
-  padding: 8px 15px; border-radius: 999px;
+  padding: clamp(6px, 1vh, 8px) 12px; border-radius: 999px;
   border: 1px solid var(--membrane); background: var(--skin);
-  font-size: 13px; font-weight: 600; color: var(--ink-2);
+  font-size: 12.5px; font-weight: 600; color: var(--ink-2);
   transition: color 0.25s var(--ease), border-color 0.25s var(--ease), background 0.25s var(--ease);
 }
 .guide-jump a:hover { color: var(--ink); border-color: rgba(167, 139, 250, 0.5); background: var(--skin-2); }
@@ -49,11 +49,11 @@ those pages need that the home page does not already define.
 
 .guide-note {
   max-width: 820px;
-  margin-top: 34px; padding: 20px 24px;
+  margin-top: clamp(16px, 2.8vh, 34px); padding: clamp(14px, 2.2vh, 20px) 24px;
   border-radius: var(--r-m); border: 1px solid var(--membrane);
   border-left: 2px solid var(--accent);
   background: rgba(255, 255, 255, 0.022);
-  font-size: 14.5px; line-height: 1.65; color: var(--ink-2);
+  font-size: 14.5px; line-height: 1.58; color: var(--ink-2);
 }
 .guide-note b, .guide-note strong { color: var(--ink); font-weight: 620; }
 .guide-note p { margin: 0; }

--- a/site/assets/css/nodus.css
+++ b/site/assets/css/nodus.css
@@ -418,6 +418,9 @@ body.cursor-press .cursor { width: 26px; height: 26px; margin: -13px 0 0 -13px; 
 .wrap-narrow { width: min(100% - calc(var(--gut) * 2), 820px); margin-inline: auto; }
 
 section { padding: clamp(72px, 11vw, 148px) 0; }
+/* The section that follows an inner-page hero sits closer to it, so its heading
+   is already on screen when the page loads. */
+.page-hero + section { padding-top: clamp(54px, 9vh, 132px); }
 .section-line { border-top: 1px solid var(--membrane); }
 
 .kicker {
@@ -602,11 +605,14 @@ footer.site-foot {
 }
 
 /* ============================================================ page hero (inner pages) */
+/* The hero keeps its own proportions but is measured against the height of the
+   window as well as its width, so the first section under it always breaks the
+   fold instead of being pushed out of sight on a short screen. */
 .page-hero {
-  padding: calc(var(--nav-h) + clamp(52px, 8vw, 108px)) 0 clamp(38px, 5vw, 66px);
+  padding: calc(var(--nav-h) + clamp(30px, 6vh, 86px)) 0 clamp(22px, 3.6vh, 48px);
 }
-.page-hero .display { font-size: clamp(38px, 5.6vw, 68px); }
-.page-hero .lead { margin-top: 24px; font-size: clamp(16.5px, 1.4vw, 19px); }
+.page-hero .display { font-size: clamp(34px, 3.4vw + 1.1vh, 62px); }
+.page-hero .lead { margin-top: clamp(14px, 2.2vh, 24px); font-size: clamp(16.5px, 1.4vw, 19px); line-height: 1.55; }
 
 /* ============================================================ prose */
 .prose { font-size: 16.5px; line-height: 1.75; color: var(--ink-prose); }

--- a/site/blog/how-nodus-can-support-research-in-the-humanities/index.html
+++ b/site/blog/how-nodus-can-support-research-in-the-humanities/index.html
@@ -30,7 +30,7 @@ Generated from posts/how-nodus-can-support-research-in-the-humanities.md by scri
 <link rel="alternate" type="application/rss+xml" title="Nodus Blog" href="feed.xml"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="blog.css?v=20260817"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"How Nodus can support research in the humanities","description":"Humanities projects rarely fit one tool: books, archival documents, photographs, interviews and datasets all belong to the same argument. Nodus keeps them in one local-first workspace, with every finding still attached to its source.","datePublished":"2026-08-17","dateModified":"2026-08-17","mainEntityOfPage":"https://nodusresearch.com/blog/how-nodus-can-support-research-in-the-humanities/","image":"https://nodusresearch.com/blog/media/nodus-in-humanities.webp","author":{"@type":"Person","name":"Jorge Pérez Burgueño","sameAs":"https://orcid.org/0000-0002-1150-1930"},"publisher":{"@type":"Person","name":"Jorge Pérez Burgueño","sameAs":"https://orcid.org/0000-0002-1150-1930"}}</script>
 </head>

--- a/site/blog/how-to-organize-a-large-academic-research-library/index.html
+++ b/site/blog/how-to-organize-a-large-academic-research-library/index.html
@@ -30,7 +30,7 @@ Generated from posts/how-to-organize-a-large-academic-research-library.md by scr
 <link rel="alternate" type="application/rss+xml" title="Nodus Blog" href="feed.xml"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="blog.css?v=20260817"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"How to Organize a Large Academic Research Library","description":"Once a project grows to hundreds of sources, the hard part is no longer storage but context: knowing why a source was collected and how it connects to your ideas.","datePublished":"2026-08-16","dateModified":"2026-08-16","mainEntityOfPage":"https://nodusresearch.com/blog/how-to-organize-a-large-academic-research-library/","image":"https://nodusresearch.com/blog/media/organize-large-library.webp","author":{"@type":"Person","name":"Jorge Pérez Burgueño","sameAs":"https://orcid.org/0000-0002-1150-1930"},"publisher":{"@type":"Person","name":"Jorge Pérez Burgueño","sameAs":"https://orcid.org/0000-0002-1150-1930"}}</script>
 </head>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="alternate" type="application/rss+xml" title="Nodus Blog" href="feed.xml"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="blog.css?v=20260820"/>
 </head>
 <body>

--- a/site/blog/nodus-open-source-research-workspace/index.html
+++ b/site/blog/nodus-open-source-research-workspace/index.html
@@ -30,7 +30,7 @@ Generated from posts/nodus-open-source-research-workspace.md by scripts/build-bl
 <link rel="alternate" type="application/rss+xml" title="Nodus Blog" href="feed.xml"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="blog.css?v=20260817"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Nodus: an open source research workspace for academic work","description":"Research is spread across reference managers, PDF folders, note apps and chatbots. Nodus keeps sources, ideas and the evidence behind them in one local-first workspace.","datePublished":"2026-08-16","dateModified":"2026-08-16","mainEntityOfPage":"https://nodusresearch.com/blog/nodus-open-source-research-workspace/","image":"https://nodusresearch.com/blog/media/nodus-promo.webp","author":{"@type":"Person","name":"Jorge Pérez Burgueño","sameAs":"https://orcid.org/0000-0002-1150-1930"},"publisher":{"@type":"Person","name":"Jorge Pérez Burgueño","sameAs":"https://orcid.org/0000-0002-1150-1930"}}</script>
 </head>

--- a/site/blog/post.html
+++ b/site/blog/post.html
@@ -19,7 +19,7 @@ Compatibility redirect for the former /blog/post.html?p=<slug> URLs.
 <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="blog.css?v=20260817"/>
 <script>
   (function () {

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <link rel="stylesheet" href="../assets/css/cite.css?v=20260822a"/>
 <script type="application/ld+json">
 {

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="contribute.css?v=20260816"/>
 </head>
 <body>

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="faq.css?v=20260815"/>
 </head>
 <body>

--- a/site/index.html
+++ b/site/index.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="assets/css/home.css?v=20260822a"/>
 <script>
   /* Arm the opening sequence before the first paint. Anything that goes wrong

--- a/site/legal/index.html
+++ b/site/legal/index.html
@@ -24,8 +24,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 </head>
 <body>
 

--- a/site/open-source/index.html
+++ b/site/open-source/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818b"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/site/research-atlas/index.html
+++ b/site/research-atlas/index.html
@@ -22,7 +22,7 @@
 <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
 <link rel="stylesheet" href="../assets/css/research-atlas.css?v=20260819"/>
 </head>
 <body>

--- a/site/research/index.html
+++ b/site/research/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
   <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
   <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
+  <link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
   <link rel="stylesheet" href="wiki.css?v=20260820"/>
 </head>
 <body class="wiki-page">

--- a/site/zotero/index.html
+++ b/site/zotero/index.html
@@ -28,8 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   <link rel="apple-touch-icon" href="../apple-touch-icon.png"/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/inter-latin.woff2" crossorigin/>
 <link rel="preload" as="font" type="font/woff2" href="../assets/fonts/fraunces-latin.woff2" crossorigin/>
-<link rel="stylesheet" href="../assets/css/nodus.css?v=20260819a"/>
-<link rel="stylesheet" href="../assets/css/guide.css?v=20260818"/>
+<link rel="stylesheet" href="../assets/css/nodus.css?v=20260823a"/>
+<link rel="stylesheet" href="../assets/css/guide.css?v=20260823a"/>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## What

On inner pages the hero was sized only against viewport width. On a short window (720 px tall and below) that pushed the first content section fully below the fold — noticeable on **About**, **Apps**, **App**, **Research**, **Zotero**, **AI research** and **Open source**, while **Contribute** already fitted.

The hero now scales with viewport height as well as width:

- `.page-hero` top/bottom padding, display size, lead spacing and line height are height-aware.
- Guide-page extras (breadcrumb, actions, note, jump nav) tighten the same way; the jump pills are slightly smaller, so they fold back to a single row.
- The section right after a hero uses a shorter top padding, so its heading is already on screen.

## Measured at 1280×720 (heading of the first section, top offset)

| Page | Before | After |
| --- | --- | --- |
| About / Apps / Cite | 846 | 607 |
| App | 1018 | 706 |
| Research | 1022 | 715 |
| AI research | 953 | 662 |
| Zotero | 924 | 678 |
| Open source | 876 | 634 |
| Contribute (reference) | 738 | 574 |

Every inner page now shows the start of its first section — and its heading — without scrolling.

## Verification

- Browser checks at 1280×640, 1280×720, 1280×900 and 375×812.
- `node --test scripts/test-site-*.mjs` — 62 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)