### PR TITLE
Document the documentary index campaign recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ change since 4.2.5, including the fixes merged after the first beta tag.
   lexical and vector indexes, freshness tracking and evidence-first drill-down. Background
   indexing asks for explicit one-time consent and provides durable progress with pause,
   resume, stop, retry and crash recovery from Library and Settings.
+- Fixed documentary indexing campaigns pausing again after every Resume when a legacy
+  deep-scan fingerprint differed from the canonical resolved text. Profile publication now
+  guards the resolved corpus atomically, campaign failures stay actionable and localized,
+  and warning and destructive controls remain legible in both light and dark themes.
 - Added Deep Research v2 with idea-and-relationship-first retrieval, selective expansion
   into full documents, version routing and reproducible report metadata. Source and
   proposition coverage now decide when research is complete instead of a requested word


### PR DESCRIPTION
Closes #559

## Summary

- record the documentary indexing recovery in the 5.0 release notes
- document that profile publication now uses the canonical resolved corpus hash while preserving atomic source-race protection
- call out actionable localized campaign failures and explicit warning and destructive-control contrast in light and dark themes
- link the implementation and regression coverage already delivered in #551

## Validation

- npx tsc --noEmit -p tsconfig.json --pretty false
- npx tsc --noEmit -p electron/tsconfig.json --pretty false
- node --test scripts/test-document-profile-pipeline.mjs scripts/test-document-profiles.mjs scripts/test-document-index-queue.mjs scripts/test-document-understanding-consent.mjs scripts/test-i18n-coverage.mjs
- git diff --check