### PR TITLE
Fix custom browser media controls and consent modal theming

### DIFF
--- a/electron/preload/browserPage.ts
+++ b/electron/preload/browserPage.ts
@@ -36,12 +36,15 @@ import { collectPageSnapshot } from './browserPageSnapshot';
 import {
   anyPlaying,
   applyMediaCommand,
+  applySemanticMediaCommand,
   collectMediaElements,
   isPlayableMedia,
   kindOf,
+  semanticPlaybackState,
   type MediaCommand,
   type MediaEl,
   type MediaRoot,
+  type SemanticMediaScope,
 } from './browserPageMedia';
 
 interface PageDoc extends MediaRoot {
@@ -114,15 +117,16 @@ function mediaElements(): MediaEl[] {
  * removed element simply falls out of the comparison.
  */
 let lastPlayed: MediaEl | null = null;
+let lastSemanticScope: SemanticMediaScope | null = null;
 
 /**
  * Tell main what is REALLY playing in this page.
  *
- * The bug this replaces: the page used to report each element's own play/pause
- * edge, so any one of the seven empty <audio> placeholders elevenreader.io keeps
- * around could announce "paused" while the actual track ran on. The header then
- * showed Play for something already playing, and pressing it changed nothing —
- * the reported symptom of a media button that "does nothing".
+ * The bug this replaces: pages used to report each element's own play/pause
+ * edge, so a spare <audio> placeholder could announce "paused" while the actual
+ * track ran on. The header then showed Play for something already playing, and
+ * pressing it changed nothing — the reported symptom of a media button that
+ * "does nothing".
  *
  * An aggregate cannot lie that way: it is a single answer about the whole page.
  */
@@ -184,11 +188,37 @@ ipcRenderer.on('nodus-browser:page:mediaCommand', (_event, command: string) => {
   const known: MediaCommand[] = ['previous', 'play', 'pause', 'next', 'stop'];
   if (known.indexOf(command as MediaCommand) < 0) return;
   const elements = mediaElements();
-  const handled = applyMediaCommand(elements, command as MediaCommand, lastPlayed);
+  const domHandled = applyMediaCommand(elements, command as MediaCommand, lastPlayed);
+  const semantic = domHandled
+    ? { handled: false, scope: lastSemanticScope }
+    : applySemanticMediaCommand(page.document, command as MediaCommand, lastSemanticScope);
+  if (semantic.scope) lastSemanticScope = semantic.scope;
+  const handled = domHandled || semantic.handled;
   ipcRenderer.send('nodus-browser:page:mediaCommandResult', { command, handled });
-  // Long enough for a resolved play() to have flipped `paused`, short enough
-  // that the button does not sit wrong while the user is looking at it.
-  setTimeout(() => reportPlaybackState(), 120);
+  // An aggregate report is authoritative only when this preload can actually
+  // see media elements. A WebAudio player such as ElevenReader exposes none:
+  // reporting `false` after its visible Pause button was clicked overwrote
+  // Chromium's real event and made the header lie while the audio kept going.
+  if (elements.length > 0) {
+    // Long enough for a resolved play() to have flipped `paused`, short enough
+    // that the button does not sit wrong while the user is looking at it.
+    setTimeout(() => reportPlaybackState(), 120);
+  } else if (semantic.handled) {
+    // WebAudio/custom players do not emit HTMLMediaElement events, so Chromium
+    // may keep reporting the pre-command state forever. Read the replacement
+    // Play/Pause control after React has rendered it and update the header from
+    // that. Falling back to the requested state covers players whose accessible
+    // label does not change, while a refused click remains detectable because
+    // the old control is still present.
+    setTimeout(() => {
+      const observed = semanticPlaybackState(page.document, lastSemanticScope);
+      const requested = command === 'play';
+      ipcRenderer.send('nodus-browser:page:media', {
+        playing: observed ?? requested,
+        kind: 'unknown',
+      });
+    }, 120);
+  }
 });
 
 /** Everything main can ask this page for. The command set is closed. */

--- a/electron/preload/browserPageMedia.ts
+++ b/electron/preload/browserPageMedia.ts
@@ -12,10 +12,9 @@
  * playing, not whatever `document.querySelectorAll('audio, video')` returns
  * first. Real players do not oblige.
  *
- *  - elevenreader.io keeps eight `<audio>` tags in its document and gives seven
- *    of them no source at all. Acting on the whole list meant Previous and Next
- *    landed on a dead placeholder — pausing the track that was running — and
- *    Play fired eight rejected `play()` calls to no visible effect.
+ *  - Player implementations change over time. Older ElevenReader builds kept
+ *    spare `<audio>` tags; the current player exposes no media element at all
+ *    and has to be driven through its accessible Play/Pause control.
  *  - Player UIs also live in open shadow roots and in same-origin frames, both
  *    invisible to a flat query on the top document.
  *
@@ -41,6 +40,25 @@ export interface MediaEl {
 
 export interface MediaRoot {
   querySelectorAll(selector: string): ArrayLike<unknown>;
+}
+
+export interface SemanticMediaScope extends MediaRoot {
+  parentElement?: SemanticMediaScope | null;
+  isConnected?: unknown;
+}
+
+interface SemanticMediaControl extends SemanticMediaScope {
+  textContent?: unknown;
+  disabled?: unknown;
+  isConnected?: unknown;
+  click?: () => void;
+  getAttribute?: (name: string) => string | null;
+  getClientRects?: () => ArrayLike<unknown>;
+}
+
+export interface SemanticMediaCommandResult {
+  handled: boolean;
+  scope: SemanticMediaScope | null;
 }
 
 /**
@@ -69,6 +87,209 @@ function asRoot(value: unknown): MediaRoot | null {
   return candidate && typeof candidate.querySelectorAll === 'function' ? candidate : null;
 }
 
+function reachableRoots(document: MediaRoot | null | undefined): MediaRoot[] {
+  const start = asRoot(document);
+  if (!start) return [];
+
+  const queue: MediaRoot[] = [start];
+  const visited = new Set<MediaRoot>([start]);
+  const roots: MediaRoot[] = [];
+  let scanned = 0;
+
+  while (queue.length > 0 && roots.length < MAX_ROOTS) {
+    const root = queue.shift() as MediaRoot;
+    roots.push(root);
+
+    for (const frame of elementsOf(root, 'iframe, frame')) {
+      let child: MediaRoot | null = null;
+      try {
+        child = asRoot((frame as { contentDocument?: unknown }).contentDocument);
+      } catch {
+        // Cross-origin. Not ours to touch.
+      }
+      if (child && !visited.has(child) && visited.size < MAX_ROOTS) {
+        visited.add(child);
+        queue.push(child);
+      }
+    }
+
+    if (scanned >= MAX_SCANNED) continue;
+    for (const host of elementsOf(root, '*')) {
+      scanned += 1;
+      if (scanned > MAX_SCANNED) break;
+      const shadow = asRoot((host as { shadowRoot?: unknown }).shadowRoot);
+      if (shadow && !visited.has(shadow) && visited.size < MAX_ROOTS) {
+        visited.add(shadow);
+        queue.push(shadow);
+      }
+    }
+  }
+
+  return roots;
+}
+
+/**
+ * Controls used by WebAudio/custom players that expose no <audio> or <video>.
+ *
+ * Exact labels only: a fuzzy match for "play" would happily click "Display",
+ * a playlist title or an unrelated page action. The list covers Nodus's UI
+ * languages and the common labels Chromium accessibility surfaces use.
+ */
+const PAUSE_LABELS = new Set([
+  'pause', 'pausar', 'pausa', 'duraklat', '暂停', '一時停止', 'пауза', 'призупинити',
+]);
+const PLAY_LABELS = new Set([
+  'play', 'reproducir', 'reprendre', 'lire', 'abspielen', 'riproduci', 'reproduzir', 'oynat',
+  '播放', '再生', 'воспроизвести', 'відтворити',
+]);
+
+function normalizedLabel(value: unknown): string {
+  return String(value ?? '').trim().toLocaleLowerCase();
+}
+
+function controlLabel(control: SemanticMediaControl): string {
+  for (const name of ['aria-label', 'title']) {
+    const value = normalizedLabel(control.getAttribute?.(name));
+    if (value) return value;
+  }
+  return normalizedLabel(control.textContent);
+}
+
+function isUsableControl(control: SemanticMediaControl): boolean {
+  if (control.disabled === true || control.getAttribute?.('aria-disabled') === 'true') return false;
+  if (control.getAttribute?.('hidden') !== null && control.getAttribute?.('hidden') !== undefined) return false;
+  try {
+    if (control.getClientRects && control.getClientRects().length === 0) return false;
+  } catch {
+    return false;
+  }
+  return typeof control.click === 'function';
+}
+
+function matchingControls(root: MediaRoot, labels: Set<string>): SemanticMediaControl[] {
+  return elementsOf(root, 'button, [role="button"]')
+    .map((value) => value as SemanticMediaControl)
+    .filter((control) => isUsableControl(control) && labels.has(controlLabel(control)));
+}
+
+function containsProgressControl(scope: SemanticMediaScope): boolean {
+  try {
+    return scope.querySelectorAll('[role="slider"], input[type="range"], [aria-label*="progress" i]').length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The stable player shell around a control.
+ *
+ * React commonly replaces the Play/Pause <button> when its state changes, so a
+ * remembered button reference cannot resume playback. The surrounding player
+ * (the nearest ancestor containing a progress slider) normally survives and
+ * gives Play a safe, unambiguous place to look after Pause.
+ */
+function playerScope(control: SemanticMediaControl): SemanticMediaScope | null {
+  let current: SemanticMediaScope | null = control;
+  for (let depth = 0; current && depth < 10; depth += 1) {
+    if (containsProgressControl(current)) return current;
+    current = current.parentElement ?? null;
+  }
+  return control.parentElement ?? null;
+}
+
+function clickControl(control: SemanticMediaControl): boolean {
+  try {
+    control.click?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function connectedScope(scope: SemanticMediaScope | null): scope is SemanticMediaScope {
+  return Boolean(scope && scope.isConnected !== false);
+}
+
+/**
+ * Read the state a custom player exposes through its accessible control.
+ *
+ * A Pause control means the player is currently running; Play means it is
+ * paused. Prefer the remembered player shell so a library full of unrelated
+ * Play buttons cannot confuse the result. If that shell disappeared, only a
+ * single control beside a progress slider is authoritative.
+ */
+export function semanticPlaybackState(
+  document: MediaRoot | null | undefined,
+  preferredScope: SemanticMediaScope | null = null,
+): boolean | null {
+  const stateIn = (scope: MediaRoot): boolean | null => {
+    const pause = matchingControls(scope, PAUSE_LABELS);
+    const play = matchingControls(scope, PLAY_LABELS);
+    if (pause.length === 1 && play.length === 0) return true;
+    if (play.length === 1 && pause.length === 0) return false;
+    return null;
+  };
+
+  if (connectedScope(preferredScope)) {
+    const state = stateIn(preferredScope);
+    if (state !== null) return state;
+  }
+
+  const start = asRoot(document);
+  if (!start) return null;
+  const controls = reachableRoots(start).flatMap((root) => [
+    ...matchingControls(root, PAUSE_LABELS).map((control) => ({ control, playing: true })),
+    ...matchingControls(root, PLAY_LABELS).map((control) => ({ control, playing: false })),
+  ]);
+  const inPlayers = controls.filter(({ control }) => {
+    const scope = playerScope(control);
+    return Boolean(scope && containsProgressControl(scope));
+  });
+  return inPlayers.length === 1 ? inPlayers[0].playing : null;
+}
+
+/**
+ * Fallback for custom/WebAudio players.
+ *
+ * Only a unique control is safe page-wide. When several books each show Play,
+ * resuming an arbitrary one would be worse than doing nothing. Pause may select
+ * the one exact control living beside the progress slider, and remembers that
+ * stable shell so the later Play command returns to the same session.
+ */
+export function applySemanticMediaCommand(
+  document: MediaRoot | null | undefined,
+  command: MediaCommand,
+  preferredScope: SemanticMediaScope | null = null,
+): SemanticMediaCommandResult {
+  const start = asRoot(document);
+  if (!start || (command !== 'play' && command !== 'pause' && command !== 'stop')) {
+    return { handled: false, scope: preferredScope };
+  }
+
+  const labels = command === 'play' ? PLAY_LABELS : PAUSE_LABELS;
+  if (command === 'play' && connectedScope(preferredScope)) {
+    const scoped = matchingControls(preferredScope, labels);
+    if (scoped.length === 1 && clickControl(scoped[0])) {
+      return { handled: true, scope: preferredScope };
+    }
+  }
+
+  const candidates = reachableRoots(start).flatMap((root) => matchingControls(root, labels));
+  if (candidates.length === 1 && clickControl(candidates[0])) {
+    return { handled: true, scope: playerScope(candidates[0]) };
+  }
+
+  const inPlayers = candidates
+    .map((control) => ({ control, scope: playerScope(control) }))
+    .filter((entry): entry is { control: SemanticMediaControl; scope: SemanticMediaScope } =>
+      Boolean(entry.scope && containsProgressControl(entry.scope)));
+  if (inPlayers.length === 1 && clickControl(inPlayers[0].control)) {
+    return { handled: true, scope: inPlayers[0].scope };
+  }
+
+  return { handled: false, scope: preferredScope };
+}
+
 /**
  * Every media element this page will let us reach.
  *
@@ -78,49 +299,15 @@ function asRoot(value: unknown): MediaRoot | null {
  * roots stay unreachable by the same principle.
  */
 export function collectMediaElements(document: MediaRoot | null | undefined): MediaEl[] {
-  const start = asRoot(document);
-  if (!start) return [];
-
   const found: MediaEl[] = [];
   const seen = new Set<unknown>();
-  const queue: MediaRoot[] = [start];
-  const visited = new Set<MediaRoot>([start]);
-  let scanned = 0;
-
-  while (queue.length > 0 && visited.size <= MAX_ROOTS) {
-    const root = queue.shift() as MediaRoot;
-
+  for (const root of reachableRoots(document)) {
     for (const element of elementsOf(root, 'audio, video')) {
       if (seen.has(element)) continue;
       seen.add(element);
       found.push(element as MediaEl);
     }
-
-    for (const frame of elementsOf(root, 'iframe, frame')) {
-      let document: MediaRoot | null = null;
-      try {
-        document = asRoot((frame as { contentDocument?: unknown }).contentDocument);
-      } catch {
-        // Cross-origin. Not ours to touch.
-      }
-      if (document && !visited.has(document)) {
-        visited.add(document);
-        queue.push(document);
-      }
-    }
-
-    if (scanned >= MAX_SCANNED) continue;
-    for (const host of elementsOf(root, '*')) {
-      scanned += 1;
-      if (scanned > MAX_SCANNED) break;
-      const shadow = asRoot((host as { shadowRoot?: unknown }).shadowRoot);
-      if (shadow && !visited.has(shadow)) {
-        visited.add(shadow);
-        queue.push(shadow);
-      }
-    }
   }
-
   return found;
 }
 

--- a/scripts/test-browser-page-media.mjs
+++ b/scripts/test-browser-page-media.mjs
@@ -2,11 +2,10 @@
 //
 // The bug this file exists to prevent: a flat `querySelectorAll('audio, video')`
 // on the top document is not "the page's media". Real players do not oblige.
-// elevenreader.io keeps EIGHT <audio> tags in its document and gives seven of
-// them no source at all, so the old code played eight elements at once, and let
-// Previous/Next land on a dead placeholder — pausing the track that was running.
-// Others put their player in an open shadow root or a same-origin frame, where a
-// flat query never looked.
+// Older elevenreader.io builds kept spare <audio> tags; the current player has
+// no media element at all and exposes only accessible Play/Pause controls.
+// Others put their player in an open shadow root or a same-origin frame, where
+// a flat query never looked.
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { execFileSync } from 'node:child_process';
@@ -60,14 +59,47 @@ const track = (options = {}) => el({ currentSrc: 'https://cdn.example/track.mp3'
 function doc(nodes, extras = {}) {
   const frames = extras.frames ?? [];
   const hosts = extras.hosts ?? [];
+  const buttons = extras.buttons ?? [];
   return {
     querySelectorAll(selector) {
       if (selector === 'audio, video') return nodes;
       if (selector === 'iframe, frame') return frames;
       if (selector === '*') return [...nodes, ...frames, ...hosts];
+      if (selector === 'button, [role="button"]') return buttons;
       return [];
     },
   };
+}
+
+function semanticButton(label, options = {}) {
+  const attributes = new Map(Object.entries({
+    'aria-label': label,
+    ...(options.attributes ?? {}),
+  }));
+  return {
+    textContent: options.textContent ?? '',
+    disabled: options.disabled ?? false,
+    parentElement: options.parentElement ?? null,
+    clicks: 0,
+    getAttribute(name) { return attributes.has(name) ? attributes.get(name) : null; },
+    getClientRects() { return options.visible === false ? [] : [{}]; },
+    querySelectorAll() { return []; },
+    click() { this.clicks += 1; options.onClick?.(); },
+  };
+}
+
+function playerScope(buttons, options = {}) {
+  const scope = {
+    parentElement: options.parentElement ?? null,
+    isConnected: options.isConnected ?? true,
+    querySelectorAll(selector) {
+      if (selector === 'button, [role="button"]') return buttons;
+      if (selector.includes('[role="slider"]')) return options.progress === false ? [] : [{}];
+      return [];
+    },
+  };
+  buttons.forEach((button) => { button.parentElement = scope; });
+  return scope;
 }
 
 test('an empty or missing document yields nothing rather than throwing', () => {
@@ -196,6 +228,75 @@ test('PAUSE on a page with nothing running reports unhandled, so main can use th
 
 test('PLAY on a page with no reachable media reports unhandled', () => {
   assert.equal(media.applyMediaCommand([], 'play', null), false);
+});
+
+test('a custom player with no media elements pauses through its visible semantic control', () => {
+  const cardPause = semanticButton('Pause');
+  const playerPause = semanticButton('Pause');
+  const scope = playerScope([playerPause]);
+  const result = media.applySemanticMediaCommand(doc([], { buttons: [cardPause, playerPause] }), 'pause');
+  assert.equal(result.handled, true);
+  assert.equal(result.scope, scope, 'the stable player shell is remembered for resume');
+  assert.equal(playerPause.clicks, 1, 'the control beside Progress is the active player');
+  assert.equal(cardPause.clicks, 0, 'a duplicate card control must not toggle too');
+});
+
+test('PLAY resumes inside the remembered player instead of choosing another book', () => {
+  const unrelated = semanticButton('Play');
+  const resume = semanticButton('Play');
+  const scope = playerScope([resume]);
+  const page = doc([], { buttons: [unrelated, resume] });
+  const result = media.applySemanticMediaCommand(page, 'play', scope);
+  assert.equal(result.handled, true);
+  assert.equal(resume.clicks, 1);
+  assert.equal(unrelated.clicks, 0);
+});
+
+test('a semantic player reports its actual state after React swaps the control', () => {
+  const controls = [];
+  const play = semanticButton('Play', {
+    onClick() { controls.splice(0, controls.length, pause); pause.parentElement = scope; },
+  });
+  const pause = semanticButton('Pause');
+  const scope = playerScope(controls);
+  controls.push(play);
+  play.parentElement = scope;
+  const page = doc([], { buttons: [play] });
+
+  assert.equal(media.semanticPlaybackState(page, scope), false);
+  assert.equal(media.applySemanticMediaCommand(page, 'play', scope).handled, true);
+  assert.equal(media.semanticPlaybackState(page, scope), true);
+});
+
+test('a detached remembered player is ignored instead of clicking a stale control', () => {
+  const stalePlay = semanticButton('Play');
+  const stale = playerScope([stalePlay], { isConnected: false });
+  const activePause = semanticButton('Pause');
+  const active = playerScope([activePause]);
+  const result = media.applySemanticMediaCommand(doc([], { buttons: [activePause] }), 'play', stale);
+  assert.equal(result.handled, false);
+  assert.equal(stalePlay.clicks, 0);
+  assert.equal(media.semanticPlaybackState(doc([], { buttons: [activePause] }), stale), true);
+  assert.equal(active.isConnected, true);
+});
+
+test('PLAY refuses an ambiguous page when no prior player scope exists', () => {
+  const first = semanticButton('Play');
+  const second = semanticButton('Play');
+  const result = media.applySemanticMediaCommand(doc([], { buttons: [first, second] }), 'play');
+  assert.equal(result.handled, false, 'starting the wrong book is worse than doing nothing');
+  assert.equal(first.clicks + second.clicks, 0);
+});
+
+test('semantic media controls work in open shadow roots and ignore hidden controls', () => {
+  const hidden = semanticButton('Pause', { visible: false });
+  const visible = semanticButton('Pause');
+  const shadow = doc([], { buttons: [visible] });
+  const page = doc([], { buttons: [hidden], hosts: [{ shadowRoot: shadow }] });
+  const result = media.applySemanticMediaCommand(page, 'pause');
+  assert.equal(result.handled, true);
+  assert.equal(hidden.clicks, 0);
+  assert.equal(visible.clicks, 1);
 });
 
 test('NEXT moves between real tracks, never onto a placeholder', () => {

--- a/scripts/test-document-understanding-consent.mjs
+++ b/scripts/test-document-understanding-consent.mjs
@@ -34,6 +34,14 @@ test('acceptance starts the current vault campaign and optionally enables future
   );
 });
 
+test('the consent modal defines separate light and dark surfaces', async () => {
+  const modal = await read('src/components/DocumentUnderstandingConsentModal.tsx');
+  assert.match(modal, /from-cyan-50 via-white to-indigo-50/);
+  assert.match(modal, /dark:from-cyan-950\/55 dark:via-neutral-950 dark:to-indigo-950\/35/);
+  assert.match(modal, /text-neutral-900 dark:text-neutral-100/);
+  assert.match(modal, /border-amber-300 bg-amber-50[\s\S]*dark:border-amber-900\/50 dark:bg-amber-950\/15/);
+});
+
 test('the consent is academic-only and its campaign has a global progress/control bar', async () => {
   const [app, bar, api, ipc, main, rootIpc, exportImport] = await Promise.all([
     read('src/App.tsx'),

--- a/src/components/DocumentUnderstandingConsentModal.tsx
+++ b/src/components/DocumentUnderstandingConsentModal.tsx
@@ -45,39 +45,39 @@ export function DocumentUnderstandingConsentModal({
 
   return (
     <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 p-4 sm:p-8" role="dialog" aria-modal="true" aria-labelledby="document-understanding-consent-title" aria-describedby="document-understanding-consent-description" data-testid="document-understanding-consent">
-      <div className="card w-full max-w-2xl overflow-hidden border border-cyan-900/70 bg-neutral-950 shadow-2xl">
-        <header className="border-b border-neutral-800 bg-gradient-to-br from-cyan-950/55 via-neutral-950 to-indigo-950/35 px-6 py-5">
-          <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-cyan-700/60 bg-cyan-950/70 text-cyan-300"><Icon name="layers" size={23} /></div>
-          <h2 id="document-understanding-consent-title" className="text-xl font-semibold text-neutral-100">{t('Comprender tus obras completas')}</h2>
-          <p id="document-understanding-consent-description" className="mt-2 text-sm leading-6 text-neutral-400">{t('Nodus puede analizar cada obra completa por secciones y construir una ficha jerárquica auditada de su tesis, método, estructura y conceptos principales.')}</p>
+      <div className="card w-full max-w-2xl overflow-hidden border border-cyan-200 bg-white shadow-2xl dark:border-cyan-900/70 dark:bg-neutral-950">
+        <header className="border-b border-neutral-200 bg-gradient-to-br from-cyan-50 via-white to-indigo-50 px-6 py-5 dark:border-neutral-800 dark:from-cyan-950/55 dark:via-neutral-950 dark:to-indigo-950/35">
+          <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-cyan-300 bg-cyan-50 text-cyan-700 dark:border-cyan-700/60 dark:bg-cyan-950/70 dark:text-cyan-300"><Icon name="layers" size={23} /></div>
+          <h2 id="document-understanding-consent-title" className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">{t('Comprender tus obras completas')}</h2>
+          <p id="document-understanding-consent-description" className="mt-2 text-sm leading-6 text-neutral-600 dark:text-neutral-400">{t('Nodus puede analizar cada obra completa por secciones y construir una ficha jerárquica auditada de su tesis, método, estructura y conceptos principales.')}</p>
         </header>
 
         <main className="space-y-5 px-6 py-5">
           <section>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-cyan-400">{t('Qué mejora')}</h3>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-400">{t('Qué mejora')}</h3>
             <div className="space-y-2">
               {[
                 'Selecciona mejor qué obras consultar antes de buscar ideas y pasajes.',
                 'Añade contexto global a Chat, Nodi, Deep Research e Immersion sin sustituir las ideas ni sus relaciones.',
                 'Mantiene la trazabilidad: las respuestas siguen citando el texto original, nunca la ficha generada.',
-              ].map((item) => <div key={item} className="flex gap-2.5 text-sm leading-5 text-neutral-300"><Icon name="check" size={15} className="mt-0.5 shrink-0 text-emerald-400" /><span>{t(item)}</span></div>)}
+              ].map((item) => <div key={item} className="flex gap-2.5 text-sm leading-5 text-neutral-700 dark:text-neutral-300"><Icon name="check" size={15} className="mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400" /><span>{t(item)}</span></div>)}
             </div>
           </section>
 
-          <section className="rounded-xl border border-amber-900/50 bg-amber-950/15 p-4">
-            <h3 className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-amber-300">{t('Antes de empezar')}</h3>
-            <p className="text-xs leading-5 text-neutral-400">{t('El primer análisis de un vault grande puede tardar y utilizará los proveedores de IA y embeddings que tengas configurados. Se ejecuta en segundo plano, puede pausarse y omite las obras que ya estén actualizadas.')}</p>
+          <section className="rounded-xl border border-amber-300 bg-amber-50 p-4 dark:border-amber-900/50 dark:bg-amber-950/15">
+            <h3 className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">{t('Antes de empezar')}</h3>
+            <p className="text-xs leading-5 text-neutral-600 dark:text-neutral-400">{t('El primer análisis de un vault grande puede tardar y utilizará los proveedores de IA y embeddings que tengas configurados. Se ejecuta en segundo plano, puede pausarse y omite las obras que ya estén actualizadas.')}</p>
           </section>
 
-          <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-neutral-800 bg-neutral-900/40 px-4 py-3 text-sm text-neutral-300">
+          <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900/40 dark:text-neutral-300">
             <input type="checkbox" checked={automatic} onChange={(event) => setAutomatic(event.target.checked)} disabled={busy} />
             <span>{t('Analizar automáticamente las obras nuevas')}</span>
           </label>
-          {error && <p className="text-xs leading-5 text-red-300" role="alert">{t('No se pudo iniciar el análisis documental. Revisa los modelos configurados e inténtalo desde la Biblioteca.')}</p>}
-          <p className="text-[11px] leading-5 text-neutral-600">{t('Podrás activarlo más adelante desde Biblioteca → Índice documental o desde Ajustes → Biblioteca.')}</p>
+          {error && <p className="text-xs leading-5 text-red-600 dark:text-red-300" role="alert">{t('No se pudo iniciar el análisis documental. Revisa los modelos configurados e inténtalo desde la Biblioteca.')}</p>}
+          <p className="text-[11px] leading-5 text-neutral-500 dark:text-neutral-600">{t('Podrás activarlo más adelante desde Biblioteca → Índice documental o desde Ajustes → Biblioteca.')}</p>
         </main>
 
-        <footer className="flex flex-col-reverse gap-2 border-t border-neutral-800 px-6 py-4 sm:flex-row sm:justify-end">
+        <footer className="flex flex-col-reverse gap-2 border-t border-neutral-200 px-6 py-4 dark:border-neutral-800 sm:flex-row sm:justify-end">
           <button className="btn btn-ghost" disabled={busy} onClick={() => void finish(false)}>{t('Ahora no')}</button>
           <button className="btn btn-primary" disabled={busy} autoFocus onClick={() => void finish(true)}><Icon name={busy ? 'sync' : 'play'} className={busy ? 'animate-spin' : ''} />{t('Analizar mi vault ahora')}</button>
         </footer>


### PR DESCRIPTION
## Summary

- Control custom and WebAudio players through exact accessible Play/Pause controls when a page exposes no HTML media element.
- Remember the active player scope, prefer the control associated with its progress slider, and refuse ambiguous page-wide Play commands.
- Synchronize the Nodus media panel after React replaces the player control so Pause and Resume reflect the real state.
- Give the document-understanding consent modal explicit light and dark surfaces, borders, icon colors, and text contrast.
- Add focused regression coverage for custom players, stale player scopes, state changes, and modal theme variants.

## Related issue

Closes #536

## Type of change

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation or translation
- [ ] Refactor or maintenance
- [ ] Database, privacy, security, or infrastructure change

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `node --test scripts/test-browser-page-media.mjs`
- [x] `node --test scripts/test-browser-media-sessions.mjs`
- [x] `node --test scripts/test-document-understanding-consent.mjs`
- [x] `npm run build`
- [ ] `npm run test:e2e` — focused tests and live Electron verification were used instead

Manual verification:

- ElevenReader Pause froze progress and changed the Nodus action to Resume.
- Resume advanced progress and changed the action back to Pause.
- The consent modal was visually verified in both light and dark themes.

## Screenshots

Not attached because the live verification used a private local profile. No private library or vault content is included in this PR.

## Privacy and data review

- [x] No secrets, credentials, private vault content, personal data, student data, or confidential documents are included.
- [x] No new network access is introduced.
- [x] The change does not send rosters, grades, student answers, or other protected data to AI providers.
- [x] The change does not use AI to grade, rank, profile, or evaluate students.
- [x] There are no database, backup, synchronization, or migration effects.

The temporary local test profile and its backup preferences are not part of the repository, commit, branch, or PR.

## Contributor checklist

- [x] I added or updated focused tests.
- [x] No documentation update is required for these bug fixes.
- [x] No static UI text was added, so translation tables are unchanged.
- [x] I preserved local-first behavior and existing privacy boundaries.
- [x] I have read and followed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.