### PR TITLE
Update State of the Art icon assertions

### DIFF
--- a/scripts/test-coverage-workspace-ui.mjs
+++ b/scripts/test-coverage-workspace-ui.mjs
@@ -6,7 +6,7 @@ test('Estado de la cuestión is a Library-style workspace with three ordered tab
   const workspace = await readSource('src/views/CoverageWorkspace.tsx');
   assert.match(workspace, /data-testid="coverage-workspace"/);
   assert.match(workspace, /data-testid="coverage-tabs"/);
-  assert.match(workspace, /<Icon name="compass"/);
+  assert.match(workspace, /<Icon name="strata"/);
   assert.match(workspace, /bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100/);
   assert.match(workspace, /border-neutral-300 bg-white text-neutral-900[^\n]*dark:border-neutral-700 dark:bg-neutral-900/);
   assert.match(

--- a/scripts/test-section-headers.mjs
+++ b/scripts/test-section-headers.mjs
@@ -84,7 +84,7 @@ test('no two sections that can share a sidebar share an icon', async () => {
   assert.equal(byId.deepResearch, 'telescope', 'Deep Research takes the telescope');
   assert.equal(byId.studyGraph, 'network', 'and the study variants follow');
   assert.equal(byId.studyDeepResearch, 'telescope');
-  assert.equal(byId.research, 'compass', 'Estado de la cuestión takes the compass');
+  assert.equal(byId.research, 'strata', 'Estado de la cuestión takes the strata icon');
 
   // Una bóveda genealógica muestra la navegación completa: el grafo y las relaciones
   // sociales conviven en ella, así que no pueden llevar el mismo icono.

--- a/scripts/test-view-registry.mjs
+++ b/scripts/test-view-registry.mjs
@@ -103,10 +103,10 @@ test('debate is routable without a sidebar section, and lands on its own tab', (
     'debate must NOT have a NAV_ITEM: it is a tab inside Estado de la cuestión, not a section'
   );
 
-  // The section that holds it keeps its own entry, renamed and with the compass.
+  // The section that holds it keeps its own entry and its dedicated strata icon.
   assert.match(
     navigation,
-    /\{ id: 'research', label: 'Estado de la cuestión', icon: 'compass', group: 'analyze' \}/,
+    /\{ id: 'research', label: 'Estado de la cuestión', icon: 'strata', group: 'analyze' \}/,
     'the three tabs live under one renamed section'
   );
 


### PR DESCRIPTION
## Summary

- update Coverage workspace tests to expect the new strata icon
- update section-header invariants for the dedicated State of the Art glyph
- update view-registry assertions and comments after #580

## Validation

- `node --test scripts/test-coverage-workspace-ui.mjs scripts/test-section-headers.mjs scripts/test-view-registry.mjs` (15 passed)
- `git diff --check`

Follow-up to #580.