### PR TITLE
Prevent degraded Dictionary fallbacks from replacing synthesized prose

### DIFF
--- a/electron/ai/dictionary.ts
+++ b/electron/ai/dictionary.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type {
   DictionaryAuthorView,
   DictionaryCitationRecord,
+  DictionaryDegradationReason,
   DictionaryDuplicateMatch,
   DictionaryEntryDetail,
   DictionaryEvidenceItem,
@@ -56,18 +57,66 @@ type WorkRow = {
 type GeneratedDictionary = {
   descriptionMarkdown: string;
   authorSummaries: Array<{ authorName: string; summaryMarkdown: string }>;
+  invalidEvidenceRefs?: number;
 };
 
-const isGeneratedDictionary = (
+type GeneratedDictionaryClaims = {
+  paragraphs: Array<{
+    claims: Array<{
+      text: string;
+      evidence: Array<{ kind: "idea" | "passage"; id: string }>;
+    }>;
+  }>;
+};
+
+type GeneratedAuthorSummaries = Pick<GeneratedDictionary, "authorSummaries">;
+
+const isGeneratedDictionaryClaims = (
   value: unknown,
-): value is GeneratedDictionary => {
+): value is GeneratedDictionaryClaims => {
   if (!value || typeof value !== "object") return false;
   const row = value as Record<string, unknown>;
   return (
-    typeof row.descriptionMarkdown === "string" &&
-    row.descriptionMarkdown.trim().length > 0 &&
-    Array.isArray(row.authorSummaries) &&
-    row.authorSummaries.every(
+    Array.isArray(row.paragraphs) &&
+    row.paragraphs.length > 0 &&
+    row.paragraphs.every((paragraph) => {
+      if (!paragraph || typeof paragraph !== "object") return false;
+      const claims = (paragraph as Record<string, unknown>).claims;
+      return (
+        Array.isArray(claims) &&
+        claims.length > 0 &&
+        claims.every((claim) => {
+          if (!claim || typeof claim !== "object") return false;
+          const candidate = claim as Record<string, unknown>;
+          return (
+            typeof candidate.text === "string" &&
+            candidate.text.trim().length > 0 &&
+            Array.isArray(candidate.evidence) &&
+            candidate.evidence.length > 0 &&
+            candidate.evidence.every(
+              (ref) =>
+                !!ref &&
+                typeof ref === "object" &&
+                ["idea", "passage"].includes(
+                  String((ref as Record<string, unknown>).kind),
+                ) &&
+                typeof (ref as Record<string, unknown>).id === "string",
+            )
+          );
+        })
+      );
+    })
+  );
+};
+
+const isGeneratedAuthorSummaries = (
+  value: unknown,
+): value is GeneratedAuthorSummaries => {
+  if (!value || typeof value !== "object") return false;
+  const summaries = (value as Record<string, unknown>).authorSummaries;
+  return (
+    Array.isArray(summaries) &&
+    summaries.every(
       (item) =>
         !!item &&
         typeof item === "object" &&
@@ -584,6 +633,111 @@ function evidencePrompt(evidence: DictionaryEvidenceItem[]): string {
   );
 }
 
+function dictionaryCitationLabel(item: DictionaryEvidenceItem): string {
+  const author = item.authors.find(
+    (candidate) => candidate.attributionBasis !== "editor_only",
+  )?.name ?? item.authors[0]?.name;
+  const year = item.works.find((work) => work.year != null)?.year;
+  if (author) return year ? `${author} (${year})` : author;
+  const work = item.works[0]?.title || item.workTitle || item.label;
+  return year ? `${work} (${year})` : work || "fuente";
+}
+
+function cleanAtomicClaim(value: string): string {
+  return value
+    .replace(/\[[^\]]*\]\(nodus:\/\/[^)]+\)/g, "")
+    .replace(/nodus:\/\/\S+/g, "")
+    .replace(/^\s*(?:#{1,6}|[-*>])\s*/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * The provider chooses and orders atomic claims, but it never writes citation
+ * syntax. Nodus resolves every id against the selected evidence and renders one
+ * independently verifiable sentence per claim. This prevents a malformed link or
+ * a citation attached to the wrong clause from reaching semantic verification.
+ */
+function renderStructuredDictionary(
+  generated: GeneratedDictionaryClaims,
+  evidence: DictionaryEvidenceItem[],
+): { markdown: string; invalidEvidenceRefs: number } {
+  const sources = new Map(
+    evidence.map((item) => [`${item.kind}:${item.id}`, item]),
+  );
+  let invalidEvidenceRefs = 0;
+  const paragraphs = generated.paragraphs.flatMap((paragraph) => {
+    const sentences = paragraph.claims.flatMap((claim) => {
+      const text = cleanAtomicClaim(claim.text);
+      const refs = new Map<string, DictionaryEvidenceItem>();
+      for (const ref of claim.evidence) {
+        const key = `${ref.kind}:${ref.id}`;
+        const source = sources.get(key);
+        if (!source) {
+          invalidEvidenceRefs += 1;
+          continue;
+        }
+        refs.set(key, source);
+      }
+      if (!text || !refs.size) return [];
+      const prose = text.replace(/[.!?]+$/u, "").trim();
+      if (!prose) return [];
+      const citations = [...refs.values()]
+        .map(
+          (item) =>
+            `[${dictionaryCitationLabel(item)}](nodus://${item.kind}/${encodeURIComponent(item.id)})`,
+        )
+        .join(", ");
+      return [`${prose} ${citations}.`];
+    });
+    return sentences.length ? [sentences.join(" ")] : [];
+  });
+  return { markdown: paragraphs.join("\n\n"), invalidEvidenceRefs };
+}
+
+export const __renderStructuredDictionaryForTesting =
+  renderStructuredDictionary;
+
+function citedEvidence(
+  markdown: string,
+  evidence: DictionaryEvidenceItem[],
+): DictionaryEvidenceItem[] {
+  const cited = new Set<string>();
+  for (const match of markdown.matchAll(
+    /nodus:\/\/(idea|passage)\/([^)\s]+)/g,
+  )) {
+    let id = match[2];
+    try {
+      id = decodeURIComponent(id);
+    } catch {
+      /* raw id */
+    }
+    cited.add(`${match[1]}:${id}`);
+  }
+  return evidence.filter((item) => cited.has(`${item.kind}:${item.id}`));
+}
+
+function mainDictionaryAuthors(
+  evidence: DictionaryEvidenceItem[],
+  limit = 6,
+): string[] {
+  const counts = new Map<string, { name: string; count: number }>();
+  for (const item of evidence) {
+    for (const author of item.authors) {
+      if (author.attributionBasis === "editor_only") continue;
+      const key = normalizeDictionaryTerm(author.name);
+      if (!key) continue;
+      const current = counts.get(key) ?? { name: author.name, count: 0 };
+      current.count += 1;
+      counts.set(key, current);
+    }
+  }
+  return [...counts.values()]
+    .sort((left, right) => right.count - left.count || left.name.localeCompare(right.name))
+    .slice(0, limit)
+    .map((item) => item.name);
+}
+
 function uncitedSubstantiveSentences(markdown: string): string[] {
   const body = markdown
     .replace(/^#{1,6} .*$/gm, "")
@@ -664,23 +818,31 @@ function extractiveDictionaryFallback(
   return `## Evidencia verificable\n\n${excerpts.join("\n\n")}`;
 }
 
-function recoverableDictionaryOutputError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
+function dictionaryOutputErrorReason(
+  error: unknown,
+): DictionaryDegradationReason | null {
+  if (!error || typeof error !== "object") return null;
   const candidate = error as { code?: unknown; message?: unknown };
-  if (candidate.code === "output_truncated") return true;
+  if (candidate.code === "output_truncated") return "output_truncated";
   const message =
     typeof candidate.message === "string" ? candidate.message.toLowerCase() : "";
-  return [
+  if (
+    ["esquema", "schema", "structured output", "formato de respuesta"].some(
+      (fragment) => message.includes(fragment),
+    )
+  )
+    return "schema_error";
+  if (
+    [
     "json",
     "parse",
     "parsing",
-    "esquema",
-    "schema",
-    "structured output",
-    "formato de respuesta",
     "respuesta truncada",
     "respuesta se cortó",
-  ].some((fragment) => message.includes(fragment));
+    ].some((fragment) => message.includes(fragment))
+  )
+    return "malformed_output";
+  return null;
 }
 
 async function groundGeneratedDescription(
@@ -692,11 +854,20 @@ async function groundGeneratedDescription(
   markdown: string;
   problems: string[];
   strippedSentences: string[];
+  invalidCitationRefs: number;
 }> {
   const maps = buildSnapshotMaps(snapshot);
   for (const id of [...maps.validIds])
     if (id.startsWith("work:")) maps.validIds.delete(id);
+  const rawCitationCount = [
+    ...generated.descriptionMarkdown.matchAll(
+      /nodus:\/\/(?:idea|passage)\//g,
+    ),
+  ].length;
   let cleaned = applyCitationPolicy(generated.descriptionMarkdown, maps).markdown;
+  const validCitationCount = [
+    ...cleaned.matchAll(/nodus:\/\/(?:idea|passage)\//g),
+  ].length;
   const claims = extractCitationClaims(cleaned, maps);
   let strippedSentences: string[] = [];
   if (claims.length) {
@@ -710,7 +881,12 @@ async function groundGeneratedDescription(
   }
 
   const problems = groundingProblems(cleaned, maps);
-  return { markdown: cleaned, problems, strippedSentences };
+  return {
+    markdown: cleaned,
+    problems,
+    strippedSentences,
+    invalidCitationRefs: Math.max(0, rawCitationCount - validCitationCount),
+  };
 }
 
 function decorateIdeaTags(
@@ -745,56 +921,85 @@ async function synthesize(
   correction = "",
 ): Promise<GeneratedDictionary> {
   const entry = getDictionaryEntry(entryId)!;
-  const system = `Eres el redactor del Dictionary académico de Nodus. Redacta exclusivamente a partir de EVIDENCE. No uses conocimiento externo ni inventes autores, obras, páginas, citas, etiquetas, ideas o pasajes. El FOCO es una instrucción editorial: nunca lo copies ni lo presentes como definición. Abre con una definición sustantiva del concepto y desarróllala de acuerdo con DETALLE. Cada frase sustantiva debe terminar con una o más citas Markdown exactamente en el formato nodus://idea/ID o nodus://passage/ID ofrecido. Cada fuente citada debe respaldar la frase completa: si dos fuentes sostienen cláusulas distintas, escribe frases separadas, cada una con su propia cita. Compara autores y obras mediante atribuciones separadas; identifica acuerdos, desacuerdos, contradicciones y cambios temporales solo cuando EVIDENCE lo sostenga. Di explícitamente qué no permite establecer la evidencia. Devuelve JSON {"descriptionMarkdown":"...","authorSummaries":[{"authorName":"...","summaryMarkdown":"..."}]}. Los resúmenes de autor también deben estar citados.`;
+  const system = `Eres el redactor del Dictionary académico de Nodus. Trabaja exclusivamente a partir de EVIDENCE. No uses conocimiento externo ni inventes autores, obras, páginas, etiquetas, ideas, pasajes o identificadores. El FOCO es una instrucción editorial: nunca lo copies ni lo presentes como definición. Abre con una definición sustantiva del concepto y desarróllala de acuerdo con DETALLE. Devuelve prosa continua organizada en párrafos, pero representa cada frase como una afirmación atómica independiente. Cada afirmación debe expresar una sola relación verificable y llevar los identificadores exactos de la evidencia que la sostiene. Si dos fuentes sostienen cláusulas diferentes, crea afirmaciones separadas. Usa varias evidencias en una misma afirmación solo si CADA una sostiene por sí sola toda la afirmación. Para comparar autores, formula por separado la posición atribuida a cada autor y solo después una afirmación comparativa respaldada plenamente. Identifica acuerdos, desacuerdos, contradicciones y cambios temporales únicamente cuando EVIDENCE los documente. Explicita los límites de la evidencia cuando sean relevantes. No escribas Markdown ni citas dentro de text. Devuelve SOLO JSON válido con esta forma exacta: {"paragraphs":[{"claims":[{"text":"Una afirmación completa","evidence":[{"kind":"idea|passage","id":"ID exacto de EVIDENCE"}]}]}]}.`;
   const user = `CONCEPTO: ${entry.name}\nALIASES: ${entry.aliases.join(", ")}\nFOCO: ${entry.focusPrompt || "(sin foco adicional)"}\nDETALLE: ${entry.detailLevel}\nIDIOMA DE SALIDA: ${entry.outputLanguage}\n${prior ? `VERSIÓN ACTUAL A ACTUALIZAR SIN COPIAR AFIRMACIONES NO RESPALDADAS:\n${prior}\n` : ""}${correction ? `CORRECCIÓN OBLIGATORIA DE LA SALIDA ANTERIOR:\n${correction}\n` : ""}EVIDENCE:\n${evidencePrompt(evidence)}`;
-  let generated = await completeJson<GeneratedDictionary>(
+  const baseMaxTokens =
+    entry.detailLevel === "detailed"
+      ? 4400
+      : entry.detailLevel === "concise"
+        ? 1600
+        : 2800;
+  const structured = await completeJson<GeneratedDictionaryClaims>(
     {
       system,
       user,
-      temperature: 0.1,
-      maxTokens:
-        entry.detailLevel === "detailed"
-          ? 6500
-          : entry.detailLevel === "concise"
-            ? 1800
-            : 3800,
+      temperature: correction ? 0 : 0.1,
+      // The retry gets extra room, while local providers still clamp this to the
+      // space left in their real context window.
+      maxTokens: baseMaxTokens + (correction ? 800 : 0),
     },
-    isGeneratedDictionary,
+    isGeneratedDictionaryClaims,
     model,
   );
-  if (uncitedSubstantiveSentences(generated.descriptionMarkdown).length) {
-    generated = await completeJson<GeneratedDictionary>(
-      {
-        system: `${system}\nLa versión anterior dejó frases sin cita. Reescríbela: divide o elimina esas frases; ninguna afirmación sustantiva puede quedar sin una cita de EVIDENCE.`,
-        user: `${user}\nBORRADOR A REPARAR:\n${JSON.stringify(generated)}`,
-        temperature: 0,
-        maxTokens: entry.detailLevel === "detailed" ? 6500 : 3800,
-      },
-      isGeneratedDictionary,
-      model,
-    );
-  }
-  return generated;
+  const rendered = renderStructuredDictionary(structured, evidence);
+  return {
+    descriptionMarkdown: rendered.markdown,
+    authorSummaries: [],
+    invalidEvidenceRefs: rendered.invalidEvidenceRefs,
+  };
+}
+
+async function synthesizeAuthorSummaries(
+  entryId: string,
+  evidence: DictionaryEvidenceItem[],
+  descriptionMarkdown: string,
+  model: ModelRef | null,
+): Promise<GeneratedAuthorSummaries> {
+  const selectedEvidence = citedEvidence(descriptionMarkdown, evidence);
+  const authors = mainDictionaryAuthors(selectedEvidence);
+  if (!authors.length) return { authorSummaries: [] };
+  const entry = getDictionaryEntry(entryId)!;
+  const system = `Redacta fichas muy breves para los autores principales de una entrada del Dictionary académico de Nodus. Usa exclusivamente EVIDENCE y solo los autores enumerados en AUTHORS. Resume únicamente la aportación documentada de cada autor al concepto; no rellenes lagunas. Cada frase sustantiva debe terminar con una o más citas Markdown nodus:// copiadas exactamente de EVIDENCE. Devuelve SOLO JSON válido {"authorSummaries":[{"authorName":"nombre exacto de AUTHORS","summaryMarkdown":"una o dos frases citadas"}]}.`;
+  const user = `CONCEPTO: ${entry.name}\nIDIOMA DE SALIDA: ${entry.outputLanguage}\nAUTHORS: ${JSON.stringify(authors)}\nDESCRIPCIÓN VERIFICADA:\n${descriptionMarkdown}\nEVIDENCE:\n${evidencePrompt(selectedEvidence)}`;
+  return completeJson<GeneratedAuthorSummaries>(
+    { system, user, temperature: 0, maxTokens: 1800 },
+    isGeneratedAuthorSummaries,
+    model,
+  );
 }
 
 export async function generateDictionaryEntry(
   request: DictionaryGenerationRequest,
 ): Promise<DictionaryVersion> {
-  return generateDictionaryEntryUsing(request, synthesize, aiVerifyCitations);
+  return generateDictionaryEntryUsing(
+    request,
+    synthesize,
+    aiVerifyCitations,
+    synthesizeAuthorSummaries,
+  );
 }
 
 export async function __generateDictionaryEntryForTesting(
   request: DictionaryGenerationRequest,
   generator: typeof synthesize,
   verifyCitations: typeof aiVerifyCitations = aiVerifyCitations,
+  authorGenerator: typeof synthesizeAuthorSummaries = async () => ({
+    authorSummaries: [],
+  }),
 ): Promise<DictionaryVersion> {
-  return generateDictionaryEntryUsing(request, generator, verifyCitations);
+  return generateDictionaryEntryUsing(
+    request,
+    generator,
+    verifyCitations,
+    authorGenerator,
+  );
 }
 
 async function generateDictionaryEntryUsing(
   request: DictionaryGenerationRequest,
   generator: typeof synthesize,
   verifyCitations: typeof aiVerifyCitations,
+  authorGenerator: typeof synthesizeAuthorSummaries,
 ): Promise<DictionaryVersion> {
   const entry = getDictionaryEntry(request.entryId);
   if (!entry) throw new Error("La entrada de Dictionary ya no existe.");
@@ -809,6 +1014,12 @@ async function generateDictionaryEntryUsing(
   const insufficient = evidence.length < 2;
   let markdown: string;
   let authorSummaries: DictionaryAuthorView[] = [];
+  let outcome: DictionaryVersion["outcome"] = insufficient
+    ? "insufficient"
+    : "synthesis";
+  let degradationReason: DictionaryDegradationReason | null = null;
+  let generationAttempts = 1;
+  let generationProblems: string[] = [];
   if (insufficient) {
     const citation = evidence[0]
       ? ` [evidencia disponible](nodus://${evidence[0].kind}/${encodeURIComponent(evidence[0].id)})`
@@ -822,8 +1033,11 @@ async function generateDictionaryEntryUsing(
     let generated!: GeneratedDictionary;
     let grounded!: Awaited<ReturnType<typeof groundGeneratedDescription>>;
     let correction = "";
-    let verificationRemovedClaims = false;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
+    let completed = false;
+    let lastReason: DictionaryDegradationReason = "grounding_failure";
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      generationAttempts = attempt;
       try {
         generated = await generator(
           request.entryId,
@@ -833,21 +1047,18 @@ async function generateDictionaryEntryUsing(
           correction,
         );
       } catch (error) {
-        if (!recoverableDictionaryOutputError(error)) throw error;
-        // completeJson has already exhausted its local JSON repair and structured
-        // retries by this point. Do not multiply those calls at queue level or show
-        // a recurring terminal error: persist a fully traceable extractive result.
-        const extractiveMarkdown = extractiveDictionaryFallback(evidence);
-        generated = {
-          descriptionMarkdown: extractiveMarkdown,
-          authorSummaries: [],
-        };
-        grounded = {
-          markdown: extractiveMarkdown,
-          problems: groundingProblems(extractiveMarkdown, maps),
-          strippedSentences: [],
-        };
-        break;
+        const recoverable = dictionaryOutputErrorReason(error);
+        if (!recoverable) throw error;
+        lastReason = recoverable;
+        generationProblems = [
+          error instanceof Error ? error.message : String(error),
+        ];
+        correction = [
+          `El intento ${attempt} no produjo JSON estructurado utilizable: ${generationProblems[0]}.`,
+          "Devuelve de nuevo el objeto completo con paragraphs, claims, text y evidence.",
+          "Reduce la longitud de cada afirmación y conserva únicamente IDs exactos de EVIDENCE.",
+        ].join("\n");
+        continue;
       }
       grounded = await groundGeneratedDescription(
         generated,
@@ -855,53 +1066,93 @@ async function generateDictionaryEntryUsing(
         verifyCitations,
         request.model ?? null,
       );
-      verificationRemovedClaims ||= grounded.strippedSentences.length > 0;
-      if (!grounded.problems.length) break;
+      const originalGroundingProblems = [...grounded.problems];
+      if (originalGroundingProblems.length) {
+        // A provider used through the testing seam (or a legacy provider adapter)
+        // may still append uncited prose. Keep already verified sentences and retry
+        // the missing material before accepting the locally salvaged definition.
+        const salvagedMarkdown = stripUncitedSubstantiveSentences(
+          grounded.markdown,
+        );
+        grounded = {
+          ...grounded,
+          markdown: salvagedMarkdown,
+          problems: groundingProblems(salvagedMarkdown, maps),
+        };
+      }
+      const needsSemanticRepair = grounded.strippedSentences.length > 0;
+      const needsLocalRepair = originalGroundingProblems.length > 0;
+      if (!grounded.problems.length && !needsSemanticRepair && !needsLocalRepair) {
+        completed = true;
+        break;
+      }
+      lastReason = generated.invalidEvidenceRefs || grounded.invalidCitationRefs
+        ? "invalid_evidence_refs"
+        : needsSemanticRepair
+          ? "semantic_rejection"
+          : /ninguna afirmación con una cita válida/.test(
+                grounded.problems.join(" "),
+              ) &&
+              !/nodus:\/\/(?:idea|passage)\//.test(
+                generated.descriptionMarkdown,
+              )
+            ? "missing_citations"
+            : "grounding_failure";
+      generationProblems = [
+        ...(grounded.problems.length
+          ? grounded.problems
+          : originalGroundingProblems),
+        ...(generated.invalidEvidenceRefs || grounded.invalidCitationRefs
+          ? [`${(generated.invalidEvidenceRefs ?? 0) + grounded.invalidCitationRefs} referencias de evidencia no eran válidas`]
+          : []),
+        ...(needsSemanticRepair
+          ? [`${grounded.strippedSentences.length} afirmaciones no superaron la verificación semántica`]
+          : []),
+      ];
       correction = [
-        `La salida fue rechazada porque ${grounded.problems.join("; ")}.`,
+        `El intento ${attempt} fue rechazado porque ${generationProblems.join("; ")}.`,
         "Reescribe desde cero una definición sustantiva. No copies el FOCO.",
-        "Haz afirmaciones atómicas y coloca en cada frase solo citas que respalden la frase completa.",
+        "Haz afirmaciones atómicas y asigna a cada una solo evidencia que respalde la afirmación completa.",
         grounded.strippedSentences.length
           ? `Estas frases no superaron la verificación y no deben repetirse sin estrecharlas: ${grounded.strippedSentences.slice(0, 4).join(" | ")}`
           : "",
       ]
         .filter(Boolean)
         .join("\n");
+      // On the final attempt, a substantive remainder whose rejected claims were
+      // safely removed is still a genuine synthesis. Empty/invalid output degrades.
+      if (attempt === maxAttempts && !grounded.problems.length) completed = true;
     }
-    if (grounded.problems.length) {
-      // A provider may keep appending a closing sentence without a citation even
-      // after the bounded rewrite attempts. Preserve the verified, cited claims
-      // instead of rejecting the entire generation for that removable tail.
-      const salvagedMarkdown = stripUncitedSubstantiveSentences(
-        grounded.markdown,
+    if (!completed) {
+      outcome = "degraded";
+      degradationReason = lastReason;
+      markdown = decorateIdeaTags(
+        extractiveDictionaryFallback(evidence),
+        evidence,
       );
-      grounded = {
-        ...grounded,
-        markdown: salvagedMarkdown,
-        problems: groundingProblems(salvagedMarkdown, maps),
-      };
+      if (!generationProblems.length)
+        generationProblems = [
+          "No sobrevivió una síntesis sustantiva respaldada por citas válidas.",
+        ];
+      generated = { descriptionMarkdown: markdown, authorSummaries: [] };
+    } else {
+      markdown = decorateIdeaTags(grounded.markdown, evidence);
+      try {
+        generated.authorSummaries = (
+          await authorGenerator(
+            request.entryId,
+            evidence,
+            markdown,
+            request.model ?? null,
+          )
+        ).authorSummaries;
+      } catch {
+        // Author cards are a secondary, separately bounded request. The verified
+        // definition remains valid and the deterministic author counts still load.
+        generated.authorSummaries = [];
+      }
+      generationProblems = [];
     }
-    const providerReturnedNoNodusCitation =
-      !/nodus:\/\/(?:idea|passage)\//.test(generated.descriptionMarkdown);
-    if (
-      grounded.problems.length &&
-      (verificationRemovedClaims || providerReturnedNoNodusCitation)
-    ) {
-      // If semantic verification rejects every generated claim, use the selected
-      // evidence itself as a cited, extractive result. This is deliberately less
-      // polished, but it remains useful and cannot introduce unsupported prose.
-      const extractiveMarkdown = extractiveDictionaryFallback(evidence);
-      grounded = {
-        ...grounded,
-        markdown: extractiveMarkdown,
-        problems: groundingProblems(extractiveMarkdown, maps),
-      };
-    }
-    if (grounded.problems.length)
-      throw new Error(
-        `El proveedor no produjo una síntesis sustantiva respaldada por citas válidas (${grounded.problems.join("; ")}). La versión anterior se conserva.`,
-      );
-    markdown = decorateIdeaTags(grounded.markdown, evidence);
     const summaries = new Map(
       generated.authorSummaries.map((item) => [
         normalizeDictionaryTerm(item.authorName),
@@ -985,7 +1236,16 @@ async function generateDictionaryEntryUsing(
     // Regenerate is an explicit replacement action. The previous version remains
     // immutable in history and can be restored, so making the new definition current
     // immediately matches the button's promise without sacrificing reversibility.
-    state: request.mode === "update" ? "proposed" : "applied",
+    state:
+      outcome === "degraded"
+        ? "degraded"
+        : request.mode === "update"
+          ? "proposed"
+          : "applied",
+    outcome,
+    degradationReason,
+    generationAttempts,
+    generationProblems,
     insufficientEvidence: insufficient,
   });
 }

--- a/electron/ai/dictionaryGenerationQueue.ts
+++ b/electron/ai/dictionaryGenerationQueue.ts
@@ -1,6 +1,7 @@
 import type {
   DictionaryGenerationRequest,
   DictionaryProgress,
+  DictionaryVersion,
 } from "@shared/dictionary";
 
 export type DictionaryGenerationProgressReporter = (
@@ -10,10 +11,10 @@ export type DictionaryGenerationProgressReporter = (
 export type DictionaryGenerationExecutor = (
   request: DictionaryGenerationRequest,
   report: DictionaryGenerationProgressReporter,
-) => Promise<void>;
+) => Promise<DictionaryVersion | void>;
 
 const isRunning = (progress: DictionaryProgress): boolean =>
-  !["done", "failed"].includes(progress.phase);
+  !["done", "degraded", "failed"].includes(progress.phase);
 
 const MAX_TRANSIENT_RETRIES = 2;
 
@@ -77,7 +78,19 @@ export class DictionaryGenerationQueue {
       this.#set({ ...progress, mode: request.mode }, token);
     for (let attempt = 0; ; attempt += 1) {
       try {
-        await this.execute(request, report);
+        const result = await this.execute(request, report);
+        if (result?.outcome === "degraded") {
+          report({
+            entryId: request.entryId,
+            mode: request.mode,
+            phase: "degraded",
+            message: "La síntesis necesita revisión",
+            error: result.generationProblems.join(" · "),
+            degradationReason: result.degradationReason ?? undefined,
+            attempts: result.generationAttempts,
+          });
+          return;
+        }
         report({
           entryId: request.entryId,
           mode: request.mode,

--- a/electron/db/dictionaryRepo.ts
+++ b/electron/db/dictionaryRepo.ts
@@ -16,6 +16,8 @@ import type {
   DictionaryEvidenceRequest,
   DictionaryFacets,
   DictionaryGenerationRequest,
+  DictionaryGenerationOutcome,
+  DictionaryDegradationReason,
   DictionaryListRequest,
   DictionaryRelation,
   DictionaryRelationType,
@@ -49,6 +51,8 @@ type VersionRow = {
   citations_json: string; author_summaries_json: string; focus_prompt: string; scope_json: string;
   output_language: PromptLanguage; detail_level: DictionaryEntry['detailLevel']; model_json: string | null;
   generated_at: string; trigger: DictionaryVersionTrigger; state: DictionaryVersionState;
+  outcome: DictionaryGenerationOutcome; degradation_reason: DictionaryDegradationReason | null;
+  generation_attempts: number; generation_problems_json: string;
   insufficient_evidence: number; created_at: string; updated_at: string;
 };
 
@@ -80,6 +84,10 @@ export interface SaveDictionaryVersionInput {
   model: ModelRef | null;
   trigger: DictionaryVersionTrigger;
   state: DictionaryVersionState;
+  outcome: DictionaryGenerationOutcome;
+  degradationReason: DictionaryDegradationReason | null;
+  generationAttempts: number;
+  generationProblems: string[];
   insufficientEvidence: boolean;
 }
 
@@ -311,6 +319,8 @@ export function updateDictionaryEntry(id: string, patch: DictionaryEntryPatch, e
     const citations = citationRecordsForMarkdown(id, content);
     const versionId = insertVersion({ entryId: id, contentMarkdown: content, evidence, citations,
       authorSummaries: currentVersionAuthorSummaries(current.currentVersionId), model: null, trigger: 'manual_edit', state: 'applied',
+      outcome: current.insufficientEvidence ? 'insufficient' : 'synthesis', degradationReason: null,
+      generationAttempts: 1, generationProblems: [],
       insufficientEvidence: current.insufficientEvidence }, stamp);
     db.prepare('UPDATE dictionary_entries SET current_version_id=?, proposed_version_id=NULL WHERE id=?').run(versionId, id);
     if (patch.focusPrompt !== undefined || patch.scope !== undefined) markDictionaryRetrievalStale(id, db);
@@ -463,8 +473,12 @@ export function saveDictionaryVersion(input: SaveDictionaryVersionInput): Dictio
       db.prepare("UPDATE dictionary_versions SET state='applied', updated_at=? WHERE entry_id=? AND id<>? AND state='proposed'").run(stamp, input.entryId, id);
       db.prepare("UPDATE dictionary_evidence SET is_new=0, updated_at=? WHERE entry_id=? AND decision='included'").run(stamp, input.entryId);
       refreshNewEvidenceCount(input.entryId, db);
-    } else {
+    } else if (input.state === 'proposed') {
       db.prepare('UPDATE dictionary_entries SET proposed_version_id=?, updated_at=? WHERE id=?').run(id, stamp, input.entryId);
+    } else {
+      // Degraded attempts remain auditable in Versions, but never replace the
+      // current definition or become an accept-able proposal.
+      db.prepare('UPDATE dictionary_entries SET updated_at=? WHERE id=?').run(stamp, input.entryId);
     }
     return id;
   })();
@@ -473,13 +487,20 @@ export function saveDictionaryVersion(input: SaveDictionaryVersionInput): Dictio
 
 function insertVersion(input: SaveDictionaryVersionInput, stamp: string): string {
   const entry = getDictionaryEntry(input.entryId); if (!entry) throw new Error('La entrada de Dictionary ya no existe.');
+  const outcome = input.outcome ?? (input.insufficientEvidence ? 'insufficient' : 'synthesis');
+  const degradationReason = input.degradationReason ?? null;
+  const generationAttempts = Math.max(1, input.generationAttempts ?? 1);
+  const generationProblems = input.generationProblems ?? [];
   const id = uuid(); const snapshots = includedEvidence(input.entryId).filter((item) => input.evidence.some((ref) => ref.kind === item.kind && ref.id === item.id));
   getDb().prepare(`INSERT INTO dictionary_versions (
     id,entry_id,content_markdown,evidence_json,evidence_snapshot_json,citations_json,author_summaries_json,
-    focus_prompt,scope_json,output_language,detail_level,model_json,generated_at,trigger,state,insufficient_evidence,created_at,updated_at
-  ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`).run(id, input.entryId, input.contentMarkdown, JSON.stringify(input.evidence), JSON.stringify(snapshots),
+    focus_prompt,scope_json,output_language,detail_level,model_json,generated_at,trigger,state,outcome,degradation_reason,
+    generation_attempts,generation_problems_json,insufficient_evidence,created_at,updated_at
+  ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`).run(id, input.entryId, input.contentMarkdown, JSON.stringify(input.evidence), JSON.stringify(snapshots),
     JSON.stringify(input.citations), JSON.stringify(input.authorSummaries), entry.focusPrompt, JSON.stringify(entry.scope), entry.outputLanguage,
-    entry.detailLevel, input.model ? JSON.stringify(input.model) : null, stamp, input.trigger, input.state, input.insufficientEvidence ? 1 : 0, stamp, stamp);
+    entry.detailLevel, input.model ? JSON.stringify(input.model) : null, stamp, input.trigger, input.state, outcome,
+    degradationReason, generationAttempts, JSON.stringify(generationProblems),
+    input.insufficientEvidence ? 1 : 0, stamp, stamp);
   return id;
 }
 
@@ -488,6 +509,8 @@ function toVersion(row: VersionRow): DictionaryVersion {
     citations: parseJson(row.citations_json, []), authorSummaries: parseJson(row.author_summaries_json, []), focusPrompt: row.focus_prompt,
     scope: parseJson(row.scope_json, { kind: 'vault' }), outputLanguage: row.output_language, detailLevel: row.detail_level,
     model: parseJson<ModelRef | null>(row.model_json, null), generatedAt: row.generated_at, trigger: row.trigger, state: row.state,
+    outcome: row.outcome, degradationReason: row.degradation_reason, generationAttempts: row.generation_attempts,
+    generationProblems: parseJson(row.generation_problems_json, []),
     insufficientEvidence: !!row.insufficient_evidence };
 }
 
@@ -518,13 +541,16 @@ export function acceptDictionaryVersion(entryId: string, versionId: string, expe
 export function restoreDictionaryVersion(entryId: string, versionId: string, expectedCurrentVersionId: string | null): DictionaryEntryDetail {
   const entry = getDictionaryEntry(entryId); const source = getDictionaryVersion(versionId);
   if (!entry || !source || source.entryId !== entryId) throw new Error('No se encontró esa versión.');
+  if (source.outcome === 'degraded') throw new Error('Una generación degradada no puede restaurarse como definición.');
   if (entry.currentVersionId !== expectedCurrentVersionId) throw new Error('La entrada cambió antes de restaurarla.');
   for (const citation of source.citations) if (evidenceReferenceUnavailable(entryId, citation.kind, citation.id)) throw new Error('La versión contiene fuentes que ya no existen y no puede restaurarse de forma verificable.');
   getDb().transaction(() => {
     getDb().prepare('UPDATE dictionary_entries SET focus_prompt=?, scope_kind=?, scope_json=?, output_language=?, detail_level=? WHERE id=?')
       .run(source.focusPrompt, source.scope.kind, JSON.stringify(source.scope), source.outputLanguage, source.detailLevel, entryId);
     const id = insertVersion({ entryId, contentMarkdown: source.contentMarkdown, evidence: source.evidence, citations: source.citations,
-      authorSummaries: source.authorSummaries, model: source.model, trigger: 'restore', state: 'applied', insufficientEvidence: source.insufficientEvidence }, now());
+      authorSummaries: source.authorSummaries, model: source.model, trigger: 'restore', state: 'applied',
+      outcome: source.insufficientEvidence ? 'insufficient' : 'synthesis', degradationReason: null,
+      generationAttempts: 1, generationProblems: [], insufficientEvidence: source.insufficientEvidence }, now());
     getDb().prepare('UPDATE dictionary_entries SET current_version_id=?, proposed_version_id=NULL, content_markdown=?, insufficient_evidence=?, updated_at=? WHERE id=?')
       .run(id, source.contentMarkdown, source.insufficientEvidence ? 1 : 0, now(), entryId);
   })();
@@ -564,6 +590,10 @@ export function getDictionaryEntryDetail(id: string): DictionaryEntryDetail | nu
   const evidence = getDb().prepare('SELECT * FROM dictionary_evidence WHERE entry_id=?').all(id) as EvidenceRow[];
   const currentVersion = entry.currentVersionId ? getDictionaryVersion(entry.currentVersionId) : null;
   const proposedVersion = entry.proposedVersionId ? getDictionaryVersion(entry.proposedVersionId) : null;
+  const latestVersion = (getDb().prepare(
+    'SELECT * FROM dictionary_versions WHERE entry_id=? ORDER BY generated_at DESC, rowid DESC LIMIT 1',
+  ).get(id) as VersionRow | undefined);
+  const latestDegradedVersion = latestVersion?.outcome === 'degraded' ? toVersion(latestVersion) : null;
   const used = new Set((currentVersion?.evidence ?? []).map((ref) => `${ref.kind}:${ref.id}`));
   const cited = new Set((currentVersion?.citations ?? []).map((ref) => `${ref.kind}:${ref.id}`));
   const unavailable = new Set(evidence.filter((item) => evidenceUnavailable(item)).map((item) => `${item.kind}:${item.ref_id}`));
@@ -576,7 +606,7 @@ export function getDictionaryEntryDetail(id: string): DictionaryEntryDetail | nu
     unavailable: unavailable.size };
   const authors = buildAuthors(evidence.filter((item) => used.has(`${item.kind}:${item.ref_id}`)), currentVersion?.authorSummaries ?? []);
   const works = buildWorks(evidence.filter((item) => used.has(`${item.kind}:${item.ref_id}`)));
-  return { entry, coverage, authors, works, currentVersion, proposedVersion };
+  return { entry, coverage, authors, works, currentVersion, proposedVersion, latestDegradedVersion };
 }
 
 function buildAuthors(rows: EvidenceRow[], summaries: DictionaryAuthorView[]): DictionaryAuthorView[] {

--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -15,7 +15,7 @@ export interface Migration {
 
 // Versioned, append-only migrations. Never edit an existing migration's SQL once
 // shipped — add a new one. The current schema version is the highest applied.
-export const SCHEMA_VERSION = 165;
+export const SCHEMA_VERSION = 166;
 
 export const migrations: Migration[] = [
   {
@@ -8930,6 +8930,119 @@ export const migrations: Migration[] = [
         running_jobs=(SELECT COUNT(*) FROM document_index_jobs j WHERE j.campaign_id=document_index_campaigns.campaign_id AND j.status='running'),
         queued_jobs=(SELECT COUNT(*) FROM document_index_jobs j WHERE j.campaign_id=document_index_campaigns.campaign_id AND j.status='queued'),
         paused_jobs=(SELECT COUNT(*) FROM document_index_jobs j WHERE j.campaign_id=document_index_campaigns.campaign_id AND j.status='paused');
+    `,
+  },
+  {
+    version: 166,
+    up: /* sql */ `
+      -- A traceable extractive fallback is useful diagnostic material, but it is
+      -- not a Dictionary synthesis and must never silently become the current
+      -- definition. Rebuild the versions table so degradation is a first-class
+      -- state with a persisted cause and retry count.
+      ALTER TABLE dictionary_versions RENAME TO dictionary_versions_v165;
+      DROP INDEX dictionary_versions_entry_idx;
+      DROP INDEX dictionary_versions_proposed_idx;
+
+      CREATE TABLE dictionary_versions (
+        id                       TEXT PRIMARY KEY,
+        entry_id                 TEXT NOT NULL,
+        content_markdown         TEXT NOT NULL,
+        evidence_json            TEXT NOT NULL DEFAULT '[]',
+        evidence_snapshot_json   TEXT NOT NULL DEFAULT '[]',
+        citations_json           TEXT NOT NULL DEFAULT '[]',
+        author_summaries_json    TEXT NOT NULL DEFAULT '[]',
+        focus_prompt             TEXT NOT NULL,
+        scope_json               TEXT NOT NULL,
+        output_language          TEXT NOT NULL,
+        detail_level             TEXT NOT NULL,
+        model_json               TEXT,
+        generated_at             TEXT NOT NULL,
+        trigger                  TEXT NOT NULL CHECK (trigger IN ('creation','update','regeneration','manual_edit','restore')),
+        state                    TEXT NOT NULL CHECK (state IN ('applied','proposed','degraded')),
+        outcome                  TEXT NOT NULL DEFAULT 'synthesis' CHECK (outcome IN ('synthesis','insufficient','degraded')),
+        degradation_reason       TEXT CHECK (degradation_reason IN ('output_truncated','malformed_output','schema_error','invalid_evidence_refs','missing_citations','semantic_rejection','grounding_failure','legacy_extractive_fallback')),
+        generation_attempts      INTEGER NOT NULL DEFAULT 1 CHECK (generation_attempts >= 1),
+        generation_problems_json TEXT NOT NULL DEFAULT '[]',
+        insufficient_evidence    INTEGER NOT NULL DEFAULT 0,
+        created_at               TEXT NOT NULL,
+        updated_at               TEXT NOT NULL
+      );
+
+      INSERT INTO dictionary_versions (
+        id,entry_id,content_markdown,evidence_json,evidence_snapshot_json,citations_json,author_summaries_json,
+        focus_prompt,scope_json,output_language,detail_level,model_json,generated_at,trigger,state,outcome,
+        degradation_reason,generation_attempts,generation_problems_json,insufficient_evidence,created_at,updated_at
+      )
+      SELECT
+        id,entry_id,content_markdown,evidence_json,evidence_snapshot_json,citations_json,author_summaries_json,
+        focus_prompt,scope_json,output_language,detail_level,model_json,generated_at,trigger,
+        CASE
+          WHEN content_markdown LIKE '## Evidencia verificable%'
+            AND trigger IN ('creation','update','regeneration') THEN 'degraded'
+          ELSE state
+        END,
+        CASE
+          WHEN content_markdown LIKE '## Evidencia verificable%'
+            AND trigger IN ('creation','update','regeneration') THEN 'degraded'
+          WHEN insufficient_evidence=1 THEN 'insufficient'
+          ELSE 'synthesis'
+        END,
+        CASE
+          WHEN content_markdown LIKE '## Evidencia verificable%'
+            AND trigger IN ('creation','update','regeneration') THEN 'legacy_extractive_fallback'
+          ELSE NULL
+        END,
+        1,
+        CASE
+          WHEN content_markdown LIKE '## Evidencia verificable%'
+            AND trigger IN ('creation','update','regeneration')
+            THEN '["La versión fue creada por el fallback extractivo legado."]'
+          ELSE '[]'
+        END,
+        insufficient_evidence,created_at,updated_at
+      FROM dictionary_versions_v165;
+
+      CREATE INDEX dictionary_versions_entry_idx ON dictionary_versions(entry_id, generated_at DESC);
+      CREATE INDEX dictionary_versions_proposed_idx ON dictionary_versions(entry_id, state, generated_at DESC);
+
+      -- If a degraded fallback had replaced a good definition, restore the latest
+      -- earlier applied synthesis. A first-generation fallback returns the entry to
+      -- draft and leaves its extractive evidence only in Versions/Evidence.
+      UPDATE dictionary_entries
+         SET current_version_id=(
+               SELECT v.id FROM dictionary_versions v
+                WHERE v.entry_id=dictionary_entries.id
+                  AND v.state='applied' AND v.outcome<>'degraded'
+                ORDER BY v.generated_at DESC, v.rowid DESC LIMIT 1
+             ),
+             content_markdown=COALESCE((
+               SELECT v.content_markdown FROM dictionary_versions v
+                WHERE v.entry_id=dictionary_entries.id
+                  AND v.state='applied' AND v.outcome<>'degraded'
+                ORDER BY v.generated_at DESC, v.rowid DESC LIMIT 1
+             ), ''),
+             insufficient_evidence=COALESCE((
+               SELECT v.insufficient_evidence FROM dictionary_versions v
+                WHERE v.entry_id=dictionary_entries.id
+                  AND v.state='applied' AND v.outcome<>'degraded'
+                ORDER BY v.generated_at DESC, v.rowid DESC LIMIT 1
+             ), 0),
+             status=CASE WHEN EXISTS(
+               SELECT 1 FROM dictionary_versions v
+                WHERE v.entry_id=dictionary_entries.id
+                  AND v.state='applied' AND v.outcome<>'degraded'
+             ) THEN status ELSE 'draft' END
+       WHERE current_version_id IN (
+         SELECT id FROM dictionary_versions WHERE outcome='degraded'
+       );
+
+      UPDATE dictionary_entries
+         SET proposed_version_id=NULL
+       WHERE proposed_version_id IN (
+         SELECT id FROM dictionary_versions WHERE outcome='degraded'
+       );
+
+      DROP TABLE dictionary_versions_v165;
     `,
   },
 ];

--- a/electron/ipc/academic.ts
+++ b/electron/ipc/academic.ts
@@ -378,8 +378,9 @@ const dictionaryGenerationJobs = new DictionaryGenerationQueue(
     }
 
     report({ entryId: request.entryId, phase: 'generating', message: 'Generando definición' });
-    await generateDictionaryEntry(request);
+    const version = await generateDictionaryEntry(request);
     announceDictionary(request.entryId);
+    return version;
   },
   announceDictionaryProgress,
 );

--- a/scripts/test-dictionary-generation-queue.mjs
+++ b/scripts/test-dictionary-generation-queue.mjs
@@ -175,3 +175,41 @@ test("Dictionary retries transient provider failures without exposing a terminal
     await rm(output, { recursive: true, force: true });
   }
 });
+
+test("Dictionary reports degraded attempts without presenting them as generated", async () => {
+  const output = await mkdtemp(path.join(os.tmpdir(), "nodus-dictionary-degraded-"));
+  try {
+    const bundle = path.join(output, "queue.mjs");
+    await build({
+      entryPoints: [path.join(root, "electron/ai/dictionaryGenerationQueue.ts")],
+      outfile: bundle,
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      logLevel: "silent",
+    });
+    const { DictionaryGenerationQueue } = await import(pathToFileURL(bundle));
+    const events = [];
+    const queue = new DictionaryGenerationQueue(
+      async () => ({
+        outcome: "degraded",
+        degradationReason: "semantic_rejection",
+        generationAttempts: 3,
+        generationProblems: ["no valid claims survived"],
+      }),
+      (progress) => events.push(progress),
+    );
+    queue.start({ entryId: "degraded", mode: "creation", model: null });
+    await waitFor(
+      () => queue.list().find((job) => job.entryId === "degraded")?.phase === "degraded",
+      "degraded terminal state",
+    );
+    const terminal = queue.list().find((job) => job.entryId === "degraded");
+    assert.equal(terminal.phase, "degraded");
+    assert.equal(terminal.attempts, 3);
+    assert.equal(terminal.degradationReason, "semantic_rejection");
+    assert.equal(events.some((event) => event.phase === "done"), false);
+  } finally {
+    await rm(output, { recursive: true, force: true });
+  }
+});

--- a/scripts/test-dictionary-ui.mjs
+++ b/scripts/test-dictionary-ui.mjs
@@ -348,14 +348,14 @@ assert.ok(
   "provider generation completes before any version is saved, so failure preserves current content",
 );
 assert.match(
-  ai,
+  view,
   /La versión anterior se conserva/,
-  "citation-validation failure reports that the previous version is preserved",
+  "a degraded generation reports that the previous version is preserved",
 );
 assert.match(
   ai,
-  /groundGeneratedDescription[\s\S]*attempt < 2/,
-  "an empty post-verification synthesis gets one bounded grounded rewrite",
+  /const maxAttempts = 3/,
+  "generation makes an initial attempt plus two bounded automatic retries",
 );
 assert.match(
   ai,

--- a/scripts/test-dictionary.mjs
+++ b/scripts/test-dictionary.mjs
@@ -159,6 +159,65 @@ try {
     repo.includedEvidence(automatic.id).length >= 2,
     "automatic retrieval selects relevant ideas/passages before generation",
   );
+  const structuredEvidence = repo.includedEvidence(automatic.id).slice(0, 2);
+  const renderedStructured = ai.__renderStructuredDictionaryForTesting(
+    {
+      paragraphs: [
+        {
+          claims: [
+            {
+              text: "La memoria se configura mediante prácticas colectivas.",
+              evidence: [
+                {
+                  kind: structuredEvidence[0].kind,
+                  id: structuredEvidence[0].id,
+                },
+              ],
+            },
+            {
+              text: "Su transmisión está documentada en procesos sociales.",
+              evidence: [
+                {
+                  kind: structuredEvidence[1].kind,
+                  id: structuredEvidence[1].id,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    structuredEvidence,
+  );
+  assert.equal(renderedStructured.invalidEvidenceRefs, 0);
+  assert.doesNotMatch(
+    renderedStructured.markdown,
+    /Evidencia verificable|^\s*[-*>#]/m,
+    "structured claims render as continuous prose rather than an evidence list",
+  );
+  assert.equal(
+    [...renderedStructured.markdown.matchAll(/nodus:\/\/(?:idea|passage)\//g)]
+      .length,
+    2,
+    "Nodus deterministically attaches one validated citation to each atomic claim",
+  );
+  const renderedWithUnknownId = ai.__renderStructuredDictionaryForTesting(
+    {
+      paragraphs: [
+        {
+          claims: [
+            {
+              text: "Esta afirmación no puede publicarse.",
+              evidence: [{ kind: "idea", id: "missing-evidence-id" }],
+            },
+          ],
+        },
+      ],
+    },
+    structuredEvidence,
+  );
+  assert.equal(renderedWithUnknownId.markdown, "");
+  assert.equal(renderedWithUnknownId.invalidEvidenceRefs, 1);
   assert.equal(
     repo.getDictionaryEntryDetail(automatic.id).coverage.included,
     repo.includedEvidence(automatic.id).filter((item) => !item.unavailable).length,
@@ -319,8 +378,8 @@ try {
   );
   assert.equal(
     salvageAttempts,
-    2,
-    "an uncited tail still receives the bounded rewrite before local salvage",
+    3,
+    "an uncited tail receives two automatic rewrites before local salvage",
   );
   assert.match(
     salvagedUncitedTail.contentMarkdown,
@@ -333,6 +392,7 @@ try {
     "only the persistently uncited sentence is removed",
   );
 
+  const currentBeforeDegraded = repo.getDictionaryEntry(automatic.id).currentVersionId;
   let extractiveFallbackAttempts = 0;
   const extractiveFallback = await ai.__generateDictionaryEntryForTesting(
     { entryId: automatic.id, mode: "regeneration", model: null },
@@ -348,8 +408,8 @@ try {
   );
   assert.equal(
     extractiveFallbackAttempts,
-    2,
-    "semantic rejection receives the bounded provider rewrite first",
+    3,
+    "semantic rejection receives two automatic provider rewrites first",
   );
   assert.match(
     extractiveFallback.contentMarkdown,
@@ -365,6 +425,15 @@ try {
     extractiveFallback.contentMarkdown,
     /absolutamente cualquier transformación/,
     "unsupported provider prose is never persisted in the fallback",
+  );
+  assert.equal(extractiveFallback.outcome, "degraded");
+  assert.equal(extractiveFallback.state, "degraded");
+  assert.equal(extractiveFallback.degradationReason, "semantic_rejection");
+  assert.equal(extractiveFallback.generationAttempts, 3);
+  assert.equal(
+    repo.getDictionaryEntry(automatic.id).currentVersionId,
+    currentBeforeDegraded,
+    "a degraded regeneration never replaces the current synthesis",
   );
 
   const missingCitationFallback = await ai.__generateDictionaryEntryForTesting(
@@ -385,6 +454,13 @@ try {
     /conserva información entre generaciones/,
     "uncited provider prose is not persisted",
   );
+  assert.equal(missingCitationFallback.outcome, "degraded");
+  assert.equal(missingCitationFallback.degradationReason, "missing_citations");
+  assert.equal(
+    repo.getDictionaryEntryDetail(automatic.id).latestDegradedVersion.id,
+    missingCitationFallback.id,
+    "the latest degraded attempt remains inspectable without becoming current",
+  );
 
   let malformedOutputCalls = 0;
   const malformedOutputFallback =
@@ -399,18 +475,24 @@ try {
     );
   assert.equal(
     malformedOutputCalls,
-    1,
-    "Dictionary does not multiply completeJson's exhausted repair attempts",
+    3,
+    "a truncated structured output receives two top-level automatic retries",
   );
   assert.match(
     malformedOutputFallback.contentMarkdown,
     /## Evidencia verificable/,
     "malformed or truncated structured output recovers to cited evidence",
   );
+  assert.equal(malformedOutputFallback.state, "degraded");
+  assert.equal(malformedOutputFallback.outcome, "degraded");
   assert.equal(
-    malformedOutputFallback.state,
-    "applied",
-    "structured-output recovery still produces a current Dictionary version",
+    malformedOutputFallback.degradationReason,
+    "output_truncated",
+  );
+  assert.equal(
+    repo.getDictionaryEntry(automatic.id).currentVersionId,
+    currentBeforeDegraded,
+    "structured-output degradation preserves the prior current version",
   );
 
   // A provider failure must reject the IPC operation without creating an empty
@@ -468,20 +550,26 @@ try {
     "provider failure creates no version row",
   );
 
-  // A generated citation to a ref outside the selected evidence is stripped and
-  // then rejected as an uncited substantive claim; the draft remains untouched.
-  await assert.rejects(
-    () =>
-      ai.__generateDictionaryEntryForTesting(
-        { entryId: failed.id, mode: "creation", model: null },
-        async () => ({
+  // A generated citation outside the selected evidence is stripped, retried twice
+  // and retained only as a degraded audit row; the draft remains untouched.
+  let invalidCitationAttempts = 0;
+  const invalidCitationFallback =
+    await ai.__generateDictionaryEntryForTesting(
+      { entryId: failed.id, mode: "creation", model: null },
+      async () => {
+        invalidCitationAttempts += 1;
+        return {
           descriptionMarkdown:
             "Esta afirmación inventada no procede de la evidencia disponible [fuente](nodus://idea/no-existe).",
           authorSummaries: [],
-        }),
-      ),
-    /versión anterior se conserva/,
-    "nonexistent generated citations cannot be persisted",
+        };
+      },
+    );
+  assert.equal(invalidCitationAttempts, 3);
+  assert.equal(invalidCitationFallback.outcome, "degraded");
+  assert.equal(
+    invalidCitationFallback.degradationReason,
+    "invalid_evidence_refs",
   );
   assert.equal(
     repo.getDictionaryEntry(failed.id).currentVersionId,

--- a/scripts/test-migration-160-baseline.mjs
+++ b/scripts/test-migration-160-baseline.mjs
@@ -20,7 +20,7 @@ const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-migration-160-'));
 installTsHook();
 try {
   const Database = require('better-sqlite3');
-  const { runMigrations, SCHEMA_VERSION } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
+  const { migrations, runMigrations, SCHEMA_VERSION } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
   const source = process.env.NODUS_BASELINE_DB;
   const target = path.join(root, 'baseline.sqlite');
   if (source) await copyFile(source, target);
@@ -35,7 +35,7 @@ try {
     : [];
   runMigrations(db);
   assert.equal(db.pragma('user_version', { simple: true }), SCHEMA_VERSION);
-  assert.equal(SCHEMA_VERSION, 165);
+  assert.equal(SCHEMA_VERSION, 166);
   const workColumns = new Set(db.prepare('PRAGMA table_info(works)').all().map((row) => row.name));
   for (const column of ['resolved_source_type', 'resolved_text_hash', 'text_block_reason', 'resolved_text_notes', 'deep_error', 'deep_queued']) {
     assert.ok(workColumns.has(column), `works.${column} exists`);
@@ -50,6 +50,89 @@ try {
     const columns = new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((row) => row.name));
     for (const column of ['source_ref', 'page_start_number', 'page_end_number']) assert.ok(columns.has(column), `${table}.${column} exists`);
   }
+  const dictionaryVersionColumns = new Set(
+    db.prepare('PRAGMA table_info(dictionary_versions)').all().map((row) => row.name)
+  );
+  for (const column of ['outcome', 'degradation_reason', 'generation_attempts', 'generation_problems_json']) {
+    assert.ok(dictionaryVersionColumns.has(column), `dictionary_versions.${column} exists`);
+  }
+  const legacyDictionaryDb = new Database(path.join(root, 'dictionary-v165.sqlite'));
+  legacyDictionaryDb.exec(`
+    CREATE TABLE dictionary_entries (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      normalized_name TEXT NOT NULL,
+      aliases_json TEXT NOT NULL DEFAULT '[]',
+      focus_prompt TEXT NOT NULL DEFAULT '',
+      scope_kind TEXT NOT NULL CHECK (scope_kind IN ('vault','authors','works','tags_collections')),
+      scope_json TEXT NOT NULL,
+      output_language TEXT NOT NULL DEFAULT 'es',
+      detail_level TEXT NOT NULL DEFAULT 'standard' CHECK (detail_level IN ('concise','standard','detailed')),
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      content_markdown TEXT NOT NULL DEFAULT '',
+      notes TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','active','archived')),
+      current_version_id TEXT,
+      proposed_version_id TEXT,
+      insufficient_evidence INTEGER NOT NULL DEFAULT 0,
+      new_evidence_count INTEGER NOT NULL DEFAULT 0,
+      last_evidence_scan_at TEXT,
+      last_change_seq INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE dictionary_versions (
+      id TEXT PRIMARY KEY,
+      entry_id TEXT NOT NULL,
+      content_markdown TEXT NOT NULL,
+      evidence_json TEXT NOT NULL DEFAULT '[]',
+      evidence_snapshot_json TEXT NOT NULL DEFAULT '[]',
+      citations_json TEXT NOT NULL DEFAULT '[]',
+      author_summaries_json TEXT NOT NULL DEFAULT '[]',
+      focus_prompt TEXT NOT NULL,
+      scope_json TEXT NOT NULL,
+      output_language TEXT NOT NULL,
+      detail_level TEXT NOT NULL,
+      model_json TEXT,
+      generated_at TEXT NOT NULL,
+      trigger TEXT NOT NULL CHECK (trigger IN ('creation','update','regeneration','manual_edit','restore')),
+      state TEXT NOT NULL CHECK (state IN ('applied','proposed')),
+      insufficient_evidence INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE INDEX dictionary_versions_entry_idx ON dictionary_versions(entry_id, generated_at DESC);
+    CREATE INDEX dictionary_versions_proposed_idx ON dictionary_versions(entry_id, state, generated_at DESC);
+  `);
+  const insertLegacyEntry = legacyDictionaryDb.prepare(`INSERT INTO dictionary_entries(
+    id,name,normalized_name,scope_kind,scope_json,content_markdown,status,current_version_id,proposed_version_id,created_at,updated_at
+  ) VALUES(?,?,?,'vault','{}',?,'active',?,?,?,?)`);
+  const legacyFallback = '## Evidencia verificable\n\n> Una retahíla extractiva.';
+  insertLegacyEntry.run('legacy-recover','Legacy recover','legacy recover',legacyFallback,'fallback-recover','fallback-recover','2026-01-01','2026-01-03');
+  insertLegacyEntry.run('legacy-draft','Legacy draft','legacy draft',legacyFallback,'fallback-draft','fallback-draft','2026-01-01','2026-01-03');
+  const insertLegacyVersion = legacyDictionaryDb.prepare(`INSERT INTO dictionary_versions(
+    id,entry_id,content_markdown,focus_prompt,scope_json,output_language,detail_level,model_json,generated_at,trigger,state,created_at,updated_at
+  ) VALUES(?,?,?,'','{}','es','standard',?,?,?,'applied',?,?)`);
+  insertLegacyVersion.run('good-recover','legacy-recover','Una síntesis anterior válida.',null,'2026-01-01','creation','2026-01-01','2026-01-01');
+  insertLegacyVersion.run('fallback-recover','legacy-recover',legacyFallback,null,'2026-01-02','regeneration','2026-01-02','2026-01-02');
+  insertLegacyVersion.run('fallback-draft','legacy-draft',legacyFallback,null,'2026-01-02','creation','2026-01-02','2026-01-02');
+  legacyDictionaryDb.exec(migrations.find((migration) => migration.version === 166).up);
+  assert.deepEqual(
+    legacyDictionaryDb.prepare(`SELECT state,outcome,degradation_reason FROM dictionary_versions WHERE id='fallback-recover'`).get(),
+    { state: 'degraded', outcome: 'degraded', degradation_reason: 'legacy_extractive_fallback' },
+    'v166 identifies the legacy extractive fallback even when no explicit model was persisted'
+  );
+  assert.deepEqual(
+    legacyDictionaryDb.prepare(`SELECT current_version_id,proposed_version_id,content_markdown,status FROM dictionary_entries WHERE id='legacy-recover'`).get(),
+    { current_version_id: 'good-recover', proposed_version_id: null, content_markdown: 'Una síntesis anterior válida.', status: 'active' },
+    'v166 restores the last good synthesis instead of keeping the extractive fallback current'
+  );
+  assert.deepEqual(
+    legacyDictionaryDb.prepare(`SELECT current_version_id,proposed_version_id,content_markdown,status FROM dictionary_entries WHERE id='legacy-draft'`).get(),
+    { current_version_id: null, proposed_version_id: null, content_markdown: '', status: 'draft' },
+    'v166 returns a first-generation legacy fallback to draft without discarding its version record'
+  );
+  legacyDictionaryDb.close();
   if (before) assert.deepEqual(counts(db), before, 'additive migration preserves corpus row counts');
   assert.deepEqual(db.pragma('quick_check'), [{ quick_check: 'ok' }]);
   assert.equal(db.pragma('foreign_key_check').length, 0);

--- a/shared/dictionary.ts
+++ b/shared/dictionary.ts
@@ -6,7 +6,20 @@ export type DictionaryEvidenceKind = "idea" | "passage";
 export type DictionaryEvidenceDecision = "included" | "unused" | "excluded";
 export type DictionaryVersionTrigger =
   "creation" | "update" | "regeneration" | "manual_edit" | "restore";
-export type DictionaryVersionState = "applied" | "proposed";
+export type DictionaryVersionState = "applied" | "proposed" | "degraded";
+export type DictionaryGenerationOutcome =
+  | "synthesis"
+  | "insufficient"
+  | "degraded";
+export type DictionaryDegradationReason =
+  | "output_truncated"
+  | "malformed_output"
+  | "schema_error"
+  | "invalid_evidence_refs"
+  | "missing_citations"
+  | "semantic_rejection"
+  | "grounding_failure"
+  | "legacy_extractive_fallback";
 export type DictionaryRelationType =
   | "related"
   | "broader"
@@ -202,6 +215,10 @@ export interface DictionaryVersion {
   generatedAt: string;
   trigger: DictionaryVersionTrigger;
   state: DictionaryVersionState;
+  outcome: DictionaryGenerationOutcome;
+  degradationReason: DictionaryDegradationReason | null;
+  generationAttempts: number;
+  generationProblems: string[];
   insufficientEvidence: boolean;
 }
 
@@ -219,6 +236,8 @@ export interface DictionaryEntryDetail {
   works: DictionaryWorkView[];
   currentVersion: DictionaryVersion | null;
   proposedVersion: DictionaryVersion | null;
+  /** Present only when the latest generation attempt degraded. It is never current. */
+  latestDegradedVersion: DictionaryVersion | null;
 }
 
 export interface DictionaryDuplicateMatch {
@@ -238,9 +257,12 @@ export interface DictionaryProgress {
     | "validating"
     | "saving"
     | "done"
+    | "degraded"
     | "failed";
   message: string;
   error?: string;
+  degradationReason?: DictionaryDegradationReason;
+  attempts?: number;
 }
 
 export interface DictionaryGenerationRequest {

--- a/src/i18n.dictionary.ts
+++ b/src/i18n.dictionary.ts
@@ -158,6 +158,38 @@ export const DICTIONARY_TRANSLATIONS = {
     "Error al generar": "Generation error",
     "La generación no pudo completarse.": "Generation could not be completed.",
     Generada: "Generated",
+    "Síntesis pendiente": "Synthesis pending",
+    "Último intento degradado": "Latest attempt degraded",
+    "El último intento no produjo una síntesis verificable":
+      "The latest attempt did not produce a verifiable synthesis",
+    "La respuesta se truncó antes de completarse.":
+      "The response was truncated before it completed.",
+    "El modelo devolvió una respuesta que no se pudo interpretar.":
+      "The model returned a response that could not be interpreted.",
+    "La respuesta no respetó la estructura requerida.":
+      "The response did not follow the required structure.",
+    "La respuesta utilizó referencias de evidencia no válidas.":
+      "The response used invalid evidence references.",
+    "La síntesis no incluyó citas verificables.":
+      "The synthesis did not include verifiable citations.",
+    "La verificación rechazó las afirmaciones generadas.":
+      "Verification rejected the generated claims.",
+    "Esta versión procedía del fallback extractivo anterior.":
+      "This version came from the previous extractive fallback.",
+    "No se obtuvo una síntesis verificable.":
+      "A verifiable synthesis could not be obtained.",
+    "Se intentó {n} veces. La versión anterior se conserva.":
+      "It was attempted {n} times. The previous version is preserved.",
+    "Nodus realizó {n} intentos automáticos.":
+      "Nodus made {n} automatic attempts.",
+    "La versión anterior permanece intacta.":
+      "The previous version remains unchanged.",
+    "La evidencia extractiva se conserva en Versiones, pero no se ha aplicado como definición.":
+      "The extractive evidence is kept in Versions, but it has not been applied as the definition.",
+    "Generación degradada": "Degraded generation",
+    "Se realizaron {n} intentos automáticos.":
+      "{n} automatic attempts were made.",
+    degradada: "degraded",
     "En cola": "Queued",
     "Analizando corpus…": "Analyzing corpus…",
     "Generando definición…": "Generating definition…",
@@ -355,6 +387,38 @@ export const DICTIONARY_TRANSLATIONS = {
     "La generación no pudo completarse.":
       "La génération n’a pas pu être terminée.",
     Generada: "Générée",
+    "Síntesis pendiente": "Synthèse en attente",
+    "Último intento degradado": "Dernière tentative dégradée",
+    "El último intento no produjo una síntesis verificable":
+      "La dernière tentative n’a pas produit de synthèse vérifiable",
+    "La respuesta se truncó antes de completarse.":
+      "La réponse a été tronquée avant d’être terminée.",
+    "El modelo devolvió una respuesta que no se pudo interpretar.":
+      "Le modèle a renvoyé une réponse impossible à interpréter.",
+    "La respuesta no respetó la estructura requerida.":
+      "La réponse n’a pas respecté la structure requise.",
+    "La respuesta utilizó referencias de evidencia no válidas.":
+      "La réponse a utilisé des références de preuve non valides.",
+    "La síntesis no incluyó citas verificables.":
+      "La synthèse ne comportait pas de citations vérifiables.",
+    "La verificación rechazó las afirmaciones generadas.":
+      "La vérification a rejeté les affirmations générées.",
+    "Esta versión procedía del fallback extractivo anterior.":
+      "Cette version provenait de l’ancien repli extractif.",
+    "No se obtuvo una síntesis verificable.":
+      "Aucune synthèse vérifiable n’a pu être obtenue.",
+    "Se intentó {n} veces. La versión anterior se conserva.":
+      "{n} tentatives ont été effectuées. La version précédente est conservée.",
+    "Nodus realizó {n} intentos automáticos.":
+      "Nodus a effectué {n} tentatives automatiques.",
+    "La versión anterior permanece intacta.":
+      "La version précédente reste intacte.",
+    "La evidencia extractiva se conserva en Versiones, pero no se ha aplicado como definición.":
+      "Les extraits sont conservés dans Versions, mais n’ont pas été appliqués comme définition.",
+    "Generación degradada": "Génération dégradée",
+    "Se realizaron {n} intentos automáticos.":
+      "{n} tentatives automatiques ont été effectuées.",
+    degradada: "dégradée",
     "En cola": "En file",
     "Analizando corpus…": "Analyse du corpus…",
     "Generando definición…": "Génération de la définition…",

--- a/src/views/DictionaryView.tsx
+++ b/src/views/DictionaryView.tsx
@@ -236,6 +236,27 @@ function dictionaryVersionText(value: string): string {
   return t(key);
 }
 
+function dictionaryDegradationText(value?: string | null): string {
+  switch (value) {
+    case "output_truncated":
+      return t("La respuesta se truncó antes de completarse.");
+    case "malformed_output":
+      return t("El modelo devolvió una respuesta que no se pudo interpretar.");
+    case "schema_error":
+      return t("La respuesta no respetó la estructura requerida.");
+    case "invalid_evidence_refs":
+      return t("La respuesta utilizó referencias de evidencia no válidas.");
+    case "missing_citations":
+      return t("La síntesis no incluyó citas verificables.");
+    case "semantic_rejection":
+      return t("La verificación rechazó las afirmaciones generadas.");
+    case "legacy_extractive_fallback":
+      return t("Esta versión procedía del fallback extractivo anterior.");
+    default:
+      return t("No se obtuvo una síntesis verificable.");
+  }
+}
+
 function StatusPill({ status }: { status: string }) {
   const classes =
     status === "active"
@@ -1154,7 +1175,7 @@ export function DictionaryView({
           next.set(progress.entryId, progress);
           return next;
         });
-        if (progress.phase === "done") void reload(false);
+        if (["done", "degraded"].includes(progress.phase)) void reload(false);
       }),
     [reload],
   );
@@ -1681,6 +1702,25 @@ function DictionaryGenerationState({
       </span>
     );
   }
+  if (progress.phase === "degraded") {
+    return (
+      <span
+        className="min-w-0 text-xs text-amber-700 dark:text-amber-300"
+        title={progress.error}
+      >
+        <span className="flex items-center gap-1.5 font-medium">
+          <Icon name="warning" size={12} /> {t("Síntesis pendiente")}
+        </span>
+        <span className="mt-0.5 block truncate text-[10px] opacity-80">
+          {progress.attempts
+            ? tx("Se intentó {n} veces. La versión anterior se conserva.", {
+                n: progress.attempts,
+              })
+            : dictionaryDegradationText(progress.degradationReason)}
+        </span>
+      </span>
+    );
+  }
   return (
     <span className="flex items-center gap-1.5 text-xs font-medium text-indigo-600 dark:text-indigo-300">
       <Icon name="refresh" size={13} className="animate-spin" />
@@ -1767,7 +1807,7 @@ function DictionaryEntryView({
   const entry = detail.entry;
   const hasEvidence = detail.coverage.included > 0;
   const backgroundBusy =
-    !!progress && !["done", "failed"].includes(progress.phase);
+    !!progress && !["done", "degraded", "failed"].includes(progress.phase);
   const backgroundFailure =
     progress?.phase === "failed" && !hideBackgroundFailure
       ? progress.error || t("La generación no pudo completarse.")
@@ -1844,6 +1884,11 @@ function DictionaryEntryView({
                 {entry.insufficientEvidence && (
                   <span className="text-[10px] text-amber-600 dark:text-amber-400">
                     {t("Evidencia insuficiente")}
+                  </span>
+                )}
+                {detail.latestDegradedVersion && (
+                  <span className="text-[10px] text-amber-700 dark:text-amber-300">
+                    {t("Último intento degradado")}
                   </span>
                 )}
               </div>
@@ -2210,6 +2255,31 @@ function OverviewTab({
     );
   return (
     <div className="grid items-start gap-4 xl:grid-cols-12">
+      {detail.latestDegradedVersion && (
+        <section className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-amber-900 xl:col-span-12 dark:border-amber-900 dark:bg-amber-950/25 dark:text-amber-200">
+          <div className="flex items-start gap-3">
+            <Icon name="warning" className="mt-0.5 shrink-0" />
+            <div>
+              <h3 className="text-sm font-semibold">
+                {t("El último intento no produjo una síntesis verificable")}
+              </h3>
+              <p className="mt-1 text-xs leading-5 opacity-80">
+                {dictionaryDegradationText(
+                  detail.latestDegradedVersion.degradationReason,
+                )}{" "}
+                {tx("Nodus realizó {n} intentos automáticos.", {
+                  n: detail.latestDegradedVersion.generationAttempts,
+                })}{" "}
+                {entry.currentVersionId
+                  ? t("La versión anterior permanece intacta.")
+                  : t(
+                      "La evidencia extractiva se conserva en Versiones, pero no se ha aplicado como definición.",
+                    )}
+              </p>
+            </div>
+          </div>
+        </section>
+      )}
       <section className={`${panel} p-5 xl:col-span-8`}>
         <div className="mb-4 flex items-start gap-3">
           <div className="min-w-0 flex-1">
@@ -2846,7 +2916,7 @@ function VersionsTab({
       {versions.map((version) => (
         <article
           key={version.id}
-          className={`${panel} p-4 ${version.id === detail.entry.currentVersionId ? "!border-emerald-300 dark:!border-emerald-900" : version.state === "proposed" ? "!border-cyan-300 dark:!border-cyan-900" : ""}`}
+          className={`${panel} p-4 ${version.id === detail.entry.currentVersionId ? "!border-emerald-300 dark:!border-emerald-900" : version.state === "proposed" ? "!border-cyan-300 dark:!border-cyan-900" : version.outcome === "degraded" ? "!border-amber-300 dark:!border-amber-900" : ""}`}
         >
           <button
             className="flex w-full items-center gap-3 text-left"
@@ -2860,7 +2930,9 @@ function VersionsTab({
               <p className="text-[10px] text-neutral-500">
                 {date(version.generatedAt)} ·{" "}
                 {tx("{n} evidencias", { n: version.evidence.length })} ·{" "}
-                {dictionaryVersionText(version.state)}
+                {dictionaryVersionText(
+                  version.outcome === "degraded" ? "degradada" : version.state,
+                )}
               </p>
             </div>
             {version.insufficientEvidence && (
@@ -2875,13 +2947,25 @@ function VersionsTab({
           </button>
           {open === version.id && (
             <div className="mt-4 border-t border-neutral-200 pt-4 dark:border-neutral-800">
+              {version.outcome === "degraded" && (
+                <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs leading-5 text-amber-800 dark:border-amber-900 dark:bg-amber-950/25 dark:text-amber-200">
+                  <p className="font-semibold">{t("Generación degradada")}</p>
+                  <p className="mt-1">
+                    {dictionaryDegradationText(version.degradationReason)}{" "}
+                    {tx("Se realizaron {n} intentos automáticos.", {
+                      n: version.generationAttempts,
+                    })}
+                  </p>
+                </div>
+              )}
               <Markdown
                 content={version.contentMarkdown}
                 onCitation={onCitation}
               />
               <div className="mt-4 flex justify-end">
                 {version.id !== detail.entry.currentVersionId &&
-                  version.state !== "proposed" && (
+                  version.state !== "proposed" &&
+                  version.outcome !== "degraded" && (
                     <button
                       className="btn btn-ghost border border-neutral-300 dark:border-neutral-700"
                       disabled={busy}


### PR DESCRIPTION
## Summary

- Generate Dictionary definitions as structured atomic claims and render continuous prose with deterministic, locally validated citations.
- Retry malformed, truncated, ungrounded, or semantically rejected output twice after the initial attempt.
- Persist terminal fallback output as a degraded diagnostic version instead of applying it as the current definition.
- Keep the previous valid definition active and show the degradation reason and attempt count in the queue, overview, and version history.
- Split author-summary generation from the verified definition so a secondary failure cannot invalidate the main synthesis.
- Add migration 166 to identify legacy extractive fallbacks, restore the latest valid synthesis, or return entries without a valid synthesis to draft.

## Related issue

Closes #577

## Type of change

- [x] Bug fix
- [x] New feature or improvement
- [ ] Documentation or translation
- [ ] Refactor or maintenance
- [x] Database, privacy, security, or infrastructure change

## Validation

- [ ] npm run lint
- [x] Targeted ESLint for all modified TypeScript and TSX files
- [x] npm run typecheck
- [x] node scripts/test-dictionary.mjs
- [x] node scripts/test-dictionary-generation-queue.mjs
- [x] node scripts/test-dictionary-ui.mjs
- [x] node scripts/test-migration-160-baseline.mjs
- [ ] npm test
- [x] npm run build
- [ ] npm run test:e2e when relevant

The focused tests cover deterministic prose rendering, invalid evidence identifiers, missing citations, semantic rejection, truncated output, two automatic retries, degraded queue state, preservation of the previous version, and legacy migration recovery.

## Screenshots

Not included. The visible change is an amber degraded-generation notice in the Dictionary overview and version history; the UI contract is covered by the focused test.

## Privacy and data review

- [x] No secrets, credentials, private vault content, personal data, student data, or confidential documents are included.
- [x] New network access is explicit, documented, and initiated by the user.
- [x] The change does not send rosters, grades, student answers, or other protected data to AI providers.
- [x] The change does not use AI to grade, rank, profile, or evaluate students.
- [x] Database, backup, synchronization, and migration effects are documented and tested.

## Contributor checklist

- [x] I added or updated focused tests.
- [ ] I updated documentation where behavior changed.
- [ ] I updated every language table for new static UI text.
- [x] I preserved local-first behavior and existing privacy boundaries.
- [ ] I have read and followed CONTRIBUTING.md and CODE_OF_CONDUCT.md.