### PR TITLE
Drop Apps from the shared site header

### DIFF
--- a/site/about/index.html
+++ b/site/about/index.html
@@ -112,7 +112,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="about"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/ai-research/index.html
+++ b/site/ai-research/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="ai-research"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -87,7 +87,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="app"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/apps/index.html
+++ b/site/apps/index.html
@@ -92,8 +92,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <a class="skip-link" href="#main">Skip to content</a>
 <canvas id="organism" aria-hidden="true"></canvas>
 
-<div data-nodus-site-header data-base="../" data-page="apps"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<div data-nodus-site-header data-base="../"></div>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/blog/how-nodus-can-support-research-in-the-humanities/index.html
+++ b/site/blog/how-nodus-can-support-research-in-the-humanities/index.html
@@ -41,7 +41,7 @@ Generated from posts/how-nodus-can-support-research-in-the-humanities.md by scri
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">

--- a/site/blog/how-to-organize-a-large-academic-research-library/index.html
+++ b/site/blog/how-to-organize-a-large-academic-research-library/index.html
@@ -41,7 +41,7 @@ Generated from posts/how-to-organize-a-large-academic-research-library.md by scr
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -30,7 +30,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#22d3ee" data-energy="0.28">
   <header class="page-hero">

--- a/site/blog/nodus-open-source-research-workspace/index.html
+++ b/site/blog/nodus-open-source-research-workspace/index.html
@@ -41,7 +41,7 @@ Generated from posts/nodus-open-source-research-workspace.md by scripts/build-bl
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.22">
   <article class="post-page">

--- a/site/blog/post.html
+++ b/site/blog/post.html
@@ -32,7 +32,7 @@ Compatibility redirect for the former /blog/post.html?p=<slug> URLs.
 <a class="skip-link" href="#main">Skip to the message</a>
 <canvas id="organism" aria-hidden="true"></canvas>
 <div data-nodus-site-header data-base="../" data-page="blog"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main" data-accent="#c084fc" data-second="#a78bfa" data-energy="0.18">
   <section class="page-hero">

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -91,7 +91,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="cite"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -29,7 +29,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="contribute"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/demo/databases.html
+++ b/site/demo/databases.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page db">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/genealogy.html
+++ b/site/demo/genealogy.html
@@ -19,7 +19,7 @@
 </head>
 <body class="demo-page gen">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/study.html
+++ b/site/demo/study.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page st">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/demo/teaching.html
+++ b/site/demo/teaching.html
@@ -18,7 +18,7 @@
 </head>
 <body class="demo-page teach">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
   <div class="demo-frame">
     <div class="mac-titlebar"><span class="mac-dots"><i></i><i></i><i></i></span><span class="mac-title">Nodus — Teaching demo</span></div>
     <div class="shell teach">

--- a/site/demo/worldbuilding.html
+++ b/site/demo/worldbuilding.html
@@ -19,7 +19,7 @@
 </head>
 <body class="demo-page worldbuilding">
   <div data-nodus-site-header data-base="../" data-context="demo" data-page="demo"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
   <div class="demo-frame">
     <div class="mac-titlebar">
       <span class="mac-dots"><i></i><i></i><i></i></span>

--- a/site/faq/index.html
+++ b/site/faq/index.html
@@ -29,7 +29,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="faq"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main" data-accent="#22d3ee" data-second="#a78bfa" data-energy="0.26">
   <header class="page-hero">

--- a/site/index.html
+++ b/site/index.html
@@ -110,7 +110,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <div id="scroll-progress" aria-hidden="true"></div>
 
 <div data-nodus-site-header data-base="" data-page="home"></div>
-<script defer src="site-header.js?v=20260822b"></script>
+<script defer src="site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/legal/index.html
+++ b/site/legal/index.html
@@ -33,7 +33,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="about"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/open-source/index.html
+++ b/site/open-source/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="open-source"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/research-atlas/index.html
+++ b/site/research-atlas/index.html
@@ -30,7 +30,7 @@
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="atlas"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main" class="atlas-main" data-accent="#a78bfa" data-second="#22d3ee" data-energy="0.30">
   <div class="atlas-shell">

--- a/site/research/index.html
+++ b/site/research/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="research"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 

--- a/site/site-header.js
+++ b/site/site-header.js
@@ -9,7 +9,7 @@ Hosts opt in with a placeholder element:
   <div data-nodus-site-header data-base="../" data-page="wiki" data-context="wiki"></div>
 
   data-base    path back to site/ from the current page ('' at the root)
-  data-page    home | atlas | apps | wiki | blog | about | contribute | faq | demo — marks the current item
+  data-page    home | atlas | wiki | blog | about | contribute | faq | demo — marks the current item
   data-context 'wiki' adds the docs menu button
 */
 (function () {
@@ -32,7 +32,6 @@ Hosts opt in with a placeholder element:
   const PAGES = [
     { id: 'home', label: 'Home', href: (base) => base || './' },
     { id: 'atlas', label: 'Atlas', href: (base) => `${base}research-atlas/` },
-    { id: 'apps', label: 'Apps', href: (base) => `${base}apps/` },
     // Nodus Browser reveals this prepared slot from its isolated preload. It is
     // hidden everywhere else, so a normal web visitor never sees a local-only
     // destination or a custom-protocol prompt that cannot work in their browser.

--- a/site/wiki/index.html
+++ b/site/wiki/index.html
@@ -42,7 +42,7 @@
     <aside class="toc" aria-label="On this page"><b>On this page</b><nav id="page-toc"></nav></aside>
   </div>
   <script src="../assets/js/organism.js?v=20260820a"></script>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
   <script src="wiki.js?v=20260822a" type="module"></script>
   <script src="../assets/js/back-to-top.js?v=20260817b"></script>
 </body>

--- a/site/zotero/index.html
+++ b/site/zotero/index.html
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <canvas id="organism" aria-hidden="true"></canvas>
 
 <div data-nodus-site-header data-base="../" data-page="zotero"></div>
-<script defer src="../site-header.js?v=20260822b"></script>
+<script defer src="../site-header.js?v=20260823a"></script>
 
 <main id="main">
 


### PR DESCRIPTION
The home page already leads to Nodus Apps from its own **Explore Nodus Apps** section, and the footer of every page keeps the link, so the header no longer carries a separate *Apps* destination.

- Removed the `apps` entry from `PAGES` in `site/site-header.js` and from the `data-page` list in its header comment.
- Dropped the now-meaningless `data-page="apps"` marker on `site/apps/index.html`.
- Bumped the `site-header.js` cache-busting query across the 25 pages that load it.

The `/apps/` page itself is untouched and still reachable from the home page and from every footer.

## Verification

- Rendered header link list in the browser: Home, Atlas, Bookmarks (hidden, Browser-only), Wiki, Blog, About, Contribute, FAQ — no Apps.
- `node --test scripts/test-site-*.mjs` — 62 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)