### PR TITLE
test: prevent legacy Cytoscape lockfile regressions

### DIFF
--- a/scripts/test-graph-progressive.mjs
+++ b/scripts/test-graph-progressive.mjs
@@ -304,11 +304,13 @@ async function assertRendererContracts() {
   const graphView = await readFile(path.join(repoRoot, 'src/views/GraphView.tsx'), 'utf8');
   const sigmaGraph = await readFile(path.join(repoRoot, 'src/views/graph/SigmaGraph.tsx'), 'utf8');
   const packageJson = await readFile(path.join(repoRoot, 'package.json'), 'utf8');
+  const packageLock = await readFile(path.join(repoRoot, 'package-lock.json'), 'utf8');
   const preload = await Promise.resolve(readSource('@bridge'));
   const ipc = await Promise.resolve(readSource('@main'));
 
   assert.doesNotMatch(graphView, /USE_SIGMA|cytoscape|nodus\.graph\.engine/i, 'GraphView contains no legacy renderer branch or preference');
   assert.doesNotMatch(packageJson, /cytoscape/i, 'the legacy renderer is absent from runtime and type dependencies');
+  assert.doesNotMatch(packageLock, /cytoscape/i, 'the legacy renderer is absent from the dependency lockfile');
   assert.match(graphView, /const focusPendingNavigation = useCallback/, 'cross-view graph targets are focused through the active renderer');
   assert.match(graphView, /api\.focusNode\(current\.nodeId\)/, 'idea deep-links use the Sigma focus API');
   assert.match(graphView, /onReady=\{handleGraphReady\}/, 'deep-link focus waits for the requested Sigma scene');


### PR DESCRIPTION
## Summary

This PR completes the Sigma-only graph work tracked in #561 against the latest origin/main.

The mainline fix now:

- renders Graph exclusively through Sigma;
- routes pending idea and edge navigation through the Sigma API after the requested scene is ready;
- focuses the selected idea and opens its matching detail panel;
- removes the legacy Cytoscape renderer, preference, runtime dependency, type dependency, and lockfile entries;
- covers the reported Ideas → idea tab → Graph flow in a real Electron E2E test.

Because those functional changes reached main while this follow-up was being prepared, the remaining diff adds the final dependency regression guard: package-lock.json is now checked alongside package.json so Cytoscape cannot return through a stale lockfile.

## Verification

- npm run build
- npx eslint scripts/test-graph-progressive.mjs --ext .mjs
- node --test scripts/test-graph-progressive.mjs
- node scripts/e2e-graph-progressive.mjs

The Electron E2E passed with the idea deep-link focused by Sigma.

Closes #561.