### PR TITLE
Refresh v5.1.0 sitemap date

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -30,7 +30,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/zotero-plugin/</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-30</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/ai-research/</loc>


### PR DESCRIPTION
## Summary

- refreshes the Zotero plugin sitemap date after the v5.1.0 release commit
- fixes the only failing assertion from PR #624 CI

## Verification

- `node --test scripts/test-site-sitemap.mjs`