### PR TITLE
Refresh the sitemap lastmod for the pages sourced from package.json

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nodusresearch.com/</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/about/</loc>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/app/</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/apps/</loc>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/cite/</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-29</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/demo/</loc>


### PR DESCRIPTION
`main` is failing CI right now, independently of any feature work: the sitemap test is red.

## The failure

`scripts/test-site-sitemap.mjs` derives every `lastmod` from the last commit that touched each URL's declared sources. Three URLs — `/`, `/app/` and `/cite/` — list `package.json` among their sources, and the newest commit touching it is already dated `2026-08-29`, while `site/sitemap.xml` still carried `2026-08-28`:

```
https://nodusresearch.com/ uses its relevant source date
+ actual - expected
+ '2026-08-28'
- '2026-08-29'
```

## The fix

Regenerated with `npm run site:sitemap`. Only those three stamps move.

No page declares the generated sitemap among its own sources (the test asserts this), so committing the regenerated file does not move any date again — it stays correct until a real content source is touched.

## Verification

`node --test scripts/test-site-sitemap.mjs` passes, 3/3.
