### PR TITLE
Nodus Copilot for Word and LibreOffice: keep proposals, follow the selection, new pane design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 5.0.5 — 2026-08-27
+
+Nodus 5.0.5 refines the Word and LibreOffice copilot pane: it stops discarding
+generated proposals, keeps up with the selection on its own and adopts the
+visual language the Zotero sidebar already used.
+
+- Kept a generated proposal on screen until the next generation instead of
+  discarding it whenever the Word selection moved.
+- Made the prompts tab poll the Word selection while it is open, so selecting
+  text updates the pane without touching an unrelated control.
+- Froze the selected-text box while a proposal is generating, so moving the
+  cursor never looks like it redirected the running request.
+- Marked the prompts tab while a generation is running, which continues and is
+  delivered even from another tab.
+- Redesigned the task pane around the Nodus accent, rounded cards and pill
+  badges shared with the Zotero sidebar, in light and dark.
+- Fixed every tab of the strip in place, moved the search box below the tabs and
+  adopted the desktop Nodus mark.
+- Added the 5.0.5 change to the What's New modal in all eight interface languages.
+
 ## 5.0.4 — 2026-08-27
 
 Nodus 5.0.4 brings secure multi-user web parity to Nodus Server, extends Word

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "5.0.4"
+version: "5.0.5"
 date-released: "2026-08-27"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://nodusresearch.com/"
-# Zenodo assigns the immutable v5.0.4 DOI after the GitHub release is archived.
+# Zenodo assigns the immutable v5.0.5 DOI after the GitHub release is archived.
 # Until then the concept DOI is 10.5281/zenodo.21515531 for Nodus over time.
 doi: "10.5281/zenodo.21515531"
 keywords:

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.0.4 is licensed exclusively under the GNU Affero General Public
+Nodus 5.0.5 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.0.4 release is available
+The preferred form for modifying the official Nodus 5.0.5 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.4
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.4
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.5
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.5
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.5.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.5.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.0.4 is free software distributed exclusively under the GNU Affero
+Nodus 5.0.5 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": {
     "name": "Jorge Pérez Burgueño",

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '5.0.4';
+const VERSION = '5.0.5';
 
 test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 5.0.4 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 5.0.5 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-copilot-addin.mjs
+++ b/scripts/test-copilot-addin.mjs
@@ -74,12 +74,28 @@ try {
   assert.match(taskpaneHtml, />Analyze paragraph</);
   assert.doesNotMatch(taskpaneHtml, /Conectando|Buscar ideas|Analizar párrafo|Selección|Insertar en|Nota al pie|Pasajes/);
   assert.match(taskpaneJs, /table\[key\] !== undefined \? table\[key\] : STR\.en\[key\]/);
-  assert.match(taskpaneHtml, /<img class="mark" src="\/addin\/assets\/icon-32\.png"/, 'the pane must use the stylized Nodus mark');
+  // The pane wears the desktop app's own mark, inlined: its geometry is checked
+  // against src/assets/nodus-logo.svg so the two can never drift into two logos.
+  const desktopLogo = fs.readFileSync(path.join(repoRoot, 'src/assets/nodus-logo.svg'), 'utf8');
+  const markPath = (desktopLogo.match(/<path d="([^"]+)"/) || [])[1];
+  assert.equal(typeof markPath, 'string', 'the desktop logo must declare its mark path');
+  assert.match(taskpaneHtml, /<svg class="mark"/, 'the pane must use the stylized Nodus mark');
+  assert.ok(taskpaneHtml.includes(`d="${markPath}"`), 'the pane mark must be the desktop mark, stroke for stroke');
+  for (const node of desktopLogo.match(/<circle[^>]*\/>/g) || []) {
+    assert.ok(taskpaneHtml.includes(node.trim()), `the pane mark is missing a node of the desktop logo: ${node.trim()}`);
+  }
   assert.doesNotMatch(taskpaneHtml, /<div class="mark">N<\/div>/, 'a generic letter N must not be used as the brand');
+
+  // The tab strip stays above the search box: the tabs are the pane's spine and
+  // the search box only belongs to the section it filters.
+  assert.ok(
+    taskpaneHtml.indexOf('id="searchMode"') < taskpaneHtml.indexOf('id="searchControls"'),
+    'the tab strip must come before the search box',
+  );
   assert.match(taskpaneHtml, /data-mode="references"/);
   assert.match(taskpaneHtml, /data-mode="prompts"/);
   assert.equal((taskpaneHtml.match(/class="seg-icon"/g) || []).length, 4, 'every pane tab must have an icon');
-  for (const id of ['promptControls', 'promptStyle', 'promptModel', 'promptSelection', 'applyPrompt', 'promptOutput', 'copyPromptOutput', 'pastePromptOutput']) {
+  for (const id of ['promptControls', 'promptStyle', 'promptModel', 'promptSelection', 'applyPrompt', 'promptOutput', 'promptOutputStale', 'copyPromptOutput', 'pastePromptOutput']) {
     assert.match(taskpaneHtml, new RegExp(`id="${id}"`), `Prompt UI must contain ${id}`);
   }
   assert.equal((taskpaneHtml.match(/class="prompt-typing-dot"/g) || []).length, 3, 'prompt generation must use the Nodi-style three-dot indicator');
@@ -109,9 +125,89 @@ try {
   assert.match(taskpaneJs, /\\uFFFD\\u25A1\\u2610\\u2612/);
   assert.match(taskpaneJs, /\/api\/prompts\/apply/);
   assert.match(taskpaneJs, /insertAtCursor\(promptOutputText, \{ replace: true \}\)/, 'pasting a proposal replaces the unchanged Word selection');
-  assert.match(taskpaneCss, /\.seg-label\s*\{[^}]*display:\s*none/);
-  assert.match(taskpaneCss, /\.seg:not\(\.active\) \.seg-label\s*\{[^}]*display:\s*none !important;[^}]*inline-size:\s*0/);
-  assert.match(taskpaneCss, /\.seg\.active \.seg-label\s*\{[^}]*display:\s*inline-block/);
+
+  // A proposal costs tokens, so moving the Word selection must never discard
+  // it: only the next generation (or pasting it) clears the box. While the
+  // selection differs from the one that produced it, the proposal stays on
+  // screen but cannot be pasted over the wrong text.
+  assert.doesNotMatch(
+    taskpaneJs,
+    /if \(text !== promptSourceText\) clearPromptOutput\(\);/,
+    'changing the Word selection must not discard a generated proposal',
+  );
+  assert.match(
+    taskpaneJs,
+    /normalizedSelection\(current\) !== promptOutputSourceText/,
+    'pasting must compare against the selection the proposal was generated from',
+  );
+  assert.match(
+    taskpaneJs,
+    /var stale = !!promptOutputText && promptSourceText !== promptOutputSourceText;[\s\S]*els\.pastePromptOutput\.disabled = !promptOutputText \|\| stale;/,
+    'a proposal from another selection must stay visible with pasting disabled',
+  );
+
+  // Moving the Word selection while a proposal is generating must not look
+  // like it redirected the generation: the box keeps showing the text that was
+  // sent and only goes live again once the generation settles.
+  assert.match(
+    taskpaneJs,
+    /if \(!promptGenerating && \(changed \|\| !promptSelectionPainted\)\) paintPromptSelection\(text\);/,
+    'the selection box must freeze while a proposal is generating',
+  );
+  assert.match(
+    taskpaneJs,
+    /var settled = promptGenerating && !generating;[\s\S]*if \(settled\) paintPromptSelection\(promptSourceText\);/,
+    'the selection box must go live again when the generation settles',
+  );
+
+  // A generation survives leaving its tab, so the tab has to say so.
+  assert.match(
+    taskpaneJs,
+    /els\.promptTab\.classList\.toggle\('is-busy', generating\)/,
+    'the prompts tab must be marked while a proposal is generating',
+  );
+  assert.match(taskpaneCss, /\.seg\.is-busy::after \{/, 'the busy tab needs its marker');
+  assert.match(taskpaneCss, /\.prompt-stale\[hidden\] \{ display: none; \}/);
+
+  // The pane and the Zotero sidebar are one product: they must not drift into
+  // two different accents. Both read their violet from their own stylesheet.
+  const zoteroCss = fs.readFileSync(path.join(repoRoot, 'zotero-plugin/content/sidebar.css'), 'utf8');
+  const zoteroAccent = (zoteroCss.match(/--nd-accent:\s*(#[0-9a-f]{6})/i) || [])[1];
+  assert.equal(typeof zoteroAccent, 'string', 'the Zotero sidebar must declare its accent');
+  assert.match(
+    taskpaneCss,
+    new RegExp(`--primary: ${zoteroAccent}`, 'i'),
+    'the Word pane must use the same accent as the Zotero sidebar',
+  );
+
+  // An explicit display on a class beats the UA [hidden] rule, which is why the
+  // search box used to stay on screen in the prompts tab.
+  assert.match(
+    taskpaneCss,
+    /\[hidden\] \{ display: none !important; \}/,
+    'panels the script hides must actually disappear',
+  );
+
+  // Word does not raise DocumentSelectionChanged for every way of selecting
+  // text, so the open prompts tab polls the selection instead of waiting for
+  // an unrelated control to force a refresh.
+  assert.match(
+    taskpaneJs,
+    /function startPromptSelectionPolling\(\)[\s\S]*setInterval\([\s\S]*refreshPromptSelection\(\)/,
+    'the prompts tab must poll the Word selection',
+  );
+  assert.match(
+    taskpaneJs,
+    /if \(promptMode\) \{[\s\S]*startPromptSelectionPolling\(\);[\s\S]*\}\s*\n\s*stopPromptSelectionPolling\(\);/,
+    'the selection poll must stop when the prompts tab is left',
+  );
+  // The tab strip must not reflow when the selection moves: every tab owns an
+  // equal slot and the active one may not grow into its neighbours' space.
+  assert.match(taskpaneCss, /\.seg \{[^}]*flex: 1 1 0;/, 'every tab must take an equal slot');
+  const segActiveRule = (taskpaneCss.match(/\.seg\.active \{([^}]*)\}/) || [])[1] || '';
+  assert.doesNotMatch(segActiveRule, /flex:/, 'the active tab must not resize its slot');
+  assert.match(taskpaneCss, /\.seg-label \{[^}]*display: block;/, 'every tab keeps its label, not just the active one');
+  assert.match(taskpaneCss, /@media \(max-width: 310px\)[\s\S]*\.seg-label \{ display: none; \}/, 'a very narrow pane falls back to icons');
   assert.match(taskpaneCss, /\.results\[hidden\]\s*\{[^}]*display:\s*none !important/, 'search results must stay hidden in prompt mode');
   assert.match(taskpaneCss, /\.empty\[hidden\]\s*\{[^}]*display:\s*none !important/, 'empty search messages must stay hidden in prompt mode');
   assert.match(taskpaneCss, /@keyframes prompt-typing-dot/, 'the prompt loading dots must animate');

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -74,7 +74,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '5.0.4');
+      assert.equal(info.version, '5.0.5');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -24,11 +24,19 @@ try {
   );
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
+  // 5.0.5 ships a single highlight: from the outside, the copilot work is one thing.
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '5.0.4');
+  assert.equal(currentRelease?.version, '5.0.5');
   assert.equal(currentRelease?.date, '2026-08-27');
-  assert.equal(currentRelease?.highlights.length, 7);
-  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), [
+  assert.equal(currentRelease?.highlights.length, 1);
+  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['plugin']);
+  assert.match(currentRelease?.highlights[0]?.en ?? '', /Nodus Copilot for Word and LibreOffice/);
+
+  // 5.0.4 keeps the seven highlights it shipped with underneath 5.0.5.
+  const serverWebRelease = RELEASE_NOTES.find((note) => note.version === '5.0.4');
+  assert.equal(serverWebRelease?.date, '2026-08-27');
+  assert.equal(serverWebRelease?.highlights.length, 7);
+  assert.deepEqual(serverWebRelease?.highlights.map((highlight) => highlight.scope), [
     'general', 'general', 'general', 'estudio', 'estudio', 'general', 'general',
   ]);
   for (const phrase of [
@@ -39,9 +47,9 @@ try {
     /own result isolated/,
     /two most recent verified snapshots/,
     /download counter is current again/,
-  ]) assert.ok(currentRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
+  ]) assert.ok(serverWebRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
 
-  // 5.0.3 keeps the eight highlights it shipped with underneath 5.0.4.
+  // 5.0.3 keeps the eight highlights it shipped with underneath 5.0.5.
   const previousPatch = RELEASE_NOTES.find((note) => note.version === '5.0.3');
   assert.equal(previousPatch?.date, '2026-08-26');
   assert.equal(previousPatch?.highlights.length, 8);

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '5.0.4');
+  assert.equal(pluginManifest.version, '5.0.5');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,9 +54,9 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '5\.0\.4'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '5\.0\.5'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.0\.4\.tar\.gz/);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.0\.5\.tar\.gz/);
   assert.match(citation, /^date-released: "2026-08-27"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1257,9 +1257,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '5.0.4', 'the add-on shares the Nodus 5 release version');
+  assert.equal(manifest.version, '5.0.5', 'the add-on shares the Nodus 5 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.0\.4/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.0\.5/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.0.4 is licensed exclusively under the GNU Affero General Public
+Nodus 5.0.5 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.0.4 release is available
+The preferred form for modifying the official Nodus 5.0.5 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.4
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.4
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.4.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.0.5
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.0.5
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.5.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.0.5.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.0.4 is free software distributed exclusively under the GNU Affero
+Nodus 5.0.5 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '5.0.4';
+export const NODUS_VERSION = '5.0.5';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -155,6 +155,9 @@ const RELEASE_3_2_4_IT: string[] = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "5.0.5": [
+    "Miglioramenti generali in Nodus Copilot per Word e LibreOffice. Il riquadro conserva la proposta generata, segue la tua selezione da solo e adotta l’aspetto di Nodus.",
+  ],
   "5.0.4": [
     "Nodus Server introduce un’interfaccia web reattiva per lavorare dal telefono o da qualsiasi browser. Riproduce l’esperienza dell’applicazione e apre gli spazi di lavoro condivisi insieme a conversazioni, note, annotazioni e file personali visibili soltanto al proprietario.",
     "Ogni account del server può configurare i propri fornitori, modelli e credenziali IA. Le chiavi vengono archiviate in forma cifrata e non tornano mai al browser, le attività e i risultati restano privati e le preferenze ti seguono tra i dispositivi senza compromettere la compatibilità con Desktop o con i depositi connessi.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -95,6 +95,9 @@ const RELEASE_3_2_4_TR: string[] = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "5.0.5": [
+    "Word ve LibreOffice için Nodus Copilot'ta genel iyileştirmeler. Panel ürettiği öneriyi saklıyor, seçiminizi kendiliğinden izliyor ve Nodus'un görünümünü benimsiyor.",
+  ],
   "5.0.4": [
     "Nodus Server telefondan veya herhangi bir tarayıcıdan çalışmak için uyarlanabilir bir web arayüzü kazanıyor. Uygulama deneyimini yansıtıyor ve paylaşılan çalışma alanlarını yalnızca sahibinin görebildiği konuşmalar, notlar, açıklamalar ve kişisel dosyalarla birlikte açıyor.",
     "Her sunucu hesabı kendi yapay zekâ sağlayıcılarını, modellerini ve kimlik bilgilerini yapılandırabilir. Anahtarlar şifreli saklanır ve tarayıcıya hiçbir zaman geri dönmez, işler ve sonuçlar özel kalır, tercihler ise Desktop ve bağlı kasalarla uyumluluğu bozmadan cihazlar arasında sizi izler.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1763,6 +1763,25 @@ const RELEASE_4_2_5_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 /**
+ * v5.0.5 — the Word and LibreOffice copilot, tidied.
+ *
+ * One highlight, because from the outside this is one thing: the pane keeps the
+ * proposals you paid for, follows the selection without being nudged, and now
+ * looks like the rest of Nodus.
+ */
+const RELEASE_5_0_5_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'plugin',
+    es: 'Mejoras generales en Nodus Copilot para Word y LibreOffice. El panel conserva la propuesta que ha generado, sigue tu selección por su cuenta y estrena el aspecto de Nodus.',
+    en: 'General improvements to Nodus Copilot for Word and LibreOffice. The pane keeps the proposal it generated, follows your selection on its own and adopts the Nodus look.',
+    fr: 'Améliorations générales de Nodus Copilot pour Word et LibreOffice. Le volet conserve la proposition générée, suit votre sélection de lui-même et adopte l’apparence de Nodus.',
+    de: 'Allgemeine Verbesserungen an Nodus Copilot für Word und LibreOffice. Der Bereich behält den erzeugten Vorschlag, folgt Ihrer Auswahl von selbst und übernimmt das Erscheinungsbild von Nodus.',
+    pt: 'Melhorias gerais no Nodus Copilot para o Word e o LibreOffice. O painel mantém a proposta que gerou, acompanha a sua seleção sozinho e adota o aspeto do Nodus.',
+    'pt-BR': 'Melhorias gerais no Nodus Copilot para Word e LibreOffice. O painel mantém a proposta que gerou, acompanha sua seleção sozinho e adota a aparência do Nodus.',
+  },
+];
+
+/**
  * 5.0.4 — every user-visible change merged after 5.0.3. Keep this list aligned
  * by index with the Italian and Turkish tables so all eight interface languages
  * receive the same release.
@@ -2126,6 +2145,11 @@ const RELEASE_5_0_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '5.0.5',
+    date: '2026-08-27',
+    highlights: RELEASE_5_0_5_HIGHLIGHTS,
+  },
   {
     version: '5.0.4',
     date: '2026-08-27',

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.0.4",
+      "softwareVersion": "5.0.5",
       "datePublished": "2026-08-27",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.4",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.5",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -103,7 +103,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.0.4"
+          "value": "v5.0.5"
         }
       ],
       "sameAs": [

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -87,9 +87,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.0.4",
+      "softwareVersion": "5.0.5",
       "datePublished": "2026-08-27",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.4",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.5",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -104,7 +104,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.0.4"
+          "value": "v5.0.5"
         }
       ],
       "sameAs": [
@@ -170,9 +170,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 <dl class="citation-meta reveal">
       <div><dt>Project</dt><dd>Nodus Research</dd></div>
       <div><dt>Software</dt><dd>Nodus</dd></div>
-      <div><dt>Version</dt><dd>5.0.4</dd></div>
+      <div><dt>Version</dt><dd>5.0.5</dd></div>
       <div><dt>Released</dt><dd>27 August 2026</dd></div>
-      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.4" target="_blank" rel="noopener">v5.0.4</a></dd></div>
+      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.5" target="_blank" rel="noopener">v5.0.5</a></dd></div>
       <div><dt>Author</dt><dd><a href="https://orcid.org/0000-0002-1150-1930" target="_blank" rel="noopener">Jorge Pérez Burgueño · ORCID</a></dd></div>
       <div><dt>Licence</dt><dd><a href="https://spdx.org/licenses/AGPL-3.0-only.html" target="_blank" rel="noopener">AGPL-3.0-only</a></dd></div>
     </dl>
@@ -197,10 +197,10 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a class="doi-value" href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">10.5281/zenodo.21515531</a>
       </article>
       <article class="card lit doi-card reveal" style="--delay:80ms">
-        <span class="kicker">Nodus 5.0.4 · archive pending</span>
+        <span class="kicker">Nodus 5.0.5 · archive pending</span>
         <h3>Version DOI pending</h3>
-        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.0.4 release tag shown here.</p>
-        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.4" target="_blank" rel="noopener">v5.0.4</a>
+        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.0.5 release tag shown here.</p>
+        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.0.5" target="_blank" rel="noopener">v5.0.5</a>
       </article>
     </div>
 <!-- generated:citation-dois:end -->
@@ -218,7 +218,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- generated:citation-formats:start -->
 <div class="citation-block reveal">
       <h3>APA</h3>
-      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.0.4) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
+      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.0.5) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
     </div>
 
     <div class="citation-block reveal">
@@ -226,11 +226,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       <pre><code>@software{perez_burgueno_nodus_2026,
   author    = {Pérez Burgueño, Jorge and Nodus contributors},
   title     = {Nodus: Open-Source Research Workspace},
-  version   = {5.0.4},
+  version   = {5.0.5},
   year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.21515531},
-  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.0.4},
+  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.0.5},
   license   = {AGPL-3.0-only}
 }</code></pre>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -97,9 +97,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.0.4",
+      "softwareVersion": "5.0.5",
       "datePublished": "2026-08-27",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.4",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.0.5",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -114,7 +114,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.0.4"
+          "value": "v5.0.5"
         }
       ],
       "sameAs": [

--- a/word-addin/taskpane.css
+++ b/word-addin/taskpane.css
@@ -1,37 +1,55 @@
+/* Nodus Copilot task pane.
+   The visual language deliberately mirrors the Nodus Zotero sidebar: violet
+   accent, soft tinted surfaces, pill badges and rounded cards, so both
+   integrations feel like the same product. */
+
 :root {
   color-scheme: light;
   --bg: #ffffff;
   --panel: #ffffff;
-  --surface: #f6f6f6;
-  --border: #d5d5d5;
-  --text: #1f1f1f;
-  --control-text: #1f1f1f;
-  --muted: #646464;
-  --primary: #4f46e5;
+  --surface: #f6f5fb;
+  --border: #e5e3ef;
+  --border-strong: #d2cfe1;
+  --text: #1f2430;
+  --control-text: #1f2430;
+  --muted: #6b7280;
+  --primary: #7c3aed;
+  --primary-strong: #6d28d9;
+  --primary-soft: rgba(124, 58, 237, 0.10);
+  --primary-line: rgba(124, 58, 237, 0.28);
   --primary-text: #ffffff;
-  --green: #168a46;
-  --red: #c4362e;
-  --amber: #a15c00;
-  --cyan: #007c89;
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  --green: #059669;
+  --red: #dc2626;
+  --amber: #b45309;
+  --cyan: #0e7490;
+  --shadow: 0 1px 2px rgba(20, 14, 46, 0.06);
+  --shadow-md: 0 6px 18px rgba(20, 14, 46, 0.10);
+  --shadow-lg: 0 14px 34px rgba(20, 14, 46, 0.20);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #1f1f1f;
+    color-scheme: dark;
+    --bg: #1c1c22;
     --panel: #2b2b2b;
-    --surface: #242424;
-    --border: #454545;
-    --text: #f3f3f3;
-    --control-text: #f3f3f3;
-    --muted: #b8b8b8;
-    --primary: #7c83ff;
-    --primary-text: #ffffff;
-    --green: #4bd27b;
-    --red: #ff766d;
-    --amber: #ffbf5b;
-    --cyan: #55d6e1;
-    --shadow: none;
+    --surface: #26262e;
+    --border: #3d3d47;
+    --border-strong: #4d4d59;
+    --text: #e7e6ee;
+    --control-text: #e7e6ee;
+    --muted: #9aa0ac;
+    --primary: #a78bfa;
+    --primary-strong: #8b5cf6;
+    --primary-soft: rgba(167, 139, 250, 0.16);
+    --primary-line: rgba(167, 139, 250, 0.34);
+    --primary-text: #1b1726;
+    --green: #34d399;
+    --red: #f87171;
+    --amber: #fbbf24;
+    --cyan: #22d3ee;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.30);
+    --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.38);
+    --shadow-lg: 0 14px 34px rgba(0, 0, 0, 0.50);
   }
 }
 
@@ -41,51 +59,83 @@ body.light {
   color-scheme: light;
   --bg: #ffffff;
   --panel: #ffffff;
-  --surface: #f6f6f6;
-  --border: #d5d5d5;
-  --text: #1f1f1f;
-  --control-text: #1f1f1f;
-  --muted: #646464;
-  --primary: #4f46e5;
+  --surface: #f6f5fb;
+  --border: #e5e3ef;
+  --border-strong: #d2cfe1;
+  --text: #1f2430;
+  --control-text: #1f2430;
+  --muted: #6b7280;
+  --primary: #7c3aed;
+  --primary-strong: #6d28d9;
+  --primary-soft: rgba(124, 58, 237, 0.10);
+  --primary-line: rgba(124, 58, 237, 0.28);
   --primary-text: #ffffff;
-  --green: #168a46;
-  --red: #c4362e;
-  --amber: #a15c00;
-  --cyan: #007c89;
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  --green: #059669;
+  --red: #dc2626;
+  --amber: #b45309;
+  --cyan: #0e7490;
+  --shadow: 0 1px 2px rgba(20, 14, 46, 0.06);
+  --shadow-md: 0 6px 18px rgba(20, 14, 46, 0.10);
+  --shadow-lg: 0 14px 34px rgba(20, 14, 46, 0.20);
 }
 
 body.dark {
   color-scheme: dark;
-  --bg: #1f1f1f;
+  --bg: #1c1c22;
   --panel: #2b2b2b;
-  --surface: #242424;
-  --border: #4a4a4a;
-  --text: #f3f3f3;
-  --control-text: #f3f3f3;
-  --muted: #b8b8b8;
-  --primary: #7c83ff;
-  --primary-text: #ffffff;
-  --green: #4bd27b;
-  --red: #ff766d;
-  --amber: #ffbf5b;
-  --cyan: #55d6e1;
-  --shadow: none;
+  --surface: #26262e;
+  --border: #3d3d47;
+  --border-strong: #4d4d59;
+  --text: #e7e6ee;
+  --control-text: #e7e6ee;
+  --muted: #9aa0ac;
+  --primary: #a78bfa;
+  --primary-strong: #8b5cf6;
+  --primary-soft: rgba(167, 139, 250, 0.16);
+  --primary-line: rgba(167, 139, 250, 0.34);
+  --primary-text: #1b1726;
+  --green: #34d399;
+  --red: #f87171;
+  --amber: #fbbf24;
+  --cyan: #22d3ee;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.30);
+  --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.38);
+  --shadow-lg: 0 14px 34px rgba(0, 0, 0, 0.50);
 }
 
 * { box-sizing: border-box; }
+
+/* An explicit display on a class (grid/flex) beats the UA [hidden] rule, so
+   panels the script hides would leak — the search box used to stay on screen in
+   the prompts tab for exactly this reason. Force it. */
+[hidden] { display: none !important; }
 
 body {
   margin: 0;
   font-family: -apple-system, "Segoe UI", system-ui, sans-serif;
   font-size: 13px;
+  line-height: 1.45;
   color: var(--text);
   background: var(--bg);
+  -webkit-font-smoothing: antialiased;
 }
 
 main {
   min-height: calc(100vh - 56px);
   background: var(--bg);
+}
+
+/* Slim scrollbars everywhere, so inner panels do not look like 2003. */
+* { scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; border: 2px solid transparent; background-clip: content-box; }
+::-webkit-scrollbar-thumb:hover { background: var(--muted); background-clip: content-box; }
+
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--primary-line);
+  border-radius: 8px;
 }
 
 .head {
@@ -101,25 +151,47 @@ main {
   background: var(--bg);
 }
 
+/* The mark is the desktop app's own logo, inlined: it carries its gradient and
+   its drop shadow, so it needs no tile or box-shadow of its own. */
 .mark {
   width: 28px;
   height: 28px;
-  border-radius: 7px;
-  object-fit: contain;
   flex: 0 0 auto;
+  overflow: visible;
 }
 
-.title { font-weight: 650; line-height: 1.15; }
+.title { font-weight: 700; font-size: 14px; line-height: 1.15; letter-spacing: -0.01em; }
 .caption { font-size: 11px; color: var(--muted); margin-top: 1px; }
-.status { margin-left: auto; font-size: 11px; color: var(--muted); text-align: right; max-width: 118px; }
-.status.ok { color: var(--green); }
-.status.err { color: var(--red); }
+
+.status {
+  margin-left: auto;
+  max-width: 128px;
+  padding: 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 10.5px;
+  line-height: 1.3;
+  text-align: center;
+  transition: color .18s ease, background-color .18s ease, border-color .18s ease;
+}
+.status.ok {
+  color: var(--green);
+  background: color-mix(in srgb, var(--green) 12%, transparent);
+  border-color: color-mix(in srgb, var(--green) 32%, transparent);
+}
+.status.err {
+  color: var(--red);
+  background: color-mix(in srgb, var(--red) 12%, transparent);
+  border-color: color-mix(in srgb, var(--red) 32%, transparent);
+}
 
 .controls {
   padding: 10px 12px 8px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 9px;
 }
 
 .search {
@@ -134,12 +206,19 @@ main {
   border: 1px solid var(--border);
   background: var(--panel);
   color: var(--control-text);
-  border-radius: 6px;
-  padding: 7px 9px;
+  border-radius: 9px;
+  padding: 8px 10px;
   font: inherit;
+  transition: border-color .16s ease, box-shadow .16s ease;
 }
 
 .search input::placeholder { color: var(--muted); }
+.search input:focus,
+.search input:focus-visible {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
+}
 
 .toolbar {
   display: flex;
@@ -156,32 +235,76 @@ main {
   white-space: nowrap;
 }
 
+input[type="checkbox"],
+input[type="radio"] { accent-color: var(--primary); }
+
 .btn {
   border: 1px solid var(--border);
   background: var(--panel);
   color: var(--control-text);
-  border-radius: 6px;
-  padding: 6px 9px;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font: inherit;
   font-size: 12px;
   line-height: 1.2;
+  font-weight: 550;
   cursor: pointer;
   min-height: 30px;
+  transition: background-color .16s ease, border-color .16s ease, color .16s ease,
+    box-shadow .16s ease, transform .08s ease;
 }
 
-.btn:hover { filter: brightness(0.97); }
-.dark .btn:hover { filter: brightness(1.08); }
-.btn.primary { background: var(--primary); border-color: var(--primary); color: var(--primary-text); }
+.btn:hover {
+  border-color: var(--primary-line);
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+.btn:active { transform: translateY(1px); }
+.btn.primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-text);
+  box-shadow: 0 2px 10px var(--primary-line);
+}
+.btn.primary:hover {
+  background: var(--primary-strong);
+  border-color: var(--primary-strong);
+  color: var(--primary-text);
+}
 .btn.danger { color: var(--red); }
-.btn:disabled { opacity: 0.56; cursor: default; }
-.btn.small { padding: 5px 7px; font-size: 11px; min-height: 26px; }
-.btn.tiny { padding: 3px 7px; font-size: 11px; min-height: 22px; }
-.btn.icon { padding: 0; font-size: 19px; font-weight: 600; }
+.btn.danger:hover {
+  color: var(--red);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent);
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+.btn:disabled:hover {
+  background: var(--panel);
+  border-color: var(--border);
+  color: var(--control-text);
+}
+.btn.primary:disabled:hover { background: var(--primary); border-color: var(--primary); color: var(--primary-text); }
+.btn.small { padding: 5px 9px; font-size: 11px; min-height: 26px; }
+.btn.tiny { padding: 3px 8px; font-size: 11px; min-height: 22px; border-radius: 7px; }
+.btn.icon { padding: 0; font-size: 17px; font-weight: 600; }
+.search .btn.icon {
+  border-color: transparent;
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+.search .btn.icon:hover { background: var(--primary-line); }
 
 .paragraph {
   margin: 0 12px 8px;
-  padding: 8px 10px;
-  border: 1px dashed var(--border);
-  border-radius: 6px;
+  padding: 8px 11px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--primary-line);
+  border-radius: 4px 10px 10px 4px;
   color: var(--muted);
   font-size: 12px;
   max-height: 86px;
@@ -202,7 +325,7 @@ main {
 .reference-controls {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 9px;
 }
 
 .reference-controls[hidden] { display: none; }
@@ -210,25 +333,38 @@ main {
 .reference-preferences {
   display: grid;
   grid-template-columns: minmax(0, 1.4fr) minmax(82px, .8fr);
-  gap: 6px;
+  gap: 7px;
 }
 
 .reference-preferences > label:last-child { grid-column: 1 / -1; }
 .reference-preferences label { min-width: 0; color: var(--muted); font-size: 10px; }
 .reference-preferences > label > span,
-.reference-style-head > label > span { display: block; margin: 0 0 3px 2px; }
+.reference-style-head > label > span {
+  display: block;
+  margin: 0 0 4px 2px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
 .reference-preferences select,
 .reference-preferences input[type="search"] {
   width: 100%;
   min-width: 0;
-  min-height: 30px;
+  min-height: 32px;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 5px 7px;
+  border-radius: 8px;
+  padding: 6px 8px;
   background: var(--panel);
   color: var(--control-text);
   font: inherit;
   font-size: 11px;
+  transition: border-color .16s ease, box-shadow .16s ease;
+}
+.reference-preferences select:focus,
+.reference-preferences input[type="search"]:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
 }
 .reference-preferences select option { background: var(--panel); color: var(--control-text); }
 
@@ -238,43 +374,47 @@ main {
 .reference-style-picker { position: relative; }
 .reference-style-picker input[type="search"] {
   margin: 0;
-  padding-right: 30px;
+  padding-right: 32px;
 }
 .reference-style-toggle {
   position: absolute;
   right: 1px;
   top: 1px;
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   border: 0;
-  border-left: 1px solid var(--border);
-  border-radius: 0 5px 5px 0;
-  background: var(--panel);
+  border-radius: 0 8px 8px 0;
+  background: transparent;
   color: var(--muted);
   cursor: pointer;
+  transition: color .16s ease;
 }
+.reference-style-toggle:hover { color: var(--primary); }
 .reference-style-toggle span {
+  display: block;
   width: 7px;
   height: 7px;
   margin: -3px auto 0;
   border-right: 1.5px solid currentColor;
   border-bottom: 1.5px solid currentColor;
   transform: rotate(45deg);
+  transition: transform .18s ease, margin-top .18s ease;
 }
 .reference-style-picker.open .reference-style-toggle span { margin-top: 3px; transform: rotate(225deg); }
 .reference-style-options {
   position: absolute;
   z-index: 8;
-  top: calc(100% + 4px);
+  top: calc(100% + 5px);
   left: 0;
   right: 0;
   max-height: 208px;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 7px;
-  padding: 3px;
+  border-radius: 10px;
+  padding: 4px;
   background: var(--panel);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, .24);
+  box-shadow: var(--shadow-lg);
+  animation: pop-in .14s ease;
 }
 .reference-style-options[hidden] { display: none; }
 .reference-style-option {
@@ -283,17 +423,18 @@ main {
   gap: 7px;
   width: 100%;
   border: 0;
-  border-radius: 5px;
-  padding: 7px 8px;
+  border-radius: 7px;
+  padding: 7px 9px;
   background: transparent;
   color: var(--control-text);
   font: inherit;
   font-size: 11px;
   text-align: left;
   cursor: pointer;
+  transition: background-color .12s ease, color .12s ease;
 }
 .reference-style-option:hover,
-.reference-style-option.active { background: var(--surface); }
+.reference-style-option.active { background: var(--primary-soft); color: var(--primary); }
 .reference-style-option[aria-selected="true"] { color: var(--primary); font-weight: 650; }
 .reference-style-option-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .reference-style-option-meta { color: var(--muted); font-size: 9px; }
@@ -308,13 +449,16 @@ main {
   color: var(--primary);
   font: inherit;
   font-size: 9px;
+  font-weight: 600;
   line-height: 1.4;
   white-space: nowrap;
   text-align: left;
   text-decoration: underline;
   text-underline-offset: 2px;
   cursor: pointer;
+  transition: opacity .16s ease;
 }
+.reference-style-manager:hover { opacity: 0.75; }
 
 .reference-auto { padding: 2px 1px; }
 .reference-document-actions { display: flex; gap: 6px; }
@@ -323,9 +467,9 @@ main {
 .citation-composer,
 .bibliography-actions {
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 12px;
   background: var(--surface);
-  padding: 8px;
+  padding: 10px;
 }
 
 .composer-head,
@@ -336,30 +480,33 @@ main {
 }
 
 .composer-head strong,
-.bibliography-actions strong { font-size: 11px; }
+.bibliography-actions strong { font-size: 11px; letter-spacing: 0.01em; }
 .composer-head span,
 .bibliography-actions small { margin-left: auto; color: var(--muted); font-size: 9px; text-align: right; }
 .bibliography-actions > div { min-width: 0; flex: 1; }
-.bibliography-actions small { display: block; margin: 2px 0 0; text-align: left; line-height: 1.3; }
-.selected-references { display: flex; flex-direction: column; gap: 6px; margin-top: 7px; }
+.bibliography-actions small { display: block; margin: 2px 0 0; text-align: left; line-height: 1.35; }
+.selected-references { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
 .selected-references:empty { display: none; }
 
 .citation-source {
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 10px;
   background: var(--panel);
   overflow: hidden;
+  transition: border-color .16s ease, box-shadow .16s ease;
 }
+.citation-source:hover { border-color: var(--primary-line); }
+.citation-source.open { border-color: var(--primary-line); box-shadow: var(--shadow); }
 
 .citation-source-head {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr) auto;
   align-items: center;
   gap: 5px;
-  padding: 7px;
+  padding: 7px 8px;
 }
 
-.citation-source-index { color: var(--muted); font-size: 10px; text-align: center; }
+.citation-source-index { color: var(--muted); font-size: 10px; text-align: center; font-variant-numeric: tabular-nums; }
 .citation-source-title { min-width: 0; font-size: 11px; font-weight: 650; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .citation-source-buttons { display: flex; gap: 2px; }
 .citation-source-buttons button {
@@ -367,14 +514,15 @@ main {
   height: 22px;
   padding: 0;
   border: 0;
-  border-radius: 4px;
+  border-radius: 6px;
   color: var(--muted);
   background: transparent;
   cursor: pointer;
+  transition: background-color .14s ease, color .14s ease;
 }
-.citation-source-buttons button:hover { background: var(--surface); color: var(--text); }
-.citation-source-options { display: none; grid-template-columns: 102px minmax(0, 1fr); gap: 6px; padding: 0 7px 7px; }
-.citation-source.open .citation-source-options { display: grid; }
+.citation-source-buttons button:hover { background: var(--primary-soft); color: var(--primary); }
+.citation-source-options { display: none; grid-template-columns: 102px minmax(0, 1fr); gap: 7px; padding: 0 8px 9px; }
+.citation-source.open .citation-source-options { display: grid; animation: fade-in .16s ease; }
 .citation-source-options label { min-width: 0; color: var(--muted); font-size: 9px; }
 .citation-source-options label.wide { grid-column: 1 / -1; }
 .citation-source-options input,
@@ -383,16 +531,23 @@ main {
   min-width: 0;
   margin-top: 3px;
   border: 1px solid var(--border);
-  border-radius: 5px;
-  padding: 5px 6px;
+  border-radius: 7px;
+  padding: 5px 7px;
   background: var(--panel);
   color: var(--control-text);
   font: inherit;
   font-size: 10px;
+  transition: border-color .16s ease, box-shadow .16s ease;
+}
+.citation-source-options input:focus,
+.citation-source-options select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
 }
 .citation-source-options .check { grid-column: 1 / -1; display: flex; align-items: center; gap: 5px; }
 .citation-source-options .check input { width: auto; margin: 0; }
-.composer-actions { display: flex; justify-content: flex-end; gap: 6px; margin-top: 7px; }
+.composer-actions { display: flex; justify-content: flex-end; gap: 6px; margin-top: 8px; }
 
 .reference-result .actions .primary { margin-left: auto; }
 .reference-identifiers { margin-top: 4px; font-size: 9px; color: var(--muted); overflow-wrap: anywhere; }
@@ -404,51 +559,83 @@ main {
 }
 
 .empty {
-  padding: 26px 18px;
+  margin: 4px 12px;
+  padding: 28px 18px;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
   text-align: center;
   color: var(--muted);
   font-size: 12px;
+  line-height: 1.5;
 }
 .empty[hidden] { display: none !important; }
 
 .card {
   border: 1px solid var(--border);
   background: var(--panel);
-  border-radius: 8px;
-  padding: 10px;
+  border-radius: 12px;
+  padding: 11px 12px;
   box-shadow: var(--shadow);
+  transition: border-color .16s ease, box-shadow .16s ease, transform .16s ease;
+  /* Entrance animations carry no fill mode and no delay: the fade still plays
+     from the first painted frame, and an animation that is cancelled or never
+     supported leaves the card at its normal style instead of transparent. */
+  animation: card-in .17s ease;
 }
+.card:hover { border-color: var(--primary-line); box-shadow: var(--shadow-md); }
 
 .row {
   display: flex;
   align-items: flex-start;
-  gap: 7px;
+  gap: 8px;
 }
 
 .badge {
-  font-size: 10px;
+  font-size: 9.5px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
   border: 1px solid var(--border);
-  border-radius: 5px;
-  padding: 2px 5px;
+  border-radius: 999px;
+  padding: 2px 8px;
   white-space: nowrap;
   color: var(--muted);
   background: var(--surface);
 }
 
-.badge.supports { color: var(--green); border-color: color-mix(in srgb, var(--green) 42%, var(--border)); }
+.badge.supports {
+  color: var(--green);
+  border-color: color-mix(in srgb, var(--green) 32%, transparent);
+  background: color-mix(in srgb, var(--green) 12%, transparent);
+}
 .badge.contradicts,
-.badge.refutes { color: var(--red); border-color: color-mix(in srgb, var(--red) 42%, var(--border)); }
-.badge.refines { color: var(--amber); border-color: color-mix(in srgb, var(--amber) 42%, var(--border)); }
-.badge.extends { color: var(--cyan); border-color: color-mix(in srgb, var(--cyan) 42%, var(--border)); }
-.badge.idea { color: var(--primary); border-color: color-mix(in srgb, var(--primary) 42%, var(--border)); }
-.badge.passage { color: var(--cyan); border-color: color-mix(in srgb, var(--cyan) 42%, var(--border)); }
+.badge.refutes {
+  color: var(--red);
+  border-color: color-mix(in srgb, var(--red) 32%, transparent);
+  background: color-mix(in srgb, var(--red) 12%, transparent);
+}
+.badge.refines {
+  color: var(--amber);
+  border-color: color-mix(in srgb, var(--amber) 32%, transparent);
+  background: color-mix(in srgb, var(--amber) 12%, transparent);
+}
+.badge.extends {
+  color: var(--cyan);
+  border-color: color-mix(in srgb, var(--cyan) 32%, transparent);
+  background: color-mix(in srgb, var(--cyan) 12%, transparent);
+}
+.badge.idea,
+.badge.passage {
+  color: var(--primary);
+  border-color: var(--primary-line);
+  background: var(--primary-soft);
+}
+.badge.passage { color: var(--cyan); border-color: color-mix(in srgb, var(--cyan) 32%, transparent); background: color-mix(in srgb, var(--cyan) 12%, transparent); }
 
 .label {
   font-size: 13px;
   font-weight: 650;
-  line-height: 1.25;
+  line-height: 1.3;
   flex: 1;
   min-width: 0;
   overflow-wrap: anywhere;
@@ -463,16 +650,20 @@ main {
 
 .pct {
   font-size: 10px;
-  color: var(--muted);
+  color: var(--primary);
+  background: var(--primary-soft);
+  border-radius: 999px;
+  padding: 1px 7px;
   margin-left: auto;
+  font-weight: 650;
   font-variant-numeric: tabular-nums;
 }
 
 .rationale,
 .statement {
-  margin: 7px 0 0;
+  margin: 8px 0 0;
   font-size: 12px;
-  line-height: 1.38;
+  line-height: 1.45;
   color: var(--muted);
 }
 
@@ -480,26 +671,29 @@ main {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-top: 9px;
+  margin-top: 10px;
 }
 
 .detail {
-  margin-top: 10px;
+  margin-top: 11px;
   border-top: 1px solid var(--border);
-  padding-top: 10px;
+  padding-top: 11px;
+  animation: fade-in .18s ease;
 }
 
-.detail-section { margin-top: 10px; }
+.detail-section { margin-top: 11px; }
 .section-title {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
-  color: var(--text);
-  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-bottom: 7px;
 }
 
 .source,
 .connection {
-  padding: 7px 0;
+  padding: 8px 0;
   border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
 }
 
@@ -510,7 +704,7 @@ main {
 .connection-title {
   font-size: 12px;
   font-weight: 620;
-  line-height: 1.25;
+  line-height: 1.3;
   overflow-wrap: anywhere;
 }
 
@@ -520,14 +714,14 @@ main {
 .muted {
   font-size: 11px;
   color: var(--muted);
-  line-height: 1.35;
+  line-height: 1.4;
 }
 
 .source-text,
 .connection-text { margin: 4px 0 5px; }
 .connection-head { display: flex; align-items: center; gap: 6px; }
-.spin { color: var(--muted); font-size: 12px; padding: 4px 0; }
-.copied { color: var(--green); font-size: 11px; align-self: center; }
+.spin { color: var(--muted); font-size: 12px; padding: 6px 0; animation: pulse 1.4s ease-in-out infinite; }
+.copied { color: var(--green); font-size: 11px; font-weight: 600; align-self: center; }
 
 /* Compact icon tabs. Only the active tab expands to reveal its label. */
 .segmented {
@@ -535,42 +729,60 @@ main {
   align-items: stretch;
   min-width: 0;
   overflow: hidden;
-  gap: 4px;
+  gap: 3px;
   padding: 3px;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 11px;
   background: var(--surface);
 }
 
-#analysisControls { display: flex; flex-direction: column; gap: 8px; }
+#analysisControls { display: flex; flex-direction: column; gap: 9px; }
 #analysisControls[hidden] { display: none; }
 .seg {
-  flex: 0 0 34px;
+  /* Every tab keeps the same slot whichever one is selected: an active tab that
+     grows would shuffle the others under the pointer. The label rides under the
+     icon so all four stay readable inside an equal column. */
+  flex: 1 1 0;
+  min-width: 0;
+  position: relative;
   border: 0;
   background: transparent;
   color: var(--muted);
-  border-radius: 5px;
-  padding: 5px 8px;
+  border-radius: 8px;
+  padding: 6px 4px;
   font: inherit;
   font-size: 12px;
   cursor: pointer;
-  min-height: 26px;
-  min-width: 34px;
+  min-height: 44px;
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 3px;
   overflow: hidden;
+  transition: background-color .18s ease, color .18s ease, box-shadow .18s ease;
 }
-.seg:hover { color: var(--text); }
+.seg:hover { color: var(--primary); background: var(--primary-soft); }
 .seg.active {
-  flex: 1 1 auto;
-  min-width: 0;
-  background: var(--panel);
-  color: var(--text);
-  font-weight: 620;
-  box-shadow: var(--shadow);
+  background: var(--primary);
+  color: var(--primary-text);
+  font-weight: 650;
+  box-shadow: 0 2px 10px var(--primary-line);
 }
+/* A generation keeps running when its tab is left behind, so the tab says so. */
+.seg.is-busy::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+.seg.active.is-busy::after { background: var(--primary-text); }
+.seg.active:hover { background: var(--primary); color: var(--primary-text); }
 .seg-icon {
   width: 15px;
   height: 15px;
@@ -582,27 +794,29 @@ main {
   stroke-linejoin: round;
 }
 .seg-label {
-  display: none;
+  display: block;
   min-width: 0;
   max-width: 100%;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: 0.01em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-/* A later localization pass must never let an inactive label reclaim space. */
-.seg:not(.active) .seg-label {
-  display: none !important;
-  inline-size: 0;
-  max-inline-size: 0;
-  visibility: hidden;
+/* Equal columns make every label safe to show, but a pane dragged this narrow
+   has no room for text: fall back to icons, which keep their tooltips. */
+@media (max-width: 310px) {
+  .seg { min-height: 30px; }
+  .seg-label { display: none; }
 }
-.seg.active .seg-label { display: inline-block; visibility: visible; }
 
 /* Saved workspace prompts */
 .prompt-controls {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 9px;
 }
 .prompt-controls[hidden] { display: none; }
 .prompt-heading,
@@ -613,58 +827,74 @@ main {
   gap: 8px;
 }
 .prompt-heading strong,
-.prompt-output-head strong { display: block; font-size: 12px; }
+.prompt-output-head strong { display: block; font-size: 12px; letter-spacing: -0.01em; }
 .prompt-heading small {
   display: block;
-  margin-top: 2px;
+  margin-top: 3px;
   color: var(--muted);
   font-size: 10px;
-  line-height: 1.35;
+  line-height: 1.4;
 }
 .prompt-field { display: block; min-width: 0; color: var(--muted); font-size: 10px; }
 .prompt-field > span,
-.prompt-block-label { display: block; margin: 0 0 3px 2px; }
+.prompt-block-label {
+  display: block;
+  margin: 0 0 4px 2px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
 .prompt-field select {
   width: 100%;
   min-width: 0;
-  min-height: 32px;
+  min-height: 34px;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 5px 7px;
+  border-left: 3px solid var(--primary-line);
+  border-radius: 9px;
+  padding: 6px 9px;
   background: var(--panel);
   color: var(--control-text);
   font: inherit;
-  font-size: 11px;
+  font-size: 11.5px;
+  transition: border-color .16s ease, box-shadow .16s ease;
+}
+.prompt-field select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
 }
 .prompt-field select option { background: var(--panel); color: var(--control-text); }
 .prompt-description {
   min-height: 0;
-  margin: -2px 2px 0;
+  margin: -3px 2px 0;
   color: var(--muted);
   font-size: 10px;
-  line-height: 1.35;
+  line-height: 1.4;
 }
 .prompt-selection-block { min-width: 0; color: var(--muted); font-size: 10px; }
 .prompt-selection {
   min-height: 48px;
   max-height: 104px;
   overflow: auto;
-  border: 1px dashed var(--border);
-  border-radius: 6px;
-  padding: 8px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--primary-line);
+  border-radius: 4px 10px 10px 4px;
+  padding: 8px 10px;
   background: var(--surface);
   color: var(--text);
-  font-size: 11px;
-  line-height: 1.4;
+  font-size: 11.5px;
+  line-height: 1.45;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
-.prompt-selection.placeholder { color: var(--muted); }
+.prompt-selection.placeholder { color: var(--muted); font-style: italic; }
 .prompt-generate {
   width: 100%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-height: 34px;
+  border-radius: 9px;
 }
 .prompt-generate.is-generating:disabled { opacity: 1; cursor: progress; }
 .prompt-generate > [hidden] { display: none; }
@@ -689,16 +919,14 @@ main {
   0%, 60%, 100% { opacity: .35; transform: translateY(0); }
   30% { opacity: 1; transform: translateY(-4px); }
 }
-@media (prefers-reduced-motion: reduce) {
-  .prompt-typing-dot { animation: none; opacity: .75; }
-}
 .prompt-output-wrap {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 8px;
   margin-top: 2px;
-  padding-top: 9px;
+  padding-top: 10px;
   border-top: 1px solid var(--border);
+  animation: fade-in .18s ease;
 }
 .prompt-output-wrap[hidden] { display: none; }
 .prompt-output-head { align-items: baseline; }
@@ -709,24 +937,41 @@ main {
   max-height: 320px;
   resize: vertical;
   border: 1px solid var(--border);
-  border-radius: 7px;
-  padding: 9px;
+  border-radius: 10px;
+  padding: 10px;
   background: var(--panel);
   color: var(--control-text);
   font: inherit;
   font-size: 12px;
-  line-height: 1.45;
+  line-height: 1.5;
+  transition: border-color .16s ease, box-shadow .16s ease;
+}
+.prompt-output:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
 }
 .prompt-warnings {
-  border: 1px solid color-mix(in srgb, var(--amber) 40%, var(--border));
-  border-radius: 6px;
-  padding: 7px;
-  background: color-mix(in srgb, var(--amber) 9%, var(--panel));
+  border: 1px solid color-mix(in srgb, var(--amber) 34%, transparent);
+  border-radius: 9px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--amber) 11%, transparent);
   color: var(--amber);
   font-size: 10px;
-  line-height: 1.35;
+  line-height: 1.4;
 }
 .prompt-warnings[hidden] { display: none; }
+.prompt-stale {
+  border: 1px solid color-mix(in srgb, var(--cyan) 34%, transparent);
+  border-radius: 9px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--cyan) 11%, transparent);
+  color: var(--cyan);
+  font-size: 10px;
+  line-height: 1.4;
+  animation: fade-in .16s ease;
+}
+.prompt-stale[hidden] { display: none; }
 .prompt-output-actions { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 6px; }
 
 /* Selection actions (Rewrite / Expand / Counter) and insert target */
@@ -739,10 +984,11 @@ main {
 }
 .sa-label,
 .it-label {
-  font-size: 11px;
+  font-size: 9.5px;
+  font-weight: 700;
   color: var(--muted);
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.05em;
   margin-right: 2px;
 }
 .insert-target label {
@@ -757,4 +1003,32 @@ main {
 .insert-target label.disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+@keyframes card-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to { opacity: 1; transform: none; }
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes pop-in {
+  from { opacity: 0; transform: translateY(-4px) scale(0.99); }
+  to { opacity: 1; transform: none; }
+}
+@keyframes pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prompt-typing-dot { animation: none; opacity: .75; }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }

--- a/word-addin/taskpane.html
+++ b/word-addin/taskpane.html
@@ -13,7 +13,25 @@
   </head>
   <body>
     <header class="head">
-      <img class="mark" src="/addin/assets/icon-32.png" alt="Nodus" width="28" height="28" />
+      <svg class="mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="28" height="28" role="img" aria-label="Nodus">
+        <defs>
+          <linearGradient id="nodusMark" x1="14" y1="10" x2="50" y2="54" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#ddd6fe"/>
+            <stop offset="0.45" stop-color="#a78bfa"/>
+            <stop offset="1" stop-color="#7c3aed"/>
+          </linearGradient>
+          <filter id="nodusShadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="0" dy="2" stdDeviation="1.8" flood-color="#0f0b1d" flood-opacity="0.35"/>
+          </filter>
+        </defs>
+        <g filter="url(#nodusShadow)">
+          <path d="M18 48V16L46 48V16" fill="none" stroke="url(#nodusMark)" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="18" cy="16" r="6.5" fill="#ddd6fe"/>
+          <circle cx="18" cy="48" r="6.5" fill="#a78bfa"/>
+          <circle cx="46" cy="48" r="6.5" fill="#8b5cf6"/>
+          <circle cx="46" cy="16" r="6.5" fill="#7c3aed"/>
+        </g>
+      </svg>
       <div>
         <div class="title">Nodus Copilot</div>
         <div class="caption">Word + Nodus</div>
@@ -23,10 +41,6 @@
 
     <main>
       <section class="controls">
-        <div class="search" id="searchControls">
-          <input id="searchBox" type="search" placeholder="Search ideas, authors or works" autocomplete="off" />
-          <button id="searchBtn" class="btn icon" type="button" title="Search">⌕</button>
-        </div>
         <div class="segmented" id="searchMode" role="tablist">
           <button class="seg active" data-mode="ideas" type="button" role="tab" aria-selected="true" aria-label="Ideas" title="Ideas">
             <svg class="seg-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18h6M10 22h4M8.2 14.5A7 7 0 1 1 15.8 14.5c-.9.7-1.4 1.6-1.5 2.5h-4.6c-.1-.9-.6-1.8-1.5-2.5Z"/></svg>
@@ -44,6 +58,10 @@
             <svg class="seg-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m14 4 1-2 1 2 2 1-2 1-1 2-1-2-2-1zM5 17l9-9 3 3-9 9H5zM12.5 9.5l3 3M18 16l.8-1.8.8 1.8 1.8.8-1.8.8-.8 1.8-.8-1.8-1.8-.8z"/></svg>
             <span class="seg-label">AI prompts</span>
           </button>
+        </div>
+        <div class="search" id="searchControls">
+          <input id="searchBox" type="search" placeholder="Search ideas, authors or works" autocomplete="off" />
+          <button id="searchBtn" class="btn icon" type="button" title="Search">⌕</button>
         </div>
         <div id="analysisControls">
           <div class="toolbar">
@@ -129,6 +147,7 @@
             <div class="prompt-output-head"><strong>Proposal</strong><span id="promptOutputMeta"></span></div>
             <textarea id="promptOutput" class="prompt-output" readonly aria-label="Generated proposal"></textarea>
             <div id="promptWarnings" class="prompt-warnings" hidden></div>
+            <div id="promptOutputStale" class="prompt-stale" hidden></div>
             <div class="prompt-output-actions">
               <button id="copyPromptOutput" class="btn small" type="button">Copy</button>
               <button id="pastePromptOutput" class="btn small primary" type="button">Paste and replace selection</button>

--- a/word-addin/taskpane.js
+++ b/word-addin/taskpane.js
@@ -5,6 +5,7 @@
   var TOKEN = (window.NODUS && window.NODUS.token) || '';
   var LANG = (window.NODUS && window.NODUS.lang) === 'en' ? 'en' : 'es';
   var DEBOUNCE_MS = 700;
+  var PROMPT_POLL_MS = 700;
   var MIN_CHARS = 12;
 
   var els = {};
@@ -25,8 +26,12 @@
   var promptModels = [];
   var promptSourceText = '';
   var promptOutputText = '';
+  var promptOutputSourceText = '';
   var promptRequestSeq = 0;
   var promptGenerating = false;
+  var promptSelectionPainted = false;
+  var promptPollTimer = null;
+  var promptPollBusy = false;
 
   // The pane follows the Nodus UI language (injected by the copilot server).
   var STR = {
@@ -107,6 +112,7 @@
       promptCopied: 'Propuesta copiada',
       promptPasted: 'Selección reemplazada',
       promptSelectionChanged: 'La selección de Word ha cambiado. Vuelve a seleccionar el texto original antes de pegar.',
+      promptOutputStale: 'Esta propuesta se generó con otra selección. Vuelve a seleccionar ese texto para poder pegarla.',
       promptLoading: 'Cargando prompts del workspace…',
       promptLoadError: 'No se pudieron cargar los prompts: ',
       promptNoStyles: 'No hay prompts activos en este workspace.',
@@ -195,6 +201,7 @@
       promptCopied: 'Proposal copied',
       promptPasted: 'Selection replaced',
       promptSelectionChanged: 'The Word selection changed. Select the original text again before pasting.',
+      promptOutputStale: 'This proposal came from a different selection. Select that text again to paste it.',
       promptLoading: 'Loading workspace prompts…',
       promptLoadError: 'Could not load prompts: ',
       promptNoStyles: 'There are no active prompts in this workspace.',
@@ -817,11 +824,25 @@
 
   function clearPromptOutput() {
     promptOutputText = '';
+    promptOutputSourceText = '';
     els.promptOutput.value = '';
     els.promptOutputMeta.textContent = '';
     els.promptWarnings.textContent = '';
     els.promptWarnings.hidden = true;
     els.promptOutputWrap.hidden = true;
+    updatePromptOutputState();
+  }
+
+  // A generated proposal only disappears on the next generation: moving the
+  // Word selection re-reads the source text but never throws away tokens that
+  // were already paid for. While the selection differs from the one that
+  // produced the proposal, the proposal stays readable but cannot be pasted
+  // over the wrong text.
+  function updatePromptOutputState() {
+    var stale = !!promptOutputText && promptSourceText !== promptOutputSourceText;
+    els.promptOutputStale.textContent = stale ? T('promptOutputStale') : '';
+    els.promptOutputStale.hidden = !stale;
+    els.pastePromptOutput.disabled = !promptOutputText || stale;
   }
 
   function updatePromptGenerateState() {
@@ -829,8 +850,11 @@
   }
 
   function setPromptGenerating(generating) {
+    var settled = promptGenerating && !generating;
     promptGenerating = generating;
     els.applyPrompt.classList.toggle('is-generating', generating);
+    if (els.promptTab) els.promptTab.classList.toggle('is-busy', generating);
+    if (settled) paintPromptSelection(promptSourceText);
     if (generating) {
       els.applyPrompt.setAttribute('aria-busy', 'true');
       els.applyPrompt.setAttribute('aria-label', T('promptGenerating'));
@@ -851,16 +875,51 @@
     updatePromptGenerateState();
   }
 
+  function paintPromptSelection(text) {
+    promptSelectionPainted = true;
+    els.promptSelection.textContent = text || T('promptSelectionEmpty');
+    els.promptSelection.classList.toggle('placeholder', !text);
+  }
+
   function refreshPromptSelection() {
     return getSelectionText().then(function (value) {
       var text = normalizedSelection(value);
-      if (text !== promptSourceText) clearPromptOutput();
+      var changed = text !== promptSourceText;
       promptSourceText = text;
-      els.promptSelection.textContent = text || T('promptSelectionEmpty');
-      els.promptSelection.classList.toggle('placeholder', !text);
+      // While a proposal is generating the box keeps showing the text that was
+      // actually sent: moving the cursor in Word must never look like it
+      // redirected the generation. Only pressing Generate again does that. The
+      // live selection returns the moment the generation settles.
+      // Repainting an unchanged box would also drop any in-pane text selection.
+      if (!promptGenerating && (changed || !promptSelectionPainted)) paintPromptSelection(text);
       updatePromptGenerateState();
+      updatePromptOutputState();
       return text;
     });
+  }
+
+  // Word's DocumentSelectionChanged does not fire for every way of selecting
+  // text (dragging inside a paragraph is the usual miss), which used to leave
+  // the box stale until an unrelated control forced a refresh. While the
+  // prompts tab is open the pane also polls the selection itself.
+  function startPromptSelectionPolling() {
+    if (promptPollTimer) return;
+    promptPollTimer = setInterval(function () {
+      // Deliberately no document.hidden guard: an embedded webview can report
+      // itself hidden while its pane is perfectly visible, and a poll that
+      // stops without saying so is the very bug this exists to fix.
+      if (promptPollBusy) return;
+      promptPollBusy = true;
+      var done = function () { promptPollBusy = false; };
+      refreshPromptSelection().then(done, done);
+    }, PROMPT_POLL_MS);
+  }
+
+  function stopPromptSelectionPolling() {
+    if (!promptPollTimer) return;
+    clearInterval(promptPollTimer);
+    promptPollTimer = null;
+    promptPollBusy = false;
   }
 
   function fillPromptCatalogue(data) {
@@ -933,10 +992,12 @@
 
   function runSavedPrompt() {
     var model = selectedPromptModel();
+    var requestedSource = '';
     setPromptGenerating(true);
     clearPromptOutput();
     refreshPromptSelection()
       .then(function (selection) {
+        requestedSource = selection;
         if (!selection) {
           setStatus(T('promptSelectionEmpty'), 'err');
           return null;
@@ -959,6 +1020,7 @@
         if (!result) return;
         promptOutputText = String(result.text || '');
         if (!promptOutputText) throw new Error(T('composeEmpty'));
+        promptOutputSourceText = requestedSource;
         els.promptOutput.value = promptOutputText;
         var used = result.model || model;
         var usedLabel = used && (used.label || (used.provider + ' · ' + used.model));
@@ -967,6 +1029,7 @@
         els.promptWarnings.textContent = warnings.length ? T('promptWarnings') + warnings.join(' · ') : '';
         els.promptWarnings.hidden = !warnings.length;
         els.promptOutputWrap.hidden = false;
+        updatePromptOutputState();
         setStatus(T('promptProposal'), 'ok');
       })
       .catch(function (error) { setStatus((error && error.message) || String(error), 'err'); })
@@ -995,7 +1058,7 @@
     if (!promptOutputText) return;
     getSelectionText()
       .then(function (current) {
-        if (normalizedSelection(current) !== promptSourceText) throw new Error(T('promptSelectionChanged'));
+        if (normalizedSelection(current) !== promptOutputSourceText) throw new Error(T('promptSelectionChanged'));
         return insertAtCursor(promptOutputText, { replace: true });
       })
       .then(function () {
@@ -1028,8 +1091,10 @@
     if (promptMode) {
       refreshPromptSelection();
       loadPromptCatalogue();
+      startPromptSelectionPolling();
       return;
     }
+    stopPromptSelectionPolling();
     if (referenceMode) {
       runSearch();
       return;
@@ -1119,6 +1184,8 @@
     els.promptOutput = document.getElementById('promptOutput');
     els.promptOutputMeta = document.getElementById('promptOutputMeta');
     els.promptWarnings = document.getElementById('promptWarnings');
+    els.promptOutputStale = document.getElementById('promptOutputStale');
+    els.promptTab = document.querySelector('.seg[data-mode="prompts"]');
     els.copyPromptOutput = document.getElementById('copyPromptOutput');
     els.pastePromptOutput = document.getElementById('pastePromptOutput');
 
@@ -1182,6 +1249,7 @@
     els.promptOutput.setAttribute('aria-label', T('promptProposal'));
     els.copyPromptOutput.textContent = T('promptCopy');
     els.pastePromptOutput.textContent = T('promptPaste');
+    updatePromptOutputState();
 
     // Footnotes need WordApi 1.5. Standalone (LibreOffice) relies on the macro,
     // which falls back to inline if its Writer build cannot place a footnote.

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
The Word and LibreOffice task pane keeps the work it generates, follows the selection on its own, and now looks like the rest of Nodus.

## Proposals survive the selection

A generated proposal disappeared the moment the Word selection moved, which threw away tokens that were already paid for. It now stays until the next generation or until it is pasted. While the live selection differs from the one that produced it, the proposal stays readable and copyable and pasting is disabled with a note explaining how to re-enable it, so a proposal can never replace the wrong passage.

## The pane follows the selection

Word does not raise `DocumentSelectionChanged` for every way of selecting text, and dragging inside a paragraph is the usual miss. That left the selected-text box stale until an unrelated control forced a refresh. The prompts tab now polls the selection itself while it is open and stops when it is left. There is deliberately no `document.hidden` guard on that poll: an embedded webview can report itself hidden while its pane is perfectly visible, and a poll that stops without saying so is the very bug this fixes.

## A running generation is not affected by what happens next

The request keeps the text it was sent with. The selected-text box now freezes on that text for the duration of the generation, so moving the cursor in Word never looks like it redirected the running request, and only pressing Generate again starts a new one with the new selection. The tab is marked while the work is in flight: the generation continues and is delivered even from another tab.

## Design

The pane adopts the visual language of the Nodus Zotero sidebar: the same violet accent, tinted surfaces, rounded cards, pill badges, focus rings and short transitions, in light and dark. Every tab of the strip keeps its slot whichever one is active, the search box moved below the tabs, and the pane now wears the desktop app's own mark.

Two invariants are pinned by tests rather than by convention: the accent is read from `zotero-plugin/content/sidebar.css` and compared with the pane's, and the mark is compared stroke for stroke against `src/assets/nodus-logo.svg`. Neither can drift into a second design without failing.

Also fixed along the way: a panel the script hides could still be painted, because an explicit `display` on a class beats the browser's `[hidden]` rule. That is why the search box stayed visible in the prompts tab.

## Verification

- `npm test`: 2414 pass, 0 fail, 1 skipped. `npm run typecheck` and `npm run lint` clean.
- Driven in a real browser against the pane itself, in LibreOffice mode and in Word mode with the host stubbed so it never raises its selection event, in light and dark, at 264 / 296 / 340 / 360 / 380 px pane widths.
- Timing-sensitive behaviour was measured with an in-page probe rather than screenshots: the generation was observed running across a tab switch and landing while another tab was open, and the request body was confirmed to keep the original selection after the selection changed mid-flight.
- New assertions in `scripts/test-copilot-addin.mjs` cover each contract above.

## Release

Prepared as 5.0.5 across `package.json`, `server/package.json`, `server/lib/version.mjs` and the rest of the release metadata, with a single What's New highlight in all eight interface languages.
