### PR TITLE
Fix Word synonym generation and add model selectors

### DIFF
--- a/electron/ai/liveRelations.ts
+++ b/electron/ai/liveRelations.ts
@@ -717,11 +717,12 @@ export async function composeCopilotIdeaInsertion(input: {
   ideaId: string;
   paragraphText: string;
   selectionText?: string;
+  model?: ModelRef | null;
 }): Promise<CopilotInsertionResult> {
   const detail = getCopilotIdeaDetail(input.ideaId);
   if (!detail) throw new Error('No se encontró la idea en Nodus.');
   const settings = getSettings();
-  const model = settings.synthesisModel;
+  const model = input.model ?? settings.synthesisModel;
   const authorYear = detail.authorYear ?? detail.occurrences[0]?.authorYear ?? null;
   const source = detail.occurrences[0] ?? null;
   const text = await completeText(

--- a/electron/ai/studySynonyms.ts
+++ b/electron/ai/studySynonyms.ts
@@ -7,41 +7,63 @@ import { runStudyAiTask } from './studyAiPolicy';
 
 const MAX_SENTENCE_CHARS = 4_000;
 const ALTERNATIVE_COUNT = 5;
+const CANDIDATE_COUNT = 8;
 
 interface SynonymPayload {
-  alternatives: Array<{ target: string; replacement: string }>;
+  alternatives: Array<{ target?: string; replacement: string }>;
 }
 
 function parsePayload(value: string): SynonymPayload {
   const trimmed = value.trim().replace(/^```(?:json)?\s*/iu, '').replace(/\s*```$/u, '');
-  const start = trimmed.indexOf('{');
-  const end = trimmed.lastIndexOf('}');
+  const objectStart = trimmed.indexOf('{');
+  const arrayStart = trimmed.indexOf('[');
+  const starts = [objectStart, arrayStart].filter((index) => index >= 0);
+  const start = starts.length ? Math.min(...starts) : -1;
+  const opening = trimmed[start];
+  const end = opening === '[' ? trimmed.lastIndexOf(']') : trimmed.lastIndexOf('}');
   if (start < 0 || end <= start) throw new Error('La IA no devolvió alternativas válidas.');
-  const parsed = JSON.parse(jsonrepair(trimmed.slice(start, end + 1))) as Partial<SynonymPayload>;
-  if (!Array.isArray(parsed.alternatives)) throw new Error('La IA no devolvió alternativas válidas.');
+  const parsed = JSON.parse(jsonrepair(trimmed.slice(start, end + 1))) as Partial<SynonymPayload> | unknown[];
+  const candidates = Array.isArray(parsed) ? parsed : parsed.alternatives;
+  if (!Array.isArray(candidates)) throw new Error('La IA no devolvió alternativas válidas.');
   return {
-    alternatives: parsed.alternatives.filter((item): item is { target: string; replacement: string } => (
-      Boolean(item) && typeof item.target === 'string' && typeof item.replacement === 'string'
-    )),
+    alternatives: candidates.flatMap((item) => {
+      if (typeof item === 'string') return [{ replacement: item }];
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return [];
+      const candidate = item as { target?: unknown; replacement?: unknown };
+      if (typeof candidate.replacement !== 'string') return [];
+      return [{
+        ...(typeof candidate.target === 'string' ? { target: candidate.target } : {}),
+        replacement: candidate.replacement,
+      }];
+    }),
   };
 }
 
-function normalizeAlternatives(request: StudySynonymRequest, payload: SynonymPayload): StudySynonymAlternative[] {
-  const previous = new Set((request.previousAlternatives ?? []).map((value) => value.trim().toLocaleLowerCase()).filter(Boolean));
+function comparisonKey(value: string): string {
+  return value.normalize('NFC').trim().toLocaleLowerCase();
+}
+
+function normalizeAlternatives(
+  request: StudySynonymRequest,
+  payload: SynonymPayload,
+): StudySynonymAlternative[] {
+  const previous = new Set((request.previousAlternatives ?? []).map(comparisonKey).filter(Boolean));
   const seen = new Set<string>();
   const alternatives: StudySynonymAlternative[] = [];
   for (const candidate of payload.alternatives) {
-    const target = candidate.target.trim();
+    // Smaller/less strict models sometimes copy the selection markers into
+    // `target`, or return a bare replacement string. Both still have an
+    // unambiguous, safe range: the exact selection supplied by the caller.
+    const target = (candidate.target ?? request.selectedText)
+      .replace(/<<<(?:SELECCIÓN|FIN_SELECCIÓN)>>>/giu, '')
+      .trim();
     const replacement = candidate.replacement.trim();
     const range = resolveStudySynonymTarget(request.sentence, target, request.selectionFrom, request.selectionTo);
-    const key = replacement.toLocaleLowerCase();
-    if (!range || !replacement || replacement === target || previous.has(key) || seen.has(key)) continue;
+    const key = comparisonKey(replacement);
+    if (!range || !replacement || key === comparisonKey(target) || previous.has(key) || seen.has(key)) continue;
     seen.add(key);
     alternatives.push({ target, replacement, ...range });
     if (alternatives.length === ALTERNATIVE_COUNT) break;
-  }
-  if (alternatives.length !== ALTERNATIVE_COUNT) {
-    throw new Error('La IA no pudo proponer cinco alternativas distintas. Regenera para intentarlo de nuevo.');
   }
   return alternatives;
 }
@@ -56,7 +78,7 @@ Devuelve exclusivamente JSON válido con esta forma exacta:
 {"alternatives":[{"target":"fragmento original exacto","replacement":"alternativa"}]}
 
 REGLAS:
-- Devuelve exactamente cinco alternativas naturales, distintas entre sí y distintas del original.
+- Devuelve ${CANDIDATE_COUNT} alternativas naturales, distintas entre sí y distintas del original. El servidor seleccionará las cinco primeras válidas.
 - Detecta el idioma de la frase y escribe TODAS las alternativas en ese mismo idioma. Nunca traduzcas.
 - Conserva significado, registro, género, número, tiempo verbal, datos, citas y fuerza de la afirmación.
 - "target" debe ser una subcadena literal y contigua de la frase original que contenga toda la selección.
@@ -64,6 +86,7 @@ REGLAS:
 - Solo amplía "target" a la porción mínima necesaria de la frase si una reformulación más amplia evita discordancias o resulta claramente más natural.
 - No incluyas explicaciones, notas, Markdown envolvente ni alternativas ya excluidas.`,
     user: JSON.stringify({
+      originalSentence: request.sentence,
       sentenceWithSelection: markedSentence,
       selectedText: request.selectedText,
       excludedAlternatives: excluded,
@@ -81,24 +104,28 @@ export async function suggestStudySynonyms(request: StudySynonymRequest): Promis
     throw new Error('La selección ya no coincide con la frase. Vuelve a seleccionar el texto.');
   }
   const normalizedRequest = { ...request, sentence };
-  const prompt = buildStudySynonymPrompt(normalizedRequest);
+  const initialPrompt = buildStudySynonymPrompt(normalizedRequest);
   const completed = await runStudyAiTask({
     task: 'improve',
     explicitModel: request.model as ModelRef | null | undefined,
     subjectId: request.subjectId,
-    inputChars: prompt.system.length + prompt.user.length,
+    inputChars: initialPrompt.system.length + initialPrompt.user.length,
     outputChars: (value: StudySynonymAlternative[]) => JSON.stringify(value).length,
     externalConsentModelKey: '*',
   }, async (model) => {
     const raw = await completeTextNeutral({
-      system: prompt.system,
-      user: prompt.user,
+      system: initialPrompt.system,
+      user: initialPrompt.user,
       temperature: 0.65,
-      maxTokens: 900,
+      maxTokens: 1_200,
       reasoning: 'off',
       plainContext: true,
     }, model);
-    return normalizeAlternatives(normalizedRequest, parsePayload(raw));
+    const alternatives = normalizeAlternatives(normalizedRequest, parsePayload(raw));
+    if (alternatives.length !== ALTERNATIVE_COUNT) {
+      throw new Error('La IA no pudo proponer cinco alternativas distintas. Regenera para intentarlo de nuevo.');
+    }
+    return alternatives;
   });
   return {
     alternatives: completed.value,

--- a/electron/copilot/server.ts
+++ b/electron/copilot/server.ts
@@ -377,7 +377,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
   try {
     if (urlPath === '/api/relations' && req.method === 'POST') {
       const body = (await readJsonBody(req)) as { text?: string; model?: unknown };
-      const result = await analyzeText(String(body.text ?? ''), (body.model ?? null) as never);
+      const result = await analyzeText(String(body.text ?? ''), modelRef(body.model));
       sendJson(res, 200, result);
       return;
     }
@@ -394,12 +394,13 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
       return;
     }
     if (urlPath === '/api/compose' && req.method === 'POST') {
-      const body = (await readJsonBody(req)) as { mode?: string; selectionText?: string; paragraphText?: string };
+      const body = (await readJsonBody(req)) as { mode?: string; selectionText?: string; paragraphText?: string; model?: unknown };
       const mode: CopilotComposeMode = body.mode === 'rewrite' || body.mode === 'counter' ? body.mode : 'expand';
       const result = await composeFromSelection({
         mode,
         selectionText: String(body.selectionText ?? ''),
         paragraphText: String(body.paragraphText ?? ''),
+        model: modelRef(body.model),
       });
       sendJson(res, 200, result);
       return;
@@ -415,6 +416,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
         previousAlternatives: Array.isArray(body.previousAlternatives)
           ? body.previousAlternatives.map(String).slice(-50)
           : [],
+        model: modelRef(body.model),
       });
       sendJson(res, 200, result);
       return;
@@ -519,7 +521,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
       return;
     }
     if (urlPath === '/api/insert' && req.method === 'POST') {
-      const body = (await readJsonBody(req)) as { ideaId?: string; paragraphText?: string; selectionText?: string };
+      const body = (await readJsonBody(req)) as { ideaId?: string; paragraphText?: string; selectionText?: string; model?: unknown };
       if (!body.ideaId) {
         sendJson(res, 400, { error: copilotText('Falta ideaId.', 'Missing ideaId.') });
         return;
@@ -528,6 +530,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
         ideaId: body.ideaId,
         paragraphText: String(body.paragraphText ?? ''),
         selectionText: String(body.selectionText ?? ''),
+        model: modelRef(body.model),
       });
       sendJson(res, 200, insertion);
       return;

--- a/scripts/test-copilot-addin.mjs
+++ b/scripts/test-copilot-addin.mjs
@@ -99,7 +99,7 @@ try {
   assert.match(taskpaneHtml, /data-mode="chat"/);
   assert.match(taskpaneHtml, /data-mode="prompts"[\s\S]*?<span class="seg-label">AI Edition<\/span>/);
   assert.equal((taskpaneHtml.match(/class="seg-icon"/g) || []).length, 6, 'every pane tab must have an icon');
-  for (const id of ['synonymControls', 'synonymContext', 'generateSynonyms', 'synonymStale', 'synonymRounds']) {
+  for (const id of ['searchModel', 'synonymControls', 'synonymModel', 'synonymContext', 'generateSynonyms', 'synonymStale', 'synonymRounds']) {
     assert.match(taskpaneHtml, new RegExp(`id="${id}"`), `Synonyms UI must contain ${id}`);
   }
   for (const id of ['promptControls', 'promptStyle', 'promptModel', 'promptSelection', 'applyPrompt', 'promptOutput', 'promptOutputStale', 'copyPromptOutput', 'pastePromptOutput']) {
@@ -136,6 +136,10 @@ try {
   assert.match(taskpaneJs, /\\uFFFD\\u25A1\\u2610\\u2612/);
   assert.match(taskpaneJs, /\/api\/prompts\/apply/);
   assert.match(taskpaneJs, /\/api\/synonyms/);
+  assert.match(taskpaneJs, /text: text, model: selectedModelFrom\(els\.searchModel\)/, 'Ideas sends the selected model');
+  assert.match(taskpaneJs, /ideaId: ideaId,[\s\S]*?model: selectedModelFrom\(els\.searchModel\)/, 'Insert with AI uses the Ideas model selector');
+  assert.match(taskpaneJs, /var selectedModel = selectedModelFrom\(els\.synonymModel\);[\s\S]*?model: selectedModel/, 'Synonyms sends the selected model');
+  assert.match(taskpaneJs, /\[els\.promptModel, els\.searchModel, els\.synonymModel\]\.forEach\(fillModelSelect\)/, 'the writing surfaces share the configured model catalogue');
   assert.match(taskpaneJs, /WordApiDesktop', '1\.2'/, 'current-page chat must be capability-gated');
   assert.match(taskpaneJs, /var pages = selection\.pages;/, 'current-page chat must read the page containing the Word selection');
   assert.match(taskpaneJs, /var pageRange = page\.getRange\(\);/, 'current-page chat must send the complete page range');
@@ -277,6 +281,9 @@ try {
   assert.match(copilotChatSource, /No inventes contenido ausente del contexto/, 'chat must stay grounded in the selected Word context');
   assert.match(referencesJs, /fingerprint === externalStateFingerprint/, 'identical Writer polling snapshots must not rebuild the citation composer');
   assert.match(serverSource, /suggestStudySynonyms\(\{/, 'the Word endpoint must reuse the workspace synonym engine');
+  assert.match(serverSource, /composeFromSelection\(\{[\s\S]*?model: modelRef\(body\.model\)/, 'selection actions must honor the Ideas/Passages model selector');
+  assert.match(serverSource, /composeCopilotIdeaInsertion\(\{[\s\S]*?model: modelRef\(body\.model\)/, 'Insert with AI must honor the Ideas model selector');
+  assert.match(serverSource, /suggestStudySynonyms\(\{[\s\S]*?model: modelRef\(body\.model\)/, 'synonyms must honor their model selector');
   assert.match(serverSource, /destination: 'ideas'/);
   assert.match(serverSource, /destination === 'citation-styles'[\s\S]*destination: 'library-citation-styles'/);
   assert.match(appSource, /target\.destination === 'library-citation-styles'[\s\S]*citationStyles: true[\s\S]*setView\('library'\)/);

--- a/scripts/test-study-improve.mjs
+++ b/scripts/test-study-improve.mjs
@@ -21,6 +21,7 @@ if (!process.argv.includes('--electron-study-improve-test')) {
 }
 
 const root = await mkdtemp(path.join(os.tmpdir(), 'nodus-study-improve-test-'));
+let synonymGenerationCalls = 0;
 installRuntimeHooks(root);
 
 try {
@@ -164,7 +165,10 @@ try {
   });
   assert.equal(synonymResult.alternatives.length, 5, 'the contextual thesaurus always returns five alternatives');
   assert.deepEqual(synonymResult.alternatives.at(-1), { target: 'es sólido', replacement: 'está bien fundamentado', from: 13, to: 22 }, 'an alternative may expand the exact replacement target');
-  assert.match(synonyms.buildStudySynonymPrompt({ sentence: sentenceContext.sentence, selectedText: 'sólido', selectionFrom: sentenceContext.selectionFrom, selectionTo: sentenceContext.selectionTo }).user, /<<<SELECCIÓN>>>sólido<<<FIN_SELECCIÓN>>>/);
+  assert.equal(synonymGenerationCalls, 1, 'over-generation fills five alternatives without an extra provider call');
+  const synonymPrompt = synonyms.buildStudySynonymPrompt({ sentence: sentenceContext.sentence, selectedText: 'sólido', selectionFrom: sentenceContext.selectionFrom, selectionTo: sentenceContext.selectionTo });
+  assert.match(synonymPrompt.user, /<<<SELECCIÓN>>>sólido<<<FIN_SELECCIÓN>>>/);
+  assert.equal(JSON.parse(synonymPrompt.user).originalSentence, sentenceContext.sentence, 'the model can copy an exact target from an unmarked sentence');
 
   const exported = styles.exportStudyStyles([custom.id]);
   assert.equal(exported.format, 'nodus-study-styles');
@@ -235,13 +239,18 @@ function installRuntimeHooks(userDataPath) {
     }
     if (request === './aiClient' && parent?.filename?.endsWith('/electron/ai/studySynonyms.ts')) {
       return {
-        completeTextNeutral: async () => JSON.stringify({ alternatives: [
-          { target: 'sólido', replacement: 'robusto' },
-          { target: 'sólido', replacement: 'consistente' },
-          { target: 'sólido', replacement: 'firme' },
-          { target: 'sólido', replacement: 'fundado' },
-          { target: 'es sólido', replacement: 'está bien fundamentado' },
-        ] }),
+        completeTextNeutral: async () => {
+          synonymGenerationCalls += 1;
+          return JSON.stringify({ alternatives: [
+            { target: 'sólido', replacement: 'robusto' },
+            'consistente',
+            { target: '<<<SELECCIÓN>>>sólido<<<FIN_SELECCIÓN>>>', replacement: 'firme' },
+            { target: 'otro fragmento', replacement: 'se descarta' },
+            { target: 'sólido', replacement: 'robusto' },
+            { target: 'sólido', replacement: 'fundado' },
+            { target: 'es sólido', replacement: 'está bien fundamentado' },
+          ] });
+        },
       };
     }
     if (request === './aiClient' && parent?.filename?.endsWith('/electron/ai/copilotChat.ts')) {

--- a/word-addin/taskpane.html
+++ b/word-addin/taskpane.html
@@ -72,6 +72,7 @@
           <button id="searchBtn" class="btn icon" type="button" title="Search">⌕</button>
         </div>
         <div id="analysisControls">
+          <label class="prompt-field mode-model-field"><span data-model-label>Model</span><select id="searchModel"></select></label>
           <div class="toolbar">
             <label class="auto"><input type="checkbox" id="autoToggle" checked /> Auto</label>
             <button id="analyzeBtn" class="btn primary" type="button">Analyze paragraph</button>
@@ -168,6 +169,7 @@
             <div><strong>Synonyms and rephrasings</strong><small>Select one or more words. Nodus uses the complete sentence to preserve meaning and grammar.</small></div>
             <button id="refreshSynonymSelection" class="btn tiny" type="button" title="Refresh selected text" aria-label="Refresh selected text">↻</button>
           </div>
+          <label class="prompt-field"><span data-model-label>Model</span><select id="synonymModel"></select></label>
           <div class="synonym-selection-block">
             <span class="synonym-block-label">Sentence context</span>
             <div id="synonymContext" class="synonym-context placeholder">Select one or more words in Word.</div>

--- a/word-addin/taskpane.js
+++ b/word-addin/taskpane.js
@@ -774,7 +774,12 @@
         return api('/api/insert', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ideaId: ideaId, paragraphText: values[0], selectionText: values[1] }),
+          body: JSON.stringify({
+            ideaId: ideaId,
+            paragraphText: values[0],
+            selectionText: values[1],
+            model: selectedModelFrom(els.searchModel),
+          }),
         });
       })
       .then(function (result) {
@@ -862,7 +867,7 @@
       api('/api/relations', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: text }),
+        body: JSON.stringify({ text: text, model: selectedModelFrom(els.searchModel) }),
       })
         .then(function (data) {
           if (seq !== requestSeq) return;
@@ -1036,7 +1041,12 @@
         return api('/api/compose', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ mode: mode, selectionText: selectionText, paragraphText: paragraphText }),
+          body: JSON.stringify({
+            mode: mode,
+            selectionText: selectionText,
+            paragraphText: paragraphText,
+            model: selectedModelFrom(els.searchModel),
+          }),
         });
       })
       .then(function (result) {
@@ -1093,7 +1103,11 @@
   }
 
   function selectedPromptModel() {
-    var value = els.promptModel.value;
+    return selectedModelFrom(els.promptModel);
+  }
+
+  function selectedModelFrom(select) {
+    var value = select && select.value;
     for (var i = 0; i < promptModels.length; i++) {
       if (promptModelValue(promptModels[i]) === value) {
         return { provider: promptModels[i].provider, model: promptModels[i].model };
@@ -1209,7 +1223,6 @@
 
   function fillPromptCatalogue(data) {
     var previousStyle = els.promptStyle.value;
-    var previousModel = els.promptModel.value;
     promptStyles = Array.isArray(data.styles) ? data.styles : [];
     promptModels = Array.isArray(data.models) ? data.models : [];
 
@@ -1234,41 +1247,46 @@
       if (wantedStyle) els.promptStyle.value = wantedStyle;
     }
 
-    els.promptModel.innerHTML = '';
-    if (!promptModels.length) {
-      var noModel = document.createElement('option');
-      noModel.value = '';
-      noModel.textContent = T('promptNoModels');
-      els.promptModel.appendChild(noModel);
-      els.promptModel.disabled = true;
-    } else {
-      els.promptModel.disabled = false;
+    function fillModelSelect(select) {
+      var previousModel = select.value;
+      select.innerHTML = '';
+      if (!promptModels.length) {
+        var noModel = document.createElement('option');
+        noModel.value = '';
+        noModel.textContent = T('promptNoModels');
+        select.appendChild(noModel);
+        select.disabled = true;
+        return;
+      }
+      select.disabled = false;
       promptModels.forEach(function (model) {
         var option = document.createElement('option');
         option.value = promptModelValue(model);
         option.textContent = model.label || (model.provider + ' · ' + model.model);
-        els.promptModel.appendChild(option);
+        select.appendChild(option);
       });
       var wantedModel = promptModels.some(function (model) { return promptModelValue(model) === previousModel; })
         ? previousModel
         : promptModelValue(data.defaultModel);
-      if (wantedModel) els.promptModel.value = wantedModel;
+      if (wantedModel) select.value = wantedModel;
     }
+    [els.promptModel, els.searchModel, els.synonymModel].forEach(fillModelSelect);
     renderPromptDescription();
+    updateSynonymState();
   }
 
-  function loadPromptCatalogue() {
+  function loadPromptCatalogue(silent) {
     var seq = ++promptRequestSeq;
-    setStatus(T('promptLoading'), '');
+    if (!silent) setStatus(T('promptLoading'), '');
     return api('/api/prompts')
       .then(function (data) {
         if (seq !== promptRequestSeq) return;
         fillPromptCatalogue(data || {});
-        checkHealth();
+        if (!silent) checkHealth();
       })
       .catch(function (error) {
         if (seq !== promptRequestSeq) return;
-        setStatus(T('promptLoadError') + error.message, 'err');
+        if (!silent) setStatus(T('promptLoadError') + error.message, 'err');
         promptStyles = [];
         promptModels = [];
         fillPromptCatalogue({ styles: [], models: [] });
@@ -1388,7 +1406,7 @@
     var stale = synonymStateIsStale();
     els.synonymStale.textContent = stale ? T('synonymStale') : '';
     els.synonymStale.hidden = !stale;
-    els.generateSynonyms.disabled = synonymGenerating || !synonymLiveContext;
+    els.generateSynonyms.disabled = synonymGenerating || !synonymLiveContext || !selectedModelFrom(els.synonymModel);
     els.synonymGenerateLabel.textContent = synonymRounds.length && !stale
       ? T('synonymRegenerate')
       : T('synonymGenerate');
@@ -1470,6 +1488,11 @@
   }
 
   function generateSynonymRound() {
+    var selectedModel = selectedModelFrom(els.synonymModel);
+    if (!selectedModel) {
+      setStatus(T('promptNoModels'), 'err');
+      return;
+    }
     var requested = null;
     var seq = ++synonymRequestSeq;
     setSynonymGenerating(true);
@@ -1498,6 +1521,7 @@
             selectionFrom: context.selectionFrom,
             selectionTo: context.selectionTo,
             previousAlternatives: previous,
+            model: selectedModel,
           }),
         });
       })
@@ -1608,7 +1632,7 @@
     }
     if (synonymMode) {
       refreshSynonymSelection().then(function (context) {
-        if (context && !synonymRequestContext && !synonymGenerating) generateSynonymRound();
+        if (context && selectedModelFrom(els.synonymModel) && !synonymRequestContext && !synonymGenerating) generateSynonymRound();
       });
       startPromptSelectionPolling();
       return;
@@ -1692,6 +1716,7 @@
     els.autoToggle = document.getElementById('autoToggle');
     els.searchBox = document.getElementById('searchBox');
     els.searchBtn = document.getElementById('searchBtn');
+    els.searchModel = document.getElementById('searchModel');
     els.searchControls = document.getElementById('searchControls');
     els.searchModeEl = document.getElementById('searchMode');
     els.analysisControls = document.getElementById('analysisControls');
@@ -1717,6 +1742,7 @@
     els.copyPromptOutput = document.getElementById('copyPromptOutput');
     els.pastePromptOutput = document.getElementById('pastePromptOutput');
     els.synonymControls = document.getElementById('synonymControls');
+    els.synonymModel = document.getElementById('synonymModel');
     els.synonymContext = document.getElementById('synonymContext');
     els.refreshSynonymSelection = document.getElementById('refreshSynonymSelection');
     els.generateSynonyms = document.getElementById('generateSynonyms');
@@ -1781,6 +1807,8 @@
     var promptProposalLabel = els.promptControls.querySelector('.prompt-output-head strong');
     if (promptStyleLabel) promptStyleLabel.textContent = T('promptStyle');
     if (promptModelLabel) promptModelLabel.textContent = T('promptModel');
+    var contextualModelLabels = document.querySelectorAll('[data-model-label]');
+    for (var mli = 0; mli < contextualModelLabels.length; mli++) contextualModelLabels[mli].textContent = T('promptModel');
     if (promptBlockLabel) promptBlockLabel.textContent = T('promptSelection');
     if (promptProposalLabel) promptProposalLabel.textContent = T('promptProposal');
     els.promptSelection.textContent = T('promptSelectionEmpty');
@@ -1866,6 +1894,16 @@
     els.autoToggle.onchange = function () { autoAnalyze = els.autoToggle.checked; };
     els.promptStyle.onchange = function () { clearPromptOutput(); renderPromptDescription(); };
     els.promptModel.onchange = function () { clearPromptOutput(); updatePromptGenerateState(); };
+    els.searchModel.onchange = function () {
+      lastHash = '';
+      if (searchMode === 'ideas' && !els.searchBox.value.trim()) analyze(true);
+    };
+    els.synonymModel.onchange = function () {
+      synonymRounds = [];
+      synonymRequestContext = null;
+      synonymModelLabel = '';
+      renderSynonymRounds();
+    };
     els.refreshPromptSelection.onclick = refreshPromptSelection;
     els.applyPrompt.onclick = runSavedPrompt;
     els.copyPromptOutput.onclick = copyPromptOutput;
@@ -1916,6 +1954,7 @@
     });
     if (chatController) chatController.init();
 
+    loadPromptCatalogue(true);
     checkHealth();
     var requestedMode = window.location.hash.indexOf('references') >= 0 ? 'references' : 'ideas';
     if (requestedMode === 'references') {


### PR DESCRIPTION
## Summary

- make contextual synonym parsing resilient to Gemini response variations and selection markers
- provide the unmodified sentence to the synonym model and over-generate candidates so five valid alternatives can be returned
- add model selectors to Ideas, Passages, and Synonyms in the Word add-in
- route the selected model through relation analysis, AI insertion, selection composition, and synonym generation

## Validation

- `scripts/test-study-improve.mjs --electron-study-improve-test`
- `scripts/test-copilot-addin.mjs --electron-copilot-addin-test`
- renderer and Electron TypeScript checks
- `node --check word-addin/taskpane.js`