### PR TITLE
Keep Settings inspections off the Electron main process

### DIFF
--- a/electron/db/migrationRecoveryUtilityHost.ts
+++ b/electron/db/migrationRecoveryUtilityHost.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { utilityProcess } from 'electron';
+import type { MigrationRecoverySnapshot } from '@shared/types';
+import type {
+  MigrationRecoveryUtilityRequest,
+  MigrationRecoveryUtilityResponse,
+} from './migrationRecoveryUtilityTypes';
+
+let nextId = 1;
+const VALIDATION_TIMEOUT_MS = 10 * 60_000;
+const inFlight = new Map<string, Promise<MigrationRecoverySnapshot[]>>();
+
+function workerFile(): string {
+  return process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE
+    || path.join(__dirname, 'migrationRecoveryUtilityWorker.js');
+}
+
+function runUtility(databasePath: string): Promise<MigrationRecoverySnapshot[]> {
+  const request: MigrationRecoveryUtilityRequest = { id: nextId++, databasePath };
+  if (process.env.ELECTRON_RUN_AS_NODE === '1' || process.env.NODUS_MIGRATION_RECOVERY_INLINE === '1') {
+    return import('./migrationRecoveryUtilityWorker').then(({ runMigrationRecoveryUtilityRequest }) => {
+      const response = runMigrationRecoveryUtilityRequest(request);
+      if (response.kind === 'error') throw new Error(response.error);
+      return response.snapshots;
+    });
+  }
+
+  const file = workerFile();
+  if (!fs.existsSync(file)) return Promise.reject(new Error('El proceso auxiliar de recuperación no está disponible.'));
+  const child = utilityProcess.fork(file, [], {
+    serviceName: 'Nodus migration recovery validation',
+    stdio: 'inherit',
+  });
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error, snapshots?: MigrationRecoverySnapshot[]): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.removeAllListeners();
+      child.kill();
+      if (error) reject(error); else resolve(snapshots!);
+    };
+    const timeout = setTimeout(
+      () => finish(new Error('La validación de las copias de migración superó diez minutos.')),
+      VALIDATION_TIMEOUT_MS,
+    );
+    timeout.unref?.();
+    child.on('message', (response: MigrationRecoveryUtilityResponse) => {
+      if (!response || response.id !== request.id) return;
+      if (response.kind === 'error') finish(new Error(response.error));
+      else finish(undefined, response.snapshots);
+    });
+    child.once('error', (error) => finish(new Error(String(error))));
+    child.once('exit', (code) => {
+      if (!settled) finish(new Error(`El proceso auxiliar de recuperación terminó con código ${code}.`));
+    });
+    child.postMessage(request);
+  });
+}
+
+/** Hashing and SQLite quick_check may scan the complete snapshot. Keep both away from
+ * Electron's main event loop and coalesce repeated Settings requests for the same vault. */
+export function listMigrationRecoverySnapshotsInUtility(
+  databasePath: string,
+): Promise<MigrationRecoverySnapshot[]> {
+  const resolved = path.resolve(databasePath);
+  const current = inFlight.get(resolved);
+  if (current) return current;
+  const task = runUtility(resolved).finally(() => {
+    if (inFlight.get(resolved) === task) inFlight.delete(resolved);
+  });
+  inFlight.set(resolved, task);
+  return task;
+}

--- a/electron/db/migrationRecoveryUtilityTypes.ts
+++ b/electron/db/migrationRecoveryUtilityTypes.ts
@@ -1,0 +1,16 @@
+import type { MigrationRecoverySnapshot } from '@shared/types';
+
+export interface MigrationRecoveryUtilityRequest {
+  id: number;
+  databasePath: string;
+}
+
+export type MigrationRecoveryUtilityResponse = {
+  kind: 'list-done';
+  id: number;
+  snapshots: MigrationRecoverySnapshot[];
+} | {
+  kind: 'error';
+  id: number;
+  error: string;
+};

--- a/electron/db/migrationRecoveryUtilityWorker.ts
+++ b/electron/db/migrationRecoveryUtilityWorker.ts
@@ -1,0 +1,28 @@
+import { listMigrationRecoverySnapshots } from './migrationSafety';
+import type {
+  MigrationRecoveryUtilityRequest,
+  MigrationRecoveryUtilityResponse,
+} from './migrationRecoveryUtilityTypes';
+
+export function runMigrationRecoveryUtilityRequest(
+  request: MigrationRecoveryUtilityRequest,
+): MigrationRecoveryUtilityResponse {
+  return {
+    kind: 'list-done',
+    id: request.id,
+    snapshots: listMigrationRecoverySnapshots(request.databasePath),
+  };
+}
+
+process.parentPort?.on('message', (event) => {
+  const request = event.data as MigrationRecoveryUtilityRequest;
+  try {
+    process.parentPort?.postMessage(runMigrationRecoveryUtilityRequest(request));
+  } catch (error) {
+    process.parentPort?.postMessage({
+      kind: 'error',
+      id: request.id,
+      error: error instanceof Error ? error.message : String(error),
+    } satisfies MigrationRecoveryUtilityResponse);
+  }
+});

--- a/electron/export/autoBackup.ts
+++ b/electron/export/autoBackup.ts
@@ -365,7 +365,7 @@ function cleanupResultFailure(message: string): BackupCleanupResult {
   };
 }
 
-function readCleanupContext(now = new Date()): CleanupContext | { error: string } {
+async function readCleanupContext(now = new Date()): Promise<CleanupContext | { error: string }> {
   const settings = getSettings();
   const cutoff = retentionCutoff(settings.backupRetentionValue, settings.backupRetentionUnit, now);
   if (!cutoff) return { error: 'La antigüedad configurada no es válida. No se ha movido ni eliminado ninguna copia.' };
@@ -374,9 +374,9 @@ function readCleanupContext(now = new Date()): CleanupContext | { error: string 
   const folder = resolveBackupOutputDir(settings.autoBackupFolder);
   let entries: fs.Dirent[];
   try {
-    const folderStat = fs.lstatSync(folder);
+    const folderStat = await fs.promises.lstat(folder);
     if (!folderStat.isDirectory()) return { error: 'La carpeta de copias configurada no es un directorio. No se ha modificado nada.' };
-    entries = fs.readdirSync(folder, { withFileTypes: true });
+    entries = await fs.promises.readdir(folder, { withFileTypes: true });
   } catch (error) {
     return { error: `No se puede leer la carpeta de copias. No se ha modificado nada: ${error instanceof Error ? error.message : String(error)}` };
   }
@@ -391,7 +391,7 @@ function readCleanupContext(now = new Date()): CleanupContext | { error: string 
     if (!parsed) continue;
     const filePath = path.join(folder, entry.name);
     try {
-      const stat = fs.lstatSync(filePath);
+      const stat = await fs.promises.lstat(filePath);
       if (!stat.isFile() || stat.isSymbolicLink()) continue;
       active.push({
         ...parsed,
@@ -411,35 +411,35 @@ function readCleanupContext(now = new Date()): CleanupContext | { error: string 
 
   const trashPath = path.join(folder, CLEANUP_TRASH_DIR);
   const trash: TrashedBackup[] = [];
-  if (fs.existsSync(trashPath)) {
-    try {
-      const trashStat = fs.lstatSync(trashPath);
-      if (!trashStat.isDirectory() || trashStat.isSymbolicLink()) {
-        return { error: 'La papelera de seguridad no es un directorio válido. No se ha modificado nada.' };
-      }
-      for (const entry of fs.readdirSync(trashPath, { withFileTypes: true })) {
-        if (!entry.isFile()) continue;
-        const match = TRASHED_BACKUP_RE.exec(entry.name);
-        if (!match) continue;
-        const [, originalFile, trashedAtRaw] = match;
-        if (!parseBackupFile(hostname, originalFile)) continue;
-        const trashedAt = Number(trashedAtRaw);
-        if (!Number.isSafeInteger(trashedAt) || trashedAt <= 0) continue;
-        const filePath = path.join(trashPath, entry.name);
-        const stat = fs.lstatSync(filePath);
-        if (!stat.isFile() || stat.isSymbolicLink()) continue;
-        trash.push({
-          path: filePath,
-          file: entry.name,
-          originalFile,
-          trashedAt,
-          bytes: stat.size,
-          modifiedAt: stat.mtimeMs,
-          device: stat.dev,
-          inode: stat.ino,
-        });
-      }
-    } catch (error) {
+  try {
+    const trashStat = await fs.promises.lstat(trashPath);
+    if (!trashStat.isDirectory() || trashStat.isSymbolicLink()) {
+      return { error: 'La papelera de seguridad no es un directorio válido. No se ha modificado nada.' };
+    }
+    for (const entry of await fs.promises.readdir(trashPath, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      const match = TRASHED_BACKUP_RE.exec(entry.name);
+      if (!match) continue;
+      const [, originalFile, trashedAtRaw] = match;
+      if (!parseBackupFile(hostname, originalFile)) continue;
+      const trashedAt = Number(trashedAtRaw);
+      if (!Number.isSafeInteger(trashedAt) || trashedAt <= 0) continue;
+      const filePath = path.join(trashPath, entry.name);
+      const stat = await fs.promises.lstat(filePath);
+      if (!stat.isFile() || stat.isSymbolicLink()) continue;
+      trash.push({
+        path: filePath,
+        file: entry.name,
+        originalFile,
+        trashedAt,
+        bytes: stat.size,
+        modifiedAt: stat.mtimeMs,
+        device: stat.dev,
+        inode: stat.ino,
+      });
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       return { error: `No se puede inspeccionar la papelera de seguridad. No se ha modificado nada: ${error instanceof Error ? error.message : String(error)}` };
     }
   }
@@ -448,9 +448,10 @@ function readCleanupContext(now = new Date()): CleanupContext | { error: string 
 }
 
 /** Read-only and deliberately password-free: Settings can show the exact scope before
- * the user opts into a destructive policy. */
-export function previewBackupCleanup(now = new Date()): BackupCleanupPreview {
-  const context = readCleanupContext(now);
+ * the user opts into a destructive policy. File Provider calls use asynchronous fs so
+ * an iCloud/Dropbox placeholder cannot stop Electron's main event loop. */
+export async function previewBackupCleanup(now = new Date()): Promise<BackupCleanupPreview> {
+  const context = await readCleanupContext(now);
   if ('error' in context) return cleanupPreviewFailure(context.error);
   return cleanupPreviewFromContext(context, now);
 }
@@ -484,7 +485,7 @@ function cleanupPreviewFromContext(context: CleanupContext, now: Date): BackupCl
 }
 
 async function executeBackupCleanup(now: Date, expectedScopeToken?: string): Promise<BackupCleanupResult> {
-  const context = readCleanupContext(now);
+  const context = await readCleanupContext(now);
   if ('error' in context) return cleanupResultFailure(context.error);
   const preview = cleanupPreviewFromContext(context, now);
   if (expectedScopeToken && preview.scopeToken !== expectedScopeToken) {

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -159,7 +159,7 @@ import { initializeVaultModelSelection, validateVaultModelSelection } from './va
 import { setPersistentDockIcon } from './dockIcon';
 import { closeCrossVaultConnections } from './db/crossVault';
 import { assertNotBrowserIpcSender } from './ipc/trust';
-import { listMigrationRecoverySnapshots } from './db/migrationSafety';
+import { listMigrationRecoverySnapshotsInUtility } from './db/migrationRecoveryUtilityHost';
 import { documentIndexQueue } from './pipeline/documentIndexQueue';
 
 
@@ -643,10 +643,11 @@ export function registerIpc(
       if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
     }
   });
-  h('migrationRecovery:list', async () => listMigrationRecoverySnapshots(getActiveVault().path));
+  h('migrationRecovery:list', async () => listMigrationRecoverySnapshotsInUtility(getActiveVault().path));
   h('migrationRecovery:open', async (_e, id: string) => {
     const source = getActiveVault();
-    const snapshot = listMigrationRecoverySnapshots(source.path).find((candidate) => candidate.id === id);
+    const snapshot = (await listMigrationRecoverySnapshotsInUtility(source.path))
+      .find((candidate) => candidate.id === id);
     if (!snapshot) throw new Error('La copia previa a la migración no existe o ya no supera la validación.');
     const name = `${source.name} · antes de v${snapshot.targetVersion}`;
     const vault = createVaultFromDatabaseFile(snapshot.databasePath, name, source.type);

--- a/scripts/test-auto-backup.mjs
+++ b/scripts/test-auto-backup.mjs
@@ -313,7 +313,7 @@ try {
     lastBackupCleanupAt: null,
     lastBackupCleanupStatus: null,
   });
-  const cleanupPreview = autoBackup.previewBackupCleanup(cleanupNow);
+  const cleanupPreview = await autoBackup.previewBackupCleanup(cleanupNow);
   assert.equal(cleanupPreview.ok, true, cleanupPreview.message);
   assert.equal(cleanupPreview.protectedCount, 3, 'the three newest regular backups are unconditionally protected');
   assert.equal(cleanupPreview.candidateCount, 3, 'only old files beyond the protected floor are candidates');
@@ -334,7 +334,7 @@ try {
   assert.equal(existsSync(path.join(backupDir, '.nodus-cleanup-trash')), false, 'a stale confirmation moves and deletes nothing');
   await rm(path.join(backupDir, appearedAfterPreview));
 
-  const refreshedPreview = autoBackup.previewBackupCleanup(cleanupNow);
+  const refreshedPreview = await autoBackup.previewBackupCleanup(cleanupNow);
   const cleaned = await autoBackup.runBackupCleanupNow(cleanupNow, refreshedPreview.scopeToken);
   assert.equal(cleaned.ok, true, cleaned.message);
   assert.equal(cleaned.quarantinedCount, 3, 'eligible files move to quarantine first');

--- a/scripts/test-backup-cleanup.mjs
+++ b/scripts/test-backup-cleanup.mjs
@@ -67,6 +67,8 @@ test('Settings requires confirmation and explains every destructive boundary', a
 
 test('cleanup implementation is scoped, verified, quarantined and rollback-aware', async () => {
   const source = await read('electron/export/autoBackup.ts');
+  assert.match(source, /export async function previewBackupCleanup/, 'cloud-backed folder reads do not block Electron');
+  assert.match(source, /await fs\.promises\.readdir\(folder/, 'directory enumeration runs through asynchronous fs');
   assert.match(source, /entry\.isFile\(\)/, 'only direct regular files are considered');
   assert.match(source, /parseBackupFile\(hostname, entry\.name\)/, 'filenames must belong to the current host lineage');
   assert.match(source, /KEEP_ACTIVE_DURING_CLEANUP = 3/);

--- a/scripts/test-settings-background-inspection.mjs
+++ b/scripts/test-settings-background-inspection.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks } from './lib/tsRuntimeHooks.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const source = (relative) => fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+const require = createRequire(import.meta.url);
+let forkUtility = () => { throw new Error('unexpected migration utility launch'); };
+installRuntimeHooks(os.tmpdir(), { utilityProcess: { fork: (...args) => forkUtility(...args) } });
+
+test('migration snapshot validation runs in a disposable utility process', () => {
+  const ipc = source('electron/ipc.ts');
+  const host = source('electron/db/migrationRecoveryUtilityHost.ts');
+  const worker = source('electron/db/migrationRecoveryUtilityWorker.ts');
+  const vite = source('vite.config.ts');
+
+  assert.match(ipc, /listMigrationRecoverySnapshotsInUtility\(getActiveVault\(\)\.path\)/);
+  assert.doesNotMatch(ipc, /listMigrationRecoverySnapshots\(getActiveVault\(\)\.path\)/);
+  assert.match(host, /utilityProcess\.fork\(file/);
+  assert.match(host, /const inFlight = new Map/, 'repeated opens coalesce instead of scanning the same vault twice');
+  assert.match(worker, /snapshots: listMigrationRecoverySnapshots\(request\.databasePath\)/);
+  assert.match(vite, /utilityBuild\('migrationRecoveryUtilityWorker'/);
+});
+
+test('repeated requests coalesce and the migration utility is reaped', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-settings-utility-'));
+  const workerFile = path.join(root, 'migrationRecoveryUtilityWorker.js');
+  fs.writeFileSync(workerFile, '// existence sentinel');
+  let forks = 0;
+  let kills = 0;
+  class FakeUtility extends EventEmitter {
+    postMessage(request) {
+      queueMicrotask(() => this.emit('message', { kind: 'list-done', id: request.id, snapshots: [] }));
+    }
+    kill() { kills += 1; return true; }
+  }
+  forkUtility = (file, args, options) => {
+    forks += 1;
+    assert.equal(file, workerFile);
+    assert.deepEqual(args, []);
+    assert.equal(options.serviceName, 'Nodus migration recovery validation');
+    return new FakeUtility();
+  };
+  const previousWorker = process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE;
+  const previousRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+  process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE = workerFile;
+  delete process.env.ELECTRON_RUN_AS_NODE;
+  try {
+    const host = require(path.join(repoRoot, 'electron/db/migrationRecoveryUtilityHost.ts'));
+    const databasePath = path.join(root, 'vault.sqlite');
+    const [first, second] = await Promise.all([
+      host.listMigrationRecoverySnapshotsInUtility(databasePath),
+      host.listMigrationRecoverySnapshotsInUtility(databasePath),
+    ]);
+    assert.deepEqual(first, []);
+    assert.deepEqual(second, []);
+    assert.equal(forks, 1, 'one vault scan serves both callers');
+    assert.equal(kills, 1, 'the one-shot child is killed after returning its result');
+  } finally {
+    if (previousWorker === undefined) delete process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE;
+    else process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE = previousWorker;
+    if (previousRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+    else process.env.ELECTRON_RUN_AS_NODE = previousRunAsNode;
+    forkUtility = () => { throw new Error('unexpected migration utility launch'); };
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Settings starts expensive inspections only for the visible tab', () => {
+  const settings = source('src/views/Settings.tsx');
+  assert.match(settings, /if \(!dataTabRequested \|\| !activeVault\)/);
+  assert.match(settings, /if \(!dataTabRequested \|\| !settings\.autoBackupFolder\)/);
+  assert.match(settings, /if \(!integrationsTabRequested\) return;/);
+  assert.match(settings, /if \(!serverTabRequested\) return;/);
+});
+
+test('backup-folder preview uses asynchronous filesystem calls', () => {
+  const backup = source('electron/export/autoBackup.ts');
+  const start = backup.indexOf('async function readCleanupContext');
+  const end = backup.indexOf('function cleanupPreviewFromContext', start);
+  const inspection = backup.slice(start, end);
+  assert.ok(start >= 0 && end > start);
+  assert.match(inspection, /await fs\.promises\.lstat/);
+  assert.match(inspection, /await fs\.promises\.readdir/);
+  assert.doesNotMatch(inspection, /lstatSync|readdirSync|existsSync/);
+  assert.match(inspection, /export async function previewBackupCleanup/);
+});

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -99,6 +99,15 @@ function normalizeSettingsText(value: string): string {
     .trim();
 }
 
+function settingsTabRequested(tab: SettingsTabId, selected: SettingsTabId, query: string): boolean {
+  const normalizedQuery = normalizeSettingsText(query);
+  if (!normalizedQuery) return selected === tab;
+  const metadata = SETTINGS_TABS.find((item) => item.id === tab);
+  return metadata
+    ? normalizeSettingsText(`${metadata.label} ${t(metadata.label)} ${metadata.keywords}`).includes(normalizedQuery)
+    : false;
+}
+
 function formatBackupBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
@@ -156,6 +165,10 @@ export function Settings({
   const [importOpen, setImportOpen] = useState(false);
   const [primarySourcePolicy, setPrimarySourcePolicy] = useState<PrimarySourcePolicySettings | null>(null);
   const hasZoteroLibraryWorkflow = !activeVault || !ZOTERO_FREE_VAULT_TYPES.has(activeVault.type);
+  const dataTabRequested = settingsTabRequested('data', settingsTab, settingsQuery);
+  const integrationsTabRequested = settingsTabRequested('integrations', settingsTab, settingsQuery);
+  const modelsTabRequested = settingsTabRequested('models', settingsTab, settingsQuery);
+  const serverTabRequested = settingsTabRequested('server', settingsTab, settingsQuery);
 
   useEffect(() => {
     if (localStorage.getItem('nodus.settingsTarget') !== 'nodi') return;
@@ -165,7 +178,7 @@ export function Settings({
   }, []);
 
   useEffect(() => {
-    if (activeVault?.type !== 'primary_sources') {
+    if (activeVault?.type !== 'primary_sources' || !modelsTabRequested) {
       setPrimarySourcePolicy(null);
       return;
     }
@@ -174,7 +187,7 @@ export function Settings({
       if (!cancelled) setPrimarySourcePolicy(workspace.policy);
     });
     return () => { cancelled = true; };
-  }, [activeVault?.id, activeVault?.type]);
+  }, [activeVault?.id, activeVault?.type, modelsTabRequested]);
 
   useEffect(() => {
     if (!hasZoteroLibraryWorkflow && settingsTab === 'library') setSettingsTab('providers');
@@ -248,6 +261,7 @@ export function Settings({
   }, []);
 
   useEffect(() => {
+    if (!dataTabRequested) return;
     let active = true;
     void window.nodus.hasBackupPassword().then((has) => {
       if (active) setAutoBackupHasPassword(has);
@@ -255,22 +269,22 @@ export function Settings({
     return () => {
       active = false;
     };
-  }, []);
+  }, [dataTabRequested]);
 
   useEffect(() => {
     let active = true;
     setMigrationRecoverySnapshots([]);
-    if (!activeVault) return () => { active = false; };
+    if (!dataTabRequested || !activeVault) return () => { active = false; };
     void window.nodus.listMigrationRecoverySnapshots()
       .then((snapshots) => { if (active) setMigrationRecoverySnapshots(snapshots); })
       .catch(() => { if (active) setMigrationRecoverySnapshots([]); });
     return () => { active = false; };
-  }, [activeVault?.id]);
+  }, [activeVault?.id, dataTabRequested]);
 
   useEffect(() => {
     let active = true;
     setBackupCleanupPreview(null);
-    if (!settings.autoBackupFolder) {
+    if (!dataTabRequested || !settings.autoBackupFolder) {
       return () => { active = false; };
     }
     void window.nodus.previewBackupCleanup().then((preview) => {
@@ -278,6 +292,7 @@ export function Settings({
     });
     return () => { active = false; };
   }, [
+    dataTabRequested,
     settings.autoBackupFolder,
     settings.backupRetentionUnit,
     settings.backupRetentionValue,
@@ -286,6 +301,7 @@ export function Settings({
   ]);
 
   useEffect(() => {
+    if (!integrationsTabRequested) return;
     let active = true;
     const refresh = async () => {
       const [next, tunnel] = await Promise.all([window.nodus.getMcpStatus(), window.nodus.getMcpTunnelStatus()]);
@@ -300,13 +316,14 @@ export function Settings({
       active = false;
       window.clearInterval(interval);
     };
-  }, [settings.mcpEnabled, settings.mcpPort, settings.mcpToken]);
+  }, [integrationsTabRequested, settings.mcpEnabled, settings.mcpPort, settings.mcpToken]);
 
   useEffect(() => setMcpPortInput(String(settings.mcpPort)), [settings.mcpPort]);
 
   // Basic mode polls on a slow tick, unlike MCP's 1.5s: the answers here involve running the
   // Tailscale CLI, and a status read should not cost a subprocess every second and a half.
   useEffect(() => {
+    if (!serverTabRequested) return;
     let active = true;
     const refresh = async () => {
       try {
@@ -338,11 +355,12 @@ export function Settings({
       active = false;
       window.clearInterval(interval);
     };
-  }, [settings.localServerAccess, settings.localServerPort]);
+  }, [serverTabRequested, settings.localServerAccess, settings.localServerPort]);
 
   useEffect(() => setNodusServerUrlInput(settings.nodusServerUrl), [settings.nodusServerUrl]);
 
   useEffect(() => {
+    if (!serverTabRequested) return;
     let cancelled = false;
     const load = async () => {
       try {
@@ -355,7 +373,7 @@ export function Settings({
     void load();
     const timer = window.setInterval(() => void load(), 5000);
     return () => { cancelled = true; window.clearInterval(timer); };
-  }, []);
+  }, [serverTabRequested]);
 
   const syncReplica = async (vaultId: string) => {
     setReplicaBusy(vaultId);
@@ -373,6 +391,7 @@ export function Settings({
   };
 
   useEffect(() => {
+    if (!serverTabRequested) return;
     let active = true;
     const refresh = async () => {
       const next = await window.nodus.getNodusServerOverview();
@@ -384,9 +403,10 @@ export function Settings({
       active = false;
       window.clearInterval(interval);
     };
-  }, [settings.nodusServerEnabled, settings.nodusServerUrl, settings.nodusServerSpaceId]);
+  }, [serverTabRequested, settings.nodusServerEnabled, settings.nodusServerUrl, settings.nodusServerSpaceId]);
 
   useEffect(() => {
+    if (!integrationsTabRequested) return;
     let active = true;
     const refresh = async () => {
       const next = await window.nodus.getCopilotStatus();
@@ -398,9 +418,10 @@ export function Settings({
       active = false;
       window.clearInterval(interval);
     };
-  }, [settings.copilotEnabled, settings.copilotPort, settings.copilotToken]);
+  }, [integrationsTabRequested, settings.copilotEnabled, settings.copilotPort, settings.copilotToken]);
 
   useEffect(() => {
+    if (!integrationsTabRequested) return;
     let active = true;
     const refresh = async () => {
       const next = await window.nodus.getZoteroPluginStatus();
@@ -412,7 +433,7 @@ export function Settings({
       active = false;
       window.clearInterval(interval);
     };
-  }, [settings.zoteroPluginEnabled, settings.browserConnectorEnabled, settings.zoteroPluginPort, settings.zoteroPluginToken, settings.browserConnectorToken]);
+  }, [integrationsTabRequested, settings.zoteroPluginEnabled, settings.browserConnectorEnabled, settings.zoteroPluginPort, settings.zoteroPluginToken, settings.browserConnectorToken]);
 
   useEffect(() => {
     if (!mcpHelpOpen) return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -299,6 +299,7 @@ export default defineConfig({
       databaseAggregateWorkerBuild,
       utilityBuild('backupUtilityWorker', 'electron/export/backupUtilityWorker.ts'),
       utilityBuild('recoveryProbeUtilityWorker', 'electron/recovery/recoveryProbeUtilityWorker.ts'),
+      utilityBuild('migrationRecoveryUtilityWorker', 'electron/db/migrationRecoveryUtilityWorker.ts'),
       utilityBuild('serverPublishWorker', 'electron/serverSync/serverPublishWorker.ts'),
     ]),
     renderer(),


### PR DESCRIPTION
## Summary

- move migration snapshot hashing and SQLite integrity validation into a disposable Electron utility process
- coalesce concurrent validation requests for the same vault and reap the utility process after completion
- inspect cloud-backed backup folders with asynchronous filesystem calls
- defer Data, Integrations, Models, and Server inspections and polling until the relevant Settings tab is visible
- add regression coverage for utility-process isolation, request coalescing, tab-scoped work, and asynchronous backup-folder inspection

Fixes #548.

## Validation

- `node --test scripts/test-settings-background-inspection.mjs scripts/test-backup-cleanup.mjs`
- `node scripts/test-auto-backup.mjs`
- `node scripts/test-major-migration-recovery.mjs`
- `npx tsc --noEmit -p electron/tsconfig.json`
- targeted ESLint for all changed TypeScript/TSX files
- `npx vite build` (including the new utility-process bundle)