### PR TITLE
Release v5.1.1

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Build smoke-test image
-        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.0 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
+        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.1 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
 
       - name: Run image health smoke test
         shell: bash
@@ -114,7 +114,7 @@ jobs:
           scripts/test-server-vectors.mjs
 
       - name: Build smoke-test image
-        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.0 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
+        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.1 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
 
       - name: Run image health smoke test
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ## Unreleased
 
+## 5.1.1 — 2026-08-31
+
+Nodus 5.1.1 is a Zotero hotfix that keeps the header refresh limited to the
+catalog of monitored collections and prevents false whole-library changes.
+
 - Made the header's Zotero refresh strictly catalog-only: it updates monitored
   collections and shows new or changed items without starting theme, deep,
   summary, embedding, passage, graph or documentary-index work.
 - Added a stable metadata fingerprint for Zotero 10 local APIs that report every
   item as version zero, preventing both whole-library false changes and missed
   edits after the compatibility transition.
+- Kept every 5.1.0 entry in the What's New modal and added this correction in
+  all eight interface languages.
 
 ## 5.1.0 — 2026-08-30
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "5.1.0"
-date-released: "2026-08-30"
+version: "5.1.1"
+date-released: "2026-08-31"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://nodusresearch.com/"
-# Zenodo assigns the immutable v5.1.0 DOI after the GitHub release is archived.
+# Zenodo assigns the immutable v5.1.1 DOI after the GitHub release is archived.
 # Until then the concept DOI is 10.5281/zenodo.21515531 for Nodus over time.
 doi: "10.5281/zenodo.21515531"
 keywords:

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.1.0 is licensed exclusively under the GNU Affero General Public
+Nodus 5.1.1 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.1.0 release is available
+The preferred form for modifying the official Nodus 5.1.1 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.0
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.0
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.0.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.0.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.1
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.1
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.1.0 is free software distributed exclusively under the GNU Affero
+Nodus 5.1.1 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": {
     "name": "Jorge Pérez Burgueño",
@@ -13,7 +13,7 @@
     "url": "https://github.com/Drakonis96/nodus.git"
   },
   "releaseMetadata": {
-    "dateReleased": "2026-08-30",
+    "dateReleased": "2026-08-31",
     "conceptDoi": "10.5281/zenodo.21515531",
     "versionDoi": null
   },

--- a/scripts/e2e-browser-connector.mjs
+++ b/scripts/e2e-browser-connector.mjs
@@ -138,7 +138,7 @@ async function exerciseMultiCapture() {
       scripting: { executeScript: async () => [{ result: nextSnapshot }] },
       storage: { local: { get: async (defaults) => ({ ...defaults, ...values }), set: async (input) => Object.assign(values, input), remove: async (keys) => { for (const key of keys) delete values[key]; } } },
       permissions: { request: async () => true, contains: async () => false, remove: async () => true },
-      runtime: { getManifest: () => ({ version: '5.1.0' }), getURL: (path = '') => `chrome-extension://ilcclajjhofhieoljdjmikmfopfbamej/${path}`, openOptionsPage: async () => undefined },
+      runtime: { getManifest: () => ({ version: '5.1.1' }), getURL: (path = '') => `chrome-extension://ilcclajjhofhieoljdjmikmfopfbamej/${path}`, openOptionsPage: async () => undefined },
     };
   }, { messages: english, snapshot: detected });
   let saves = 0;

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '5.1.0';
+const VERSION = '5.1.1';
 
 test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 5.1.0 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 5.1.1 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -76,7 +76,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '5.1.0');
+      assert.equal(info.version, '5.1.1');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -24,14 +24,14 @@ try {
   );
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
-  // 5.1.0 groups the user-visible result of PRs #599 through #623 by product
-  // surface so fixes from the same workflow read as one coherent announcement.
+  // 5.1.1 preserves the complete 5.1.0 announcement and adds the catalog-only
+  // Zotero header refresh hotfix in every interface language.
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '5.1.0');
-  assert.equal(currentRelease?.date, '2026-08-30');
-  assert.equal(currentRelease?.highlights.length, 8);
+  assert.equal(currentRelease?.version, '5.1.1');
+  assert.equal(currentRelease?.date, '2026-08-31');
+  assert.equal(currentRelease?.highlights.length, 9);
   assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), [
-    'ai', 'ai', 'zotero', 'server', 'library', 'databases', 'word', 'connector',
+    'ai', 'ai', 'zotero', 'server', 'library', 'databases', 'word', 'connector', 'zotero',
   ]);
   for (const phrase of [
     /more than twice as fast/,
@@ -42,9 +42,16 @@ try {
     /same clear library, composer, queue, and reading flow/,
     /Word ribbon adds shortcuts/,
     /Nodus Research Connector/,
+    /without starting or queuing analysis/,
+    /entire library appear to have changed at once/,
   ]) assert.ok(currentRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
 
-  // 5.0.6 remains intact beneath the new minor release.
+  const minorRelease = RELEASE_NOTES.find((note) => note.version === '5.1.0');
+  assert.equal(minorRelease?.date, '2026-08-30');
+  assert.equal(minorRelease?.highlights.length, 8);
+  assert.deepEqual(currentRelease?.highlights.slice(0, 8), minorRelease?.highlights);
+
+  // 5.0.6 remains intact beneath the new hotfix and minor release.
   const previousStableRelease = RELEASE_NOTES.find((note) => note.version === '5.0.6');
   assert.equal(previousStableRelease?.date, '2026-08-28');
   assert.equal(previousStableRelease?.highlights.length, 7);

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '5.1.0');
+  assert.equal(pluginManifest.version, '5.1.1');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,10 +54,10 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '5\.1\.0'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '5\.1\.1'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.1\.0\.tar\.gz/);
-  assert.match(citation, /^date-released: "2026-08-30"$/m);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.1\.1\.tar\.gz/);
+  assert.match(citation, /^date-released: "2026-08-31"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);
   }

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1563,9 +1563,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '5.1.0', 'the add-on shares the Nodus 5 release version');
+  assert.equal(manifest.version, '5.1.1', 'the add-on shares the Nodus 5 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.1\.0/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.1\.1/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -15,13 +15,13 @@ RUN npm run build:server-web
 
 FROM node:22-alpine
 
-ARG NODUS_VERSION=5.1.0
+ARG NODUS_VERSION=5.1.1
 ARG NODUS_REVISION=unknown
 LABEL org.opencontainers.image.title="Nodus Server" \
       org.opencontainers.image.description="Experimental self-hosted Nodus MCP server" \
       org.opencontainers.image.source="https://github.com/Drakonis96/nodus" \
       org.opencontainers.image.url="https://github.com/Drakonis96/nodus" \
-      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v5.1.0/server/README.md" \
+      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v5.1.1/server/README.md" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.version="${NODUS_VERSION}" \
       org.opencontainers.image.revision="${NODUS_REVISION}" \
@@ -45,7 +45,7 @@ COPY --from=web-build /src/server/dist/web ./dist/web
 ENV NODUS_DATA_DIR=/data \
     NODUS_HOST=0.0.0.0 \
     NODUS_PORT=7443 \
-    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v5.1.0
+    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v5.1.1
 
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.1.0 is licensed exclusively under the GNU Affero General Public
+Nodus 5.1.1 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.1.0 release is available
+The preferred form for modifying the official Nodus 5.1.1 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.0
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.0
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.0.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.0.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.1
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.1
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.1.0 is free software distributed exclusively under the GNU Affero
+Nodus 5.1.1 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -36,7 +36,7 @@ services:
       # With the pair, the account is created on first boot and its password is rotated
       # whenever you change the value here.
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       # Optional ceilings. Unset they default to 8 MiB per image, 2 GiB of images per

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -26,7 +26,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
       # Optional ceilings. Left unset they default to 8 MiB per image, 2 GiB of images per
       # space, and the snapshot limits documented in the README.
       NODUS_MAX_ASSET_BYTES: ${NODUS_MAX_ASSET_BYTES:-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
     volumes:
       - nodus_data:/data
       # Mount a versioned 0600 keyring outside /data and set NODUS_AI_KEYRING_FILE to

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '5.1.0';
+export const NODUS_VERSION = '5.1.1';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/server/portainer-stack.yml
+++ b/server/portainer-stack.yml
@@ -16,7 +16,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.0}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
     volumes:
       - nodus_data:/data
     expose:

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -154,8 +154,7 @@ const RELEASE_3_2_4_IT: string[] = [
   "Un deposito accademico si apre con meno sezioni. Lacune diventa una scheda dentro Copertura, perché una lacuna significa qualcosa solo guardando che cosa manca alla tua domanda. Ipotesi e Percorso di lettura restano nascosti all'inizio, dato che su un corpus appena sincronizzato rispondevano con rumore. Entrambi tornano dalle Impostazioni.",
 ];
 
-export const RELEASE_NOTES_IT: Record<string, string[]> = {
-  "5.1.0": [
+const RELEASE_5_1_0_IT = [
     "La modalità Automatica distribuisce ora il lavoro dell’IA in parallelo e adatta il ritmo a ogni fornitore, modello e credenziale. Nei test certificati, l’indicizzazione è terminata più di due volte più velocemente senza perdere citazioni, ordine o controlli di integrità. Le barre di elaborazione mostrano ora il tempo totale e quello di ogni elemento. Se devi limitare il carico, puoi scegliere da 1 a 8 attività simultanee.",
     "I modelli di LM Studio, Ollama e Nodus hanno ora abbastanza tempo per completare analisi impegnative. Se un passaggio è troppo pesante, Nodus lo divide e prosegue invece di abbandonare l’intero documento. Gli errori spiegano la causa nella lingua dell’interfaccia e il selettore generale consente di caricare e salvare modelli senza tornare alla configurazione iniziale.",
     "L’importazione percorre ora per intero le librerie personali e di gruppo, inclusi allegati, note, collezioni, documenti autonomi e metadati bibliografici. Nodus verifica ogni copia, ripara i file incompleti e consente di riprendere un’importazione annullata senza segnare come concluso un lavoro difettoso. I nomi di file lunghi non interrompono più il processo e gli errori di connessione spiegano come risolverli. La procedura guidata distingue visivamente Nodus Library e Zotero e si collega direttamente all’API locale corretta.",
@@ -164,7 +163,14 @@ export const RELEASE_NOTES_IT: Record<string, string[]> = {
     "Deep Research nei depositi Database adotta lo stesso flusso chiaro di libreria, composizione, coda e lettura della modalità accademica. Include configurazione locale automatica, lavoro su più database, stato di lettura persistente, annotazioni ed esportazioni. Le opzioni dei ruoli e la modifica dell’anteprima del rapporto restano disponibili nelle impostazioni avanzate.",
     "Idee, Passaggi e Sinonimi possono scegliere ciascuno il proprio modello. La generazione di sinonimi comprende meglio l’intera frase e restituisce alternative valide anche quando il fornitore cambia il formato della risposta. La barra multifunzione di Word aggiunge collegamenti a Modifica con IA, Sinonimi e Chat, mentre il selettore degli stili non si apre più espanso all’avvio del componente aggiuntivo.",
     "L’estensione Chrome si chiama ora Nodus Research Connector e collega direttamente al sito del progetto. L’associazione con l’applicazione utilizza un dialogo chiaro e tradotto che mette per prima l’opzione di annullamento e non dipende più da un avviso nativo del sistema.",
+];
+
+export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "5.1.1": [
+    ...RELEASE_5_1_0_IT,
+    "Il pulsante Aggiorna nell’intestazione ora aggiorna soltanto il catalogo delle collezioni Zotero monitorate. I nuovi elementi compaiono nella Libreria senza avviare né accodare analisi. Questa versione gestisce anche il valore zero restituito da Zotero 10, che poteva far apparire modificata tutta la libreria in una sola volta.",
   ],
+  "5.1.0": RELEASE_5_1_0_IT,
   "5.0.6": [
     "Nodus Copilot introduce Sinonimi e Chat. Sinonimi legge l’intera frase attorno alla selezione, propone cinque alternative adatte al contesto e sostituisce soltanto il termine scelto. La Chat risponde usando la pagina corrente o l’intero documento, dà priorità al testo selezionato e consente di interrompere, rigenerare, modificare e copiare le risposte. Ogni documento conserva la propria cronologia.",
     "Nodus per Zotero lavora con il contenuto completo di tutti gli allegati selezionati e trova prove sia per parole sia per significato tramite un indice locale. Le risposte collegano passaggi, pagine e sezioni esatti, indicano quali affermazioni richiedono maggiore sostegno e conservano un audit consultabile quando si riapre la conversazione. Può anche interpretare pagine, tabelle, figure e documenti scansionati mediante catture e OCR, mentre la chat mostra la risposta durante la generazione. L’installazione e gli aggiornamenti del plugin sono ora integrati nel pacchetto ufficiale di ogni versione.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -94,8 +94,7 @@ const RELEASE_3_2_4_TR: string[] = [
   "Akademik bir kasa daha az bölümle açılıyor. Boşluklar, Kapsam içinde bir sekmeye dönüşüyor, çünkü bir boşluk ancak kendi sorunuza neyin eksik olduğuna bakarken anlam taşır. Hipotez ve Okuma yolu başlangıçta gizli geliyor, çünkü yeni eşitlenmiş bir külliyatta gürültüyle yanıt veriyorlardı. İkisi de Ayarlar üzerinden geri gelir.",
 ];
 
-export const RELEASE_NOTES_TR: Record<string, string[]> = {
-  "5.1.0": [
+const RELEASE_5_1_0_TR = [
     "Otomatik mod artık yapay zeka işlerini paralel yürütüyor ve hızını her sağlayıcıya, modele ve kimlik bilgisine göre ayarlıyor. Sertifikalı testlerde dizinleme, alıntıları, sıralamayı veya bütünlük kontrollerini kaybetmeden iki kattan daha hızlı tamamlandı. İşlem çubukları artık toplam süreyi ve öğe başına süreyi gösteriyor. Yükü sınırlamanız gerekirse aynı anda 1 ile 8 görev arasında seçim yapabilirsiniz.",
     "LM Studio, Ollama ve Nodus modellerinin zorlu analizleri tamamlamak için artık yeterli süresi var. Bir bölüm fazla ağırsa Nodus tüm belgeyi bırakmak yerine bölümü parçalayıp devam ediyor. Hatalar nedenlerini arayüz dilinde açıklıyor ve genel seçici ilk kurulum sihirbazına dönmeden model yükleyip kaydetmenizi sağlıyor.",
     "İçe aktarma artık ekler, notlar, koleksiyonlar, bağımsız belgeler ve bibliyografik üst veriler dahil olmak üzere kişisel ve grup kitaplıklarının tamamını tarıyor. Nodus her kopyayı doğruluyor, eksik dosyaları onarıyor ve iptal edilen bir içe aktarmayı kusurlu işi tamamlanmış saymadan sürdürmenizi sağlıyor. Uzun dosya adları işlemi durdurmuyor ve bağlantı hataları çözümü açıklıyor. Kurulum sihirbazı Nodus Library ile Zotero’yu görsel olarak ayırıyor ve doğrudan doğru yerel API’ye bağlanıyor.",
@@ -104,7 +103,14 @@ export const RELEASE_NOTES_TR: Record<string, string[]> = {
     "Veritabanı kasalarındaki Deep Research artık akademik moddaki açık kitaplık, oluşturma, kuyruk ve okuma akışını kullanıyor. Otomatik yerel kurulum, birden fazla veritabanıyla çalışma, kalıcı okuma durumu, ek açıklamalar ve dışa aktarmalar içeriyor. Rol seçenekleri ve rapor önizleme düzenlemesi gelişmiş ayarlar olarak kullanılmaya devam ediyor.",
     "Fikirler, Pasajlar ve Eş Anlamlılar artık kendi modellerini seçebiliyor. Eş anlamlı üretimi tüm cümleyi daha iyi anlıyor ve sağlayıcı yanıt biçimini değiştirse bile geçerli alternatifler döndürüyor. Word şeridine Yapay Zeka ile Düzenleme, Eş Anlamlılar ve Sohbet kısayolları eklendi, stil seçici de eklenti açıldığında artık genişletilmiş görünmüyor.",
     "Chrome uzantısının adı artık Nodus Research Connector ve doğrudan proje sitesine bağlantı veriyor. Uygulamayla eşleştirme, iptal seçeneğini ilk sıraya koyan açık ve çevrilmiş bir iletişim kutusu kullanıyor ve artık yerel sistem uyarısına bağlı değil.",
+];
+
+export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "5.1.1": [
+    ...RELEASE_5_1_0_TR,
+    "Başlıktaki Güncelle düğmesi artık yalnızca izlediğiniz Zotero koleksiyonlarının kataloğunu yeniliyor. Yeni öğeler analiz başlatılmadan veya kuyruğa eklenmeden Kitaplıkta görünüyor. Bu sürüm ayrıca Zotero 10’un döndürdüğü sıfır öğe sürümünü düzeltiyor. Bu değer daha önce tüm kitaplığı bir anda değişmiş gibi gösterebiliyordu.",
   ],
+  "5.1.0": RELEASE_5_1_0_TR,
   "5.0.6": [
     "Nodus Copilot Eş Anlamlılar ve Sohbet özelliklerini kazanıyor. Eş Anlamlılar, seçiminizin çevresindeki cümlenin tamamını okuyor, bağlama uygun beş alternatif öneriyor ve yalnızca seçtiğiniz terimi değiştiriyor. Sohbet geçerli sayfayı veya belgenin tamamını kullanarak yanıt veriyor, seçili metne öncelik tanıyor ve yanıtları durdurmanıza, yeniden üretmenize, düzenlemenize ve kopyalamanıza izin veriyor. Her belge kendi geçmişini koruyor.",
     "Zotero için Nodus, seçilen tüm eklerin eksiksiz içeriğiyle çalışıyor ve yerel bir dizin üzerinden hem sözcüklere hem de anlama göre kanıt buluyor. Yanıtlar kesin pasajlara, sayfalara ve bölümlere bağlanıyor, daha fazla desteğe ihtiyaç duyan iddiaları belirtiyor ve konuşma yeniden açıldığında incelenebilir bir denetim kaydını koruyor. Ayrıca yakalamalar ve OCR aracılığıyla sayfaları, tabloları, şekilleri ve taranmış belgeleri yorumlayabiliyor, sohbet ise yanıtı üretilirken gösteriyor. Eklentinin kurulumu ve güncellemeleri artık her resmi sürüm paketine entegre ediliyor.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1859,6 +1859,24 @@ const RELEASE_5_1_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 /**
+ * v5.1.1 deliberately keeps the complete v5.1.0 announcement and appends the
+ * Zotero catalog-only hotfix. This makes the patch modal self-contained without
+ * rewriting or dropping anything that shipped in the minor release.
+ */
+const RELEASE_5_1_1_HIGHLIGHTS: RawReleaseHighlight[] = [
+  ...RELEASE_5_1_0_HIGHLIGHTS,
+  {
+    scope: 'zotero',
+    es: 'El botón Actualizar del encabezado ahora solo sincroniza el catálogo de las colecciones de Zotero que monitorizas. Los artículos nuevos aparecen en la Biblioteca sin iniciar ni encolar análisis. También se corrige la versión cero que devolvía Zotero 10 y que podía hacer que toda la biblioteca pareciera modificada de golpe.',
+    en: 'The Update button in the header now only refreshes the catalog for the Zotero collections you monitor. New items appear in the Library without starting or queuing analysis. This also fixes Zotero 10 returning item version zero, which could make the entire library appear to have changed at once.',
+    fr: 'Le bouton Actualiser de l’en-tête met désormais à jour uniquement le catalogue des collections Zotero que vous surveillez. Les nouveaux éléments apparaissent dans la Bibliothèque sans lancer ni mettre d’analyse en file d’attente. Cette version corrige aussi la valeur zéro renvoyée par Zotero 10, qui pouvait faire croire que toute la bibliothèque avait changé d’un coup.',
+    de: 'Die Schaltfläche Aktualisieren in der Kopfzeile aktualisiert jetzt nur den Katalog der überwachten Zotero-Sammlungen. Neue Einträge erscheinen in der Bibliothek, ohne Analysen zu starten oder einzureihen. Außerdem wird die von Zotero 10 gemeldete Elementversion null korrekt behandelt, durch die zuvor die gesamte Bibliothek auf einmal als geändert erscheinen konnte.',
+    pt: 'O botão Atualizar do cabeçalho passa a atualizar apenas o catálogo das coleções do Zotero que monitoriza. Os novos elementos aparecem na Biblioteca sem iniciar nem colocar análises em fila. Esta versão também corrige o valor zero devolvido pelo Zotero 10, que podia fazer parecer que toda a biblioteca tinha mudado de uma só vez.',
+    'pt-BR': 'O botão Atualizar do cabeçalho agora atualiza apenas o catálogo das coleções do Zotero que você monitora. Os novos itens aparecem na Biblioteca sem iniciar nem colocar análises na fila. Esta versão também corrige o valor zero retornado pelo Zotero 10, que podia fazer parecer que toda a biblioteca havia mudado de uma só vez.',
+  },
+];
+
+/**
  * v5.0.6 — every user-visible change merged after v5.0.5, excluding the
  * independent server-web parity branch. Keep this list aligned by index with
  * the Italian and Turkish tables so all eight interface languages receive the
@@ -2313,6 +2331,11 @@ const RELEASE_5_0_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '5.1.1',
+    date: '2026-08-31',
+    highlights: RELEASE_5_1_1_HIGHLIGHTS,
+  },
   {
     version: '5.1.0',
     date: '2026-08-30',

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.0",
-      "datePublished": "2026-08-30",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.0",
+      "softwareVersion": "5.1.1",
+      "datePublished": "2026-08-31",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.1",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -103,7 +103,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.0"
+          "value": "v5.1.1"
         }
       ],
       "sameAs": [

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -87,9 +87,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.0",
-      "datePublished": "2026-08-30",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.0",
+      "softwareVersion": "5.1.1",
+      "datePublished": "2026-08-31",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.1",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -104,7 +104,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.0"
+          "value": "v5.1.1"
         }
       ],
       "sameAs": [
@@ -170,9 +170,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 <dl class="citation-meta reveal">
       <div><dt>Project</dt><dd>Nodus Research</dd></div>
       <div><dt>Software</dt><dd>Nodus</dd></div>
-      <div><dt>Version</dt><dd>5.1.0</dd></div>
-      <div><dt>Released</dt><dd>30 August 2026</dd></div>
-      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.0" target="_blank" rel="noopener">v5.1.0</a></dd></div>
+      <div><dt>Version</dt><dd>5.1.1</dd></div>
+      <div><dt>Released</dt><dd>31 August 2026</dd></div>
+      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.1" target="_blank" rel="noopener">v5.1.1</a></dd></div>
       <div><dt>Author</dt><dd><a href="https://orcid.org/0000-0002-1150-1930" target="_blank" rel="noopener">Jorge Pérez Burgueño · ORCID</a></dd></div>
       <div><dt>Licence</dt><dd><a href="https://spdx.org/licenses/AGPL-3.0-only.html" target="_blank" rel="noopener">AGPL-3.0-only</a></dd></div>
     </dl>
@@ -197,10 +197,10 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a class="doi-value" href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">10.5281/zenodo.21515531</a>
       </article>
       <article class="card lit doi-card reveal" style="--delay:80ms">
-        <span class="kicker">Nodus 5.1.0 · archive pending</span>
+        <span class="kicker">Nodus 5.1.1 · archive pending</span>
         <h3>Version DOI pending</h3>
-        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.1.0 release tag shown here.</p>
-        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.0" target="_blank" rel="noopener">v5.1.0</a>
+        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.1.1 release tag shown here.</p>
+        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.1" target="_blank" rel="noopener">v5.1.1</a>
       </article>
     </div>
 <!-- generated:citation-dois:end -->
@@ -218,7 +218,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- generated:citation-formats:start -->
 <div class="citation-block reveal">
       <h3>APA</h3>
-      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.1.0) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
+      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.1.1) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
     </div>
 
     <div class="citation-block reveal">
@@ -226,11 +226,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       <pre><code>@software{perez_burgueno_nodus_2026,
   author    = {Pérez Burgueño, Jorge and Nodus contributors},
   title     = {Nodus: Open-Source Research Workspace},
-  version   = {5.1.0},
+  version   = {5.1.1},
   year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.21515531},
-  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.1.0},
+  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.1.1},
   license   = {AGPL-3.0-only}
 }</code></pre>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -97,9 +97,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.0",
-      "datePublished": "2026-08-30",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.0",
+      "softwareVersion": "5.1.1",
+      "datePublished": "2026-08-31",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.1",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -114,7 +114,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.0"
+          "value": "v5.1.1"
         }
       ],
       "sameAs": [

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -30,7 +30,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/zotero-plugin/</loc>
-    <lastmod>2026-08-30</lastmod>
+    <lastmod>2026-08-31</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/ai-research/</loc>

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
## Summary

- release Nodus 5.1.1 as a Zotero hotfix
- keep every v5.1.0 What's New highlight and append the catalog-only header refresh correction in all eight interface languages
- synchronize Desktop, Server, browser connector, Zotero plugin, source-offer, citation, website, and container metadata

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm test` (2,691 tests; a clean rerun confirmed two transient failures from the first run)
- `npm run build`
- `node scripts/build-zotero-xpi.mjs`
- `npm run citation:check`
- `node scripts/verify-source-offer.mjs`
- `node scripts/verify-release-channel.mjs latest v5.1.1`
- release-notes, What's New, AGPL, Server deployment, and v4 readiness contract tests