### PR TITLE
Restore CI compatibility after the Compass merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Sitemap freshness is derived from the latest commit touching each
+          # content source, so the test needs history rather than a shallow tip.
+          fetch-depth: 0
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/electron/compass/compassService.ts
+++ b/electron/compass/compassService.ts
@@ -283,7 +283,7 @@ export class CompassService {
       (candidate) => candidate.webContents.id === owner,
     );
     if (window && !window.isDestroyed())
-      window.webContents.send("compass:searchProgress", progress);
+      window.webContents.send('compass:searchProgress', progress);
   }
   private emitImport(progress: CompassImportProgress): void {
     for (const listener of this.importListeners) listener(progress);
@@ -292,7 +292,7 @@ export class CompassService {
       (candidate) => candidate.webContents.id === owner,
     );
     if (window && !window.isDestroyed())
-      window.webContents.send("compass:importProgress", progress);
+      window.webContents.send('compass:importProgress', progress);
   }
   claimSearch(searchId: string, webContentsId: number): void {
     const key = clean(searchId, 200);

--- a/src/views/CompassView.tsx
+++ b/src/views/CompassView.tsx
@@ -558,7 +558,7 @@ export function CompassView({
         <div className="mx-auto max-w-6xl">
           <div className="flex items-start gap-3">
             <span className="grid h-11 w-11 place-items-center rounded-xl bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
-              <Icon name="compassSearch" size={22} />
+              <Icon name="compass" size={22} />
             </span>
             <div>
               <h1 className="text-xl font-semibold">


### PR DESCRIPTION
## Summary

Follow-up to #583 after the full GitHub Actions suite exposed three integration assumptions that the targeted Compass checks did not exercise:

- use the existing compass icon after the intervening icon cleanup removed compassSearch
- keep Compass push-channel literals visible to the static IPC contract census
- fetch full Git history in CI because sitemap freshness is derived from the last commit touching each content source

## Related issue and PR

- Follow-up to #583
- Related to #582

## Validation

- [x] node --test scripts/test-icon-names.mjs scripts/test-ipc-contract.mjs scripts/test-site-sitemap.mjs (12 passed)
- [x] npm run typecheck
- [x] npm test (2,383 passed, 0 failed, 1 expected skip)
- [x] git diff --check

## Privacy and data review

- [x] No credentials or user data are included.
- [x] No network or privacy behavior changed.
- [x] The IPC change is lexical only and preserves per-window event isolation.

## Contributor checklist

- [x] The fix is rebased on the latest main after the intervening blog merge.
- [x] The full suite passes locally.