### PR TITLE
Declare pdf-lib in the server image and smoke that image on pull requests

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -19,6 +19,17 @@ on:
       - 'scripts/lib/nodusServerHarness.mjs'
       - 'scripts/lib/nodusServerFixtures.mjs'
       - '.github/workflows/nodus-server-image.yml'
+  # The image only ever built after a merge, so a server change that stops the
+  # container booting reached main before anyone saw it. Pull requests now build
+  # and smoke the same image; they never publish it.
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.server-web.config.ts'
+      - 'src/serverWeb/**'
+      - 'server/**'
+      - '.github/workflows/nodus-server-image.yml'
   workflow_dispatch:
 
 permissions:
@@ -33,6 +44,42 @@ env:
   IMAGE: ghcr.io/drakonis96/nodus-server
 
 jobs:
+  # Build and boot the image without publishing it. The image's dependencies are
+  # server/package.json alone, so a module the server imports at startup but does
+  # not declare there only shows up here, never in the main CI workflow.
+  smoke-pull-request:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build smoke-test image
+        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.0.6 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
+
+      - name: Run image health smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --name nodus-server-ci \
+            -p 127.0.0.1:17443:7443 \
+            -e NODUS_PUBLIC_URL=http://localhost:17443 \
+            -e NODUS_ADMIN_EMAIL=ci-admin@example.test \
+            -e NODUS_ADMIN_PASSWORD=ci-only-admin-password-123456 \
+            nodus-server:ci
+          for _ in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:17443/healthz | grep --quiet '"ok":true'; then
+              curl --silent --head http://127.0.0.1:17443/ | grep --ignore-case --quiet '^location: /login'
+              docker rm -f nodus-server-ci >/dev/null
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs nodus-server-ci
+          docker rm -f nodus-server-ci >/dev/null
+          exit 1
+
   publish-main:
     # A manual run from another branch must never replace the image consumed by
     # production-like Portainer tests.

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.11.1",
-    "esbuild": "^0.28.2"
+    "esbuild": "^0.28.2",
+    "pdf-lib": "^1.17.1"
   }
 }


### PR DESCRIPTION
The published server image stops booting on `main`, and has done since #609.

## The failure

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pdf-lib'
  imported from /app/lib/core/deepResearchPdf.mjs
```

`server/server.mjs` imports `deepResearchPdf.mjs` at module load (line 35), that module imports `pdf-lib`, and `server/package.json` declared only `better-sqlite3` and `esbuild`. The container dies before it listens, so the health smoke never gets an answer.

`pdf-lib` is a genuine runtime dependency — `deepResearchPdfBytes` is wired into the routes as `renderPdf` — so it is declared rather than deferred behind a lazy import.

`serverBackup.mjs` imports `adm-zip` and is undeclared too, but nothing in the running server imports it (only a test does), which is why the image booted before this.

## Why it reached main twice

The image workflow only runs on `push` to `main`. It went red at #609's merge (`b8de9e43`), green again at the revert (`b27bd28c`), and red again at #611 (`b05ee213`) — never visible on a pull request.

A separate `smoke-pull-request` job now builds and boots the same image for pull requests touching the server. It does not publish, and `publish-main` is untouched (still `if: github.ref == 'refs/heads/main'`, still the only job that logs into GHCR).

This matters because the image's dependency set is `server/package.json` alone. A module the server imports at startup but does not declare there is invisible to the main CI workflow, which resolves against the repo root's `node_modules`.

## Verification

Reproduced the image layout locally without Docker: the files `server/Dockerfile` copies, `npm install --omit=dev` against `server/package.json` alone, then `node server.mjs`. Before the fix it died on `pdf-lib`; after it boots, `/healthz` answers `"ok":true` and `/` redirects to `/login` — the two checks the workflow makes.
