### PR TITLE
Preseed document consent in the progressive graph E2E

### DIFF
--- a/scripts/e2e-graph-progressive.mjs
+++ b/scripts/e2e-graph-progressive.mjs
@@ -78,6 +78,7 @@ try {
     localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
     localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
     localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
+    localStorage.setItem('nodus.documentUnderstandingConsent.2026-08', '1');
     await window.nodus.updateSettings({
       onboardingComplete: true,
       basicsTutorialVersion: 5,


### PR DESCRIPTION
Follow-up to #550, #551, and #552.

## Summary
- mark document-understanding consent as accepted in the progressive graph E2E fixture so the graph can open without an overlay

## Validation
- node --check scripts/e2e-graph-progressive.mjs
- git diff --check