### PR TITLE
Stop the macOS updater leaving a second Nodus installed (4.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed the macOS updater leaving a second Nodus behind. It moved the running bundle to `Nodus.app.previous` and never removed it, and that suffix is on the directory name only: what stayed was a complete application bundle with the same identifier, which LaunchServices registered as a second copy of Nodus. macOS then showed two Dock icons for one app, and every update kept another 1.8 GB forever. The displaced bundle is now unregistered before the relaunch and deleted after it.
+- The updater relaunches with `open` rather than `open -n`, which forced a new process even when one was already running.
+
 ## 4.2.4 — 2026-08-23
 
 - Fixed the Nodus Browser media button, which reported a tab as paused as soon as any spare player on the page stopped and then did nothing when pressed. Playback state is now the page's own answer about the whole document, Play and Pause act on the track actually playing, and the search reaches same-origin frames and open shadow roots.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 4.2.5 — 2026-08-23
 
 - Fixed the macOS updater leaving a second Nodus behind. It moved the running bundle to `Nodus.app.previous` and never removed it, and that suffix is on the directory name only: what stayed was a complete application bundle with the same identifier, which LaunchServices registered as a second copy of Nodus. macOS then showed two Dock icons for one app, and every update kept another 1.8 GB forever. The displaced bundle is now unregistered before the relaunch and deleted after it.
 - The updater relaunches with `open` rather than `open -n`, which forced a new process even when one was already running.
+- Nodus also removes such a bundle on launch. An updater fix only reaches the update *after* the one that ships it, so without this a 4.2.4 install would keep its duplicate for one more cycle.
 
 ## 4.2.4 — 2026-08-23
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "4.2.4"
+version: "4.2.5"
 date-released: "2026-08-23"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.2.4 is licensed exclusively under the GNU Affero General Public
+Nodus 4.2.5 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.2.4 release is available
+The preferred form for modifying the official Nodus 4.2.5 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.4
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.4
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.4.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.4.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.5
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.5
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.5.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.5.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.2.4 is free software distributed exclusively under the GNU Affero
+Nodus 4.2.5 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -231,8 +231,24 @@ function unsignedMacUpdateHelperScript(): string {
     '/bin/mv "$TARGET" "$BACKUP" || fail',
     'if ! /bin/mv "$NEW_APP" "$TARGET"; then /bin/mv "$BACKUP" "$TARGET" || true; fail; fi',
     '/usr/bin/xattr -dr com.apple.quarantine "$TARGET" 2>/dev/null || true',
+    // The swap has landed, so the displaced copy has stopped being a rollback and
+    // started being a problem. `.previous` is a suffix on the DIRECTORY name only:
+    // inside it is a complete application bundle carrying the same
+    // CFBundleIdentifier, so LaunchServices registers it as a second copy of Nodus
+    // and macOS shows two Dock icons for one app. It is also ~1.8 GB, kept forever,
+    // by every update.
+    //
+    // Unregister before relaunching, so nothing can resolve to it, but delete after,
+    // because removing that much takes seconds the user would spend staring at no
+    // window at all.
+    'LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister',
+    '[ -x "$LSREGISTER" ] && "$LSREGISTER" -u "$BACKUP" >/dev/null 2>&1 || true',
     " /usr/bin/printf '%s\\n' '{\"status\":\"installed\"}' > \"$STATE\"",
-    '/usr/bin/open -n "$TARGET" || true',
+    // Not `open -n`. The app is known dead here (the wait above only ends when the
+    // PID is gone), so -n buys nothing, and if anything did manage to start Nodus
+    // meanwhile it would force a SECOND process instead of activating the first.
+    '/usr/bin/open "$TARGET" || true',
+    '/bin/rm -rf "$BACKUP" 2>/dev/null || true',
   ].join('\n');
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -252,6 +252,52 @@ function unsignedMacUpdateHelperScript(): string {
   ].join('\n');
 }
 
+/**
+ * Remove a bundle an earlier update left standing beside this one.
+ *
+ * The helper that performs an update always belongs to the version being
+ * REPLACED, so fixing the helper only helps the update after next. Every release
+ * up to 4.2.4 moved the running bundle to "<app>.previous" and left it there, and
+ * ".previous" is a suffix on the directory name only: what remains is a complete
+ * application bundle carrying the same CFBundleIdentifier, which LaunchServices
+ * registers as a second copy of Nodus. macOS then shows two Dock icons for one
+ * app, and roughly 1.8 GB stays on disk forever.
+ *
+ * So the app also cleans up after itself on launch. That closes the gap the
+ * helper cannot reach: whichever version installed this one, the leftover is gone
+ * the first time it runs.
+ *
+ * Unregistered before deletion so nothing resolves to it in the meantime, and
+ * done off the startup path entirely — it is housekeeping, not a prerequisite for
+ * a window.
+ */
+function removeDisplacedMacBundle(): void {
+  if (process.platform !== 'darwin' || !app.isPackaged) return;
+  const appPath = macAppBundlePath();
+  if (!appPath) return;
+  const displaced = `${appPath}.previous`;
+  void (async () => {
+    try {
+      await fs.access(displaced, fsConstants.F_OK);
+    } catch {
+      return; // Nothing left behind. The common case once this has run once.
+    }
+    const lsregister = '/System/Library/Frameworks/CoreServices.framework/Frameworks/'
+      + 'LaunchServices.framework/Support/lsregister';
+    try {
+      spawnSync(lsregister, ['-u', displaced], { stdio: 'ignore', timeout: 20_000 });
+    } catch {
+      // Unregistering is a courtesy to the Dock; removal is the part that matters.
+    }
+    try {
+      await fs.rm(displaced, { recursive: true, force: true });
+      console.log(`[updates] removed the bundle a previous update left behind: ${displaced}`);
+    } catch (error) {
+      console.warn(`[updates] could not remove ${displaced}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  })();
+}
+
 async function installUnsignedMacUpdate(downloadedFile: string): Promise<void> {
   const appPath = macAppBundlePath();
   if (!appPath) throw new Error('No se pudo localizar la aplicación de macOS para actualizarla.');
@@ -851,6 +897,7 @@ app.on('second-instance', (_event, argv) => {
 app.whenReady().then(async () => {
   // Losing the lock queues a quit; do not open the database or a window.
   if (!hasSingleInstanceLock) return;
+  removeDisplacedMacBundle();
   restorePersistedDockIcon();
   // YouTube (embedded by the PDF Presenter's audience overlay) flags Electron's
   // User-Agent as a bot. Strip the Electron/app tokens so the embed loads; the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": "Nodus",
   "license": "AGPL-3.0-only",

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '4.2.4';
+const VERSION = '4.2.5';
 
 test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 4 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 4.2.4 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 4.2.5 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-mac-bundle-name.mjs
+++ b/scripts/test-mac-bundle-name.mjs
@@ -164,3 +164,56 @@ test('a released helper installs the bundle name we are about to ship', { skip: 
   assert.equal(result.replaced, true, 'the old bundle must have been replaced, not left in place');
   assert.equal(result.isApplication, true);
 });
+
+// ── What the update LEAVES BEHIND ───────────────────────────────────────────
+// 4.2.4 updated correctly and still put two Nodus icons in the Dock. The helper
+// moves the running bundle to "<target>.previous" and never removes it, and that
+// suffix is on the DIRECTORY name only: inside is a complete application bundle
+// with the same CFBundleIdentifier. LaunchServices registers it as a second copy
+// of the app — confirmed on a real machine after the 4.2.4 update:
+//
+//   path: /Applications/Nodus.app            (0x17b74)
+//   path: /Applications/Nodus.app.previous   (0x17b38)
+//
+// It is also ~1.8 GB, kept forever, by every update.
+
+test('the update does not leave a second application behind', { skip: process.platform !== 'darwin' }, () => {
+  const script = helperFromSource();
+  assert.ok(script, 'unsignedMacUpdateHelperScript() not found');
+
+  const root = mkdtempSync(path.join(tmpdir(), 'nodus-leftover-'));
+  try {
+    const scriptPath = path.join(root, 'helper.sh');
+    writeFileSync(scriptPath, script, { mode: 0o700 });
+
+    const stage = path.join(root, 'stage', BUNDLE, 'Contents', 'MacOS');
+    mkdirSync(stage, { recursive: true });
+    writeFileSync(path.join(stage, 'nodus'), 'new');
+    const zip = path.join(root, 'update.zip');
+    execFileSync('/usr/bin/ditto', ['-c', '-k', '--sequesterRsrc', '--keepParent', path.join(root, 'stage', BUNDLE), zip]);
+
+    const target = path.join(root, 'Nodus.app');
+    mkdirSync(path.join(target, 'Contents'), { recursive: true });
+    writeFileSync(path.join(target, 'Contents', 'marker'), 'old');
+
+    const state = path.join(root, 'state.json');
+    const dead = execFileSync('/bin/sh', ['-c', '(exec /usr/bin/true) & echo $!'], { encoding: 'utf8' }).trim();
+    try { execFileSync('/bin/sh', [scriptPath, dead, zip, target, state], { stdio: 'ignore' }); } catch { /* reported through state */ }
+
+    assert.equal(JSON.parse(readFileSync(state, 'utf8')).status, 'installed');
+    assert.ok(!existsSync(`${target}.previous`),
+      'the displaced bundle must be removed: it is a second registered application, not a backup');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the relaunch activates rather than forcing a duplicate process', () => {
+  // `open -n` forces a NEW instance even when one is running. The app is known
+  // dead by this point, so -n bought nothing and could only ever add a second
+  // process for the single-instance lock to have to kill.
+  const helper = read('electron/main.ts');
+  const open = helper.match(/'\/usr\/bin\/open[^\n]*/)?.[0];
+  assert.ok(open, 'the helper must relaunch the app');
+  assert.doesNotMatch(open, /open -n/, 'plain `open` activates an existing instance instead of duplicating it');
+});

--- a/scripts/test-mac-bundle-name.mjs
+++ b/scripts/test-mac-bundle-name.mjs
@@ -217,3 +217,35 @@ test('the relaunch activates rather than forcing a duplicate process', () => {
   assert.ok(open, 'the helper must relaunch the app');
   assert.doesNotMatch(open, /open -n/, 'plain `open` activates an existing instance instead of duplicating it');
 });
+
+// ── Self-healing, because a helper fix cannot reach backwards ────────────────
+// The helper that performs an update belongs to the version being REPLACED, so
+// #530's cleanup only takes effect for the update AFTER the one that ships it.
+// Going 4.2.4 -> 4.2.5 still runs 4.2.4's helper and still leaves a bundle
+// behind. The app therefore also clears it on launch, which is what actually
+// gets a duplicated Dock back to one icon.
+
+test('the app removes a bundle an earlier update left beside it', () => {
+  const main = read('electron/main.ts');
+  const fn = main.match(/function removeDisplacedMacBundle\(\): void \{[\s\S]*?\n\}/)?.[0];
+  assert.ok(fn, 'removeDisplacedMacBundle() is what closes the gap the helper cannot reach');
+
+  assert.match(fn, /\$\{appPath\}\.previous/, 'it must target the displaced bundle beside this one');
+  assert.match(fn, /lsregister/, 'unregister before deleting, so nothing resolves to it meanwhile');
+  assert.match(fn, /recursive: true, force: true/);
+  // Packaged only: a dev checkout has no bundle, and app.isPackaged is the guard.
+  assert.match(fn, /process\.platform !== 'darwin' \|\| !app\.isPackaged/);
+  // Never on the critical path — housekeeping must not delay or block a window.
+  assert.match(fn, /void \(async \(\) => \{/, 'it must not be awaited during startup');
+});
+
+test('the cleanup runs at startup, and only once the instance lock is held', () => {
+  // A second copy that is about to quit must not delete anything underneath the
+  // copy that owns the profile.
+  const main = read('electron/main.ts');
+  const ready = main.slice(main.indexOf('app.whenReady()'));
+  const lockGuard = ready.indexOf('if (!hasSingleInstanceLock) return;');
+  const call = ready.indexOf('removeDisplacedMacBundle();');
+  assert.ok(call > lockGuard && lockGuard >= 0,
+    'removeDisplacedMacBundle() must run after the single-instance guard');
+});

--- a/scripts/test-macos-update-helper.mjs
+++ b/scripts/test-macos-update-helper.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -44,7 +45,14 @@ try {
   });
   assert.equal(result, 0, 'The update helper should finish successfully');
   assert.equal(await readFile(path.join(targetApp, 'Contents', 'version.txt'), 'utf8'), 'new');
-  assert.equal(await readFile(path.join(`${targetApp}.previous`, 'Contents', 'version.txt'), 'utf8'), 'old');
+  // The displaced bundle must be GONE. This assertion used to require the opposite,
+  // and that is what shipped two Dock icons in 4.2.4: ".previous" is a suffix on the
+  // directory name only, so what stayed behind was a complete application bundle
+  // carrying the same CFBundleIdentifier. LaunchServices duly registered it as a
+  // second copy of Nodus. It was never a rollback either — nothing has ever read it
+  // — just ~1.8 GB kept forever by every update.
+  assert.equal(existsSync(`${targetApp}.previous`), false,
+    'the helper must not leave a second, registered application behind');
   assert.deepEqual(JSON.parse(await readFile(statePath, 'utf8')), { status: 'installed' });
   console.log('macOS update-helper replacement test passed');
 } finally {

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -74,7 +74,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '4.2.4');
+      assert.equal(info.version, '4.2.5');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,23 +25,31 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '4.2.4');
+  assert.equal(currentRelease?.version, '4.2.5');
   assert.equal(currentRelease?.date, '2026-08-23');
-  assert.equal(currentRelease?.highlights.length, 4);
-  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['browser', 'browser', 'browser', 'browser']);
+  assert.equal(currentRelease?.highlights.length, 1);
+  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['general']);
+  assert.match(currentRelease?.highlights[0]?.en ?? '', /stops installing itself twice on macOS/);
+  assert.match(currentRelease?.highlights[0]?.en ?? '', /two Nodus icons in the Dock/);
+
+  // 4.2.4 keeps the four highlights it shipped with. They are published history.
+  const browserFixesRelease = RELEASE_NOTES.find((note) => note.version === '4.2.4');
+  assert.equal(browserFixesRelease?.date, '2026-08-23');
+  assert.equal(browserFixesRelease?.highlights.length, 4);
+  assert.deepEqual(browserFixesRelease?.highlights.map((highlight) => highlight.scope), ['browser', 'browser', 'browser', 'browser']);
   for (const phrase of [
     /media button tells the truth again/,
     /no longer makes the website vanish/,
     /Cut, Copy and Paste in text fields, in that order/,
     /opens a new tab, including while you are reading a page/,
-  ]) assert.ok(currentRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
+  ]) assert.ok(browserFixesRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
 
-  const mediaHighlight = currentRelease?.highlights.find((highlight) =>
+  const mediaHighlight = browserFixesRelease?.highlights.find((highlight) =>
     /media button tells the truth again/.test(highlight.en));
   assert.match(mediaHighlight?.en ?? '', /spare player/);
   assert.match(mediaHighlight?.en ?? '', /the track you are actually listening to/);
 
-  const addressBarHighlight = currentRelease?.highlights.find((highlight) =>
+  const addressBarHighlight = browserFixesRelease?.highlights.find((highlight) =>
     /Cut, Copy and Paste/.test(highlight.en));
   assert.match(addressBarHighlight?.en ?? '', /address bar/);
 

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '4.2.4');
+  assert.equal(pluginManifest.version, '4.2.5');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,9 +54,9 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '4\.2\.4'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '4\.2\.5'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.2\.4\.tar\.gz/);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v4\.2\.5\.tar\.gz/);
   assert.match(citation, /^date-released: "2026-08-23"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1244,9 +1244,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '4.2.4', 'the add-on shares the Nodus 4 release version');
+  assert.equal(manifest.version, '4.2.5', 'the add-on shares the Nodus 4 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.2\.4/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v4\.2\.5/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 4.2.4 is licensed exclusively under the GNU Affero General Public
+Nodus 4.2.5 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 4.2.4 release is available
+The preferred form for modifying the official Nodus 4.2.5 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.4
-- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.4
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.4.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.4.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v4.2.5
+- Source tree: https://github.com/Drakonis96/nodus/tree/v4.2.5
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.5.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v4.2.5.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 4.2.4 is free software distributed exclusively under the GNU Affero
+Nodus 4.2.5 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '4.2.4';
+export const NODUS_VERSION = '4.2.5';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -155,6 +155,9 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "4.2.5": [
+    "Nodus smette di installarsi due volte su macOS. Ogni aggiornamento metteva da parte la versione precedente e la lasciava lì per sempre, e macOS continuava a vederla come un'altra applicazione. Da qui venivano le due icone di Nodus nel Dock. Aprendo questa versione quella copia si cancella da sola e recuperi quasi 2 GB di disco.",
+  ],
   "4.2.4": [
     "Il pulsante multimediale del browser torna a dire la verità e a obbedire. Dava una scheda per messa in pausa non appena un qualsiasi lettore di riserva della pagina si fermava, quindi offriva Riproduci su un audio che stava già suonando e premerlo non faceva nulla. Ora Nodus guarda l'intera pagina, compresi i frame dello stesso sito e i componenti propri, e agisce sulla traccia che stai davvero ascoltando.",
     "Aprire il pannello multimediale non fa più sparire il sito. La pagina si congela al suo posto mentre il pannello è aperto e ricompare intatta alla chiusura.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -95,6 +95,9 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "4.2.5": [
+    "Nodus artık macOS'ta kendini iki kez kurmuyor. Her güncelleme bir önceki sürümü kenara koyuyor ve orada temelli bırakıyordu, macOS da onu ayrı bir uygulama olarak görmeye devam ediyordu. Dock'taki iki Nodus simgesi buradan geliyordu. Bu sürümü açtığınızda o kopya kendiliğinden siliniyor ve neredeyse 2 GB disk alanı geri geliyor.",
+  ],
   "4.2.4": [
     "Tarayıcının medya düğmesi yeniden doğruyu söylüyor ve söz dinliyor. Sayfadaki yedek oynatıcılardan herhangi biri durur durmaz sekmeyi duraklatılmış sayıyordu, bu yüzden zaten çalan bir ses için Oynat sunuyor ve basıldığında hiçbir şey yapmıyordu. Nodus artık aynı siteye ait çerçeveler ve özel bileşenler dahil sayfanın tamamına bakıyor ve gerçekten dinlediğiniz parça üzerinde işlem yapıyor.",
     "Medya panelini açmak artık siteyi yok etmiyor. Panel açıkken sayfa yerinde donuyor ve panel kapandığında olduğu gibi geri geliyor.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1750,7 +1750,24 @@ const RELEASE_4_2_4_HIGHLIGHTS: RawReleaseHighlight[] = [
   },
 ];
 
+const RELEASE_4_2_5_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'Nodus deja de instalarse dos veces en macOS. Cada actualización apartaba la versión anterior y la dejaba ahí para siempre, y macOS la seguía viendo como una aplicación más. De ahí venían los dos iconos de Nodus en el Dock. Al abrir esta versión, esa copia se borra sola y recuperas casi 2 GB de disco.',
+    en: 'Nodus stops installing itself twice on macOS. Every update set the previous version aside and left it there for good, and macOS went on seeing it as another application. That is where the two Nodus icons in the Dock came from. Opening this version deletes that copy on its own and gives you back nearly 2 GB of disk.',
+    fr: 'Nodus cesse de s’installer en double sur macOS. Chaque mise à jour mettait la version précédente de côté et l’y laissait pour de bon, et macOS continuait de la voir comme une application à part entière. D’où les deux icônes Nodus dans le Dock. Ouvrir cette version supprime cette copie toute seule et vous rend près de 2 Go de disque.',
+    de: 'Nodus installiert sich auf macOS nicht mehr doppelt. Jedes Update stellte die vorherige Version beiseite und ließ sie dort für immer, und macOS sah sie weiterhin als eigene Anwendung. Daher die zwei Nodus-Symbole im Dock. Beim Öffnen dieser Version wird diese Kopie von selbst gelöscht und gibt fast 2 GB Speicher frei.',
+    pt: 'O Nodus deixa de se instalar duas vezes no macOS. Cada atualização punha a versão anterior de lado e deixava-a lá para sempre, e o macOS continuava a vê-la como mais uma aplicação. Era daí que vinham os dois ícones do Nodus na Dock. Ao abrir esta versão, essa cópia apaga-se sozinha e recupera quase 2 GB de disco.',
+    'pt-BR': 'O Nodus para de se instalar duas vezes no macOS. Cada atualização punha a versão anterior de lado e a deixava ali para sempre, e o macOS continuava enxergando ela como mais um aplicativo. Era daí que vinham os dois ícones do Nodus no Dock. Ao abrir esta versão, essa cópia se apaga sozinha e você recupera quase 2 GB de disco.',
+  },
+];
+
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '4.2.5',
+    date: '2026-08-23',
+    highlights: RELEASE_4_2_5_HIGHLIGHTS,
+  },
   {
     version: '4.2.4',
     date: '2026-08-23',

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -55,7 +55,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       "@id": "https://nodusresearch.com/#software",
       "name": "Nodus",
       "isPartOf": { "@id": "https://nodusresearch.com/#website" },
-      "softwareVersion": "4.2.4",
+      "softwareVersion": "4.2.5",
       "applicationCategory": "EducationalApplication",
       "operatingSystem": "macOS, Windows, Linux",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
@@ -131,7 +131,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dl class="citation-meta reveal">
       <div><dt>Project</dt><dd>Nodus Research</dd></div>
       <div><dt>Software</dt><dd>Nodus</dd></div>
-      <div><dt>Version</dt><dd>4.2.4</dd></div>
+      <div><dt>Version</dt><dd>4.2.5</dd></div>
       <div><dt>Released</dt><dd>22 August 2026</dd></div>
       <div><dt>Author</dt><dd><a href="https://orcid.org/0000-0002-1150-1930" target="_blank" rel="noopener">Jorge Pérez Burgueño · ORCID</a></dd></div>
       <div><dt>Licence</dt><dd><a href="https://spdx.org/licenses/AGPL-3.0-only.html" target="_blank" rel="noopener">AGPL-3.0-only</a></dd></div>
@@ -155,7 +155,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a class="doi-value" href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">10.5281/zenodo.21515531</a>
       </article>
       <article class="card lit doi-card reveal" style="--delay:80ms">
-        <span class="kicker">Nodus 4.2.4 · version DOI</span>
+        <span class="kicker">Nodus 4.2.5 · version DOI</span>
         <h3>The exact software release</h3>
         <p>Use this DOI when methods, results or supplementary material depend on the version of Nodus used in the work.</p>
         <a class="doi-value" href="https://doi.org/10.5281/zenodo.22055445" target="_blank" rel="noopener">10.5281/zenodo.22055445</a>
@@ -174,7 +174,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
     <div class="citation-block reveal">
       <h3>APA</h3>
-      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 4.2.4) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.22055445" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.22055445</a></p>
+      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 4.2.5) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.22055445" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.22055445</a></p>
     </div>
 
     <div class="citation-block reveal">
@@ -182,7 +182,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <pre><code>@software{perez_burgueno_nodus_2026,
   author    = {Pérez Burgueño, Jorge and Nodus contributors},
   title     = {Nodus: Open-Source Research Workspace},
-  version   = {4.2.4},
+  version   = {4.2.5},
   year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.22055445},

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
Reported after updating to 4.2.4: the update worked, but **two Nodus icons appeared
in the Dock**. Nothing was clicked, and only one process was running.

## Cause

On the affected machine, LaunchServices had registered **two applications**:

```
path: /Applications/Nodus.app            (0x17b74)   4.2.4
path: /Applications/Nodus.app.previous   (0x17b38)   4.2.3
```

The update helper moves the running bundle to `"<target>.previous"` before moving
the new one in, and never removes it. `.previous` is a suffix on the **directory
name only** — inside is a complete, valid application bundle carrying the same
`CFBundleIdentifier`, so macOS treats it as a second copy of Nodus and gives it its
own Dock tile.

It was never a rollback, either: nothing in the codebase has ever read it. It is
**1.8 GB, kept forever, by every update**.

## Fix

Once the second `mv` succeeds the displaced copy has stopped being a safety net.
It is now unregistered from LaunchServices **before** the relaunch — so nothing can
resolve to it — and deleted **after** it, because removing 1.8 GB takes seconds the
user would otherwise spend looking at no window at all.

The relaunch also drops `-n`. The helper only reaches that line once the old PID is
gone, so `open -n` bought nothing and could only ever add a second process for the
single-instance lock to have to kill.

## What I checked and ruled out

Before landing this I verified the things that *sounded* like the cause and were not:

- **The single-instance lock works.** I launched two copies against one profile: the
  second quit correctly. I had a theory that `app.quit()` before `whenReady` fails to
  terminate, tested it, and it was wrong.
- **Window creation is already deduplicated.** Both `restoreAppWindows` and
  `applyMascotWindow` guard on an existing, non-destroyed window.
- **No crash reports, no stale helper scripts**, and the profile was healthy.

So the duplication was never two processes — it was two registered *applications*.

## Verification

`scripts/test-mac-bundle-name.mjs` gains two cases that run the real helper:
no second bundle may survive an install, and the relaunch may not use `open -n`.

`scripts/test-macos-update-helper.mjs` asserted the old bundle was **kept** — the
precise behaviour that shipped this. It now requires the opposite.

Restoring the 4.2.4 behaviour fails 2 of the new cases. Full suite: **2246 pass**.

## Note on reach

Like every updater change, this only takes effect for updates **from** the version
that ships it. A `Nodus.app.previous` already on disk has to be removed by hand:

```
rm -rf /Applications/Nodus.app.previous
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)