### PR TITLE
Generate Dictionary entries in parallel batches

### DIFF
--- a/electron/ai/dictionaryGenerationQueue.ts
+++ b/electron/ai/dictionaryGenerationQueue.ts
@@ -1,0 +1,94 @@
+import type {
+  DictionaryGenerationRequest,
+  DictionaryProgress,
+} from "@shared/dictionary";
+
+export type DictionaryGenerationProgressReporter = (
+  progress: DictionaryProgress,
+) => void;
+
+export type DictionaryGenerationExecutor = (
+  request: DictionaryGenerationRequest,
+  report: DictionaryGenerationProgressReporter,
+) => Promise<void>;
+
+const isRunning = (progress: DictionaryProgress): boolean =>
+  !["done", "failed"].includes(progress.phase);
+
+/**
+ * Owns the lifetime of background Dictionary work independently from any
+ * renderer. Every entry gets its own scheduled execution, so starting a batch
+ * does not serialize retrieval or synthesis behind the preceding entry.
+ */
+export class DictionaryGenerationQueue {
+  readonly #jobs = new Map<string, DictionaryProgress>();
+  readonly #tokens = new Map<string, symbol>();
+
+  constructor(
+    private readonly execute: DictionaryGenerationExecutor,
+    private readonly publish: DictionaryGenerationProgressReporter,
+  ) {}
+
+  start(request: DictionaryGenerationRequest): DictionaryProgress {
+    const running = this.#jobs.get(request.entryId);
+    if (running && isRunning(running)) return running;
+
+    const token = Symbol(request.entryId);
+    const queued: DictionaryProgress = {
+      entryId: request.entryId,
+      phase: "queued",
+      message: "En cola",
+    };
+    this.#tokens.set(request.entryId, token);
+    this.#set(queued, token);
+
+    setImmediate(() => {
+      void this.#run(request, token);
+    });
+    return queued;
+  }
+
+  list(): DictionaryProgress[] {
+    return [...this.#jobs.values()];
+  }
+
+  delete(entryIds: Iterable<string>): void {
+    for (const entryId of entryIds) {
+      this.#tokens.delete(entryId);
+      this.#jobs.delete(entryId);
+    }
+  }
+
+  async #run(
+    request: DictionaryGenerationRequest,
+    token: symbol,
+  ): Promise<void> {
+    const report = (progress: DictionaryProgress) => this.#set(progress, token);
+    try {
+      await this.execute(request, report);
+      report({
+        entryId: request.entryId,
+        phase: "done",
+        message: "Definición generada",
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[dictionary] background generation failed for ${request.entryId}`,
+        error,
+      );
+      report({
+        entryId: request.entryId,
+        phase: "failed",
+        message: "Error al generar",
+        error: detail,
+      });
+    }
+  }
+
+  #set(progress: DictionaryProgress, token: symbol): void {
+    if (this.#tokens.get(progress.entryId) !== token) return;
+    this.#jobs.set(progress.entryId, progress);
+    this.publish(progress);
+  }
+}

--- a/electron/ipc/academic.ts
+++ b/electron/ipc/academic.ts
@@ -134,6 +134,7 @@ import type {
 } from '@shared/dictionary';
 import { immersionAnnotationDocumentId } from '@shared/readerAnnotations';
 import { applyDecorativeImageOption, invalidateDecorativeImageGeneration } from '../ai/decorativeImages';
+import { DictionaryGenerationQueue } from '../ai/dictionaryGenerationQueue';
 import * as zotero from '../zotero/zoteroClient';
 import * as dedupe from '../db/dedupeRepo';
 import * as ideaDedupe from '../db/ideaDedupeRepo';
@@ -359,7 +360,22 @@ function announceDictionaryProgress(progress: DictionaryProgress): void {
   }
 }
 
-const dictionaryGenerationJobs = new Map<string, DictionaryProgress>();
+const dictionaryGenerationJobs = new DictionaryGenerationQueue(
+  async (request, report) => {
+    const current = dictionaryRepo.getDictionaryEntryDetail(request.entryId);
+    const needsInitialRetrieval = request.mode === 'creation' && (current?.coverage.included ?? 0) === 0;
+    if (needsInitialRetrieval) {
+      report({ entryId: request.entryId, phase: 'retrieving', message: 'Analizando corpus' });
+      await retrieveDictionaryEvidence(request.entryId, 'initial');
+      announceDictionary(request.entryId);
+    }
+
+    report({ entryId: request.entryId, phase: 'generating', message: 'Generando definición' });
+    await generateDictionaryEntry(request);
+    announceDictionary(request.entryId);
+  },
+  announceDictionaryProgress,
+);
 
 function announceWritingDraftAnnotations(draftId: string | null): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -397,7 +413,7 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
   });
   h('dictionary:delete', async (_e, ids: string[]) => {
     const changed = dictionaryRepo.deleteDictionaryEntries(ids);
-    for (const id of ids) dictionaryGenerationJobs.delete(id);
+    dictionaryGenerationJobs.delete(ids);
     if (changed) announceDictionary(null);
     return changed;
   });
@@ -434,45 +450,9 @@ export function registerAcademicIpc({ h, getWindow, chatAborters }: IpcContext):
     }
   });
   h('dictionary:generate:start', async (_e, request: DictionaryGenerationRequest) => {
-    const running = dictionaryGenerationJobs.get(request.entryId);
-    if (running && !['done', 'failed'].includes(running.phase)) return running;
-    const queued: DictionaryProgress = { entryId: request.entryId, phase: 'queued', message: 'En cola' };
-    dictionaryGenerationJobs.set(request.entryId, queued);
-    announceDictionaryProgress(queued);
-    setImmediate(() => {
-      void (async () => {
-        try {
-          const current = dictionaryRepo.getDictionaryEntryDetail(request.entryId);
-          const needsInitialRetrieval = request.mode === 'creation' && (current?.coverage.included ?? 0) === 0;
-          if (needsInitialRetrieval) {
-            const retrieving: DictionaryProgress = { entryId: request.entryId, phase: 'retrieving', message: 'Analizando corpus' };
-            dictionaryGenerationJobs.set(request.entryId, retrieving);
-            announceDictionaryProgress(retrieving);
-            await retrieveDictionaryEvidence(request.entryId, 'initial');
-            announceDictionary(request.entryId);
-          }
-
-          const generating: DictionaryProgress = { entryId: request.entryId, phase: 'generating', message: 'Generando definición' };
-          dictionaryGenerationJobs.set(request.entryId, generating);
-          announceDictionaryProgress(generating);
-          await generateDictionaryEntry(request);
-          announceDictionary(request.entryId);
-
-          const done: DictionaryProgress = { entryId: request.entryId, phase: 'done', message: 'Definición generada' };
-          dictionaryGenerationJobs.set(request.entryId, done);
-          announceDictionaryProgress(done);
-        } catch (error) {
-          const detail = error instanceof Error ? error.message : String(error);
-          console.error(`[dictionary] background generation failed for ${request.entryId}`, error);
-          const failed: DictionaryProgress = { entryId: request.entryId, phase: 'failed', message: 'Error al generar', error: detail };
-          dictionaryGenerationJobs.set(request.entryId, failed);
-          announceDictionaryProgress(failed);
-        }
-      })();
-    });
-    return queued;
+    return dictionaryGenerationJobs.start(request);
   });
-  h('dictionary:generate:jobs', async () => [...dictionaryGenerationJobs.values()]);
+  h('dictionary:generate:jobs', async () => dictionaryGenerationJobs.list());
   h('dictionary:versions:list', async (_e, entryId: string) => dictionaryRepo.listDictionaryVersions(entryId));
   h('dictionary:versions:accept', async (_e, entryId: string, versionId: string, expectedCurrentVersionId: string | null) => {
     const detail = dictionaryRepo.acceptDictionaryVersion(entryId, versionId, expectedCurrentVersionId);

--- a/scripts/test-dictionary-generation-queue.mjs
+++ b/scripts/test-dictionary-generation-queue.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { build } from "esbuild";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+const waitFor = async (predicate, label) => {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+
+test("Dictionary jobs run in parallel and remain isolated", async () => {
+  const output = await mkdtemp(path.join(os.tmpdir(), "nodus-dictionary-queue-"));
+  try {
+    const bundle = path.join(output, "queue.mjs");
+    await build({
+      entryPoints: [
+        path.join(root, "electron/ai/dictionaryGenerationQueue.ts"),
+      ],
+      outfile: bundle,
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      logLevel: "silent",
+    });
+    const { DictionaryGenerationQueue } = await import(pathToFileURL(bundle));
+
+    const gates = new Map();
+    const invocations = new Map();
+    const events = [];
+    let active = 0;
+    let peak = 0;
+    const queue = new DictionaryGenerationQueue(
+      async (request, report) => {
+        invocations.set(
+          request.entryId,
+          (invocations.get(request.entryId) ?? 0) + 1,
+        );
+        active += 1;
+        peak = Math.max(peak, active);
+        report({
+          entryId: request.entryId,
+          phase: "generating",
+          message: "Generando definición",
+        });
+        const gate = deferred();
+        gates.set(request.entryId, gate);
+        await gate.promise;
+        active -= 1;
+        if (request.entryId === "bad") throw new Error("provider down");
+      },
+      (progress) => events.push(progress),
+    );
+
+    const request = (entryId) => ({ entryId, mode: "creation", model: null });
+    queue.start(request("slow"));
+    queue.start(request("bad"));
+    queue.start(request("fast"));
+    const duplicate = queue.start(request("slow"));
+    assert.equal(duplicate.phase, "queued");
+
+    await waitFor(() => gates.size === 3, "all three concurrent jobs");
+    assert.equal(peak, 3, "all entries reach the provider before any completes");
+    assert.equal(invocations.get("slow"), 1, "an active entry is not started twice");
+
+    const originalConsoleError = console.error;
+    console.error = () => undefined;
+    try {
+      gates.get("fast").resolve();
+      gates.get("bad").resolve();
+      await waitFor(
+        () =>
+          queue.list().find((job) => job.entryId === "fast")?.phase ===
+            "done" &&
+          queue.list().find((job) => job.entryId === "bad")?.phase ===
+            "failed",
+        "independent success and failure",
+      );
+    } finally {
+      console.error = originalConsoleError;
+    }
+    assert.equal(
+      queue.list().find((job) => job.entryId === "slow")?.phase,
+      "generating",
+      "out-of-order completions do not change another entry",
+    );
+
+    queue.delete(["slow"]);
+    gates.get("slow").resolve();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.ok(
+      !queue.list().some((job) => job.entryId === "slow"),
+      "a deleted entry cannot reappear through stale completion",
+    );
+
+    console.error = () => undefined;
+    try {
+      queue.start(request("bad"));
+      await waitFor(() => invocations.get("bad") === 2, "failed job retry");
+      gates.get("bad").resolve();
+      await waitFor(
+        () => queue.list().find((job) => job.entryId === "bad")?.phase === "failed",
+        "retried failure",
+      );
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    assert.ok(
+      events.some((event) => event.entryId === "fast" && event.phase === "done"),
+    );
+    assert.ok(
+      events.some(
+        (event) =>
+          event.entryId === "bad" &&
+          event.phase === "failed" &&
+          event.error === "provider down",
+      ),
+    );
+  } finally {
+    await rm(output, { recursive: true, force: true });
+  }
+});

--- a/scripts/test-dictionary-ui.mjs
+++ b/scripts/test-dictionary-ui.mjs
@@ -11,6 +11,7 @@ const [
   authors,
   ai,
   academicIpc,
+  generationQueue,
   preload,
   promptPresets,
   dictionaryI18n,
@@ -23,6 +24,10 @@ const [
     readFile(path.join(root, "src/views/AuthorsView.tsx"), "utf8"),
     readFile(path.join(root, "electron/ai/dictionary.ts"), "utf8"),
     readFile(path.join(root, "electron/ipc/academic.ts"), "utf8"),
+    readFile(
+      path.join(root, "electron/ai/dictionaryGenerationQueue.ts"),
+      "utf8",
+    ),
     readFile(path.join(root, "electron/preload/academic.ts"), "utf8"),
     readFile(path.join(root, "shared/dictionaryPromptPresets.ts"), "utf8"),
     readFile(path.join(root, "src/i18n.dictionary.ts"), "utf8"),
@@ -226,6 +231,26 @@ assert.equal(
   2,
   "creation, regeneration and update all enter the main-process background pipeline",
 );
+assert.match(
+  view,
+  /data-testid="dictionary-add-concept"/,
+  "the creation dialog can add more concepts to a batch",
+);
+assert.match(
+  view,
+  /Promise\.allSettled\([\s\S]*batch\.map[\s\S]*startDictionaryGeneration/,
+  "all concepts are persisted and queued independently without one failure cancelling the batch",
+);
+assert.match(
+  view,
+  /if \(!queuedDrafts\.has\(draft\.key\)\)[\s\S]*startDictionaryGeneration[\s\S]*setQueuedDrafts/,
+  "retrying a partial batch does not generate entries that were already queued successfully",
+);
+assert.match(
+  view,
+  /new Set\(names\)\.size !== names\.length/,
+  "a batch rejects duplicate normalized concept names before persisting them",
+);
 assert.doesNotMatch(
   view,
   /window\.nodus\.generateDictionaryEntry/,
@@ -258,8 +283,8 @@ assert.match(
 );
 assert.match(
   academicIpc,
-  /dictionary:generate:start[\s\S]*retrieveDictionaryEvidence[\s\S]*generateDictionaryEntry/,
-  "the background IPC automatically retrieves and generates in order",
+  /new DictionaryGenerationQueue\([\s\S]*retrieveDictionaryEvidence[\s\S]*generateDictionaryEntry/,
+  "the background queue automatically retrieves and generates each entry in order",
 );
 assert.match(
   academicIpc,
@@ -268,8 +293,18 @@ assert.match(
 );
 assert.match(
   academicIpc,
-  /dictionary:generate:jobs[\s\S]*dictionaryGenerationJobs\.values/,
+  /dictionary:generate:jobs[\s\S]*dictionaryGenerationJobs\.list\(\)/,
   "the main process exposes running and completed jobs for view reconnection",
+);
+assert.match(
+  generationQueue,
+  /setImmediate\([\s\S]*this\.#run\(request, token\)/,
+  "every entry gets its own independently scheduled background execution",
+);
+assert.match(
+  generationQueue,
+  /#tokens[\s\S]*delete\(entryIds[\s\S]*#tokens\.delete/,
+  "deleting an entry invalidates its running job so stale progress cannot return",
 );
 assert.match(
   preload,
@@ -288,8 +323,8 @@ assert.match(
 );
 assert.match(
   view,
-  /<ButtonBusy label=\{t\("Preparando definición…"\)\} \/>/,
-  "creation closes after preparing the persisted background job",
+  /<ButtonBusy[\s\S]*tx\("Preparando \{n\} definiciones…"/,
+  "batch creation closes after preparing all persisted background jobs",
 );
 assert.match(
   view,

--- a/src/i18n.dictionary.ts
+++ b/src/i18n.dictionary.ts
@@ -14,6 +14,18 @@ export const DICTIONARY_TRANSLATIONS = {
     Cancelar: "Cancel",
     "Generar de todos modos": "Generate anyway",
     Concepto: "Concept",
+    "Añadir concepto": "Add concept",
+    "Quitar concepto": "Remove concept",
+    "Cada concepto se guardará como una entrada independiente y se procesará en paralelo.":
+      "Each concept will be saved as a separate entry and processed in parallel.",
+    "Hay conceptos repetidos en el lote.":
+      "The batch contains duplicate concepts.",
+    "Preparando {n} definiciones…": "Preparing {n} definitions…",
+    "Generar {n} definiciones": "Generate {n} definitions",
+    "Generar {n} definiciones de todos modos":
+      "Generate {n} definitions anyway",
+    "{n} entradas ya están guardadas; reintentar no creará duplicados.":
+      "{n} entries are already saved; retrying will not create duplicates.",
     "Aliases o términos alternativos": "Aliases or alternative terms",
     "Separados por comas": "Separated by commas",
     "Prompt de enfoque": "Focus prompt",
@@ -182,6 +194,18 @@ export const DICTIONARY_TRANSLATIONS = {
     Cancelar: "Annuler",
     "Generar de todos modos": "Générer quand même",
     Concepto: "Concept",
+    "Añadir concepto": "Ajouter un concept",
+    "Quitar concepto": "Supprimer le concept",
+    "Cada concepto se guardará como una entrada independiente y se procesará en paralelo.":
+      "Chaque concept sera enregistré comme une entrée distincte et traité en parallèle.",
+    "Hay conceptos repetidos en el lote.":
+      "Le lot contient des concepts en double.",
+    "Preparando {n} definiciones…": "Préparation de {n} définitions…",
+    "Generar {n} definiciones": "Générer {n} définitions",
+    "Generar {n} definiciones de todos modos":
+      "Générer quand même {n} définitions",
+    "{n} entradas ya están guardadas; reintentar no creará duplicados.":
+      "{n} entrées sont déjà enregistrées ; réessayer ne créera pas de doublons.",
     "Aliases o términos alternativos": "Alias ou termes alternatifs",
     "Separados por comas": "Séparés par des virgules",
     "Prompt de enfoque": "Question de cadrage",

--- a/src/views/DictionaryView.tsx
+++ b/src/views/DictionaryView.tsx
@@ -97,6 +97,25 @@ const emptyInput = (): DictionaryEntryInput => ({
   outputLanguage: "es",
   detailLevel: "standard",
 });
+type DictionaryCreationDraft = {
+  key: number;
+  name: string;
+  aliases: string;
+};
+let dictionaryCreationDraftKey = 0;
+const emptyCreationDraft = (): DictionaryCreationDraft => ({
+  key: ++dictionaryCreationDraftKey,
+  name: "",
+  aliases: "",
+});
+const normalizedCreationName = (value: string): string =>
+  value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
 const promptLanguageLabel = (language: PromptLanguage): string => {
   switch (language) {
     case "es":
@@ -400,19 +419,24 @@ function CreationDialog({
   onModel: (model: ModelRef | null) => void;
   onClose: () => void;
   onOpenExisting: (entry: DictionaryEntrySummary) => void;
-  onQueued: (id: string, name: string) => void;
+  onQueued: (entries: Array<Pick<DictionaryEntry, "id" | "name">>) => void;
 }) {
   const [input, setInput] = useState(emptyInput);
+  const [drafts, setDrafts] = useState<DictionaryCreationDraft[]>(() => [
+    emptyCreationDraft(),
+  ]);
   const [promptPreset, setPromptPreset] = useState<
     DictionaryPromptPreset | "custom"
   >(DEFAULT_DICTIONARY_PROMPT_PRESET);
-  const [aliases, setAliases] = useState("");
   const [duplicates, setDuplicates] = useState<
-    DictionaryDuplicateMatch[] | null
+    Map<number, DictionaryDuplicateMatch[]> | null
   >(null);
-  const [relateTo, setRelateTo] = useState<string | null>(null);
-  const [created, setCreated] = useState<DictionaryEntry | null>(null);
-  const [relationAdded, setRelationAdded] = useState(false);
+  const [relateTo, setRelateTo] = useState<Map<number, string>>(new Map());
+  const [created, setCreated] = useState<Map<number, DictionaryEntry>>(
+    new Map(),
+  );
+  const [relationsAdded, setRelationsAdded] = useState<Set<number>>(new Set());
+  const [queuedDrafts, setQueuedDrafts] = useState<Set<number>>(new Set());
   const [phase, setPhase] = useState<"checking" | "creating" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const interfaceLanguage = getActiveLang();
@@ -429,43 +453,127 @@ function CreationDialog({
     );
   }, [interfaceLanguage, promptPreset]);
 
+  const updateDraft = (
+    key: number,
+    patch: Partial<Pick<DictionaryCreationDraft, "name" | "aliases">>,
+  ) =>
+    setDrafts((current) =>
+      current.map((draft) =>
+        draft.key === key ? { ...draft, ...patch } : draft,
+      ),
+    );
+  const removeDraft = (key: number) => {
+    setDrafts((current) => current.filter((draft) => draft.key !== key));
+    setCreated((current) => {
+      const next = new Map(current);
+      next.delete(key);
+      return next;
+    });
+    setRelateTo((current) => {
+      const next = new Map(current);
+      next.delete(key);
+      return next;
+    });
+    setRelationsAdded((current) => {
+      const next = new Set(current);
+      next.delete(key);
+      return next;
+    });
+    setQueuedDrafts((current) => {
+      const next = new Set(current);
+      next.delete(key);
+      return next;
+    });
+  };
+  const namedDrafts = () => drafts.filter((draft) => draft.name.trim());
+
   const createAndQueue = async () => {
+    const batch = namedDrafts();
+    if (!batch.length) return;
     setPhase("creating");
     setError(null);
+    setDuplicates(null);
     try {
-      const entry =
-        created ??
-        (await window.nodus.createDictionaryEntry({
-          ...input,
-          aliases: csv(aliases),
-        }));
-      if (!created) setCreated(entry);
-      if (relateTo && !relationAdded) {
-        await window.nodus.addDictionaryRelation(entry.id, relateTo, "related");
-        setRelationAdded(true);
+      const results = await Promise.allSettled(
+        batch.map(async (draft) => {
+          const existing = created.get(draft.key);
+          const entry =
+            existing ??
+            (await window.nodus.createDictionaryEntry({
+              ...input,
+              name: draft.name,
+              aliases: csv(draft.aliases),
+            }));
+          if (!existing) {
+            setCreated((current) => new Map(current).set(draft.key, entry));
+          }
+          const relation = relateTo.get(draft.key);
+          if (relation && !relationsAdded.has(draft.key)) {
+            await window.nodus.addDictionaryRelation(
+              entry.id,
+              relation,
+              "related",
+            );
+            setRelationsAdded((current) => new Set(current).add(draft.key));
+          }
+          if (!queuedDrafts.has(draft.key)) {
+            await window.nodus.startDictionaryGeneration({
+              entryId: entry.id,
+              mode: "creation",
+              model,
+            });
+            setQueuedDrafts((current) => new Set(current).add(draft.key));
+          }
+          return entry;
+        }),
+      );
+      const failures = results.flatMap((result, index) =>
+        result.status === "rejected"
+          ? [`${batch[index]?.name ?? index + 1}: ${message(result.reason)}`]
+          : [],
+      );
+      if (failures.length) {
+        setError(failures.join(" · "));
+        setPhase(null);
+        return;
       }
-      await window.nodus.startDictionaryGeneration({
-        entryId: entry.id,
-        mode: "creation",
-        model,
-      });
-      onQueued(entry.id, entry.name);
+      onQueued(
+        results.flatMap((result) =>
+          result.status === "fulfilled" ? [result.value] : [],
+        ),
+      );
     } catch (reason) {
       setError(message(reason));
       setPhase(null);
     }
   };
   const check = async () => {
-    if (!input.name.trim()) return;
+    const batch = namedDrafts();
+    if (!batch.length) return;
+    const names = batch.map((draft) => normalizedCreationName(draft.name));
+    if (new Set(names).size !== names.length) {
+      setError(t("Hay conceptos repetidos en el lote."));
+      return;
+    }
     setPhase("checking");
     setError(null);
     try {
-      const matches = await window.nodus.detectDictionaryDuplicates(
-        input.name,
-        csv(aliases),
+      const matches = await Promise.all(
+        batch.map((draft) =>
+          created.has(draft.key)
+            ? Promise.resolve([])
+            : window.nodus.detectDictionaryDuplicates(
+                draft.name,
+                csv(draft.aliases),
+              ),
+        ),
       );
-      if (matches.length) {
-        setDuplicates(matches);
+      const matching = new Map<number, DictionaryDuplicateMatch[]>();
+      matches.forEach((items, index) => {
+        if (items.length) matching.set(batch[index]!.key, items);
+      });
+      if (matching.size) {
+        setDuplicates(matching);
         setPhase(null);
       } else await createAndQueue();
     } catch (reason) {
@@ -517,40 +625,57 @@ function CreationDialog({
                 {t("No se fusionará nada automáticamente.")}
               </p>
             </div>
-            {duplicates.map((match) => (
-              <div
-                key={match.entry.id}
-                className="flex items-center gap-3 rounded-xl border border-neutral-200 p-3 dark:border-neutral-800"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">
-                    {match.entry.name}
-                  </p>
-                  <p className="text-[10px] uppercase tracking-wider text-neutral-500">
-                    {t(match.match)}
-                    {match.similarity
-                      ? ` · ${Math.round(match.similarity * 100)}%`
-                      : ""}
-                  </p>
-                </div>
-                <button
-                  className="btn btn-ghost"
-                  onClick={() => onOpenExisting(match.entry)}
+            {[...duplicates.entries()].map(([draftKey, matches]) => {
+              const draft = drafts.find((item) => item.key === draftKey);
+              return (
+                <section
+                  key={draftKey}
+                  className="space-y-2 rounded-xl border border-neutral-200 p-3 dark:border-neutral-800"
                 >
-                  {t("Abrir")}
-                </button>
-                <button
-                  className={`btn ${relateTo === match.entry.id ? "btn-primary" : "btn-ghost"}`}
-                  onClick={() =>
-                    setRelateTo(
-                      relateTo === match.entry.id ? null : match.entry.id,
-                    )
-                  }
-                >
-                  {t("Relacionar")}
-                </button>
-              </div>
-            ))}
+                  <h4 className="text-sm font-semibold">
+                    {draft?.name ?? t("Concepto")}
+                  </h4>
+                  {matches.map((match) => (
+                    <div
+                      key={match.entry.id}
+                      className="flex items-center gap-3 rounded-lg bg-neutral-50 p-2 dark:bg-neutral-900/60"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">
+                          {match.entry.name}
+                        </p>
+                        <p className="text-[10px] uppercase tracking-wider text-neutral-500">
+                          {t(match.match)}
+                          {match.similarity
+                            ? ` · ${Math.round(match.similarity * 100)}%`
+                            : ""}
+                        </p>
+                      </div>
+                      <button
+                        className="btn btn-ghost"
+                        onClick={() => onOpenExisting(match.entry)}
+                      >
+                        {t("Abrir")}
+                      </button>
+                      <button
+                        className={`btn ${relateTo.get(draftKey) === match.entry.id ? "btn-primary" : "btn-ghost"}`}
+                        onClick={() =>
+                          setRelateTo((current) => {
+                            const next = new Map(current);
+                            if (next.get(draftKey) === match.entry.id)
+                              next.delete(draftKey);
+                            else next.set(draftKey, match.entry.id);
+                            return next;
+                          })
+                        }
+                      >
+                        {t("Relacionar")}
+                      </button>
+                    </div>
+                  ))}
+                </section>
+              );
+            })}
             {error && <ErrorNotice>{error}</ErrorNotice>}
             <div className="flex justify-end gap-2">
               <button
@@ -566,34 +691,93 @@ function CreationDialog({
                 onClick={() => void createAndQueue()}
               >
                 {phase === "creating" ? (
-                  <ButtonBusy label={t("Preparando definición…")} />
+                  <ButtonBusy
+                    label={tx("Preparando {n} definiciones…", {
+                      n: namedDrafts().length,
+                    })}
+                  />
                 ) : (
-                  t("Generar de todos modos")
+                  namedDrafts().length > 1
+                    ? tx("Generar {n} definiciones de todos modos", {
+                        n: namedDrafts().length,
+                      })
+                    : t("Generar de todos modos")
                 )}
               </button>
             </div>
           </div>
         ) : (
           <div className="space-y-4">
-            <div className="grid gap-4 md:grid-cols-2">
-              <Field label={t("Concepto")}>
-                <input
-                  autoFocus
-                  className="input mt-1 w-full"
-                  value={input.name}
-                  onChange={(event) =>
-                    setInput({ ...input, name: event.target.value })
+            <div className="space-y-2">
+              {drafts.map((draft, index) => {
+                const persisted = created.has(draft.key);
+                return (
+                  <div
+                    key={draft.key}
+                    data-testid="dictionary-concept-row"
+                    className="grid items-end gap-3 rounded-xl border border-neutral-200 p-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] dark:border-neutral-800"
+                  >
+                    <Field label={`${t("Concepto")} ${index + 1}`}>
+                      <input
+                        autoFocus={index === 0}
+                        data-testid={`dictionary-concept-name-${index}`}
+                        className="input mt-1 w-full"
+                        value={draft.name}
+                        disabled={persisted || phase !== null}
+                        onChange={(event) =>
+                          updateDraft(draft.key, { name: event.target.value })
+                        }
+                      />
+                    </Field>
+                    <Field label={t("Aliases o términos alternativos")}>
+                      <input
+                        className="input mt-1 w-full"
+                        placeholder={t("Separados por comas")}
+                        value={draft.aliases}
+                        disabled={persisted || phase !== null}
+                        onChange={(event) =>
+                          updateDraft(draft.key, {
+                            aliases: event.target.value,
+                          })
+                        }
+                      />
+                    </Field>
+                    <button
+                      type="button"
+                      className="btn btn-ghost h-9 w-9 p-0"
+                      aria-label={t("Quitar concepto")}
+                      title={t("Quitar concepto")}
+                      disabled={
+                        drafts.length === 1 || persisted || phase !== null
+                      }
+                      onClick={() => removeDraft(draft.key)}
+                    >
+                      <Icon name="x" />
+                    </button>
+                  </div>
+                );
+              })}
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  data-testid="dictionary-add-concept"
+                  className="btn btn-ghost"
+                  disabled={phase !== null}
+                  onClick={() =>
+                    setDrafts((current) => [
+                      ...current,
+                      emptyCreationDraft(),
+                    ])
                   }
-                />
-              </Field>
-              <Field label={t("Aliases o términos alternativos")}>
-                <input
-                  className="input mt-1 w-full"
-                  placeholder={t("Separados por comas")}
-                  value={aliases}
-                  onChange={(event) => setAliases(event.target.value)}
-                />
-              </Field>
+                >
+                  <Icon name="plus" /> {t("Añadir concepto")}
+                </button>
+                <p className="text-xs text-neutral-500">
+                  {t(
+                    "Cada concepto se guardará como una entrada independiente y se procesará en paralelo.",
+                  )}
+                </p>
+              </div>
             </div>
             <div className="grid gap-4 md:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.6fr)]">
               <label className="rounded-xl border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-900/50">
@@ -711,11 +895,16 @@ function CreationDialog({
             </div>
             {error && <ErrorNotice>{error}</ErrorNotice>}
             <div className="flex items-center justify-end gap-2">
-              {created && (
+              {created.size > 0 && (
                 <span className="mr-auto text-xs text-neutral-500">
-                  {t(
-                    "La entrada ya está guardada; reintentar no creará un duplicado.",
-                  )}
+                  {created.size === 1
+                    ? t(
+                        "La entrada ya está guardada; reintentar no creará un duplicado.",
+                      )
+                    : tx(
+                        "{n} entradas ya están guardadas; reintentar no creará duplicados.",
+                        { n: created.size },
+                      )}
                 </span>
               )}
               <button
@@ -727,15 +916,24 @@ function CreationDialog({
               </button>
               <button
                 className="btn btn-primary !text-white disabled:!text-white"
-                disabled={phase !== null || !input.name.trim()}
-                onClick={() => void (created ? createAndQueue() : check())}
+                disabled={
+                  phase !== null ||
+                  !drafts.some((draft) => draft.name.trim())
+                }
+                onClick={() => void check()}
               >
                 {phase === "checking" ? (
                   <ButtonBusy label={t("Comprobando duplicados…")} />
                 ) : phase === "creating" ? (
-                  <ButtonBusy label={t("Preparando definición…")} />
-                ) : created ? (
+                  <ButtonBusy
+                    label={tx("Preparando {n} definiciones…", {
+                      n: namedDrafts().length,
+                    })}
+                  />
+                ) : created.size > 0 ? (
                   t("Reintentar generación")
+                ) : namedDrafts().length > 1 ? (
+                  tx("Generar {n} definiciones", { n: namedDrafts().length })
                 ) : (
                   t("Generar definición")
                 )}
@@ -1304,17 +1502,20 @@ export function DictionaryView({
             setCreating(false);
             openEntry(entry);
           }}
-          onQueued={(id) => {
+          onQueued={(queuedEntries) => {
             setCreating(false);
             setActiveId(null);
             setGenerationJobs((current) => {
-              if (current.has(id)) return current;
               const next = new Map(current);
-              next.set(id, {
-                entryId: id,
-                phase: "queued",
-                message: t("En cola"),
-              });
+              for (const entry of queuedEntries) {
+                if (!next.has(entry.id)) {
+                  next.set(entry.id, {
+                    entryId: entry.id,
+                    phase: "queued",
+                    message: t("En cola"),
+                  });
+                }
+              }
               return next;
             });
             void reload(false);


### PR DESCRIPTION
## Summary

- let users add multiple Dictionary concepts in one creation dialog, with per-entry aliases and shared generation settings
- validate normalized duplicates within the batch and review existing duplicate candidates per concept
- persist and enqueue each entry independently with partial-failure isolation and retry only for entries that were not already queued
- extract Dictionary background execution into an entry-keyed queue that deduplicates active starts and suppresses stale progress after deletion
- add localized batch-generation copy and expand the Dictionary UI contract tests
- add a runtime concurrency test covering simultaneous provider work, out-of-order completion, isolated failure, duplicate starts, retries, and deletion

## Verification

- `npm run typecheck`
- `npx eslint electron/ai/dictionaryGenerationQueue.ts electron/ipc/academic.ts src/views/DictionaryView.tsx`
- `node scripts/test-dictionary-generation-queue.mjs`
- `node scripts/test-dictionary-ui.mjs`
- `node scripts/test-dictionary.mjs`
- `node scripts/test-i18n-coverage.mjs`
- `npx vite build`

Closes #563