### PR TITLE
Keep header Zotero refresh catalog-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Made the header's Zotero refresh strictly catalog-only: it updates monitored
+  collections and shows new or changed items without starting theme, deep,
+  summary, embedding, passage, graph or documentary-index work.
+- Added a stable metadata fingerprint for Zotero 10 local APIs that report every
+  item as version zero, preventing both whole-library false changes and missed
+  edits after the compatibility transition.
+
 ## 5.1.0 — 2026-08-30
 
 Nodus 5.1.0 is a repair-focused release that makes AI processing faster and

--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -65,6 +65,28 @@ function ensureDatabaseResearchReaderColumns(db: Database.Database): void {
   db.exec('CREATE INDEX IF NOT EXISTS idx_database_research_report_annotations_report ON database_research_report_annotations(report_id, scope, start_offset, created_at)');
 }
 
+/** v171 is idempotent because recovery can replay additive migrations after a
+ * user_version rollback while the physical column is already present. */
+function ensureZoteroFingerprintColumn(db: Database.Database): void {
+  const hasFingerprint = (db.prepare('PRAGMA table_info(works)').all() as Array<{ name: string }>)
+    .some((row) => row.name === 'zotero_fingerprint');
+  if (!hasFingerprint) db.exec('ALTER TABLE works ADD COLUMN zotero_fingerprint TEXT');
+  db.exec(`
+    DROP TRIGGER IF EXISTS works_document_profile_stale_deep;
+    CREATE TRIGGER works_document_profile_stale_deep
+    AFTER UPDATE OF deep_hash, zotero_version, zotero_fingerprint ON works
+    WHEN OLD.deep_hash IS NOT NEW.deep_hash
+      OR OLD.zotero_version IS NOT NEW.zotero_version
+      OR (OLD.zotero_fingerprint IS NOT NULL AND OLD.zotero_fingerprint IS NOT NEW.zotero_fingerprint)
+    BEGIN
+      UPDATE document_profile_state
+         SET status='stale', stale_reason='source_changed', error=NULL,
+             updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now')
+       WHERE nodus_id=NEW.nodus_id AND current_version_id IS NOT NULL;
+    END;
+  `);
+}
+
 // Versioned, append-only migrations. Never edit an existing migration's SQL once
 // shipped — add a new one. The current schema version is the highest applied.
 export const SCHEMA_VERSION = 171;
@@ -9224,21 +9246,8 @@ export const migrations: Migration[] = [
   },
   {
     version: 171,
-    up: /* sql */ `
-      ALTER TABLE works ADD COLUMN zotero_fingerprint TEXT;
-      DROP TRIGGER IF EXISTS works_document_profile_stale_deep;
-      CREATE TRIGGER works_document_profile_stale_deep
-      AFTER UPDATE OF deep_hash, zotero_version, zotero_fingerprint ON works
-      WHEN OLD.deep_hash IS NOT NEW.deep_hash
-        OR OLD.zotero_version IS NOT NEW.zotero_version
-        OR (OLD.zotero_fingerprint IS NOT NULL AND OLD.zotero_fingerprint IS NOT NEW.zotero_fingerprint)
-      BEGIN
-        UPDATE document_profile_state
-           SET status='stale', stale_reason='source_changed', error=NULL,
-               updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now')
-         WHERE nodus_id=NEW.nodus_id AND current_version_id IS NOT NULL;
-      END;
-    `,
+    up: /* sql */ `SELECT 1;`,
+    after: ensureZoteroFingerprintColumn,
   },
 ];
 

--- a/electron/db/migrations.ts
+++ b/electron/db/migrations.ts
@@ -67,7 +67,7 @@ function ensureDatabaseResearchReaderColumns(db: Database.Database): void {
 
 // Versioned, append-only migrations. Never edit an existing migration's SQL once
 // shipped — add a new one. The current schema version is the highest applied.
-export const SCHEMA_VERSION = 170;
+export const SCHEMA_VERSION = 171;
 
 export const migrations: Migration[] = [
   {
@@ -9221,6 +9221,24 @@ export const migrations: Migration[] = [
     version: 170,
     up: /* sql */ `SELECT 1;`,
     after: ensureDatabaseResearchReaderColumns,
+  },
+  {
+    version: 171,
+    up: /* sql */ `
+      ALTER TABLE works ADD COLUMN zotero_fingerprint TEXT;
+      DROP TRIGGER IF EXISTS works_document_profile_stale_deep;
+      CREATE TRIGGER works_document_profile_stale_deep
+      AFTER UPDATE OF deep_hash, zotero_version, zotero_fingerprint ON works
+      WHEN OLD.deep_hash IS NOT NEW.deep_hash
+        OR OLD.zotero_version IS NOT NEW.zotero_version
+        OR (OLD.zotero_fingerprint IS NOT NULL AND OLD.zotero_fingerprint IS NOT NEW.zotero_fingerprint)
+      BEGIN
+        UPDATE document_profile_state
+           SET status='stale', stale_reason='source_changed', error=NULL,
+               updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now')
+         WHERE nodus_id=NEW.nodus_id AND current_version_id IS NOT NULL;
+      END;
+    `,
   },
 ];
 

--- a/electron/db/worksRepo.ts
+++ b/electron/db/worksRepo.ts
@@ -452,6 +452,7 @@ export interface UpsertWorkInput {
   nodus_id: string;
   zotero_key: string;
   zotero_version: number | null;
+  zotero_fingerprint?: string | null;
   title: string;
   authors: string[];
   creators?: WorkCreator[];
@@ -468,22 +469,24 @@ export function upsertWork(input: UpsertWorkInput): void {
   const existing = getWorkByZoteroKey(input.zotero_key);
   if (!existing) {
     db.prepare(
-      `INSERT INTO works (nodus_id, zotero_key, zotero_version, title, authors_json, creators_json, year, item_type, doi, read_tag, light_status)
-       VALUES (@nodus_id, @zotero_key, @zotero_version, @title, @authors_json, @creators_json, @year, @item_type, @doi, @read_tag, 'none')`
+      `INSERT INTO works (nodus_id, zotero_key, zotero_version, zotero_fingerprint, title, authors_json, creators_json, year, item_type, doi, read_tag, light_status)
+       VALUES (@nodus_id, @zotero_key, @zotero_version, @zotero_fingerprint, @title, @authors_json, @creators_json, @year, @item_type, @doi, @read_tag, 'none')`
     ).run({
       ...input,
+      zotero_fingerprint: input.zotero_fingerprint ?? null,
       authors_json: JSON.stringify(input.authors),
       creators_json: input.creators ? JSON.stringify(input.creators) : null,
       read_tag: input.read_tag ? 1 : 0,
     });
   } else {
     db.prepare(
-      `UPDATE works SET zotero_version=@zotero_version, title=@title, authors_json=@authors_json,
+      `UPDATE works SET zotero_version=@zotero_version, zotero_fingerprint=COALESCE(@zotero_fingerprint, zotero_fingerprint), title=@title, authors_json=@authors_json,
        creators_json=COALESCE(@creators_json, creators_json),
        year=@year, item_type=@item_type, doi=@doi, read_tag=@read_tag, archived=0 WHERE zotero_key=@zotero_key`
     ).run({
       zotero_key: input.zotero_key,
       zotero_version: input.zotero_version,
+      zotero_fingerprint: input.zotero_fingerprint ?? null,
       title: input.title,
       authors_json: JSON.stringify(input.authors),
       creators_json: input.creators ? JSON.stringify(input.creators) : null,

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -776,7 +776,9 @@ export function registerIpc(
   // ── Core: sync, backups, recovery, updates ─────────────────────────────────
   // Regrouped here so the academic and study channels above form one range. They
   // used to sit inside it, which is why extracting that range needed this first.
-  h('sync:now', async () => fullSync('manual'));
+  h('sync:now', async (_e, options?: { catalogOnly?: boolean }) => fullSync('manual', {
+    catalogOnly: options?.catalogOnly === true,
+  }));
   h('sync:log', async () => getSyncLog());
   // automatic encrypted backups (master password lives in the OS keychain)
   h('sync:hasPassphrase', async () => hasSyncPassphrase());

--- a/electron/preload/api.ts
+++ b/electron/preload/api.ts
@@ -224,7 +224,7 @@ export const nodusApi: NodusApi = {
 
   // Core: sync, backups, recovery. Regrouped here so the academic and study
   // bindings above form one range — they used to sit inside it.
-  syncNow: () => ipcRenderer.invoke('sync:now'),
+  syncNow: (options) => ipcRenderer.invoke('sync:now', options),
   getSyncLog: () => ipcRenderer.invoke('sync:log'),
   hasSyncPassphrase: () => ipcRenderer.invoke('sync:hasPassphrase'),
   setSyncPassphrase: (passphrase: string) => ipcRenderer.invoke('sync:setPassphrase', passphrase),

--- a/electron/sync/syncService.ts
+++ b/electron/sync/syncService.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { getSettings } from '../db/settingsRepo';
-import { addSyncLog } from '../db/syncRepo';
+import { addSyncLog, getSyncLog } from '../db/syncRepo';
 import {
   upsertWork,
   getWorkByZoteroKey,
@@ -23,6 +23,15 @@ import { probeWorkTextAvailability } from '../extraction/textExtractor';
 import { getActiveVault } from '../vaults/vaultRegistry';
 import { documentIndexQueue } from '../pipeline/documentIndexQueue';
 import { DOCUMENT_INDEX_CONTINUOUS_AVAILABLE } from '@shared/documentIndexPolicy';
+import type { ZoteroSyncOptions } from '@shared/types';
+import {
+  classifyZoteroItemChange,
+  persistedZoteroVersion,
+  shouldAutomateAnalysisAfterSync,
+  zoteroItemFingerprint,
+  zoteroLibraryVersionsChanged,
+  type ZoteroSyncMode,
+} from './zoteroSyncPolicy';
 
 
 /** Structured creators kept for building canonical author identity. Only authors
@@ -76,7 +85,8 @@ export function ingestZoteroItem(item: ZoteroItem, readTagName: string): { nodus
   upsertWork({
     nodus_id: nodusId,
     zotero_key: item.key,
-    zotero_version: item.version,
+    zotero_version: persistedZoteroVersion(existing, item.version),
+    zotero_fingerprint: zoteroItemFingerprint(item),
     title: item.title,
     // Byline and structured creators are derived from the same filtered list, so
     // the display string can never disagree with the roles stored beside it.
@@ -268,11 +278,15 @@ function reconcileMonitoredCollectionMemberships(
 }
 
 /** Full sync over all monitored collections. */
-export async function fullSync(mode: 'manual' | 'realtime'): Promise<SyncLogEntry> {
+export async function fullSync(mode: ZoteroSyncMode, options: ZoteroSyncOptions = {}): Promise<SyncLogEntry> {
   const settings = getSettings();
   const userId = settings.zoteroUserId;
+  const catalogOnly = options.catalogOnly === true;
+  const automateAnalysis = shouldAutomateAnalysisAfterSync(mode, options);
+  const lastSuccessfulSyncAt = getSyncLog(1)[0]?.at ?? null;
   let added = 0;
   let changed = 0;
+  let baselined = 0;
   let lightQueued = 0;
   let deepQueued = 0;
   const collectionFailures: string[] = [];
@@ -302,52 +316,73 @@ export async function fullSync(mode: 'manual' | 'realtime'): Promise<SyncLogEntr
     const items = await collectionItemsRecursiveObserved(userId, collectionKey, collectionFailures);
     for (const item of items) {
       observedMemberships.set(item.key, new Set(item.collections));
-      const before = getWorkByZoteroKey(item.key);
+      const directBefore = getWorkByZoteroKey(item.key);
+      const before = directBefore
+        ?? getWorkByAliasKey(item.key)
+        ?? (item.doi ? getWorkByDoi(item.doi) : null);
+      const incomingAuthors = bylineFromCreators(creatorsOf(item));
+      const incomingHasReadTag = item.tags.some((tag) => tag.toLowerCase() === settings.readTag.toLowerCase());
+      // Alias/DOI matches describe a second Zotero record attached to one canonical
+      // work. Its metadata must not invalidate or reanalyse that canonical record.
+      const changeState = directBefore
+        ? classifyZoteroItemChange(directBefore, item, {
+          authors: incomingAuthors,
+          hasReadTag: incomingHasReadTag,
+          lastSuccessfulSyncAt,
+        })
+        : before ? 'unchanged' : 'new';
       const { nodusId, isNew, hasReadTag } = ingestZoteroItem(item, settings.readTag);
       const workMemberships = observedWorkMemberships.get(nodusId) ?? new Set<string>();
       for (const collectionKey of item.collections) workMemberships.add(collectionKey);
       observedWorkMemberships.set(nodusId, workMemberships);
-      const didChange = !!before && before.zotero_version !== item.version;
+      const didChange = !isNew && changeState === 'changed';
       if (isNew) {
         added++;
       } else if (didChange) {
         changed++;
+      } else if (changeState === 'baseline') {
+        baselined++;
       }
-      if (settings.autoLightScan && (isNew || didChange)) {
+      // A user-initiated refresh is deliberately catalog-only: it updates monitored
+      // Zotero membership and metadata, and leaves every AI queue untouched. Automatic
+      // analysis belongs exclusively to the opt-in realtime background path.
+      if (automateAnalysis && settings.autoLightScan && (isNew || didChange)) {
         setLightPending(nodusId);
         scanQueue.enqueue(nodusId, item.title, 'light');
         lightQueued++;
       }
-      const after = getWorkByZoteroKey(item.key);
-      let recoverableText = false;
-      if (after?.deep_status === 'skipped_no_text' && !probeRequeuedThisSession.has(item.key)) {
-        const probe = await probeWorkTextAvailability(settings.zoteroUserId, item.key, settings.zoteroStoragePath, {
-          preferZoteroFulltext: settings.preferZoteroFulltext,
-          itemType: after.item_type,
-        });
-        recoverableText = probe.available;
-        // A present-but-unextractable file (e.g. a scanned PDF with OCR off) keeps
-        // probing as available while every retry ends in skipped_no_text again. Cap
-        // probe-driven requeues at one per work per session so each sync doesn't
-        // re-parse the same stuck attachments. Real changes (new tag, new file
-        // version) still requeue via isNew/didChange.
-        if (recoverableText) probeRequeuedThisSession.add(item.key);
-      }
-      const needsDeep =
-        !!after &&
-        shouldQueueDeepAfterSync({
-          autoDeepScanOnReadTag: settings.autoDeepScanOnReadTag,
-          hasReadTag,
-          manualDeep: after.manual_deep === 1,
-          isNew,
-          didChange,
-          deepStatus: after.deep_status,
-          recoverableText,
-        });
-      if (needsDeep) {
-        setDeepPending(nodusId);
-        scanQueue.enqueue(nodusId, item.title, 'deep');
-        deepQueued++;
+      if (automateAnalysis) {
+        const after = getWorkByZoteroKey(item.key);
+        let recoverableText = false;
+        if (after?.deep_status === 'skipped_no_text' && !probeRequeuedThisSession.has(item.key)) {
+          const probe = await probeWorkTextAvailability(settings.zoteroUserId, item.key, settings.zoteroStoragePath, {
+            preferZoteroFulltext: settings.preferZoteroFulltext,
+            itemType: after.item_type,
+          });
+          recoverableText = probe.available;
+          // A present-but-unextractable file (e.g. a scanned PDF with OCR off) keeps
+          // probing as available while every retry ends in skipped_no_text again. Cap
+          // probe-driven requeues at one per work per session so each sync doesn't
+          // re-parse the same stuck attachments. Real changes (new tag, new file
+          // version) still requeue via isNew/didChange.
+          if (recoverableText) probeRequeuedThisSession.add(item.key);
+        }
+        const needsDeep =
+          !!after &&
+          shouldQueueDeepAfterSync({
+            autoDeepScanOnReadTag: settings.autoDeepScanOnReadTag,
+            hasReadTag,
+            manualDeep: after.manual_deep === 1,
+            isNew,
+            didChange,
+            deepStatus: after.deep_status,
+            recoverableText,
+          });
+        if (needsDeep) {
+          setDeepPending(nodusId);
+          scanQueue.enqueue(nodusId, item.title, 'deep');
+          deepQueued++;
+        }
       }
     }
   }
@@ -378,7 +413,7 @@ export async function fullSync(mode: 'manual' | 'realtime'): Promise<SyncLogEntr
 
   // Continuous document understanding is opt-in. When enabled, reconcile now so
   // newly synced or changed works do not have to wait for the periodic safety poll.
-  if (DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && settings.documentIndexingEnabled && (added > 0 || changed > 0)) {
+  if (automateAnalysis && DOCUMENT_INDEX_CONTINUOUS_AVAILABLE && settings.documentIndexingEnabled && (added > 0 || changed > 0)) {
     await documentIndexQueue.refreshVault(getActiveVault().id).catch((error) => {
       console.error('[document-index] post-sync refresh failed', error);
     });
@@ -386,7 +421,10 @@ export async function fullSync(mode: 'manual' | 'realtime'): Promise<SyncLogEntr
 
   for (const failure of collectionFailures) console.warn(`[zotero-sync] collection traversal failed: ${failure}`);
   const failureSummary = collectionFailures.length ? `, ${collectionFailures.length} fallos de colección` : '';
-  const summary = `${added} altas, ${changed} cambios, ${lightQueued} temas encolados, ${deepQueued} profundos encolados${failureSummary}`;
+  const baselineSummary = baselined > 0 ? `, ${baselined} revisiones locales adoptadas` : '';
+  const summary = catalogOnly
+    ? `${added} altas, ${changed} cambios${baselineSummary}; catálogo actualizado sin iniciar análisis${failureSummary}`
+    : `${added} altas, ${changed} cambios${baselineSummary}, ${lightQueued} temas encolados, ${deepQueued} profundos encolados${failureSummary}`;
   const log = addSyncLog(mode, summary);
   if (collectionFailures.length) {
     throw new Error(`La sincronización de Zotero quedó incompleta: ${collectionFailures.length} lectura(s) fallaron. No se avanzó el checkpoint.`);
@@ -438,7 +476,7 @@ export function startRealtimeSync(): void {
     try {
       const versions = await fetchLibraryVersions(settings.zoteroUserId, settings.monitoredCollections);
       const previous = getLibraryVersions();
-      if (Object.entries(versions).some(([key, version]) => version > (previous[key] ?? 0))) {
+      if (zoteroLibraryVersionsChanged(previous, versions)) {
         await fullSync('realtime');
       }
     } catch {

--- a/electron/sync/zoteroSyncPolicy.ts
+++ b/electron/sync/zoteroSyncPolicy.ts
@@ -1,0 +1,130 @@
+import { createHash } from 'node:crypto';
+import type { Work, ZoteroItem, ZoteroSyncOptions } from '@shared/types';
+
+export type ZoteroSyncMode = 'manual' | 'realtime';
+export type ZoteroItemChange = 'new' | 'changed' | 'unchanged' | 'baseline';
+
+export interface ZoteroChangeContext {
+  authors: string[];
+  hasReadTag: boolean;
+  lastSuccessfulSyncAt: string | null;
+}
+
+function sortedStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.normalize('NFC')))].sort((left, right) => left.localeCompare(right));
+}
+
+function sortedRecord(values: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(values).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+/**
+ * Stable fallback revision for Zotero local APIs that expose every item as version 0.
+ * Arrays whose order carries no meaning are sorted; creator order remains intact because
+ * it is bibliographic data.
+ */
+export function zoteroItemFingerprint(item: ZoteroItem): string {
+  const payload = {
+    title: item.title,
+    creators: item.creators.map((creator) => ({
+      creatorType: creator.creatorType ?? 'author',
+      firstName: creator.firstName ?? '',
+      lastName: creator.lastName ?? '',
+      name: creator.name ?? '',
+    })),
+    year: item.year,
+    itemType: item.itemType,
+    doi: item.doi,
+    abstract: item.abstract,
+    tags: sortedStrings(item.tags),
+    collections: sortedStrings(item.collections),
+    publisher: item.publisher,
+    publicationTitle: item.publicationTitle,
+    isbn: item.isbn,
+    issn: item.issn,
+    url: item.url,
+    date: item.date,
+    language: item.language,
+    volume: item.volume,
+    issue: item.issue,
+    pages: item.pages,
+    edition: item.edition,
+    place: item.place,
+    rights: item.rights,
+    extra: item.extra,
+    fields: sortedRecord(item.fields),
+    dateAdded: item.dateAdded,
+    dateModified: item.dateModified,
+  };
+  return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+}
+
+function positiveVersion(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function modifiedAfter(item: ZoteroItem, timestamp: string | null): boolean {
+  if (!item.dateModified || !timestamp) return false;
+  const modifiedAt = Date.parse(item.dateModified);
+  const syncedAt = Date.parse(timestamp);
+  return Number.isFinite(modifiedAt) && Number.isFinite(syncedAt) && modifiedAt > syncedAt;
+}
+
+function coreMetadataChanged(previous: Work, item: ZoteroItem, context: ZoteroChangeContext): boolean {
+  let previousAuthors: string[] = [];
+  try { previousAuthors = JSON.parse(previous.authors_json || '[]') as string[]; } catch { previousAuthors = []; }
+  return previous.title !== item.title
+    || JSON.stringify(previousAuthors) !== JSON.stringify(context.authors)
+    || previous.year !== item.year
+    || previous.item_type !== item.itemType
+    || previous.doi !== item.doi
+    || Boolean(previous.read_tag) !== context.hasReadTag;
+}
+
+/**
+ * Classify a Zotero item without treating a transport-version transition as a content
+ * change. Zotero 10.0.1's local API returns version 0 for every item. On the first sync
+ * after that transition there is no stored fingerprint yet, so the last completed sync
+ * and persisted core metadata distinguish a real edit from adopting the new baseline.
+ */
+export function classifyZoteroItemChange(
+  previous: Work | null,
+  item: ZoteroItem,
+  context: ZoteroChangeContext,
+): ZoteroItemChange {
+  if (!previous) return 'new';
+
+  const incomingVersion = positiveVersion(item.version);
+  const previousVersion = positiveVersion(previous.zotero_version);
+  if (incomingVersion !== null && previousVersion !== null) {
+    return incomingVersion === previousVersion ? 'unchanged' : 'changed';
+  }
+
+  const fingerprint = zoteroItemFingerprint(item);
+  if (previous.zotero_fingerprint) {
+    return previous.zotero_fingerprint === fingerprint ? 'unchanged' : 'changed';
+  }
+
+  if (coreMetadataChanged(previous, item, context) || modifiedAfter(item, context.lastSuccessfulSyncAt)) {
+    return 'changed';
+  }
+  return 'baseline';
+}
+
+/** Never replace a valid historical Zotero revision with the local API's sentinel 0. */
+export function persistedZoteroVersion(previous: Work | null, incomingVersion: number): number {
+  return positiveVersion(incomingVersion) ?? previous?.zotero_version ?? 0;
+}
+
+/** The header opts into catalog-only refresh; setup and realtime retain their explicit automation settings. */
+export function shouldAutomateAnalysisAfterSync(mode: ZoteroSyncMode, options: ZoteroSyncOptions = {}): boolean {
+  return mode === 'realtime' || options.catalogOnly !== true;
+}
+
+/** A Zotero upgrade may reset its local library revision, so inequality matters in both directions. */
+export function zoteroLibraryVersionsChanged(
+  previous: Record<string, number>,
+  current: Record<string, number>,
+): boolean {
+  return Object.entries(current).some(([key, version]) => version !== (previous[key] ?? 0));
+}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "verify:library-metadata-live": "node scripts/verify-library-metadata-live.mjs",
     "verify:zotero:live": "node scripts/audit-zotero-live-import.mjs --all",
     "verify:zotero:ping": "node scripts/audit-zotero-live-import.mjs",
+    "verify:zotero:manual-sync-live": "node scripts/verify-zotero-manual-sync-live.mjs",
     "verify:browser-connector": "node scripts/verify-browser-connector-server.mjs",
     "verify:browser-connector-live": "node scripts/verify-browser-connector-live.mjs",
     "verify:study-whisper": "node scripts/verify-study-whisper.mjs",

--- a/scripts/test-zotero-sync-policy.mjs
+++ b/scripts/test-zotero-sync-policy.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks } from './lib/tsRuntimeHooks.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+installRuntimeHooks(path.join(os.tmpdir(), 'nodus-zotero-sync-policy-test'));
+const require = createRequire(import.meta.url);
+const policy = require(path.join(repoRoot, 'electron/sync/zoteroSyncPolicy.ts'));
+
+function item(overrides = {}) {
+  return {
+    key: 'ITEM0001', itemKey: 'ITEM0001', library: { type: 'user', id: '0', name: 'Mi biblioteca' },
+    version: 0, title: 'A stable title', creators: [{ firstName: 'Ada', lastName: 'Lovelace', creatorType: 'author' }],
+    year: 1843, itemType: 'journalArticle', doi: '10.1000/example', abstract: 'An abstract',
+    tags: ['/read', 'history'], collections: ['ROOT', 'CHILD'], publisher: 'Publisher', publicationTitle: 'Journal',
+    isbn: null, issn: '0000-0000', url: 'https://example.test', date: '1843', language: 'en', volume: '1', issue: '2',
+    pages: '1-20', edition: null, place: 'London', rights: null, extra: null, fields: { archive: 'Example', callNumber: 'A-1' },
+    dateAdded: '2026-01-01T00:00:00Z', dateModified: '2026-01-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function work(overrides = {}) {
+  return {
+    nodus_id: 'work-1', zotero_key: 'ITEM0001', zotero_version: 5131, zotero_fingerprint: null,
+    title: 'A stable title', authors_json: JSON.stringify(['Ada Lovelace']), year: 1843,
+    item_type: 'journalArticle', doi: '10.1000/example', read_tag: 1, manual_deep: 1, deep_trigger: 'both',
+    source_type: 'full_text', light_status: 'done', light_at: null, light_hash: 'light', deep_status: 'done', deep_at: null,
+    deep_hash: 'deep', resolved_source_type: 'pdf', resolved_text_hash: 'deep', resolved_text_chars: 100,
+    resolved_text_source_count: 1, resolved_has_page_markers: 1, text_block_reason: null, text_resolved_at: null,
+    resolved_text_notes: null, deep_error: null, deep_queued: 0, summary_status: 'done', summary_at: null,
+    summary_hash: 'summary', archived: 0, notes: null,
+    ...overrides,
+  };
+}
+
+const context = {
+  authors: ['Ada Lovelace'],
+  hasReadTag: true,
+  lastSuccessfulSyncAt: '2026-02-01T00:00:00Z',
+};
+
+test('the header refresh is catalog-only without changing onboarding or realtime automation', () => {
+  assert.equal(policy.shouldAutomateAnalysisAfterSync('manual', { catalogOnly: true }), false);
+  assert.equal(policy.shouldAutomateAnalysisAfterSync('manual'), true, 'onboarding keeps its configured automation');
+  assert.equal(policy.shouldAutomateAnalysisAfterSync('realtime'), true);
+});
+
+test('Zotero 10 version zero adopts a baseline instead of changing the whole library', () => {
+  assert.equal(policy.classifyZoteroItemChange(work(), item(), context), 'baseline');
+  assert.equal(policy.persistedZoteroVersion(work(), 0), 5131, 'a sentinel zero never overwrites a useful revision');
+});
+
+test('the baseline transition still detects a real edit made after the last sync', () => {
+  assert.equal(
+    policy.classifyZoteroItemChange(work(), item({ dateModified: '2026-02-02T00:00:00Z' }), context),
+    'changed',
+  );
+  assert.equal(
+    policy.classifyZoteroItemChange(work(), item({ title: 'A genuinely changed title' }), context),
+    'changed',
+  );
+});
+
+test('fingerprints detect later zero-version edits and ignore unordered metadata order', () => {
+  const original = item();
+  const fingerprint = policy.zoteroItemFingerprint(original);
+  const reordered = item({
+    tags: [...original.tags].reverse(),
+    collections: [...original.collections].reverse(),
+    fields: { callNumber: 'A-1', archive: 'Example' },
+  });
+  assert.equal(policy.zoteroItemFingerprint(reordered), fingerprint);
+  const persisted = work({ zotero_version: 0, zotero_fingerprint: fingerprint });
+  assert.equal(policy.classifyZoteroItemChange(persisted, reordered, context), 'unchanged');
+  assert.equal(policy.classifyZoteroItemChange(persisted, item({ abstract: 'A revised abstract' }), context), 'changed');
+});
+
+test('positive Zotero revisions remain authoritative', () => {
+  assert.equal(policy.classifyZoteroItemChange(work(), item({ version: 5131 }), context), 'unchanged');
+  assert.equal(policy.classifyZoteroItemChange(work(), item({ version: 5132 }), context), 'changed');
+});
+
+test('realtime sync notices a Zotero library revision reset as well as an increase', () => {
+  assert.equal(policy.zoteroLibraryVersionsChanged({ 'user:0': 50_271 }, { 'user:0': 38 }), true);
+  assert.equal(policy.zoteroLibraryVersionsChanged({ 'user:0': 38 }, { 'user:0': 39 }), true);
+  assert.equal(policy.zoteroLibraryVersionsChanged({ 'user:0': 38 }, { 'user:0': 38 }), false);
+});
+
+test('the production manual path guards every analysis side effect', async () => {
+  const sync = await fs.readFile(path.join(repoRoot, 'electron/sync/syncService.ts'), 'utf8');
+  assert.match(sync, /const automateAnalysis = shouldAutomateAnalysisAfterSync\(mode, options\)/);
+  assert.match(sync, /if \(automateAnalysis && settings\.autoLightScan/);
+  assert.match(sync, /if \(automateAnalysis\) \{[\s\S]*probeWorkTextAvailability[\s\S]*scanQueue\.enqueue\(nodusId, item\.title, 'deep'\)/);
+  assert.match(sync, /if \(automateAnalysis && DOCUMENT_INDEX_CONTINUOUS_AVAILABLE/);
+  assert.match(sync, /const summary = catalogOnly[\s\S]*catálogo actualizado sin iniciar análisis/);
+  const app = await fs.readFile(path.join(repoRoot, 'src/App.tsx'), 'utf8');
+  assert.match(app, /window\.nodus\.syncNow\(\{ catalogOnly: true \}\)/);
+});

--- a/scripts/verify-zotero-manual-sync-live.mjs
+++ b/scripts/verify-zotero-manual-sync-live.mjs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Run the production legacy Zotero sync against the live, read-only local Zotero API
+ * and a temporary SQLite backup. The user's source vault and Zotero profile are never
+ * opened for writing. Pass --source-db /path/to/snapshot.sqlite to reproduce a historical
+ * click; otherwise the active Nodus vault is used.
+ */
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { installRuntimeHooks, requireElectronRuntime } from './lib/tsRuntimeHooks.mjs';
+
+if (!process.argv.includes('--electron-zotero-manual-sync-live')) {
+  process.env.NODUS_ZOTERO_MANUAL_SYNC_ARGS = JSON.stringify(process.argv.slice(2));
+}
+if (!requireElectronRuntime(fileURLToPath(import.meta.url), '--electron-zotero-manual-sync-live')) process.exit(0);
+
+const args = (() => {
+  try { return JSON.parse(process.env.NODUS_ZOTERO_MANUAL_SYNC_ARGS ?? '[]'); } catch { return []; }
+})();
+const sourceArg = args.indexOf('--source-db');
+const requestedSource = sourceArg >= 0 ? args[sourceArg + 1] : null;
+if (sourceArg >= 0 && !requestedSource) throw new Error('--source-db requires a path');
+
+const scratch = await mkdtemp(path.join(os.tmpdir(), 'nodus-zotero-manual-sync-live-'));
+const userData = path.join(scratch, 'user-data');
+const targetDb = path.join(userData, 'vault.sqlite');
+installRuntimeHooks(userData);
+const require = createRequire(import.meta.url);
+
+function analysisRows(db) {
+  return db.prepare(`SELECT nodus_id, light_status, light_at, light_hash,
+    deep_status, deep_at, deep_hash, deep_error, deep_queued,
+    summary_status, summary_at, summary_hash
+    FROM works ORDER BY nodus_id`).all();
+}
+
+function derivedCounts(db) {
+  const count = (table) => db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get().n;
+  return {
+    ideas: count('ideas'),
+    occurrences: count('idea_occurrences'),
+    evidence: count('evidence'),
+    passages: count('passages'),
+  };
+}
+
+let closeDb = () => {};
+try {
+  const defaultUserData = path.join(os.homedir(), 'Library', 'Application Support', 'Nodus');
+  const registry = JSON.parse(await readFile(path.join(defaultUserData, 'vaults.json'), 'utf8'));
+  const active = registry.vaults.find((vault) => vault.id === registry.activeVaultId);
+  const sourceDbValue = requestedSource ?? active?.path;
+  assert.ok(sourceDbValue, 'No active Nodus vault was found');
+  const sourceDbPath = path.resolve(sourceDbValue);
+
+  await mkdir(userData, { recursive: true });
+  const Database = require('better-sqlite3');
+  const source = new Database(sourceDbPath, { readonly: true, fileMustExist: true });
+  try { await source.backup(targetDb); } finally { source.close(); }
+
+  await writeFile(path.join(userData, 'vaults.json'), JSON.stringify({
+    formatVersion: 1,
+    activeVaultId: 'verification',
+    vaults: [{
+      id: 'verification', name: 'Read-only verification copy', path: targetDb,
+      createdAt: new Date(0).toISOString(), lastOpenedAt: new Date(0).toISOString(),
+      legacy: false, type: 'academic', origin: 'local',
+    }],
+  }, null, 2));
+
+  const database = require('../electron/db/database.ts');
+  closeDb = database.closeDb;
+  const db = database.getDb();
+  const beforeWorks = db.prepare('SELECT COUNT(*) AS n FROM works').get().n;
+  const beforeAnalysis = analysisRows(db);
+  const beforeDerived = derivedCounts(db);
+
+  const { scanQueue } = require('../electron/pipeline/scanQueue.ts');
+  const { documentIndexQueue } = require('../electron/pipeline/documentIndexQueue.ts');
+  let analysisEnqueues = 0;
+  let documentaryRefreshes = 0;
+  scanQueue.enqueue = () => { analysisEnqueues += 1; throw new Error('manual refresh attempted to enqueue analysis'); };
+  documentIndexQueue.refreshVault = () => { documentaryRefreshes += 1; throw new Error('manual refresh attempted documentary indexing'); };
+
+  const zotero = require('../electron/zotero/zoteroClient.ts');
+  const ping = await zotero.ping();
+  assert.equal(ping.ok, true, `Zotero local API is unavailable: ${ping.message ?? ping.reason}`);
+  const { fullSync } = require('../electron/sync/syncService.ts');
+  const result = await fullSync('manual', { catalogOnly: true });
+
+  const afterWorks = db.prepare('SELECT COUNT(*) AS n FROM works').get().n;
+  const afterAnalysisById = new Map(analysisRows(db).map((row) => [row.nodus_id, row]));
+  const afterDerived = derivedCounts(db);
+  for (const before of beforeAnalysis) {
+    assert.deepEqual(afterAnalysisById.get(before.nodus_id), before, `manual refresh changed analysis state for ${before.nodus_id}`);
+  }
+  assert.deepEqual(afterDerived, beforeDerived, 'manual refresh changed derived ideas, evidence or passages');
+  assert.equal(analysisEnqueues, 0, 'manual refresh enqueued AI analysis');
+  assert.equal(documentaryRefreshes, 0, 'manual refresh started documentary indexing');
+  assert.match(result.summary, /catálogo actualizado sin iniciar análisis/);
+
+  const newStatuses = db.prepare(`SELECT light_status, deep_status, summary_status, deep_queued, COUNT(*) AS n
+    FROM works WHERE nodus_id NOT IN (${beforeAnalysis.map(() => '?').join(',') || "''"})
+    GROUP BY light_status, deep_status, summary_status, deep_queued`).all(...beforeAnalysis.map((row) => row.nodus_id));
+  for (const row of newStatuses) {
+    assert.equal(row.light_status, 'none');
+    assert.equal(row.deep_status, 'none');
+    assert.equal(row.summary_status, 'none');
+    assert.equal(row.deep_queued, 0);
+  }
+
+  console.log(JSON.stringify({
+    sourceDb: path.basename(sourceDbPath),
+    zoteroVersion: ping.version,
+    beforeWorks,
+    afterWorks,
+    newWorks: afterWorks - beforeWorks,
+    derivedCounts: afterDerived,
+    analysisEnqueues,
+    documentaryRefreshes,
+    summary: result.summary,
+  }, null, 2));
+  console.log('STRICT PASS: live Zotero catalog refresh changed only the isolated catalog copy.');
+} finally {
+  try { closeDb(); } catch { /* already closed */ }
+  await rm(scratch, { recursive: true, force: true });
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -693,6 +693,8 @@ export interface Work {
   nodus_id: string;
   zotero_key: string;
   zotero_version: number | null;
+  /** Stable metadata revision used when Zotero's local API reports item version 0. */
+  zotero_fingerprint: string | null;
   title: string;
   authors_json: string; // JSON-encoded string[]
   year: number | null;
@@ -4925,6 +4927,11 @@ export interface SyncLogEntry {
   summary: string;
 }
 
+export interface ZoteroSyncOptions {
+  /** Update monitored catalog metadata and membership without starting analysis. */
+  catalogOnly?: boolean;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Graph payloads (renderer consumes these directly)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -8725,7 +8732,7 @@ export interface NodusApi extends ProsopographyApi, TestimoniesApi, ToolkitApi, 
 
   // core: sync, backups, recovery. Regrouped here so the academic and study
   // declarations above form one range — they used to sit inside it.
-  syncNow(): Promise<SyncLogEntry>;
+  syncNow(options?: ZoteroSyncOptions): Promise<SyncLogEntry>;
   getSyncLog(): Promise<SyncLogEntry[]>;
   /** Sync packages are encrypted with a passphrase the user sets on both machines. */
   hasSyncPassphrase(): Promise<boolean>;

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nodusresearch.com/</loc>
-    <lastmod>2026-08-30</lastmod>
+    <lastmod>2026-08-31</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/about/</loc>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/app/</loc>
-    <lastmod>2026-08-30</lastmod>
+    <lastmod>2026-08-31</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/apps/</loc>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/cite/</loc>
-    <lastmod>2026-08-30</lastmod>
+    <lastmod>2026-08-31</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/demo/</loc>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1033,7 +1033,7 @@ export function App() {
   const onSync = async () => {
     setSyncing(true);
     try {
-      const result = await window.nodus.syncNow();
+      const result = await window.nodus.syncNow({ catalogOnly: true });
       setLastSync(result);
       notifyDataChanged();
     } finally {
@@ -1465,7 +1465,7 @@ export function App() {
             <HeaderAction
               dataTour="sync"
               icon="refresh"
-              label={syncing ? t('Actualizando…') : t('Actualizar')}
+              label={syncing ? t('Actualizando…') : t('Actualizar (sincronizar Zotero)')}
               spinning={syncing}
               showLabel={syncing}
               disabled={syncing}


### PR DESCRIPTION
## Summary

- make the desktop header's Zotero refresh explicitly catalog-only, while preserving onboarding and realtime automation behavior
- prevent light, deep, summary-chain, graph, and documentary-index work from being queued by that header action
- handle Zotero local item version `0` with stable metadata fingerprints and preserve useful historical revisions
- add an idempotent migration, regression tests, and a strict live-Zotero verifier that operates only on a temporary database copy

## Root cause

Nodus compared persisted positive Zotero item revisions directly with the `0` returned by Zotero 10.0.1's local API. That made every existing item look changed. Because the header used an analysis-capable manual sync, one click queued the whole monitored library.

## Live reproduction and verification

The verifier used the pre-incident Nodus snapshot as a read-only source, backed it up into a temporary vault, and ran the production header-sync path against the real local Zotero API:

```text
Zotero library version: 38
Works before: 1214
Works after: 1223
New works: 9
Existing changes: 0
Analysis enqueues: 0
Documentary refreshes: 0
Ideas: 14850 (unchanged)
Idea occurrences: 15555 (unchanged)
Evidence: 29561 (unchanged)
Passages: 47568 (unchanged)
STRICT PASS
```

A separate read-only integrity check confirmed that the active user vault remained at schema v170 with the same 1,223 works and the same last sync row (id 491). Zotero was only read through its local API.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `node --test scripts/test-zotero-sync-policy.mjs scripts/test-zotero-import-coordination.mjs`
- `node scripts/test-migration-160-baseline.mjs`
- `node --test scripts/test-site-sitemap.mjs`
- `node scripts/test-text-recovery.mjs`
- `node scripts/test-document-profiles.mjs`
- `npm run test:e2e`
- `npm run test:e2e:prosopography`
- `npm run verify:zotero:manual-sync-live -- --source-db <pre-incident-snapshot>`

Fixes #626
