### PR TITLE
test: handle Nodi style onboarding in graph E2E

### DIFF
--- a/scripts/e2e-graph-progressive.mjs
+++ b/scripts/e2e-graph-progressive.mjs
@@ -93,6 +93,12 @@ try {
     });
   }, appVersion);
   await page.reload();
+  const nodiStyleModal = page.getByTestId('nodi-style-modal');
+  await nodiStyleModal.waitFor({ state: 'attached', timeout: 1_000 }).catch(() => {});
+  if (await nodiStyleModal.count()) {
+    await page.getByTestId('nodi-style-orb').click();
+    await nodiStyleModal.waitFor({ state: 'detached' });
+  }
   await page.locator('[data-tour="nav-graph"]').click();
   await page.locator('canvas').first().waitFor({ state: 'visible' });
   await page.waitForTimeout(250);


### PR DESCRIPTION
## Summary

- dismiss the optional Nodi style onboarding modal after the graph reload
- keep the progressive graph E2E flow from being blocked by the onboarding overlay
- preserve the existing preference-persistence assertions

## Verification

- `node --test scripts/test-graph-progressive.mjs`
- `node scripts/e2e-graph-progressive.mjs`
- `git diff --check`

Closes #556