### PR TITLE
Release Nodus 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 5.0.4 — 2026-08-27
+
+Nodus 5.0.4 brings secure multi-user web parity to Nodus Server, extends Word
+Copilot writing workflows and limits accumulated migration recovery snapshots.
+
+- Added a responsive Nodus Server web client that follows the Desktop visual
+  language and opens shared workspace views from phones and browsers.
+- Added private per-user conversations, notes, annotations and artifacts, plus
+  synchronized profile preferences across connected devices.
+- Added per-account AI providers, models and encrypted credentials, with private
+  jobs and results and an immutable embedding compatibility contract.
+- Enforced ownership, membership and provenance across server mutations and
+  hardened login, secret redaction, quotas, backups and Docker deployment.
+- Added a review-first Word Copilot tab for saved workspace writing styles, with
+  model selection and explicit copy or replace actions.
+- Kept Word reference tabs compact, isolated concurrent prompt results and added
+  visible generation feedback without changing the document prematurely.
+- Retained only the two newest managed migration recovery snapshots per vault in
+  a serialized background cleanup that preserves unrelated recovery material.
+- Allowed the public GitHub download total to be refreshed manually and updated
+  the figures displayed by the website.
+- Added every 5.0.4 change to the What's New modal in all eight interface languages.
+
 ## 5.0.3 — 2026-08-26
 
 Nodus 5.0.3 turns Compass into a credential-free discovery engine, protects

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "5.0.3"
-date-released: "2026-08-26"
+version: "5.0.4"
+date-released: "2026-08-27"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://nodusresearch.com/"
-# Zenodo assigns the immutable v5.0.3 DOI after the GitHub release is archived.
+# Zenodo assigns the immutable v5.0.4 DOI after the GitHub release is archived.
 # Until then the concept DOI is 10.5281/zenodo.21515531 for Nodus over time.
 doi: "10.5281/zenodo.21515531"
 keywords:

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.0.3 is licensed exclusively under the GNU Affero General Public
+Nodus 5.0.4 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.0.3 release is available
+The preferred form for modifying the official Nodus 5.0.4 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.3
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.3
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.3.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.3.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.4
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.4
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.0.3 is free software distributed exclusively under the GNU Affero
+Nodus 5.0.4 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": {
     "name": "Jorge Pérez Burgueño",
@@ -13,7 +13,7 @@
     "url": "https://github.com/Drakonis96/nodus.git"
   },
   "releaseMetadata": {
-    "dateReleased": "2026-08-26",
+    "dateReleased": "2026-08-27",
     "conceptDoi": "10.5281/zenodo.21515531",
     "versionDoi": null
   },

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '5.0.3';
+const VERSION = '5.0.4';
 
 test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 5.0.3 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 5.0.4 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -74,7 +74,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '5.0.3');
+      assert.equal(info.version, '5.0.4');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -25,29 +25,33 @@ try {
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '5.0.3');
-  assert.equal(currentRelease?.date, '2026-08-26');
-  assert.equal(currentRelease?.highlights.length, 8);
+  assert.equal(currentRelease?.version, '5.0.4');
+  assert.equal(currentRelease?.date, '2026-08-27');
+  assert.equal(currentRelease?.highlights.length, 7);
   assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), [
-    'toolkit', 'toolkit', 'academic', 'academic', 'estudio', 'general', 'general', 'general',
+    'general', 'general', 'general', 'estudio', 'estudio', 'general', 'general',
   ]);
   for (const phrase of [
-    /no longer needs credentials/,
-    /distinguishes verified open files/,
-    /uses version 1 by default again/,
-    /never applied as the definition/,
-    /thirteen text transformations/,
-    /name of the vault/,
-    /distinct icons/,
-    /public website gains/,
+    /responsive web interface/,
+    /own AI providers/,
+    /enforces ownership and permissions/,
+    /fourth tab/,
+    /own result isolated/,
+    /two most recent verified snapshots/,
+    /download counter is current again/,
   ]) assert.ok(currentRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
 
-  // 5.0.2 keeps the six highlights it shipped with underneath 5.0.3.
+  // 5.0.3 keeps the eight highlights it shipped with underneath 5.0.4.
+  const previousPatch = RELEASE_NOTES.find((note) => note.version === '5.0.3');
+  assert.equal(previousPatch?.date, '2026-08-26');
+  assert.equal(previousPatch?.highlights.length, 8);
+
+  // 5.0.2 keeps the six highlights it shipped with underneath 5.0.4.
   const compassRelease = RELEASE_NOTES.find((note) => note.version === '5.0.2');
   assert.equal(compassRelease?.date, '2026-08-26');
   assert.equal(compassRelease?.highlights.length, 6);
 
-  // 5.0.1 keeps the seven repair highlights it shipped with underneath 5.0.3.
+  // 5.0.1 keeps the seven repair highlights it shipped with underneath 5.0.4.
   const previousPatchRelease = RELEASE_NOTES.find((note) => note.version === '5.0.1');
   assert.equal(previousPatchRelease?.date, '2026-08-25');
   assert.equal(previousPatchRelease?.highlights.length, 7);

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '5.0.3');
+  assert.equal(pluginManifest.version, '5.0.4');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,10 +54,10 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '5\.0\.3'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '5\.0\.4'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.0\.3\.tar\.gz/);
-  assert.match(citation, /^date-released: "2026-08-26"$/m);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.0\.4\.tar\.gz/);
+  assert.match(citation, /^date-released: "2026-08-27"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);
   }

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1257,9 +1257,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '5.0.3', 'the add-on shares the Nodus 5 release version');
+  assert.equal(manifest.version, '5.0.4', 'the add-on shares the Nodus 5 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.0\.3/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.0\.4/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.0.3 is licensed exclusively under the GNU Affero General Public
+Nodus 5.0.4 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.0.3 release is available
+The preferred form for modifying the official Nodus 5.0.4 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.3
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.3
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.3.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.3.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.4
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.4
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.0.3 is free software distributed exclusively under the GNU Affero
+Nodus 5.0.4 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '5.0.3';
+export const NODUS_VERSION = '5.0.4';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -155,6 +155,15 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "5.0.4": [
+    "Nodus Server introduce un’interfaccia web reattiva per lavorare dal telefono o da qualsiasi browser. Riproduce l’esperienza dell’applicazione e apre gli spazi di lavoro condivisi insieme a conversazioni, note, annotazioni e file personali visibili soltanto al proprietario.",
+    "Ogni account del server può configurare i propri fornitori, modelli e credenziali IA. Le chiavi vengono archiviate in forma cifrata e non tornano mai al browser, le attività e i risultati restano privati e le preferenze ti seguono tra i dispositivi senza compromettere la compatibilità con Desktop o con i depositi connessi.",
+    "Il server applica ora proprietà e autorizzazioni a ogni modifica, file e attività prima di accettare un’operazione. Rafforza inoltre l’accesso, impedisce ai segreti di apparire nei registri, nelle pubblicazioni o nei backup e aggiunge strumenti di backup verificato e ripristino per le installazioni Docker.",
+    "Word Copilot aggiunge una quarta scheda per gli stili di scrittura salvati nel tuo spazio. Scegli uno stile e un modello, trasforma il testo selezionato e controlla la proposta nel riquadro prima di copiarla o sostituire il passaggio originale.",
+    "Le quattro schede di Word occupano meno spazio e soltanto quella attiva espande il proprio nome. Riferimenti mantiene la larghezza compatta, ogni richiesta di scrittura conserva isolato il proprio risultato e il testo di Word non cambia finché non scegli l’azione di sostituzione.",
+    "Nodus conserva soltanto le due istantanee verificate più recenti create prima di migrare ogni deposito. La pulizia avviene in background e lascia intatti rapporti, file sconosciuti, coppie incomplete, backup e dati speciali di recupero, impedendo alle vecchie migrazioni di consumare spazio su disco senza limiti.",
+    "Il contatore pubblico dei download del sito è di nuovo aggiornato e ora può essere ricaricato manualmente quando serve. I totali visibili non dipendono più soltanto dall’esecuzione programmata.",
+  ],
   "5.0.3": [
     "Compass non richiede più credenziali per cercare. Interroga direttamente un catalogo molto più ampio di letteratura accademica e fonti primarie aperte, adatta ogni ricerca alla disciplina e combina i risultati con una classificazione più solida. L’interpretazione con IA resta facoltativa e disattivata per impostazione predefinita.",
     "Compass conserva ricerche e candidati, indica quale fornitore ha restituito ogni risultato e distingue i file aperti verificati dalle semplici pagine di riferimento. L’importazione controlla i duplicati, completa i metadati e può allegare i file disponibili, mentre la coda segnala limiti temporanei, lavoro parziale ed elementi ignorati.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -95,6 +95,15 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "5.0.4": [
+    "Nodus Server telefondan veya herhangi bir tarayıcıdan çalışmak için uyarlanabilir bir web arayüzü kazanıyor. Uygulama deneyimini yansıtıyor ve paylaşılan çalışma alanlarını yalnızca sahibinin görebildiği konuşmalar, notlar, açıklamalar ve kişisel dosyalarla birlikte açıyor.",
+    "Her sunucu hesabı kendi yapay zekâ sağlayıcılarını, modellerini ve kimlik bilgilerini yapılandırabilir. Anahtarlar şifreli saklanır ve tarayıcıya hiçbir zaman geri dönmez, işler ve sonuçlar özel kalır, tercihler ise Desktop ve bağlı kasalarla uyumluluğu bozmadan cihazlar arasında sizi izler.",
+    "Sunucu artık bir işlemi kabul etmeden önce her değişiklik, dosya ve iş için sahipliği ve izinleri uygular. Ayrıca oturum açmayı güçlendirir, gizli bilgileri günlüklerden, yayınlardan ve yedeklerden uzak tutar ve Docker kurulumları için doğrulanmış yedekleme ve geri yükleme araçları ekler.",
+    "Word Copilot, çalışma alanınızda kayıtlı yazma stilleri için dördüncü bir sekme ekliyor. Bir stil ve model seçin, seçili metni dönüştürün ve özgün parçayı kopyalamadan ya da değiştirmeden önce öneriyi panelde inceleyin.",
+    "Dört Word sekmesi daha az yer kaplıyor ve yalnızca etkin olan adını genişletiyor. Kaynaklar kompakt genişliğini koruyor, her yazma isteği kendi sonucunu ayrı tutuyor ve Word metni siz değiştirme eylemini seçene kadar değişmiyor.",
+    "Nodus her kasayı taşımadan önce oluşturduğu yalnızca en yeni iki doğrulanmış anlık görüntüyü saklıyor. Temizlik arka planda çalışıyor ve raporları, bilinmeyen dosyaları, eksik çiftleri, yedekleri ve özel kurtarma verilerini olduğu gibi bırakıyor. Böylece eski taşımalar disk alanını sınırsız tüketmiyor.",
+    "Web sitesindeki herkese açık indirme sayacı yeniden güncel ve gerektiğinde artık elle yenilenebiliyor. Görünen toplamlar yalnızca zamanlanmış çalışmaya bağlı kalmıyor.",
+  ],
   "5.0.3": [
     "Compass artık arama yapmak için kimlik bilgisi istemiyor. Çok daha geniş bir akademik yayın ve açık birincil kaynak kataloğunu doğrudan sorguluyor, her aramayı disipline uyarlıyor ve sonuçları daha güçlü bir sıralamayla birleştiriyor. Yapay zekâ ile yorumlama isteğe bağlı kalıyor ve varsayılan olarak kapalı geliyor.",
     "Compass aramaları ve adayları saklıyor, her sonucu hangi sağlayıcının getirdiğini açıklıyor ve doğrulanmış açık dosyaları basit başvuru sayfalarından ayırıyor. İçe aktarma yinelenenleri denetliyor, üstveriyi tamamlıyor ve mevcut dosyaları ekleyebiliyor. Kuyruk ise hız sınırlarını, kısmi çalışmayı ve atlanan öğeleri bildiriyor.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1763,6 +1763,77 @@ const RELEASE_4_2_5_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 /**
+ * 5.0.4 — every user-visible change merged after 5.0.3. Keep this list aligned
+ * by index with the Italian and Turkish tables so all eight interface languages
+ * receive the same release.
+ */
+const RELEASE_5_0_4_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'general',
+    es: 'Nodus Server estrena una interfaz web adaptable para trabajar desde el móvil o cualquier navegador. Reproduce el aspecto de la aplicación y abre los espacios de trabajo compartidos, junto con conversaciones, notas, anotaciones y archivos personales que solo ve su propietario.',
+    en: 'Nodus Server gains a responsive web interface for working from a phone or any browser. It mirrors the desktop experience and opens shared workspaces alongside conversations, notes, annotations, and personal files that only their owner can see.',
+    fr: 'Nodus Server inaugure une interface web adaptative pour travailler depuis un téléphone ou n’importe quel navigateur. Elle reprend l’expérience de l’application et ouvre les espaces de travail partagés avec des conversations, des notes, des annotations et des fichiers personnels que seul leur propriétaire peut voir.',
+    de: 'Nodus Server erhält eine responsive Weboberfläche für die Arbeit vom Smartphone oder jedem Browser aus. Sie übernimmt das Erscheinungsbild der Anwendung und öffnet geteilte Arbeitsbereiche zusammen mit Unterhaltungen, Notizen, Anmerkungen und persönlichen Dateien, die nur ihr Eigentümer sehen kann.',
+    pt: 'O Nodus Server estreia uma interface web adaptável para trabalhar a partir do telemóvel ou de qualquer navegador. Reproduz a experiência da aplicação e abre os espaços de trabalho partilhados, juntamente com conversas, notas, anotações e ficheiros pessoais que só o proprietário pode ver.',
+    'pt-BR': 'O Nodus Server ganha uma interface web responsiva para trabalhar pelo celular ou por qualquer navegador. Ela reproduz a experiência do aplicativo e abre os espaços de trabalho compartilhados, junto com conversas, notas, anotações e arquivos pessoais que só o proprietário pode ver.',
+  },
+  {
+    scope: 'general',
+    es: 'Cada cuenta del servidor puede configurar sus propios proveedores, modelos y credenciales de IA. Las claves se guardan cifradas y nunca vuelven al navegador, los trabajos y resultados permanecen privados y las preferencias te acompañan entre dispositivos sin romper la compatibilidad con Desktop ni con las bóvedas conectadas.',
+    en: 'Each server account can configure its own AI providers, models, and credentials. Keys are stored encrypted and never returned to the browser, jobs and results stay private, and preferences follow you across devices without breaking Desktop or Connected Vault compatibility.',
+    fr: 'Chaque compte du serveur peut configurer ses propres fournisseurs, modèles et identifiants d’IA. Les clés sont conservées sous forme chiffrée et ne reviennent jamais au navigateur, les tâches et leurs résultats restent privés et les préférences vous suivent entre les appareils sans rompre la compatibilité avec Desktop ni les coffres connectés.',
+    de: 'Jedes Serverkonto kann eigene KI-Anbieter, Modelle und Zugangsdaten einrichten. Schlüssel werden verschlüsselt gespeichert und nie an den Browser zurückgegeben, Aufträge und Ergebnisse bleiben privat und Einstellungen folgen Ihnen zwischen Geräten, ohne die Kompatibilität mit Desktop oder verbundenen Tresoren zu beeinträchtigen.',
+    pt: 'Cada conta do servidor pode configurar os seus próprios fornecedores, modelos e credenciais de IA. As chaves ficam cifradas e nunca regressam ao navegador, as tarefas e os resultados permanecem privados e as preferências acompanham-no entre dispositivos sem quebrar a compatibilidade com o Desktop nem com os cofres ligados.',
+    'pt-BR': 'Cada conta do servidor pode configurar seus próprios provedores, modelos e credenciais de IA. As chaves ficam criptografadas e nunca voltam ao navegador, os trabalhos e resultados permanecem privados e as preferências acompanham você entre dispositivos sem quebrar a compatibilidade com o Desktop nem com os cofres conectados.',
+  },
+  {
+    scope: 'general',
+    es: 'El servidor aplica ahora la propiedad y los permisos a cada cambio, archivo y tarea antes de aceptar una operación. También refuerza el inicio de sesión, evita que secretos aparezcan en registros, publicaciones o copias y añade copias de seguridad verificadas con restauración para las instalaciones Docker.',
+    en: 'The server now enforces ownership and permissions for every change, file, and job before accepting an operation. It also hardens sign-in, keeps secrets out of logs, publications, and backups, and adds verified backup and restore tooling for Docker installations.',
+    fr: 'Le serveur vérifie désormais la propriété et les autorisations de chaque modification, fichier et tâche avant d’accepter une opération. Il renforce aussi la connexion, empêche les secrets d’apparaître dans les journaux, les publications ou les sauvegardes et ajoute des outils de sauvegarde vérifiée et de restauration pour les installations Docker.',
+    de: 'Der Server prüft jetzt Eigentum und Berechtigungen für jede Änderung, Datei und Aufgabe, bevor er einen Vorgang annimmt. Außerdem schützt er die Anmeldung stärker, hält Geheimnisse aus Protokollen, Veröffentlichungen und Sicherungen fern und ergänzt geprüfte Sicherungs- und Wiederherstellungswerkzeuge für Docker-Installationen.',
+    pt: 'O servidor aplica agora a propriedade e as permissões a cada alteração, ficheiro e tarefa antes de aceitar uma operação. Também reforça o início de sessão, impede que segredos apareçam em registos, publicações ou cópias e acrescenta ferramentas de cópia verificada e restauro para instalações Docker.',
+    'pt-BR': 'O servidor agora aplica propriedade e permissões a cada alteração, arquivo e tarefa antes de aceitar uma operação. Ele também reforça o login, impede que segredos apareçam em registros, publicações ou backups e adiciona ferramentas de backup verificado e restauração para instalações Docker.',
+  },
+  {
+    scope: 'estudio',
+    es: 'Word Copilot añade una cuarta pestaña para los estilos de escritura guardados en tu espacio. Elige un estilo y un modelo, transforma el texto seleccionado y revisa la propuesta en el panel antes de copiarla o sustituir el fragmento original.',
+    en: 'Word Copilot adds a fourth tab for the writing styles saved in your workspace. Choose a style and model, transform the selected text, and review the proposal in the pane before copying it or replacing the original passage.',
+    fr: 'Word Copilot ajoute un quatrième onglet pour les styles d’écriture enregistrés dans votre espace. Choisissez un style et un modèle, transformez le texte sélectionné et relisez la proposition dans le volet avant de la copier ou de remplacer le passage original.',
+    de: 'Word Copilot ergänzt eine vierte Registerkarte für die in Ihrem Arbeitsbereich gespeicherten Schreibstile. Wählen Sie Stil und Modell, wandeln Sie den markierten Text um und prüfen Sie den Vorschlag im Bereich, bevor Sie ihn kopieren oder die ursprüngliche Passage ersetzen.',
+    pt: 'O Word Copilot acrescenta um quarto separador para os estilos de escrita guardados no seu espaço. Escolha um estilo e um modelo, transforme o texto selecionado e reveja a proposta no painel antes de a copiar ou substituir o excerto original.',
+    'pt-BR': 'O Word Copilot adiciona uma quarta aba para os estilos de escrita salvos no seu espaço. Escolha um estilo e um modelo, transforme o texto selecionado e revise a proposta no painel antes de copiá-la ou substituir o trecho original.',
+  },
+  {
+    scope: 'estudio',
+    es: 'Las cuatro pestañas de Word ocupan menos espacio y solo la activa despliega su nombre. Referencias conserva su anchura compacta, cada solicitud de escritura mantiene aislado su propio resultado y el texto de Word no cambia hasta que pulsas la acción de reemplazo.',
+    en: 'The four Word tabs use less space and only the active one expands its label. References keeps its compact width, each writing request keeps its own result isolated, and the Word text does not change until you choose the replace action.',
+    fr: 'Les quatre onglets de Word prennent moins de place et seul l’onglet actif déploie son nom. Références conserve sa largeur compacte, chaque demande d’écriture garde son propre résultat isolé et le texte de Word ne change que lorsque vous choisissez l’action de remplacement.',
+    de: 'Die vier Word-Registerkarten benötigen weniger Platz und nur die aktive blendet ihren Namen ein. Referenzen behält seine kompakte Breite, jede Schreibanfrage hält ihr eigenes Ergebnis getrennt und der Word-Text ändert sich erst, wenn Sie Ersetzen wählen.',
+    pt: 'Os quatro separadores do Word ocupam menos espaço e só o ativo mostra o nome completo. Referências conserva a largura compacta, cada pedido de escrita mantém o seu próprio resultado isolado e o texto do Word só muda quando escolhe a ação de substituição.',
+    'pt-BR': 'As quatro abas do Word ocupam menos espaço e só a ativa expande o nome. Referências mantém a largura compacta, cada solicitação de escrita preserva seu próprio resultado isolado e o texto do Word só muda quando você escolhe a ação de substituição.',
+  },
+  {
+    scope: 'general',
+    es: 'Nodus conserva solo las dos copias verificadas más recientes que crea antes de migrar cada bóveda. La limpieza se hace en segundo plano y deja intactos informes, archivos desconocidos, pares incompletos, backups y datos especiales de recuperación, evitando que las migraciones antiguas sigan ocupando disco sin límite.',
+    en: 'Nodus keeps only the two most recent verified snapshots it creates before migrating each vault. Cleanup runs in the background and leaves reports, unknown files, incomplete pairs, backups, and special recovery data untouched, preventing old migrations from consuming disk space without limit.',
+    fr: 'Nodus ne conserve que les deux instantanés vérifiés les plus récents créés avant la migration de chaque coffre. Le nettoyage s’exécute en arrière-plan et laisse intacts les rapports, les fichiers inconnus, les paires incomplètes, les sauvegardes et les données de récupération spéciales, afin que les anciennes migrations ne consomment plus le disque sans limite.',
+    de: 'Nodus bewahrt nur die zwei neuesten geprüften Schnappschüsse auf, die vor der Migration jedes Tresors angelegt werden. Die Bereinigung läuft im Hintergrund und lässt Berichte, unbekannte Dateien, unvollständige Paare, Sicherungen und besondere Wiederherstellungsdaten unberührt, damit alte Migrationen nicht unbegrenzt Speicherplatz belegen.',
+    pt: 'O Nodus conserva apenas as duas cópias verificadas mais recentes que cria antes de migrar cada cofre. A limpeza decorre em segundo plano e deixa intactos relatórios, ficheiros desconhecidos, pares incompletos, backups e dados especiais de recuperação, evitando que migrações antigas continuem a ocupar disco sem limite.',
+    'pt-BR': 'O Nodus mantém apenas os dois snapshots verificados mais recentes que cria antes de migrar cada cofre. A limpeza ocorre em segundo plano e deixa intactos relatórios, arquivos desconhecidos, pares incompletos, backups e dados especiais de recuperação, evitando que migrações antigas continuem ocupando disco sem limite.',
+  },
+  {
+    scope: 'general',
+    es: 'El contador público de descargas de la web vuelve a estar al día y su actualización puede lanzarse manualmente cuando haga falta. Así las cifras visibles no dependen únicamente de la ejecución programada.',
+    en: 'The public website download counter is current again and its refresh can now be started manually when needed. Visible totals no longer depend only on the scheduled run.',
+    fr: 'Le compteur public des téléchargements du site est de nouveau à jour et son actualisation peut désormais être lancée manuellement lorsque nécessaire. Les totaux visibles ne dépendent plus uniquement de l’exécution programmée.',
+    de: 'Der öffentliche Downloadzähler der Website ist wieder aktuell und kann bei Bedarf jetzt manuell aufgefrischt werden. Die sichtbaren Summen hängen nicht mehr nur vom geplanten Lauf ab.',
+    pt: 'O contador público de transferências do site está novamente atualizado e a sua atualização pode agora ser iniciada manualmente quando for necessário. Os totais visíveis deixam de depender apenas da execução programada.',
+    'pt-BR': 'O contador público de downloads do site está atualizado novamente e sua atualização agora pode ser iniciada manualmente quando necessário. Os totais visíveis não dependem mais apenas da execução programada.',
+  },
+];
+
+/**
  * 5.0.3 — every user-visible change merged after 5.0.2. Keep this list aligned
  * by index with the Italian and Turkish tables so all eight interface languages
  * receive the same release.
@@ -2055,6 +2126,11 @@ const RELEASE_5_0_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '5.0.4',
+    date: '2026-08-27',
+    highlights: RELEASE_5_0_4_HIGHLIGHTS,
+  },
   {
     version: '5.0.3',
     date: '2026-08-26',

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.0.3",
-      "datePublished": "2026-08-26",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.3",
+      "softwareVersion": "5.0.4",
+      "datePublished": "2026-08-27",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.4",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -103,7 +103,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.0.3"
+          "value": "v5.0.4"
         }
       ],
       "sameAs": [

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -87,9 +87,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.0.3",
-      "datePublished": "2026-08-26",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.3",
+      "softwareVersion": "5.0.4",
+      "datePublished": "2026-08-27",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.4",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -104,7 +104,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.0.3"
+          "value": "v5.0.4"
         }
       ],
       "sameAs": [
@@ -170,9 +170,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 <dl class="citation-meta reveal">
       <div><dt>Project</dt><dd>Nodus Research</dd></div>
       <div><dt>Software</dt><dd>Nodus</dd></div>
-      <div><dt>Version</dt><dd>5.0.3</dd></div>
-      <div><dt>Released</dt><dd>26 August 2026</dd></div>
-      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.3" target="_blank" rel="noopener">v5.0.3</a></dd></div>
+      <div><dt>Version</dt><dd>5.0.4</dd></div>
+      <div><dt>Released</dt><dd>27 August 2026</dd></div>
+      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.4" target="_blank" rel="noopener">v5.0.4</a></dd></div>
       <div><dt>Author</dt><dd><a href="https://orcid.org/0000-0002-1150-1930" target="_blank" rel="noopener">Jorge Pérez Burgueño · ORCID</a></dd></div>
       <div><dt>Licence</dt><dd><a href="https://spdx.org/licenses/AGPL-3.0-only.html" target="_blank" rel="noopener">AGPL-3.0-only</a></dd></div>
     </dl>
@@ -197,10 +197,10 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a class="doi-value" href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">10.5281/zenodo.21515531</a>
       </article>
       <article class="card lit doi-card reveal" style="--delay:80ms">
-        <span class="kicker">Nodus 5.0.3 · archive pending</span>
+        <span class="kicker">Nodus 5.0.4 · archive pending</span>
         <h3>Version DOI pending</h3>
-        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.0.3 release tag shown here.</p>
-        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.3" target="_blank" rel="noopener">v5.0.3</a>
+        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.0.4 release tag shown here.</p>
+        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.4" target="_blank" rel="noopener">v5.0.4</a>
       </article>
     </div>
 <!-- generated:citation-dois:end -->
@@ -218,7 +218,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- generated:citation-formats:start -->
 <div class="citation-block reveal">
       <h3>APA</h3>
-      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.0.3) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
+      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.0.4) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
     </div>
 
     <div class="citation-block reveal">
@@ -226,11 +226,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       <pre><code>@software{perez_burgueno_nodus_2026,
   author    = {Pérez Burgueño, Jorge and Nodus contributors},
   title     = {Nodus: Open-Source Research Workspace},
-  version   = {5.0.3},
+  version   = {5.0.4},
   year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.21515531},
-  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.0.3},
+  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.0.4},
   license   = {AGPL-3.0-only}
 }</code></pre>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -97,9 +97,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.0.3",
-      "datePublished": "2026-08-26",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.3",
+      "softwareVersion": "5.0.4",
+      "datePublished": "2026-08-27",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.4",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -114,7 +114,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.0.3"
+          "value": "v5.0.4"
         }
       ],
       "sameAs": [

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -30,7 +30,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/zotero-plugin/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/ai-research/</loc>

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
## Resumen

- añade al modal de novedades todos los cambios incorporados desde v5.0.3
- publica las siete novedades en español, inglés, francés, alemán, portugués, portugués de Brasil, italiano y turco
- sincroniza la versión 5.0.4 en Desktop, servidor, extensiones, documentación legal, cita y metadatos web
- documenta la release en el changelog y actualiza las pruebas de preparación

## Validación

- `npm test` — 2413 superadas, 0 fallidas, 1 omitida
- `npm run test:e2e`
- `npm run lint`
- `npm run build`
- `npm run citation:check`
- `npm run release:verify-source`
- `node scripts/verify-release-channel.mjs latest v5.0.4`
- `git diff --check`