### PR TITLE
Fix Zotero selection popup action overflow

### DIFF
--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1145,6 +1145,19 @@ test('composer: Enter sends and Alt+Enter keeps the textarea newline', () => {
   );
 });
 
+test('reader selection popup keeps icon actions inside Zotero popup bounds', () => {
+  const src = readSource('zotero-plugin/bootstrap.js');
+  const popup = src.slice(src.indexOf('function registerSelectionPopup()'));
+
+  assert.match(popup, /wrap\.style\.cssText = "[^"]*width:238px[^"]*max-width:100%[^"]*min-width:0[^"]*overflow:hidden/, 'the whole Nodus block respects a narrower host popup');
+  assert.match(popup, /row\.style\.cssText = "[^"]*flex-wrap:wrap[^"]*max-width:100%[^"]*overflow:hidden/, 'the action row wraps and clips to the host popup');
+  assert.match(popup, /b\.style\.cssText = "[^"]*flex:1 1 44px[^"]*min-width:0[^"]*max-width:100%[^"]*overflow:hidden/, 'actions can shrink without intrinsic-width overflow');
+  assert.match(popup, /b\.setAttribute\("aria-label", label\)/, 'icon-only actions retain an accessible name');
+  assert.match(popup, /b\.title = label/, 'icon-only actions explain themselves on hover');
+  assert.match(popup, /b\.innerHTML = iconSvg;/, 'actions render only their icon');
+  assert.doesNotMatch(popup, /iconSvg \+ "<span>" \+ label/, 'visible labels cannot widen the action buttons');
+});
+
 // ─────────────────────────────────────────── auto-highlighter engine (pure)
 test('highlighter: parsePassages extracts {text,level} robustly', () => {
   const { NodusHighlighter: H } = loadModule('highlighter.js');

--- a/zotero-plugin/bootstrap.js
+++ b/zotero-plugin/bootstrap.js
@@ -339,18 +339,24 @@ function registerSelectionPopup() {
       const L = POPUP_I18N[lang];
 
       const wrap = doc.createElement("div");
-      wrap.style.cssText = "display:flex;flex-direction:column;gap:6px;padding:5px 4px;width:238px;max-width:238px;box-sizing:border-box;";
+      wrap.style.cssText = "display:flex;flex-direction:column;gap:6px;padding:5px 4px;width:238px;max-width:100%;min-width:0;box-sizing:border-box;overflow:hidden;";
       const head = doc.createElement("div");
       head.style.cssText = "display:flex;align-items:center;gap:5px;font-size:11px;font-weight:700;color:#7c3aed;";
       head.innerHTML = MARK_SVG + "<span>Nodus</span>";
       wrap.appendChild(head);
 
       const row = doc.createElement("div");
-      row.style.cssText = "display:flex;gap:5px;";
+      // Zotero owns the popup and may make it narrower than our preferred
+      // width. Let actions shrink (and, if more are added, wrap) inside that
+      // available width instead of allowing their intrinsic content to escape.
+      row.style.cssText = "display:flex;flex-wrap:wrap;gap:5px;width:100%;max-width:100%;min-width:0;box-sizing:border-box;overflow:hidden;";
       const mkBtn = (label, iconSvg) => {
         const b = doc.createElement("button");
-        b.style.cssText = "flex:1;display:inline-flex;align-items:center;justify-content:center;gap:4px;padding:5px 6px;border:1px solid rgba(124,58,237,.35);border-radius:6px;background:#fff;color:#7c3aed;font-size:11px;font-weight:600;cursor:pointer;";
-        b.innerHTML = iconSvg + "<span>" + label + "</span>";
+        b.type = "button";
+        b.title = label;
+        b.setAttribute("aria-label", label);
+        b.style.cssText = "flex:1 1 44px;min-width:0;max-width:100%;height:32px;box-sizing:border-box;overflow:hidden;display:inline-flex;align-items:center;justify-content:center;padding:5px;border:1px solid rgba(124,58,237,.35);border-radius:6px;background:#fff;color:#7c3aed;cursor:pointer;";
+        b.innerHTML = iconSvg;
         return b;
       };
       const citeBtn = mkBtn(L.cite, POPUP_ICO.quote);


### PR DESCRIPTION
## Summary

- replace the text-and-icon Zotero selection actions with compact icon-only buttons
- preserve localized labels through tooltips and accessible names
- constrain the Nodus block and action row to the host popup width
- let future actions shrink and wrap instead of overflowing
- add regression assertions for layout containment and accessibility

## Testing

- `node --check zotero-plugin/bootstrap.js`
- `node --check scripts/test-zotero-plugin.mjs`
- selection popup DOM smoke test
- regression containment assertions
- `git diff --check`

Closes #531
