### PR TITLE
Stabilize progressive graph E2E preferences

### DIFF
--- a/scripts/e2e-graph-progressive.mjs
+++ b/scripts/e2e-graph-progressive.mjs
@@ -85,6 +85,11 @@ try {
       recoverySetupVersion: 1,
       tourComplete: true,
       advancedTourComplete: true,
+      uiLanguage: 'es',
+      mascotStyle: 'orb',
+      mascotStyleChosen: true,
+      mascotEnabled: false,
+      reduceMotion: true,
     });
   }, appVersion);
   await page.reload();


### PR DESCRIPTION
Closes #554

Follow-up to #550, #551, #552, and #553.

## Summary
- force the progressive graph E2E to use the Spanish UI
- mark mascot style selection as complete and disable the mascot
- enable reduced motion to remove animation timing from the fixture

## Validation
- `node --check scripts/e2e-graph-progressive.mjs`
- `git diff --check`