### PR TITLE
Stabilize the progressive graph E2E setup

### DIFF
--- a/scripts/e2e-graph-progressive.mjs
+++ b/scripts/e2e-graph-progressive.mjs
@@ -37,6 +37,7 @@ try {
     ...process.env,
     NODUS_USERDATA: userData,
     NODUS_DISABLE_AUTO_UPDATE: '1',
+    NODUS_E2E_UPDATE_STATUS: 'not-available',
   };
   delete childEnv.ELECTRON_RUN_AS_NODE;
   app = await electron.launch({
@@ -71,8 +72,12 @@ try {
   );
 
   await page.evaluate(async (version) => {
+    sessionStorage.setItem('nodus.startupUpdateChecked', '1');
     localStorage.setItem('nodus.lastSeenVersion', version);
     localStorage.setItem(`nodus.mobileTeaserSeen.${version}`, '1');
+    localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
+    localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
     await window.nodus.updateSettings({
       onboardingComplete: true,
       basicsTutorialVersion: 5,


### PR DESCRIPTION
Follow-up to #550 and #551.

## Summary
- force the startup update state to a deterministic no-update result
- mark the startup update check and announcement overlays as already seen before opening the graph

## Validation
- node --check scripts/e2e-graph-progressive.mjs
- git diff --check