### PR TITLE
Pin installer filenames so a product rename cannot move a download URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,6 +319,7 @@
       "category": "Office",
       "maintainer": "Drakonis96 <Drakonis96@users.noreply.github.com>"
     },
-    "artifactName": "${productName}-${os}-${arch}.${ext}"
+    "_artifactNameComment": "Literal Nodus-, NOT ${productName}. The installer filenames are a public contract: the site download buttons, the README and every electron-updater manifest resolve https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-<os>-<arch>.<ext>. Renaming productName to \"Nodus Research\" in 4.2.4 silently renamed every artifact through this template, which broke the v4.2.4 upload and would have broken existing installs' auto-update had it published. The displayed product name is free to change; these filenames are not.",
+    "artifactName": "Nodus-${os}-${arch}.${ext}"
   }
 }

--- a/scripts/test-release-artifact-names.mjs
+++ b/scripts/test-release-artifact-names.mjs
@@ -1,0 +1,103 @@
+// The installer filenames are a PUBLIC CONTRACT, and nothing used to hold them.
+//
+// https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-mac-arm64.dmg
+// is what the site's download buttons, the README and every electron-updater
+// manifest resolve. Those URLs outlive any one release: an install from a year
+// ago auto-updates through them.
+//
+// electron-builder derives each filename from `build.artifactName`. That template
+// used to interpolate ${productName}, so renaming the product to "Nodus Research"
+// in 4.2.4 silently renamed every artifact — `Nodus Research-linux-amd64.deb` —
+// and the v4.2.4 release failed at upload on all three platforms. Nothing had
+// connected the template to the names the rest of the project depends on, so the
+// break was invisible until the release ran.
+//
+// This file is that connection. The displayed product name is free to change;
+// these filenames are not.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (relative) => readFileSync(path.join(repoRoot, relative), 'utf8');
+const pkg = JSON.parse(read('package.json'));
+
+/** What electron-builder would name each artifact, from the real template. */
+function artifactName(template, { os, arch, ext }) {
+  return template
+    .replaceAll('${productName}', pkg.build.productName)
+    .replaceAll('${name}', pkg.name)
+    .replaceAll('${version}', pkg.version)
+    .replaceAll('${os}', os)
+    .replaceAll('${arch}', arch)
+    .replaceAll('${ext}', ext);
+}
+
+const PUBLISHED = [
+  { os: 'mac', arch: 'arm64', ext: 'dmg', name: 'Nodus-mac-arm64.dmg' },
+  { os: 'mac', arch: 'arm64', ext: 'zip', name: 'Nodus-mac-arm64.zip' },
+  { os: 'win', arch: 'x64', ext: 'exe', name: 'Nodus-win-x64.exe' },
+  { os: 'linux', arch: 'amd64', ext: 'deb', name: 'Nodus-linux-amd64.deb' },
+  { os: 'linux', arch: 'x86_64', ext: 'AppImage', name: 'Nodus-linux-x86_64.AppImage' },
+];
+
+test('THE REGRESSION: the artifact template does not interpolate the product name', () => {
+  // The whole failure in one line. A display name can be rebranded at any time,
+  // and doing so must not touch a single published URL.
+  assert.doesNotMatch(pkg.build.artifactName, /\$\{productName\}/,
+    'artifactName must not depend on productName: renaming the product would rename every download URL');
+  assert.ok(pkg.build.artifactName.startsWith('Nodus-'),
+    `artifactName must start with the literal "Nodus-", got ${pkg.build.artifactName}`);
+});
+
+test('every artifact electron-builder builds is named exactly what is published', () => {
+  for (const target of PUBLISHED) {
+    assert.equal(artifactName(pkg.build.artifactName, target), target.name);
+  }
+});
+
+test('renaming the product cannot move a single download URL', () => {
+  // Proves the property rather than the current value: pretend the product is
+  // called something else entirely and check the filenames do not budge.
+  const rebranded = { ...pkg, build: { ...pkg.build, productName: 'Something Else Entirely' } };
+  for (const target of PUBLISHED) {
+    const name = rebranded.build.artifactName
+      .replaceAll('${os}', target.os).replaceAll('${arch}', target.arch).replaceAll('${ext}', target.ext);
+    assert.equal(name, target.name);
+  }
+});
+
+test('no artifact filename contains a space', () => {
+  // A space becomes %20 in a download URL and breaks hand-written links and
+  // shell one-liners alike. "Nodus Research-linux-amd64.deb" was exactly this.
+  for (const target of PUBLISHED) {
+    assert.doesNotMatch(artifactName(pkg.build.artifactName, target), /\s/, target.name);
+  }
+});
+
+test('the uploader expects the names the builder produces', () => {
+  const uploader = read('scripts/upload-release-assets.mjs');
+  for (const target of PUBLISHED) {
+    assert.ok(uploader.includes(`'${target.name}'`),
+      `upload-release-assets.mjs must expect ${target.name}`);
+  }
+  // And it selects by the same literal prefix the template is pinned to.
+  assert.match(uploader, /startsWith\('Nodus-'\)/);
+});
+
+test('the release workflow verifies the same names before publishing', () => {
+  const workflow = read('.github/workflows/release-build.yml');
+  for (const name of ['Nodus-mac-arm64.dmg', 'Nodus-win-x64.exe', 'Nodus-linux-amd64.deb', 'Nodus-linux-x86_64.AppImage']) {
+    assert.ok(workflow.includes(name), `the release workflow must verify ${name}`);
+  }
+});
+
+test('the download links the public actually clicks resolve to these names', () => {
+  const base = 'https://github.com/Drakonis96/nodus/releases/latest/download/';
+  const page = read('site/app/index.html');
+  for (const name of ['Nodus-mac-arm64.dmg', 'Nodus-win-x64.exe', 'Nodus-linux-amd64.deb', 'Nodus-linux-x86_64.AppImage']) {
+    assert.ok(page.includes(`${base}${name}`), `site/app/index.html links ${name}`);
+  }
+});


### PR DESCRIPTION
The v4.2.4 release failed to upload on **all three platforms**. The builds
themselves succeeded — the names did not match.

```
• building  target=deb arch=x64 file=release/Nodus Research-linux-amd64.deb
...
Error: Missing linux release asset: Nodus-linux-amd64.deb
```

## Cause

`build.artifactName` was `${productName}-${os}-${arch}.${ext}`, and 6c0c4669
(PR #522) renamed `productName` from `Nodus` to `Nodus Research`. Every artifact
was therefore built as `Nodus Research-*`, while the uploader, the release
workflow's asset verification, the site's download buttons and the README all
resolve `Nodus-*`.

Nothing connected the template to the names the rest of the project depends on,
so the rename looked harmless and the break stayed invisible until a release ran.
v4.2.3 was tagged before #522 landed, so this is the first release to hit it.

## Why the filenames, not the uploader, are what must not move

`https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-mac-arm64.dmg`
is what the download buttons point at and what electron-updater follows — an
install from a year ago updates through those URLs. Renaming the *published
assets* to match the new product name would break every download link and the
auto-update path for existing installs. (It also puts a space in a URL.)

So the template is pinned to the literal `Nodus-`, which reproduces the 4.2.3
filenames exactly. The displayed product name stays "Nodus Research" and is free
to change again.

## The missing connection

`scripts/test-release-artifact-names.mjs` derives each filename from the real
template and checks it against the uploader, the workflow and the site. It proves
the *property* rather than the current value: it rebrands the product to something
else entirely and asserts no filename budges, and it rejects any name containing a
space.

Mutation-checked — restoring the old template fails **4 of its 7 cases**:

```
not ok 1 - THE REGRESSION: the artifact template does not interpolate the product name
not ok 2 - every artifact electron-builder builds is named exactly what is published
not ok 3 - renaming the product cannot move a single download URL
not ok 4 - no artifact filename contains a space
```

## Verification

2231 unit tests pass. The one apparent failure, `test-prosopography-e2e`, is the
known stale-build flake: it passes once `npm run build` is current, on this branch
and on an untouched checkout alike.

I did not rebuild installers locally to confirm the names — the evidence is already
in the two CI logs. v4.2.3 built `Nodus-mac-arm64.dmg` from this template with
`productName: "Nodus"`, and v4.2.4 built `Nodus Research-linux-amd64.deb` from it
with the new name. The product name is the only differing segment, so pinning it to
the literal reproduces the 4.2.3 names byte for byte.

## Release state

The v4.2.4 draft exists with **zero assets** — nothing was ever published and no
user has seen it — so the tag will be moved to include this fix rather than burning
a version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)