### PR TITLE
Fix macOS packaging for Sharp 0.35

### DIFF
--- a/scripts/test-packaged-native-runtime.mjs
+++ b/scripts/test-packaged-native-runtime.mjs
@@ -10,6 +10,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const {
   assertArm64Binary,
   findIntelRuntimePaths,
+  findUniquePackagedBinary,
 } = require(path.join(repoRoot, 'scripts/verify-packaged-native-runtime.cjs'));
 
 test('packaged runtime audit detects Intel-only optional dependencies', () => {
@@ -26,6 +27,26 @@ test('packaged runtime audit requires an ARM64 slice', () => {
   assert.throws(
     () => assertArm64Binary('fixture', import.meta.filename, () => ['x86_64']),
     /is not ARM64/,
+  );
+});
+
+test('packaged runtime audit accepts versioned Sharp and libvips binary names', () => {
+  const readDirectory = () => [
+    'index.js',
+    'libvips-cpp.8.18.6.dylib',
+    'sharp-darwin-arm64-0.35.4.node',
+  ];
+  assert.equal(
+    findUniquePackagedBinary('Sharp', '/sharp/lib', /^sharp-darwin-arm64(?:-[0-9.]+)?\.node$/, readDirectory),
+    path.join('/sharp/lib', 'sharp-darwin-arm64-0.35.4.node'),
+  );
+  assert.equal(
+    findUniquePackagedBinary('libvips', '/libvips/lib', /^libvips-cpp\.[0-9.]+\.dylib$/, readDirectory),
+    path.join('/libvips/lib', 'libvips-cpp.8.18.6.dylib'),
+  );
+  assert.throws(
+    () => findUniquePackagedBinary('Sharp', '/sharp/lib', /^sharp-.*\.node$/, () => []),
+    /found 0/,
   );
 });
 

--- a/scripts/verify-packaged-native-runtime.cjs
+++ b/scripts/verify-packaged-native-runtime.cjs
@@ -1,16 +1,19 @@
 const { execFileSync } = require('node:child_process');
-const { existsSync } = require('node:fs');
+const { existsSync, readdirSync } = require('node:fs');
 const path = require('node:path');
 const asar = require('@electron/asar');
 
 const REQUIRED_ARM64_BINARIES = [
   ['Canvas', '@napi-rs/canvas-darwin-arm64/skia.darwin-arm64.node'],
-  ['Sharp', '@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node'],
-  ['libvips', '@img/sharp-libvips-darwin-arm64/lib/libvips-cpp.8.17.3.dylib'],
   ['Koffi', '@koromix/koffi-darwin-arm64/darwin_arm64/koffi.node'],
   ['Codex', '@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex'],
   ['Copilot', '@github/copilot-darwin-arm64/copilot'],
   ['Copilot native runtime', '@github/copilot-darwin-arm64/prebuilds/darwin-arm64/runtime.node'],
+];
+
+const REQUIRED_ARM64_BINARY_PATTERNS = [
+  ['Sharp', '@img/sharp-darwin-arm64/lib', /^sharp-darwin-arm64(?:-[0-9.]+)?\.node$/],
+  ['libvips', '@img/sharp-libvips-darwin-arm64/lib', /^libvips-cpp\.[0-9.]+\.dylib$/],
 ];
 
 const INTEL_PACKAGE_MARKERS = [
@@ -35,6 +38,22 @@ function assertArm64Binary(label, filename, architectureReader = getArchitecture
   }
 }
 
+function findUniquePackagedBinary(label, directory, pattern, directoryReader = readdirSync) {
+  let entries;
+  try {
+    entries = directoryReader(directory);
+  } catch {
+    throw new Error(`Missing packaged ARM64 ${label} directory: ${directory}`);
+  }
+  const matches = entries.filter((entry) => pattern.test(entry)).sort();
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one packaged ARM64 ${label} binary in ${directory}; found ${matches.length}`,
+    );
+  }
+  return path.join(directory, matches[0]);
+}
+
 function verifyPackagedNativeRuntime(appPath, options = {}) {
   const resourcesPath = path.join(appPath, 'Contents', 'Resources');
   const asarPath = path.join(resourcesPath, 'app.asar');
@@ -56,12 +75,23 @@ function verifyPackagedNativeRuntime(appPath, options = {}) {
   for (const [label, relativePath] of REQUIRED_ARM64_BINARIES) {
     assertArm64Binary(label, path.join(unpackedModules, relativePath), options.getArchitectures);
   }
+  for (const [label, relativeDirectory, pattern] of REQUIRED_ARM64_BINARY_PATTERNS) {
+    const filename = findUniquePackagedBinary(
+      label,
+      path.join(unpackedModules, relativeDirectory),
+      pattern,
+      options.readDirectory,
+    );
+    assertArm64Binary(label, filename, options.getArchitectures);
+  }
   console.log(`[native-runtime] Verified ARM64 Electron, Canvas, Sharp, Koffi, Codex and Copilot in ${appPath}`);
 }
 
 module.exports = {
   REQUIRED_ARM64_BINARIES,
+  REQUIRED_ARM64_BINARY_PATTERNS,
   assertArm64Binary,
+  findUniquePackagedBinary,
   findIntelRuntimePaths,
   verifyPackagedNativeRuntime,
 };


### PR DESCRIPTION
## Causa

Sharp 0.35 versiona los nombres de su binario nativo y de la biblioteca libvips. El auditor del paquete macOS buscaba todavía los nombres usados por Sharp 0.34, por lo que rechazaba un runtime ARM64 válido presente en el bundle.

## Corrección

- descubre de forma estricta un único binario ARM64 compatible con los nombres versionados y no versionados
- conserva la comprobación de arquitectura con `lipo`
- añade cobertura para Sharp 0.35.4 y libvips 8.18.6

## Validación

- `node --test scripts/test-packaged-native-runtime.mjs scripts/test-update-channels.mjs`
- `npm run lint`
- empaquetado completo local `latest` para macOS ARM64: app, auditoría nativa, firma ad-hoc, DMG, ZIP y blockmaps