### PR TITLE
Tell the user how to fix a failed Zotero check

### DIFF
--- a/electron/zotero/zoteroClient.ts
+++ b/electron/zotero/zoteroClient.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import type { ZoteroAttachmentInfo, ZoteroCollection, ZoteroItem, ZoteroLibrary, WorkMeta } from '@shared/types';
+import type { ZoteroAttachmentInfo, ZoteroCollection, ZoteroItem, ZoteroLibrary, ZoteroPingResult, WorkMeta } from '@shared/types';
 
 // Read-only client for Zotero's local API: the desktop app's local implementation
 // of Web API v3, served from port 23119 since Zotero 7. There is no "Zotero 7 API" —
@@ -103,21 +103,19 @@ export async function libraries(): Promise<ZoteroLibrary[]> {
 /**
  * Verify the local API is reachable. The local API has no auth and uses users/0,
  * so we just confirm a 200 and read the library version header.
+ *
+ * `message` stays technical (the transport error, or the HTTP status): the renderer
+ * localizes the actionable part from `reason`, so no Spanish is written here.
  */
-export async function ping(): Promise<{ ok: boolean; userId?: string; version?: number; message?: string }> {
+export async function ping(): Promise<ZoteroPingResult> {
   try {
     const res = await zfetch(`${BASE}/users/${LOCAL_USER_ID}/items?limit=1`);
-    if (!res.ok) {
-      const hint =
-        res.status === 403
-          ? 'Habilita "Permitir que otras aplicaciones se comuniquen con Zotero" en Ajustes › Avanzado.'
-          : `HTTP ${res.status}`;
-      return { ok: false, message: hint };
-    }
+    if (!res.ok) return { ok: false, message: `HTTP ${res.status}`, reason: res.status === 403 ? 'forbidden' : 'http' };
     const v = res.headers.get('Last-Modified-Version');
     return { ok: true, userId: LOCAL_USER_ID, version: v ? parseInt(v, 10) : 0 };
   } catch (e) {
-    return { ok: false, message: (e as Error).message };
+    // Nothing answered on the local port: Zotero is closed, or its local API is off.
+    return { ok: false, message: (e as Error).message, reason: 'unreachable' };
   }
 }
 

--- a/scripts/test-vault-onboarding-ui.mjs
+++ b/scripts/test-vault-onboarding-ui.mjs
@@ -139,6 +139,31 @@ test('academic onboarding offers Nodus Library or optional Zotero while dedicate
   assert.match(onboarding, /Construye un mundo de ficción coherente a partir de tu propio canon/);
 });
 
+test('a failed Zotero check names the setting that fixes it', async () => {
+  const [client, helper, onboarding, translate, en] = await Promise.all([
+    read('electron/zotero/zoteroClient.ts'),
+    read('src/lib/zoteroConnection.ts'),
+    read('src/views/Onboarding.tsx'),
+    read('src/views/ToolkitTranslateView.tsx'),
+    read('src/i18n.en.ts'),
+  ]);
+  // A closed Zotero answers with a bare transport error ("The operation could not be
+  // completed."), so the cause has to travel as a reason the renderer can localize.
+  assert.match(client, /reason: res\.status === 403 \? 'forbidden' : 'http'/);
+  assert.match(client, /reason: 'unreachable'/);
+  assert.doesNotMatch(client, /Habilita "Permitir/);
+  // …and a Zotero that DID answer, with some other status, must not be blamed on it.
+  assert.match(helper, /if \(status\?\.reason === 'http'\) return null;/);
+  const hint = /Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero\./;
+  assert.match(helper, hint);
+  assert.match(en, hint);
+  // Both surfaces that check the connection show it: the academic wizard and Translate.
+  for (const view of [onboarding, translate]) {
+    assert.match(view, /zoteroConnectionHint/);
+    assert.match(view, /zoteroPingErrorText/);
+  }
+});
+
 test('Zotero controls stay out of testimonies, prosopography and worldbuilding', async () => {
   const [app, settings] = await Promise.all([
     read('src/App.tsx'),

--- a/shared/api/platform.ts
+++ b/shared/api/platform.ts
@@ -58,6 +58,7 @@ import type {
   ZoteroInstallResult,
   ZoteroItem,
   ZoteroLibrary,
+  ZoteroPingResult,
   ZoteroPluginServerStatus,
   ZoteroPluginOpenTarget,
 } from '../types';
@@ -254,7 +255,7 @@ export interface PlatformApi {
   humeSynthesize(voiceId: string, provider: 'HUME_AI' | 'CUSTOM_VOICE', text: string): Promise<Uint8Array>;
 
   // zotero
-  zoteroPing(): Promise<{ ok: boolean; userId?: string; message?: string }>;
+  zoteroPing(): Promise<ZoteroPingResult>;
   zoteroLibraries(): Promise<ZoteroLibrary[]>;
   zoteroCollections(library?: ZoteroLibrary): Promise<ZoteroCollection[]>;
   zoteroChildCollections(parentKey: string, library?: ZoteroLibrary): Promise<ZoteroCollection[]>;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4740,6 +4740,21 @@ export interface ZoteroLibrary {
   name: string;
 }
 
+/**
+ * Outcome of checking Zotero's local API. On failure `message` carries the technical
+ * detail (a transport error such as "The operation could not be completed.", or the
+ * HTTP status) and `reason` says what the user has to do about it, which the renderer
+ * turns into a localized hint. 'forbidden' and 'unreachable' come down to the same
+ * fix: Zotero open, and its local API allowed in Advanced settings.
+ */
+export interface ZoteroPingResult {
+  ok: boolean;
+  userId?: string;
+  version?: number;
+  message?: string;
+  reason?: 'forbidden' | 'unreachable' | 'http';
+}
+
 export interface ZoteroAttachmentInfo {
   key: string;
   itemKey: string;

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -2046,6 +2046,8 @@ export const DE: Record<string, string> = {
   'Conectado (userID {id})': 'Verbunden (Benutzer-ID {id})',
   'No disponible: {msg}': 'Nicht verfügbar: {msg}',
   'sin respuesta': 'keine Antwort',
+  'Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.':
+    'Prüfe, ob Zotero geöffnet ist und ob „Anderen Programmen auf diesem Computer die Kommunikation mit Zotero erlauben“ in den erweiterten Einstellungen von Zotero aktiviert ist.',
   'Elige las colecciones a monitorizar. Se incorporan metadatos; los análisis se lanzan manualmente salvo que actives automatización en Ajustes.':
     'Wählen Sie die zu überwachenden Sammlungen aus. Metadaten werden übernommen; Analysen werden manuell gestartet, es sei denn, Sie aktivieren die Automatisierung in den Einstellungen.',
   'ítems': 'Elemente',

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -2072,6 +2072,8 @@ export const EN: Record<string, string> = {
   'Conectado (userID {id})': 'Connected (userID {id})',
   'No disponible: {msg}': 'Unavailable: {msg}',
   'sin respuesta': 'no response',
+  'Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.':
+    'Make sure Zotero is open and that “Allow other applications on this computer to communicate with Zotero” is enabled in Zotero’s Advanced settings.',
   'Elige las colecciones a monitorizar. Se incorporan metadatos; los análisis se lanzan manualmente salvo que actives automatización en Ajustes.':
     'Choose the collections to monitor. Metadata is ingested; analyses run manually unless you enable automation in Settings.',
   ítems: 'items',

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -2045,6 +2045,8 @@ export const FR: Record<string, string> = {
   'Conectado (userID {id})': 'Connecté (userID {id})',
   'No disponible: {msg}': 'Indisponible : {msg}',
   'sin respuesta': 'aucune réponse',
+  'Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.':
+    'Vérifiez que Zotero est ouvert et que « Autoriser les autres applications de cet ordinateur à communiquer avec Zotero » est activé dans les réglages Avancés de Zotero.',
   'Elige las colecciones a monitorizar. Se incorporan metadatos; los análisis se lanzan manualmente salvo que actives automatización en Ajustes.':
     'Choisissez les collections à surveiller. Les métadonnées sont importées ; les analyses sont lancées manuellement, sauf si vous activez l\'automatisation dans les paramètres.',
   'ítems': 'éléments',

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -1831,6 +1831,8 @@ export const IT: Record<string, string> = {
   "Conectado (userID {id})": "Connesso (ID utente {id})",
   "No disponible: {msg}": "Non disponibile: {msg}",
   "sin respuesta": "nessuna risposta",
+  "Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.":
+    "Verifica che Zotero sia aperto e che «Consenti ad altre applicazioni di questo computer di comunicare con Zotero» sia attivo nelle impostazioni Avanzate di Zotero.",
   "Elige las colecciones a monitorizar. Se incorporan metadatos; los análisis se lanzan manualmente salvo que actives automatización en Ajustes.": "Scegli le collezioni da monitorare. I metadati vengono acquisiti; le analisi vengono eseguite manualmente a meno che non si abiliti l'automazione in Impostazioni.",
   "ítems": "elementi",
   "subcol.": "sottocol.",

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -2031,6 +2031,8 @@ export const PT_BR: Record<string, string> = {
   'Conectado (userID {id})': 'Conectado (userID {id})',
   'No disponible: {msg}': 'Indisponível: {msg}',
   'sin respuesta': 'sem resposta',
+  'Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.':
+    'Verifique se o Zotero está aberto e se «Permitir que outros aplicativos deste computador se comuniquem com o Zotero» está ativado nas configurações Avançadas do Zotero.',
   'Elige las colecciones a monitorizar. Se incorporan metadatos; los análisis se lanzan manualmente salvo que actives automatización en Ajustes.':
     'Escolha as coleções a monitorar. Os metadados são incorporados; as análises são iniciadas manualmente, a menos que você ative a automação em Configurações.',
   'ítems': 'itens',

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -2028,6 +2028,8 @@ export const PT: Record<string, string> = {
   'Conectado (userID {id})': 'Ligado (userID {id})',
   'No disponible: {msg}': 'Não disponível: {msg}',
   'sin respuesta': 'sem resposta',
+  'Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.':
+    'Verifique se o Zotero está aberto e se «Permitir que outras aplicações deste computador comuniquem com o Zotero» está ativado nas definições Avançadas do Zotero.',
   'Elige las colecciones a monitorizar. Se incorporan metadatos; los análisis se lanzan manualmente salvo que actives automatización en Ajustes.':
     'Escolha as coleções a monitorizar. Os metadados são incorporados; as análises são iniciadas manualmente, exceto se ativar a automatização nas Definições.',
   'ítems': 'itens',

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -2215,6 +2215,8 @@ export const TR: Record<string, string> = {
   "Conectado (userID {id})": "Bağlandı (kullanıcı kimliği {id})",
   "No disponible: {msg}": "Mevcut değil: {msg}",
   "sin respuesta": "yanıt yok",
+  "Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.":
+    "Zotero’nun açık olduğundan ve Zotero’nun Gelişmiş ayarlarında “Bu bilgisayardaki diğer uygulamaların Zotero ile iletişim kurmasına izin ver” seçeneğinin etkin olduğundan emin olun.",
   "Elige las colecciones a monitorizar. Se incorporan metadatos; los análisis se lanzan manualmente salvo que actives automatización en Ajustes.": "İzlenecek koleksiyonları seçin. Meta veriler dahil edilmiştir; Ayarlar'da otomasyonu etkinleştirmediğiniz sürece analizler manuel olarak başlatılır.",
   "ítems": "öğeler",
   "subcol.": "alt sütun",

--- a/src/lib/zoteroConnection.ts
+++ b/src/lib/zoteroConnection.ts
@@ -1,0 +1,25 @@
+import type { ZoteroPingResult } from '@shared/types';
+import { t, tx } from '../i18n';
+
+/**
+ * The line every Zotero connection check shows when it fails, plus what to do about it.
+ *
+ * A closed Zotero — or one whose local API is switched off — answers nothing at all, so
+ * the check only has a bare transport error to report ("The operation could not be
+ * completed."). That names neither the cause nor the fix, which is why the hint travels
+ * with the failure instead of living in one screen's copy.
+ */
+
+/** "Unavailable: <technical detail>", the detail being the transport error or HTTP status. */
+export function zoteroPingErrorText(status: Pick<ZoteroPingResult, 'message'> | null | undefined): string {
+  return tx('No disponible: {msg}', { msg: status?.message?.trim() || t('sin respuesta') });
+}
+
+/**
+ * The one setting that explains both a refused connection and a 403. An HTTP failure
+ * with any other status came from a Zotero that IS running, so it gets no hint.
+ */
+export function zoteroConnectionHint(status: Pick<ZoteroPingResult, 'reason'> | null | undefined): string | null {
+  if (status?.reason === 'http') return null;
+  return t('Comprueba que Zotero esté abierto y que «Permitir que otras aplicaciones de este ordenador se comuniquen con Zotero» esté activado en los ajustes Avanzados de Zotero.');
+}

--- a/src/views/Onboarding.tsx
+++ b/src/views/Onboarding.tsx
@@ -1,12 +1,13 @@
 import { useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import type { AiProvider, AppSettings, ZoteroCollection, ModelRef, VaultSummary } from '@shared/types';
+import type { AiProvider, AppSettings, ZoteroCollection, ModelRef, VaultSummary, ZoteroPingResult } from '@shared/types';
 import { normalizeEmbeddingModel, normalizeEmbeddingProvider } from '@shared/providers';
 import { getNodusLocalModel } from '@shared/localAiModels';
 import { Spinner, Icon } from '../components/ui';
 import { ConfirmModal } from '../components/ConfirmModal';
 import { OnboardingModelStep } from '../components/OnboardingModelStep';
 import { t, tx } from '../i18n';
+import { zoteroConnectionHint, zoteroPingErrorText } from '../lib/zoteroConnection';
 
 type OnboardingExit = 'home' | 'library' | 'settings';
 
@@ -28,7 +29,7 @@ export function Onboarding({
   discardsVault?: boolean;
 }) {
   const [step, setStep] = useState(0);
-  const [ping, setPing] = useState<{ ok: boolean; userId?: string; message?: string } | null>(null);
+  const [ping, setPing] = useState<ZoteroPingResult | null>(null);
   const [collections, setCollections] = useState<ZoteroCollection[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [librarySetup, setLibrarySetup] = useState<'nodus' | 'zotero'>('nodus');
@@ -224,6 +225,9 @@ export function Onboarding({
     }
   };
 
+  // A failed check names the setting that fixes it; an HTTP failure from a Zotero that
+  // did answer gets no hint (zoteroConnectionHint decides).
+  const pingHint = ping && !ping.ok ? zoteroConnectionHint(ping) : null;
   const steps = simple
     ? [t('Introducción'), t('Proveedor de IA'), t('Listo')]
     : [t('Biblioteca'), connectsZotero ? t('Colecciones de Zotero') : t('Añadir contenido'), connectsZotero ? t('Lecturas de Zotero') : t('Cómo funciona'), t('Proveedor de IA'), t('Primer resultado')];
@@ -348,7 +352,14 @@ export function Onboarding({
             {connectsZotero && <div className="rounded-xl border border-neutral-800 p-3">
               <p className="text-xs text-neutral-400">{t('Nodus usa la API local de Zotero en modo solo lectura (requiere Zotero 7 o posterior). Abre Zotero y verifica la conexión.')}</p>
               <button className="btn btn-secondary mt-3" onClick={checkZotero}>{t('Verificar conexión')}</button>
-              {ping && <div className={`mt-2 text-sm ${ping.ok ? 'text-emerald-400' : 'text-red-400'}`}>{ping.ok ? tx('Conectado (userID {id})', { id: ping.userId ?? '' }) : tx('No disponible: {msg}', { msg: ping.message ?? t('sin respuesta') })}</div>}
+              {ping && (ping.ok ? (
+                <div className="mt-2 text-sm text-emerald-400">{tx('Conectado (userID {id})', { id: ping.userId ?? '' })}</div>
+              ) : (
+                <div role="alert" data-testid="onboarding-zotero-error" className="mt-2 text-sm text-red-400">
+                  {zoteroPingErrorText(ping)}
+                  {pingHint && <p className="mt-1 text-xs leading-5 text-amber-300">{pingHint}</p>}
+                </div>
+              ))}
             </div>}
             {librarySetup === 'nodus' && (
               <div className="rounded-xl border border-emerald-700/30 bg-emerald-500/5 p-3 text-xs leading-5 text-emerald-300">

--- a/src/views/ToolkitTranslateView.tsx
+++ b/src/views/ToolkitTranslateView.tsx
@@ -17,6 +17,7 @@ import { ModelPicker, SubscriptionQuotaNotice } from '../components/ModelPicker'
 import { ToolkitAppHero } from '../components/ToolkitAppHero';
 import { Icon, Spinner } from '../components/ui';
 import { errorText, t, tr, tx } from '../i18n';
+import { zoteroConnectionHint, zoteroPingErrorText } from '../lib/zoteroConnection';
 import {
   TRANSLATE_JOB_KEY,
   clearBackgroundJob,
@@ -76,6 +77,7 @@ export function ToolkitTranslateView({ onBack, settings }: { onBack: () => void;
   const [zoteroConnecting, setZoteroConnecting] = useState(false);
   const [zoteroSearching, setZoteroSearching] = useState(false);
   const [zoteroError, setZoteroError] = useState<string | null>(null);
+  const [zoteroHint, setZoteroHint] = useState<string | null>(null);
   const [zoteroConnectAttempt, setZoteroConnectAttempt] = useState(0);
 
   const [history, setHistory] = useState<TranslateHistoryEntry[]>([]);
@@ -91,8 +93,13 @@ export function ToolkitTranslateView({ onBack, settings }: { onBack: () => void;
     let disposed = false;
     setZoteroConnecting(true);
     setZoteroError(null);
+    setZoteroHint(null);
     void window.nodus.zoteroPing().then(async (status) => {
-      if (!status.ok) throw new Error(status.message || t('Zotero no está disponible.'));
+      if (!status.ok) {
+        // The hint survives the throw below: the catch only knows the message.
+        setZoteroHint(zoteroConnectionHint(status));
+        throw new Error(zoteroPingErrorText(status));
+      }
       const next = await window.nodus.zoteroLibraries();
       if (disposed) return;
       setLibraries(next);
@@ -255,7 +262,10 @@ export function ToolkitTranslateView({ onBack, settings }: { onBack: () => void;
     {tab === 'zotero' && <section className="space-y-3">
       <div className={`flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2 text-xs ${zoteroError ? 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300' : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/20 dark:text-emerald-300'}`}>
         <Icon name={zoteroError ? 'alert' : zoteroConnecting ? 'sync' : 'check'} size={14} className={zoteroConnecting ? 'animate-spin' : ''} />
-        <span className="min-w-0 flex-1">{zoteroConnecting ? t('Conectando con Zotero…') : zoteroError || tx(libraries.length === 1 ? 'Conectado a Zotero · {count} biblioteca' : 'Conectado a Zotero · {count} bibliotecas', { count: libraries.length })}</span>
+        <span className="min-w-0 flex-1">
+          {zoteroConnecting ? t('Conectando con Zotero…') : zoteroError || tx(libraries.length === 1 ? 'Conectado a Zotero · {count} biblioteca' : 'Conectado a Zotero · {count} bibliotecas', { count: libraries.length })}
+          {!zoteroConnecting && zoteroError && zoteroHint && <span className="mt-1 block font-normal leading-5 opacity-90">{zoteroHint}</span>}
+        </span>
         <button data-testid="translate-zotero-reconnect" type="button" className="btn btn-ghost !px-2 !py-1" disabled={zoteroConnecting} onClick={() => setZoteroConnectAttempt((value) => value + 1)}>{t('Reconectar')}</button>
       </div>
       <div className="grid gap-4 lg:grid-cols-2">


### PR DESCRIPTION
## The problem

When a vault offers the choice between the Nodus Library and Zotero, and the connection check fails, the wizard said only:

> Unavailable: The operation could not be completed.

That is the raw transport error from a port nobody answered. It names neither the cause — Zotero closed, or its local API switched off — nor the fix, which is a single checkbox.

## What changes

`ping()` now reports **why** it failed alongside the technical detail:

- `unreachable` — nothing answered on the local port (Zotero closed, or its local API off)
- `forbidden` — HTTP 403
- `http` — any other status

Both screens that run the check show the actionable line under the error:

> Make sure Zotero is open and that "Allow other applications on this computer to communicate with Zotero" is enabled in Zotero's Advanced settings.

A Zotero that **did** answer, with some other HTTP status, is running — so that case gets no hint.

The hint travels with the failure instead of living in one screen's copy, so the onboarding wizard and Toolkit → Translate → Zotero say the same thing. This also removes the last Spanish sentence the main process wrote for the interface (the old 403 message), which never passed through the translation tables and shipped untranslated to the other six languages.

## Where it shows

- **Vault onboarding** — the Library step of the academic wizard, the only vault type that offers Zotero.
- **Toolkit → Translate → Zotero** — its connection status bar.

## Notes

- Translated into all seven interface languages, each using the label as Zotero itself words it in that language.
- `scripts/test-vault-onboarding-ui.mjs` pins the contract: the three reasons, the excluded `http` case, the sentence itself, and its presence in both views.
- Not addressed here: the Zotero collections modal (`src/views/CollectionsModal.tsx`) never checks the connection and shows an empty list with no explanation when Zotero is closed. Separate, larger fix.

## Verification

`tsc` on both projects, `eslint` on the touched files, and `test-i18n-coverage` (24), `test-vault-onboarding-ui` (18), `test-toolkit-localization` (5) and the three Zotero client tests all green. The screenshot state was confirmed by mounting the real `Onboarding` component against the compiled stylesheet with a `zoteroPing` that answers the way a closed Zotero does.
