### PR TITLE
Fix Server Web settings, navigation feedback, and library loading

### DIFF
--- a/docs/ai-parity-manifest.json
+++ b/docs/ai-parity-manifest.json
@@ -88,7 +88,7 @@
         { "path": "server/lib/ai/providerGateway.mjs", "line": 4, "symbol": "Nodi capability", "contains": "'assistant', 'nodi'" }
       ] },
       "serverWeb": { "status": "implemented", "required": true, "evidence": [
-        { "path": "src/serverWeb/App.tsx", "line": 1, "symbol": "Nodi header", "contains": "dataTestId=\"header-nodi\"" }
+        { "path": "src/serverWeb/App.tsx", "line": 1, "symbol": "Assistant header", "contains": "dataTestId=\"header-assistant\"" }
       ] }
     },
     {

--- a/scripts/test-server-web-boundary.mjs
+++ b/scripts/test-server-web-boundary.mjs
@@ -53,7 +53,11 @@ test('Server settings use the native app navigation and visual surface', () => {
   const settings = variants(read('src/serverWeb/settings/ServerSettingsView.tsx'));
   assert.match(app, /dataTestId="header-settings"/);
   assert.match(app, /dataTestId="header-account"/);
-  assert.match(app, /key={settingsTab}/, 'settings must remount when the URL tab changes');
+  assert.match(
+    app,
+    /key={`\$\{settingsTab\}:\$\{settingsFocus\}`}/,
+    'settings must remount when the URL tab or focused section changes',
+  );
   assert.match(app, /data-theme={theme}/, 'the shell must expose the resolved theme to its token scope');
   assert.match(app, /icon="settings"[\s\S]*?onClick=\{\(\) => navigate\('\/view\/settings\?tab=server'\)\}/);
   assert.match(app, /<ServerSettingsView/);

--- a/scripts/test-server-web-i18n-settings.mjs
+++ b/scripts/test-server-web-i18n-settings.mjs
@@ -10,6 +10,7 @@ const shim = read("src/serverWeb/i18nShim.ts");
 const app = read("src/serverWeb/App.tsx");
 const settings = read("src/serverWeb/settings/ServerSettingsView.tsx");
 const css = read("src/serverWeb/settings/ServerSettings.css");
+const settingsTranslations = read("src/serverWeb/i18nServerSettings.ts");
 
 test("Server Web defaults to English and reuses every Desktop language catalogue", () => {
   assert.match(shim, /let active: AppLanguage = ["']en["']/);
@@ -103,6 +104,40 @@ test("Server Settings accent follows the active vault in dark and light themes",
   assert.match(settings, /data-testid="interface-language"/);
 });
 
+test("Server Settings owns a height-constrained vertical scroll viewport", () => {
+  assert.match(
+    css,
+    /\.server-settings-native\s*\{[\s\S]*?height:\s*100%;[\s\S]*?min-height:\s*0;[\s\S]*?max-height:\s*100%;[\s\S]*?overflow-y:\s*auto;/,
+  );
+  assert.match(css, /scrollbar-gutter:\s*stable/);
+});
+
+test("every Server administration block exposes translated contextual help", () => {
+  assert.match(settings, /help\?: string/);
+  assert.match(settings, /className=["']ss-help-button["']/);
+  assert.match(settings, /aria-expanded=\{helpOpen\}/);
+  assert.match(settings, /aria-controls=\{helpId\}/);
+  assert.match(settings, /tx\(["']Ayuda sobre \{section\}["']/);
+  assert.match(settings, /className=["']ss-section-help["']/);
+  for (const title of [
+    "Nodus Server",
+    "Nuevo vault",
+    "Vaults del servidor",
+    "Usuarios y acceso",
+    "Dispositivos publicadores",
+    "Mi cuenta",
+  ]) {
+    const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(
+      settings,
+      new RegExp(`title=["']${escaped}["'][\\s\\S]{0,420}?help=["']`),
+      `${title} must include contextual help`,
+    );
+  }
+  assert.match(css, /\.ss-help-button/);
+  assert.match(css, /\.ss-section-help/);
+});
+
 test("Server Settings translates mixed chrome without translating published values", () => {
   assert.match(settings, /setActiveLang, t, tx/);
   for (const source of [
@@ -157,6 +192,12 @@ test("requested locale catalogues win before the English safety fallback", () =>
   );
   for (const source of [
     "Abrir navegación",
+    "Connected Vault",
+    "Crear un vault editable directamente en Server.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.",
+    "La biblioteca aún no se ha publicado",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.",
+    "Abrir Ajustes de Server",
     "Introducir una clave nueva para sustituirla",
     "Esta superficie es privada y no contiene datos publicados.",
     "Árbol genealógico publicado",
@@ -167,5 +208,47 @@ test("requested locale catalogues win before the English safety fallback", () =>
         .length >= 7,
       `${source} must have complete non-Spanish locale coverage`,
     );
+  }
+});
+
+test("Server Settings prose is translated in every supported non-Spanish locale", () => {
+  assert.match(
+    shim,
+    /SERVER_SETTINGS_TRANSLATIONS\[normalized\]\?\.\[source\]/,
+  );
+  const localeOrder = ["en", "fr", "de", "pt", "pt-BR", "it", "tr"];
+  const localeBlocks = new Map();
+  for (let index = 0; index < localeOrder.length; index += 1) {
+    const locale = localeOrder[index];
+    const next = localeOrder[index + 1];
+    const startToken = locale === "pt-BR" ? '"pt-BR": {' : `${locale}: {`;
+    const start = settingsTranslations.indexOf(startToken);
+    const end = next
+      ? settingsTranslations.indexOf(
+          next === "pt-BR" ? '"pt-BR": {' : `${next}: {`,
+          start + startToken.length,
+        )
+      : settingsTranslations.lastIndexOf("};");
+    assert.ok(
+      start >= 0 && end > start,
+      `${locale} Settings catalogue exists`,
+    );
+    localeBlocks.set(locale, settingsTranslations.slice(start, end));
+  }
+  const englishKeys = [
+    ...localeBlocks.get("en").matchAll(/^\s{4}"([^"]+)":/gm),
+  ].map((match) => match[1]);
+  assert.ok(
+    englishKeys.length >= 35,
+    "the complete Settings prose catalogue is covered",
+  );
+  for (const locale of localeOrder) {
+    const block = localeBlocks.get(locale);
+    for (const source of englishKeys) {
+      assert.ok(
+        block.includes(`${JSON.stringify(source)}:`),
+        `${locale} must translate Settings copy: ${source}`,
+      );
+    }
   }
 });

--- a/scripts/test-server-web-library-reader-parity.mjs
+++ b/scripts/test-server-web-library-reader-parity.mjs
@@ -9,6 +9,10 @@ const view = variants(fs.readFileSync(
   `${root}/src/serverWeb/LibraryServerView.tsx`,
   "utf8",
 ));
+const routes = variants(fs.readFileSync(
+  `${root}/server/lib/routes/api.mjs`,
+  "utf8",
+));
 const docs = fs.readFileSync(
   `${root}/docs/server-web-academic-parity.md`,
   "utf8",
@@ -35,6 +39,24 @@ test("library catalogue preserves Desktop table affordances and tab-safe opening
   assert.match(view, /target="_blank"/);
   assert.match(view, /api\.libraryCollections/);
   assert.match(view, /api\.library\(spaceId/);
+});
+
+test("an unpublished library is an empty catalogue rather than a permanent error", () => {
+  assert.match(view, /error instanceof ApiError/);
+  assert.match(view, /error\.code === ["']library_not_published["']/);
+  assert.match(view, /setItems\(\[\]\)[\s\S]{0,120}setTotal\(0\)[\s\S]{0,120}setHasMore\(false\)/);
+  assert.match(view, /setCollections\(\[\]\)/);
+  assert.match(view, /setPublished\(false\)/);
+  assert.match(view, /La biblioteca aún no se ha publicado/);
+  assert.match(view, /\/view\/settings\?tab=server&focus=connected-vault/);
+  assert.match(
+    routes,
+    /function libraryCollections[\s\S]*?if \(!library\)[\s\S]*?collections:\s*\[\][\s\S]*?published:\s*false/,
+  );
+  assert.match(
+    routes,
+    /function libraryDocuments[\s\S]*?if \(!library\)[\s\S]*?items:\s*\[\][\s\S]*?total:\s*0[\s\S]*?hasMore:\s*false/,
+  );
 });
 
 test("reader preserves safe published reading and private overlay capabilities", () => {

--- a/scripts/test-server-web-residual-i18n.mjs
+++ b/scripts/test-server-web-residual-i18n.mjs
@@ -10,7 +10,7 @@ const read = (file) => variants(fs.readFileSync(path.join(root, file), 'utf8'));
 test('server vault manager localises lifecycle UI instead of leaking Spanish copy', () => {
   const manager = read('src/serverWeb/vaults/ServerVaultManager.tsx');
   const shim = read('src/serverWeb/i18nShim.ts');
-  for (const source of ['Vaults', 'Añadir', 'Buscar vaults…', 'Todos los tipos', 'Último uso', 'Vault creado.', 'Vault eliminado.', 'Exportación preparada.', 'Importación recibida.']) {
+  for (const source of ['Vaults', 'Añadir', 'Nuevo vault', 'Connected Vault', 'Crear un vault editable directamente en Server.', 'Conectar un vault de Desktop para publicarlo y sincronizarlo.', 'Buscar vaults…', 'Todos los tipos', 'Último uso', 'Vault eliminado.', 'Exportación preparada.', 'Importación recibida.']) {
     assert.match(manager, new RegExp(`t\\(['"]${source.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}['"]\\)`), `${source} must use the translation adapter`);
     assert.ok(shim.includes(source), `${source} must be registered in the server catalogue`);
   }
@@ -19,6 +19,22 @@ test('server vault manager localises lifecycle UI instead of leaking Spanish cop
     assert.match(shim, new RegExp(`\\n  ${localePattern}`), `${locale} catalogue must remain available`);
   }
   assert.match(manager, /^(?:.*)const match = \/\^\(Eliminar\|Renombrar\|Duplicar\|Exportar\|Importar\|Activar\|Importar en\)/m, 'dynamic action labels must preserve the record name while translating the action');
+});
+
+test('vault Add distinguishes native and connected setup routes in Server Settings', () => {
+  const manager = read('src/serverWeb/vaults/ServerVaultManager.tsx');
+  const app = read('src/serverWeb/App.tsx');
+  const settings = read('src/serverWeb/settings/ServerSettingsView.tsx');
+  const css = read('src/serverWeb/serverDesktop.css');
+  assert.match(manager, /aria-haspopup=["']menu["']/);
+  assert.match(manager, /data-testid=["']vault-add-native["'][\s\S]*?onAddVault\(["']native["']\)/);
+  assert.match(manager, /data-testid=["']vault-add-connected["'][\s\S]*?onAddVault\(["']connected["']\)/);
+  assert.match(app, /kind === ["']native["'] \? ["']new-vault["'] : ["']connected-vault["']/);
+  assert.match(app, /\/view\/settings\?tab=server&focus=/);
+  assert.match(settings, /focusId=["']server-new-vault["']/);
+  assert.match(settings, /focusId=["']server-connected-vault["']/);
+  assert.match(settings, /scrollIntoView\(/);
+  assert.match(css, /\.server-vault-add-options/);
 });
 
 test('citation modal localises its fixed chrome', () => {

--- a/scripts/test-server-web-security.mjs
+++ b/scripts/test-server-web-security.mjs
@@ -36,6 +36,15 @@ test('Server web sessions are read-only while personal annotations stay private 
     assert.equal(meA.value.spaces[0].role, 'reader');
     assert.equal(meA.response.headers.get('access-control-allow-origin'), null);
 
+    const emptyLibrary = await json(await sessionFetch(server.origin, cookieA, `/api/v1/spaces/${spaceId}/library/documents`));
+    assert.equal(emptyLibrary.response.status, 200, 'a library that has not been published is a valid empty catalogue');
+    assert.deepEqual(emptyLibrary.value.items, []);
+    assert.equal(emptyLibrary.value.total, 0);
+    assert.equal(emptyLibrary.value.published, false);
+    const emptyCollections = await json(await sessionFetch(server.origin, cookieA, `/api/v1/spaces/${spaceId}/library/collections`));
+    assert.equal(emptyCollections.response.status, 200);
+    assert.deepEqual(emptyCollections.value.collections, []);
+
     const context = await json(await sessionFetch(server.origin, cookieA, `/api/v1/spaces/${spaceId}/context`, {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ query: 'memoria', budget: 32_000 }),
     }));

--- a/scripts/test-server-web-shell-parity.mjs
+++ b/scripts/test-server-web-shell-parity.mjs
@@ -41,10 +41,45 @@ test('Server header mirrors Desktop measured geometry and action semantics', () 
   assert.match(app, /dataTestId="header-account"/);
 });
 
-test('Server responsive header preserves account/settings/theme and yields optional actions first', () => {
-  assert.match(css, /header-action-rail > \[data-testid='header-nodi'\]/);
+test('Server header orders commands, assistant, account, theme and settings', () => {
+  const orderedActions = [
+    'header-search',
+    'header-assistant',
+    'header-account',
+    'theme-toggle',
+    'header-settings',
+  ].map((testId) => app.indexOf(`dataTestId="${testId}"`));
+  assert.ok(orderedActions.every((position) => position >= 0));
+  assert.deepEqual(orderedActions, [...orderedActions].sort((a, b) => a - b));
+  assert.doesNotMatch(app, /dataTestId="header-nodi"/);
   assert.match(css, /header-action-rail > \[data-testid='header-assistant'\]/);
+  assert.doesNotMatch(css, /header-action-rail > \[data-testid='header-nodi'\]/);
   assert.doesNotMatch(css, /header-action-rail > :nth-last-child\(-n\+2\)/);
+});
+
+test('active Server header actions retain contrast in light mode and on hover', () => {
+  assert.match(
+    css,
+    /\.server-desktop-surface \.server-header-action\.bg-indigo-600:hover[\s\S]*?background:\s*var\(--vault-accent,\s*#4f46e5\);[\s\S]*?color:\s*#fff;/,
+  );
+  assert.match(
+    css,
+    /\.server-desktop-surface \.server-header-action\.bg-indigo-600:focus-visible/,
+  );
+});
+
+test('central view shows a circular loader while sidebar navigation resolves', () => {
+  assert.match(app, /const \[pendingView, setPendingView\] = useState<View \| null>\(null\)/);
+  assert.match(app, /setPendingView\(view\)[\s\S]*?navigate\(viewPath\(view\)\)/);
+  assert.match(app, /className=["']server-view-host relative[\s\S]*?data-loading-view=/);
+  assert.match(app, /aria-busy=\{pendingView === activeView \? true : undefined\}/);
+  assert.match(app, /data-testid=["']view-loading-spinner["']/);
+  assert.match(app, /querySelector\('\[data-testid="loading"\]'\)/);
+  assert.doesNotMatch(app, /<nav[\s\S]{0,400}?data-loading-view=/);
+  assert.match(css, /\.server-view-loading-overlay[\s\S]*?place-items:\s*center/);
+  assert.match(css, /\.server-view-loading-spinner[\s\S]*?border-radius:\s*50%/);
+  assert.match(css, /@keyframes server-view-loading-spin/);
+  assert.doesNotMatch(css, /server-sidebar-loading-dots|content:\s*"•••"/);
 });
 
 test('Server light mode remaps shell hovers, nav, switcher and settings controls', () => {

--- a/server/lib/routes/api.mjs
+++ b/server/lib/routes/api.mjs
@@ -772,18 +772,27 @@ export function createApiRoutes(ctx) {
 
   function libraryCollections(req, res, space) {
     const library = libraryManifest(space.id);
-    if (!library) return libraryUnavailable(res);
+    // An authorised space without a library publication is a valid empty
+    // catalogue, not a failed request. This distinction lets Server Web render
+    // its normal empty state while the owner has not published any documents.
+    if (!library) {
+      json(res, 200, { collections: [], published: false, generatedAt: null });
+      return true;
+    }
     json(res, 200, { collections: Array.isArray(library.collections) ? library.collections : [], generatedAt: library.generatedAt });
     return true;
   }
 
   function libraryDocuments(req, res, space, url) {
     const library = libraryManifest(space.id);
-    if (!library) return libraryUnavailable(res);
-    const query = String(url.searchParams.get('q') || '').trim().toLocaleLowerCase();
-    const collectionId = String(url.searchParams.get('collectionId') || '');
     const limit = Math.max(1, Math.min(200, Number(url.searchParams.get('limit')) || 50));
     const offset = Math.max(0, Number(url.searchParams.get('offset')) || 0);
+    if (!library) {
+      json(res, 200, { items: [], total: 0, limit, offset, hasMore: false, published: false, generatedAt: null });
+      return true;
+    }
+    const query = String(url.searchParams.get('q') || '').trim().toLocaleLowerCase();
+    const collectionId = String(url.searchParams.get('collectionId') || '');
     const all = (Array.isArray(library.documents) ? library.documents : []).filter((document) => {
       if (collectionId && !(Array.isArray(document?.collectionIds) && document.collectionIds.includes(collectionId))) return false;
       if (!query) return true;

--- a/src/serverWeb/App.tsx
+++ b/src/serverWeb/App.tsx
@@ -1770,6 +1770,7 @@ export default function App() {
     () => localStorage.getItem(SERVER_NAV_COLLAPSED_STORAGE_KEY) === "1",
   );
   const [drawer, setDrawer] = useState(false);
+  const [pendingView, setPendingView] = useState<View | null>(null);
   const [vaultsOpen, setVaultsOpen] = useState(false);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
     try {
@@ -1796,6 +1797,7 @@ export default function App() {
     useState<HeaderBadgePlacement | null>(null);
   const profileThemeRef =
     useRef<PortableProfileValues["appearance"]["theme"]>("system");
+  const viewHostRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     const listener = () => setRoute(routeFromLocation());
     addEventListener("popstate", listener);
@@ -1947,9 +1949,36 @@ export default function App() {
   }, [active?.id]);
   const openView = (view: View) => {
     if (SERVER_TOOL_VIEWS.has(view)) return;
+    if (view === activeView) {
+      setDrawer(false);
+      return;
+    }
+    setPendingView(view);
     navigate(viewPath(view));
     setDrawer(false);
   };
+  useEffect(() => {
+    if (!pendingView || pendingView !== activeView) return undefined;
+    const host = viewHostRef.current;
+    if (!host) return undefined;
+    let observer: MutationObserver | undefined;
+    const finishWhenContentIsReady = () => {
+      if (host.querySelector('[data-testid="loading"]')) return;
+      setPendingView((current) =>
+        current === pendingView ? null : current,
+      );
+      observer?.disconnect();
+    };
+    const frame = requestAnimationFrame(() => {
+      observer = new MutationObserver(finishWhenContentIsReady);
+      observer.observe(host, { childList: true, subtree: true });
+      finishWhenContentIsReady();
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      observer?.disconnect();
+    };
+  }, [activeView, pendingView]);
   const resize = (event: ReactPointerEvent) => {
     const start = event.clientX;
     const initial = sidebarWidth;
@@ -2388,9 +2417,11 @@ export default function App() {
       // example) Providers changed the URL but left the old tab on screen.
       const settingsTab =
         new URLSearchParams(location.search).get("tab") || "server";
+      const settingsFocus =
+        new URLSearchParams(location.search).get("focus") || "";
       return (
         <ServerSettingsView
-          key={settingsTab}
+          key={`${settingsTab}:${settingsFocus}`}
           csrfToken={me.csrfToken}
           isAdmin={me.user?.role === "admin"}
           theme={theme}
@@ -2595,14 +2626,6 @@ export default function App() {
             }
           />
           <ServerHeaderAction
-            icon="sparkles"
-            label="Nodi"
-            title={t("Abrir Nodi")}
-            onClick={() => navigate("/view/nodi")}
-            dataTestId="header-nodi"
-            className={activeView === "nodi" ? "bg-indigo-600 text-white" : ""}
-          />
-          <ServerHeaderAction
             icon="chat"
             label={t("Asistente")}
             title={t("Abrir asistente de investigación")}
@@ -2613,14 +2636,14 @@ export default function App() {
             }
           />
           <ServerHeaderAction
-            icon="settings"
-            label={t("Ajustes")}
-            title={t("Ajustes")}
-            onClick={() => navigate("/view/settings?tab=server")}
-            dataTestId="header-settings"
-            className={
-              activeView === "settings" ? "bg-indigo-600 text-white" : ""
-            }
+            icon="user"
+            label={t("Mi cuenta")}
+            title={t("Mi cuenta")}
+            onClick={() => {
+              setDrawer(false);
+              navigate("/view/settings?tab=server");
+            }}
+            dataTestId="header-account"
           />
           <ServerHeaderAction
             icon={theme === "dark" ? "sun" : "moon"}
@@ -2632,14 +2655,14 @@ export default function App() {
             dataTestId="theme-toggle"
           />
           <ServerHeaderAction
-            icon="user"
-            label={t("Mi cuenta")}
-            title={t("Mi cuenta")}
-            onClick={() => {
-              setDrawer(false);
-              navigate("/view/settings?tab=server");
-            }}
-            dataTestId="header-account"
+            icon="settings"
+            label={t("Ajustes")}
+            title={t("Ajustes")}
+            onClick={() => navigate("/view/settings?tab=server")}
+            dataTestId="header-settings"
+            className={
+              activeView === "settings" ? "bg-indigo-600 text-white" : ""
+            }
           />
         </div>
         {vaultsOpen && active && (
@@ -2655,6 +2678,14 @@ export default function App() {
               navigate("/");
             }}
             onChanged={refreshSpaces}
+            onAddVault={(kind) => {
+              setVaultsOpen(false);
+              navigate(
+                `/view/settings?tab=server&focus=${
+                  kind === "native" ? "new-vault" : "connected-vault"
+                }`,
+              );
+            }}
             onClose={() => setVaultsOpen(false)}
           />
         )}
@@ -2704,8 +2735,26 @@ export default function App() {
           />
         </nav>
         <main className="server-main min-h-0 min-w-0 flex-1" id="main-content">
-          <div className="server-view-host min-h-0 flex-1 overflow-hidden">
+          <div
+            ref={viewHostRef}
+            className="server-view-host relative min-h-0 flex-1 overflow-hidden"
+            data-loading-view={
+              pendingView === activeView ? pendingView : undefined
+            }
+            aria-busy={pendingView === activeView ? true : undefined}
+          >
             <Suspense fallback={<Loading />}>{content}</Suspense>
+            {pendingView === activeView && (
+              <div
+                className="server-view-loading-overlay"
+                role="status"
+                aria-label={t("Cargando…")}
+                data-testid="view-loading-spinner"
+              >
+                <span className="server-view-loading-spinner" aria-hidden="true" />
+                <span className="sr-only">{t("Cargando…")}</span>
+              </div>
+            )}
           </div>
         </main>
       </div>

--- a/src/serverWeb/LibraryServerView.tsx
+++ b/src/serverWeb/LibraryServerView.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { Icon } from "../components/ui";
 import { MarkdownReader } from "./readers";
-import { api } from "./api";
+import { api, ApiError } from "./api";
 import type { AIJob, Annotation, JsonRecord, LibraryDocument } from "./types";
 import { t } from "./i18nShim";
 
@@ -18,6 +18,14 @@ const PAGE_SIZE = 50;
 const annotationResource = "library";
 type ReaderOpeningFormat = "clean" | "original";
 const READER_OPENING_FORMAT_KEY = "nodus.libraryReader.openingFormat";
+
+function isUnpublishedLibrary(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    error.status === 409 &&
+    error.code === "library_not_published"
+  );
+}
 
 function readOpeningFormatPreference(): ReaderOpeningFormat | null {
   try {
@@ -107,12 +115,33 @@ async function waitForJob(id: string, signal: AbortSignal): Promise<AIJob> {
   );
 }
 
-function LibraryEmpty({ title }: { title: string }) {
+function LibraryEmpty({
+  title,
+  detail,
+  settingsLink = false,
+}: {
+  title: string;
+  detail?: string;
+  settingsLink?: boolean;
+}) {
   return (
     <div className="server-unavailable" data-testid="library-empty">
       <div>
         <Icon name="inbox" size={32} className="mx-auto text-neutral-500" />
         <h2 className="mt-3 text-lg font-semibold">{title}</h2>
+        {detail && (
+          <p className="mt-2 max-w-md text-sm leading-6 text-neutral-500">
+            {detail}
+          </p>
+        )}
+        {settingsLink && (
+          <a
+            className="btn btn-primary mt-4"
+            href="/view/settings?tab=server&focus=connected-vault"
+          >
+            {t("Abrir Ajustes de Server")}
+          </a>
+        )}
       </div>
     </div>
   );
@@ -313,13 +342,20 @@ export function PublishedLibraryView({ spaceId, onOpen }: LibraryProps) {
   const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState(0);
   const [hasMore, setHasMore] = useState(false);
+  const [published, setPublished] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>();
   const loadCollections = useCallback(async () => {
     try {
       setCollections((await api.libraryCollections(spaceId)).collections || []);
     } catch (cause) {
-      setError(cause);
+      // Collections are an optional facet. Older Server releases answer 409
+      // before the first library publication; keep the document table usable
+      // and render that state as an empty catalogue instead of a fatal error.
+      setCollections([]);
+      if (!isUnpublishedLibrary(cause)) {
+        console.warn("[nodus-server] library collections unavailable", cause);
+      }
     }
   }, [spaceId]);
   const load = useCallback(async () => {
@@ -335,8 +371,16 @@ export function PublishedLibraryView({ spaceId, onOpen }: LibraryProps) {
       setItems(page.items || []);
       setTotal(page.total || 0);
       setHasMore(Boolean(page.hasMore));
+      setPublished(page.published !== false);
     } catch (cause) {
-      setError(cause);
+      if (isUnpublishedLibrary(cause)) {
+        setItems([]);
+        setTotal(0);
+        setHasMore(false);
+        setPublished(false);
+      } else {
+        setError(cause);
+      }
     } finally {
       setLoading(false);
     }
@@ -456,8 +500,20 @@ export function PublishedLibraryView({ spaceId, onOpen }: LibraryProps) {
           ) : items.length === 0 ? (
             <LibraryEmpty
               title={
-                total ? "No hay coincidencias" : "La biblioteca está vacía"
+                total
+                  ? t("No hay coincidencias")
+                  : published === false
+                    ? t("La biblioteca aún no se ha publicado")
+                    : t("La biblioteca está vacía")
               }
+              detail={
+                published === false
+                  ? t(
+                      "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.",
+                    )
+                  : undefined
+              }
+              settingsLink={published === false}
             />
           ) : (
             items.map((item) => {

--- a/src/serverWeb/i18nServerSettings.ts
+++ b/src/serverWeb/i18nServerSettings.ts
@@ -1,0 +1,524 @@
+import type { AppLanguage } from "@shared/types";
+
+/** Copy owned by the native Server Settings surface.
+ *
+ * Keep this catalogue complete for every non-Spanish UI language. The generic
+ * Server translator deliberately has an English safety fallback, but Settings
+ * is account-facing chrome and must never turn into a Spanish/English mixture
+ * when a person has explicitly selected another language.
+ */
+export const SERVER_SETTINGS_TRANSLATIONS: Record<
+  Exclude<AppLanguage, "es">,
+  Record<string, string>
+> = {
+  en: {
+    "Las claves y los modelos configurados se comparten entre todas tus bóvedas. Las credenciales siguen siendo privadas de esta cuenta.":
+      "Configured keys and models are shared across all your vaults. Credentials remain private to this account.",
+    "El operador debe configurar la keyring cifrada del servidor para guardar credenciales.":
+      "The operator must configure the server's encrypted keyring before credentials can be saved.",
+    "Abre un proveedor y marca con una estrella los modelos que quieras usar en los selectores.":
+      "Open a provider and star the models you want to use in selectors.",
+    "Configurado en Server": "Configured on Server",
+    "Sin credencial en Server": "No credential on Server",
+    "Disponible mediante Desktop": "Available through Desktop",
+    Sustituir: "Replace",
+    Guardar: "Save",
+    Eliminar: "Remove",
+    "Este proveedor requiere el runtime o la red local de Nodus Desktop; sus favoritos se conservan, pero Server no intenta ejecutarlo.":
+      "This provider requires the Nodus Desktop runtime or local network. Its favourites are preserved, but Server does not attempt to run it.",
+    "Actualizando catálogo…": "Refreshing catalogue…",
+    "Catálogo en vivo del proveedor": "Live provider catalogue",
+    "Catálogo compatible integrado": "Built-in compatible catalogue",
+    "Buscar modelo…": "Search models…",
+    "Ningún modelo coincide con la búsqueda.": "No models match your search.",
+    "Modo básico para un modelo general; modo avanzado para elegir cada tarea de forma independiente.":
+      "Basic mode uses one general model; advanced mode lets you choose each task independently.",
+    "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.":
+      "There are pending inherited assignments ({assignments}). Downloadable local models do not run on Server and are not replaced with a paid model.",
+    "Un modelo general atiende las tareas de texto compatibles.":
+      "One general model handles compatible text tasks.",
+    "Cada tarea usa su modelo seleccionado de forma independiente.":
+      "Each task uses its selected model independently.",
+    "Server muestra la misma biblioteca tabular de Desktop usando únicamente los documentos que el propietario decidió publicar.":
+      "Server shows the same tabular library as Desktop using only the documents the owner chose to publish.",
+    "La publicación es independiente para cada vault.":
+      "Publishing is independent for each vault.",
+    "PDF, rutas locales y credenciales no se incluyen salvo publicación explícita del contenido permitido.":
+      "PDFs, local paths and credentials are excluded unless permitted content is explicitly published.",
+    "La cuenta Server conserva la vista publicada. La conexión, storage y sincronización de Zotero se ejecutan en Desktop.":
+      "The Server account keeps the published view. Zotero connection, storage and synchronisation run on Desktop.",
+    "Abre Ajustes → Biblioteca en Desktop para cambiar la fuente Zotero. Server aplicará la siguiente publicación a todos los vaults conectados sin inventar una biblioteca distinta.":
+      "Open Settings → Library in Desktop to change the Zotero source. Server will apply the next publication to every connected vault without inventing a separate library.",
+    "Estos ajustes dependen de archivos locales y permanecen en Desktop.":
+      "These settings depend on local files and remain in Desktop.",
+    "Server consume el texto limpio incluido por el publicador.":
+      "Server uses the clean text included by the publisher.",
+    "Tesseract, idiomas y límites de páginas se ejecutan donde reside el documento.":
+      "Tesseract, languages and page limits run where the document resides.",
+    "Apariencia y accesibilidad forman parte del perfil portable y se comparten transversalmente.":
+      "Appearance and accessibility are part of the portable profile and are shared across devices.",
+    "Conecta ChatGPT, Claude y clientes compatibles con este usuario y sus vaults asignados.":
+      "Connect ChatGPT, Claude and compatible clients to this user and their assigned vaults.",
+    "Sincroniza publicación y perfil portable desde Nodus Desktop.":
+      "Synchronises publishing and the portable profile from Nodus Desktop.",
+    "Los complementos de escritorio conservan su configuración local.":
+      "Desktop add-ons keep their local configuration.",
+    "El navegador integrado requiere Electron y permanece fuera de la barra lateral de Server.":
+      "The integrated browser requires Electron and remains outside the Server sidebar.",
+    "Cookies, permisos, descargas y almacenamiento web nunca se copian al servidor. La extensión y Nodus Browser se configuran en Desktop.":
+      "Cookies, permissions, downloads and web storage are never copied to the server. The extension and Nodus Browser are configured in Desktop.",
+    "Publicar un vault, asignar acceso y consultar la réplica.":
+      "Publish a vault, assign access and inspect the replica.",
+    "Credenciales por usuario, modelos favoritos y privacidad.":
+      "Per-user credentials, favourite models and privacy.",
+    "Connected Vault, MCP y clientes compatibles.":
+      "Connected Vault, MCP and compatible clients.",
+    "Las copias contienen datos locales, rutas y secretos que nunca cruzan el perfil portable. Se crean y restauran exclusivamente en Desktop o mediante la política de copias del operador de Server.":
+      "Backups contain local data, paths and secrets that never cross the portable profile. They are created and restored only in Desktop or through the Server operator's backup policy.",
+    "Favoritos, modelos, interfaz y políticas compatibles.":
+      "Favourites, models, interface and compatible policies.",
+    "Local-first · publicación explícita · credenciales aisladas":
+      "Local-first · explicit publishing · isolated credentials",
+    "Ayuda sobre {section}": "Help for {section}",
+    "Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso.":
+      "Summarises this server and shows how many vaults, users and devices it manages, together with its access addresses.",
+    "Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial.":
+      "Creates an editable vault that lives directly on Server. Choose its name, type and initial description.",
+    "Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión.":
+      "Shows native vaults and those published from Desktop. Here you can review their status, adjust what is published and generate connection codes.",
+    "Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario.":
+      "Creates accounts and controls what each user can do in each vault: read, write or manage it as an owner.",
+    "Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar.":
+      "Lists Desktop devices authorised to publish vaults to this server. You can revoke a device that should no longer synchronise.",
+    "Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual.":
+      "Shows the account and role you used to sign in. You can also change the password or sign out of the current session.",
+    "Las actualizaciones se aplican en el host de Server. Esta vista no simula descargas ni reinicios que el navegador no puede ejecutar.":
+      "Updates are applied on the Server host. This view does not simulate downloads or restarts that the browser cannot perform.",
+  },
+  fr: {
+    "Las claves y los modelos configurados se comparten entre todas tus bóvedas. Las credenciales siguen siendo privadas de esta cuenta.":
+      "Les clés et modèles configurés sont partagés entre tous vos coffres. Les identifiants restent privés pour ce compte.",
+    "El operador debe configurar la keyring cifrada del servidor para guardar credenciales.":
+      "L’opérateur doit configurer le trousseau chiffré du serveur avant de pouvoir enregistrer des identifiants.",
+    "Abre un proveedor y marca con una estrella los modelos que quieras usar en los selectores.":
+      "Ouvrez un fournisseur et ajoutez aux favoris les modèles à utiliser dans les sélecteurs.",
+    "Configurado en Server": "Configuré sur Server",
+    "Sin credencial en Server": "Aucun identifiant sur Server",
+    "Disponible mediante Desktop": "Disponible via Desktop",
+    Sustituir: "Remplacer",
+    Guardar: "Enregistrer",
+    Eliminar: "Supprimer",
+    "Este proveedor requiere el runtime o la red local de Nodus Desktop; sus favoritos se conservan, pero Server no intenta ejecutarlo.":
+      "Ce fournisseur nécessite l’environnement d’exécution ou le réseau local de Nodus Desktop. Ses favoris sont conservés, mais Server ne tente pas de l’exécuter.",
+    "Actualizando catálogo…": "Actualisation du catalogue…",
+    "Catálogo en vivo del proveedor": "Catalogue en direct du fournisseur",
+    "Catálogo compatible integrado": "Catalogue compatible intégré",
+    "Buscar modelo…": "Rechercher un modèle…",
+    "Ningún modelo coincide con la búsqueda.": "Aucun modèle ne correspond à la recherche.",
+    "Modo básico para un modelo general; modo avanzado para elegir cada tarea de forma independiente.":
+      "Le mode simple utilise un modèle général ; le mode avancé permet de choisir chaque tâche séparément.",
+    "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.":
+      "Des affectations héritées sont en attente ({assignments}). Les modèles locaux téléchargeables ne s’exécutent pas sur Server et ne sont pas remplacés par un modèle payant.",
+    "Un modelo general atiende las tareas de texto compatibles.":
+      "Un modèle général prend en charge les tâches de texte compatibles.",
+    "Cada tarea usa su modelo seleccionado de forma independiente.":
+      "Chaque tâche utilise indépendamment le modèle sélectionné.",
+    "Server muestra la misma biblioteca tabular de Desktop usando únicamente los documentos que el propietario decidió publicar.":
+      "Server affiche la même bibliothèque tabulaire que Desktop, uniquement avec les documents que le propriétaire a choisi de publier.",
+    "La publicación es independiente para cada vault.": "La publication est indépendante pour chaque coffre.",
+    "PDF, rutas locales y credenciales no se incluyen salvo publicación explícita del contenido permitido.":
+      "Les PDF, chemins locaux et identifiants sont exclus, sauf publication explicite du contenu autorisé.",
+    "La cuenta Server conserva la vista publicada. La conexión, storage y sincronización de Zotero se ejecutan en Desktop.":
+      "Le compte Server conserve la vue publiée. La connexion, le stockage et la synchronisation Zotero s’exécutent dans Desktop.",
+    "Abre Ajustes → Biblioteca en Desktop para cambiar la fuente Zotero. Server aplicará la siguiente publicación a todos los vaults conectados sin inventar una biblioteca distinta.":
+      "Ouvrez Paramètres → Bibliothèque dans Desktop pour changer la source Zotero. Server appliquera la prochaine publication à tous les coffres connectés sans créer une bibliothèque distincte.",
+    "Estos ajustes dependen de archivos locales y permanecen en Desktop.": "Ces paramètres dépendent de fichiers locaux et restent dans Desktop.",
+    "Server consume el texto limpio incluido por el publicador.": "Server utilise le texte nettoyé inclus par l’éditeur.",
+    "Tesseract, idiomas y límites de páginas se ejecutan donde reside el documento.":
+      "Tesseract, les langues et les limites de pages s’exécutent là où se trouve le document.",
+    "Apariencia y accesibilidad forman parte del perfil portable y se comparten transversalmente.":
+      "L’apparence et l’accessibilité font partie du profil portable et sont partagées entre les appareils.",
+    "Conecta ChatGPT, Claude y clientes compatibles con este usuario y sus vaults asignados.":
+      "Connectez ChatGPT, Claude et les clients compatibles à cet utilisateur et à ses coffres attribués.",
+    "Sincroniza publicación y perfil portable desde Nodus Desktop.": "Synchronise la publication et le profil portable depuis Nodus Desktop.",
+    "Los complementos de escritorio conservan su configuración local.": "Les extensions Desktop conservent leur configuration locale.",
+    "El navegador integrado requiere Electron y permanece fuera de la barra lateral de Server.":
+      "Le navigateur intégré nécessite Electron et reste en dehors de la barre latérale de Server.",
+    "Cookies, permisos, descargas y almacenamiento web nunca se copian al servidor. La extensión y Nodus Browser se configuran en Desktop.":
+      "Les cookies, autorisations, téléchargements et données web ne sont jamais copiés sur le serveur. L’extension et Nodus Browser se configurent dans Desktop.",
+    "Publicar un vault, asignar acceso y consultar la réplica.": "Publier un coffre, attribuer les accès et consulter la réplique.",
+    "Credenciales por usuario, modelos favoritos y privacidad.": "Identifiants par utilisateur, modèles favoris et confidentialité.",
+    "Connected Vault, MCP y clientes compatibles.": "Connected Vault, MCP et clients compatibles.",
+    "Las copias contienen datos locales, rutas y secretos que nunca cruzan el perfil portable. Se crean y restauran exclusivamente en Desktop o mediante la política de copias del operador de Server.":
+      "Les sauvegardes contiennent des données locales, chemins et secrets qui ne traversent jamais le profil portable. Elles sont créées et restaurées uniquement dans Desktop ou selon la politique de sauvegarde de l’opérateur Server.",
+    "Favoritos, modelos, interfaz y políticas compatibles.": "Favoris, modèles, interface et politiques compatibles.",
+    "Local-first · publicación explícita · credenciales aisladas":
+      "Local-first · publication explicite · identifiants isolés",
+    "Ayuda sobre {section}": "Aide sur {section}",
+    "Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso.":
+      "Résume ce serveur et indique le nombre de coffres, d’utilisateurs et d’appareils qu’il gère, ainsi que ses adresses d’accès.",
+    "Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial.":
+      "Crée un coffre modifiable qui réside directement sur Server. Choisissez son nom, son type et sa description initiale.",
+    "Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión.":
+      "Affiche les coffres natifs et ceux publiés depuis Desktop. Vous pouvez consulter leur état, régler ce qui est publié et générer des codes de connexion.",
+    "Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario.":
+      "Crée des comptes et définit ce que chaque utilisateur peut faire dans chaque coffre : lire, écrire ou l’administrer en tant que propriétaire.",
+    "Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar.":
+      "Répertorie les appareils Desktop autorisés à publier des coffres sur ce serveur. Vous pouvez révoquer un appareil qui ne doit plus se synchroniser.",
+    "Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual.":
+      "Affiche le compte et le rôle utilisés pour vous connecter. Vous pouvez également modifier le mot de passe ou fermer la session actuelle.",
+    "Las actualizaciones se aplican en el host de Server. Esta vista no simula descargas ni reinicios que el navegador no puede ejecutar.":
+      "Les mises à jour sont appliquées sur l’hôte Server. Cette vue ne simule pas les téléchargements ou redémarrages que le navigateur ne peut pas effectuer.",
+  },
+  de: {
+    "Las claves y los modelos configurados se comparten entre todas tus bóvedas. Las credenciales siguen siendo privadas de esta cuenta.":
+      "Konfigurierte Schlüssel und Modelle werden von allen Tresoren gemeinsam genutzt. Zugangsdaten bleiben für dieses Konto privat.",
+    "El operador debe configurar la keyring cifrada del servidor para guardar credenciales.":
+      "Der Betreiber muss den verschlüsselten Schlüsselbund des Servers konfigurieren, bevor Zugangsdaten gespeichert werden können.",
+    "Abre un proveedor y marca con una estrella los modelos que quieras usar en los selectores.":
+      "Öffnen Sie einen Anbieter und markieren Sie die Modelle als Favoriten, die Sie in Auswahllisten verwenden möchten.",
+    "Configurado en Server": "Auf Server konfiguriert",
+    "Sin credencial en Server": "Keine Zugangsdaten auf Server",
+    "Disponible mediante Desktop": "Über Desktop verfügbar",
+    Sustituir: "Ersetzen",
+    Guardar: "Speichern",
+    Eliminar: "Entfernen",
+    "Este proveedor requiere el runtime o la red local de Nodus Desktop; sus favoritos se conservan, pero Server no intenta ejecutarlo.":
+      "Dieser Anbieter benötigt die Laufzeitumgebung oder das lokale Netzwerk von Nodus Desktop. Favoriten bleiben erhalten, Server versucht ihn jedoch nicht auszuführen.",
+    "Actualizando catálogo…": "Katalog wird aktualisiert…",
+    "Catálogo en vivo del proveedor": "Live-Katalog des Anbieters",
+    "Catálogo compatible integrado": "Integrierter kompatibler Katalog",
+    "Buscar modelo…": "Modell suchen…",
+    "Ningún modelo coincide con la búsqueda.": "Kein Modell entspricht der Suche.",
+    "Modo básico para un modelo general; modo avanzado para elegir cada tarea de forma independiente.":
+      "Im Basismodus wird ein allgemeines Modell verwendet; im erweiterten Modus kann jede Aufgabe separat gewählt werden.",
+    "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.":
+      "Es gibt ausstehende übernommene Zuweisungen ({assignments}). Herunterladbare lokale Modelle laufen nicht auf Server und werden nicht durch ein kostenpflichtiges Modell ersetzt.",
+    "Un modelo general atiende las tareas de texto compatibles.": "Ein allgemeines Modell übernimmt kompatible Textaufgaben.",
+    "Cada tarea usa su modelo seleccionado de forma independiente.": "Jede Aufgabe verwendet unabhängig das ausgewählte Modell.",
+    "Server muestra la misma biblioteca tabular de Desktop usando únicamente los documentos que el propietario decidió publicar.":
+      "Server zeigt dieselbe tabellarische Bibliothek wie Desktop und verwendet nur die vom Eigentümer veröffentlichten Dokumente.",
+    "La publicación es independiente para cada vault.": "Die Veröffentlichung erfolgt für jeden Tresor unabhängig.",
+    "PDF, rutas locales y credenciales no se incluyen salvo publicación explícita del contenido permitido.":
+      "PDFs, lokale Pfade und Zugangsdaten sind ausgeschlossen, sofern erlaubte Inhalte nicht ausdrücklich veröffentlicht werden.",
+    "La cuenta Server conserva la vista publicada. La conexión, storage y sincronización de Zotero se ejecutan en Desktop.":
+      "Das Server-Konto bewahrt die veröffentlichte Ansicht. Zotero-Verbindung, Speicherung und Synchronisierung laufen in Desktop.",
+    "Abre Ajustes → Biblioteca en Desktop para cambiar la fuente Zotero. Server aplicará la siguiente publicación a todos los vaults conectados sin inventar una biblioteca distinta.":
+      "Öffnen Sie Einstellungen → Bibliothek in Desktop, um die Zotero-Quelle zu ändern. Server übernimmt die nächste Veröffentlichung für alle verbundenen Tresore, ohne eine eigene Bibliothek zu erfinden.",
+    "Estos ajustes dependen de archivos locales y permanecen en Desktop.": "Diese Einstellungen hängen von lokalen Dateien ab und verbleiben in Desktop.",
+    "Server consume el texto limpio incluido por el publicador.": "Server verwendet den vom Herausgeber bereitgestellten bereinigten Text.",
+    "Tesseract, idiomas y límites de páginas se ejecutan donde reside el documento.": "Tesseract, Sprachen und Seitenlimits werden dort ausgeführt, wo das Dokument liegt.",
+    "Apariencia y accesibilidad forman parte del perfil portable y se comparten transversalmente.":
+      "Darstellung und Barrierefreiheit gehören zum portablen Profil und werden geräteübergreifend geteilt.",
+    "Conecta ChatGPT, Claude y clientes compatibles con este usuario y sus vaults asignados.":
+      "Verbindet ChatGPT, Claude und kompatible Clients mit diesem Benutzer und den zugewiesenen Tresoren.",
+    "Sincroniza publicación y perfil portable desde Nodus Desktop.": "Synchronisiert Veröffentlichung und portables Profil aus Nodus Desktop.",
+    "Los complementos de escritorio conservan su configuración local.": "Desktop-Erweiterungen behalten ihre lokale Konfiguration.",
+    "El navegador integrado requiere Electron y permanece fuera de la barra lateral de Server.": "Der integrierte Browser benötigt Electron und bleibt außerhalb der Server-Seitenleiste.",
+    "Cookies, permisos, descargas y almacenamiento web nunca se copian al servidor. La extensión y Nodus Browser se configuran en Desktop.":
+      "Cookies, Berechtigungen, Downloads und Webspeicher werden nie auf den Server kopiert. Erweiterung und Nodus Browser werden in Desktop konfiguriert.",
+    "Publicar un vault, asignar acceso y consultar la réplica.": "Einen Tresor veröffentlichen, Zugriff zuweisen und das Replikat prüfen.",
+    "Credenciales por usuario, modelos favoritos y privacidad.": "Zugangsdaten pro Benutzer, Favoritenmodelle und Datenschutz.",
+    "Connected Vault, MCP y clientes compatibles.": "Connected Vault, MCP und kompatible Clients.",
+    "Las copias contienen datos locales, rutas y secretos que nunca cruzan el perfil portable. Se crean y restauran exclusivamente en Desktop o mediante la política de copias del operador de Server.":
+      "Sicherungen enthalten lokale Daten, Pfade und Geheimnisse, die nie in das portable Profil gelangen. Sie werden ausschließlich in Desktop oder nach der Sicherungsrichtlinie des Server-Betreibers erstellt und wiederhergestellt.",
+    "Favoritos, modelos, interfaz y políticas compatibles.": "Favoriten, Modelle, Oberfläche und kompatible Richtlinien.",
+    "Local-first · publicación explícita · credenciales aisladas":
+      "Local-first · ausdrückliche Veröffentlichung · isolierte Zugangsdaten",
+    "Ayuda sobre {section}": "Hilfe zu {section}",
+    "Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso.":
+      "Fasst diesen Server zusammen und zeigt die Anzahl der verwalteten Tresore, Benutzer und Geräte sowie seine Zugriffsadressen.",
+    "Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial.":
+      "Erstellt einen bearbeitbaren Tresor, der direkt auf Server liegt. Wählen Sie Namen, Typ und anfängliche Beschreibung.",
+    "Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión.":
+      "Zeigt native und aus Desktop veröffentlichte Tresore. Hier können Sie ihren Status prüfen, Veröffentlichungsinhalte festlegen und Verbindungscodes erzeugen.",
+    "Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario.":
+      "Erstellt Konten und legt fest, was jeder Benutzer in jedem Tresor darf: lesen, schreiben oder ihn als Eigentümer verwalten.",
+    "Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar.":
+      "Listet Desktop-Geräte auf, die Tresore auf diesem Server veröffentlichen dürfen. Geräte, die nicht mehr synchronisieren sollen, können widerrufen werden.",
+    "Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual.":
+      "Zeigt das Konto und die Rolle der aktuellen Anmeldung. Hier können Sie auch das Passwort ändern oder die aktuelle Sitzung abmelden.",
+    "Las actualizaciones se aplican en el host de Server. Esta vista no simula descargas ni reinicios que el navegador no puede ejecutar.":
+      "Aktualisierungen werden auf dem Server-Host angewendet. Diese Ansicht simuliert keine Downloads oder Neustarts, die der Browser nicht ausführen kann.",
+  },
+  pt: {
+    "Las claves y los modelos configurados se comparten entre todas tus bóvedas. Las credenciales siguen siendo privadas de esta cuenta.":
+      "As chaves e os modelos configurados são partilhados entre todos os seus cofres. As credenciais permanecem privadas desta conta.",
+    "El operador debe configurar la keyring cifrada del servidor para guardar credenciales.":
+      "O operador tem de configurar o porta-chaves cifrado do servidor antes de guardar credenciais.",
+    "Abre un proveedor y marca con una estrella los modelos que quieras usar en los selectores.":
+      "Abra um provedor e marque como favoritos os modelos que pretende usar nos seletores.",
+    "Configurado en Server": "Configurado no Server",
+    "Sin credencial en Server": "Sem credencial no Server",
+    "Disponible mediante Desktop": "Disponível através do Desktop",
+    Sustituir: "Substituir",
+    Guardar: "Guardar",
+    Eliminar: "Remover",
+    "Este proveedor requiere el runtime o la red local de Nodus Desktop; sus favoritos se conservan, pero Server no intenta ejecutarlo.":
+      "Este provedor requer o runtime ou a rede local do Nodus Desktop. Os favoritos são preservados, mas o Server não tenta executá-lo.",
+    "Actualizando catálogo…": "A atualizar o catálogo…",
+    "Catálogo en vivo del proveedor": "Catálogo em direto do provedor",
+    "Catálogo compatible integrado": "Catálogo compatível integrado",
+    "Buscar modelo…": "Procurar modelo…",
+    "Ningún modelo coincide con la búsqueda.": "Nenhum modelo corresponde à pesquisa.",
+    "Modo básico para un modelo general; modo avanzado para elegir cada tarea de forma independiente.":
+      "O modo básico usa um modelo geral; o modo avançado permite escolher cada tarefa separadamente.",
+    "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.":
+      "Existem atribuições herdadas pendentes ({assignments}). Os modelos locais descarregáveis não são executados no Server nem substituídos por um modelo pago.",
+    "Un modelo general atiende las tareas de texto compatibles.": "Um modelo geral trata das tarefas de texto compatíveis.",
+    "Cada tarea usa su modelo seleccionado de forma independiente.": "Cada tarefa usa de forma independente o modelo selecionado.",
+    "Server muestra la misma biblioteca tabular de Desktop usando únicamente los documentos que el propietario decidió publicar.":
+      "O Server mostra a mesma biblioteca tabular do Desktop usando apenas os documentos que o proprietário decidiu publicar.",
+    "La publicación es independiente para cada vault.": "A publicação é independente para cada cofre.",
+    "PDF, rutas locales y credenciales no se incluyen salvo publicación explícita del contenido permitido.":
+      "PDF, caminhos locais e credenciais são excluídos, salvo publicação explícita do conteúdo permitido.",
+    "La cuenta Server conserva la vista publicada. La conexión, storage y sincronización de Zotero se ejecutan en Desktop.":
+      "A conta Server conserva a vista publicada. A ligação, o armazenamento e a sincronização do Zotero são executados no Desktop.",
+    "Abre Ajustes → Biblioteca en Desktop para cambiar la fuente Zotero. Server aplicará la siguiente publicación a todos los vaults conectados sin inventar una biblioteca distinta.":
+      "Abra Definições → Biblioteca no Desktop para alterar a fonte do Zotero. O Server aplicará a publicação seguinte a todos os cofres ligados sem criar uma biblioteca separada.",
+    "Estos ajustes dependen de archivos locales y permanecen en Desktop.": "Estas definições dependem de ficheiros locais e permanecem no Desktop.",
+    "Server consume el texto limpio incluido por el publicador.": "O Server utiliza o texto limpo incluído pelo publicador.",
+    "Tesseract, idiomas y límites de páginas se ejecutan donde reside el documento.": "O Tesseract, os idiomas e os limites de páginas são executados onde reside o documento.",
+    "Apariencia y accesibilidad forman parte del perfil portable y se comparten transversalmente.":
+      "A aparência e a acessibilidade fazem parte do perfil portátil e são partilhadas entre dispositivos.",
+    "Conecta ChatGPT, Claude y clientes compatibles con este usuario y sus vaults asignados.": "Liga o ChatGPT, Claude e clientes compatíveis a este utilizador e aos cofres atribuídos.",
+    "Sincroniza publicación y perfil portable desde Nodus Desktop.": "Sincroniza a publicação e o perfil portátil a partir do Nodus Desktop.",
+    "Los complementos de escritorio conservan su configuración local.": "Os suplementos do Desktop mantêm a configuração local.",
+    "El navegador integrado requiere Electron y permanece fuera de la barra lateral de Server.": "O navegador integrado requer Electron e permanece fora da barra lateral do Server.",
+    "Cookies, permisos, descargas y almacenamiento web nunca se copian al servidor. La extensión y Nodus Browser se configuran en Desktop.":
+      "Cookies, permissões, transferências e armazenamento web nunca são copiados para o servidor. A extensão e o Nodus Browser são configurados no Desktop.",
+    "Publicar un vault, asignar acceso y consultar la réplica.": "Publicar um cofre, atribuir acesso e consultar a réplica.",
+    "Credenciales por usuario, modelos favoritos y privacidad.": "Credenciais por utilizador, modelos favoritos e privacidade.",
+    "Connected Vault, MCP y clientes compatibles.": "Connected Vault, MCP e clientes compatíveis.",
+    "Las copias contienen datos locales, rutas y secretos que nunca cruzan el perfil portable. Se crean y restauran exclusivamente en Desktop o mediante la política de copias del operador de Server.":
+      "As cópias contêm dados locais, caminhos e segredos que nunca atravessam o perfil portátil. São criadas e restauradas apenas no Desktop ou através da política de cópias do operador do Server.",
+    "Favoritos, modelos, interfaz y políticas compatibles.": "Favoritos, modelos, interface e políticas compatíveis.",
+    "Local-first · publicación explícita · credenciales aisladas":
+      "Local-first · publicação explícita · credenciais isoladas",
+    "Ayuda sobre {section}": "Ajuda sobre {section}",
+    "Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso.":
+      "Resume este servidor e mostra quantos cofres, utilizadores e dispositivos gere, juntamente com os respetivos endereços de acesso.",
+    "Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial.":
+      "Cria um cofre editável que reside diretamente no Server. Escolha o nome, o tipo e a descrição inicial.",
+    "Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión.":
+      "Mostra os cofres nativos e os publicados a partir do Desktop. Aqui pode rever o estado, ajustar o que é publicado e gerar códigos de ligação.",
+    "Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario.":
+      "Cria contas e decide o que cada utilizador pode fazer em cada cofre: ler, escrever ou administrá-lo como proprietário.",
+    "Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar.":
+      "Lista os dispositivos Desktop autorizados a publicar cofres neste servidor. Pode revogar um dispositivo que já não deva sincronizar.",
+    "Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual.":
+      "Mostra a conta e a função usadas para iniciar sessão. Também permite alterar a palavra-passe ou terminar a sessão atual.",
+    "Las actualizaciones se aplican en el host de Server. Esta vista no simula descargas ni reinicios que el navegador no puede ejecutar.":
+      "As atualizações são aplicadas no anfitrião do Server. Esta vista não simula transferências ou reinícios que o navegador não pode executar.",
+  },
+  "pt-BR": {
+    "Las claves y los modelos configurados se comparten entre todas tus bóvedas. Las credenciales siguen siendo privadas de esta cuenta.":
+      "As chaves e os modelos configurados são compartilhados entre todos os seus cofres. As credenciais permanecem privadas desta conta.",
+    "El operador debe configurar la keyring cifrada del servidor para guardar credenciales.":
+      "O operador precisa configurar o chaveiro criptografado do servidor antes de salvar credenciais.",
+    "Abre un proveedor y marca con una estrella los modelos que quieras usar en los selectores.":
+      "Abra um provedor e marque como favoritos os modelos que deseja usar nos seletores.",
+    "Configurado en Server": "Configurado no Server",
+    "Sin credencial en Server": "Sem credencial no Server",
+    "Disponible mediante Desktop": "Disponível pelo Desktop",
+    Sustituir: "Substituir",
+    Guardar: "Salvar",
+    Eliminar: "Remover",
+    "Este proveedor requiere el runtime o la red local de Nodus Desktop; sus favoritos se conservan, pero Server no intenta ejecutarlo.":
+      "Este provedor requer o runtime ou a rede local do Nodus Desktop. Os favoritos são preservados, mas o Server não tenta executá-lo.",
+    "Actualizando catálogo…": "Atualizando catálogo…",
+    "Catálogo en vivo del proveedor": "Catálogo ao vivo do provedor",
+    "Catálogo compatible integrado": "Catálogo compatível integrado",
+    "Buscar modelo…": "Buscar modelo…",
+    "Ningún modelo coincide con la búsqueda.": "Nenhum modelo corresponde à busca.",
+    "Modo básico para un modelo general; modo avanzado para elegir cada tarea de forma independiente.":
+      "O modo básico usa um modelo geral; o modo avançado permite escolher cada tarefa separadamente.",
+    "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.":
+      "Há atribuições herdadas pendentes ({assignments}). Os modelos locais para download não são executados no Server nem substituídos por um modelo pago.",
+    "Un modelo general atiende las tareas de texto compatibles.": "Um modelo geral atende às tarefas de texto compatíveis.",
+    "Cada tarea usa su modelo seleccionado de forma independiente.": "Cada tarefa usa seu modelo selecionado de forma independente.",
+    "Server muestra la misma biblioteca tabular de Desktop usando únicamente los documentos que el propietario decidió publicar.":
+      "O Server mostra a mesma biblioteca tabular do Desktop usando somente os documentos que o proprietário decidiu publicar.",
+    "La publicación es independiente para cada vault.": "A publicação é independente para cada cofre.",
+    "PDF, rutas locales y credenciales no se incluyen salvo publicación explícita del contenido permitido.":
+      "PDFs, caminhos locais e credenciais ficam de fora, exceto quando o conteúdo permitido é publicado explicitamente.",
+    "La cuenta Server conserva la vista publicada. La conexión, storage y sincronización de Zotero se ejecutan en Desktop.":
+      "A conta Server mantém a vista publicada. A conexão, o armazenamento e a sincronização do Zotero são executados no Desktop.",
+    "Abre Ajustes → Biblioteca en Desktop para cambiar la fuente Zotero. Server aplicará la siguiente publicación a todos los vaults conectados sin inventar una biblioteca distinta.":
+      "Abra Configurações → Biblioteca no Desktop para alterar a fonte do Zotero. O Server aplicará a próxima publicação a todos os cofres conectados sem criar uma biblioteca separada.",
+    "Estos ajustes dependen de archivos locales y permanecen en Desktop.": "Estas configurações dependem de arquivos locais e permanecem no Desktop.",
+    "Server consume el texto limpio incluido por el publicador.": "O Server usa o texto limpo incluído pelo publicador.",
+    "Tesseract, idiomas y límites de páginas se ejecutan donde reside el documento.": "O Tesseract, os idiomas e os limites de páginas são executados onde o documento está.",
+    "Apariencia y accesibilidad forman parte del perfil portable y se comparten transversalmente.":
+      "A aparência e a acessibilidade fazem parte do perfil portátil e são compartilhadas entre dispositivos.",
+    "Conecta ChatGPT, Claude y clientes compatibles con este usuario y sus vaults asignados.": "Conecta o ChatGPT, Claude e clientes compatíveis a este usuário e aos cofres atribuídos.",
+    "Sincroniza publicación y perfil portable desde Nodus Desktop.": "Sincroniza a publicação e o perfil portátil pelo Nodus Desktop.",
+    "Los complementos de escritorio conservan su configuración local.": "Os complementos do Desktop mantêm sua configuração local.",
+    "El navegador integrado requiere Electron y permanece fuera de la barra lateral de Server.": "O navegador integrado requer Electron e permanece fora da barra lateral do Server.",
+    "Cookies, permisos, descargas y almacenamiento web nunca se copian al servidor. La extensión y Nodus Browser se configuran en Desktop.":
+      "Cookies, permissões, downloads e armazenamento web nunca são copiados para o servidor. A extensão e o Nodus Browser são configurados no Desktop.",
+    "Publicar un vault, asignar acceso y consultar la réplica.": "Publicar um cofre, atribuir acesso e consultar a réplica.",
+    "Credenciales por usuario, modelos favoritos y privacidad.": "Credenciais por usuário, modelos favoritos e privacidade.",
+    "Connected Vault, MCP y clientes compatibles.": "Connected Vault, MCP e clientes compatíveis.",
+    "Las copias contienen datos locales, rutas y secretos que nunca cruzan el perfil portable. Se crean y restauran exclusivamente en Desktop o mediante la política de copias del operador de Server.":
+      "Os backups contêm dados locais, caminhos e segredos que nunca atravessam o perfil portátil. Eles são criados e restaurados somente no Desktop ou pela política de backup do operador do Server.",
+    "Favoritos, modelos, interfaz y políticas compatibles.": "Favoritos, modelos, interface e políticas compatíveis.",
+    "Local-first · publicación explícita · credenciales aisladas":
+      "Local-first · publicação explícita · credenciais isoladas",
+    "Ayuda sobre {section}": "Ajuda sobre {section}",
+    "Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso.":
+      "Resume este servidor e mostra quantos cofres, usuários e dispositivos ele gerencia, além dos respectivos endereços de acesso.",
+    "Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial.":
+      "Cria um cofre editável que fica diretamente no Server. Escolha o nome, o tipo e a descrição inicial.",
+    "Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión.":
+      "Mostra os cofres nativos e os publicados pelo Desktop. Aqui você pode verificar o status, ajustar o que é publicado e gerar códigos de conexão.",
+    "Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario.":
+      "Cria contas e define o que cada usuário pode fazer em cada cofre: ler, escrever ou administrá-lo como proprietário.",
+    "Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar.":
+      "Lista os dispositivos Desktop autorizados a publicar cofres neste servidor. Você pode revogar um dispositivo que não deve mais sincronizar.",
+    "Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual.":
+      "Mostra a conta e a função usadas para entrar. Também permite alterar a senha ou sair da sessão atual.",
+    "Las actualizaciones se aplican en el host de Server. Esta vista no simula descargas ni reinicios que el navegador no puede ejecutar.":
+      "As atualizações são aplicadas no host do Server. Esta vista não simula downloads ou reinicializações que o navegador não pode executar.",
+  },
+  it: {
+    "Las claves y los modelos configurados se comparten entre todas tus bóvedas. Las credenciales siguen siendo privadas de esta cuenta.":
+      "Le chiavi e i modelli configurati sono condivisi tra tutti i tuoi vault. Le credenziali restano private per questo account.",
+    "El operador debe configurar la keyring cifrada del servidor para guardar credenciales.":
+      "L’operatore deve configurare il portachiavi cifrato del server prima di salvare le credenziali.",
+    "Abre un proveedor y marca con una estrella los modelos que quieras usar en los selectores.":
+      "Apri un provider e aggiungi ai preferiti i modelli da usare nei selettori.",
+    "Configurado en Server": "Configurato su Server",
+    "Sin credencial en Server": "Nessuna credenziale su Server",
+    "Disponible mediante Desktop": "Disponibile tramite Desktop",
+    Sustituir: "Sostituisci",
+    Guardar: "Salva",
+    Eliminar: "Rimuovi",
+    "Este proveedor requiere el runtime o la red local de Nodus Desktop; sus favoritos se conservan, pero Server no intenta ejecutarlo.":
+      "Questo provider richiede il runtime o la rete locale di Nodus Desktop. I preferiti vengono conservati, ma Server non tenta di eseguirlo.",
+    "Actualizando catálogo…": "Aggiornamento del catalogo…",
+    "Catálogo en vivo del proveedor": "Catalogo in tempo reale del provider",
+    "Catálogo compatible integrado": "Catalogo compatibile integrato",
+    "Buscar modelo…": "Cerca modello…",
+    "Ningún modelo coincide con la búsqueda.": "Nessun modello corrisponde alla ricerca.",
+    "Modo básico para un modelo general; modo avanzado para elegir cada tarea de forma independiente.":
+      "La modalità base usa un modello generale; la modalità avanzata consente di scegliere ogni attività separatamente.",
+    "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.":
+      "Sono presenti assegnazioni ereditate in sospeso ({assignments}). I modelli locali scaricabili non vengono eseguiti su Server né sostituiti da un modello a pagamento.",
+    "Un modelo general atiende las tareas de texto compatibles.": "Un modello generale gestisce le attività di testo compatibili.",
+    "Cada tarea usa su modelo seleccionado de forma independiente.": "Ogni attività usa in modo indipendente il modello selezionato.",
+    "Server muestra la misma biblioteca tabular de Desktop usando únicamente los documentos que el propietario decidió publicar.":
+      "Server mostra la stessa biblioteca tabellare di Desktop usando solo i documenti che il proprietario ha scelto di pubblicare.",
+    "La publicación es independiente para cada vault.": "La pubblicazione è indipendente per ogni vault.",
+    "PDF, rutas locales y credenciales no se incluyen salvo publicación explícita del contenido permitido.":
+      "PDF, percorsi locali e credenziali sono esclusi, salvo pubblicazione esplicita dei contenuti consentiti.",
+    "La cuenta Server conserva la vista publicada. La conexión, storage y sincronización de Zotero se ejecutan en Desktop.":
+      "L’account Server conserva la vista pubblicata. Connessione, archiviazione e sincronizzazione di Zotero vengono eseguite in Desktop.",
+    "Abre Ajustes → Biblioteca en Desktop para cambiar la fuente Zotero. Server aplicará la siguiente publicación a todos los vaults conectados sin inventar una biblioteca distinta.":
+      "Apri Impostazioni → Biblioteca in Desktop per cambiare la fonte Zotero. Server applicherà la pubblicazione successiva a tutti i vault connessi senza creare una biblioteca separata.",
+    "Estos ajustes dependen de archivos locales y permanecen en Desktop.": "Queste impostazioni dipendono da file locali e rimangono in Desktop.",
+    "Server consume el texto limpio incluido por el publicador.": "Server utilizza il testo pulito incluso dall’editore.",
+    "Tesseract, idiomas y límites de páginas se ejecutan donde reside el documento.": "Tesseract, le lingue e i limiti di pagina vengono eseguiti dove risiede il documento.",
+    "Apariencia y accesibilidad forman parte del perfil portable y se comparten transversalmente.":
+      "Aspetto e accessibilità fanno parte del profilo portatile e sono condivisi tra i dispositivi.",
+    "Conecta ChatGPT, Claude y clientes compatibles con este usuario y sus vaults asignados.": "Collega ChatGPT, Claude e i client compatibili a questo utente e ai vault assegnati.",
+    "Sincroniza publicación y perfil portable desde Nodus Desktop.": "Sincronizza pubblicazione e profilo portatile da Nodus Desktop.",
+    "Los complementos de escritorio conservan su configuración local.": "I componenti aggiuntivi Desktop mantengono la configurazione locale.",
+    "El navegador integrado requiere Electron y permanece fuera de la barra lateral de Server.": "Il browser integrato richiede Electron e rimane fuori dalla barra laterale di Server.",
+    "Cookies, permisos, descargas y almacenamiento web nunca se copian al servidor. La extensión y Nodus Browser se configuran en Desktop.":
+      "Cookie, autorizzazioni, download e archiviazione web non vengono mai copiati sul server. L’estensione e Nodus Browser si configurano in Desktop.",
+    "Publicar un vault, asignar acceso y consultar la réplica.": "Pubblica un vault, assegna l’accesso e consulta la replica.",
+    "Credenciales por usuario, modelos favoritos y privacidad.": "Credenziali per utente, modelli preferiti e privacy.",
+    "Connected Vault, MCP y clientes compatibles.": "Connected Vault, MCP e client compatibili.",
+    "Las copias contienen datos locales, rutas y secretos que nunca cruzan el perfil portable. Se crean y restauran exclusivamente en Desktop o mediante la política de copias del operador de Server.":
+      "I backup contengono dati locali, percorsi e segreti che non attraversano mai il profilo portatile. Vengono creati e ripristinati solo in Desktop o tramite la politica di backup dell’operatore Server.",
+    "Favoritos, modelos, interfaz y políticas compatibles.": "Preferiti, modelli, interfaccia e criteri compatibili.",
+    "Local-first · publicación explícita · credenciales aisladas":
+      "Local-first · pubblicazione esplicita · credenziali isolate",
+    "Ayuda sobre {section}": "Aiuto su {section}",
+    "Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso.":
+      "Riepiloga questo server e mostra quanti vault, utenti e dispositivi gestisce, insieme ai relativi indirizzi di accesso.",
+    "Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial.":
+      "Crea un vault modificabile che risiede direttamente su Server. Scegli nome, tipo e descrizione iniziale.",
+    "Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión.":
+      "Mostra i vault nativi e quelli pubblicati da Desktop. Qui puoi verificarne lo stato, scegliere cosa pubblicare e generare codici di connessione.",
+    "Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario.":
+      "Crea account e stabilisce cosa può fare ogni utente in ciascun vault: leggere, scrivere o amministrarlo come proprietario.",
+    "Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar.":
+      "Elenca i dispositivi Desktop autorizzati a pubblicare vault su questo server. Puoi revocare un dispositivo che non deve più sincronizzarsi.",
+    "Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual.":
+      "Mostra l’account e il ruolo usati per accedere. Consente anche di cambiare la password o terminare la sessione corrente.",
+    "Las actualizaciones se aplican en el host de Server. Esta vista no simula descargas ni reinicios que el navegador no puede ejecutar.":
+      "Gli aggiornamenti vengono applicati sull’host Server. Questa vista non simula download o riavvii che il browser non può eseguire.",
+  },
+  tr: {
+    "Las claves y los modelos configurados se comparten entre todas tus bóvedas. Las credenciales siguen siendo privadas de esta cuenta.":
+      "Yapılandırılan anahtarlar ve modeller tüm kasalarınız arasında paylaşılır. Kimlik bilgileri bu hesaba özel kalır.",
+    "El operador debe configurar la keyring cifrada del servidor para guardar credenciales.":
+      "Kimlik bilgileri kaydedilmeden önce operatör sunucunun şifreli anahtarlığını yapılandırmalıdır.",
+    "Abre un proveedor y marca con una estrella los modelos que quieras usar en los selectores.":
+      "Bir sağlayıcı açın ve seçicilerde kullanmak istediğiniz modelleri favorilere ekleyin.",
+    "Configurado en Server": "Server üzerinde yapılandırıldı",
+    "Sin credencial en Server": "Server üzerinde kimlik bilgisi yok",
+    "Disponible mediante Desktop": "Desktop üzerinden kullanılabilir",
+    Sustituir: "Değiştir",
+    Guardar: "Kaydet",
+    Eliminar: "Kaldır",
+    "Este proveedor requiere el runtime o la red local de Nodus Desktop; sus favoritos se conservan, pero Server no intenta ejecutarlo.":
+      "Bu sağlayıcı Nodus Desktop çalışma ortamını veya yerel ağını gerektirir. Favoriler korunur, ancak Server sağlayıcıyı çalıştırmayı denemez.",
+    "Actualizando catálogo…": "Katalog yenileniyor…",
+    "Catálogo en vivo del proveedor": "Sağlayıcının canlı kataloğu",
+    "Catálogo compatible integrado": "Yerleşik uyumlu katalog",
+    "Buscar modelo…": "Model ara…",
+    "Ningún modelo coincide con la búsqueda.": "Aramayla eşleşen model yok.",
+    "Modo básico para un modelo general; modo avanzado para elegir cada tarea de forma independiente.":
+      "Temel mod tek bir genel model kullanır; gelişmiş mod her görevi ayrı seçmenizi sağlar.",
+    "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.":
+      "Bekleyen devralınmış atamalar var ({assignments}). İndirilebilir yerel modeller Server üzerinde çalışmaz ve ücretli bir modelle değiştirilmez.",
+    "Un modelo general atiende las tareas de texto compatibles.": "Tek bir genel model uyumlu metin görevlerini yürütür.",
+    "Cada tarea usa su modelo seleccionado de forma independiente.": "Her görev seçilen modelini bağımsız olarak kullanır.",
+    "Server muestra la misma biblioteca tabular de Desktop usando únicamente los documentos que el propietario decidió publicar.":
+      "Server, yalnızca sahibinin yayımlamayı seçtiği belgeleri kullanarak Desktop ile aynı tablo kitaplığını gösterir.",
+    "La publicación es independiente para cada vault.": "Yayımlama her kasa için bağımsızdır.",
+    "PDF, rutas locales y credenciales no se incluyen salvo publicación explícita del contenido permitido.":
+      "İzin verilen içerik açıkça yayımlanmadıkça PDF'ler, yerel yollar ve kimlik bilgileri dahil edilmez.",
+    "La cuenta Server conserva la vista publicada. La conexión, storage y sincronización de Zotero se ejecutan en Desktop.":
+      "Server hesabı yayımlanan görünümü saklar. Zotero bağlantısı, depolaması ve eşitlemesi Desktop üzerinde çalışır.",
+    "Abre Ajustes → Biblioteca en Desktop para cambiar la fuente Zotero. Server aplicará la siguiente publicación a todos los vaults conectados sin inventar una biblioteca distinta.":
+      "Zotero kaynağını değiştirmek için Desktop'ta Ayarlar → Kitaplık bölümünü açın. Server ayrı bir kitaplık oluşturmadan sonraki yayını tüm bağlı kasalara uygular.",
+    "Estos ajustes dependen de archivos locales y permanecen en Desktop.": "Bu ayarlar yerel dosyalara bağlıdır ve Desktop'ta kalır.",
+    "Server consume el texto limpio incluido por el publicador.": "Server, yayımcının eklediği temiz metni kullanır.",
+    "Tesseract, idiomas y límites de páginas se ejecutan donde reside el documento.": "Tesseract, diller ve sayfa sınırları belgenin bulunduğu yerde çalışır.",
+    "Apariencia y accesibilidad forman parte del perfil portable y se comparten transversalmente.":
+      "Görünüm ve erişilebilirlik taşınabilir profilin parçasıdır ve cihazlar arasında paylaşılır.",
+    "Conecta ChatGPT, Claude y clientes compatibles con este usuario y sus vaults asignados.": "ChatGPT, Claude ve uyumlu istemcileri bu kullanıcıya ve atanmış kasalarına bağlar.",
+    "Sincroniza publicación y perfil portable desde Nodus Desktop.": "Yayımlamayı ve taşınabilir profili Nodus Desktop'tan eşitler.",
+    "Los complementos de escritorio conservan su configuración local.": "Desktop eklentileri yerel yapılandırmalarını korur.",
+    "El navegador integrado requiere Electron y permanece fuera de la barra lateral de Server.": "Entegre tarayıcı Electron gerektirir ve Server kenar çubuğunun dışında kalır.",
+    "Cookies, permisos, descargas y almacenamiento web nunca se copian al servidor. La extensión y Nodus Browser se configuran en Desktop.":
+      "Çerezler, izinler, indirmeler ve web depolaması hiçbir zaman sunucuya kopyalanmaz. Uzantı ve Nodus Browser, Desktop'ta yapılandırılır.",
+    "Publicar un vault, asignar acceso y consultar la réplica.": "Bir kasayı yayımlayın, erişim atayın ve kopyayı inceleyin.",
+    "Credenciales por usuario, modelos favoritos y privacidad.": "Kullanıcı başına kimlik bilgileri, favori modeller ve gizlilik.",
+    "Connected Vault, MCP y clientes compatibles.": "Connected Vault, MCP ve uyumlu istemciler.",
+    "Las copias contienen datos locales, rutas y secretos que nunca cruzan el perfil portable. Se crean y restauran exclusivamente en Desktop o mediante la política de copias del operador de Server.":
+      "Yedekler, taşınabilir profile asla geçmeyen yerel veriler, yollar ve gizli bilgiler içerir. Yalnızca Desktop'ta veya Server operatörünün yedekleme politikasıyla oluşturulur ve geri yüklenir.",
+    "Favoritos, modelos, interfaz y políticas compatibles.": "Favoriler, modeller, arayüz ve uyumlu politikalar.",
+    "Local-first · publicación explícita · credenciales aisladas":
+      "Local-first · açık yayımlama · yalıtılmış kimlik bilgileri",
+    "Ayuda sobre {section}": "{section} yardımı",
+    "Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso.":
+      "Bu sunucuyu özetler; yönettiği kasa, kullanıcı ve cihaz sayılarını erişim adresleriyle birlikte gösterir.",
+    "Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial.":
+      "Doğrudan Server üzerinde bulunan düzenlenebilir bir kasa oluşturur. Adını, türünü ve başlangıç açıklamasını seçin.",
+    "Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión.":
+      "Yerel kasaları ve Desktop’tan yayımlanan kasaları gösterir. Durumlarını inceleyebilir, nelerin yayımlanacağını ayarlayabilir ve bağlantı kodları oluşturabilirsiniz.",
+    "Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario.":
+      "Hesaplar oluşturur ve her kullanıcının her kasada neler yapabileceğini belirler: okuma, yazma veya sahip olarak yönetme.",
+    "Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar.":
+      "Bu sunucuda kasa yayımlama yetkisi olan Desktop cihazlarını listeler. Artık eşitleme yapmaması gereken bir cihazın yetkisini kaldırabilirsiniz.",
+    "Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual.":
+      "Oturum açtığınız hesabı ve rolü gösterir. Parolayı değiştirebilir veya mevcut oturumu kapatabilirsiniz.",
+    "Las actualizaciones se aplican en el host de Server. Esta vista no simula descargas ni reinicios que el navegador no puede ejecutar.":
+      "Güncellemeler Server ana makinesinde uygulanır. Bu görünüm, tarayıcının gerçekleştiremeyeceği indirmeleri veya yeniden başlatmaları taklit etmez.",
+  },
+};

--- a/src/serverWeb/i18nShim.ts
+++ b/src/serverWeb/i18nShim.ts
@@ -2970,6 +2970,9 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   en: {
     "Nuevo vault": "New vault",
     "Connected Vault": "Connected Vault",
+    "Añadir vault": "Add vault",
+    "No hay coincidencias": "No matches",
+    "La biblioteca está vacía": "The library is empty",
     "Crear un vault editable directamente en Server.":
       "Create an editable vault directly on Server.",
     "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
@@ -3019,6 +3022,9 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   fr: {
     "Nuevo vault": "Nouveau coffre",
     "Connected Vault": "Coffre connecté",
+    "Añadir vault": "Ajouter un coffre",
+    "No hay coincidencias": "Aucun résultat",
+    "La biblioteca está vacía": "La bibliothèque est vide",
     "Crear un vault editable directamente en Server.":
       "Créer un coffre modifiable directement sur Server.",
     "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
@@ -3061,6 +3067,9 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   de: {
     "Nuevo vault": "Neuer Tresor",
     "Connected Vault": "Verbundener Tresor",
+    "Añadir vault": "Tresor hinzufügen",
+    "No hay coincidencias": "Keine Treffer",
+    "La biblioteca está vacía": "Die Bibliothek ist leer",
     "Crear un vault editable directamente en Server.":
       "Einen bearbeitbaren Tresor direkt auf Server erstellen.",
     "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
@@ -3103,6 +3112,9 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   pt: {
     "Nuevo vault": "Novo cofre",
     "Connected Vault": "Cofre ligado",
+    "Añadir vault": "Adicionar cofre",
+    "No hay coincidencias": "Sem resultados",
+    "La biblioteca está vacía": "A biblioteca está vazia",
     "Crear un vault editable directamente en Server.":
       "Criar um cofre editável diretamente no Server.",
     "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
@@ -3167,6 +3179,9 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   "pt-BR": {
     "Nuevo vault": "Novo cofre",
     "Connected Vault": "Cofre conectado",
+    "Añadir vault": "Adicionar cofre",
+    "No hay coincidencias": "Nenhum resultado",
+    "La biblioteca está vacía": "A biblioteca está vazia",
     "Crear un vault editable directamente en Server.":
       "Criar um cofre editável diretamente no Server.",
     "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
@@ -3230,6 +3245,9 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   it: {
     "Nuevo vault": "Nuovo vault",
     "Connected Vault": "Vault connesso",
+    "Añadir vault": "Aggiungi vault",
+    "No hay coincidencias": "Nessun risultato",
+    "La biblioteca está vacía": "La biblioteca è vuota",
     "Crear un vault editable directamente en Server.":
       "Crea un vault modificabile direttamente su Server.",
     "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
@@ -3274,6 +3292,9 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   tr: {
     "Nuevo vault": "Yeni kasa",
     "Connected Vault": "Bağlı kasa",
+    "Añadir vault": "Kasa ekle",
+    "No hay coincidencias": "Eşleşme yok",
+    "La biblioteca está vacía": "Kütüphane boş",
     "Crear un vault editable directamente en Server.":
       "Doğrudan Server üzerinde düzenlenebilir bir kasa oluşturun.",
     "Conectar un vault de Desktop para publicarlo y sincronizarlo.":

--- a/src/serverWeb/i18nShim.ts
+++ b/src/serverWeb/i18nShim.ts
@@ -14,6 +14,7 @@ import { PT_BR } from "../i18n.pt-BR";
 import { IT } from "../i18n.it";
 import { TR } from "../i18n.tr";
 import { SERVER_TRANSLATIONS } from "../i18n.server";
+import { SERVER_SETTINGS_TRANSLATIONS } from "./i18nServerSettings";
 
 /**
  * Server Web uses the same translation tables as Desktop.  This used to be a
@@ -29,6 +30,11 @@ const SERVER_WEB_TRANSLATIONS: Partial<
   Record<AppLanguage, Record<string, string>>
 > = {
   en: {
+    "La biblioteca aún no se ha publicado":
+      "The library has not been published yet",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.":
+      "Enable Library in Settings → Server and publish again from Desktop.",
+    "Abrir Ajustes de Server": "Open Server Settings",
     // Non-academic vault chrome and renderer-owned fallbacks. Published record
     // values never use these entries; only labels/status placeholders do.
     "Bases de datos": "Databases",
@@ -710,6 +716,11 @@ const SERVER_WEB_TRANSLATIONS: Partial<
     "Obras y ocurrencias ({n})": "Works and occurrences ({n})",
   },
   fr: {
+    "La biblioteca aún no se ha publicado":
+      "La bibliothèque n’a pas encore été publiée",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.":
+      "Activez Bibliothèque dans Paramètres → Server, puis republiez depuis Desktop.",
+    "Abrir Ajustes de Server": "Ouvrir les paramètres Server",
     Ajustes: "Paramètres",
     Servidor: "Serveur",
     Proveedores: "Fournisseurs",
@@ -755,6 +766,11 @@ const SERVER_WEB_TRANSLATIONS: Partial<
     "No hay coincidencias.": "Aucun résultat.",
   },
   de: {
+    "La biblioteca aún no se ha publicado":
+      "Die Bibliothek wurde noch nicht veröffentlicht",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.":
+      "Aktivieren Sie Bibliothek unter Einstellungen → Server und veröffentlichen Sie erneut aus Desktop.",
+    "Abrir Ajustes de Server": "Server-Einstellungen öffnen",
     Ajustes: "Einstellungen",
     Servidor: "Server",
     Proveedores: "Anbieter",
@@ -802,6 +818,11 @@ const SERVER_WEB_TRANSLATIONS: Partial<
     "No hay coincidencias.": "Keine Treffer.",
   },
   pt: {
+    "La biblioteca aún no se ha publicado":
+      "A biblioteca ainda não foi publicada",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.":
+      "Ative Biblioteca em Definições → Server e volte a publicar a partir do Desktop.",
+    "Abrir Ajustes de Server": "Abrir definições do Server",
     Ajustes: "Definições",
     Servidor: "Servidor",
     Proveedores: "Provedores",
@@ -847,6 +868,11 @@ const SERVER_WEB_TRANSLATIONS: Partial<
     "No hay coincidencias.": "Sem correspondências.",
   },
   "pt-BR": {
+    "La biblioteca aún no se ha publicado":
+      "A biblioteca ainda não foi publicada",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.":
+      "Ative Biblioteca em Configurações → Server e publique novamente pelo Desktop.",
+    "Abrir Ajustes de Server": "Abrir configurações do Server",
     Ajustes: "Configurações",
     Servidor: "Servidor",
     Proveedores: "Provedores",
@@ -892,6 +918,11 @@ const SERVER_WEB_TRANSLATIONS: Partial<
     "No hay coincidencias.": "Nenhuma correspondência.",
   },
   it: {
+    "La biblioteca aún no se ha publicado":
+      "La biblioteca non è ancora stata pubblicata",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.":
+      "Attiva Biblioteca in Impostazioni → Server e pubblica di nuovo da Desktop.",
+    "Abrir Ajustes de Server": "Apri impostazioni Server",
     Ajustes: "Impostazioni",
     Servidor: "Server",
     Proveedores: "Provider",
@@ -937,6 +968,11 @@ const SERVER_WEB_TRANSLATIONS: Partial<
     "No hay coincidencias.": "Nessuna corrispondenza.",
   },
   tr: {
+    "La biblioteca aún no se ha publicado":
+      "Kütüphane henüz yayımlanmadı",
+    "Activa Biblioteca en Ajustes → Server y vuelve a publicar desde Desktop.":
+      "Ayarlar → Server bölümünde Kütüphane’yi etkinleştirin ve Desktop’tan yeniden yayımlayın.",
+    "Abrir Ajustes de Server": "Server ayarlarını aç",
     Ajustes: "Ayarlar",
     Servidor: "Sunucu",
     Proveedores: "Sağlayıcılar",
@@ -2932,6 +2968,12 @@ type TranslationTables = Partial<
 >;
 const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
   en: {
+    "Nuevo vault": "New vault",
+    "Connected Vault": "Connected Vault",
+    "Crear un vault editable directamente en Server.":
+      "Create an editable vault directly on Server.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
+      "Connect a Desktop vault to publish and synchronise it.",
     "Abrir navegación": "Open navigation",
     "Abrir Nodi": "Open Nodi",
     "Cerrar navegación": "Close navigation",
@@ -2975,6 +3017,12 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
     "No se ha podido cargar el registro.": "The record could not be loaded.",
   },
   fr: {
+    "Nuevo vault": "Nouveau coffre",
+    "Connected Vault": "Coffre connecté",
+    "Crear un vault editable directamente en Server.":
+      "Créer un coffre modifiable directement sur Server.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
+      "Connecter un coffre Desktop pour le publier et le synchroniser.",
     "Abrir navegación": "Ouvrir la navigation",
     "Abrir Nodi": "Ouvrir Nodi",
     "Cerrar navegación": "Fermer la navigation",
@@ -3011,6 +3059,12 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
       "L’enregistrement n’a pas pu être chargé.",
   },
   de: {
+    "Nuevo vault": "Neuer Tresor",
+    "Connected Vault": "Verbundener Tresor",
+    "Crear un vault editable directamente en Server.":
+      "Einen bearbeitbaren Tresor direkt auf Server erstellen.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
+      "Einen Desktop-Tresor verbinden, um ihn zu veröffentlichen und zu synchronisieren.",
     "Abrir navegación": "Navigation öffnen",
     "Abrir Nodi": "Nodi öffnen",
     "Cerrar navegación": "Navigation schließen",
@@ -3047,6 +3101,12 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
       "Der Datensatz konnte nicht geladen werden.",
   },
   pt: {
+    "Nuevo vault": "Novo cofre",
+    "Connected Vault": "Cofre ligado",
+    "Crear un vault editable directamente en Server.":
+      "Criar um cofre editável diretamente no Server.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
+      "Ligar um cofre do Desktop para o publicar e sincronizar.",
     "Vault de worldbuilding": "Vault de construção de mundos",
     "Abrir navegación": "Abrir navegação",
     "Abrir Nodi": "Abrir o Nodi",
@@ -3105,6 +3165,12 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
       "Não foi possível carregar o registo.",
   },
   "pt-BR": {
+    "Nuevo vault": "Novo cofre",
+    "Connected Vault": "Cofre conectado",
+    "Crear un vault editable directamente en Server.":
+      "Criar um cofre editável diretamente no Server.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
+      "Conectar um cofre do Desktop para publicá-lo e sincronizá-lo.",
     "Vault de worldbuilding": "Vault de construção de mundos",
     "Registro publicado": "Registro publicado",
     "Abrir navegación": "Abrir navegação",
@@ -3162,6 +3228,12 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
       "Não foi possível carregar o registro.",
   },
   it: {
+    "Nuevo vault": "Nuovo vault",
+    "Connected Vault": "Vault connesso",
+    "Crear un vault editable directamente en Server.":
+      "Crea un vault modificabile direttamente su Server.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
+      "Connetti un vault Desktop per pubblicarlo e sincronizzarlo.",
     "Abrir navegación": "Apri navigazione",
     "Abrir Nodi": "Apri Nodi",
     "Cerrar navegación": "Chiudi navigazione",
@@ -3200,6 +3272,12 @@ const SERVER_WEB_FINAL_CHROME_TRANSLATIONS: TranslationTables = {
       "Non è stato possibile caricare il record.",
   },
   tr: {
+    "Nuevo vault": "Yeni kasa",
+    "Connected Vault": "Bağlı kasa",
+    "Crear un vault editable directamente en Server.":
+      "Doğrudan Server üzerinde düzenlenebilir bir kasa oluşturun.",
+    "Conectar un vault de Desktop para publicarlo y sincronizarlo.":
+      "Yayımlamak ve eşitlemek için bir Desktop kasasını bağlayın.",
     "Abrir navegación": "Gezinmeyi aç",
     "Abrir Nodi": "Nodi’yi aç",
     "Cerrar navegación": "Gezinmeyi kapat",
@@ -3258,6 +3336,7 @@ export function resolveTranslation(
   const normalized = normalizeUiLanguage(language);
   if (normalized === "es") return source;
   return (
+    SERVER_SETTINGS_TRANSLATIONS[normalized]?.[source] ??
     SERVER_WEB_FINAL_CHROME_TRANSLATIONS[normalized]?.[source] ??
     SERVER_WEB_PERSONAL_STATUS_TRANSLATIONS[normalized]?.[source] ??
     SERVER_WEB_ADVANCED_TRANSLATIONS[normalized]?.[source] ??
@@ -3276,6 +3355,7 @@ export function resolveTranslation(
     // English is the final safety net only after every catalogue for the
     // requested locale has had an opportunity to resolve the key. An English
     // table earlier in the chain masked valid translations from later tables.
+    SERVER_SETTINGS_TRANSLATIONS.en?.[source] ??
     SERVER_WEB_PERSONAL_STATUS_TRANSLATIONS.en?.[source] ??
     SERVER_WEB_ADVANCED_TRANSLATIONS.en?.[source] ??
     SERVER_WEB_CONVERSATION_TRANSLATIONS.en?.[source] ??
@@ -3297,6 +3377,7 @@ export function resolveTranslation(
  * chain above belongs here too.
  */
 const LOCALE_CATALOGUES: Partial<Record<string, Record<string, string>>>[] = [
+  SERVER_SETTINGS_TRANSLATIONS,
   SERVER_WEB_FINAL_CHROME_TRANSLATIONS,
   SERVER_WEB_PERSONAL_STATUS_TRANSLATIONS,
   SERVER_WEB_ADVANCED_TRANSLATIONS,

--- a/src/serverWeb/serverDesktop.css
+++ b/src/serverWeb/serverDesktop.css
@@ -35,7 +35,10 @@
   color: var(--server-shell-text);
 }
 
-.server-desktop-surface .server-header-action.bg-indigo-600 {
+.server-desktop-surface .server-header-action.bg-indigo-600,
+.server-desktop-surface .server-header-action.bg-indigo-600:hover,
+.server-desktop-surface .server-header-action.bg-indigo-600:focus-visible {
+  background: var(--vault-accent, #4f46e5);
   color: #fff;
 }
 
@@ -123,6 +126,34 @@ html.light .server-desktop-surface .server-sidebar-nav-item.is-active {
 }
 .server-sidebar-nav-item:focus-visible,
 .server-sidebar-nav-group:focus-visible { outline: 2px solid #818cf8; outline-offset: -2px; }
+
+/* Route latency belongs to the view being opened. Cover only the central pane
+   while its lazy bundle or request resolves, leaving the navigation stable. */
+.server-view-loading-overlay {
+  position: absolute;
+  z-index: 10;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--server-shell-bg) 88%, transparent);
+  cursor: progress;
+}
+.server-view-loading-spinner {
+  width: 30px;
+  height: 30px;
+  border: 3px solid color-mix(in srgb, var(--server-shell-muted) 32%, transparent);
+  border-top-color: var(--vault-accent, #6366f1);
+  border-radius: 50%;
+  animation: server-view-loading-spin 700ms linear infinite;
+}
+@keyframes server-view-loading-spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .server-view-loading-spinner {
+    animation: none;
+  }
+}
 
 /* The shared Desktop nav uses utility classes whose dark hover colours are
    intentionally global. Scope the web overrides to the shell so switching to
@@ -343,6 +374,40 @@ html[data-theme='light'] .server-desktop-surface :is(input, select, textarea),
   min-height: 0;
   flex: 1 1 auto;
 }
+.server-vault-add-menu { position: relative; flex: 0 0 auto; }
+.server-vault-add-options {
+  position: absolute;
+  z-index: 4;
+  top: calc(100% + 7px);
+  right: 0;
+  display: grid;
+  width: min(270px, calc(100vw - 48px));
+  overflow: hidden;
+  border: 1px solid var(--server-shell-border);
+  border-radius: 10px;
+  padding: 5px;
+  background: var(--server-shell-panel);
+  box-shadow: 0 14px 36px rgb(0 0 0 / .38);
+}
+.server-vault-add-options button {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 10px;
+  border: 0;
+  border-radius: 7px;
+  padding: 10px;
+  background: transparent;
+  color: var(--server-shell-muted);
+  text-align: left;
+  cursor: pointer;
+}
+.server-vault-add-options button:hover,
+.server-vault-add-options button:focus-visible { background: var(--server-shell-panel-soft); color: var(--server-shell-text); outline: none; }
+.server-vault-add-options button > svg { flex: 0 0 auto; margin-top: 2px; color: var(--vault-accent, #6366f1); }
+.server-vault-add-options button span { min-width: 0; }
+.server-vault-add-options strong { display: block; color: var(--server-shell-text); font-size: 12px; font-weight: 650; }
+.server-vault-add-options small { display: block; margin-top: 3px; color: var(--server-shell-muted); font-size: 10px; line-height: 1.4; }
 @keyframes server-vault-open { from { opacity: 0; transform: translateX(-50%) translateY(-8px) scaleY(.84); } }
 
 .server-record-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 12px; }
@@ -605,10 +670,8 @@ html[data-theme='light'] [class~='to-neutral-900'] {
   .server-mobile-menu { display: inline-flex; }
   .server-header-secondary { display: none !important; }
   /* Keep the controls that remain actionable on a narrow viewport (search,
-     settings, theme and account). Nodi and the assistant are optional
-     destinations and yield first, instead of hiding the account control as
-     the old positional selector did. */
-  .header-action-rail > [data-testid='header-nodi'],
+     account, theme and settings). The assistant yields first, instead of
+     hiding one of those core controls. */
   .header-action-rail > [data-testid='header-assistant'] { display: none !important; }
   .header-vault-badge { max-width: 132px; }
   .header-vault-badge span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/src/serverWeb/settings/ServerSettings.css
+++ b/src/serverWeb/settings/ServerSettings.css
@@ -10,8 +10,13 @@
   --ss-accent: var(--vault-accent, #6366f1);
   --ss-accent-soft: color-mix(in srgb, var(--ss-accent) 18%, transparent);
   --ss-good: #2dd4bf;
-  min-height: 100%;
+  box-sizing: border-box;
+  height: 100%;
+  min-height: 0;
+  max-height: 100%;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   padding: 24px;
   background: var(--ss-bg);
   color: var(--ss-text);
@@ -73,9 +78,15 @@ html[data-theme='light'] .server-settings-native .ss-warning { background: #fffb
 .ss-panels { max-width: 1180px; margin: 0 auto; }
 .ss-result-title { margin: 24px 0 9px; color: var(--ss-muted); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
 .ss-card { overflow: hidden; margin-bottom: 16px; border: 1px solid var(--ss-border); border-radius: 11px; background: var(--ss-panel); box-shadow: 0 1px 2px rgb(0 0 0 / .08); }
+.ss-card[id] { scroll-margin-top: 18px; }
+.ss-card[id]:focus { border-color: var(--ss-accent); outline: 2px solid var(--ss-accent-soft); outline-offset: 2px; }
 .ss-section-head { padding: 15px 16px 13px; border-bottom: 1px solid var(--ss-border-soft); }
+.ss-section-title-line { display: flex; align-items: center; gap: 7px; }
 .ss-section-head h2 { margin: 0; color: var(--ss-muted); font-size: 12px; font-weight: 700; letter-spacing: .075em; text-transform: uppercase; }
 .ss-section-head p { max-width: 820px; margin: 7px 0 0; color: var(--ss-muted); font-size: 12px; font-weight: 400; letter-spacing: 0; line-height: 1.55; text-transform: none; }
+.ss-help-button { display: grid; width: 20px; height: 20px; flex: 0 0 auto; place-items: center; border: 1px solid var(--ss-border); border-radius: 50%; padding: 0; background: var(--ss-panel-soft); color: var(--ss-muted); cursor: pointer; }
+.ss-help-button:hover, .ss-help-button:focus-visible, .ss-help-button[aria-expanded='true'] { border-color: var(--ss-accent); background: var(--ss-accent-soft); color: var(--ss-accent); outline: none; }
+.ss-section-head .ss-section-help { max-width: 900px; margin-top: 10px; border-left: 3px solid var(--ss-accent); border-radius: 0 7px 7px 0; padding: 8px 10px; background: var(--ss-accent-soft); color: var(--ss-text); }
 .ss-row { display: grid; grid-template-columns: minmax(180px, .78fr) minmax(220px, 1.22fr); align-items: center; gap: 22px; min-height: 57px; padding: 10px 16px; border-bottom: 1px solid var(--ss-border-soft); }
 .ss-row:last-child { border-bottom: 0; }
 .ss-row strong { display: block; font-size: 12px; font-weight: 550; }

--- a/src/serverWeb/settings/ServerSettingsView.tsx
+++ b/src/serverWeb/settings/ServerSettingsView.tsx
@@ -3,6 +3,7 @@ import {
   isValidElement,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useState,
   type FormEvent,
@@ -346,19 +347,51 @@ function translateSettingsNode(node: ReactNode): ReactNode {
 function Section({
   title,
   description,
+  help,
   children,
   testId,
+  focusId,
 }: {
   title: string;
   description?: string;
+  help?: string;
   children: React.ReactNode;
   testId?: string;
+  focusId?: string;
 }) {
+  const [helpOpen, setHelpOpen] = useState(false);
+  const helpId = useId();
+  const helpLabel = tx("Ayuda sobre {section}", { section: t(title) });
   return (
-    <section className="ss-card" data-testid={testId}>
+    <section
+      className="ss-card"
+      data-testid={testId}
+      id={focusId}
+      tabIndex={focusId ? -1 : undefined}
+    >
       <header className="ss-section-head">
-        <h2>{t(title)}</h2>
+        <div className="ss-section-title-line">
+          <h2>{t(title)}</h2>
+          {help && (
+            <button
+              type="button"
+              className="ss-help-button"
+              aria-label={helpLabel}
+              title={helpLabel}
+              aria-expanded={helpOpen}
+              aria-controls={helpId}
+              onClick={() => setHelpOpen((current) => !current)}
+            >
+              <Icon name="help" size={12} />
+            </button>
+          )}
+        </div>
         {description && <p>{t(description)}</p>}
+        {helpOpen && help && (
+          <p className="ss-section-help" id={helpId} role="status">
+            {t(help)}
+          </p>
+        )}
       </header>
       {translateSettingsNode(children)}
     </section>
@@ -488,6 +521,7 @@ export function ServerSettingsView({
 }: ServerSettingsViewProps) {
   const requested =
     initialTab || new URLSearchParams(location.search).get("tab") || "server";
+  const requestedFocus = new URLSearchParams(location.search).get("focus");
   const [tab, setTab] = useState<TabId>(
     TABS.some((entry) => entry.id === requested)
       ? (requested as TabId)
@@ -574,6 +608,21 @@ export function ServerSettingsView({
     addEventListener("popstate", onPopState);
     return () => removeEventListener("popstate", onPopState);
   }, []);
+
+  useEffect(() => {
+    if (tab !== "server" || !requestedFocus || !profile) return undefined;
+    const frame = requestAnimationFrame(() => {
+      const section = document.getElementById(`server-${requestedFocus}`);
+      if (!section) return;
+      const reduceMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
+      section.scrollIntoView({
+        behavior: reduceMotion ? "auto" : "smooth",
+        block: "start",
+      });
+      section.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [profile, requestedFocus, tab]);
 
   const selectTab = (next: TabId) => {
     setTab(next);
@@ -1067,10 +1116,10 @@ export function ServerSettingsView({
     >
       {profile.ai.pendingAssignments.length > 0 && (
         <div className="ss-warning" data-testid="server-pending-models">
-          Hay asignaciones heredadas pendientes (
-          {profile.ai.pendingAssignments.join(", ")}). Los modelos locales
-          descargables no se ejecutan en Server ni se sustituyen por un modelo
-          de pago.
+          {tx(
+            "Hay asignaciones heredadas pendientes ({assignments}). Los modelos locales descargables no se ejecutan en Server ni se sustituyen por un modelo de pago.",
+            { assignments: profile.ai.pendingAssignments.join(", ") },
+          )}
         </div>
       )}
       <Row label="Configuración">
@@ -1363,6 +1412,7 @@ export function ServerSettingsView({
       <Section
         title="Nodus Server"
         description="Administración integrada, sin iframe ni rutas a puertos auxiliares."
+        help="Resume este servidor y muestra cuántos vaults, usuarios y dispositivos administra, junto con sus direcciones de acceso."
         testId="server-native-admin"
       >
         <div className="ss-metrics">
@@ -1399,6 +1449,8 @@ export function ServerSettingsView({
         <Section
           title="Nuevo vault"
           description="Crea una bóveda nativa administrada íntegramente por Server, sin depender de Nodus Desktop."
+          help="Crea un vault editable que vive directamente en Server. Elige su nombre, tipo y descripción inicial."
+          focusId="server-new-vault"
         >
           <form
             className="ss-inline-form"
@@ -1459,7 +1511,11 @@ export function ServerSettingsView({
           </form>
         </Section>
       )}
-      <Section title="Vaults del servidor">
+      <Section
+        title="Vaults del servidor"
+        help="Muestra los vaults nativos y los publicados desde Desktop. Aquí puedes revisar su estado, ajustar qué se publica y generar códigos de conexión."
+        focusId="server-connected-vault"
+      >
         <div className="ss-admin-list">
           {(admin?.spaces || me?.spaces || []).map((space) => {
             const policy = (
@@ -1575,7 +1631,10 @@ export function ServerSettingsView({
         )}
       </Section>
       {isAdmin && (
-        <Section title="Usuarios y acceso">
+        <Section
+          title="Usuarios y acceso"
+          help="Crea cuentas y decide qué puede hacer cada usuario en cada vault: leer, escribir o administrarlo como propietario."
+        >
           <form
             className="ss-inline-form"
             onSubmit={(event) => void createUser(event)}
@@ -1708,7 +1767,10 @@ export function ServerSettingsView({
         </Section>
       )}
       {isAdmin && (
-        <Section title="Dispositivos publicadores">
+        <Section
+          title="Dispositivos publicadores"
+          help="Enumera los dispositivos Desktop autorizados para publicar vaults en este servidor. Puedes revocar un dispositivo que ya no deba sincronizar."
+        >
           <div className="ss-table">
             <div className="ss-table-head">
               <span>Dispositivo</span>
@@ -1750,6 +1812,7 @@ export function ServerSettingsView({
       <Section
         title="Mi cuenta"
         description="La cuenta se administra dentro de Ajustes; nunca se abre un puerto ni una página externa."
+        help="Muestra la cuenta y el rol con los que has iniciado sesión. También permite cambiar la contraseña o cerrar la sesión actual."
       >
         <Row label="Cuenta activa">
           <span className="ss-value">{me?.user?.email || "—"}</span>

--- a/src/serverWeb/vaults/ServerVaultManager.tsx
+++ b/src/serverWeb/vaults/ServerVaultManager.tsx
@@ -11,7 +11,6 @@ import {
 } from "react";
 import { normalizeVaultType, type VaultType } from "@shared/vaultTypes";
 import {
-  VaultTypePicker,
   vaultTypeIcon,
   vaultTypeLabel,
   VAULT_TYPE_COLOR,
@@ -117,6 +116,7 @@ export function ServerVaultManager({
   csrfToken,
   onSelect,
   onChanged,
+  onAddVault,
   onClose,
 }: {
   spaces: Space[];
@@ -125,6 +125,7 @@ export function ServerVaultManager({
   csrfToken?: string;
   onSelect: (id: string) => void;
   onChanged: () => Promise<void>;
+  onAddVault: (kind: "native" | "connected") => void;
   onClose: () => void;
 }) {
   const [query, setQuery] = useState("");
@@ -133,10 +134,7 @@ export function ServerVaultManager({
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState("");
   const [error, setError] = useState("");
-  const [addOpen, setAddOpen] = useState(false);
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [vaultType, setVaultType] = useState<VaultType>("academic");
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [renameTarget, setRenameTarget] = useState<ManagedSpace | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const [duplicateTarget, setDuplicateTarget] = useState<ManagedSpace | null>(
@@ -220,25 +218,6 @@ export function ServerVaultManager({
     } finally {
       setBusy(false);
     }
-  };
-
-  const add = async () => {
-    if (!name.trim()) {
-      setError(t("Escribe un nombre para el vault."));
-      return;
-    }
-    await run(
-      () =>
-        api.createVault(
-          { name: name.trim(), description: description.trim(), vaultType },
-          csrfToken,
-        ),
-      t("Vault creado."),
-    );
-    setAddOpen(false);
-    setName("");
-    setDescription("");
-    setVaultType("academic");
   };
 
   const rename = async () => {
@@ -367,18 +346,60 @@ export function ServerVaultManager({
                 </small>
               </div>
               {isAdmin && (
-                <button
-                  type="button"
-                  className="btn btn-primary gap-1 px-2 py-1 text-xs"
-                  onClick={() => {
-                    setError("");
-                    setAddOpen(true);
-                  }}
-                  data-testid="vault-add"
-                >
-                  <Icon name="plus" size={14} />
-                  {t("Añadir")}
-                </button>
+                <div className="server-vault-add-menu">
+                  <button
+                    type="button"
+                    className="btn btn-primary gap-1 px-2 py-1 text-xs"
+                    onClick={() => {
+                      setError("");
+                      setAddMenuOpen((open) => !open);
+                    }}
+                    aria-haspopup="menu"
+                    aria-expanded={addMenuOpen}
+                    data-testid="vault-add"
+                  >
+                    <Icon name="plus" size={14} />
+                    {t("Añadir")}
+                    <Icon name="chevronDown" size={12} />
+                  </button>
+                  {addMenuOpen && (
+                    <div
+                      className="server-vault-add-options"
+                      role="menu"
+                      aria-label={t("Añadir vault")}
+                      data-testid="vault-add-options"
+                    >
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => onAddVault("native")}
+                        data-testid="vault-add-native"
+                      >
+                        <Icon name="vault" size={16} />
+                        <span>
+                          <strong>{t("Nuevo vault")}</strong>
+                          <small>
+                            {t("Crear un vault editable directamente en Server.")}
+                          </small>
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => onAddVault("connected")}
+                        data-testid="vault-add-connected"
+                      >
+                        <Icon name="link" size={16} />
+                        <span>
+                          <strong>{t("Connected Vault")}</strong>
+                          <small>
+                            {t("Conectar un vault de Desktop para publicarlo y sincronizarlo.")}
+                          </small>
+                        </span>
+                      </button>
+                    </div>
+                  )}
+                </div>
               )}
               <button
                 type="button"
@@ -612,52 +633,6 @@ export function ServerVaultManager({
               )}
             </div>
           </div>
-          {addOpen && (
-            <Modal title="Añadir vault" onClose={() => setAddOpen(false)}>
-              <label className="block text-sm">
-                Nombre
-                <input
-                  className="input mt-1 w-full"
-                  autoFocus
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                />
-              </label>
-              <label className="mt-3 block text-sm">
-                Descripción
-                <input
-                  className="input mt-1 w-full"
-                  value={description}
-                  onChange={(event) => setDescription(event.target.value)}
-                />
-              </label>
-              <div className="mt-4">
-                <p className="mb-2 text-xs text-neutral-500">Tipo de vault</p>
-                <VaultTypePicker
-                  value={vaultType}
-                  onChange={setVaultType}
-                  disabled={busy}
-                />
-              </div>
-              <div className="mt-5 flex justify-end gap-2">
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  onClick={() => setAddOpen(false)}
-                >
-                  Cancelar
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={() => void add()}
-                  disabled={busy}
-                >
-                  Crear vault
-                </button>
-              </div>
-            </Modal>
-          )}
           {renameTarget && (
             <Modal
               title="Renombrar vault"


### PR DESCRIPTION
## Summary
- fix Server Settings scrolling, localization, contextual help, and active-action contrast in light mode
- align header actions, add a central route-loading spinner, and distinguish native from connected vault setup
- treat unpublished libraries as empty catalogues while preserving document results when collection metadata is unavailable

## Testing
- `git diff --check origin/main...HEAD`
- `node --test scripts/test-server-web-library-reader-parity.mjs scripts/test-server-web-academic-parity.mjs scripts/test-server-web-i18n-settings.mjs scripts/test-server-web-residual-i18n.mjs scripts/test-server-web-shell-parity.mjs scripts/test-server-web-theme.mjs` (43 tests passed)
