### PR TITLE
Validate the packaging config against electron-builder's own schema

### DIFF
--- a/build/electron-builder.release.cjs
+++ b/build/electron-builder.release.cjs
@@ -7,6 +7,26 @@ if (channel !== 'latest' && channel !== 'beta') {
 
 // Keep one packaging definition. The release workflow only overrides the feed
 // channel, which GitHub publishing cannot infer reliably from a prerelease tag.
+//
+// Two things about `pkg.build` that are easy to get wrong, and that this file is
+// the only sensible place to write down, because package.json is JSON and cannot
+// hold a comment:
+//
+//  1. `artifactName` is the literal `Nodus-`, NOT `${productName}`. The installer
+//     filenames are a public contract: the site's download buttons, the README
+//     and every electron-updater manifest resolve
+//     releases/latest/download/Nodus-<os>-<arch>.<ext>, so an install from a year
+//     ago updates through them. Renaming the product to "Nodus Research" once
+//     went through that template and renamed every artifact, which failed the
+//     v4.2.4 upload on all three platforms. The displayed name may change freely;
+//     these filenames may not. Held by scripts/test-release-artifact-names.mjs.
+//
+//  2. electron-builder validates this object against a STRICT schema that rejects
+//     unknown properties outright, so `pkg.build` cannot carry a documentation
+//     key either — a `_comment` there aborts every packaging run with "Invalid
+//     configuration object". That is why this note lives here. Held by
+//     scripts/test-electron-builder-config.mjs, which validates against
+//     app-builder-lib's own scheme.json rather than waiting for a release.
 module.exports = {
   ...pkg.build,
   publish: pkg.build.publish.map((target) => ({ ...target, channel })),

--- a/package.json
+++ b/package.json
@@ -319,7 +319,6 @@
       "category": "Office",
       "maintainer": "Drakonis96 <Drakonis96@users.noreply.github.com>"
     },
-    "_artifactNameComment": "Literal Nodus-, NOT ${productName}. The installer filenames are a public contract: the site download buttons, the README and every electron-updater manifest resolve https://github.com/Drakonis96/nodus/releases/latest/download/Nodus-<os>-<arch>.<ext>. Renaming productName to \"Nodus Research\" in 4.2.4 silently renamed every artifact through this template, which broke the v4.2.4 upload and would have broken existing installs' auto-update had it published. The displayed product name is free to change; these filenames are not.",
     "artifactName": "Nodus-${os}-${arch}.${ext}"
   }
 }

--- a/scripts/test-electron-builder-config.mjs
+++ b/scripts/test-electron-builder-config.mjs
@@ -1,0 +1,89 @@
+// The packaging config, checked against electron-builder's OWN schema.
+//
+// Why this file exists: electron-builder validates its configuration against a
+// strict schema whose root is `additionalProperties: false`, and it does so at
+// the START of packaging. An unknown key is not ignored and does not warn — it
+// aborts the run:
+//
+//   Invalid configuration object. electron-builder 26.15.3 has been initialized
+//   using a configuration object that does not match the API schema.
+//   - configuration has an unknown property '_artifactNameComment'
+//
+// That is a real v4.2.4 release failure, on all three platforms at once. The key
+// was a documentation comment added to `build` in package.json, which is JSON and
+// cannot hold a real comment. Nothing caught it locally, because `npm run build`
+// is Vite and never loads this config; the only thing that reads it is a release,
+// which costs three platform builds to find out.
+//
+// So the schema is checked here instead, from the copy electron-builder ships.
+// Notes about the config belong in build/electron-builder.release.cjs, which is
+// JavaScript and where a comment is free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const Ajv = require('ajv');
+const schema = require(path.join(repoRoot, 'node_modules/app-builder-lib/scheme.json'));
+const pkg = require(path.join(repoRoot, 'package.json'));
+
+const ajv = new Ajv({ allErrors: true, verbose: true, logger: false });
+const validate = ajv.compile(schema);
+
+const describeErrors = (errors) => (errors ?? [])
+  .map((error) => `${error.dataPath || '(root)'} ${error.message}${error.params?.additionalProperty ? `: '${error.params.additionalProperty}'` : ''}`)
+  .join('\n  ');
+
+test('package.json "build" is a configuration electron-builder will accept', () => {
+  assert.ok(validate(pkg.build), `electron-builder would refuse to start:\n  ${describeErrors(validate.errors)}`);
+});
+
+test('THE REGRESSION: an unknown key is refused, not ignored', () => {
+  // Proves the check has teeth. This is the exact shape that failed v4.2.4.
+  assert.equal(validate({ ...pkg.build, _artifactNameComment: 'a note' }), false,
+    'the schema must reject unknown properties, or this file guards nothing');
+});
+
+test('the config carries no documentation keys, because JSON cannot hold a comment', () => {
+  // The temptation this file exists to resist. Notes go in
+  // build/electron-builder.release.cjs, which is JavaScript.
+  const commentish = Object.keys(pkg.build).filter((key) => key.startsWith('_') || /comment|note|todo/i.test(key));
+  assert.deepEqual(commentish, [],
+    'move these into build/electron-builder.release.cjs as real comments');
+});
+
+test('the release config the workflow actually loads is valid on both channels', () => {
+  // The workflow never packages from package.json directly: it passes
+  // --config build/electron-builder.release.cjs, which spreads pkg.build and
+  // rewrites the publish channel. That result is what must satisfy the schema.
+  const configPath = path.join(repoRoot, 'build/electron-builder.release.cjs');
+  for (const channel of ['latest', 'beta']) {
+    process.env.NODUS_RELEASE_CHANNEL = channel;
+    delete require.cache[configPath];
+    const config = require(configPath);
+    assert.ok(validate(config), `${channel} config is invalid:\n  ${describeErrors(validate.errors)}`);
+    assert.ok(config.publish.every((target) => target.channel === channel));
+  }
+  delete process.env.NODUS_RELEASE_CHANNEL;
+});
+
+test('the release config refuses to load without an explicit channel', () => {
+  const configPath = path.join(repoRoot, 'build/electron-builder.release.cjs');
+  delete process.env.NODUS_RELEASE_CHANNEL;
+  delete require.cache[configPath];
+  assert.throws(() => require(configPath), /NODUS_RELEASE_CHANNEL/,
+    'a missing channel must fail loudly rather than publish to the wrong feed');
+});
+
+test('the schema is the one electron-builder itself will use', () => {
+  // A stale vendored copy would validate against rules the installed builder no
+  // longer applies, which is worse than no check at all.
+  const builderVersion = require(path.join(repoRoot, 'node_modules/app-builder-lib/package.json')).version;
+  const declared = pkg.devDependencies['electron-builder'] ?? '';
+  assert.ok(builderVersion.length > 0);
+  assert.ok(declared.includes(builderVersion.split('.')[0]),
+    `app-builder-lib ${builderVersion} does not match the declared electron-builder ${declared}`);
+});


### PR DESCRIPTION
Follow-up to #527, which I broke.

## What happened

#527 pinned `artifactName` to the literal `Nodus-` and added a
`_artifactNameComment` key next to it explaining why. package.json is JSON and
cannot hold a comment, and electron-builder validates its configuration against
a schema whose root is `additionalProperties: false`. The key was not ignored
and did not warn — it aborted packaging on all three platforms before a single
file was built:

```
Invalid configuration object. electron-builder 26.15.3 has been initialized
using a configuration object that does not match the API schema.
- configuration has an unknown property '_artifactNameComment'
```

## Why nothing caught it

`npm run build` is Vite and never loads this config. The only thing that reads it
is a release, so the cost of discovering a one-key typo was three platform builds
and a failed run. The whole config was unguarded.

## The fix

The key is gone, and the explanation moved to `build/electron-builder.release.cjs`
— JavaScript, where a comment is free, and the file the workflow actually passes
to `--config`. It now documents both traps: that `artifactName` must stay literal,
and that `pkg.build` cannot carry a documentation key either.

`scripts/test-electron-builder-config.mjs` validates `package.json`'s `build`
**and** the release config on each channel against the `scheme.json`
electron-builder itself ships, so the check moves from release time to test time.
It also asserts the vendored schema still matches the installed builder version —
a stale copy would validate rules the builder no longer applies, which is worse
than no check.

Mutation-checked — restoring the bad key fails **3 of its 6 cases**:

```
not ok 1 - package.json "build" is a configuration electron-builder will accept
not ok 3 - the config carries no documentation keys, because JSON cannot hold a comment
not ok 4 - the release config the workflow actually loads is valid on both channels
```

## Verification

Beyond the suite, I am running `electron-builder --mac` locally this time — the
step I skipped on #527, and the reason that PR shipped broken. That proves the
config loads and, from the filenames it writes, that #527's `Nodus-mac-arm64.dmg`
naming is right too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)