### PR TITLE
Make Documentary Index opt-in per work

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ dist-zotero
 dist-browser
 release
 output
+artifacts
 reports
 server/data
 server/dist/web

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ reports/
 # Local artifact previews (published website manuals live in site/manuals/)
 output/
 pages-artifact/
+artifacts/
 
 # Locally generated legal texts (rebuilt from node_modules on every build).
 legal/generated/*

--- a/electron/ai/documentPreparation.ts
+++ b/electron/ai/documentPreparation.ts
@@ -19,7 +19,7 @@ export interface DocumentPreparationResult {
  */
 export async function prepareRelevantDocumentProfiles(
   orderedNodusIds: string[],
-  reason: 'deep-research' | 'immersion',
+  reason: 'deep-research',
   limit = 32,
   signal?: AbortSignal,
 ): Promise<DocumentPreparationResult> {

--- a/electron/ai/documentProfile.ts
+++ b/electron/ai/documentProfile.ts
@@ -745,7 +745,13 @@ export async function runDocumentProfileScan(work: Work, options: RunDocumentPro
   const settings = getSettings();
   const userId = settings.zoteroUserId || LOCAL_USER_ID;
   emit(options, 'waiting_source', 0.01, 'Resolviendo el texto completo…');
-  const item = await getItem(userId, work.zotero_key).catch(() => null);
+  // Nodus-owned Library references already point at a materialized, clean local
+  // document. Asking Zotero about that synthetic key first is both unnecessary
+  // and harmful when Zotero's local server accepts the connection but never
+  // answers: a manual Documentary Index then appears frozen at waiting_source.
+  const item = work.zotero_key.startsWith('nodus-library:')
+    ? null
+    : await getItem(userId, work.zotero_key).catch(() => null);
   const document = await resolveWorkText(
     userId, work.zotero_key, settings.zoteroStoragePath, item?.abstract ?? null, work.doi,
     {

--- a/electron/ai/immersion.ts
+++ b/electron/ai/immersion.ts
@@ -19,7 +19,6 @@ import { getApiKey } from '../secrets/secretStore';
 import { buildIdeaGraph, getContradictions } from '../graph/graphService';
 import { getImmersionSession, recordImmersionAnswer, saveImmersionSession } from '../db/immersionRepo';
 import { buildWritingWorkshopSnapshot } from './writingWorkshop';
-import { prepareRelevantDocumentProfiles } from './documentPreparation';
 import { completeJson, embed } from './aiClient';
 import {
   IMMERSION_LIMITS,
@@ -439,22 +438,14 @@ export async function generateImmersionSession(
     try { onProgress?.(progress); } catch { /* progress cannot abort generation */ }
   };
   emit({ phase: 'discovery', message: 'Cartografiando ideas, obras y pasajes relevantes…' });
-  const preliminary = await buildImmersionMaterial(request.topic);
-  const candidates = preliminary.works.map((work) => work.nodusId);
+  const material = await buildImmersionMaterial(request.topic);
   emit({
     phase: 'document_preparation',
-    message: `Preparando la comprensión integral de hasta ${Math.min(32, candidates.length)} obras para la ruta…`,
+    message: 'Usando las fichas documentales ya disponibles junto con ideas y evidencia literal…',
   });
-  const prepared = await prepareRelevantDocumentProfiles(candidates, 'immersion', 32);
-  emit({
-    phase: 'document_preparation',
-    message: prepared.requested
-      ? `${prepared.prepared} fichas documentales auditadas listas para estructurar la inmersión; ${prepared.unavailable + prepared.failed} obras continúan mediante ideas y pasajes.`
-      : 'El material ya estaba preparado; continuando con ideas y evidencia literal.',
-  });
-  // Rebuild once: new profiles can change which works and sections route the topic.
-  const refreshed = prepared.requested ? await buildImmersionMaterial(request.topic) : preliminary;
-  const plan = await orchestrateImmersion({ ...request, model }, realDeps(model, refreshed), onProgress);
+  // Immersion may consume profiles already prepared by Deep Research or a manual
+  // reader action, but it never creates new Documentary Index work itself.
+  const plan = await orchestrateImmersion({ ...request, model }, realDeps(model, material), onProgress);
   return saveImmersionSession(plan, model);
 }
 

--- a/electron/extraction/textExtractor.ts
+++ b/electron/extraction/textExtractor.ts
@@ -893,6 +893,7 @@ export async function resolveWorkText(
   // so deep scans can still find local PDFs instead of degrading to abstract-only.
   const effectiveStorage = storagePath || defaultZoteroStorage();
   const isAttachmentItem = (itemType ?? '').toLowerCase() === 'attachment';
+  const isNodusLibraryItem = zoteroKey.startsWith('nodus-library:');
 
   // (1+2) Resolve text from the Zotero attachments. A scan can race a just-attached
   // file — the attachment child, its filename, or the on-disk copy may surface a
@@ -901,7 +902,11 @@ export async function resolveWorkText(
   let hadTextAttachment = false;
   let scanNote: string | null = null;
   let blockReason: TextBlockReason | null = null;
-  for (let attempt = 0; attempt < ATTACHMENT_READ_ATTEMPTS; attempt++) {
+  // A `nodus-library:` key is not a Zotero item key. Its canonical clean copy is
+  // resolved by the Library fallback immediately below, so do not spend retries
+  // querying Zotero before reading the source Nodus already owns locally.
+  const attachmentReadAttempts = isNodusLibraryItem ? 0 : ATTACHMENT_READ_ATTEMPTS;
+  for (let attempt = 0; attempt < attachmentReadAttempts; attempt++) {
     opts.signal?.throwIfAborted();
     if (attempt > 0) await abortableDelay(ATTACHMENT_RETRY_DELAYS_MS[attempt] ?? 1500, opts.signal);
     let textAttachments: ZoteroAttachment[] = [];

--- a/electron/pipeline/documentIndexQueue.ts
+++ b/electron/pipeline/documentIndexQueue.ts
@@ -27,6 +27,7 @@ import { AiError } from '../ai/aiClient';
 import { coalesce } from '../util/coalesce';
 import { registerDocumentIndexMaintenanceController } from './documentIndexMaintenance';
 import { compareDocumentIndexJobsForDisplay } from '@shared/documentIndexProgress';
+import { DOCUMENT_INDEX_CONTINUOUS_AVAILABLE } from '@shared/documentIndexPolicy';
 
 type Listener = (progress: DocumentIndexProgress) => void;
 const POLL_MS = 350;
@@ -113,15 +114,21 @@ class DocumentIndexQueue {
       await withVaultDatabase(vault.id, async () => {
         recoverInterruptedDocumentJobs();
         const settings = getSettings();
-        if (settings.documentIndexingEnabled) {
+        if (DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && settings.documentIndexingEnabled) {
           await this.ensureContinuousCampaignInside(vault.id, settings.documentIndexIncludeArchived);
+        } else {
+          for (const campaign of listDocumentIndexCampaigns().filter((item) =>
+            item.mode === 'continuous' && ['queued', 'running'].includes(item.status)
+          )) setDocumentCampaignStatus(campaign.campaignId, 'paused');
         }
       }).catch((error) => console.error('[document-index] resume failed', vault.id, error));
     }
-    this.continuousTimer = setInterval(() => {
-      void this.refreshContinuousCampaigns();
-    }, 30_000);
-    this.continuousTimer.unref?.();
+    if (DOCUMENT_INDEX_CONTINUOUS_AVAILABLE) {
+      this.continuousTimer = setInterval(() => {
+        void this.refreshContinuousCampaigns();
+      }, 30_000);
+      this.continuousTimer.unref?.();
+    }
     this.schedule();
   }
 
@@ -130,7 +137,7 @@ class DocumentIndexQueue {
     for (const vault of listVaults().filter((item) => writable(item) && !this.maintenanceVaults.has(item.id))) {
       await withVaultDatabase(vault.id, async () => {
         const settings = getSettings();
-        if (settings.documentIndexingEnabled) {
+        if (DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && settings.documentIndexingEnabled) {
           await this.ensureContinuousCampaignInside(vault.id, settings.documentIndexIncludeArchived);
         }
       }).catch((error) => console.error('[document-index] continuous refresh failed', vault.id, error));
@@ -146,7 +153,7 @@ class DocumentIndexQueue {
     if (!vault || !writable(vault) || this.stopping || this.maintenanceAll || this.maintenanceVaults.has(vaultId)) return;
     await withVaultDatabase(vault.id, async () => {
       const settings = getSettings();
-      if (settings.documentIndexingEnabled) {
+      if (DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && settings.documentIndexingEnabled) {
         await this.ensureContinuousCampaignInside(vault.id, settings.documentIndexIncludeArchived);
       }
     });
@@ -163,7 +170,7 @@ class DocumentIndexQueue {
       const campaigns = listDocumentIndexCampaigns().filter((campaign) =>
         campaign.mode === 'continuous' && ['queued', 'running', 'paused'].includes(campaign.status)
       );
-      if (!enabled) {
+      if (!DOCUMENT_INDEX_CONTINUOUS_AVAILABLE || !enabled) {
         for (const campaign of campaigns) setDocumentCampaignStatus(campaign.campaignId, 'paused');
         return;
       }

--- a/electron/sync/syncService.ts
+++ b/electron/sync/syncService.ts
@@ -22,6 +22,7 @@ import { getDb } from '../db/database';
 import { probeWorkTextAvailability } from '../extraction/textExtractor';
 import { getActiveVault } from '../vaults/vaultRegistry';
 import { documentIndexQueue } from '../pipeline/documentIndexQueue';
+import { DOCUMENT_INDEX_CONTINUOUS_AVAILABLE } from '@shared/documentIndexPolicy';
 
 
 /** Structured creators kept for building canonical author identity. Only authors
@@ -240,7 +241,7 @@ export async function fullSync(mode: 'manual' | 'realtime'): Promise<SyncLogEntr
 
   // Continuous document understanding is opt-in. When enabled, reconcile now so
   // newly synced or changed works do not have to wait for the periodic safety poll.
-  if (settings.documentIndexingEnabled && (added > 0 || changed > 0)) {
+  if (DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && settings.documentIndexingEnabled && (added > 0 || changed > 0)) {
     await documentIndexQueue.refreshVault(getActiveVault().id).catch((error) => {
       console.error('[document-index] post-sync refresh failed', error);
     });

--- a/scripts/test-document-index-queue.mjs
+++ b/scripts/test-document-index-queue.mjs
@@ -78,15 +78,14 @@ test('persistent scheduler processes two vaults without using an active-vault si
   assert.equal(snapshot.campaigns.filter(c=>c.status==='completed').length,2);
 });
 
-test('continuous mode discovers newly imported works immediately and remains vault-scoped',async()=>{
+test('continuous mode stays disabled until the beta policy is reopened',async()=>{
   globalThis.__documentQueue.continuousEnabled=true;
   await documentIndexQueue.configureContinuous('v1',true);
   globalThis.__documentQueue.works.get('v1').push({nodus_id:'v1-new',title:'Obra recién importada'});
   await documentIndexQueue.refreshVault('v1');
-  const deadline=Date.now()+2000;
-  do{await new Promise(r=>setTimeout(r,20));}while(globalThis.__documentQueue.data.get('v1').profiles.get('v1-new')!=='current'&&Date.now()<deadline);
-  assert.equal(globalThis.__documentQueue.data.get('v1').profiles.get('v1-new'),'current');
-  assert.ok(globalThis.__documentQueue.runs.some(run=>run.vault==='v1'&&run.work==='v1-new'));
+  await new Promise(r=>setTimeout(r,60));
+  assert.equal(globalThis.__documentQueue.data.get('v1').profiles.get('v1-new'),undefined);
+  assert.ok(!globalThis.__documentQueue.runs.some(run=>run.vault==='v1'&&run.work==='v1-new'));
   assert.ok(!globalThis.__documentQueue.runs.some(run=>run.vault==='v2'&&run.work==='v1-new'));
 });
 

--- a/scripts/test-library-status.mjs
+++ b/scripts/test-library-status.mjs
@@ -41,7 +41,9 @@ const work = (over = {}) => ({
 const embedded = (over = {}) => ({ nodus_id: 'w1', totalIdeas: 10, embeddedIdeas: 10, complete: true, ...over });
 const indexed = (over = {}) => ({ nodus_id: 'w1', totalPassages: 40, status: 'complete', outdatedReason: null, ...over });
 
-test('a fully processed work is ready, and the summary does not gate it', () => {
+test('a fully processed work is ready without a documentary index, and the summary does not gate it', () => {
+  // deriveWorkStatus deliberately has no document-profile input: an absent beta
+  // index cannot turn a completed work amber.
   assert.equal(deriveWorkStatus(work(), embedded(), indexed()).readiness, 'ready');
   // Summary is an orientation aid, not citable evidence: missing it stays green.
   const noSummary = deriveWorkStatus(work({ summary_status: 'none' }), embedded(), indexed());
@@ -213,16 +215,43 @@ test('the status modal repairs missing steps without wasting work', async () => 
   // Blocked and not-applicable steps are terminal: offering a retry there spends
   // tokens on something that cannot succeed.
   assert.match(source, /const RETRYABLE: StepState\[\] = \['partial', 'missing', 'failed'\]/);
+  assert.match(source, /data-testid="work-status-documentary-index"/);
+  assert.match(source, /data-testid="work-status-documentary-beta"[^>]*>BETA</);
+  assert.match(source, /enqueueDocumentProfile\(work\.nodus_id\)/, 'the documentary index remains an explicit per-work action');
+  assert.match(source, /no afecta al estado general de la obra/, 'the optional index is explained next to its action');
   assert.match(source, /role="dialog"[\s\S]{0,120}aria-modal="true"/);
 });
 
 test('the library row renders the derived status instead of the five pipeline columns', async () => {
   const source = await readFile(path.join(root, 'src/views/Library.tsx'), 'utf8');
   assert.match(source, /deriveWorkStatus/);
+  assert.match(source, /DOCUMENT_INDEX_MANAGER_VISIBLE && vaultType === 'academic'/, 'the global documentary-index button remains implemented but hidden');
   // The tour and the tutorial video both anchor on this.
   assert.match(source, /data-tour="library-actions"/);
   // The pipeline columns and the per-row icon toolbar are gone.
   assert.doesNotMatch(source, /sortKey="embeddings"/);
   assert.doesNotMatch(source, /sortKey="passages"/);
   assert.doesNotMatch(source, /nodus_id\.slice\(0, 8\)/);
+});
+
+test('documentary indexing is limited to Deep Research and explicit reader actions', async () => {
+  const [policy, queue, immersion, deepResearch, modal, profile, extractor] = await Promise.all([
+    readFile(path.join(root, 'shared/documentIndexPolicy.ts'), 'utf8'),
+    readFile(path.join(root, 'electron/pipeline/documentIndexQueue.ts'), 'utf8'),
+    readFile(path.join(root, 'electron/ai/immersion.ts'), 'utf8'),
+    readFile(path.join(root, 'electron/ai/deepResearch.ts'), 'utf8'),
+    readFile(path.join(root, 'src/views/WorkStatusModal.tsx'), 'utf8'),
+    readFile(path.join(root, 'electron/ai/documentProfile.ts'), 'utf8'),
+    readFile(path.join(root, 'electron/extraction/textExtractor.ts'), 'utf8'),
+  ]);
+  assert.match(policy, /DOCUMENT_INDEX_CONTINUOUS_AVAILABLE = false/);
+  assert.match(policy, /DOCUMENT_INDEX_MANAGER_VISIBLE = false/);
+  assert.match(queue, /DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && settings\.documentIndexingEnabled/);
+  assert.doesNotMatch(immersion, /prepareRelevantDocumentProfiles/, 'Immersion may reuse profiles but never creates them');
+  assert.match(deepResearch, /prepareRelevantDocumentProfiles\([\s\S]{0,180}'deep-research'/);
+  assert.match(modal, /enqueueDocumentProfile\(work\.nodus_id\)/);
+  assert.match(profile, /work\.zotero_key\.startsWith\('nodus-library:'\)[\s\S]{0,120}\? null[\s\S]{0,80}getItem/,
+    'Nodus-owned Library works bypass the Zotero metadata request');
+  assert.match(extractor, /attachmentReadAttempts = isNodusLibraryItem \? 0 : ATTACHMENT_READ_ATTEMPTS/,
+    'Nodus-owned Library works resolve their clean local copy without Zotero attachment retries');
 });

--- a/scripts/verify-documentary-index-button-isolated.mjs
+++ b/scripts/verify-documentary-index-button-isolated.mjs
@@ -1,0 +1,490 @@
+/**
+ * Focused live verification for the per-work Documentary Index button.
+ *
+ * The run creates a brand-new Nodus profile below the OS temporary directory,
+ * copies only the encrypted OpenRouter key, imports one synthetic PDF, clicks the
+ * renderer button and removes the profile afterward. Real vault paths are never
+ * registered in the test process.
+ */
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { _electron as electron } from 'playwright-core';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const fixturePath = path.resolve(
+  process.env.NODUS_DOCUMENTARY_FIXTURE
+    ?? path.join(repoRoot, 'output/pdf/documentary-index-isolated-test.pdf'),
+);
+const reportPath = path.resolve(
+  process.env.NODUS_DOCUMENTARY_REPORT
+    ?? path.join(repoRoot, 'artifacts/documentary-index-verification/report.json'),
+);
+const screenshotDirectory = path.dirname(reportPath);
+const defaultSourceUserData = process.platform === 'darwin'
+  ? path.join(os.homedir(), 'Library', 'Application Support', 'Nodus')
+  : process.platform === 'win32'
+    ? path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), 'Nodus')
+    : path.join(process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config'), 'Nodus');
+const sourceUserData = path.resolve(
+  process.env.NODUS_SOURCE_USERDATA
+    ?? defaultSourceUserData,
+);
+const textModel = Object.freeze({ provider: 'openrouter', model: 'deepseek/deepseek-v4-flash' });
+const embeddingModel = Object.freeze({ provider: 'openrouter', model: 'baai/bge-m3' });
+const sourceKeyPath = path.join(sourceUserData, 'secrets/ai_key_openrouter.bin');
+const appVersion = require(path.join(repoRoot, 'package.json')).version;
+const startedAt = new Date().toISOString();
+const isolatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-documentary-button-'));
+const userData = path.join(isolatedRoot, 'profile');
+const backupRoot = path.join(isolatedRoot, 'library-root');
+const isolatedKeyPath = path.join(userData, 'secrets', path.basename(sourceKeyPath));
+
+const translations = [
+  { language: 'es', heading: 'Índice documental', action: 'Escanear obra completa' },
+  { language: 'en', heading: 'Documentary index', action: 'Scan complete work' },
+  { language: 'fr', heading: 'Index documentaire', action: 'Analyser l’œuvre complète' },
+  { language: 'de', heading: 'Dokumentenindex', action: 'Vollständiges Werk scannen' },
+  { language: 'pt', heading: 'Índice documental', action: 'Analisar obra completa' },
+  { language: 'pt-BR', heading: 'Índice documental', action: 'Escanear obra completa' },
+  { language: 'it', heading: 'Indice documentario', action: 'Analizza l’opera completa' },
+  { language: 'tr', heading: 'Belgesel dizin', action: 'Eserin tamamını tara' },
+];
+
+const report = {
+  startedAt,
+  finishedAt: null,
+  success: false,
+  isolation: {
+    temporaryProfileCreated: true,
+    temporaryProfileDeleted: false,
+    onlyLocalVaultPaths: false,
+    sourceUnchanged: false,
+  },
+  fixture: {},
+  models: { text: textModel, embedding: embeddingModel },
+  import: {},
+  button: {},
+  translations: [],
+  generation: {},
+  ui: {},
+  errors: [],
+};
+
+let app = null;
+let page = null;
+let sourceBefore = null;
+
+function log(message) {
+  process.stdout.write(`[documentary-button] ${message}\n`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hashFile(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function fileState(file, includeHash = false) {
+  if (!fs.existsSync(file)) return null;
+  const stat = fs.statSync(file);
+  return {
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    ...(includeHash ? { sha256: hashFile(file) } : {}),
+  };
+}
+
+function sourceState() {
+  const registryPath = path.join(sourceUserData, 'vaults.json');
+  assert.ok(fs.existsSync(registryPath), `Missing source vault registry: ${registryPath}`);
+  const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+  const active = registry.vaults?.find((vault) => vault.id === registry.activeVaultId) ?? null;
+  return {
+    registry: fileState(registryPath, true),
+    activeDatabase: active?.path ? fileState(active.path, false) : null,
+    activeDatabasePath: active?.path ?? null,
+    openrouterKey: fileState(sourceKeyPath, true),
+  };
+}
+
+function isInside(child, parent) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function comparableSourceState(value) {
+  return {
+    registry: value.registry,
+    activeDatabase: value.activeDatabase,
+    activeDatabasePath: value.activeDatabasePath,
+    openrouterKey: value.openrouterKey,
+  };
+}
+
+async function dismissStartupUi() {
+  const modal = page.getByTestId('startup-update-modal');
+  await modal.waitFor({ state: 'attached', timeout: 1_500 }).catch(() => undefined);
+  if (await modal.count()) {
+    await page.waitForFunction(() => document.querySelector('[data-testid="startup-update-modal"]')?.getAttribute('data-update-status') === 'not-available');
+    const accept = modal.getByRole('button').last();
+    await accept.click();
+    await modal.waitFor({ state: 'detached' });
+  }
+}
+
+async function waitForExtraction(itemId) {
+  const deadline = Date.now() + 4 * 60_000;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await page.evaluate((id) => window.nodus.getGlobalLibraryItem(id), itemId);
+    if (last?.files?.reader && last?.extraction?.status === 'ready') return last;
+    if (last?.extraction?.status === 'failed' || last?.extraction?.status === 'unsupported') {
+      throw new Error(`PDF extraction failed: ${last.extraction.error ?? last.extraction.status}`);
+    }
+    await sleep(500);
+  }
+  const jobs = await page.evaluate(() => window.nodus.listLibraryExtractionJobs());
+  throw new Error(`Timed out waiting for PDF extraction: ${JSON.stringify({ extraction: last?.extraction, jobs })}`);
+}
+
+async function openLibraryWork(workId, workTitle) {
+  await page.locator('[data-tour="nav-library"]').click();
+  await page.getByTestId('library-vault-header').waitFor({ state: 'visible' });
+  const search = page.getByTestId('library-vault-search');
+  await search.fill(workTitle);
+  const row = page.getByTestId(`vault-library-item-${workId}`);
+  await row.waitFor({ state: 'visible' });
+  return row;
+}
+
+async function openStatusModal(workId, workTitle) {
+  const row = await openLibraryWork(workId, workTitle);
+  const pill = row.locator('.library-status-pill');
+  await pill.waitFor({ state: 'visible' });
+  await pill.click();
+  const section = page.getByTestId('work-status-documentary-index');
+  await section.waitFor({ state: 'visible' });
+  return { row, pill, section, dialog: section.locator('xpath=ancestor::*[@role="dialog"]').first() };
+}
+
+async function closeStatusModal(dialog) {
+  await dialog.click({ position: { x: 5, y: 5 } });
+  await page.getByTestId('work-status-documentary-index').waitFor({ state: 'detached' });
+}
+
+async function verifyTranslations(workId, workTitle) {
+  const rendered = [];
+  for (const expected of translations) {
+    await page.evaluate((language) => window.nodus.updateSettings({ uiLanguage: language }), expected.language);
+    await page.reload();
+    await page.getByTestId('app-shell').waitFor({ state: 'visible' });
+    await dismissStartupUi();
+    const { section, dialog } = await openStatusModal(workId, workTitle);
+    const heading = (await section.locator('span').first().innerText()).trim();
+    const action = (await page.getByTestId('work-status-documentary-action').innerText()).trim();
+    const beta = (await page.getByTestId('work-status-documentary-beta').innerText()).trim();
+    assert.equal(heading, expected.heading, `Documentary heading is not translated in ${expected.language}`);
+    assert.equal(action, expected.action, `Documentary action is not translated in ${expected.language}`);
+    assert.equal(beta, 'BETA', `Beta tag is missing in ${expected.language}`);
+    assert.equal(await page.evaluate(() => document.documentElement.lang), expected.language);
+    rendered.push({ ...expected, beta, rendered: true });
+    await closeStatusModal(dialog);
+  }
+  return rendered;
+}
+
+async function waitForDocumentJob(workId) {
+  const deadline = Date.now() + 25 * 60_000;
+  let lastLine = '';
+  let lastJob = null;
+  while (Date.now() < deadline) {
+    const snapshot = await page.evaluate(() => window.nodus.getDocumentIndexProgress());
+    lastJob = snapshot.jobs.find((job) => job.nodusId === workId) ?? null;
+    if (lastJob) {
+      const line = `${lastJob.status} · ${lastJob.phase} · ${Math.round(lastJob.progress * 100)}%`;
+      if (line !== lastLine) {
+        log(line);
+        lastLine = line;
+      }
+      if (['completed', 'failed', 'unavailable', 'cancelled'].includes(lastJob.status)) return lastJob;
+    }
+    await sleep(1_000);
+  }
+  throw new Error(`Timed out waiting for Documentary Index: ${JSON.stringify(lastJob)}`);
+}
+
+try {
+  assert.ok(fs.existsSync(path.join(repoRoot, 'dist-electron/main.js')), 'Run npm run build before this verification.');
+  assert.ok(fs.existsSync(fixturePath), `Missing PDF fixture: ${fixturePath}`);
+  assert.ok(fs.existsSync(sourceKeyPath), 'The encrypted OpenRouter key is not available.');
+  sourceBefore = sourceState();
+  report.fixture = {
+    path: fixturePath,
+    bytes: fs.statSync(fixturePath).size,
+    sha256: hashFile(fixturePath),
+    pages: 6,
+  };
+
+  fs.mkdirSync(path.dirname(isolatedKeyPath), { recursive: true, mode: 0o700 });
+  fs.copyFileSync(sourceKeyPath, isolatedKeyPath);
+  fs.chmodSync(isolatedKeyPath, 0o600);
+  fs.mkdirSync(backupRoot, { recursive: true });
+  fs.mkdirSync(screenshotDirectory, { recursive: true });
+
+  const env = {
+    ...process.env,
+    NODUS_USERDATA: userData,
+    NODUS_DISABLE_AUTO_UPDATE: '1',
+    NODUS_E2E_UPDATE_STATUS: 'not-available',
+    NODUS_E2E_DISABLE_STUDY_BACKGROUND_AI: '1',
+  };
+  delete env.ELECTRON_RUN_AS_NODE;
+
+  log('launching isolated Nodus profile');
+  app = await electron.launch({
+    executablePath: require('electron'),
+    args: [repoRoot],
+    cwd: repoRoot,
+    env,
+    timeout: 5 * 60_000,
+  });
+  page = await app.firstWindow({ timeout: 5 * 60_000 });
+  page.setDefaultTimeout(60_000);
+  await page.setViewportSize({ width: 1440, height: 960 });
+  await page.waitForFunction(() => Boolean(document.getElementById('root')?.children.length));
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  const setup = await page.evaluate(async ({ version, backup, model, embedding }) => {
+    localStorage.setItem('nodus.lastSeenVersion', version);
+    localStorage.setItem('nodus.mobileTeaserSeen.3.2.4', '1');
+    localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
+    localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
+    localStorage.setItem('nodus.libraryTutorialSeen.v1', '1');
+    sessionStorage.setItem('nodus.startupUpdateChecked', '1');
+    await window.nodus.updateSettings({
+      onboardingComplete: true,
+      basicsTutorialVersion: 999,
+      recoverySetupVersion: 999,
+      tourComplete: true,
+      advancedTourComplete: true,
+      uiLanguage: 'es',
+      promptLanguage: 'es',
+      mascotEnabled: false,
+      reduceMotion: true,
+      libraryGlobalEnabled: true,
+      libraryScope: 'vault',
+      libraryScopeOnboardingVersion: 1,
+      autoBackupFolder: backup,
+      autoBackupEnabled: false,
+      backupCleanupEnabled: false,
+      syncMode: 'manual',
+      autoLightScan: false,
+      autoDeepScanOnReadTag: false,
+      autoSummaryAfterDeep: false,
+      autoBridgeAfterQueue: false,
+      autoResumeQueue: false,
+      documentIndexingEnabled: false,
+      documentIndexIncludeArchived: false,
+      documentIndexConcurrency: 1,
+      announcementsEnabled: false,
+      betaUpdates: false,
+      mcpEnabled: false,
+      nodusServerEnabled: false,
+      localServerEnabled: false,
+      copilotEnabled: false,
+      zoteroPluginEnabled: false,
+      browserConnectorEnabled: false,
+    });
+    await window.nodus.seedDemoData();
+    const settings = await window.nodus.updateSettings({
+      modelSettingsMode: 'advanced',
+      documentProfileModel: model,
+      documentAuditModel: model,
+      summaryModel: model,
+      synthesisModel: model,
+      extractionModel: model,
+      fusionModel: model,
+      embeddingProvider: embedding.provider,
+      embeddingModel: embedding.model,
+      documentIndexingEnabled: false,
+      autoBackupFolder: backup,
+    });
+    await window.nodus.getGlobalLibraryStatus();
+    const librarySettings = await window.nodus.getGlobalLibrarySettings();
+    await window.nodus.setGlobalLibrarySettings({ ...librarySettings, autoPrepareAttachments: true });
+    return {
+      settings,
+      activeVault: await window.nodus.getActiveVault(),
+      vaults: await window.nodus.listVaults(),
+    };
+  }, { version: appVersion, backup: backupRoot, model: textModel, embedding: embeddingModel });
+
+  assert.equal(setup.settings.providerKeys.openrouter, true, 'The isolated profile could not decrypt the OpenRouter key.');
+  assert.deepEqual(setup.settings.documentProfileModel, textModel);
+  assert.deepEqual(setup.settings.documentAuditModel, textModel);
+  assert.equal(setup.settings.documentIndexingEnabled, false);
+  assert.ok(setup.activeVault, 'The isolated demo vault was not created.');
+  assert.ok(setup.vaults.length > 0);
+  assert.ok(setup.vaults.every((vault) => vault.origin === 'local' && isInside(vault.path, userData)));
+  report.isolation.onlyLocalVaultPaths = true;
+
+  log('importing and extracting the six-page PDF');
+  const imported = await page.evaluate((pdf) => window.nodus.importDroppedGlobalLibraryFiles([pdf]), fixturePath);
+  assert.equal(imported.created, 1, `The PDF was not imported: ${JSON.stringify(imported)}`);
+  assert.equal(imported.itemIds.length, 1);
+  const itemId = imported.itemIds[0];
+  const plan = await page.evaluate((id) => window.nodus.prepareGlobalLibraryReading(id), itemId);
+  assert.equal(plan.pageCount, 6, `Expected six pages, got ${plan.pageCount}`);
+  const libraryItem = await waitForExtraction(itemId);
+  report.import = {
+    created: imported.created,
+    warnings: imported.warnings,
+    itemId,
+    pageCount: plan.pageCount,
+    preparationAction: plan.action,
+    extractionStatus: libraryItem.extraction?.status ?? null,
+    cleanReaderCreated: Boolean(libraryItem.files?.reader),
+  };
+
+  const linked = await page.evaluate(
+    ({ id, vaultId }) => window.nodus.linkGlobalLibraryItemsToVault([id], vaultId),
+    { id: itemId, vaultId: setup.activeVault.id },
+  );
+  assert.equal(linked.linked, 1);
+  assert.equal(linked.links.length, 1);
+  const workId = linked.links[0].workId;
+  const work = await page.evaluate((id) => window.nodus.getWork(id), workId);
+  assert.ok(work, 'The imported item did not materialize as a vault work.');
+  const workTitle = work.title;
+
+  const before = await page.evaluate(async (id) => ({
+    states: await window.nodus.getDocumentProfileStatuses([id]),
+    jobs: (await window.nodus.getDocumentIndexProgress()).jobs.filter((job) => job.nodusId === id),
+    profile: await window.nodus.getDocumentProfile(id),
+  }), workId);
+  assert.equal(before.states[0]?.status, 'missing');
+  assert.equal(before.jobs.length, 0, 'Documentary Index started automatically before the button click.');
+  assert.equal(before.profile, null);
+
+  log('checking the real button in all eight interface languages');
+  report.translations = await verifyTranslations(workId, workTitle);
+
+  await page.evaluate(() => window.nodus.updateSettings({ uiLanguage: 'es' }));
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor({ state: 'visible' });
+  await dismissStartupUi();
+  const { row, pill, section } = await openStatusModal(workId, workTitle);
+  const readinessBefore = (await pill.innerText()).trim();
+  assert.equal(await page.getByTestId('document-index-manager-button').count(), 0, 'The global Documentary Index button is visible.');
+  assert.match(await section.innerText(), /opcional.*no afecta al estado general.*Deep Research/is);
+  await page.screenshot({ path: path.join(screenshotDirectory, 'button-before-click.png'), fullPage: true });
+
+  log('clicking the per-work Documentary Index action');
+  await page.getByTestId('work-status-documentary-action').click();
+  await page.waitForFunction(async (id) => {
+    const jobs = (await window.nodus.getDocumentIndexProgress()).jobs;
+    return jobs.some((job) => job.nodusId === id && job.reason === 'manual');
+  }, workId);
+  const queued = await page.evaluate(async (id) => {
+    const jobs = (await window.nodus.getDocumentIndexProgress()).jobs;
+    return jobs.find((job) => job.nodusId === id) ?? null;
+  }, workId);
+  assert.equal(queued?.reason, 'manual');
+  report.button = {
+    clicked: true,
+    queueReason: queued.reason,
+    automaticJobBeforeClick: false,
+    globalManagerHidden: true,
+    betaTagVisible: true,
+  };
+
+  const job = await waitForDocumentJob(workId);
+  assert.equal(job.status, 'completed', `Documentary Index failed: ${job.error ?? job.status}`);
+  const profile = await page.evaluate((id) => window.nodus.getDocumentProfile(id), workId);
+  assert.ok(profile, 'No document profile was published.');
+  assert.equal(profile.status, 'current');
+  assert.deepEqual(profile.generatorModel, textModel);
+  assert.deepEqual(profile.auditorModel, textModel);
+  assert.ok(profile.overview.length >= 80);
+  assert.ok(profile.fields.length >= 3);
+  assert.ok(profile.sections.length >= 3);
+  assert.ok(profile.supports.length >= 3);
+  assert.equal(profile.audit?.passed, true);
+  assert.ok((profile.audit?.supportCoverage ?? 0) >= 0.5);
+  const generatedText = [
+    profile.overview,
+    ...profile.fields.map((field) => field.text),
+    ...profile.sections.flatMap((section) => [section.title, section.summary]),
+  ].join('\n').toLocaleLowerCase('es');
+  const expectedConcepts = ['valdemora', '1908', '1967', '1998', 'escorrentía', '18 %'];
+  const conceptsFound = expectedConcepts.filter((concept) => generatedText.includes(concept));
+  assert.ok(conceptsFound.length >= 4, `The profile missed expected concepts: ${JSON.stringify(conceptsFound)}`);
+
+  await page.reload();
+  await page.getByTestId('app-shell').waitFor({ state: 'visible' });
+  await dismissStartupUi();
+  const generatedModal = await openStatusModal(workId, workTitle);
+  const readinessAfter = (await generatedModal.pill.innerText()).trim();
+  assert.equal(readinessAfter, readinessBefore, 'Documentary Index changed the work overall status.');
+  assert.equal((await page.getByTestId('work-status-documentary-action').innerText()).trim(), 'Abrir la ficha documental completa');
+  await page.getByTestId('work-status-documentary-action').click();
+  const documentDialog = page.getByRole('dialog', { name: 'Comprensión documental' });
+  await documentDialog.waitFor({ state: 'visible' });
+  await documentDialog.getByText('Visión de conjunto', { exact: true }).waitFor({ state: 'visible' });
+  assert.match((await documentDialog.innerText()).toLocaleLowerCase('es'), /valdemora/);
+  await page.screenshot({ path: path.join(screenshotDirectory, 'profile-generated.png'), fullPage: true });
+
+  report.generation = {
+    jobStatus: job.status,
+    jobReason: job.reason,
+    generatorModel: profile.generatorModel,
+    auditorModel: profile.auditorModel,
+    profileStatus: profile.status,
+    overviewCharacters: profile.overview.length,
+    fields: profile.fields.length,
+    sections: profile.sections.length,
+    supports: profile.supports.length,
+    validSupports: profile.supports.filter((support) => support.validationStatus === 'valid').length,
+    audit: profile.audit,
+    qualityScore: profile.qualityScore,
+    expectedConceptsFound: conceptsFound,
+  };
+  report.ui = {
+    readinessBefore,
+    readinessAfter,
+    overallStatusUnaffected: readinessBefore === readinessAfter,
+    generatedProfileOpenedFromSameButton: true,
+    screenshots: ['button-before-click.png', 'profile-generated.png'],
+    pageErrors,
+  };
+  assert.deepEqual(pageErrors, []);
+  report.success = true;
+  log(`completed: ${profile.fields.length} fields, ${profile.sections.length} sections, ${profile.supports.length} supports`);
+} catch (error) {
+  report.errors.push(error instanceof Error ? { message: error.message, stack: error.stack } : { message: String(error) });
+  throw error;
+} finally {
+  if (app) await app.close().catch(() => undefined);
+  const sourceAfter = sourceState();
+  report.isolation.sourceUnchanged = sourceBefore
+    ? JSON.stringify(comparableSourceState(sourceBefore)) === JSON.stringify(comparableSourceState(sourceAfter))
+    : false;
+  if (sourceBefore) assert.equal(report.isolation.sourceUnchanged, true, 'The source Nodus registry, active vault, or OpenRouter key changed.');
+  assert.ok(isInside(isolatedRoot, os.tmpdir()), 'Refusing to remove a non-temporary isolation root.');
+  fs.rmSync(isolatedRoot, { recursive: true, force: true });
+  report.isolation.temporaryProfileDeleted = !fs.existsSync(isolatedRoot);
+  report.finishedAt = new Date().toISOString();
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  log(`report: ${reportPath}`);
+}

--- a/shared/documentIndexPolicy.ts
+++ b/shared/documentIndexPolicy.ts
@@ -1,0 +1,9 @@
+/**
+ * Temporary product policy for the beta Documentary Index.
+ *
+ * The implementation stays available behind these switches so it can be exposed
+ * again without rebuilding the workflow. For now, profiles may only be requested
+ * explicitly by Deep Research or by a reader action on one or more works.
+ */
+export const DOCUMENT_INDEX_MANAGER_VISIBLE = false;
+export const DOCUMENT_INDEX_CONTINUOUS_AVAILABLE = false;

--- a/src/i18n.documentUnderstanding.ts
+++ b/src/i18n.documentUnderstanding.ts
@@ -62,6 +62,7 @@ const KEYS = [
   'Análisis documental en pausa',
   '{done} de {total} obras',
   'Se detendrá el análisis documental pendiente. Las fichas ya publicadas, las correcciones del usuario y las obras completadas se conservarán.',
+  'Es opcional y no afecta al estado general de la obra. Deep Research lo prepara cuando lo necesita; también puedes iniciarlo manualmente.',
 ] as const;
 
 function table(values: readonly string[]): Record<string, string> {
@@ -91,6 +92,7 @@ const en = table([
   'Analyzes every section and synthesizes the global architecture of each work.', 'Document-profile auditor',
   'Checks support, coverage and fidelity before publishing a new version.', 'With issues', 'Document analysis paused', '{done} of {total} works',
   'Pending document analysis will stop. Published profiles, user corrections, and completed works will be preserved.',
+  'It is optional and does not affect the work’s overall status. Deep Research prepares it when needed; you can also start it manually.',
 ]);
 
 const fr = table([
@@ -115,6 +117,7 @@ const fr = table([
   'Analyse toutes les sections et synthétise l’architecture globale de chaque œuvre.', 'Auditeur des fiches documentaires',
   'Vérifie les preuves, la couverture et la fidélité avant de publier une nouvelle version.', 'Avec incidents', 'Analyse documentaire en pause', '{done} œuvres sur {total}',
   'L’analyse documentaire en attente sera arrêtée. Les fiches publiées, les corrections de l’utilisateur et les œuvres terminées seront conservées.',
+  'Il est facultatif et n’affecte pas l’état général de l’œuvre. Deep Research le prépare si nécessaire ; vous pouvez aussi le lancer manuellement.',
 ]);
 
 const de = table([
@@ -139,6 +142,7 @@ const de = table([
   'Analysiert alle Abschnitte und synthetisiert die Gesamtarchitektur jedes Werks.', 'Prüfer für Dokumentprofile',
   'Prüft Belege, Abdeckung und Treue vor der Veröffentlichung einer neuen Version.', 'Mit Problemen', 'Dokumentanalyse pausiert', '{done} von {total} Werken',
   'Die ausstehende Dokumentanalyse wird beendet. Veröffentlichte Profile, Benutzerkorrekturen und abgeschlossene Werke bleiben erhalten.',
+  'Er ist optional und hat keinen Einfluss auf den Gesamtstatus des Werks. Deep Research bereitet ihn bei Bedarf vor; du kannst ihn auch manuell starten.',
 ]);
 
 const pt = table([
@@ -163,6 +167,7 @@ const pt = table([
   'Analisa todas as secções e sintetiza a arquitetura global de cada obra.', 'Auditor de fichas documentais',
   'Verifica o suporte, a cobertura e a fidelidade antes de publicar uma nova versão.', 'Com problemas', 'Análise documental em pausa', '{done} de {total} obras',
   'A análise documental pendente será interrompida. As fichas publicadas, as correções do utilizador e as obras concluídas serão preservadas.',
+  'É opcional e não afeta o estado geral da obra. O Deep Research prepara-o quando necessário; também pode iniciá-lo manualmente.',
 ]);
 
 const ptBR = table([
@@ -187,6 +192,7 @@ const ptBR = table([
   'Analisa todas as seções e sintetiza a arquitetura global de cada obra.', 'Auditor de fichas documentais',
   'Verifica o suporte, a cobertura e a fidelidade antes de publicar uma nova versão.', 'Com problemas', 'Análise documental pausada', '{done} de {total} obras',
   'A análise documental pendente será interrompida. As fichas publicadas, as correções do usuário e as obras concluídas serão preservadas.',
+  'É opcional e não afeta o status geral da obra. O Deep Research o prepara quando necessário; você também pode iniciá-lo manualmente.',
 ]);
 
 const it = table([
@@ -211,6 +217,7 @@ const it = table([
   'Analizza tutte le sezioni e sintetizza l’architettura globale di ogni opera.', 'Revisore delle schede documentali',
   'Verifica prove, copertura e fedeltà prima di pubblicare una nuova versione.', 'Con problemi', 'Analisi documentale in pausa', '{done} opere su {total}',
   'L’analisi documentale in sospeso verrà interrotta. Le schede pubblicate, le correzioni dell’utente e le opere completate saranno conservate.',
+  'È facoltativo e non influisce sullo stato generale dell’opera. Deep Research lo prepara quando serve; puoi anche avviarlo manualmente.',
 ]);
 
 const tr = table([
@@ -235,6 +242,7 @@ const tr = table([
   'Tüm bölümleri analiz eder ve her eserin genel mimarisini sentezler.', 'Belge profili denetçisi',
   'Yeni bir sürüm yayımlamadan önce dayanak, kapsam ve sadakati denetler.', 'Sorunlu', 'Belge analizi duraklatıldı', '{total} eserden {done} tanesi',
   'Bekleyen belge analizi durdurulacak. Yayımlanmış profiller, kullanıcı düzeltmeleri ve tamamlanan eserler korunacaktır.',
+  'İsteğe bağlıdır ve eserin genel durumunu etkilemez. Deep Research gerektiğinde hazırlar; siz de elle başlatabilirsiniz.',
 ]);
 
 export const DOCUMENT_UNDERSTANDING_TRANSLATIONS = { en, fr, de, pt, 'pt-BR': ptBR, it, tr } as const;

--- a/src/views/Library.tsx
+++ b/src/views/Library.tsx
@@ -36,6 +36,7 @@ import {
 import { t, tx } from '../i18n';
 import { getVaultQueryCache, setVaultQueryCache } from '../vaultQueryCache';
 import { vaultTypeColor } from '@shared/vaultTypes';
+import { DOCUMENT_INDEX_MANAGER_VISIBLE } from '@shared/documentIndexPolicy';
 import type { LibraryVaultSnapshot, ListPlacement } from '../app/viewSnapshots';
 
 const LIBRARY_ROW_HEIGHT = 64;
@@ -1090,7 +1091,8 @@ export function Library({
         </div>
         {scopeControls}
         <div className="library-header-actions">
-          {vaultType === 'academic' && <button
+          {DOCUMENT_INDEX_MANAGER_VISIBLE && vaultType === 'academic' && <button
+            data-testid="document-index-manager-button"
             className="btn btn-ghost border border-neutral-700 gap-1.5"
             onClick={() => setDocumentManagerOpen(true)}
             title={t('Gestionar la comprensión jerárquica de documentos completos')}
@@ -1874,8 +1876,13 @@ export function Library({
         <WorkStatusModal
           work={currentWork}
           status={currentStatus}
+          documentStatus={documentStatuses.get(currentWork.nodus_id) ?? 'missing'}
           onClose={() => setStatusWork(null)}
           onChanged={() => load()}
+          onOpenDocument={() => {
+            setStatusWork(null);
+            setDocumentWork(currentWork);
+          }}
         />
         ) : null;
       })()}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -61,6 +61,7 @@ import { DEFAULT_EMBEDDING_MODELS, EMBEDDING_PROVIDERS } from '@shared/providers
 import { ORB_COLOR_CHOICES, orbHue } from '@shared/nodiOrb';
 import { NODI_DEFAULT_SCALE, NODI_SIZE_SCALES } from '@shared/nodiSize';
 import { effectiveSidebarHidden, isViewAllowedForVaultType } from '@shared/vaultTypes';
+import { DOCUMENT_INDEX_CONTINUOUS_AVAILABLE } from '@shared/documentIndexPolicy';
 import chromeWebStoreLogo from '../assets/brands/chrome-web-store.svg';
 
 type SettingsTabId = 'providers' | 'models' | 'library' | 'extraction' | 'interface' | 'integrations' | 'browser' | 'server' | 'system' | 'data' | 'about' | 'updates';
@@ -917,15 +918,17 @@ export function Settings({
                 <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">{t('Comprensión documental')}</h3>
                 <p className="mb-3 text-xs leading-5 text-neutral-500">{t('Crea una ficha jerárquica auditada de cada obra completa para orientar chat, Nodi, Deep Research e Immersion. Las citas siguen apuntando al texto original.')}</p>
               </div>
-              <Row label={t('Indexar obras nuevas automáticamente')} hint={t('Continúa en segundo plano y entre vaults. Las obras actuales no se vuelven a procesar.') }>
-                <input type="checkbox" checked={settings.documentIndexingEnabled} onChange={async (event) => {
-                  const enabled = event.target.checked;
-                  await patch({ documentIndexingEnabled: enabled });
-                }} />
-              </Row>
-              <Row label={t('Incluir obras archivadas')}>
-                <input type="checkbox" checked={settings.documentIndexIncludeArchived} onChange={(event) => void patch({ documentIndexIncludeArchived: event.target.checked })} />
-              </Row>
+              {DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && <>
+                <Row label={t('Indexar obras nuevas automáticamente')} hint={t('Continúa en segundo plano y entre vaults. Las obras actuales no se vuelven a procesar.') }>
+                  <input type="checkbox" checked={settings.documentIndexingEnabled} onChange={async (event) => {
+                    const enabled = event.target.checked;
+                    await patch({ documentIndexingEnabled: enabled });
+                  }} />
+                </Row>
+                <Row label={t('Incluir obras archivadas')}>
+                  <input type="checkbox" checked={settings.documentIndexIncludeArchived} onChange={(event) => void patch({ documentIndexIncludeArchived: event.target.checked })} />
+                </Row>
+              </>}
               <Row label={t('Concurrencia documental')} hint={t('Automático usa dos trabajadores; reduce el valor si el proveedor limita las solicitudes.') }>
                 <select className="input" value={settings.documentIndexConcurrency} onChange={(event) => void patch({ documentIndexConcurrency: Number(event.target.value) })}>
                   <option value={0}>{t('Automática')}</option>

--- a/src/views/WorkStatusModal.tsx
+++ b/src/views/WorkStatusModal.tsx
@@ -4,7 +4,7 @@
 // is done, what is missing, and how do I fix just that". Each step can be retried
 // on its own so a reader never has to re-run a whole analysis to repair one index.
 import { useEffect, useState } from 'react';
-import type { WorkView } from '@shared/types';
+import type { DocumentUnderstandingState, WorkView } from '@shared/types';
 import { Icon } from '../components/ui';
 import { notifyDataChanged } from '../hooks';
 import { STEP_ORDER, type StepId, type StepState, type WorkStatus } from '../libraryStatus';
@@ -46,20 +46,74 @@ const STATE_TONE: Record<StepState, string> = {
 /** States a reader can act on. `blocked` and `na` are terminal by definition. */
 const RETRYABLE: StepState[] = ['partial', 'missing', 'failed'];
 
+const DOCUMENT_STATUS_LABEL: Record<DocumentUnderstandingState, string> = {
+  missing: 'Sin preparar',
+  queued: 'En cola',
+  waiting_source: 'Resolviendo texto completo',
+  paused: 'En pausa',
+  structuring: 'Reconstruyendo estructura',
+  analyzing: 'Analizando secciones',
+  synthesizing: 'Sintetizando la obra',
+  auditing: 'Auditando',
+  embedding: 'Creando vectores',
+  aligning: 'Enlazando ideas',
+  current: 'Actual',
+  stale: 'Obsoleta',
+  failed: 'Falló',
+  unavailable: 'Sin texto completo',
+};
+
+const DOCUMENT_STATUS_TONE: Record<DocumentUnderstandingState, string> = {
+  current: STATE_TONE.done,
+  failed: STATE_TONE.failed,
+  unavailable: STATE_TONE.blocked,
+  stale: STATE_TONE.partial,
+  missing: STATE_TONE.missing,
+  queued: STATE_TONE.running,
+  waiting_source: STATE_TONE.running,
+  paused: STATE_TONE.partial,
+  structuring: STATE_TONE.running,
+  analyzing: STATE_TONE.running,
+  synthesizing: STATE_TONE.running,
+  auditing: STATE_TONE.running,
+  embedding: STATE_TONE.running,
+  aligning: STATE_TONE.running,
+};
+
+const DOCUMENT_ACTIVE = new Set<DocumentUnderstandingState>([
+  'queued',
+  'waiting_source',
+  'structuring',
+  'analyzing',
+  'synthesizing',
+  'auditing',
+  'embedding',
+  'aligning',
+]);
+
 export function WorkStatusModal({
   work,
   status,
+  documentStatus,
   onClose,
   onChanged,
+  onOpenDocument,
 }: {
   work: WorkView;
   status: WorkStatus;
+  documentStatus: DocumentUnderstandingState;
   onClose: () => void;
   onChanged: () => void | Promise<void>;
+  onOpenDocument: () => void;
 }) {
-  const [busy, setBusy] = useState<StepId | 'all' | null>(null);
+  const [busy, setBusy] = useState<StepId | 'all' | 'documentary' | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [citableQueued, setCitableQueued] = useState(false);
+  const [documentQueued, setDocumentQueued] = useState(false);
+
+  const displayedDocumentStatus = documentQueued && !DOCUMENT_ACTIVE.has(documentStatus) && documentStatus !== 'current'
+    ? 'queued'
+    : documentStatus;
 
   const retryable = STEP_ORDER.filter((id) => RETRYABLE.includes(status.steps[id].state) && !(id === 'citable' && citableQueued));
 
@@ -72,6 +126,12 @@ export function WorkStatusModal({
       else void onChanged();
     });
   }, [citableQueued, onChanged]);
+
+  useEffect(() => {
+    if (documentStatus === 'current' || documentStatus === 'failed' || documentStatus === 'unavailable') {
+      setDocumentQueued(false);
+    }
+  }, [documentStatus]);
 
   const runStep = async (id: StepId) => {
     switch (id) {
@@ -106,6 +166,21 @@ export function WorkStatusModal({
     setActionError(null);
     try {
       await runStep(id);
+      notifyDataChanged();
+      await onChanged();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const runDocumentaryIndex = async () => {
+    setBusy('documentary');
+    setActionError(null);
+    try {
+      await window.nodus.enqueueDocumentProfile(work.nodus_id);
+      setDocumentQueued(true);
       notifyDataChanged();
       await onChanged();
     } catch (error) {
@@ -248,6 +323,43 @@ export function WorkStatusModal({
                 </section>
               );
             })}
+
+            <section
+              className="mt-3 flex items-start gap-3 rounded-lg border border-cyan-200 bg-cyan-50/60 p-3 dark:border-cyan-900/70 dark:bg-cyan-950/15"
+              data-testid="work-status-documentary-index"
+            >
+              <Icon name="layers" size={16} className="mt-0.5 shrink-0 text-cyan-600 dark:text-cyan-300" />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium text-neutral-900 dark:text-neutral-200">{t('Índice documental')}</span>
+                  <em data-testid="work-status-documentary-beta" className="library-action-menu-badge is-beta">BETA</em>
+                  <span className={`work-step-state inline-flex items-center rounded-md border px-1.5 py-0.5 text-[11px] ${DOCUMENT_STATUS_TONE[displayedDocumentStatus]}`}>
+                    {t(DOCUMENT_STATUS_LABEL[displayedDocumentStatus])}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs leading-5 text-neutral-600 dark:text-neutral-500">
+                  {t('Es opcional y no afecta al estado general de la obra. Deep Research lo prepara cuando lo necesita; también puedes iniciarlo manualmente.')}
+                </p>
+              </div>
+              {!DOCUMENT_ACTIVE.has(displayedDocumentStatus) && (
+                <button
+                  className="btn btn-ghost shrink-0 border border-cyan-300 px-2 py-1 text-xs disabled:opacity-40 dark:border-cyan-800"
+                  disabled={busy != null}
+                  onClick={() => displayedDocumentStatus === 'current' || displayedDocumentStatus === 'paused'
+                    ? onOpenDocument()
+                    : void runDocumentaryIndex()}
+                  data-testid="work-status-documentary-action"
+                >
+                  {busy === 'documentary'
+                    ? t('Enviando…')
+                    : displayedDocumentStatus === 'current' || displayedDocumentStatus === 'paused'
+                      ? t('Abrir la ficha documental completa')
+                      : displayedDocumentStatus === 'missing'
+                        ? t('Escanear obra completa')
+                        : t('Volver a escanear')}
+                </button>
+              )}
+            </section>
           </div>
         </div>
 

--- a/visual-tests/library-header-harness.html
+++ b/visual-tests/library-header-harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Library header visual harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/visual-tests/library-header-harness.tsx"></script>
+  </body>
+</html>

--- a/visual-tests/library-header-harness.tsx
+++ b/visual-tests/library-header-harness.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom/client';
 import type { AppSettings } from '@shared/types';
 import { GlobalLibraryView } from '../src/views/GlobalLibraryView';
+import '../src/index.css';
 
 /**
  * The Library shell (scope switcher, header actions, the guide's «?») rendered with a

--- a/visual-tests/work-status-modal-harness.tsx
+++ b/visual-tests/work-status-modal-harness.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom/client';
-import type { NodusApi, PassageEmbeddingProgress, WorkPassageStatus, WorkView } from '../shared/types';
+import type { DocumentUnderstandingState, NodusApi, PassageEmbeddingProgress, WorkPassageStatus, WorkView } from '../shared/types';
 import { deriveWorkStatus } from '../src/libraryStatus';
 import { WorkStatusModal } from '../src/views/WorkStatusModal';
 import '../src/index.css';
@@ -10,7 +10,7 @@ const baseWork = {
   authors: [], themes: ['fotografía', 'iconografía', 'cultura visual', 'franquismo', 'sociedad', 'turismo'],
   zoteroTags: [], ideaCount: 124, year: 2024, source_type: 'pdf', resolved_source_type: 'pdf',
   light_status: 'done', deep_status: 'done', deep_error: null, summary_status: 'done',
-  light_hash: 'light', deep_hash: 'old-text', resolved_text_hash: 'new-text', text_block_reason: null,
+  light_hash: 'light', deep_hash: 'current-text', resolved_text_hash: 'current-text', text_block_reason: null,
 } as unknown as WorkView;
 
 const completeProgress: PassageEmbeddingProgress = {
@@ -22,8 +22,9 @@ const listeners = new Set<(progress: PassageEmbeddingProgress) => void>();
 
 function Harness() {
   const [passage, setPassage] = useState<WorkPassageStatus>({
-    nodus_id: baseWork.nodus_id, totalPassages: 812, status: 'outdated', outdatedReason: 'text_changed',
+    nodus_id: baseWork.nodus_id, totalPassages: 812, status: 'complete', outdatedReason: null,
   });
+  const [documentStatus, setDocumentStatus] = useState<DocumentUnderstandingState>('missing');
   const [open, setOpen] = useState(true);
 
   window.nodus = {
@@ -42,6 +43,10 @@ function Harness() {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
+    enqueueDocumentProfile: async () => {
+      setDocumentStatus('queued');
+      window.setTimeout(() => setDocumentStatus('current'), 10_000);
+    },
   } as unknown as NodusApi;
 
   const status = deriveWorkStatus(
@@ -52,7 +57,14 @@ function Harness() {
 
   return <main className="min-h-screen bg-neutral-100 p-8 text-neutral-900">
     <button className="btn btn-primary" onClick={() => setOpen(true)}>Abrir estado</button>
-    {open && <WorkStatusModal work={baseWork} status={status} onClose={() => setOpen(false)} onChanged={() => undefined} />}
+    {open && <WorkStatusModal
+      work={baseWork}
+      status={status}
+      documentStatus={documentStatus}
+      onClose={() => setOpen(false)}
+      onChanged={() => undefined}
+      onOpenDocument={() => undefined}
+    />}
   </main>;
 }
 


### PR DESCRIPTION
## Summary

- keep the global Documentary Index manager implemented but hidden, and add a translated per-work **BETA** action to the Analysis status modal
- make Documentary Index generation opt-in: only an explicit user action or Deep Research may prepare it, and its absence never lowers the work completion status
- resolve Nodus Library sources directly instead of waiting on synthetic Zotero keys, and cover the behavior with policy, queue, UI, i18n, and isolated live-verification tests
- exclude reproducible local verification artifacts from Git and Docker build contexts

## Validation

- `npm run citation:check`
- `npm run lint`
- `npm run build`
- `npm run build:server-web`
- `npm test` — 2,639 passed, 0 failed, 1 skipped
- `npm run test:e2e` — passed on the real Electron app
- isolated 6-page PDF live test through OpenRouter using `deepseek/deepseek-v4-flash`; generation, audit, all eight UI translations, and source-vault isolation passed
