### PR TITLE
test: align corpus reliability assertions

### DIFF
--- a/scripts/test-authors-ui.mjs
+++ b/scripts/test-authors-ui.mjs
@@ -17,7 +17,7 @@ test('Authors is a library-style catalogue with real metadata and saved authors 
   for (const field of ['firstName', 'lastName', 'workCount', 'ideaCount', 'relationCount', 'topTags']) {
     assert.match(view, new RegExp(`author\\.${field}`), `${field} is visible in the author catalogue`);
   }
-  assert.match(view, /setSavedOnly\(\(value\) => !value\)/, 'saved authors is a filter instead of a separate workspace');
+  assert.match(view, /const toggleSavedFilter = \(\) => \{[\s\S]*setSavedOnly\(nextSavedOnly\)[\s\S]*report\.current\?\.\(\{ savedOnly: nextSavedOnly \}\)[\s\S]*\}/, 'saved authors is a persisted filter instead of a separate workspace');
   assert.doesNotMatch(view, /AuthorsSurface[^\n]*saved/, 'saved authors is not an internal tab');
   assert.match(types, /topTags: string\[\]/, 'the author summary carries real source tags');
   assert.match(dossier, /JOIN work_zotero_tags[\s\S]*JOIN zotero_tags/, 'author tags come from Zotero work metadata');

--- a/scripts/test-global-library-release.mjs
+++ b/scripts/test-global-library-release.mjs
@@ -30,7 +30,8 @@ test('the complete Global Library ships with recovery, privacy, hardening and re
   assert.match(privacy, /Cross-vault Library/);
   assert.match(privacy, /Clean-reader chat and remote OCR/);
   assert.match(readerStore, /realpathSync\.native/);
-  assert.match(readerStore, /atomicWriteJson, configuredLibraryRootOrThrow/);
+  assert.match(readerStore, /function libraryRoot\(\): string \{\s*return configuredLibraryRootOrThrow\(\);\s*\}/, 'the reader requires a configured library root');
+  assert.match(readerStore, /atomicWriteJson\(/, 'reader writes remain atomic');
 
   for (const file of [
     'scripts/test-library-storage.mjs',


### PR DESCRIPTION
## Summary

- update the Authors UI contract test to cover the persisted saved-author filter
- verify the configured Library root and atomic writes independently of import formatting
- fix the two stale static assertions reported by the CI run for #551

## Verification

- `node --test scripts/test-authors-ui.mjs scripts/test-global-library-release.mjs`
- `npm test` (2,344 passed)
- `git diff --check`

Follow-up to #551.