### PR TITLE
Improve Dictionary generation and continuity

### DIFF
--- a/electron/ai/dictionary.ts
+++ b/electron/ai/dictionary.ts
@@ -598,9 +598,57 @@ function uncitedSubstantiveSentences(markdown: string): string[] {
     .map((part) => part.trim())
     .filter(
       (part) =>
-        part.split(/\s+/).filter(Boolean).length >= 7,
+        part.split(/\s+/).filter(Boolean).length >= 4,
     )
     .filter((part) => !part.includes("CITATION") && !part.includes("nodus://"));
+}
+
+function substantiveWordCount(markdown: string): number {
+  const body = markdown
+    .replace(/^#{1,6} .*$/gm, " ")
+    // Citation labels are bibliography, not synthesis. A citation-only response
+    // must not become an apparently non-empty Dictionary definition.
+    .replace(/\[[^\]\n]*\]\(nodus:\/\/(?:idea|passage)\/[^)\s]+\)/g, " ")
+    .replace(/[^\p{L}\p{M}'’\s-]/gu, " ");
+  return body.match(/\p{L}[\p{L}\p{M}'’-]*/gu)?.length ?? 0;
+}
+
+async function groundGeneratedDescription(
+  generated: GeneratedDictionary,
+  snapshot: WritingWorkshopSnapshot,
+  verifyCitations: typeof aiVerifyCitations,
+  model: ModelRef | null,
+): Promise<{
+  markdown: string;
+  problems: string[];
+  strippedSentences: string[];
+}> {
+  const maps = buildSnapshotMaps(snapshot);
+  for (const id of [...maps.validIds])
+    if (id.startsWith("work:")) maps.validIds.delete(id);
+  let cleaned = applyCitationPolicy(generated.descriptionMarkdown, maps).markdown;
+  const claims = extractCitationClaims(cleaned, maps);
+  let strippedSentences: string[] = [];
+  if (claims.length) {
+    const outcome = applyVerification(
+      cleaned,
+      claims,
+      await verifyCitations(claims, model),
+    );
+    cleaned = outcome.markdown;
+    strippedSentences = outcome.strippedSentences;
+  }
+
+  const survivingClaims = extractCitationClaims(cleaned, maps);
+  const uncited = uncitedSubstantiveSentences(cleaned);
+  const problems: string[] = [];
+  if (substantiveWordCount(cleaned) < 5)
+    problems.push("la definición quedó vacía o era demasiado trivial");
+  if (!survivingClaims.length)
+    problems.push("no sobrevivió ninguna afirmación con una cita válida");
+  if (uncited.length)
+    problems.push(`${uncited.length} afirmaciones quedaron sin cita`);
+  return { markdown: cleaned, problems, strippedSentences };
 }
 
 function decorateIdeaTags(
@@ -632,10 +680,11 @@ async function synthesize(
   evidence: DictionaryEvidenceItem[],
   model: ModelRef | null,
   prior: string,
+  correction = "",
 ): Promise<GeneratedDictionary> {
   const entry = getDictionaryEntry(entryId)!;
-  const system = `Eres el redactor del Dictionary académico de Nodus. Redacta exclusivamente a partir de EVIDENCE. No uses conocimiento externo ni inventes autores, obras, páginas, citas, etiquetas, ideas o pasajes. Cada frase sustantiva debe terminar con una o más citas Markdown exactamente en el formato nodus://idea/ID o nodus://passage/ID ofrecido. Compara autores y obras; identifica acuerdos, desacuerdos, contradicciones y cambios temporales solo cuando EVIDENCE lo sostenga. Di explícitamente qué no permite establecer la evidencia. Devuelve JSON {"descriptionMarkdown":"...","authorSummaries":[{"authorName":"...","summaryMarkdown":"..."}]}. Los resúmenes de autor también deben estar citados.`;
-  const user = `CONCEPTO: ${entry.name}\nALIASES: ${entry.aliases.join(", ")}\nFOCO: ${entry.focusPrompt || "(sin foco adicional)"}\nDETALLE: ${entry.detailLevel}\nIDIOMA DE SALIDA: ${entry.outputLanguage}\n${prior ? `VERSIÓN ACTUAL A ACTUALIZAR SIN COPIAR AFIRMACIONES NO RESPALDADAS:\n${prior}\n` : ""}EVIDENCE:\n${evidencePrompt(evidence)}`;
+  const system = `Eres el redactor del Dictionary académico de Nodus. Redacta exclusivamente a partir de EVIDENCE. No uses conocimiento externo ni inventes autores, obras, páginas, citas, etiquetas, ideas o pasajes. El FOCO es una instrucción editorial: nunca lo copies ni lo presentes como definición. Abre con una definición sustantiva del concepto y desarróllala de acuerdo con DETALLE. Cada frase sustantiva debe terminar con una o más citas Markdown exactamente en el formato nodus://idea/ID o nodus://passage/ID ofrecido. Cada fuente citada debe respaldar la frase completa: si dos fuentes sostienen cláusulas distintas, escribe frases separadas, cada una con su propia cita. Compara autores y obras mediante atribuciones separadas; identifica acuerdos, desacuerdos, contradicciones y cambios temporales solo cuando EVIDENCE lo sostenga. Di explícitamente qué no permite establecer la evidencia. Devuelve JSON {"descriptionMarkdown":"...","authorSummaries":[{"authorName":"...","summaryMarkdown":"..."}]}. Los resúmenes de autor también deben estar citados.`;
+  const user = `CONCEPTO: ${entry.name}\nALIASES: ${entry.aliases.join(", ")}\nFOCO: ${entry.focusPrompt || "(sin foco adicional)"}\nDETALLE: ${entry.detailLevel}\nIDIOMA DE SALIDA: ${entry.outputLanguage}\n${prior ? `VERSIÓN ACTUAL A ACTUALIZAR SIN COPIAR AFIRMACIONES NO RESPALDADAS:\n${prior}\n` : ""}${correction ? `CORRECCIÓN OBLIGATORIA DE LA SALIDA ANTERIOR:\n${correction}\n` : ""}EVIDENCE:\n${evidencePrompt(evidence)}`;
   let generated = await completeJson<GeneratedDictionary>(
     {
       system,
@@ -704,32 +753,44 @@ async function generateDictionaryEntryUsing(
       : "";
     markdown = `## Evidencia insuficiente\n\nLa evidencia seleccionada es insuficiente para ofrecer una síntesis verificable del concepto.${citation}\n\nNo es posible comparar interpretaciones, establecer acuerdos o desacuerdos, ni describir cambios en el tiempo con el material disponible.`;
   } else {
-    const generated = await generator(
-      request.entryId,
-      evidence,
-      request.model ?? null,
-      request.mode === "update" ? entry.contentMarkdown : "",
-    );
     const snapshot = makeSnapshot(request.entryId, evidence);
     const maps = buildSnapshotMaps(snapshot);
     for (const id of [...maps.validIds])
       if (id.startsWith("work:")) maps.validIds.delete(id);
-    let cleaned = applyCitationPolicy(
-      generated.descriptionMarkdown,
-      maps,
-    ).markdown;
-    const claims = extractCitationClaims(cleaned, maps);
-    if (claims.length)
-      cleaned = applyVerification(
-        cleaned,
-        claims,
-        await verifyCitations(claims, request.model ?? null),
-      ).markdown;
-    if (uncitedSubstantiveSentences(cleaned).length)
-      throw new Error(
-        "El proveedor no produjo una síntesis donde cada afirmación estuviera respaldada por una cita válida. La versión anterior se conserva.",
+    let generated!: GeneratedDictionary;
+    let grounded!: Awaited<ReturnType<typeof groundGeneratedDescription>>;
+    let correction = "";
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      generated = await generator(
+        request.entryId,
+        evidence,
+        request.model ?? null,
+        request.mode === "update" ? entry.contentMarkdown : "",
+        correction,
       );
-    markdown = decorateIdeaTags(cleaned, evidence);
+      grounded = await groundGeneratedDescription(
+        generated,
+        snapshot,
+        verifyCitations,
+        request.model ?? null,
+      );
+      if (!grounded.problems.length) break;
+      correction = [
+        `La salida fue rechazada porque ${grounded.problems.join("; ")}.`,
+        "Reescribe desde cero una definición sustantiva. No copies el FOCO.",
+        "Haz afirmaciones atómicas y coloca en cada frase solo citas que respalden la frase completa.",
+        grounded.strippedSentences.length
+          ? `Estas frases no superaron la verificación y no deben repetirse sin estrecharlas: ${grounded.strippedSentences.slice(0, 4).join(" | ")}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }
+    if (grounded.problems.length)
+      throw new Error(
+        `El proveedor no produjo una síntesis sustantiva respaldada por citas válidas (${grounded.problems.join("; ")}). La versión anterior se conserva.`,
+      );
+    markdown = decorateIdeaTags(grounded.markdown, evidence);
     const summaries = new Map(
       generated.authorSummaries.map((item) => [
         normalizeDictionaryTerm(item.authorName),
@@ -765,13 +826,19 @@ async function generateDictionaryEntryUsing(
       name: author.name,
       ideaCount: author.ideas.size,
       workCount: author.works.size,
-      summaryMarkdown: decorateIdeaTags(
-        applyCitationPolicy(
+      summaryMarkdown: (() => {
+        const cleaned = applyCitationPolicy(
           summaries.get(normalizeDictionaryTerm(author.name)) ?? "",
           maps,
-        ).markdown,
-        evidence,
-      ),
+        ).markdown;
+        // Author cards must not become a side channel for uncited model prose.
+        if (
+          !extractCitationClaims(cleaned, maps).length ||
+          uncitedSubstantiveSentences(cleaned).length
+        )
+          return "";
+        return decorateIdeaTags(cleaned, evidence);
+      })(),
       attributionBasis: author.basis,
     }));
   }

--- a/electron/db/dictionaryRepo.ts
+++ b/electron/db/dictionaryRepo.ts
@@ -566,9 +566,14 @@ export function getDictionaryEntryDetail(id: string): DictionaryEntryDetail | nu
   const proposedVersion = entry.proposedVersionId ? getDictionaryVersion(entry.proposedVersionId) : null;
   const used = new Set((currentVersion?.evidence ?? []).map((ref) => `${ref.kind}:${ref.id}`));
   const cited = new Set((currentVersion?.citations ?? []).map((ref) => `${ref.kind}:${ref.id}`));
-  const coverage = { used: used.size, cited: cited.size, unused: evidence.filter((item) => item.decision === 'unused').length,
+  const unavailable = new Set(evidence.filter((item) => evidenceUnavailable(item)).map((item) => `${item.kind}:${item.ref_id}`));
+  // `included` describes the live selection that the next generation will use.
+  // Counting the current version's snapshot here made every new draft report zero
+  // available evidence even after retrieval had selected twenty usable items.
+  const coverage = { included: evidence.filter((item) => item.decision === 'included' && !unavailable.has(`${item.kind}:${item.ref_id}`)).length,
+    cited: cited.size, unused: evidence.filter((item) => item.decision === 'unused').length,
     excluded: evidence.filter((item) => item.decision === 'excluded').length, newEvidence: evidence.filter((item) => item.is_new).length,
-    unavailable: evidence.filter((item) => evidenceUnavailable(item)).length };
+    unavailable: unavailable.size };
   const authors = buildAuthors(evidence.filter((item) => used.has(`${item.kind}:${item.ref_id}`)), currentVersion?.authorSummaries ?? []);
   const works = buildWorks(evidence.filter((item) => used.has(`${item.kind}:${item.ref_id}`)));
   return { entry, coverage, authors, works, currentVersion, proposedVersion };

--- a/electron/ipc/academic.ts
+++ b/electron/ipc/academic.ts
@@ -397,6 +397,7 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
   });
   h('dictionary:delete', async (_e, ids: string[]) => {
     const changed = dictionaryRepo.deleteDictionaryEntries(ids);
+    for (const id of ids) dictionaryGenerationJobs.delete(id);
     if (changed) announceDictionary(null);
     return changed;
   });
@@ -441,11 +442,15 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
     setImmediate(() => {
       void (async () => {
         try {
-          const retrieving: DictionaryProgress = { entryId: request.entryId, phase: 'retrieving', message: 'Analizando corpus' };
-          dictionaryGenerationJobs.set(request.entryId, retrieving);
-          announceDictionaryProgress(retrieving);
-          await retrieveDictionaryEvidence(request.entryId, 'initial');
-          announceDictionary(request.entryId);
+          const current = dictionaryRepo.getDictionaryEntryDetail(request.entryId);
+          const needsInitialRetrieval = request.mode === 'creation' && (current?.coverage.included ?? 0) === 0;
+          if (needsInitialRetrieval) {
+            const retrieving: DictionaryProgress = { entryId: request.entryId, phase: 'retrieving', message: 'Analizando corpus' };
+            dictionaryGenerationJobs.set(request.entryId, retrieving);
+            announceDictionaryProgress(retrieving);
+            await retrieveDictionaryEvidence(request.entryId, 'initial');
+            announceDictionary(request.entryId);
+          }
 
           const generating: DictionaryProgress = { entryId: request.entryId, phase: 'generating', message: 'Generando definición' };
           dictionaryGenerationJobs.set(request.entryId, generating);
@@ -467,6 +472,7 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
     });
     return queued;
   });
+  h('dictionary:generate:jobs', async () => [...dictionaryGenerationJobs.values()]);
   h('dictionary:versions:list', async (_e, entryId: string) => dictionaryRepo.listDictionaryVersions(entryId));
   h('dictionary:versions:accept', async (_e, entryId: string, versionId: string, expectedCurrentVersionId: string | null) => {
     const detail = dictionaryRepo.acceptDictionaryVersion(entryId, versionId, expectedCurrentVersionId);

--- a/electron/preload/academic.ts
+++ b/electron/preload/academic.ts
@@ -37,6 +37,7 @@ export const academicApi: AcademicApi = {
     return result.version;
   },
   startDictionaryGeneration: (request) => ipcRenderer.invoke('dictionary:generate:start', request),
+  listDictionaryGenerationJobs: () => ipcRenderer.invoke('dictionary:generate:jobs'),
   onDictionaryProgress: (callback) => {
     const listener = (_event: Electron.IpcRendererEvent, progress: Parameters<typeof callback>[0]) => callback(progress);
     ipcRenderer.on('dictionary:progress', listener);

--- a/scripts/capture-dictionary-prompt-presets.mjs
+++ b/scripts/capture-dictionary-prompt-presets.mjs
@@ -1,0 +1,223 @@
+// Exercise the Dictionary prompt presets in the real Electron app and capture
+// the new-entry view. The profile is disposable and never touches user data.
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { _electron as electron } from "playwright-core";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
+const output =
+  process.env.NODUS_DICTIONARY_PROMPTS_SCREENSHOT ??
+  path.join(os.tmpdir(), "dictionary-new-entry-prompts.png");
+
+if (
+  !existsSync(path.join(repoRoot, "dist-electron", "main.js")) ||
+  !existsSync(path.join(repoRoot, "dist", "index.html"))
+) {
+  throw new Error("Run `npm run build` before capturing Dictionary prompts.");
+}
+
+const userData = await mkdtemp(
+  path.join(os.tmpdir(), "nodus-dictionary-prompts-"),
+);
+const childEnv = {
+  ...process.env,
+  NODUS_USERDATA: userData,
+  NODUS_DISABLE_AUTO_UPDATE: "1",
+  NODUS_E2E_UPDATE_STATUS: "not-available",
+  NODUS_E2E_DISABLE_STUDY_BACKGROUND_AI: "1",
+};
+delete childEnv.ELECTRON_RUN_AS_NODE;
+
+const settings = {
+  onboardingComplete: true,
+  basicsTutorialVersion: 999,
+  recoverySetupVersion: 999,
+  tourComplete: true,
+  advancedTourComplete: true,
+  theme: "light",
+  uiLanguage: "es",
+  mascotEnabled: false,
+  mascotStyleChosen: true,
+  reduceMotion: true,
+  demoMode: false,
+  sidebarCustomized: true,
+  sidebarHidden: [],
+  sidebarOrder: [],
+};
+
+let app;
+try {
+  app = await electron.launch({
+    executablePath: require("electron"),
+    args: [repoRoot],
+    env: childEnv,
+  });
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(30_000);
+  await app.evaluate(({ BrowserWindow }) => {
+    const main =
+      BrowserWindow.getAllWindows().find(
+        (candidate) => candidate.getTitle() === "Nodus",
+      ) ?? BrowserWindow.getAllWindows()[0];
+    main.setContentSize(1600, 1000);
+    main.center();
+  });
+  await page.waitForLoadState("domcontentloaded");
+  await page.waitForFunction(() =>
+    Boolean(document.getElementById("root")?.children.length),
+  );
+
+  await page.evaluate((nextSettings) => {
+    localStorage.setItem("nodus.lastSeenVersion", "9999.0.0");
+    localStorage.setItem("nodus.mobileTeaserSeen.3.2.4", "1");
+    localStorage.setItem("nodus.documentUnderstandingConsent.2026-08", "1");
+    localStorage.setItem("nodus.platformHighlightsSeen.2026-07", "1");
+    localStorage.setItem("nodus.toolkitBetaGuideSeen.2.4.0", "1");
+    localStorage.setItem(
+      "nodus.tutorialVideosAnnouncementSeen.2026-07",
+      "1",
+    );
+    sessionStorage.setItem("nodus.startupUpdateChecked", "1");
+    return window.nodus.updateSettings(nextSettings);
+  }, settings);
+  assert.equal(await page.evaluate(() => window.nodus.seedDemoData()), true);
+  await page.reload();
+  await page.getByTestId("app-shell").waitFor({ state: "visible" });
+  await page.waitForFunction(
+    () => document.documentElement.lang === "es" && !document.body.innerText.includes("Demo mode:"),
+  );
+
+  const whatsNew = page.locator(".whats-new-close");
+  if ((await whatsNew.count()) === 1 && (await whatsNew.isVisible())) {
+    await whatsNew.click();
+  }
+  const dismiss = page.locator(".backup-health-dismiss");
+  if ((await dismiss.count()) === 1 && (await dismiss.isVisible())) {
+    await dismiss.click();
+  }
+
+  const dictionaryNav = page.locator('[data-tour="nav-dictionary"]');
+  assert.equal(await dictionaryNav.count(), 1, "Dictionary navigation is visible");
+  await dictionaryNav.click();
+  await page.getByTestId("dictionary-new").waitFor({ state: "visible" });
+  await page.getByTestId("dictionary-new").click();
+
+  const dialog = page.getByRole("dialog");
+  await dialog.waitFor({ state: "visible" });
+  const preset = page.getByTestId("dictionary-prompt-preset");
+  const prompt = page.getByTestId("dictionary-focus-prompt");
+  const expectedLabels = [
+    "Básico · definición y autores",
+    "Evolución histórica",
+    "Debate entre autores",
+    "Genealogía teórica",
+    "Usos y aplicaciones",
+    "Lectura crítica",
+    "Personalizado",
+  ];
+  assert.deepEqual(
+    await preset.locator("option").allTextContents(),
+    expectedLabels,
+    "all translated presets are available",
+  );
+
+  const generatedPrompts = new Set();
+  for (const id of [
+    "basic",
+    "historical",
+    "debate",
+    "genealogy",
+    "applications",
+    "critical",
+  ]) {
+    await preset.selectOption(id);
+    const value = await prompt.inputValue();
+    assert.ok(value.length > 60, `${id} supplies a substantive prompt`);
+    generatedPrompts.add(value);
+  }
+  assert.equal(generatedPrompts.size, 6, "each preset supplies a distinct prompt");
+
+  await preset.selectOption("basic");
+  const basicPrompt = await prompt.inputValue();
+  await prompt.fill(`${basicPrompt} Prioriza las definiciones explícitas.`);
+  assert.equal(
+    await preset.inputValue(),
+    "custom",
+    "editing a preset switches the selector to Custom",
+  );
+  await preset.selectOption("basic");
+  assert.equal(
+    await prompt.inputValue(),
+    basicPrompt,
+    "choosing a preset restores its translated prompt",
+  );
+
+  await dialog
+    .getByRole("textbox", { name: "Concepto", exact: true })
+    .fill("Propaganda hispanófila");
+  await dialog
+    .getByRole("textbox", {
+      name: "Aliases o términos alternativos",
+      exact: true,
+    })
+    .fill("hispanofilia, propaganda de la Hispanidad");
+  await page.waitForTimeout(300);
+  await mkdir(path.dirname(output), { recursive: true });
+  await page.screenshot({ path: output, animations: "disabled", type: "png" });
+  console.log(`Dictionary prompt presets screenshot: ${output}`);
+
+  // The same real-app run also verifies continuity across a shell navigation.
+  await dialog.getByRole("button", { name: "Cancelar", exact: true }).click();
+  const remembered = await page.evaluate(() =>
+    window.nodus.createDictionaryEntry({
+      name: "Continuidad del diccionario",
+      aliases: [],
+      focusPrompt: "Comprueba que esta entrada y su pestaña siguen abiertas.",
+      scope: { kind: "vault" },
+      outputLanguage: "es",
+      detailLevel: "standard",
+    }),
+  );
+  await page.getByText(remembered.name, { exact: true }).waitFor();
+  await page.getByText(remembered.name, { exact: true }).click();
+  await page.getByTestId("dictionary-entry-detail").waitFor();
+  await page.getByTestId("dictionary-detail-tab-evidence").click();
+  await page.waitForTimeout(80);
+
+  const queued = await page.evaluate((entryId) =>
+    window.nodus.startDictionaryGeneration({
+      entryId,
+      mode: "creation",
+      model: null,
+    }), remembered.id);
+  assert.equal(queued.phase, "queued");
+
+  await page.locator('[data-tour="nav-home"]').click();
+  await page.getByTestId("dictionary-workspace").waitFor({ state: "detached" });
+  await page.waitForTimeout(150);
+  const jobsWhileAway = await page.evaluate(() =>
+    window.nodus.listDictionaryGenerationJobs(),
+  );
+  assert.ok(
+    jobsWhileAway.some((job) => job.entryId === remembered.id),
+    "the main-process job survives Dictionary unmounting",
+  );
+
+  await page.locator('[data-tour="nav-dictionary"]').click();
+  await page.getByTestId(`dictionary-tab-${remembered.id}`).waitFor();
+  await page.getByTestId("dictionary-entry-detail").waitFor();
+  assert.match(
+    await page.getByTestId("dictionary-detail-tab-evidence").getAttribute("class"),
+    /border-indigo-500/,
+    "Dictionary restores the entry and inner tab that were open",
+  );
+} finally {
+  if (app) await app.close().catch(() => {});
+  await rm(userData, { recursive: true, force: true });
+}

--- a/scripts/test-dictionary-ui.mjs
+++ b/scripts/test-dictionary-ui.mjs
@@ -4,7 +4,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const [view, corpus, navigation, authors, ai, academicIpc, preload] =
+const [
+  view,
+  corpus,
+  navigation,
+  authors,
+  ai,
+  academicIpc,
+  preload,
+  promptPresets,
+  dictionaryI18n,
+  viewSnapshots,
+] =
   await Promise.all([
     readFile(path.join(root, "src/views/DictionaryView.tsx"), "utf8"),
     readFile(path.join(root, "src/app/views/corpus.tsx"), "utf8"),
@@ -13,6 +24,9 @@ const [view, corpus, navigation, authors, ai, academicIpc, preload] =
     readFile(path.join(root, "electron/ai/dictionary.ts"), "utf8"),
     readFile(path.join(root, "electron/ipc/academic.ts"), "utf8"),
     readFile(path.join(root, "electron/preload/academic.ts"), "utf8"),
+    readFile(path.join(root, "shared/dictionaryPromptPresets.ts"), "utf8"),
+    readFile(path.join(root, "src/i18n.dictionary.ts"), "utf8"),
+    readFile(path.join(root, "src/app/viewSnapshots.ts"), "utf8"),
   ]);
 
 assert.match(
@@ -24,6 +38,16 @@ assert.match(
   corpus,
   /dictionary:[\s\S]*<DictionaryView/,
   "Dictionary is registered as an internal view",
+);
+assert.match(
+  corpus,
+  /snapshot=\{snapshots\.read\('dictionary'\)\}[\s\S]*onSnapshotChange=\{\(patch\) => snapshots\.patch\('dictionary', patch\)\}/,
+  "Dictionary participates in the shared per-vault view snapshot store",
+);
+assert.match(
+  viewSnapshots,
+  /export interface DictionarySnapshot[\s\S]*openEntries: OpenEntityTab\[\][\s\S]*activeEntryId: string \| null[\s\S]*detailTabs: Record<string, DictionaryDetailTab>/,
+  "Dictionary remembers its open entries, active entry and inner tabs",
 );
 assert.match(
   view,
@@ -70,6 +94,67 @@ assert.match(
   /<ModelPicker/,
   "Dictionary exposes the shared saved-model picker",
 );
+assert.match(
+  view,
+  /data-testid="dictionary-prompt-preset"/,
+  "new entries expose a prompt preset selector",
+);
+assert.match(
+  view,
+  /data-testid="dictionary-focus-prompt"/,
+  "the selected preset remains editable",
+);
+assert.match(
+  view,
+  /setPromptPreset\(matching\?\.id \?\? "custom"\)/,
+  "editing a preset prompt switches the selector to Custom",
+);
+assert.match(
+  view,
+  /focusPrompt: t\([\s\S]*dictionaryPromptPresetOption\(DEFAULT_DICTIONARY_PROMPT_PRESET\)\.prompt/,
+  "the basic definition-and-authors prompt is the translated default",
+);
+assert.match(
+  navigation,
+  /id: 'dictionary', label: 'Diccionario'/,
+  "the sidebar uses the Spanish translation key for the section name",
+);
+assert.match(
+  view,
+  /t\("Diccionario"\)[\s\S]*tx\("Diccionario \(\{n\}\)"/,
+  "the Dictionary header and home tab use the translated section name",
+);
+for (const id of [
+  "basic",
+  "historical",
+  "debate",
+  "genealogy",
+  "applications",
+  "critical",
+]) {
+  assert.match(
+    promptPresets,
+    new RegExp(`id: ["']${id}["']`),
+    `Dictionary includes the ${id} prompt preset`,
+  );
+}
+const translatedPromptKeys = [
+  "Preconfiguración del prompt",
+  "Escribe o adapta libremente las instrucciones para la síntesis.",
+  "Básico · definición y autores",
+  "Evolución histórica",
+  "Debate entre autores",
+  "Genealogía teórica",
+  "Usos y aplicaciones",
+  "Lectura crítica",
+];
+for (const key of translatedPromptKeys) {
+  const occurrences = dictionaryI18n.split(key).length - 1;
+  assert.ok(
+    occurrences >= 7,
+    `${key} is translated for all seven non-Spanish interface languages`,
+  );
+}
 assert.match(
   view,
   /onCitation=\{onCitation\}/,
@@ -136,6 +221,31 @@ assert.match(
   /startDictionaryGeneration\(\{/,
   "creation starts the automatic background pipeline without an evidence-review gate",
 );
+assert.equal(
+  (view.match(/startDictionaryGeneration\(\{/g) ?? []).length,
+  2,
+  "creation, regeneration and update all enter the main-process background pipeline",
+);
+assert.doesNotMatch(
+  view,
+  /window\.nodus\.generateDictionaryEntry/,
+  "no Dictionary generation is owned by a disposable renderer view",
+);
+assert.match(
+  view,
+  /listDictionaryGenerationJobs\(\)/,
+  "Dictionary rehydrates background job progress when the view remounts",
+);
+assert.match(
+  view,
+  /const hasEvidence = detail\.coverage\.included > 0/,
+  "generation eligibility uses the live included selection, not a nonexistent draft version",
+);
+assert.match(
+  view,
+  /backgroundFailure && <ErrorNotice>/,
+  "a failed background generation exposes the backend reason in the entry",
+);
 assert.match(
   view,
   /onDictionaryProgress/,
@@ -150,6 +260,21 @@ assert.match(
   academicIpc,
   /dictionary:generate:start[\s\S]*retrieveDictionaryEvidence[\s\S]*generateDictionaryEntry/,
   "the background IPC automatically retrieves and generates in order",
+);
+assert.match(
+  academicIpc,
+  /needsInitialRetrieval = request\.mode === 'creation' && \(current\?\.coverage\.included \?\? 0\) === 0/,
+  "only a brand-new concept performs initial retrieval before its background generation",
+);
+assert.match(
+  academicIpc,
+  /dictionary:generate:jobs[\s\S]*dictionaryGenerationJobs\.values/,
+  "the main process exposes running and completed jobs for view reconnection",
+);
+assert.match(
+  preload,
+  /listDictionaryGenerationJobs: \(\) => ipcRenderer\.invoke\('dictionary:generate:jobs'\)/,
+  "the renderer can reconnect to Dictionary jobs after changing views",
 );
 assert.match(
   preload,
@@ -176,7 +301,7 @@ assert.match(
   /restoreDictionaryVersion/,
   "version restoration is available",
 );
-const generatedAt = ai.indexOf("const generated = await generator");
+const generatedAt = ai.indexOf("generated = await generator");
 const savedAt = ai.indexOf("return saveDictionaryVersion", generatedAt);
 assert.ok(
   generatedAt >= 0 && savedAt > generatedAt,
@@ -186,6 +311,11 @@ assert.match(
   ai,
   /La versión anterior se conserva/,
   "citation-validation failure reports that the previous version is preserved",
+);
+assert.match(
+  ai,
+  /groundGeneratedDescription[\s\S]*attempt < 2/,
+  "an empty post-verification synthesis gets one bounded grounded rewrite",
 );
 assert.match(
   ai,

--- a/scripts/test-dictionary.mjs
+++ b/scripts/test-dictionary.mjs
@@ -159,12 +159,19 @@ try {
     repo.includedEvidence(automatic.id).length >= 2,
     "automatic retrieval selects relevant ideas/passages before generation",
   );
+  assert.equal(
+    repo.getDictionaryEntryDetail(automatic.id).coverage.included,
+    repo.includedEvidence(automatic.id).filter((item) => !item.unavailable).length,
+    "a draft reports its live included evidence before any version exists",
+  );
   const generated = await ai.__generateDictionaryEntryForTesting(
     { entryId: automatic.id, mode: "creation", model: null },
     async () => ({
-      descriptionMarkdown: "Definición breve.",
+      descriptionMarkdown:
+        "La memoria se construye socialmente mediante prácticas colectivas documentadas [Autora (2020)](nodus://idea/idea-1).",
       authorSummaries: [],
     }),
+    async (claims) => claims.map(() => "supports"),
   );
   assert.equal(
     generated.trigger,
@@ -241,6 +248,47 @@ try {
     citedWithBibliographicLabel.contentMarkdown,
     /nodus:\/\/idea\/idea-1/,
     "bibliographic citation survives validation",
+  );
+
+  // Verification can legitimately remove every sentence from an overbroad first
+  // draft. Never persist the resulting blank version: feed the failure back to the
+  // writer once and save only a substantive, cited correction.
+  let repairAttempts = 0;
+  const repairedAfterVerification = await ai.__generateDictionaryEntryForTesting(
+    { entryId: automatic.id, mode: "regeneration", model: null },
+    async (_entryId, _evidence, _model, _prior, correction) => {
+      repairAttempts += 1;
+      if (repairAttempts === 1) {
+        assert.equal(correction, "");
+        return {
+          descriptionMarkdown:
+            "La memoria demuestra por sí sola todos los cambios históricos posibles [Autora (2020)](nodus://idea/idea-1).",
+          authorSummaries: [],
+        };
+      }
+      assert.match(
+        correction,
+        /no superaron la verificación/,
+        "the retry receives the concrete grounding failure",
+      );
+      return {
+        descriptionMarkdown:
+          "La evidencia presenta la memoria como una construcción social situada [Autora (2020)](nodus://idea/idea-1).",
+        authorSummaries: [],
+      };
+    },
+    async (claims) =>
+      claims.map((claim) =>
+        claim.sentence.includes("todos los cambios")
+          ? "unsupported"
+          : "supports",
+      ),
+  );
+  assert.equal(repairAttempts, 2, "a stripped synthesis gets one bounded retry");
+  assert.match(
+    repairedAfterVerification.contentMarkdown,
+    /construcción social situada/,
+    "only the grounded correction is persisted",
   );
 
   // A provider failure must reject the IPC operation without creating an empty

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -95,6 +95,21 @@ test('sections do not share a snapshot', () => {
   assert.equal(store.readViewSnapshot('vault-a', 'ideas').search, 'mímesis');
 });
 
+test('Dictionary keeps its open concepts and catalogue cut together', () => {
+  store.clearViewSnapshots();
+  const dictionaryCut = {
+    openEntries: [{ id: 'D1', label: 'Hispanofilia' }],
+    activeEntryId: 'D1',
+    detailTabs: { D1: 'evidence' },
+    query: 'propaganda',
+    sortKey: 'authors',
+    sortDir: 'desc',
+    viewMode: 'table',
+  };
+  store.patchViewSnapshot('vault-a', 'dictionary', dictionaryCut);
+  assert.deepEqual(store.readViewSnapshot('vault-a', 'dictionary'), dictionaryCut);
+});
+
 test('a snapshot is closed to the vault it was taken in', () => {
   store.clearViewSnapshots();
   store.patchViewSnapshot('vault-a', 'authors', AUTHORS_CUT);
@@ -288,12 +303,35 @@ test('the snapshot store lives above the single render point and outside React s
   assert.doesNotMatch(app, /useState[^\n]*ViewSnapshots/, 'the snapshots are not shell state');
 });
 
-test('the three opted-in sections receive their snapshot the way they already receive a target', async () => {
+test('the core catalogue sections receive their snapshot the way they already receive a target', async () => {
   const registry = await readSource('src/app/views/corpus.tsx');
-  for (const view of ['library', 'ideas', 'authors']) {
+  for (const view of ['library', 'ideas', 'authors', 'dictionary']) {
     assert.match(registry, new RegExp(`snapshots\\.read\\('${view}'\\)`), `${view} is handed its snapshot`);
     assert.match(registry, new RegExp(`snapshots\\.patch\\('${view}',`), `${view} reports its snapshot back`);
   }
+});
+
+test('Dictionary restores its filters, open entries and selected detail tab', async () => {
+  const view = await readSource('src/views/DictionaryView.tsx');
+  for (const restored of [
+    'query',
+    'letter',
+    'status',
+    'tag',
+    'authorId',
+    'workId',
+    'newOnly',
+    'insufficientOnly',
+    'sortKey',
+    'sortDir',
+    'viewMode',
+  ]) {
+    assert.match(view, new RegExp(`snapshot\\?\\.${restored}`), `${restored} survives leaving Dictionary`);
+  }
+  assert.match(view, /snapshot\?\.openEntries/);
+  assert.match(view, /snapshot\?\.detailTabs/);
+  assert.match(view, /restoredTab=\{detailTabs\[activeId\]\}/);
+  assert.match(view, /report\.current = onSnapshotChange/);
 });
 
 test('a snapshot is an initial value, never a reactive prop', async () => {

--- a/shared/api/academic.ts
+++ b/shared/api/academic.ts
@@ -235,6 +235,7 @@ export interface AcademicApi {
   setDictionaryEvidenceDecision(entryId: string, refs: DictionaryEvidenceRef[], decision: DictionaryEvidenceDecision): Promise<void>;
   generateDictionaryEntry(request: DictionaryGenerationRequest): Promise<DictionaryVersion>;
   startDictionaryGeneration(request: DictionaryGenerationRequest): Promise<DictionaryProgress>;
+  listDictionaryGenerationJobs(): Promise<DictionaryProgress[]>;
   onDictionaryProgress(callback: (progress: DictionaryProgress) => void): () => void;
   listDictionaryVersions(entryId: string): Promise<DictionaryVersion[]>;
   acceptDictionaryVersion(entryId: string, versionId: string, expectedCurrentVersionId: string | null): Promise<DictionaryEntryDetail>;

--- a/shared/dictionary.ts
+++ b/shared/dictionary.ts
@@ -208,7 +208,7 @@ export interface DictionaryVersion {
 export interface DictionaryEntryDetail {
   entry: DictionaryEntry;
   coverage: {
-    used: number;
+    included: number;
     cited: number;
     unused: number;
     excluded: number;

--- a/shared/dictionaryPromptPresets.ts
+++ b/shared/dictionaryPromptPresets.ts
@@ -1,0 +1,87 @@
+/** Stable prompt presets offered when creating Dictionary entries. */
+export const DICTIONARY_PROMPT_PRESETS = [
+  "basic",
+  "historical",
+  "debate",
+  "genealogy",
+  "applications",
+  "critical",
+] as const;
+
+export type DictionaryPromptPreset =
+  (typeof DICTIONARY_PROMPT_PRESETS)[number];
+
+const PRESET_SET = new Set<string>(DICTIONARY_PROMPT_PRESETS);
+
+export function normalizeDictionaryPromptPreset(
+  value: unknown,
+): DictionaryPromptPreset {
+  return typeof value === "string" && PRESET_SET.has(value)
+    ? (value as DictionaryPromptPreset)
+    : "basic";
+}
+
+/** Spanish source strings are translation keys in the renderer. */
+export const DICTIONARY_PROMPT_PRESET_OPTIONS: ReadonlyArray<{
+  id: DictionaryPromptPreset;
+  label: string;
+  description: string;
+  prompt: string;
+}> = [
+  {
+    id: "basic",
+    label: "Básico · definición y autores",
+    description:
+      "Define el concepto e identifica a los autores que lo desarrollan.",
+    prompt:
+      "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.",
+  },
+  {
+    id: "historical",
+    label: "Evolución histórica",
+    description:
+      "Sigue antecedentes, cambios y puntos de inflexión documentados.",
+    prompt:
+      "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.",
+  },
+  {
+    id: "debate",
+    label: "Debate entre autores",
+    description:
+      "Compara acuerdos, desacuerdos y matices entre autores.",
+    prompt:
+      "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.",
+  },
+  {
+    id: "genealogy",
+    label: "Genealogía teórica",
+    description:
+      "Reconstruye antecedentes, marcos y conceptos relacionados.",
+    prompt:
+      "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.",
+  },
+  {
+    id: "applications",
+    label: "Usos y aplicaciones",
+    description:
+      "Explica cómo se utiliza el concepto y cuáles son sus límites.",
+    prompt:
+      "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.",
+  },
+  {
+    id: "critical",
+    label: "Lectura crítica",
+    description:
+      "Examina supuestos, tensiones, críticas y preguntas abiertas.",
+    prompt:
+      "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.",
+  },
+] as const;
+
+export function dictionaryPromptPresetOption(value: unknown) {
+  const preset = normalizeDictionaryPromptPreset(value);
+  return (
+    DICTIONARY_PROMPT_PRESET_OPTIONS.find((option) => option.id === preset) ??
+    DICTIONARY_PROMPT_PRESET_OPTIONS[0]
+  );
+}

--- a/src/app/viewSnapshots.ts
+++ b/src/app/viewSnapshots.ts
@@ -51,7 +51,9 @@ import type { RouteSortKey as ArgumentRouteSortKey } from '../views/ArgumentMapV
 import type { ReadFilter as ReportReadFilter, SortKey as ReportSortKey } from '../views/DeepResearchView';
 import type { ImmersionSortKey } from '../views/ImmersionView';
 import type { WorkspaceItemKind } from '../views/WorkspaceView';
+import type { DictionaryDetailTab } from '../views/DictionaryView';
 import type { IdeaType, LibraryReaderReference, WorkFilter } from '@shared/types';
+import type { DictionaryEntryStatus, DictionarySortKey } from '@shared/dictionary';
 import type { SortState } from '../views/Library';
 import type { ReadingPlace } from '../readingPlace';
 
@@ -113,6 +115,28 @@ export interface IdeasSnapshot {
   sortKey: IdeasSortKey;
   filtersOpen: boolean;
   placement: ListPlacement | null;
+}
+
+/**
+ * Dictionary: its catalogue cut, all open concepts and the selected inner tab for
+ * each concept. Generation progress is deliberately absent because the main
+ * process owns it and the renderer rehydrates that live state on every mount.
+ */
+export interface DictionarySnapshot {
+  openEntries: OpenEntityTab[];
+  activeEntryId: string | null;
+  detailTabs: Record<string, DictionaryDetailTab>;
+  query: string;
+  letter: string;
+  status: DictionaryEntryStatus | '';
+  tag: string;
+  authorId: string;
+  workId: string;
+  newOnly: boolean;
+  insufficientOnly: boolean;
+  sortKey: DictionarySortKey;
+  sortDir: 'asc' | 'desc';
+  viewMode: 'list' | 'table';
 }
 
 /**
@@ -270,6 +294,7 @@ export interface ImmersionSnapshot {
 export interface ViewSnapshots {
   authors?: AuthorsSnapshot;
   ideas?: IdeasSnapshot;
+  dictionary?: DictionarySnapshot;
   library?: LibrarySnapshot;
   workspace?: WorkspaceSnapshot;
   /**

--- a/src/app/views/corpus.tsx
+++ b/src/app/views/corpus.tsx
@@ -60,8 +60,15 @@ export const corpusViews = {
       onOpenAssistant={openAssistant}
     />
   ),
-  dictionary: ({ openAuthor, openIdea, openLibraryItem, settings }) => (
-    <DictionaryView settings={settings} onOpenIdea={openIdea} onOpenAuthor={openAuthor} onOpenLibraryWork={(id) => openLibraryItem(id, 'vault')} />
+  dictionary: ({ openAuthor, openIdea, openLibraryItem, settings, snapshots }) => (
+    <DictionaryView
+      settings={settings}
+      snapshot={snapshots.read('dictionary')}
+      onSnapshotChange={(patch) => snapshots.patch('dictionary', patch)}
+      onOpenIdea={openIdea}
+      onOpenAuthor={openAuthor}
+      onOpenLibraryWork={(id) => openLibraryItem(id, 'vault')}
+    />
   ),
   authors: ({ activeVault, authorTarget, navigate, settings, snapshots }) => (
     <AuthorsView

--- a/src/i18n.dictionary.ts
+++ b/src/i18n.dictionary.ts
@@ -1,8 +1,8 @@
 /** Dictionary surface translations. Spanish is the source key language. */
 export const DICTIONARY_TRANSLATIONS = {
   en: {
-    Dictionary: "Dictionary",
-    "Nueva entrada de Dictionary": "New Dictionary entry",
+    Diccionario: "Dictionary",
+    "Nueva entrada del Diccionario": "New Dictionary entry",
     "Nodus buscará la evidencia más relevante y generará la definición automáticamente.":
       "Nodus will find the most relevant evidence and generate the definition automatically.",
     "Posibles conceptos duplicados": "Possible duplicate concepts",
@@ -39,13 +39,13 @@ export const DICTIONARY_TRANSLATIONS = {
     "Preparando definición…": "Preparing definition…",
     "Reintentar generación": "Retry generation",
     "Generar definición": "Generate definition",
-    "Dictionary ({n})": "Dictionary ({n})",
+    "Diccionario ({n})": "Dictionary ({n})",
     "Eliminar ({n})": "Delete ({n})",
     "Nueva entrada": "New entry",
     "Conceptos sintetizados exclusivamente desde la evidencia de la bóveda.":
       "Concepts synthesized exclusively from vault evidence.",
-    "Eliminar entrada de Dictionary": "Delete Dictionary entry",
-    "Eliminar {n} entradas de Dictionary": "Delete {n} Dictionary entries",
+    "Eliminar entrada del Diccionario": "Delete Dictionary entry",
+    "Eliminar {n} entradas del Diccionario": "Delete {n} Dictionary entries",
     "Se eliminarán también todas sus versiones y relaciones. Esta acción no se puede deshacer.":
       "All versions and relations will also be deleted. This action cannot be undone.",
     "Eliminar entrada": "Delete entry",
@@ -72,12 +72,12 @@ export const DICTIONARY_TRANSLATIONS = {
     "Aún no se ha generado una descripción.":
       "A description has not been generated yet.",
     "{n} nuevas": "{n} new",
-    "Cargando Dictionary…": "Loading Dictionary…",
+    "Cargando Diccionario…": "Loading Dictionary…",
     "No hay entradas con este filtro.": "No entries match this filter.",
     "Abriendo entrada…": "Opening entry…",
     Resumen: "Overview",
     Versiones: "Versions",
-    "Modelo de Dictionary": "Dictionary model",
+    "Modelo del Diccionario": "Dictionary model",
     Insuficiente: "Insufficient",
     "Sin aliases": "No aliases",
     "Sin foco adicional.": "No additional focus.",
@@ -169,8 +169,8 @@ export const DICTIONARY_TRANSLATIONS = {
     Italiano: "Italian",
   },
   fr: {
-    Dictionary: "Dictionnaire",
-    "Nueva entrada de Dictionary": "Nouvelle entrée de dictionnaire",
+    Diccionario: "Dictionnaire",
+    "Nueva entrada del Diccionario": "Nouvelle entrée de dictionnaire",
     "Nodus buscará la evidencia más relevante y generará la definición automáticamente.":
       "Nodus trouvera les éléments les plus pertinents et générera automatiquement la définition.",
     "Posibles conceptos duplicados": "Concepts potentiellement dupliqués",
@@ -207,13 +207,13 @@ export const DICTIONARY_TRANSLATIONS = {
     "Preparando definición…": "Préparation de la définition…",
     "Reintentar generación": "Réessayer la génération",
     "Generar definición": "Générer la définition",
-    "Dictionary ({n})": "Dictionnaire ({n})",
+    "Diccionario ({n})": "Dictionnaire ({n})",
     "Eliminar ({n})": "Supprimer ({n})",
     "Nueva entrada": "Nouvelle entrée",
     "Conceptos sintetizados exclusivamente desde la evidencia de la bóveda.":
       "Concepts synthétisés exclusivement à partir des éléments du coffre.",
-    "Eliminar entrada de Dictionary": "Supprimer l’entrée du dictionnaire",
-    "Eliminar {n} entradas de Dictionary":
+    "Eliminar entrada del Diccionario": "Supprimer l’entrée du dictionnaire",
+    "Eliminar {n} entradas del Diccionario":
       "Supprimer {n} entrées du dictionnaire",
     "Se eliminarán también todas sus versiones y relaciones. Esta acción no se puede deshacer.":
       "Toutes les versions et relations seront également supprimées. Cette action est irréversible.",
@@ -254,13 +254,13 @@ export const DICTIONARY_TRANSLATIONS = {
     "Aún no se ha generado una descripción.":
       "Aucune description n’a encore été générée.",
     "{n} nuevas": "{n} nouveaux",
-    "Cargando Dictionary…": "Chargement du dictionnaire…",
+    "Cargando Diccionario…": "Chargement du dictionnaire…",
     "No hay entradas con este filtro.":
       "Aucune entrée ne correspond à ce filtre.",
     "Abriendo entrada…": "Ouverture de l’entrée…",
     Resumen: "Résumé",
     Versiones: "Versions",
-    "Modelo de Dictionary": "Modèle du dictionnaire",
+    "Modelo del Diccionario": "Modèle du dictionnaire",
     Insuficiente: "Insuffisant",
     "Sin aliases": "Aucun alias",
     "Sin foco adicional.": "Aucun cadrage supplémentaire.",
@@ -1272,3 +1272,263 @@ Object.assign(
     "Nodus Library": "Nodus Library",
   }),
 );
+
+/** Prompt presets are authored as Spanish keys and translated explicitly. */
+Object.assign(DICTIONARY_TRANSLATIONS.en as DictionaryTable, {
+  "Preconfiguración del prompt": "Prompt preset",
+  Personalizado: "Custom",
+  "Escribe o adapta libremente las instrucciones para la síntesis.":
+    "Write or freely adapt the synthesis instructions.",
+  "Básico · definición y autores": "Basic · definition and authors",
+  "Define el concepto e identifica a los autores que lo desarrollan.":
+    "Define the concept and identify the authors who develop it.",
+  "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.":
+    "Define the concept precisely from the evidence and identify the main authors who develop it, briefly explaining each author's contribution.",
+  "Evolución histórica": "Historical evolution",
+  "Sigue antecedentes, cambios y puntos de inflexión documentados.":
+    "Trace documented precedents, changes, and turning points.",
+  "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.":
+    "Reconstruct the concept's historical evolution: its precedents, early formulations, changes in meaning, and the authors or works that mark turning points.",
+  "Debate entre autores": "Debate among authors",
+  "Compara acuerdos, desacuerdos y matices entre autores.":
+    "Compare agreements, disagreements, and nuances among authors.",
+  "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.":
+    "Compare how different authors define and use the concept. Present agreements, disagreements, nuances, and intermediate positions without attributing debates that the evidence does not support.",
+  "Genealogía teórica": "Theoretical genealogy",
+  "Reconstruye antecedentes, marcos y conceptos relacionados.":
+    "Reconstruct precedents, frameworks, and related concepts.",
+  "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.":
+    "Place the concept within its theoretical genealogy. Explain which ideas it stems from, which concepts it relates to, which traditions or frameworks articulate it, and which authors make those connections.",
+  "Usos y aplicaciones": "Uses and applications",
+  "Explica cómo se utiliza el concepto y cuáles son sus límites.":
+    "Explain how the concept is used and what its limits are.",
+  "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.":
+    "Explain how the concept is applied or operationalized in the works in the corpus. Distinguish areas of use, problems it helps analyze, documented examples, and limits of application.",
+  "Lectura crítica": "Critical reading",
+  "Examina supuestos, tensiones, críticas y preguntas abiertas.":
+    "Examine assumptions, tensions, criticisms, and open questions.",
+  "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.":
+    "Provide a critical reading of the concept: assumptions, internal tensions, ambiguities, criticisms, limits, and open questions identified by the authors or visible in the evidence.",
+});
+
+Object.assign(DICTIONARY_TRANSLATIONS.fr as DictionaryTable, {
+  "Preconfiguración del prompt": "Préconfiguration du prompt",
+  Personalizado: "Personnalisé",
+  "Escribe o adapta libremente las instrucciones para la síntesis.":
+    "Rédigez ou adaptez librement les consignes de synthèse.",
+  "Básico · definición y autores": "Basique · définition et auteurs",
+  "Define el concepto e identifica a los autores que lo desarrollan.":
+    "Définissez le concept et identifiez les auteurs qui le développent.",
+  "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.":
+    "Définissez précisément le concept à partir des sources et identifiez les principaux auteurs qui le développent, en expliquant brièvement l'apport de chacun.",
+  "Evolución histórica": "Évolution historique",
+  "Sigue antecedentes, cambios y puntos de inflexión documentados.":
+    "Retracez les antécédents, les changements et les tournants documentés.",
+  "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.":
+    "Reconstituez l'évolution historique du concept : antécédents, premières formulations, changements de sens et auteurs ou œuvres marquant des tournants.",
+  "Debate entre autores": "Débat entre auteurs",
+  "Compara acuerdos, desacuerdos y matices entre autores.":
+    "Comparez les accords, les désaccords et les nuances entre auteurs.",
+  "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.":
+    "Comparez la manière dont les différents auteurs définissent et utilisent le concept. Présentez les accords, les désaccords, les nuances et les positions intermédiaires, sans attribuer de débats que les sources n'étayent pas.",
+  "Genealogía teórica": "Généalogie théorique",
+  "Reconstruye antecedentes, marcos y conceptos relacionados.":
+    "Reconstituez les antécédents, les cadres et les concepts associés.",
+  "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.":
+    "Situez le concept dans sa généalogie théorique. Expliquez de quelles idées il procède, à quels concepts il se rapporte, quelles traditions ou quels cadres l'articulent et quels auteurs établissent ces liens.",
+  "Usos y aplicaciones": "Usages et applications",
+  "Explica cómo se utiliza el concepto y cuáles son sus límites.":
+    "Expliquez comment le concept est utilisé et quelles sont ses limites.",
+  "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.":
+    "Expliquez comment le concept est appliqué ou opérationnalisé dans les œuvres du corpus. Distinguez les domaines d'utilisation, les problèmes qu'il aide à analyser, les exemples documentés et les limites d'application.",
+  "Lectura crítica": "Lecture critique",
+  "Examina supuestos, tensiones, críticas y preguntas abiertas.":
+    "Examinez les présupposés, les tensions, les critiques et les questions ouvertes.",
+  "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.":
+    "Proposez une lecture critique du concept : présupposés, tensions internes, ambiguïtés, critiques, limites et questions ouvertes signalées par les auteurs ou visibles dans les sources.",
+});
+
+Object.assign(DICTIONARY_TRANSLATIONS.de as DictionaryTable, {
+  "Preconfiguración del prompt": "Prompt-Voreinstellung",
+  Personalizado: "Benutzerdefiniert",
+  "Escribe o adapta libremente las instrucciones para la síntesis.":
+    "Schreiben oder bearbeiten Sie die Anweisungen für die Synthese frei.",
+  "Básico · definición y autores": "Grundlegend · Definition und Autoren",
+  "Define el concepto e identifica a los autores que lo desarrollan.":
+    "Definieren Sie den Begriff und identifizieren Sie die Autoren, die ihn entwickeln.",
+  "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.":
+    "Definieren Sie den Begriff anhand der Belege präzise und identifizieren Sie die wichtigsten Autoren, die ihn entwickeln. Erläutern Sie kurz den Beitrag jedes Autors.",
+  "Evolución histórica": "Historische Entwicklung",
+  "Sigue antecedentes, cambios y puntos de inflexión documentados.":
+    "Verfolgen Sie dokumentierte Vorläufer, Veränderungen und Wendepunkte.",
+  "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.":
+    "Rekonstruieren Sie die historische Entwicklung des Begriffs: Vorläufer, frühe Formulierungen, Bedeutungswandel sowie Autoren oder Werke, die Wendepunkte markieren.",
+  "Debate entre autores": "Debatte zwischen Autoren",
+  "Compara acuerdos, desacuerdos y matices entre autores.":
+    "Vergleichen Sie Übereinstimmungen, Meinungsverschiedenheiten und Nuancen zwischen den Autoren.",
+  "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.":
+    "Vergleichen Sie, wie verschiedene Autoren den Begriff definieren und verwenden. Stellen Sie Übereinstimmungen, Meinungsverschiedenheiten, Nuancen und Zwischenpositionen dar, ohne Debatten zuzuschreiben, die durch die Belege nicht gestützt werden.",
+  "Genealogía teórica": "Theoretische Genealogie",
+  "Reconstruye antecedentes, marcos y conceptos relacionados.":
+    "Rekonstruieren Sie Vorläufer, Rahmen und verwandte Begriffe.",
+  "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.":
+    "Ordnen Sie den Begriff in seine theoretische Genealogie ein. Erklären Sie, aus welchen Ideen er hervorgeht, mit welchen Begriffen er zusammenhängt, welche Traditionen oder Rahmen ihn ausarbeiten und welche Autoren diese Verbindungen herstellen.",
+  "Usos y aplicaciones": "Verwendung und Anwendungen",
+  "Explica cómo se utiliza el concepto y cuáles son sus límites.":
+    "Erklären Sie, wie der Begriff verwendet wird und wo seine Grenzen liegen.",
+  "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.":
+    "Erklären Sie, wie der Begriff in den Werken des Korpus angewendet oder operationalisiert wird. Unterscheiden Sie Anwendungsbereiche, analysierbare Probleme, dokumentierte Beispiele und Anwendungsgrenzen.",
+  "Lectura crítica": "Kritische Lektüre",
+  "Examina supuestos, tensiones, críticas y preguntas abiertas.":
+    "Untersuchen Sie Annahmen, Spannungen, Kritikpunkte und offene Fragen.",
+  "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.":
+    "Nehmen Sie eine kritische Lektüre des Begriffs vor: Annahmen, innere Spannungen, Mehrdeutigkeiten, Kritikpunkte, Grenzen und offene Fragen, auf die Autoren hinweisen oder die in den Belegen sichtbar werden.",
+});
+
+Object.assign(DICTIONARY_TRANSLATIONS.pt as DictionaryTable, {
+  "Preconfiguración del prompt": "Predefinição do prompt",
+  Personalizado: "Personalizado",
+  "Escribe o adapta libremente las instrucciones para la síntesis.":
+    "Escreva ou adapte livremente as instruções para a síntese.",
+  "Básico · definición y autores": "Básico · definição e autores",
+  "Define el concepto e identifica a los autores que lo desarrollan.":
+    "Defina o conceito e identifique os autores que o desenvolvem.",
+  "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.":
+    "Defina o conceito com precisão a partir das evidências e identifique os principais autores que o desenvolvem, explicando brevemente o contributo de cada um.",
+  "Evolución histórica": "Evolução histórica",
+  "Sigue antecedentes, cambios y puntos de inflexión documentados.":
+    "Acompanhe antecedentes, mudanças e pontos de viragem documentados.",
+  "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.":
+    "Reconstrua a evolução histórica do conceito: antecedentes, primeiras formulações, mudanças de significado e autores ou obras que marcam pontos de viragem.",
+  "Debate entre autores": "Debate entre autores",
+  "Compara acuerdos, desacuerdos y matices entre autores.":
+    "Compare acordos, desacordos e nuances entre autores.",
+  "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.":
+    "Compare a forma como diferentes autores definem e utilizam o conceito. Apresente acordos, desacordos, nuances e posições intermédias, sem atribuir debates que as evidências não sustentem.",
+  "Genealogía teórica": "Genealogia teórica",
+  "Reconstruye antecedentes, marcos y conceptos relacionados.":
+    "Reconstrua antecedentes, quadros e conceitos relacionados.",
+  "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.":
+    "Situe o conceito na sua genealogia teórica. Explique de que ideias procede, com que conceitos se relaciona, que tradições ou quadros o articulam e que autores estabelecem essas ligações.",
+  "Usos y aplicaciones": "Usos e aplicações",
+  "Explica cómo se utiliza el concepto y cuáles son sus límites.":
+    "Explique como o conceito é utilizado e quais são os seus limites.",
+  "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.":
+    "Explique como o conceito é aplicado ou operacionalizado nas obras do corpus. Distinga âmbitos de utilização, problemas que ajuda a analisar, exemplos documentados e limites de aplicação.",
+  "Lectura crítica": "Leitura crítica",
+  "Examina supuestos, tensiones, críticas y preguntas abiertas.":
+    "Examine pressupostos, tensões, críticas e questões em aberto.",
+  "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.":
+    "Faça uma leitura crítica do conceito: pressupostos, tensões internas, ambiguidades, críticas, limites e questões em aberto apontadas pelos autores ou visíveis nas evidências.",
+});
+
+Object.assign(DICTIONARY_TRANSLATIONS["pt-BR"] as DictionaryTable, {
+  "Preconfiguración del prompt": "Predefinição do prompt",
+  Personalizado: "Personalizado",
+  "Escribe o adapta libremente las instrucciones para la síntesis.":
+    "Escreva ou adapte livremente as instruções para a síntese.",
+  "Básico · definición y autores": "Básico · definição e autores",
+  "Define el concepto e identifica a los autores que lo desarrollan.":
+    "Defina o conceito e identifique os autores que o desenvolvem.",
+  "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.":
+    "Defina o conceito com precisão a partir das evidências e identifique os principais autores que o desenvolvem, explicando brevemente a contribuição de cada um.",
+  "Evolución histórica": "Evolução histórica",
+  "Sigue antecedentes, cambios y puntos de inflexión documentados.":
+    "Acompanhe antecedentes, mudanças e pontos de inflexão documentados.",
+  "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.":
+    "Reconstrua a evolução histórica do conceito: antecedentes, primeiras formulações, mudanças de significado e autores ou obras que marcam pontos de inflexão.",
+  "Debate entre autores": "Debate entre autores",
+  "Compara acuerdos, desacuerdos y matices entre autores.":
+    "Compare acordos, desacordos e nuances entre autores.",
+  "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.":
+    "Compare como diferentes autores definem e utilizam o conceito. Apresente acordos, desacordos, nuances e posições intermediárias, sem atribuir debates que as evidências não sustentem.",
+  "Genealogía teórica": "Genealogia teórica",
+  "Reconstruye antecedentes, marcos y conceptos relacionados.":
+    "Reconstrua antecedentes, referenciais e conceitos relacionados.",
+  "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.":
+    "Situe o conceito em sua genealogia teórica. Explique de quais ideias ele procede, com quais conceitos se relaciona, quais tradições ou referenciais o articulam e quais autores estabelecem essas conexões.",
+  "Usos y aplicaciones": "Usos e aplicações",
+  "Explica cómo se utiliza el concepto y cuáles son sus límites.":
+    "Explique como o conceito é utilizado e quais são seus limites.",
+  "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.":
+    "Explique como o conceito é aplicado ou operacionalizado nas obras do corpus. Distinga áreas de uso, problemas que ele ajuda a analisar, exemplos documentados e limites de aplicação.",
+  "Lectura crítica": "Leitura crítica",
+  "Examina supuestos, tensiones, críticas y preguntas abiertas.":
+    "Examine pressupostos, tensões, críticas e questões em aberto.",
+  "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.":
+    "Faça uma leitura crítica do conceito: pressupostos, tensões internas, ambiguidades, críticas, limites e questões em aberto apontadas pelos autores ou visíveis nas evidências.",
+});
+
+Object.assign(DICTIONARY_TRANSLATIONS.it as DictionaryTable, {
+  "Preconfiguración del prompt": "Preconfigurazione del prompt",
+  Personalizado: "Personalizzato",
+  "Escribe o adapta libremente las instrucciones para la síntesis.":
+    "Scrivi o adatta liberamente le istruzioni per la sintesi.",
+  "Básico · definición y autores": "Base · definizione e autori",
+  "Define el concepto e identifica a los autores que lo desarrollan.":
+    "Definisci il concetto e identifica gli autori che lo sviluppano.",
+  "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.":
+    "Definisci con precisione il concetto sulla base delle evidenze e identifica i principali autori che lo sviluppano, spiegando brevemente il contributo di ciascuno.",
+  "Evolución histórica": "Evoluzione storica",
+  "Sigue antecedentes, cambios y puntos de inflexión documentados.":
+    "Ripercorri antecedenti, cambiamenti e punti di svolta documentati.",
+  "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.":
+    "Ricostruisci l'evoluzione storica del concetto: antecedenti, prime formulazioni, cambiamenti di significato e autori o opere che segnano punti di svolta.",
+  "Debate entre autores": "Dibattito tra autori",
+  "Compara acuerdos, desacuerdos y matices entre autores.":
+    "Confronta accordi, disaccordi e sfumature tra gli autori.",
+  "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.":
+    "Confronta il modo in cui i diversi autori definiscono e utilizzano il concetto. Presenta accordi, disaccordi, sfumature e posizioni intermedie, senza attribuire dibattiti non sostenuti dalle evidenze.",
+  "Genealogía teórica": "Genealogia teorica",
+  "Reconstruye antecedentes, marcos y conceptos relacionados.":
+    "Ricostruisci antecedenti, quadri teorici e concetti correlati.",
+  "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.":
+    "Colloca il concetto nella sua genealogia teorica. Spiega da quali idee deriva, a quali concetti è collegato, quali tradizioni o quadri teorici lo articolano e quali autori stabiliscono tali connessioni.",
+  "Usos y aplicaciones": "Usi e applicazioni",
+  "Explica cómo se utiliza el concepto y cuáles son sus límites.":
+    "Spiega come viene utilizzato il concetto e quali sono i suoi limiti.",
+  "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.":
+    "Spiega come il concetto viene applicato o operazionalizzato nelle opere del corpus. Distingui gli ambiti d'uso, i problemi che aiuta ad analizzare, gli esempi documentati e i limiti di applicazione.",
+  "Lectura crítica": "Lettura critica",
+  "Examina supuestos, tensiones, críticas y preguntas abiertas.":
+    "Esamina presupposti, tensioni, critiche e questioni aperte.",
+  "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.":
+    "Proponi una lettura critica del concetto: presupposti, tensioni interne, ambiguità, critiche, limiti e questioni aperte indicate dagli autori o visibili nelle evidenze.",
+});
+
+Object.assign(DICTIONARY_TRANSLATIONS.tr as DictionaryTable, {
+  "Preconfiguración del prompt": "İstem ön ayarı",
+  Personalizado: "Özel",
+  "Escribe o adapta libremente las instrucciones para la síntesis.":
+    "Sentez yönergelerini serbestçe yazın veya uyarlayın.",
+  "Básico · definición y autores": "Temel · tanım ve yazarlar",
+  "Define el concepto e identifica a los autores que lo desarrollan.":
+    "Kavramı tanımlayın ve onu geliştiren yazarları belirleyin.",
+  "Define el concepto con precisión a partir de la evidencia e identifica a los principales autores que lo desarrollan, explicando brevemente la aportación de cada uno.":
+    "Kavramı kanıtlara dayanarak kesin biçimde tanımlayın ve onu geliştiren başlıca yazarları belirleyerek her birinin katkısını kısaca açıklayın.",
+  "Evolución histórica": "Tarihsel gelişim",
+  "Sigue antecedentes, cambios y puntos de inflexión documentados.":
+    "Belgelenmiş öncülleri, değişimleri ve dönüm noktalarını izleyin.",
+  "Reconstruye la evolución histórica del concepto: antecedentes, primeras formulaciones, cambios de significado y autores u obras que marcan puntos de inflexión.":
+    "Kavramın tarihsel gelişimini yeniden kurun: öncülleri, ilk formülasyonları, anlam değişimleri ve dönüm noktası oluşturan yazar ya da eserleri açıklayın.",
+  "Debate entre autores": "Yazarlar arası tartışma",
+  "Compara acuerdos, desacuerdos y matices entre autores.":
+    "Yazarlar arasındaki uzlaşıları, anlaşmazlıkları ve nüansları karşılaştırın.",
+  "Compara cómo definen y utilizan el concepto los distintos autores. Expón acuerdos, desacuerdos, matices y posiciones intermedias, sin atribuir debates que la evidencia no sostenga.":
+    "Farklı yazarların kavramı nasıl tanımlayıp kullandığını karşılaştırın. Kanıtların desteklemediği tartışmalar atfetmeden uzlaşıları, anlaşmazlıkları, nüansları ve ara konumları ortaya koyun.",
+  "Genealogía teórica": "Kuramsal soykütük",
+  "Reconstruye antecedentes, marcos y conceptos relacionados.":
+    "Öncülleri, çerçeveleri ve ilişkili kavramları yeniden kurun.",
+  "Sitúa el concepto dentro de su genealogía teórica. Explica de qué ideas procede, con qué conceptos se relaciona, qué tradiciones o marcos lo articulan y qué autores realizan esas conexiones.":
+    "Kavramı kuramsal soykütüğü içinde konumlandırın. Hangi fikirlerden doğduğunu, hangi kavramlarla ilişkili olduğunu, hangi gelenek ya da çerçevelerin onu şekillendirdiğini ve hangi yazarların bu bağlantıları kurduğunu açıklayın.",
+  "Usos y aplicaciones": "Kullanımlar ve uygulamalar",
+  "Explica cómo se utiliza el concepto y cuáles son sus límites.":
+    "Kavramın nasıl kullanıldığını ve sınırlarının neler olduğunu açıklayın.",
+  "Explica cómo se aplica u operacionaliza el concepto en las obras del corpus. Distingue ámbitos de uso, problemas que ayuda a analizar, ejemplos documentados y límites de aplicación.":
+    "Kavramın korpustaki eserlerde nasıl uygulandığını veya işlevselleştirildiğini açıklayın. Kullanım alanlarını, analiz etmeye yardımcı olduğu sorunları, belgelenmiş örnekleri ve uygulama sınırlarını ayırt edin.",
+  "Lectura crítica": "Eleştirel okuma",
+  "Examina supuestos, tensiones, críticas y preguntas abiertas.":
+    "Varsayımları, gerilimleri, eleştirileri ve açık soruları inceleyin.",
+  "Realiza una lectura crítica del concepto: supuestos, tensiones internas, ambigüedades, críticas, límites y cuestiones abiertas señaladas por los autores o visibles en la evidencia.":
+    "Kavramı eleştirel biçimde okuyun: yazarların belirttiği veya kanıtlarda görülebilen varsayımları, iç gerilimleri, belirsizlikleri, eleştirileri, sınırları ve açık soruları inceleyin.",
+});

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -113,7 +113,7 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'teachingRubrics', label: 'Rúbricas', icon: 'table', group: 'analyze' },
   { id: 'teachingUnits', label: 'Diseño de unidades', icon: 'compass', group: 'create' },
   // Analizar — superficies derivadas del grafo y síntesis.
-  { id: 'dictionary', label: 'Dictionary', icon: 'thesaurus', group: 'analyze' },
+  { id: 'dictionary', label: 'Diccionario', icon: 'thesaurus', group: 'analyze' },
   { id: 'immersion', label: 'Inmersión', icon: 'target', group: 'analyze' },
   // 'gaps' NO tiene entrada propia: los huecos son una pestaña dentro del Estado de la
   // cuestión, porque solo significan algo mirando qué le falta a una pregunta concreta.

--- a/src/views/DictionaryView.tsx
+++ b/src/views/DictionaryView.tsx
@@ -23,6 +23,11 @@ import type {
   DictionaryProgress,
   DictionaryVersion,
 } from "@shared/dictionary";
+import {
+  DICTIONARY_PROMPT_PRESET_OPTIONS,
+  dictionaryPromptPresetOption,
+  type DictionaryPromptPreset,
+} from "@shared/dictionaryPromptPresets";
 import type {
   AppSettings,
   AuthorSummary,
@@ -45,8 +50,14 @@ import { Icon, Spinner } from "../components/ui";
 import { useFeatureModel } from "../hooks/useFeatureModel";
 import { getActiveLang, pick, t as appT } from "../i18n";
 import { DICTIONARY_TRANSLATIONS } from "../i18n.dictionary";
+import type { DictionarySnapshot } from "../app/viewSnapshots";
 
-type DetailTab = "overview" | "evidence" | "authors" | "works" | "versions";
+export type DictionaryDetailTab =
+  | "overview"
+  | "evidence"
+  | "authors"
+  | "works"
+  | "versions";
 type DictionaryTranslationTable = Record<string, string>;
 const t = (es: string): string => {
   const language = getActiveLang();
@@ -75,10 +86,13 @@ const emptyCatalog: CatalogData = {
   tags: [],
   collections: [],
 };
+const DEFAULT_DICTIONARY_PROMPT_PRESET: DictionaryPromptPreset = "basic";
 const emptyInput = (): DictionaryEntryInput => ({
   name: "",
   aliases: [],
-  focusPrompt: "",
+  focusPrompt: t(
+    dictionaryPromptPresetOption(DEFAULT_DICTIONARY_PROMPT_PRESET).prompt,
+  ),
   scope: { kind: "vault" },
   outputLanguage: "es",
   detailLevel: "standard",
@@ -389,6 +403,9 @@ function CreationDialog({
   onQueued: (id: string, name: string) => void;
 }) {
   const [input, setInput] = useState(emptyInput);
+  const [promptPreset, setPromptPreset] = useState<
+    DictionaryPromptPreset | "custom"
+  >(DEFAULT_DICTIONARY_PROMPT_PRESET);
   const [aliases, setAliases] = useState("");
   const [duplicates, setDuplicates] = useState<
     DictionaryDuplicateMatch[] | null
@@ -398,6 +415,19 @@ function CreationDialog({
   const [relationAdded, setRelationAdded] = useState(false);
   const [phase, setPhase] = useState<"checking" | "creating" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const interfaceLanguage = getActiveLang();
+
+  useEffect(() => {
+    if (promptPreset === "custom") return;
+    const translatedPrompt = t(
+      dictionaryPromptPresetOption(promptPreset).prompt,
+    );
+    setInput((current) =>
+      current.focusPrompt === translatedPrompt
+        ? current
+        : { ...current, focusPrompt: translatedPrompt },
+    );
+  }, [interfaceLanguage, promptPreset]);
 
   const createAndQueue = async () => {
     setPhase("creating");
@@ -452,7 +482,7 @@ function CreationDialog({
       <div
         role="dialog"
         aria-modal="true"
-        className="max-h-[92vh] w-full max-w-3xl overflow-auto rounded-2xl border border-neutral-200 bg-white p-5 text-neutral-900 shadow-2xl dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100"
+        className="max-h-[92vh] w-full max-w-4xl overflow-auto rounded-2xl border border-neutral-200 bg-white p-5 text-neutral-900 shadow-2xl dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="mb-5 flex items-center gap-3">
@@ -461,7 +491,7 @@ function CreationDialog({
           </span>
           <div>
             <h2 className="font-semibold">
-              {t("Nueva entrada de Dictionary")}
+              {t("Nueva entrada del Diccionario")}
             </h2>
             <p className="text-xs text-neutral-500">
               {t(
@@ -565,18 +595,68 @@ function CreationDialog({
                 />
               </Field>
             </div>
-            <Field label={t("Prompt de enfoque")}>
-              <textarea
-                className="input mt-1 min-h-24 w-full resize-y"
-                value={input.focusPrompt}
-                onChange={(event) =>
-                  setInput({ ...input, focusPrompt: event.target.value })
-                }
-                placeholder={t(
-                  "Qué aspecto del concepto debe priorizar la síntesis",
-                )}
-              />
-            </Field>
+            <div className="grid gap-4 md:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.6fr)]">
+              <label className="rounded-xl border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-900/50">
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <Icon name="sparkles" className="text-indigo-500" />
+                  {t("Preconfiguración del prompt")}
+                </span>
+                <select
+                  data-testid="dictionary-prompt-preset"
+                  className="input mt-2 w-full"
+                  value={promptPreset}
+                  onChange={(event) => {
+                    const value = event.target.value as
+                      | DictionaryPromptPreset
+                      | "custom";
+                    setPromptPreset(value);
+                    if (value !== "custom") {
+                      setInput({
+                        ...input,
+                        focusPrompt: t(
+                          dictionaryPromptPresetOption(value).prompt,
+                        ),
+                      });
+                    }
+                  }}
+                >
+                  {DICTIONARY_PROMPT_PRESET_OPTIONS.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {t(option.label)}
+                    </option>
+                  ))}
+                  <option value="custom">{t("Personalizado")}</option>
+                </select>
+                <p
+                  data-testid="dictionary-prompt-preset-help"
+                  className="mt-2 text-xs leading-relaxed text-neutral-500"
+                >
+                  {promptPreset === "custom"
+                    ? t(
+                        "Escribe o adapta libremente las instrucciones para la síntesis.",
+                      )
+                    : t(dictionaryPromptPresetOption(promptPreset).description)}
+                </p>
+              </label>
+              <Field label={t("Prompt de enfoque")}>
+                <textarea
+                  data-testid="dictionary-focus-prompt"
+                  className="input mt-1 min-h-32 w-full resize-y"
+                  value={input.focusPrompt}
+                  onChange={(event) => {
+                    const focusPrompt = event.target.value;
+                    setInput({ ...input, focusPrompt });
+                    const matching = DICTIONARY_PROMPT_PRESET_OPTIONS.find(
+                      (option) => t(option.prompt) === focusPrompt,
+                    );
+                    setPromptPreset(matching?.id ?? "custom");
+                  }}
+                  placeholder={t(
+                    "Qué aspecto del concepto debe priorizar la síntesis",
+                  )}
+                />
+              </Field>
+            </div>
             <ScopeEditor
               value={input.scope}
               onChange={(scope) => setInput({ ...input, scope })}
@@ -671,11 +751,16 @@ function CreationDialog({
 
 export function DictionaryView({
   settings,
+  snapshot,
+  onSnapshotChange,
   onOpenIdea,
   onOpenAuthor,
   onOpenLibraryWork,
 }: {
   settings: AppSettings;
+  /** Where this section was last left. Read once, at mount, and never again. */
+  snapshot?: DictionarySnapshot;
+  onSnapshotChange?: (patch: Partial<DictionarySnapshot>) => void;
   onOpenIdea: (id: string) => void;
   onOpenAuthor: (id: string, name: string) => void;
   onOpenLibraryWork: (id: string) => void;
@@ -692,19 +777,41 @@ export function DictionaryView({
   const [catalog, setCatalog] = useState<CatalogData>(emptyCatalog);
   const [openEntries, setOpenEntries] = useState<
     Array<{ id: string; title: string }>
-  >([]);
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const [query, setQuery] = useState("");
-  const [letter, setLetter] = useState("");
-  const [status, setStatus] = useState("");
-  const [tag, setTag] = useState("");
-  const [authorId, setAuthorId] = useState("");
-  const [workId, setWorkId] = useState("");
-  const [newOnly, setNewOnly] = useState(false);
-  const [insufficientOnly, setInsufficientOnly] = useState(false);
-  const [sortKey, setSortKey] = useState<DictionarySortKey>("updated");
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
-  const [viewMode, setViewMode] = useState<"list" | "table">("list");
+  >(() =>
+    (snapshot?.openEntries ?? []).map((entry) => ({
+      id: entry.id,
+      title: entry.label,
+    })),
+  );
+  const [activeId, setActiveId] = useState<string | null>(() =>
+    snapshot?.openEntries?.some((entry) => entry.id === snapshot.activeEntryId)
+      ? snapshot.activeEntryId
+      : null,
+  );
+  const [detailTabs, setDetailTabs] = useState<
+    Record<string, DictionaryDetailTab>
+  >(() => snapshot?.detailTabs ?? {});
+  const [query, setQuery] = useState(() => snapshot?.query ?? "");
+  const [letter, setLetter] = useState(() => snapshot?.letter ?? "");
+  const [status, setStatus] = useState<DictionaryEntryStatus | "">(
+    () => snapshot?.status ?? "",
+  );
+  const [tag, setTag] = useState(() => snapshot?.tag ?? "");
+  const [authorId, setAuthorId] = useState(() => snapshot?.authorId ?? "");
+  const [workId, setWorkId] = useState(() => snapshot?.workId ?? "");
+  const [newOnly, setNewOnly] = useState(() => snapshot?.newOnly ?? false);
+  const [insufficientOnly, setInsufficientOnly] = useState(
+    () => snapshot?.insufficientOnly ?? false,
+  );
+  const [sortKey, setSortKey] = useState<DictionarySortKey>(
+    () => snapshot?.sortKey ?? "updated",
+  );
+  const [sortDir, setSortDir] = useState<"asc" | "desc">(
+    () => snapshot?.sortDir ?? "desc",
+  );
+  const [viewMode, setViewMode] = useState<"list" | "table">(
+    () => snapshot?.viewMode ?? "list",
+  );
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [generationJobs, setGenerationJobs] = useState<
     Map<string, DictionaryProgress>
@@ -715,6 +822,41 @@ export function DictionaryView({
   const [creating, setCreating] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const report = useRef(onSnapshotChange);
+  report.current = onSnapshotChange;
+  useEffect(() => {
+    report.current?.({
+      openEntries: openEntries.map(({ id, title }) => ({ id, label: title })),
+      activeEntryId: activeId,
+      detailTabs,
+      query,
+      letter,
+      status,
+      tag,
+      authorId,
+      workId,
+      newOnly,
+      insufficientOnly,
+      sortKey,
+      sortDir,
+      viewMode,
+    });
+  }, [
+    activeId,
+    authorId,
+    detailTabs,
+    insufficientOnly,
+    letter,
+    newOnly,
+    openEntries,
+    query,
+    sortDir,
+    sortKey,
+    status,
+    tag,
+    viewMode,
+    workId,
+  ]);
   const reload = useCallback(
     async (foreground = true) => {
       if (foreground) setLoading(true);
@@ -780,6 +922,27 @@ export function DictionaryView({
       })
       .catch(() => undefined);
   }, []);
+  useEffect(() => {
+    let alive = true;
+    void window.nodus
+      .listDictionaryGenerationJobs()
+      .then((jobs) => {
+        if (!alive) return;
+        setGenerationJobs((current) => {
+          const next = new Map(jobs.map((job) => [job.entryId, job]));
+          // Events received while the IPC round-trip was in flight are newer than
+          // the returned snapshot and must win.
+          for (const [entryId, progress] of current) {
+            next.set(entryId, progress);
+          }
+          return next;
+        });
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, []);
   useEffect(
     () =>
       window.nodus.onDictionaryChanged(() => {
@@ -811,6 +974,12 @@ export function DictionaryView({
     const index = openEntries.findIndex((entry) => entry.id === id);
     const next = openEntries.filter((entry) => entry.id !== id);
     setOpenEntries(next);
+    setDetailTabs((current) => {
+      if (!(id in current)) return current;
+      const nextTabs = { ...current };
+      delete nextTabs[id];
+      return nextTabs;
+    });
     if (activeId === id)
       setActiveId(next[Math.min(index, next.length - 1)]?.id ?? null);
   };
@@ -833,6 +1002,11 @@ export function DictionaryView({
       setActiveId((current) =>
         current && deleted.has(current) ? null : current,
       );
+      setDetailTabs((current) =>
+        Object.fromEntries(
+          Object.entries(current).filter(([id]) => !deleted.has(id)),
+        ) as Record<string, DictionaryDetailTab>,
+      );
       setSelected(new Set());
       await reload();
     } catch (reason) {
@@ -851,7 +1025,7 @@ export function DictionaryView({
             <Icon name="thesaurus" size={18} />
           </span>
           <div>
-            <h1 className="text-base font-semibold">{t("Dictionary")}</h1>
+            <h1 className="text-base font-semibold">{t("Diccionario")}</h1>
             <p className="text-[11px] text-neutral-500">
               {t(
                 "Conceptos sintetizados exclusivamente desde la evidencia de la bóveda.",
@@ -886,7 +1060,7 @@ export function DictionaryView({
           </button>
         </div>
         <WorkspaceTabStrip
-          homeLabel={tx("Dictionary ({n})", { n: total })}
+          homeLabel={tx("Diccionario ({n})", { n: total })}
           homeIcon="list"
           homeTestId="dictionary-tab-home"
           tabTestId={(tab) => `dictionary-tab-${tab.key}`}
@@ -906,6 +1080,29 @@ export function DictionaryView({
         <DictionaryEntryView
           key={activeId}
           entryId={activeId}
+          restoredTab={detailTabs[activeId]}
+          onTabChange={(tab) =>
+            setDetailTabs((current) =>
+              current[activeId] === tab
+                ? current
+                : { ...current, [activeId]: tab },
+            )
+          }
+          progress={generationJobs.get(activeId)}
+          onGenerationStarted={(progress) =>
+            setGenerationJobs((current) => {
+              const existing = current.get(progress.entryId);
+              if (
+                existing &&
+                !["done", "failed"].includes(existing.phase)
+              ) {
+                return current;
+              }
+              const next = new Map(current);
+              next.set(progress.entryId, progress);
+              return next;
+            })
+          }
           settings={settings}
           model={model}
           catalog={catalog}
@@ -942,7 +1139,9 @@ export function DictionaryView({
               <select
                 className="input"
                 value={status}
-                onChange={(event) => setStatus(event.target.value)}
+                onChange={(event) =>
+                  setStatus(event.target.value as DictionaryEntryStatus | "")
+                }
               >
                 <option value="">{t("Todos los estados")}</option>
                 <option value="draft">{dictionaryStatusLabel("draft")}</option>
@@ -1061,7 +1260,7 @@ export function DictionaryView({
               <ErrorNotice>{error}</ErrorNotice>
             ) : loading ? (
               <div className="grid h-48 place-items-center">
-                <Spinner label={t("Cargando Dictionary…")} />
+                <Spinner label={t("Cargando Diccionario…")} />
               </div>
             ) : !entries.length ? (
               <div className="rounded-2xl border border-dashed border-neutral-300 p-12 text-center dark:border-neutral-800">
@@ -1126,8 +1325,8 @@ export function DictionaryView({
         <ConfirmModal
           title={
             pendingDeleteIds.length === 1
-              ? t("Eliminar entrada de Dictionary")
-              : tx("Eliminar {n} entradas de Dictionary", {
+              ? t("Eliminar entrada del Diccionario")
+              : tx("Eliminar {n} entradas del Diccionario", {
                   n: pendingDeleteIds.length,
                 })
           }
@@ -1293,6 +1492,10 @@ function DictionaryGenerationState({
 
 function DictionaryEntryView({
   entryId,
+  restoredTab,
+  onTabChange,
+  progress,
+  onGenerationStarted,
   settings,
   model,
   catalog,
@@ -1302,6 +1505,10 @@ function DictionaryEntryView({
   onOpenLibraryWork,
 }: {
   entryId: string;
+  restoredTab?: DictionaryDetailTab;
+  onTabChange: (tab: DictionaryDetailTab) => void;
+  progress?: DictionaryProgress;
+  onGenerationStarted: (progress: DictionaryProgress) => void;
   settings: AppSettings;
   model: ModelRef | null;
   catalog: CatalogData;
@@ -1311,11 +1518,14 @@ function DictionaryEntryView({
   onOpenLibraryWork: (id: string) => void;
 }) {
   const [detail, setDetail] = useState<DictionaryEntryDetail | null>(null);
-  const [tab, setTab] = useState<DetailTab>("overview");
+  const [tab, setTab] = useState<DictionaryDetailTab>(
+    () => restoredTab ?? "overview",
+  );
   const [busy, setBusy] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [citation, setCitation] = useState<CitationTarget>(null);
-  const choseTab = useRef(false);
+  const [hideBackgroundFailure, setHideBackgroundFailure] = useState(false);
+  const choseTab = useRef(restoredTab !== undefined);
   const load = useCallback(
     async () => setDetail(await window.nodus.getDictionaryEntry(entryId)),
     [entryId],
@@ -1331,10 +1541,11 @@ function DictionaryEntryView({
     choseTab.current = true;
     if (!detail.entry.currentVersionId) setTab("evidence");
   }, [detail]);
+  useEffect(() => onTabChange(tab), [onTabChange, tab]);
   const run = async (
     name: string,
     action: () => Promise<unknown>,
-    next?: DetailTab,
+    next?: DictionaryDetailTab,
   ) => {
     setBusy(name);
     setError(null);
@@ -1355,7 +1566,13 @@ function DictionaryEntryView({
       </div>
     );
   const entry = detail.entry;
-  const hasEvidence = detail.coverage.used > 0;
+  const hasEvidence = detail.coverage.included > 0;
+  const backgroundBusy =
+    !!progress && !["done", "failed"].includes(progress.phase);
+  const backgroundFailure =
+    progress?.phase === "failed" && !hideBackgroundFailure
+      ? progress.error || t("La generación no pudo completarse.")
+      : null;
   const mode = entry.currentVersionId ? "regeneration" : "creation";
   const generate = (generation: "creation" | "regeneration" | "update") => {
     if (!hasEvidence) {
@@ -1367,19 +1584,24 @@ function DictionaryEntryView({
       setTab("evidence");
       return;
     }
-    void run(
-      generation,
-      () =>
-        window.nodus.generateDictionaryEntry({
+    setHideBackgroundFailure(true);
+    setBusy(generation);
+    setError(null);
+    void window.nodus
+      .startDictionaryGeneration({
           entryId,
           mode: generation,
           model,
-        }),
-      generation === "creation" ? "overview" : "versions",
-    );
+      })
+      .then((nextProgress) => {
+        onGenerationStarted(nextProgress);
+        setTab(generation === "creation" ? "overview" : "versions");
+      })
+      .catch((reason) => setError(message(reason)))
+      .finally(() => setBusy(""));
   };
   const tabs: Array<{
-    id: DetailTab;
+    id: DictionaryDetailTab;
     label: string;
     icon: string;
     count?: number;
@@ -1453,11 +1675,11 @@ function DictionaryEntryView({
                 onChange={() => undefined}
                 compact
                 disabled
-                ariaLabel={t("Modelo de Dictionary")}
+                ariaLabel={t("Modelo del Diccionario")}
               />
               <button
                 className="btn btn-ghost h-9 w-[220px] shrink-0 justify-center whitespace-nowrap border border-neutral-300 text-xs dark:border-neutral-700"
-                disabled={!!busy}
+                disabled={!!busy || backgroundBusy}
                 onClick={() =>
                   void run(
                     "scan",
@@ -1475,7 +1697,7 @@ function DictionaryEntryView({
               </button>
               <button
                 className="btn btn-primary !text-white disabled:!text-white h-9 w-[112px] shrink-0 justify-center whitespace-nowrap text-xs"
-                disabled={!!busy || !hasEvidence}
+                disabled={!!busy || backgroundBusy || !hasEvidence}
                 onClick={() => generate(mode)}
               >
                 {busy === mode ? (
@@ -1491,6 +1713,7 @@ function DictionaryEntryView({
                 className="btn btn-ghost h-9 w-[112px] shrink-0 justify-center whitespace-nowrap border border-neutral-300 text-xs dark:border-neutral-700"
                 disabled={
                   !!busy ||
+                  backgroundBusy ||
                   !entry.currentVersionId ||
                   entry.newEvidenceCount === 0 ||
                   !hasEvidence
@@ -1503,6 +1726,7 @@ function DictionaryEntryView({
             </div>
           </div>
         </section>
+        {backgroundFailure && <ErrorNotice>{backgroundFailure}</ErrorNotice>}
         {error && <ErrorNotice>{error}</ErrorNotice>}
         {!hasEvidence && (
           <button
@@ -1520,6 +1744,7 @@ function DictionaryEntryView({
           {tabs.map((item) => (
             <button
               key={item.id}
+              data-testid={`dictionary-detail-tab-${item.id}`}
               className={`flex h-10 shrink-0 items-center gap-2 border-b-2 px-3 text-xs ${tab === item.id ? "border-indigo-500 text-indigo-700 dark:text-indigo-300" : "border-transparent text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-300"}`}
               onClick={() => setTab(item.id)}
             >
@@ -1803,7 +2028,7 @@ function OverviewTab({
           </div>
           <div className="grid grid-cols-2 gap-2 text-xs">
             {[
-              [t("Incluida"), detail.coverage.used],
+              [t("Incluida"), detail.coverage.included],
               [t("Citada"), detail.coverage.cited],
               [t("No usada"), detail.coverage.unused],
               [t("Excluida"), detail.coverage.excluded],

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -3699,7 +3699,7 @@ const VAULT_MODEL_FIELDS: Record<VaultModelKey, string> = {
   writingModel: 'Taller de escritura',
   argumentMapModel: 'Mapa argumental',
   authorModel: 'Autores y biografías',
-  dictionaryModel: 'Dictionary',
+  dictionaryModel: 'Diccionario',
   studyModel: 'Guías de estudio',
   tutorModel: 'Tutor',
   hypothesisModel: 'Laboratorio de hipótesis',


### PR DESCRIPTION
## Summary

- make concept synthesis more reliable, evidence-grounded, and explicit about generation failures
- add six localized prompt presets plus an editable Custom option to the new-entry workflow
- move create, regenerate, and update operations to the main-process background queue and reconnect the UI after navigation
- persist open entries, the active entry and tab, search, filters, ordering, and display mode per vault
- localize the Dictionary section name and related controls in every supported interface language
- extend automated and real-app coverage for generation, presets, background processing, and restored view state

## Testing

- `npm run typecheck`
- `npm run build`
- `node scripts/test-dictionary.mjs`
- `node scripts/test-dictionary-ui.mjs`
- `node scripts/test-view-snapshots.mjs`
- `node scripts/test-i18n-coverage.mjs`
- real Electron capture test covering all presets, Custom mode, navigation during generation, and restored Dictionary state

Closes #546