### PR TITLE
Build server web assets on the native platform

### DIFF
--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -46,6 +46,8 @@ test('the main workflow tests then publishes amd64 and arm64 images', () => {
 
 test('the image is non-root, health-checked and visibly experimental', () => {
   const dockerfile = read('server/Dockerfile');
+  assert.match(dockerfile, /FROM --platform=\$BUILDPLATFORM node:22-alpine AS web-build/,
+    'architecture-independent web assets must build natively instead of through QEMU');
   assert.match(dockerfile, /USER node/);
   assert.match(dockerfile, /HEALTHCHECK/);
   assert.match(dockerfile, /app\.nodus\.stability="experimental"/);

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM node:22-alpine AS web-build
+# The renderer output is architecture-independent. Build it on the runner's native
+# platform so multi-platform releases do not execute npm/Vite through QEMU.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS web-build
 
 WORKDIR /src
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Summary

- build the architecture-independent Server Web bundle on the native BuildKit platform
- keep the final Nodus Server image published for both AMD64 and ARM64
- add a deployment-contract regression test for the native web-build stage

## Context

The post-merge server image workflow for #616 timed out twice while `npm ci` ran under ARM64 QEMU. The first attempt logged an illegal instruction before hanging. Building the web-only stage on `$BUILDPLATFORM` removes emulation from npm/Vite without changing either target runtime image.

## Validation

- `node --test scripts/test-nodus-server-deployment.mjs scripts/test-server-web-boundary.mjs`
- `npm run build:server-web`
- `git diff --check`