### PR TITLE
Limit migration recovery snapshots to two per vault

### DIFF
--- a/electron/db/database.ts
+++ b/electron/db/database.ts
@@ -11,6 +11,7 @@ import { ensureOutboxTriggers } from '../serverSync/outboxTriggers';
 import { activeVaultDbPath, getVault, getVaultByPath } from '../vaults/vaultRegistry';
 import { auditQaDatabaseOpen } from '../qa/databaseAudit';
 import { migrateDatabaseSafely } from './migrationSafety';
+import { scheduleMigrationRecoveryRetention } from './migrationRecoveryUtilityHost';
 import { ensureBackupRevisionTriggers } from '../export/backupVaultRevision';
 
 let db: Database.Database | null = null;
@@ -120,7 +121,9 @@ function openDatabase(file: string): Database.Database {
     next.close();
     throw error;
   }
+  const migrationPending = Number(next.pragma('user_version', { simple: true })) < SCHEMA_VERSION;
   next = migrateDatabaseSafely(next, file, SCHEMA_VERSION, runMigrations);
+  if (migrationPending) scheduleMigrationRecoveryRetention(file);
   ensureWorkspaceDevice(next);
   // Deletion tombstones are written by triggers, which are regenerated here rather than
   // created by a migration: the set of synced tables is decided in code, so a migration

--- a/electron/db/migrationRecoveryUtilityHost.ts
+++ b/electron/db/migrationRecoveryUtilityHost.ts
@@ -2,27 +2,31 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { utilityProcess } from 'electron';
 import type { MigrationRecoverySnapshot } from '@shared/types';
+import type { MigrationRecoveryPruneReport } from './migrationSafety';
 import type {
   MigrationRecoveryUtilityRequest,
   MigrationRecoveryUtilityResponse,
 } from './migrationRecoveryUtilityTypes';
 
 let nextId = 1;
-const VALIDATION_TIMEOUT_MS = 10 * 60_000;
-const inFlight = new Map<string, Promise<MigrationRecoverySnapshot[]>>();
+const UTILITY_TIMEOUT_MS = 10 * 60_000;
+const RETENTION_DELAY_MS = 15_000;
+const listInFlight = new Map<string, Promise<MigrationRecoverySnapshot[]>>();
+let operationTail: Promise<void> = Promise.resolve();
+let retentionTimer: NodeJS.Timeout | null = null;
+const pendingRetentionPaths = new Set<string>();
 
 function workerFile(): string {
   return process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE
     || path.join(__dirname, 'migrationRecoveryUtilityWorker.js');
 }
 
-function runUtility(databasePath: string): Promise<MigrationRecoverySnapshot[]> {
-  const request: MigrationRecoveryUtilityRequest = { id: nextId++, databasePath };
+function runUtility(request: MigrationRecoveryUtilityRequest): Promise<MigrationRecoveryUtilityResponse> {
   if (process.env.ELECTRON_RUN_AS_NODE === '1' || process.env.NODUS_MIGRATION_RECOVERY_INLINE === '1') {
     return import('./migrationRecoveryUtilityWorker').then(({ runMigrationRecoveryUtilityRequest }) => {
       const response = runMigrationRecoveryUtilityRequest(request);
       if (response.kind === 'error') throw new Error(response.error);
-      return response.snapshots;
+      return response;
     });
   }
 
@@ -34,23 +38,23 @@ function runUtility(databasePath: string): Promise<MigrationRecoverySnapshot[]> 
   });
   return new Promise((resolve, reject) => {
     let settled = false;
-    const finish = (error?: Error, snapshots?: MigrationRecoverySnapshot[]): void => {
+    const finish = (error?: Error, response?: MigrationRecoveryUtilityResponse): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
       child.removeAllListeners();
       child.kill();
-      if (error) reject(error); else resolve(snapshots!);
+      if (error) reject(error); else resolve(response!);
     };
     const timeout = setTimeout(
-      () => finish(new Error('La validación de las copias de migración superó diez minutos.')),
-      VALIDATION_TIMEOUT_MS,
+      () => finish(new Error('La tarea auxiliar de recuperación superó diez minutos.')),
+      UTILITY_TIMEOUT_MS,
     );
     timeout.unref?.();
     child.on('message', (response: MigrationRecoveryUtilityResponse) => {
       if (!response || response.id !== request.id) return;
       if (response.kind === 'error') finish(new Error(response.error));
-      else finish(undefined, response.snapshots);
+      else finish(undefined, response);
     });
     child.once('error', (error) => finish(new Error(String(error))));
     child.once('exit', (code) => {
@@ -60,17 +64,93 @@ function runUtility(databasePath: string): Promise<MigrationRecoverySnapshot[]> 
   });
 }
 
+function enqueue<T>(work: () => Promise<T>): Promise<T> {
+  const task = operationTail.catch(() => undefined).then(work);
+  operationTail = task.then(() => undefined, () => undefined);
+  return task;
+}
+
 /** Hashing and SQLite quick_check may scan the complete snapshot. Keep both away from
  * Electron's main event loop and coalesce repeated Settings requests for the same vault. */
 export function listMigrationRecoverySnapshotsInUtility(
   databasePath: string,
 ): Promise<MigrationRecoverySnapshot[]> {
   const resolved = path.resolve(databasePath);
-  const current = inFlight.get(resolved);
+  const current = listInFlight.get(resolved);
   if (current) return current;
-  const task = runUtility(resolved).finally(() => {
-    if (inFlight.get(resolved) === task) inFlight.delete(resolved);
+  const task = enqueue(async () => {
+    const response = await runUtility({ kind: 'list', id: nextId++, databasePath: resolved });
+    if (response.kind !== 'list-done') throw new Error('Respuesta inesperada al listar copias de migración.');
+    return response.snapshots;
+  }).finally(() => {
+    if (listInFlight.get(resolved) === task) listInFlight.delete(resolved);
   });
-  inFlight.set(resolved, task);
+  listInFlight.set(resolved, task);
   return task;
+}
+
+/** Holds the same queue used by pruning until the caller has finished consuming the
+ * validated snapshot. This closes the gap between Settings validation and copying the
+ * immutable database into a new vault. */
+export function withMigrationRecoverySnapshotsInUtility<T>(
+  databasePath: string,
+  work: (snapshots: MigrationRecoverySnapshot[]) => Promise<T> | T,
+): Promise<T> {
+  const resolved = path.resolve(databasePath);
+  return enqueue(async () => {
+    const response = await runUtility({ kind: 'list', id: nextId++, databasePath: resolved });
+    if (response.kind !== 'list-done') throw new Error('Respuesta inesperada al validar una copia de migración.');
+    return work(response.snapshots);
+  });
+}
+
+/** Runs every requested vault in one disposable worker. The shared operation queue keeps
+ * Settings list/open requests from observing a snapshot halfway through removal. */
+export function pruneMigrationRecoverySnapshotsInUtility(
+  databasePaths: string[],
+): Promise<MigrationRecoveryPruneReport[]> {
+  const resolved = [...new Set(databasePaths.map((databasePath) => path.resolve(databasePath)))];
+  if (resolved.length === 0) return Promise.resolve([]);
+  return enqueue(async () => {
+    const response = await runUtility({ kind: 'prune', id: nextId++, databasePaths: resolved });
+    if (response.kind !== 'prune-done') throw new Error('Respuesta inesperada al limpiar copias de migración.');
+    return response.reports;
+  });
+}
+
+function logRetentionReports(reports: MigrationRecoveryPruneReport[]): void {
+  const removedSnapshots = reports.reduce((total, report) => total + report.removedSnapshots, 0);
+  const removedBytes = reports.reduce((total, report) => total + report.removedBytes, 0);
+  const errors = reports.flatMap((report) => report.errors);
+  if (removedSnapshots > 0 || errors.length > 0) {
+    console.log(`[migration-retention] removed ${removedSnapshots} snapshots (${removedBytes} bytes) across ${reports.length} vaults; errors=${errors.length}`);
+  }
+  for (const error of errors) {
+    console.warn(`[migration-retention] ${error.snapshotId}: ${error.message}`);
+  }
+}
+
+function flushScheduledRetention(): void {
+  retentionTimer = null;
+  const databasePaths = [...pendingRetentionPaths];
+  pendingRetentionPaths.clear();
+  void pruneMigrationRecoverySnapshotsInUtility(databasePaths)
+    .then(logRetentionReports)
+    .catch((error) => console.warn(`[migration-retention] failed safely: ${error instanceof Error ? error.message : String(error)}`));
+}
+
+/** Coalesces startup inventory and later vault opens into one non-blocking maintenance pass. */
+export function scheduleMigrationRecoveryRetention(databasePaths: string | string[]): void {
+  for (const databasePath of Array.isArray(databasePaths) ? databasePaths : [databasePaths]) {
+    if (databasePath) pendingRetentionPaths.add(path.resolve(databasePath));
+  }
+  if (pendingRetentionPaths.size === 0 || retentionTimer) return;
+  retentionTimer = setTimeout(flushScheduledRetention, RETENTION_DELAY_MS);
+  retentionTimer.unref?.();
+}
+
+export function cancelScheduledMigrationRecoveryRetention(): void {
+  if (retentionTimer) clearTimeout(retentionTimer);
+  retentionTimer = null;
+  pendingRetentionPaths.clear();
 }

--- a/electron/db/migrationRecoveryUtilityTypes.ts
+++ b/electron/db/migrationRecoveryUtilityTypes.ts
@@ -1,14 +1,24 @@
 import type { MigrationRecoverySnapshot } from '@shared/types';
+import type { MigrationRecoveryPruneReport } from './migrationSafety';
 
-export interface MigrationRecoveryUtilityRequest {
+export type MigrationRecoveryUtilityRequest = {
+  kind: 'list';
   id: number;
   databasePath: string;
-}
+} | {
+  kind: 'prune';
+  id: number;
+  databasePaths: string[];
+};
 
 export type MigrationRecoveryUtilityResponse = {
   kind: 'list-done';
   id: number;
   snapshots: MigrationRecoverySnapshot[];
+} | {
+  kind: 'prune-done';
+  id: number;
+  reports: MigrationRecoveryPruneReport[];
 } | {
   kind: 'error';
   id: number;

--- a/electron/db/migrationRecoveryUtilityWorker.ts
+++ b/electron/db/migrationRecoveryUtilityWorker.ts
@@ -1,4 +1,4 @@
-import { listMigrationRecoverySnapshots } from './migrationSafety';
+import { listMigrationRecoverySnapshots, pruneMigrationRecoverySnapshots } from './migrationSafety';
 import type {
   MigrationRecoveryUtilityRequest,
   MigrationRecoveryUtilityResponse,
@@ -7,6 +7,13 @@ import type {
 export function runMigrationRecoveryUtilityRequest(
   request: MigrationRecoveryUtilityRequest,
 ): MigrationRecoveryUtilityResponse {
+  if (request.kind === 'prune') {
+    return {
+      kind: 'prune-done',
+      id: request.id,
+      reports: request.databasePaths.map((databasePath) => pruneMigrationRecoverySnapshots(databasePath)),
+    };
+  }
   return {
     kind: 'list-done',
     id: request.id,

--- a/electron/db/migrationSafety.ts
+++ b/electron/db/migrationSafety.ts
@@ -7,6 +7,27 @@ import { auditQaDatabaseOpen } from '../qa/databaseAudit';
 import type { MigrationRecoverySnapshot } from '@shared/types';
 
 export const MAJOR_SCHEMA_VERSIONS = Object.freeze([134, 135]);
+export const MIGRATION_RECOVERY_RETENTION = 2;
+
+export interface MigrationRecoveryPruneError {
+  snapshotId: string;
+  file: string;
+  message: string;
+}
+
+export interface MigrationRecoveryPruneReport {
+  databasePath: string;
+  retention: number;
+  discoveredSnapshots: number;
+  keptSnapshots: number;
+  removedSnapshots: number;
+  removedBytes: number;
+  errors: MigrationRecoveryPruneError[];
+}
+
+interface MigrationRecoveryPruneOptions {
+  removeFile?: (file: string) => void;
+}
 
 export interface MigrationSafetyReport {
   format: 'nodus.schema-migration-report';
@@ -96,6 +117,131 @@ function snapshotFromManifest(value: unknown, manifestPath: string): MigrationRe
     immutable: Boolean(record.immutable),
     major: Boolean(record.major),
   };
+}
+
+function managedSnapshotFromManifest(
+  value: unknown,
+  manifestPath: string,
+  sourceDatabasePath: string,
+): MigrationRecoverySnapshot | null {
+  const snapshot = snapshotFromManifest(value, manifestPath);
+  if (!snapshot) return null;
+  const match = /^pre-v(\d+)-from-v(\d+)-[a-f0-9]{16}$/.exec(snapshot.id);
+  if (!match) return null;
+  if (Number(match[1]) !== snapshot.targetVersion || Number(match[2]) !== snapshot.fromVersion) return null;
+  if (!Number.isFinite(Date.parse(snapshot.createdAt))) return null;
+  if (!/^[a-f0-9]{64}$/.test(snapshot.sha256) || snapshot.quickCheck !== 'ok' || !snapshot.immutable) return null;
+
+  const directory = migrationDirectory(sourceDatabasePath);
+  if (path.resolve(snapshot.sourceDatabasePath) !== path.resolve(sourceDatabasePath)) return null;
+  if (path.resolve(manifestPath) !== path.resolve(directory, `${snapshot.id}.json`)) return null;
+  if (path.resolve(snapshot.databasePath) !== path.resolve(directory, `${snapshot.id}.sqlite`)) return null;
+  return snapshot;
+}
+
+function newestSnapshotFirst(a: MigrationRecoverySnapshot, b: MigrationRecoverySnapshot): number {
+  const created = b.createdAt.localeCompare(a.createdAt);
+  if (created !== 0) return created;
+  if (a.targetVersion !== b.targetVersion) return b.targetVersion - a.targetVersion;
+  if (a.fromVersion !== b.fromVersion) return b.fromVersion - a.fromVersion;
+  return b.id.localeCompare(a.id);
+}
+
+/**
+ * Removes only complete snapshot pairs created by this module. Unknown files, reports,
+ * temporary copies and snapshots for a different database are deliberately ignored.
+ * The SQLite file is always removed before its sidecar so an interrupted cleanup cannot
+ * strand a large, undiscoverable copy on disk.
+ */
+export function pruneMigrationRecoverySnapshots(
+  databasePath: string,
+  options: MigrationRecoveryPruneOptions = {},
+): MigrationRecoveryPruneReport {
+  const sourceDatabasePath = path.resolve(databasePath);
+  const directory = migrationDirectory(sourceDatabasePath);
+  const report: MigrationRecoveryPruneReport = {
+    databasePath: sourceDatabasePath,
+    retention: MIGRATION_RECOVERY_RETENTION,
+    discoveredSnapshots: 0,
+    keptSnapshots: 0,
+    removedSnapshots: 0,
+    removedBytes: 0,
+    errors: [],
+  };
+  if (!fs.existsSync(directory)) return report;
+
+  const removeFile = options.removeFile ?? ((file: string) => fs.rmSync(file, { force: true }));
+  const candidates: Array<{ snapshot: MigrationRecoverySnapshot; bytes: number }> = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    report.errors.push({
+      snapshotId: 'directory',
+      file: directory,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return report;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json') || entry.name.startsWith('report-')) continue;
+    const manifestPath = path.join(directory, entry.name);
+    let snapshot: MigrationRecoverySnapshot | null = null;
+    try {
+      snapshot = managedSnapshotFromManifest(JSON.parse(fs.readFileSync(manifestPath, 'utf8')), manifestPath, sourceDatabasePath);
+    } catch {
+      // Malformed or unreadable sidecars are not safe automatic-deletion targets.
+    }
+    if (!snapshot) continue;
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(snapshot.databasePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        report.errors.push({
+          snapshotId: snapshot.id,
+          file: snapshot.databasePath,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+      continue;
+    }
+    if (!stat.isFile() || stat.isSymbolicLink()) continue;
+    candidates.push({ snapshot, bytes: stat.size });
+  }
+
+  candidates.sort((a, b) => newestSnapshotFirst(a.snapshot, b.snapshot));
+  report.discoveredSnapshots = candidates.length;
+  report.keptSnapshots = Math.min(candidates.length, MIGRATION_RECOVERY_RETENTION);
+  for (const candidate of candidates.slice(MIGRATION_RECOVERY_RETENTION)) {
+    try {
+      // Snapshots are intentionally mode 0400. Restoring owner write permission makes
+      // removal reliable on Windows without weakening any snapshot that is retained.
+      try { fs.chmodSync(candidate.snapshot.databasePath, 0o600); } catch { /* deletion reports the real failure */ }
+      removeFile(candidate.snapshot.databasePath);
+      report.removedSnapshots += 1;
+      report.removedBytes += candidate.bytes;
+    } catch (error) {
+      try { fs.chmodSync(candidate.snapshot.databasePath, 0o400); } catch { /* the original deletion error remains authoritative */ }
+      report.errors.push({
+        snapshotId: candidate.snapshot.id,
+        file: candidate.snapshot.databasePath,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    try {
+      removeFile(candidate.snapshot.manifestPath);
+    } catch (error) {
+      report.errors.push({
+        snapshotId: candidate.snapshot.id,
+        file: candidate.snapshot.manifestPath,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return report;
 }
 
 function createVerifiedSnapshot(

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -160,7 +160,10 @@ import { initializeVaultModelSelection, validateVaultModelSelection } from './va
 import { setPersistentDockIcon } from './dockIcon';
 import { closeCrossVaultConnections } from './db/crossVault';
 import { assertNotBrowserIpcSender } from './ipc/trust';
-import { listMigrationRecoverySnapshotsInUtility } from './db/migrationRecoveryUtilityHost';
+import {
+  listMigrationRecoverySnapshotsInUtility,
+  withMigrationRecoverySnapshotsInUtility,
+} from './db/migrationRecoveryUtilityHost';
 import { documentIndexQueue } from './pipeline/documentIndexQueue';
 
 
@@ -648,12 +651,13 @@ export function registerIpc(
   h('migrationRecovery:list', async () => listMigrationRecoverySnapshotsInUtility(getActiveVault().path));
   h('migrationRecovery:open', async (_e, id: string) => {
     const source = getActiveVault();
-    const snapshot = (await listMigrationRecoverySnapshotsInUtility(source.path))
-      .find((candidate) => candidate.id === id);
-    if (!snapshot) throw new Error('La copia previa a la migración no existe o ya no supera la validación.');
-    const name = `${source.name} · antes de v${snapshot.targetVersion}`;
-    const vault = createVaultFromDatabaseFile(snapshot.databasePath, name, source.type);
-    return { vault: withVaultKeyProviders(vault) };
+    return withMigrationRecoverySnapshotsInUtility(source.path, (snapshots) => {
+      const snapshot = snapshots.find((candidate) => candidate.id === id);
+      if (!snapshot) throw new Error('La copia previa a la migración no existe o ya no supera la validación.');
+      const name = `${source.name} · antes de v${snapshot.targetVersion}`;
+      const vault = createVaultFromDatabaseFile(snapshot.databasePath, name, source.type);
+      return { vault: withVaultKeyProviders(vault) };
+    });
   });
   h('vaults:delete', async (_e, id: string, deleteFiles?: boolean) => {
     deleteVault(id, Boolean(deleteFiles));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,7 +20,11 @@ import { getSettings } from './db/settingsRepo';
 import { runDueDatabaseRowTemplates } from './db/databaseTasksRepo';
 import { runDueAutomationRules } from './db/databaseAutomationsRepo';
 import { startDatabaseFormServer, stopDatabaseFormServer } from './automation/formServer';
-import { getActiveVault } from './vaults/vaultRegistry';
+import { getActiveVault, listVaults } from './vaults/vaultRegistry';
+import {
+  cancelScheduledMigrationRecoveryRetention,
+  scheduleMigrationRecoveryRetention,
+} from './db/migrationRecoveryUtilityHost';
 import { generateDemoPortraits, hasDemoPortraitKey, demoPortraitsPending } from './ai/genealogyDemoPortraits';
 import { interruptDecorativeImageGenerations } from './ai/decorativeImages';
 import { startRealtimeSync, stopRealtimeSync } from './sync/syncService';
@@ -963,6 +967,10 @@ app.whenReady().then(async () => {
     (betaUpdates) => configureUpdateChannel(betaUpdates, 'setting changed'),
   );
   createWindow();
+  // Existing installs may have one full database copy per historical schema update.
+  // Queue every registered vault after the window exists; the utility worker applies
+  // retention without delaying startup or opening any vault on the main thread.
+  scheduleMigrationRecoveryRetention(listVaults().map((vault) => vault.path));
   // Deliver any nodus:// deeplink that launched the app (OAuth callback via
   // system browser, e.g. nodus://authorize?code=XYZ).
   if (pendingDeepLink) {
@@ -1118,6 +1126,7 @@ app.on('window-all-closed', () => {
     if (taskTemplateFirstTimer) clearTimeout(taskTemplateFirstTimer);
     if (databaseAutomationTimer) clearInterval(databaseAutomationTimer);
     if (databaseAutomationFirstTimer) clearTimeout(databaseAutomationFirstTimer);
+    cancelScheduledMigrationRecoveryRetention();
     void stopDatabaseFormServer();
     stopRealtimeSync();
     stopNodusServerSync();
@@ -1150,6 +1159,7 @@ app.on('before-quit', () => {
   if (taskTemplateFirstTimer) clearTimeout(taskTemplateFirstTimer);
   if (databaseAutomationTimer) clearInterval(databaseAutomationTimer);
   if (databaseAutomationFirstTimer) clearTimeout(databaseAutomationFirstTimer);
+  cancelScheduledMigrationRecoveryRetention();
   void stopDatabaseFormServer();
   stopRealtimeSync();
   stopNodusServerSync();
@@ -1194,6 +1204,7 @@ updateAwareApp.on('before-quit-for-update', () => {
   if (taskTemplateFirstTimer) clearTimeout(taskTemplateFirstTimer);
   if (databaseAutomationTimer) clearInterval(databaseAutomationTimer);
   if (databaseAutomationFirstTimer) clearTimeout(databaseAutomationFirstTimer);
+  cancelScheduledMigrationRecoveryRetention();
   void stopDatabaseFormServer();
   stopRealtimeSync();
   stopNodusServerSync();

--- a/electron/vaults/vaultRegistry.ts
+++ b/electron/vaults/vaultRegistry.ts
@@ -8,6 +8,7 @@ import { normalizeVaultType } from '@shared/vaultTypes';
 import { runMigrations, SCHEMA_VERSION } from '../db/migrations';
 import { auditQaDatabaseOpen } from '../qa/databaseAudit';
 import { migrateDatabaseSafely } from '../db/migrationSafety';
+import { scheduleMigrationRecoveryRetention } from '../db/migrationRecoveryUtilityHost';
 
 interface VaultRecord {
   id: string;
@@ -233,7 +234,9 @@ function initializeDatabase(file: string): void {
   let db = new Database(file);
   try {
     auditQaDatabaseOpen(file, 'initialize');
+    const migrationPending = Number(db.pragma('user_version', { simple: true })) < SCHEMA_VERSION;
     db = migrateDatabaseSafely(db, file, SCHEMA_VERSION, runMigrations);
+    if (migrationPending) scheduleMigrationRecoveryRetention(file);
   } finally {
     db.close();
   }

--- a/scripts/test-major-migration-recovery.mjs
+++ b/scripts/test-major-migration-recovery.mjs
@@ -26,7 +26,13 @@ const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-major-migration-'));
 installRuntimeHooks();
 const Database = require('better-sqlite3');
 const { migrations, runMigrations, SCHEMA_VERSION } = require(path.join(repoRoot, 'electron/db/migrations.ts'));
-const { migrateDatabaseSafely, listMigrationRecoverySnapshots, MAJOR_SCHEMA_VERSIONS } = require(
+const {
+  migrateDatabaseSafely,
+  listMigrationRecoverySnapshots,
+  pruneMigrationRecoverySnapshots,
+  MAJOR_SCHEMA_VERSIONS,
+  MIGRATION_RECOVERY_RETENTION,
+} = require(
   path.join(repoRoot, 'electron/db/migrationSafety.ts'),
 );
 
@@ -78,6 +84,23 @@ function seedDatabase(db, version = 133) {
   }
 }
 
+function databaseWithSnapshots(name, count) {
+  const directory = path.join(root, name);
+  fs.mkdirSync(directory, { recursive: true });
+  const file = path.join(directory, 'nodus.sqlite');
+  let db = new Database(file);
+  db.exec('CREATE TABLE retained_value (id INTEGER PRIMARY KEY, value TEXT NOT NULL)');
+  db.prepare('INSERT INTO retained_value (value) VALUES (?)').run(name);
+  db.pragma('user_version = 1');
+  for (let targetVersion = 2; targetVersion < count + 2; targetVersion += 1) {
+    db = migrateDatabaseSafely(db, file, targetVersion, (migrating) => {
+      migrating.pragma(`user_version = ${targetVersion}`);
+    });
+  }
+  db.close();
+  return file;
+}
+
 try {
   assert.ok(SCHEMA_VERSION >= 135, 'this test tracks the current Notion-parity major boundary');
   assert.ok(MAJOR_SCHEMA_VERSIONS.includes(134));
@@ -105,6 +128,75 @@ try {
     assert.equal(snapshots[0].immutable, true);
     assert.equal(fs.statSync(snapshots[0].databasePath).mode & 0o222, 0, 'snapshot has no writable bits');
   }
+
+  // Retention is per vault and removes only complete, Nodus-owned snapshot pairs.
+  assert.equal(MIGRATION_RECOVERY_RETENTION, 2);
+  const retainedFile = databaseWithSnapshots('retention-a', 4);
+  const untouchedFile = databaseWithSnapshots('retention-b', 3);
+  const beforeRetention = listMigrationRecoverySnapshots(retainedFile);
+  assert.equal(beforeRetention.length, 4);
+  assert.equal(listMigrationRecoverySnapshots(untouchedFile).length, 3);
+  const retentionDir = path.join(path.dirname(retainedFile), '.nodus', 'migrations');
+  const reportFile = path.join(retentionDir, 'report-keep.json');
+  const unknownFile = path.join(retentionDir, 'unfinished.tmp');
+  const manualFile = path.join(retentionDir, 'manual.sqlite');
+  fs.writeFileSync(reportFile, '{}');
+  fs.writeFileSync(unknownFile, 'partial');
+  fs.writeFileSync(manualFile, 'manual');
+
+  const outsideFile = path.join(root, 'outside.sqlite');
+  fs.writeFileSync(outsideFile, 'outside');
+  const outsideId = 'pre-v99-from-v98-aaaaaaaaaaaaaaaa';
+  fs.writeFileSync(path.join(retentionDir, `${outsideId}.json`), JSON.stringify({
+    format: 'nodus.schema-migration-snapshot', formatVersion: 1,
+    id: outsideId, databasePath: outsideFile, sourceDatabasePath: retainedFile,
+    fromVersion: 98, targetVersion: 99, createdAt: '2026-08-26T00:00:00.000Z',
+    bytes: 7, sha256: 'a'.repeat(64), quickCheck: 'ok', immutable: true, major: false,
+  }));
+  const incompleteId = 'pre-v100-from-v99-bbbbbbbbbbbbbbbb';
+  const incompleteManifest = path.join(retentionDir, `${incompleteId}.json`);
+  fs.writeFileSync(incompleteManifest, JSON.stringify({
+    format: 'nodus.schema-migration-snapshot', formatVersion: 1,
+    id: incompleteId, databasePath: path.join(retentionDir, `${incompleteId}.sqlite`), sourceDatabasePath: retainedFile,
+    fromVersion: 99, targetVersion: 100, createdAt: '2026-08-26T00:01:00.000Z',
+    bytes: 7, sha256: 'b'.repeat(64), quickCheck: 'ok', immutable: true, major: false,
+  }));
+
+  const pruneReport = pruneMigrationRecoverySnapshots(retainedFile);
+  assert.equal(pruneReport.discoveredSnapshots, 4);
+  assert.equal(pruneReport.keptSnapshots, 2);
+  assert.equal(pruneReport.removedSnapshots, 2);
+  assert.equal(pruneReport.removedBytes, beforeRetention.slice(2).reduce((sum, snapshot) => sum + snapshot.bytes, 0));
+  assert.deepEqual(pruneReport.errors, []);
+  assert.deepEqual(listMigrationRecoverySnapshots(retainedFile).map((snapshot) => snapshot.targetVersion), [5, 4]);
+  for (const removed of beforeRetention.slice(2)) {
+    assert.equal(fs.existsSync(removed.databasePath), false, 'old SQLite snapshot is removed');
+    assert.equal(fs.existsSync(removed.manifestPath), false, 'old snapshot manifest is removed after its SQLite file');
+  }
+  for (const preserved of [reportFile, unknownFile, manualFile, outsideFile, path.join(retentionDir, `${outsideId}.json`), incompleteManifest]) {
+    assert.equal(fs.existsSync(preserved), true, `unmanaged path is untouched: ${preserved}`);
+  }
+  assert.equal(listMigrationRecoverySnapshots(untouchedFile).length, 3, 'pruning one vault never changes another vault');
+  assert.equal(pruneMigrationRecoverySnapshots(untouchedFile).removedSnapshots, 1);
+  assert.equal(listMigrationRecoverySnapshots(untouchedFile).length, 2);
+
+  // A failed deletion keeps the snapshot discoverable and immutable so the next launch can retry.
+  const retryFile = databaseWithSnapshots('retention-retry', 3);
+  const retrySnapshots = listMigrationRecoverySnapshots(retryFile);
+  const failedTarget = retrySnapshots.at(-1);
+  const failedPrune = pruneMigrationRecoverySnapshots(retryFile, {
+    removeFile(file) {
+      if (file === failedTarget.databasePath) throw new Error('fallo de borrado simulado');
+      fs.rmSync(file, { force: true });
+    },
+  });
+  assert.equal(failedPrune.removedSnapshots, 0);
+  assert.equal(failedPrune.errors.length, 1);
+  assert.match(failedPrune.errors[0].message, /fallo de borrado simulado/);
+  assert.equal(fs.existsSync(failedTarget.databasePath), true);
+  assert.equal(fs.statSync(failedTarget.databasePath).mode & 0o222, 0, 'a failed deletion restores immutable mode');
+  assert.equal(listMigrationRecoverySnapshots(retryFile).length, 3);
+  assert.equal(pruneMigrationRecoverySnapshots(retryFile).removedSnapshots, 1, 'a later maintenance pass retries safely');
 
   // Failure path: even a deliberately non-transactional partial migration is undone.
   const failure = databaseAt(134, 'failure.sqlite');

--- a/scripts/test-settings-background-inspection.mjs
+++ b/scripts/test-settings-background-inspection.mjs
@@ -18,13 +18,20 @@ test('migration snapshot validation runs in a disposable utility process', () =>
   const ipc = source('electron/ipc.ts');
   const host = source('electron/db/migrationRecoveryUtilityHost.ts');
   const worker = source('electron/db/migrationRecoveryUtilityWorker.ts');
+  const main = source('electron/main.ts');
+  const database = source('electron/db/database.ts');
   const vite = source('vite.config.ts');
 
   assert.match(ipc, /listMigrationRecoverySnapshotsInUtility\(getActiveVault\(\)\.path\)/);
   assert.doesNotMatch(ipc, /listMigrationRecoverySnapshots\(getActiveVault\(\)\.path\)/);
+  assert.match(ipc, /withMigrationRecoverySnapshotsInUtility\(source\.path/);
   assert.match(host, /utilityProcess\.fork\(file/);
-  assert.match(host, /const inFlight = new Map/, 'repeated opens coalesce instead of scanning the same vault twice');
+  assert.match(host, /const listInFlight = new Map/, 'repeated opens coalesce instead of scanning the same vault twice');
+  assert.match(host, /operationTail/, 'listing and retention share one serialized utility queue');
   assert.match(worker, /snapshots: listMigrationRecoverySnapshots\(request\.databasePath\)/);
+  assert.match(worker, /pruneMigrationRecoverySnapshots\(databasePath\)/);
+  assert.match(main, /scheduleMigrationRecoveryRetention\(listVaults\(\)\.map\(\(vault\) => vault\.path\)\)/);
+  assert.match(database, /if \(migrationPending\) scheduleMigrationRecoveryRetention\(file\)/);
   assert.match(vite, /utilityBuild\('migrationRecoveryUtilityWorker'/);
 });
 
@@ -62,6 +69,68 @@ test('repeated requests coalesce and the migration utility is reaped', async () 
     assert.deepEqual(second, []);
     assert.equal(forks, 1, 'one vault scan serves both callers');
     assert.equal(kills, 1, 'the one-shot child is killed after returning its result');
+  } finally {
+    if (previousWorker === undefined) delete process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE;
+    else process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE = previousWorker;
+    if (previousRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+    else process.env.ELECTRON_RUN_AS_NODE = previousRunAsNode;
+    forkUtility = () => { throw new Error('unexpected migration utility launch'); };
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('retention batches vaults and is serialized with Settings inspection', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-retention-utility-'));
+  const workerFile = path.join(root, 'migrationRecoveryUtilityWorker.js');
+  fs.writeFileSync(workerFile, '// existence sentinel');
+  const events = [];
+  class FakeUtility extends EventEmitter {
+    postMessage(request) {
+      events.push(`start:${request.kind}`);
+      const response = request.kind === 'prune'
+        ? {
+            kind: 'prune-done', id: request.id,
+            reports: request.databasePaths.map((databasePath) => ({
+              databasePath, retention: 2, discoveredSnapshots: 3, keptSnapshots: 2,
+              removedSnapshots: 1, removedBytes: 1024, errors: [],
+            })),
+          }
+        : { kind: 'list-done', id: request.id, snapshots: [] };
+      setTimeout(() => {
+        events.push(`finish:${request.kind}`);
+        this.emit('message', response);
+      }, request.kind === 'prune' ? 20 : 0);
+    }
+    kill() { return true; }
+  }
+  forkUtility = () => new FakeUtility();
+  const previousWorker = process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE;
+  const previousRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+  process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE = workerFile;
+  delete process.env.ELECTRON_RUN_AS_NODE;
+  try {
+    const host = require(path.join(repoRoot, 'electron/db/migrationRecoveryUtilityHost.ts'));
+    const firstVault = path.join(root, 'first.sqlite');
+    const secondVault = path.join(root, 'second.sqlite');
+    const prune = host.pruneMigrationRecoverySnapshotsInUtility([firstVault, secondVault, firstVault]);
+    const list = host.listMigrationRecoverySnapshotsInUtility(firstVault);
+    const [reports, snapshots] = await Promise.all([prune, list]);
+    assert.equal(reports.length, 2, 'duplicate vault paths are pruned once');
+    assert.deepEqual(snapshots, []);
+    assert.deepEqual(events, ['start:prune', 'finish:prune', 'start:list', 'finish:list']);
+
+    events.length = 0;
+    const access = host.withMigrationRecoverySnapshotsInUtility(firstVault, async () => {
+      events.push('access:start');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      events.push('access:finish');
+    });
+    const queuedPrune = host.pruneMigrationRecoverySnapshotsInUtility([firstVault]);
+    await Promise.all([access, queuedPrune]);
+    assert.deepEqual(events, [
+      'start:list', 'finish:list', 'access:start', 'access:finish',
+      'start:prune', 'finish:prune',
+    ], 'opening holds the utility queue until the validated snapshot has been consumed');
   } finally {
     if (previousWorker === undefined) delete process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE;
     else process.env.NODUS_MIGRATION_RECOVERY_UTILITY_FILE = previousWorker;


### PR DESCRIPTION
## Summary

- retain only the two newest managed migration recovery snapshots for each vault
- prune accumulated snapshots in a deferred recovery worker task at startup and after migrations
- serialize snapshot listing, opening, and pruning to avoid recovery races
- preserve reports, unknown files, incomplete pairs, backups, caches, and special pre-v4 recovery data
- report reviewed vaults, removed snapshots, reclaimed bytes, and non-blocking errors

## Validation

- `npm run typecheck`
- ESLint on the touched TypeScript files
- `node scripts/test-major-migration-recovery.mjs`
- `node --test scripts/test-settings-background-inspection.mjs`
- `npx vite build`
- `git diff --check`

Closes #585