### PR TITLE
Fix cloud recovery checks blocking startup

### DIFF
--- a/electron/export/autoBackup.ts
+++ b/electron/export/autoBackup.ts
@@ -15,6 +15,7 @@ import { generateBackupPassword } from './backupCrypto';
 import { createBackupArchiveFile } from './exportImport';
 import { verifyBackupFileInUtility } from './backupUtilityHost';
 import { resolveBackupOutputDir } from '../recovery/recoveryPaths';
+import { recordVerifiedRecoverySnapshot } from '../recovery/recoveryFolderProbe';
 
 /**
  * Scheduled encrypted backups. Every run encrypts with the ONE master password
@@ -707,6 +708,21 @@ async function writeVerifiedBackup(options: VerifiedBackupOptions): Promise<Auto
     }
 
     const prunedCount = options.prune(folder, hostname);
+    try {
+      recordVerifiedRecoverySnapshot(configuredFolder, {
+        fileName: path.basename(target),
+        path: target,
+        date: built.manifest.date,
+        appVersion: built.manifest.appVersion,
+        schemaVersion: built.manifest.schemaVersion,
+        vaultCount: built.manifest.vaultCount ?? 1,
+        bytes: built.bytes,
+        includesSecrets: built.manifest.includesSecrets === true,
+      });
+    } catch {
+      // The archive itself is already authenticated. A cloud client refusing the tiny
+      // optional index must never turn a good backup into a failed/deleted backup.
+    }
     logBackupPerf('run:complete', backupStartedAt, { bytes: built.bytes, reusedVaults: built.reusedVaults });
     const locked = lockedApiKeyProviders();
     const warning = locked.length > 0

--- a/electron/export/exportImport.ts
+++ b/electron/export/exportImport.ts
@@ -302,7 +302,11 @@ export async function createBackupArchiveFile(options: {
   appVersion: string;
   /** Independent credential used by automatic recovery snapshots (v6). */
   recoveryKey?: string;
-}, targetPath: string): Promise<{ bytes: number; reusedVaults: number }> {
+}, targetPath: string): Promise<{
+  bytes: number;
+  reusedVaults: number;
+  manifest: Pick<BackupManifest, 'date' | 'appVersion' | 'schemaVersion' | 'vaultCount' | 'includesSecrets'>;
+}> {
   const backupStartedAt = process.hrtime.bigint();
   let phaseStartedAt = backupStartedAt;
   logBackupPerf('create:start', backupStartedAt);
@@ -429,7 +433,17 @@ export async function createBackupArchiveFile(options: {
     const bytes = (await fs.promises.stat(targetPath)).size;
     logBackupPerf('outer-zip-store:complete', phaseStartedAt, { bytes });
     logBackupPerf('create:complete', backupStartedAt, { bytes });
-    return { bytes, reusedVaults };
+    return {
+      bytes,
+      reusedVaults,
+      manifest: {
+        date: outerManifest.date,
+        appVersion: outerManifest.appVersion,
+        schemaVersion: outerManifest.schemaVersion,
+        vaultCount: outerManifest.vaultCount,
+        includesSecrets: outerManifest.includesSecrets,
+      },
+    };
   } finally {
     await fs.promises.rm(tempRoot, { recursive: true, force: true });
   }

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -123,7 +123,7 @@ import { scanQueue } from './pipeline/scanQueue';
 import {
   getRecoveryStatus,
   initializeRecoveryFolder,
-  inspectRecoveryFolder,
+  inspectRecoveryFolderSafely,
   restoreRecoverySnapshot,
 } from './recovery/recoveryManager';
 import { getTutorialCatalogue } from './tutorialCatalogue';
@@ -814,7 +814,9 @@ export function registerIpc(
       title: titles[language],
       properties: mode === 'restore' ? ['openDirectory'] : ['openDirectory', 'createDirectory'],
     });
-    return canceled || filePaths.length === 0 ? null : inspectRecoveryFolder(filePaths[0], language);
+    return canceled || filePaths.length === 0
+      ? null
+      : inspectRecoveryFolderSafely(filePaths[0], language, 'deep');
   });
   h('recovery:initialize', async (_e, folder: string, password: string, language: AppLanguage = 'es') =>
     initializeRecoveryFolder(folder, password, app.getVersion(), language)

--- a/electron/recovery/recoveryFolderProbe.ts
+++ b/electron/recovery/recoveryFolderProbe.ts
@@ -1,0 +1,157 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RecoverySnapshotSummary } from '@shared/types';
+import { readZipEntrySync } from '../export/zipFile';
+import {
+  readRecoveryManifest,
+  recoverySnapshotsDir,
+  visibleDirectoryEntries,
+} from './recoveryPaths';
+
+export type RecoveryProbeMode = 'cached' | 'deep';
+
+export interface RecoveryFolderProbe {
+  path: string;
+  kind: 'empty' | 'recovery' | 'invalid' | 'missing';
+  snapshots: RecoverySnapshotSummary[];
+  visibleEntries?: number;
+}
+
+interface OuterBackupManifest {
+  format: string;
+  formatVersion: number;
+  schemaVersion: number;
+  appVersion: string;
+  date: string;
+  includesSecrets?: boolean;
+  vaultCount?: number;
+}
+
+interface RecoverySnapshotIndex {
+  format: 'nodus.recovery-snapshot-index';
+  formatVersion: 1;
+  updatedAt: string;
+  snapshots: Omit<RecoverySnapshotSummary, 'path'>[];
+}
+
+export const RECOVERY_SNAPSHOT_INDEX_FILE = 'nodus-recovery-index.json';
+
+function recoverySnapshotIndexPath(root: string): string {
+  return path.join(root, RECOVERY_SNAPSHOT_INDEX_FILE);
+}
+
+function safeIndexedSummary(root: string, value: Omit<RecoverySnapshotSummary, 'path'>): RecoverySnapshotSummary | null {
+  if (!value || path.basename(value.fileName) !== value.fileName || !value.fileName.endsWith('.nodus')) return null;
+  if (!value.date || !value.appVersion || !Number.isFinite(value.schemaVersion) || !Number.isFinite(value.bytes)) return null;
+  return { ...value, path: path.join(recoverySnapshotsDir(root), value.fileName) };
+}
+
+export function readRecoverySnapshotIndex(root: string): RecoverySnapshotSummary[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(recoverySnapshotIndexPath(root), 'utf8')) as RecoverySnapshotIndex;
+    if (parsed.format !== 'nodus.recovery-snapshot-index' || parsed.formatVersion !== 1 || !Array.isArray(parsed.snapshots)) return [];
+    return parsed.snapshots
+      .map((snapshot) => safeIndexedSummary(root, snapshot))
+      .filter((snapshot): snapshot is RecoverySnapshotSummary => snapshot !== null)
+      .sort((a, b) => b.date.localeCompare(a.date));
+  } catch {
+    return [];
+  }
+}
+
+export function writeRecoverySnapshotIndex(root: string, snapshots: RecoverySnapshotSummary[]): void {
+  if (!readRecoveryManifest(root)) return;
+  const target = recoverySnapshotIndexPath(root);
+  const temporary = `${target}.tmp-${process.pid}`;
+  const payload: RecoverySnapshotIndex = {
+    format: 'nodus.recovery-snapshot-index',
+    formatVersion: 1,
+    updatedAt: new Date().toISOString(),
+    snapshots: snapshots.map(({ path: _snapshotPath, ...snapshot }) => snapshot),
+  };
+  fs.writeFileSync(temporary, JSON.stringify(payload, null, 2), 'utf8');
+  fs.renameSync(temporary, target);
+}
+
+/** Update the tiny sidecar only after a snapshot has been fully authenticated. */
+export function recordVerifiedRecoverySnapshot(root: string, snapshot: RecoverySnapshotSummary): void {
+  if (!readRecoveryManifest(root)) return;
+  const snapshotsDir = recoverySnapshotsDir(root);
+  let survivingNames: Set<string>;
+  try {
+    survivingNames = new Set(fs.readdirSync(snapshotsDir).filter((name) => name.endsWith('.nodus')));
+  } catch {
+    survivingNames = new Set([snapshot.fileName]);
+  }
+  const byName = new Map(
+    readRecoverySnapshotIndex(root)
+      .filter((item) => survivingNames.has(item.fileName))
+      .map((item) => [item.fileName, item]),
+  );
+  byName.set(snapshot.fileName, snapshot);
+  writeRecoverySnapshotIndex(root, [...byName.values()].sort((a, b) => b.date.localeCompare(a.date)));
+}
+
+export function snapshotSummary(filePath: string): RecoverySnapshotSummary | null {
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) return null;
+    const manifestBytes = readZipEntrySync(filePath, 'manifest.json', 1024 * 1024);
+    if (!manifestBytes) return null;
+    const manifest = JSON.parse(manifestBytes.toString('utf8')) as OuterBackupManifest;
+    if (manifest.format !== 'nodus.encrypted-backup' || !Number.isFinite(manifest.formatVersion)) return null;
+    return {
+      fileName: path.basename(filePath),
+      path: filePath,
+      date: manifest.date,
+      appVersion: manifest.appVersion,
+      schemaVersion: manifest.schemaVersion,
+      vaultCount: manifest.vaultCount ?? 1,
+      bytes: stat.size,
+      includesSecrets: manifest.includesSecrets === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Filesystem-only probe designed to run outside Electron's main process. Cached mode
+ * never opens a .nodus archive, so a cloud placeholder cannot trigger hydration at
+ * startup. Deep mode is reserved for an explicit restore-folder selection.
+ */
+export function probeRecoveryFolder(folder: string, mode: RecoveryProbeMode = 'deep'): RecoveryFolderProbe {
+  const clean = path.resolve(folder);
+  if (!fs.existsSync(clean)) return { path: clean, kind: 'missing', snapshots: [] };
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(clean);
+  } catch {
+    return { path: clean, kind: 'missing', snapshots: [] };
+  }
+  if (!stat.isDirectory()) return { path: clean, kind: 'invalid', snapshots: [] };
+
+  if (readRecoveryManifest(clean)) {
+    const snapshotsDir = recoverySnapshotsDir(clean);
+    const cached = readRecoverySnapshotIndex(clean);
+    if (mode === 'cached') return { path: clean, kind: 'recovery', snapshots: cached };
+
+    const cachedByName = new Map(cached.map((snapshot) => [snapshot.fileName, snapshot]));
+    let names: string[] = [];
+    try {
+      names = fs.readdirSync(snapshotsDir).filter((name) => name.endsWith('.nodus'));
+    } catch {
+      /* a valid root may not have its snapshots directory yet */
+    }
+    const snapshots = names
+      .map((name) => cachedByName.get(name) ?? snapshotSummary(path.join(snapshotsDir, name)))
+      .filter((item): item is RecoverySnapshotSummary => item !== null)
+      .sort((a, b) => b.date.localeCompare(a.date));
+    return { path: clean, kind: 'recovery', snapshots };
+  }
+
+  const entries = visibleDirectoryEntries(clean);
+  return entries.length === 0
+    ? { path: clean, kind: 'empty', snapshots: [] }
+    : { path: clean, kind: 'invalid', snapshots: [], visibleEntries: entries.length };
+}

--- a/electron/recovery/recoveryManager.ts
+++ b/electron/recovery/recoveryManager.ts
@@ -22,7 +22,6 @@ import {
   setBackupRecoveryKey,
 } from '../secrets/secretStore';
 import { generateBackupPassword } from '../export/backupCrypto';
-import { readZipEntrySync } from '../export/zipFile';
 import { listVaults } from '../vaults/vaultRegistry';
 import {
   createRecoveryManifest,
@@ -32,41 +31,17 @@ import {
   visibleDirectoryEntries,
   writeRecoveryManifest,
 } from './recoveryPaths';
+import {
+  snapshotSummary,
+  type RecoveryFolderProbe,
+} from './recoveryFolderProbe';
+import {
+  INTERACTIVE_RECOVERY_PROBE_TIMEOUT_MS,
+  STARTUP_RECOVERY_PROBE_TIMEOUT_MS,
+  probeRecoveryFolderInUtility,
+} from './recoveryProbeUtilityHost';
 
 export const RECOVERY_SETUP_VERSION = 1;
-
-interface OuterBackupManifest {
-  format: string;
-  formatVersion: number;
-  schemaVersion: number;
-  appVersion: string;
-  date: string;
-  includesSecrets?: boolean;
-  vaultCount?: number;
-}
-
-function snapshotSummary(filePath: string): RecoverySnapshotSummary | null {
-  try {
-    const stat = fs.statSync(filePath);
-    if (!stat.isFile()) return null;
-    const manifestBytes = readZipEntrySync(filePath, 'manifest.json', 1024 * 1024);
-    if (!manifestBytes) return null;
-    const manifest = JSON.parse(manifestBytes.toString('utf8')) as OuterBackupManifest;
-    if (manifest.format !== 'nodus.encrypted-backup' || !Number.isFinite(manifest.formatVersion)) return null;
-    return {
-      fileName: path.basename(filePath),
-      path: filePath,
-      date: manifest.date,
-      appVersion: manifest.appVersion,
-      schemaVersion: manifest.schemaVersion,
-      vaultCount: manifest.vaultCount ?? 1,
-      bytes: stat.size,
-      includesSecrets: manifest.includesSecrets === true,
-    };
-  } catch {
-    return null;
-  }
-}
 
 /**
  * The main process cannot reach the renderer's i18n table, so the handful of
@@ -133,6 +108,38 @@ export function inspectRecoveryFolder(folder: string, language: AppLanguage = 'e
   };
 }
 
+function inspectionFromProbe(probe: RecoveryFolderProbe, language: AppLanguage): RecoveryFolderInspection {
+  if (probe.kind === 'missing') {
+    return { ...probe, message: tr(language, { es: 'No se puede acceder a la carpeta.', en: 'The folder cannot be accessed.', fr: "Impossible d'accéder au dossier.", de: 'Auf den Ordner kann nicht zugegriffen werden.', pt: 'Não é possível aceder à pasta.', 'pt-BR': 'Não é possível acessar a pasta.', it: 'Impossibile accedere alla cartella.', tr: 'Klasöre erişilemiyor.' }) };
+  }
+  if (probe.kind === 'empty') {
+    return { ...probe, message: tr(language, { es: 'Carpeta vacía y disponible.', en: 'Empty folder, ready to use.', fr: 'Dossier vide et disponible.', de: 'Ordner leer und verfügbar.', pt: 'Pasta vazia e disponível.', 'pt-BR': 'Pasta vazia e disponível.', it: 'Cartella vuota e disponibile.', tr: 'Boş klasör, kullanıma hazır.' }) };
+  }
+  if (probe.kind === 'recovery') {
+    return {
+      ...probe,
+      message: probe.snapshots.length
+        ? tr(language, { es: `${probe.snapshots.length} copia(s) válida(s) encontrada(s).`, en: `${probe.snapshots.length} valid snapshot(s) found.`, fr: `${probe.snapshots.length} sauvegarde(s) valide(s) trouvée(s).`, de: `${probe.snapshots.length} gültige Sicherung(en) gefunden.`, pt: `${probe.snapshots.length} cópia(s) de segurança válida(s) encontrada(s).`, 'pt-BR': `${probe.snapshots.length} backup(s) válido(s) encontrado(s).`, it: `Trovate ${probe.snapshots.length} copie valide.`, tr: `${probe.snapshots.length} geçerli anlık görüntü bulundu.` })
+        : tr(language, { es: 'Carpeta de recuperación válida, todavía sin copias.', en: 'Valid recovery folder, with no snapshots yet.', fr: 'Dossier de récupération valide, encore sans sauvegarde.', de: 'Gültiger Wiederherstellungsordner, noch ohne Sicherungen.', pt: 'Pasta de recuperação válida, ainda sem cópias de segurança.', 'pt-BR': 'Pasta de recuperação válida, ainda sem backups.', it: 'Cartella di ripristino valida, ancora senza copie.', tr: 'Geçerli kurtarma klasörü; henüz anlık görüntü yok.' }),
+    };
+  }
+  const entries = probe.visibleEntries ?? 0;
+  return {
+    ...probe,
+    message: tr(language, { es: `La carpeta debe estar vacía o contener una recuperación de Nodus válida. Contiene ${entries} elemento(s).`, en: `The folder must be empty or contain a valid Nodus recovery. It contains ${entries} item(s).`, fr: `Le dossier doit être vide ou contenir une récupération Nodus valide. Il contient ${entries} élément(s).`, de: `Der Ordner muss leer sein oder eine gültige Nodus-Wiederherstellung enthalten. Er enthält ${entries} Element(e).`, pt: `A pasta deve estar vazia ou conter uma recuperação válida do Nodus. Contém ${entries} elemento(s).`, 'pt-BR': `A pasta deve estar vazia ou conter uma recuperação válida do Nodus. Ela contém ${entries} elemento(s).`, it: `La cartella deve essere vuota o contenere un ripristino Nodus valido. Contiene ${entries} elementi.`, tr: `Klasör boş olmalı veya geçerli bir Nodus kurtarması içermelidir. ${entries} öğe içeriyor.` }),
+  };
+}
+
+export async function inspectRecoveryFolderSafely(
+  folder: string,
+  language: AppLanguage = 'es',
+  mode: 'cached' | 'deep' = 'deep',
+  timeoutMs = INTERACTIVE_RECOVERY_PROBE_TIMEOUT_MS,
+): Promise<RecoveryFolderInspection> {
+  const probe = await probeRecoveryFolderInUtility(folder, mode, timeoutMs);
+  return inspectionFromProbe(probe, language);
+}
+
 /** How many days a snapshot may age before protection counts as lapsed. The scheduler
  *  aims for a slot per chosen weekday, so a week without one is already anomalous. */
 const STALE_AFTER_DAYS = 8;
@@ -172,10 +179,20 @@ function assessRecoveryHealth(
   return { level: 'ok', code: 'ok', daysSinceLastBackup, detail };
 }
 
-export function getRecoveryStatus(): RecoveryStatus {
+export async function getRecoveryStatus(): Promise<RecoveryStatus> {
   const settings = getSettings();
   const configuredRoot = settings.autoBackupFolder?.trim() ?? '';
-  const folder = configuredRoot ? inspectRecoveryFolder(configuredRoot, settings.uiLanguage) : null;
+  // The cloud provider owns this path. Probe it in a disposable process and accept a
+  // last-known health answer after a short deadline: startup must never depend on a
+  // File Provider placeholder completing a read.
+  const folder = configuredRoot
+    ? await inspectRecoveryFolderSafely(
+      configuredRoot,
+      settings.uiLanguage,
+      'cached',
+      STARTUP_RECOVERY_PROBE_TIMEOUT_MS,
+    ).catch(() => null)
+    : null;
   return {
     health: assessRecoveryHealth(settings, folder),
     setupVersion: settings.recoverySetupVersion ?? 0,
@@ -214,7 +231,12 @@ export async function initializeRecoveryFolder(
 ): Promise<RecoverySetupResult> {
   const cleanPassword = password.trim();
   if (cleanPassword.length < 8) return { ok: false, message: tr(language, { es: 'La contraseña debe tener al menos 8 caracteres.', en: 'The password must be at least 8 characters long.', fr: 'Le mot de passe doit contenir au moins 8 caractères.', de: 'Das Passwort muss mindestens 8 Zeichen lang sein.', pt: 'A palavra-passe deve ter pelo menos 8 caracteres.', 'pt-BR': 'A senha deve ter pelo menos 8 caracteres.', it: 'La password deve contenere almeno 8 caratteri.', tr: 'Parola en az 8 karakter uzunluğunda olmalıdır.' }) };
-  const inspection = inspectRecoveryFolder(folder, language);
+  let inspection: RecoveryFolderInspection;
+  try {
+    inspection = await inspectRecoveryFolderSafely(folder, language, 'deep');
+  } catch {
+    return { ok: false, message: tr(language, { es: 'La carpeta no respondió a tiempo. Haz que esté disponible sin conexión y vuelve a intentarlo.', en: 'The folder did not respond in time. Make it available offline and try again.', fr: 'Le dossier n’a pas répondu à temps. Rendez-le disponible hors connexion et réessayez.', de: 'Der Ordner hat nicht rechtzeitig geantwortet. Machen Sie ihn offline verfügbar und versuchen Sie es erneut.', pt: 'A pasta não respondeu a tempo. Disponibilize-a offline e tente novamente.', 'pt-BR': 'A pasta não respondeu a tempo. Disponibilize-a off-line e tente novamente.', it: 'La cartella non ha risposto in tempo. Rendila disponibile offline e riprova.', tr: 'Klasör zamanında yanıt vermedi. Çevrimdışı kullanılabilir yapıp yeniden deneyin.' }) };
+  }
   if (inspection.kind !== 'empty') return { ok: false, message: inspection.message };
 
   const root = inspection.path;
@@ -269,7 +291,12 @@ export async function restoreRecoverySnapshot(
   language: AppLanguage = 'es',
   onProgress?: (progress: RecoveryRestoreProgress) => void,
 ): Promise<RecoverySetupResult> {
-  const inspection = inspectRecoveryFolder(root, language);
+  let inspection: RecoveryFolderInspection;
+  try {
+    inspection = await inspectRecoveryFolderSafely(root, language, 'deep');
+  } catch {
+    return { ok: false, message: tr(language, { es: 'La carpeta de recuperación no respondió a tiempo. Hazla disponible sin conexión antes de restaurar.', en: 'The recovery folder did not respond in time. Make it available offline before restoring.', fr: 'Le dossier de récupération n’a pas répondu à temps. Rendez-le disponible hors connexion avant la restauration.', de: 'Der Wiederherstellungsordner hat nicht rechtzeitig geantwortet. Machen Sie ihn vor der Wiederherstellung offline verfügbar.', pt: 'A pasta de recuperação não respondeu a tempo. Disponibilize-a offline antes de restaurar.', 'pt-BR': 'A pasta de recuperação não respondeu a tempo. Disponibilize-a off-line antes de restaurar.', it: 'La cartella di ripristino non ha risposto in tempo. Rendila disponibile offline prima del ripristino.', tr: 'Kurtarma klasörü zamanında yanıt vermedi. Geri yüklemeden önce çevrimdışı kullanılabilir yapın.' }) };
+  }
   if (inspection.kind !== 'recovery') return { ok: false, message: inspection.message };
   const snapshot = inspection.snapshots.find((candidate) => candidate.fileName === path.basename(fileName));
   if (!snapshot) return { ok: false, message: tr(language, { es: 'La copia seleccionada no pertenece a esta carpeta de recuperación.', en: 'The selected snapshot does not belong to this recovery folder.', fr: "La sauvegarde sélectionnée n'appartient pas à ce dossier de récupération.", de: 'Die ausgewählte Sicherung gehört nicht zu diesem Wiederherstellungsordner.', pt: 'A cópia de segurança selecionada não pertence a esta pasta de recuperação.', 'pt-BR': 'O backup selecionado não pertence a esta pasta de recuperação.', it: 'La copia selezionata non appartiene a questa cartella di ripristino.', tr: 'Seçilen anlık görüntü bu kurtarma klasörüne ait değil.' }) };

--- a/electron/recovery/recoveryProbeUtilityHost.ts
+++ b/electron/recovery/recoveryProbeUtilityHost.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { utilityProcess } from 'electron';
+import type { RecoveryFolderProbe, RecoveryProbeMode } from './recoveryFolderProbe';
+import type { RecoveryProbeUtilityRequest, RecoveryProbeUtilityResponse } from './recoveryProbeUtilityTypes';
+
+let nextId = 1;
+export const STARTUP_RECOVERY_PROBE_TIMEOUT_MS = 1_250;
+export const INTERACTIVE_RECOVERY_PROBE_TIMEOUT_MS = 15_000;
+
+function workerFile(): string {
+  return process.env.NODUS_RECOVERY_PROBE_UTILITY_FILE || path.join(__dirname, 'recoveryProbeUtilityWorker.js');
+}
+
+export async function probeRecoveryFolderInUtility(
+  folder: string,
+  mode: RecoveryProbeMode,
+  timeoutMs: number,
+): Promise<RecoveryFolderProbe> {
+  const request: RecoveryProbeUtilityRequest = { id: nextId++, folder, mode };
+  if (process.env.ELECTRON_RUN_AS_NODE === '1' || process.env.NODUS_RECOVERY_PROBE_INLINE === '1') {
+    const { runRecoveryProbeUtilityRequest } = await import('./recoveryProbeUtilityWorker');
+    const response = runRecoveryProbeUtilityRequest(request);
+    if (response.kind === 'error') throw new Error(response.error);
+    return response.probe;
+  }
+
+  const file = workerFile();
+  if (!fs.existsSync(file)) throw new Error('The recovery inspection process is not available.');
+  const child = utilityProcess.fork(file, [], { serviceName: 'Nodus recovery inspection', stdio: 'inherit' });
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error, probe?: RecoveryFolderProbe): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.removeAllListeners();
+      child.kill();
+      if (error) reject(error); else resolve(probe!);
+    };
+    const timeout = setTimeout(
+      () => finish(new Error(`Recovery inspection exceeded ${timeoutMs} ms.`)),
+      Math.max(1, timeoutMs),
+    );
+    timeout.unref?.();
+    child.on('message', (response: RecoveryProbeUtilityResponse) => {
+      if (!response || response.id !== request.id) return;
+      if (response.kind === 'error') finish(new Error(response.error));
+      else finish(undefined, response.probe);
+    });
+    child.once('error', (error) => finish(new Error(String(error))));
+    child.once('exit', (code) => {
+      if (!settled) finish(new Error(`Recovery inspection exited with code ${code}.`));
+    });
+    child.postMessage(request);
+  });
+}

--- a/electron/recovery/recoveryProbeUtilityTypes.ts
+++ b/electron/recovery/recoveryProbeUtilityTypes.ts
@@ -1,0 +1,17 @@
+import type { RecoveryFolderProbe, RecoveryProbeMode } from './recoveryFolderProbe';
+
+export interface RecoveryProbeUtilityRequest {
+  id: number;
+  folder: string;
+  mode: RecoveryProbeMode;
+}
+
+export type RecoveryProbeUtilityResponse = {
+  kind: 'probe-done';
+  id: number;
+  probe: RecoveryFolderProbe;
+} | {
+  kind: 'error';
+  id: number;
+  error: string;
+};

--- a/electron/recovery/recoveryProbeUtilityWorker.ts
+++ b/electron/recovery/recoveryProbeUtilityWorker.ts
@@ -1,0 +1,23 @@
+import { probeRecoveryFolder } from './recoveryFolderProbe';
+import type { RecoveryProbeUtilityRequest, RecoveryProbeUtilityResponse } from './recoveryProbeUtilityTypes';
+
+export function runRecoveryProbeUtilityRequest(request: RecoveryProbeUtilityRequest): RecoveryProbeUtilityResponse {
+  return {
+    kind: 'probe-done',
+    id: request.id,
+    probe: probeRecoveryFolder(request.folder, request.mode),
+  };
+}
+
+process.parentPort?.on('message', (event) => {
+  const request = event.data as RecoveryProbeUtilityRequest;
+  try {
+    process.parentPort?.postMessage(runRecoveryProbeUtilityRequest(request));
+  } catch (error) {
+    process.parentPort?.postMessage({
+      kind: 'error',
+      id: request.id,
+      error: error instanceof Error ? error.message : String(error),
+    } satisfies RecoveryProbeUtilityResponse);
+  }
+});

--- a/scripts/test-backup-utility-process.mjs
+++ b/scripts/test-backup-utility-process.mjs
@@ -62,7 +62,10 @@ test('production backup contains no sqlite backup or synchronous auto verificati
   assert.doesNotMatch(automatic, /verifyBackupArchive\(|readFile\(target\)/);
 
   const recovery = fs.readFileSync(path.join(repoRoot, 'electron/recovery/recoveryManager.ts'), 'utf8');
-  assert.match(recovery, /readZipEntrySync\(filePath, 'manifest\.json'/);
+  const recoveryProbe = fs.readFileSync(path.join(repoRoot, 'electron/recovery/recoveryFolderProbe.ts'), 'utf8');
+  assert.match(recoveryProbe, /readZipEntrySync\(filePath, 'manifest\.json'/);
+  assert.match(recoveryProbe, /if \(mode === 'cached'\) return/);
+  assert.doesNotMatch(recovery, /readZipEntrySync\(filePath/);
   assert.match(recovery, /restoreBackupArchiveFileSafely\(snapshot\.path/);
   assert.doesNotMatch(recovery, /new AdmZip\(filePath\)|readFileSync\(snapshot\.path\)/);
 });

--- a/scripts/test-recovery-folder.mjs
+++ b/scripts/test-recovery-folder.mjs
@@ -33,6 +33,7 @@ try {
   const { closeDb } = require(path.join(repoRoot, 'electron/db/database.ts'));
   const entities = require(path.join(repoRoot, 'electron/db/entitiesRepo.ts'));
   const recovery = require(path.join(repoRoot, 'electron/recovery/recoveryManager.ts'));
+  const recoveryProbe = require(path.join(repoRoot, 'electron/recovery/recoveryFolderProbe.ts'));
 
   fs.writeFileSync(path.join(invalidRoot, 'unrelated.txt'), 'do not overwrite');
   assert.equal(recovery.inspectRecoveryFolder(recoveryRoot).kind, 'empty');
@@ -53,9 +54,15 @@ try {
   assert.equal(initialized.ok, true, initialized.message);
   assert.ok(initialized.recoveryKey && initialized.recoveryKey !== 'clave-maestra-segura', 'independent recovery key returned once');
   assert.ok(initialized.snapshot?.path && fs.existsSync(initialized.snapshot.path), 'verified initial snapshot exists');
+  assert.ok(fs.existsSync(path.join(recoveryRoot, recoveryProbe.RECOVERY_SNAPSHOT_INDEX_FILE)), 'verified backup writes the startup-safe sidecar index');
+  assert.deepEqual(
+    recoveryProbe.probeRecoveryFolder(recoveryRoot, 'cached').snapshots.map((snapshot) => snapshot.fileName),
+    [initialized.snapshot.fileName],
+    'cached startup status discovers the verified snapshot without reopening its archive',
+  );
   assert.equal(recovery.inspectRecoveryFolder(recoveryRoot).kind, 'recovery');
-  assert.equal(recovery.getRecoveryStatus().needsSetup, false, 'setup gate committed only after first verified snapshot');
-  assert.equal(recovery.getRecoveryStatus().hasRecoveryKey, true, 'recovery-key availability is exposed without revealing it');
+  assert.equal((await recovery.getRecoveryStatus()).needsSetup, false, 'setup gate committed only after first verified snapshot');
+  assert.equal((await recovery.getRecoveryStatus()).hasRecoveryKey, true, 'recovery-key availability is exposed without revealing it');
 
   entities.deletePerson(alice.personId);
   fs.writeFileSync(path.join(userData, 'nodi-chat-history.json'), '[]');
@@ -119,30 +126,30 @@ try {
   // frozen on the last success, so the UI kept reporting "ok" while nothing was being
   // written. That is the failure a backup system cannot afford.
   const settingsRepo = require(path.join(repoRoot, 'electron/db/settingsRepo.ts'));
-  assert.equal(recovery.getRecoveryStatus().health.level, 'ok', 'a working setup reads as healthy');
+  assert.equal((await recovery.getRecoveryStatus()).health.level, 'ok', 'a working setup reads as healthy');
 
   settingsRepo.updateSettings({ lastAutoBackupStatus: 'error: no se pudo leer la contraseña maestra' });
-  const failedHealth = recovery.getRecoveryStatus().health;
+  const failedHealth = (await recovery.getRecoveryStatus()).health;
   assert.equal(failedHealth.code, 'last-run-failed', 'a failed run is surfaced');
   assert.equal(failedHealth.level, 'critical', 'and it is critical, not a footnote');
 
   settingsRepo.updateSettings({ lastAutoBackupStatus: 'ok: copia verificada' });
   settingsRepo.updateSettings({ lastAutoBackupAt: new Date(Date.now() - 40 * 86400e3).toISOString() });
-  const staleHealth = recovery.getRecoveryStatus().health;
+  const staleHealth = (await recovery.getRecoveryStatus()).health;
   assert.equal(staleHealth.code, 'stale', 'a long gap since the last snapshot is surfaced');
   assert.equal(staleHealth.daysSinceLastBackup, 40, 'the age is reported so the user can judge it');
 
   settingsRepo.updateSettings({ lastAutoBackupAt: new Date().toISOString() });
   fs.rmSync(path.join(recoveryRoot, 'nodus-recovery.json'), { force: true });
   assert.equal(
-    recovery.getRecoveryStatus().health.code,
+    (await recovery.getRecoveryStatus()).health.code,
     'folder-unreachable',
     'an unusable destination outranks a successful last run'
   );
 
   settingsRepo.updateSettings({ autoBackupEnabled: false });
-  assert.equal(recovery.getRecoveryStatus().health.code, 'disabled', 'no protection at all is reported as critical');
-  assert.equal(recovery.getRecoveryStatus().health.level, 'critical');
+  assert.equal((await recovery.getRecoveryStatus()).health.code, 'disabled', 'no protection at all is reported as critical');
+  assert.equal((await recovery.getRecoveryStatus()).health.level, 'critical');
 
   closeDb();
   console.log('Recovery folder integration test passed!');

--- a/scripts/test-recovery-startup-resilience.mjs
+++ b/scripts/test-recovery-startup-resilience.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks } from './lib/tsRuntimeHooks.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const source = (relative) => fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+let forkRecoveryUtility = () => { throw new Error('unexpected recovery utility launch'); };
+installRuntimeHooks(os.tmpdir(), { utilityProcess: { fork: (...args) => forkRecoveryUtility(...args) } });
+
+test('cached recovery probes never open unindexed cloud archives', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-recovery-index-'));
+  try {
+    const paths = require(path.join(repoRoot, 'electron/recovery/recoveryPaths.ts'));
+    const probe = require(path.join(repoRoot, 'electron/recovery/recoveryFolderProbe.ts'));
+    paths.writeRecoveryManifest(root, paths.createRecoveryManifest());
+    const snapshotsDir = paths.recoverySnapshotsDir(root);
+    fs.mkdirSync(snapshotsDir, { recursive: true });
+    const indexedPath = path.join(snapshotsDir, 'indexed.nodus');
+    fs.writeFileSync(indexedPath, 'index owns startup metadata');
+    probe.recordVerifiedRecoverySnapshot(root, {
+      fileName: 'indexed.nodus', path: indexedPath, date: '2026-08-25T08:42:12.583Z',
+      appVersion: '4.2.5', schemaVersion: 154, vaultCount: 2, bytes: 26, includesSecrets: true,
+    });
+    fs.writeFileSync(path.join(snapshotsDir, 'cloud-placeholder.nodus'), 'not a zip');
+
+    const cached = probe.probeRecoveryFolder(root, 'cached');
+    assert.equal(cached.kind, 'recovery');
+    assert.deepEqual(cached.snapshots.map((item) => item.fileName), ['indexed.nodus']);
+    assert.equal(cached.snapshots[0].path, indexedPath, 'paths are rebuilt safely from the selected root');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('a non-responsive recovery utility is killed at its deadline', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-recovery-timeout-'));
+  const worker = path.join(root, 'recoveryProbeUtilityWorker.js');
+  fs.writeFileSync(worker, '// existence sentinel');
+  let kills = 0;
+  class SilentChild extends EventEmitter {
+    postMessage() { /* intentionally never answers */ }
+    kill() { kills += 1; return true; }
+  }
+  forkRecoveryUtility = () => new SilentChild();
+  process.env.NODUS_RECOVERY_PROBE_UTILITY_FILE = worker;
+  const keepAlive = setInterval(() => {}, 100);
+  try {
+    const host = require(path.join(repoRoot, 'electron/recovery/recoveryProbeUtilityHost.ts'));
+    const started = Date.now();
+    await assert.rejects(
+      host.probeRecoveryFolderInUtility('/cloud/placeholder', 'cached', 25),
+      /exceeded 25 ms/,
+    );
+    assert.ok(Date.now() - started < 1_000, 'the main process receives a bounded answer');
+    assert.equal(kills, 1, 'the wedged child is reaped without awaiting its filesystem call');
+  } finally {
+    clearInterval(keepAlive);
+    delete process.env.NODUS_RECOVERY_PROBE_UTILITY_FILE;
+    forkRecoveryUtility = () => { throw new Error('unexpected recovery utility launch'); };
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('startup and interactive folder reads both cross the utility boundary', () => {
+  const manager = source('electron/recovery/recoveryManager.ts');
+  const ipc = source('electron/ipc.ts');
+  const vite = source('vite.config.ts');
+  assert.match(manager, /export async function getRecoveryStatus\(\): Promise<RecoveryStatus>/);
+  assert.match(manager, /'cached',[\s\S]{0,100}STARTUP_RECOVERY_PROBE_TIMEOUT_MS/);
+  assert.match(manager, /\.catch\(\(\) => null\)/, 'startup degrades to last-known health instead of rejecting');
+  assert.match(ipc, /inspectRecoveryFolderSafely\(filePaths\[0\], language, 'deep'\)/);
+  assert.match(vite, /utilityBuild\('recoveryProbeUtilityWorker'/);
+});
+
+test('the protection loading mark cycles through vault colours without JavaScript work', () => {
+  const component = source('src/components/RecoveryStatusLoading.tsx');
+  const startup = source('src/app/StartupGate.tsx');
+  const css = source('src/index.css');
+  assert.match(startup, /render: \(\) => <RecoveryStatusLoading \/>/);
+  assert.match(component, />NODUS RESEARCH<\/span>/);
+  assert.match(component, /import nodusLogo from '\.\.\/assets\/nodus-logo\.svg'/);
+  assert.match(component, /nodusLogoGold/);
+  assert.match(component, /nodusLogoCrimson/);
+  assert.match(component, /nodusLogoTeal/);
+  assert.match(component, /nodusLogoOrange/);
+  assert.match(component, /nodusLogoViolet/);
+  assert.match(component, /nodusLogoCyan/);
+  assert.match(component, /VAULT_LOGOS\.map\(\(src\) => <img/);
+  assert.doesNotMatch(component, /<svg|<path|<circle/, 'the official assets are used without recreating their geometry');
+  assert.doesNotMatch(component, /requestAnimationFrame|setInterval|canvas|WebGL/i);
+  assert.match(css, /contain: layout paint/);
+  assert.match(css, /animation: startup-protection-vault-logos 7s linear infinite/);
+  assert.match(css, /prefers-reduced-motion: reduce/);
+  assert.doesNotMatch(css.match(/\/\* Startup protection probe:[\s\S]*?\.reduce-motion \.startup-protection-logo-stack img:first-child \{[^}]+\}/)?.[0] ?? '', /filter|box-shadow/);
+});

--- a/src/app/StartupGate.tsx
+++ b/src/app/StartupGate.tsx
@@ -20,6 +20,7 @@ import { FirstVaultSetup } from '../views/FirstVaultSetup';
 import { Onboarding } from '../views/Onboarding';
 import { RecoverySetupWizard } from '../views/RecoverySetupWizard';
 import { markTutorialVideosAnnouncementSeen } from '../components/TutorialVideosGuide';
+import { RecoveryStatusLoading } from '../components/RecoveryStatusLoading';
 import { preferencesForTutorialLanguage } from '@shared/tutorialPreferences';
 import { t, setActiveLang } from '../i18n';
 
@@ -127,9 +128,7 @@ const SETTLED_GUARDS: readonly Guard<SettledState>[] = [
   {
     id: 'recovery-status-unknown',
     when: (state) => !state.isPreviewVault && state.recoveryStatus === null,
-    render: () => (
-      <div className="h-full flex items-center justify-center text-neutral-500">{t('Verificando la protección de tus datos…')}</div>
-    ),
+    render: () => <RecoveryStatusLoading />,
   },
   {
     // New installs see this immediately after the cinematic tutorial. Existing

--- a/src/components/RecoveryStatusLoading.tsx
+++ b/src/components/RecoveryStatusLoading.tsx
@@ -1,0 +1,32 @@
+import { t } from '../i18n';
+import nodusLogo from '../assets/nodus-logo.svg';
+import nodusLogoGold from '../assets/nodus-logo-gold.svg';
+import nodusLogoCrimson from '../assets/nodus-logo-crimson.svg';
+import nodusLogoTeal from '../assets/nodus-logo-teal.svg';
+import nodusLogoOrange from '../assets/nodus-logo-orange.svg';
+import nodusLogoViolet from '../assets/nodus-logo-violet.svg';
+import nodusLogoCyan from '../assets/nodus-logo-cyan.svg';
+
+const VAULT_LOGOS = [
+  nodusLogo,
+  nodusLogoGold,
+  nodusLogoCrimson,
+  nodusLogoTeal,
+  nodusLogoOrange,
+  nodusLogoViolet,
+  nodusLogoCyan,
+] as const;
+
+export function RecoveryStatusLoading() {
+  return (
+    <div className="startup-protection-loading" data-testid="recovery-status-loading">
+      <div className="startup-protection-brand" aria-hidden="true">
+        <div className="startup-protection-logo-stack">
+          {VAULT_LOGOS.map((src) => <img key={src} src={src} alt="" />)}
+        </div>
+        <span>NODUS RESEARCH</span>
+      </div>
+      <p role="status">{t('Verificando la protección de tus datos…')}</p>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,36 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Startup protection probe: these are the exact SVG files used by the sidebar,
+   cross-faded through its vault variants. No recreated mark, JavaScript loop,
+   canvas, blur or simulated nodes. */
+.startup-protection-loading { display: grid; width: 100%; height: 100%; place-content: center; justify-items: center; gap: 22px; color: #737686; contain: layout paint; }
+.startup-protection-loading > p { margin: 0; font-size: 13px; letter-spacing: .01em; }
+.startup-protection-brand { display: grid; justify-items: center; gap: 15px; }
+.startup-protection-brand > span { color: #a5b4fc; font-size: 12px; font-weight: 800; letter-spacing: .22em; line-height: 1; white-space: nowrap; }
+.startup-protection-logo-stack { position: relative; width: 78px; height: 78px; }
+.startup-protection-logo-stack img { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; animation: startup-protection-vault-logos 7s linear infinite; }
+.startup-protection-logo-stack img:nth-child(1) { animation-delay: 0s; }
+.startup-protection-logo-stack img:nth-child(2) { animation-delay: -1s; }
+.startup-protection-logo-stack img:nth-child(3) { animation-delay: -2s; }
+.startup-protection-logo-stack img:nth-child(4) { animation-delay: -3s; }
+.startup-protection-logo-stack img:nth-child(5) { animation-delay: -4s; }
+.startup-protection-logo-stack img:nth-child(6) { animation-delay: -5s; }
+.startup-protection-logo-stack img:nth-child(7) { animation-delay: -6s; }
+.light .startup-protection-loading { color: #64748b; }
+.light .startup-protection-brand > span { color: #4f46e5; }
+@keyframes startup-protection-vault-logos {
+  0%, 8% { opacity: 1; }
+  14.285%, 93.7% { opacity: 0; }
+  100% { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .startup-protection-logo-stack img { display: none; animation: none; }
+  .startup-protection-logo-stack img:first-child { display: block; opacity: 1; }
+}
+.reduce-motion .startup-protection-logo-stack img { display: none; animation: none; }
+.reduce-motion .startup-protection-logo-stack img:first-child { display: block; opacity: 1; }
+
 /* Native overlay scrollbars can paint above a portalled dialog even when its source
    surface is inert. Suppress only that background surface; the dialog keeps its own
    vertical scrollbar and remains fully keyboard-scrollable. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -298,6 +298,7 @@ export default defineConfig({
       databaseScaleFixtureWorkerBuild,
       databaseAggregateWorkerBuild,
       utilityBuild('backupUtilityWorker', 'electron/export/backupUtilityWorker.ts'),
+      utilityBuild('recoveryProbeUtilityWorker', 'electron/recovery/recoveryProbeUtilityWorker.ts'),
       utilityBuild('serverPublishWorker', 'electron/serverSync/serverPublishWorker.ts'),
     ]),
     renderer(),


### PR DESCRIPTION
## Summary

- move recovery-folder probing into a disposable Electron utility process with separate startup and interactive deadlines
- avoid opening `.nodus` archives during startup by recording authenticated snapshot metadata in a small sidecar index
- fail open when a cloud provider stalls, while keeping explicit restore inspection bounded and actionable
- replace the plain protection-status wait with the official Nodus logo, seamlessly crossfading through the existing vault color variants without JavaScript animation work
- add regression and integration coverage for cached probes, utility cleanup, startup guard behavior, and sidecar creation

## Verification

- `npm run typecheck`
- targeted ESLint on all changed TypeScript and TSX files
- `node --test scripts/test-recovery-startup-resilience.mjs scripts/test-startup-gate.mjs scripts/test-backup-utility-process.mjs` (10 passed)
- `node --test scripts/test-recovery-folder.mjs` (integration passed)
- `npm run build` (production build passed and emitted `recoveryProbeUtilityWorker.js`)

Closes #543