### PR TITLE
Restore the Nodus.app bundle name so 4.2.3 can update itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Fixed the media panel blanking the web page while it was open. The page is now frozen into a snapshot before the native view is hidden, as the notifications panel already did.
 - Added Cut, Copy and Paste to the browser page context menu, in that order, and gave Nodus's own text fields a context menu of their own, including the Browser address bar.
 - Added Cmd/Ctrl+T for a new tab, working while a page has focus, and Cmd/Ctrl-click or middle-click on Back and Forward to open that destination in a new tab.
+- Fixed macOS updating, which this release would otherwise have broken. Nodus ships unsigned on macOS and replaces its own bundle with a helper script, and the helper that runs always belongs to the version being replaced. Renaming the packaged product to "Nodus Research" renamed the bundle to `Nodus Research.app`, so every installed copy searched for `Nodus.app`, found nothing, failed after the app had already quit, and never reopened. The packaged product name is `Nodus` again, which also restores the Windows install directory and the Linux package name.
+- Hardened that helper so a future rename cannot repeat this: it now locates the incoming bundle by shape rather than by a name hardcoded when it shipped.
+- Pinned the installer filenames to `Nodus-<os>-<arch>.<ext>` independently of the product name. Those filenames are what the download buttons and every electron-updater manifest resolve, and interpolating the product name into them broke the release upload.
 
 ## 4.2.3 — 2026-08-22
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -218,7 +218,14 @@ function unsignedMacUpdateHelperScript(): string {
     '  [ "$WAITED" -ge 1200 ] && fail',
     'done',
     '/usr/bin/ditto -x -k "$ZIP" "$STAGING" || fail',
-    'NEW_APP="$(/usr/bin/find "$STAGING" -type d \\( -name \'Nodus Research.app\' -o -name Nodus.app \\) -print -quit)"',
+    // Match the bundle by SHAPE, not by name. A named search is what broke the
+    // 4.2.3 -> 4.2.4 update: the helper doing the searching always belongs to the
+    // version being replaced, so the day the bundle is renamed, every copy already
+    // in the field looks for a name that is no longer there, fails after the app
+    // has quit, and never reopens. There is exactly one bundle at the top of the
+    // staging directory. `-maxdepth 2` keeps this off the nested helper apps in
+    // Contents/Frameworks, which live far deeper.
+    'NEW_APP="$(/usr/bin/find "$STAGING" -maxdepth 2 -type d -name \'*.app\' -print -quit)"',
     '[ -n "$NEW_APP" ] && [ -d "$NEW_APP/Contents" ] || fail',
     '/bin/rm -rf "$BACKUP"',
     '/bin/mv "$TARGET" "$BACKUP" || fail',

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
   },
   "build": {
     "appId": "app.nodus.desktop",
-    "productName": "Nodus Research",
+    "productName": "Nodus",
     "directories": {
       "output": "release"
     },

--- a/scripts/test-mac-bundle-name.mjs
+++ b/scripts/test-mac-bundle-name.mjs
@@ -1,0 +1,166 @@
+// The .app bundle name is a FORWARD contract: old versions read it, not new ones.
+//
+// Nodus ships unsigned on macOS, so it does not hand off to Squirrel.Mac. It
+// replaces its own bundle with a helper script it writes at update time — and the
+// helper that runs belongs to the version being REPLACED, never to the one being
+// installed. v4.2.3's helper is literally:
+//
+//   NEW_APP="$(/usr/bin/find "$STAGING" -type d -name Nodus.app -print -quit)"
+//   [ -n "$NEW_APP" ] && [ -d "$NEW_APP/Contents" ] || fail
+//
+// 4.2.4 renamed `build.productName` to "Nodus Research", so its zip contained
+// `Nodus Research.app`. That find matched nothing, the helper failed after the app
+// had already quit, and Nodus never reopened — still on 4.2.3, with no error. The
+// same commit taught the CURRENT helper both names, which cannot help: that code
+// only runs on machines already past the version that broke.
+//
+// So the bundle name cannot change while any client that hardcodes it is still in
+// the field. Every installed copy of Nodus is such a client. Renaming the product
+// for display is fine; renaming the bundle is not.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (relative) => readFileSync(path.join(repoRoot, relative), 'utf8');
+const pkg = JSON.parse(read('package.json'));
+
+/** The bundle electron-builder writes is named after productName. */
+const BUNDLE = `${pkg.build.productName}.app`;
+
+test('THE REGRESSION: the packaged bundle is Nodus.app', () => {
+  assert.equal(pkg.build.productName, 'Nodus',
+    'every already-installed Nodus looks for a bundle named exactly "Nodus.app" when it updates itself');
+  assert.equal(BUNDLE, 'Nodus.app');
+});
+
+test('the bundle name contains no space, which a shell helper would have to quote', () => {
+  assert.doesNotMatch(BUNDLE, /\s/, BUNDLE);
+});
+
+test('the current helper locates a bundle by shape, not by a name it hardcodes', () => {
+  // The root-cause fix for the whole class. A named search can only ever know the
+  // names that existed when it shipped, and it is always the OLD version's helper
+  // that runs. Matching any single top-level .app survives a rename; matching
+  // "Nodus.app" did not.
+  const find = read('electron/main.ts').match(/NEW_APP="\$\(\/usr\/bin\/find[^\n]*/)?.[0];
+  assert.ok(find, 'the update helper must still locate the new bundle');
+  assert.match(find, /-maxdepth 2/,
+    'bound the depth, or the nested helper apps in Contents/Frameworks become candidates');
+  assert.match(find, /\*\.app/, 'match any bundle rather than a hardcoded name');
+});
+
+test('app.setName pins userData, so a product rename cannot orphan a vault', () => {
+  // The other half of the same hazard, and the reason 4.2.4 did not lose data:
+  // on macOS app.getName() would otherwise follow CFBundleName, moving userData
+  // from ~/Library/Application Support/Nodus to .../Nodus Research and opening
+  // an empty profile.
+  const main = read('electron/main.ts');
+  assert.match(main, /app\.setName\('Nodus'\)/,
+    'userData must not depend on the packaged product name');
+  const setNameAt = main.indexOf("app.setName('Nodus')");
+  const firstUserData = main.indexOf("getPath('userData')");
+  assert.ok(setNameAt >= 0 && (firstUserData === -1 || setNameAt < firstUserData),
+    'app.setName must run before anything resolves userData');
+});
+
+// ── The reproduction, end to end, against the REAL v4.2.3 helper ─────────────
+// A string assertion cannot prove a shell script finds a directory. This runs the
+// helper that shipped in the version everyone is updating FROM, against a zip
+// shaped like the one we are about to publish.
+
+function helperFromRelease(tag) {
+  let source;
+  try {
+    source = execFileSync('git', ['show', `${tag}:electron/main.ts`], { cwd: repoRoot, encoding: 'utf8' });
+  } catch {
+    return null; // Tag not fetched (shallow clone): skip rather than fail.
+  }
+  const body = source.match(/function unsignedMacUpdateHelperScript\(\): string \{[\s\S]*?\n\}/)?.[0];
+  if (!body) return null;
+  const lines = [...body.matchAll(/^\s{4}(['"])((?:\\.|(?!\1).)*)\1,$/gm)]
+    .map((m) => JSON.parse(m[1] === "'" ? `"${m[2].replace(/\\'/g, "'").replace(/"/g, '\\"')}"` : `"${m[2]}"`));
+  return lines.length > 10 ? lines.join('\n') : null;
+}
+
+/** The helper as the CURRENT source emits it, for the forward direction. */
+function helperFromSource() {
+  const body = read('electron/main.ts').match(/function unsignedMacUpdateHelperScript\(\): string \{[\s\S]*?\n\}/)?.[0];
+  if (!body) return null;
+  const lines = [...body.matchAll(/^\s{4}(['"])((?:\\.|(?!\1).)*)\1,$/gm)]
+    .map((m) => JSON.parse(m[1] === "'" ? `"${m[2].replace(/\\'/g, "'").replace(/"/g, '\\"')}"` : `"${m[2]}"`));
+  return lines.length > 10 ? lines.join('\n') : null;
+}
+
+/**
+ * Run a helper against a zip shaped like the release and report what it did.
+ *
+ * The assertion that matters and that no string check can make: a shell script
+ * actually found the directory and swapped the bundle.
+ */
+function install(script, bundleName) {
+  const root = mkdtempSync(path.join(tmpdir(), 'nodus-bundle-name-'));
+  try {
+    const scriptPath = path.join(root, 'helper.sh');
+    writeFileSync(scriptPath, script, { mode: 0o700 });
+
+    const stage = path.join(root, 'stage', bundleName, 'Contents', 'MacOS');
+    mkdirSync(stage, { recursive: true });
+    writeFileSync(path.join(stage, 'nodus'), 'payload');
+    // A nested helper app, exactly as a real Electron bundle carries: nothing may
+    // ever select one of these instead of the application itself.
+    const nested = path.join(root, 'stage', bundleName, 'Contents', 'Frameworks', `${bundleName.replace('.app', '')} Helper.app`, 'Contents');
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(nested, 'marker'), 'nested');
+    const zip = path.join(root, 'update.zip');
+    execFileSync('/usr/bin/ditto', ['-c', '-k', '--sequesterRsrc', '--keepParent', path.join(root, 'stage', bundleName), zip]);
+
+    const target = path.join(root, 'Nodus.app');
+    mkdirSync(path.join(target, 'Contents'), { recursive: true });
+    writeFileSync(path.join(target, 'Contents', 'marker'), 'old');
+
+    const state = path.join(root, 'state.json');
+    const dead = execFileSync('/bin/sh', ['-c', '(exec /usr/bin/true) & echo $!'], { encoding: 'utf8' }).trim();
+    try { execFileSync('/bin/sh', [scriptPath, dead, zip, target, state], { stdio: 'ignore' }); } catch { /* the helper reports through state */ }
+
+    const status = existsSync(state) ? JSON.parse(readFileSync(state, 'utf8')).status : 'no-state';
+    return {
+      status,
+      replaced: !existsSync(path.join(target, 'Contents', 'marker')),
+      isApplication: existsSync(path.join(target, 'Contents', 'MacOS', 'nodus')),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('THE USER-VISIBLE BUG: the released helper cannot install a renamed bundle', { skip: process.platform !== 'darwin' }, () => {
+  // What 4.2.4 actually shipped, against what everyone actually runs. The app
+  // quits, this fails, nothing reopens, and the version never changes.
+  const script = helperFromRelease('v4.2.3');
+  if (!script) return;
+  const result = install(script, 'Nodus Research.app');
+  assert.equal(result.status, 'failed');
+  assert.equal(result.replaced, false, 'the old bundle is left in place, so the user stays on the old version');
+});
+
+test('the current helper installs a renamed bundle, so this cannot recur after 4.2.4', { skip: process.platform !== 'darwin' }, () => {
+  const script = helperFromSource();
+  assert.ok(script, 'unsignedMacUpdateHelperScript() not found');
+  const result = install(script, 'Some Future Name.app');
+  assert.equal(result.status, 'installed');
+  assert.equal(result.isApplication, true, 'it must install the application, not a nested helper app');
+});
+
+test('a released helper installs the bundle name we are about to ship', { skip: process.platform !== 'darwin' }, () => {
+  const script = helperFromRelease('v4.2.3');
+  if (!script) return; // history unavailable here
+  const result = install(script, BUNDLE);
+  assert.equal(result.status, 'installed', `the v4.2.3 helper could not install a zip containing ${BUNDLE}`);
+  assert.equal(result.replaced, true, 'the old bundle must have been replaced, not left in place');
+  assert.equal(result.isApplication, true);
+});


### PR DESCRIPTION
**v4.2.4 has been retracted to draft** while this lands. `releases/latest` is back
to v4.2.3 and all three update manifests serve `4.2.3`, so nothing is being offered
the broken build.

## The report

> Downloads, gets to restarting Nodus, never reopens. If I open it myself it is
> still on v4.2.3.

## Cause

Nodus ships **unsigned** on macOS, so it does not hand off to Squirrel.Mac — it
replaces its own bundle with a helper script it writes at update time. The helper
that runs therefore always belongs to the version **being replaced**. v4.2.3's is:

```sh
NEW_APP="$(/usr/bin/find "$STAGING" -type d -name Nodus.app -print -quit)"
[ -n "$NEW_APP" ] && [ -d "$NEW_APP/Contents" ] || fail
```

6c0c4669 renamed `build.productName` to `Nodus Research`, so 4.2.4's zip carried
`Nodus Research.app`. That `find` matched nothing, and the helper called `fail()`
— **after the app had already quit**, which is exactly why nothing reopened and why
no error was ever visible.

That commit also taught the *current* helper both names. That cannot help anyone:
it only runs on machines already past the version that broke.

Reproduced against the real v4.2.3 helper:

```
--- v4.2.3 helper + the zip 4.2.4 shipped (Nodus Research.app) ---
  state: {"status":"failed"}
  installed bundle still the old one? YES
--- v4.2.3 helper + a zip containing Nodus.app ---
  state: {"status":"installed"}
  installed bundle still the old one? no - it was replaced
```

## Fix

`build.productName` is `Nodus` again. Not cosmetic: it is the identity every
installed client already hardcodes, and it equally restores the **Windows install
directory** and the **Linux package name**, which the rename would have split the
same way — a `nodus-research` deb is a new package, not an upgrade.

The site keeps its "Nodus Research" branding, which is where that name belongs, and
the macOS permission-prompt strings keep it too. No data was ever at risk:
`app.setName('Nodus')` already pins userData independently of the bundle.

The helper is hardened for the version *after* this one — it now finds the incoming
bundle by shape rather than by a name fixed when it shipped, bounded to depth 2 so
the nested helper apps in `Contents/Frameworks` can never be chosen instead.

## Packaging identity vs v4.2.3

Everything an installed client keys on is byte-identical to 4.2.3 again:

| | v4.2.3 | now |
|---|---|---|
| bundle | `Nodus.app` | `Nodus.app` |
| assets | `Nodus-mac-arm64.{dmg,zip}`, `Nodus-win-x64.exe`, `Nodus-linux-{amd64.deb,x86_64.AppImage}` | identical |
| manifests | `latest-mac.yml`, `latest.yml`, `latest-linux.yml` | identical |

`artifactName` is still pinned to the literal `Nodus-` from #527, which is now a
no-op on output and purely defensive: it decouples the download URLs from the
product name for good.

## Verification

`scripts/test-mac-bundle-name.mjs` runs the **real helper extracted from the v4.2.3
tag** against **real zips**, because no string assertion can prove a shell script
found a directory:

- the released helper **fails** on a renamed bundle — the user's bug, reproduced;
- the released helper **installs** the bundle we are about to ship — the upgrade
  path that has to work;
- the hardened helper survives a rename and selects the application, not a nested
  helper app.

Restoring the old product name fails 3 of its 7 cases. I am also doing a full local
`electron-builder --mac` run and will drive the v4.2.3 helper against that real
artifact before this is released.

Version stays **4.2.4** — the release was live briefly and only I downloaded it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)