### PR TITLE
Improve Word add-in alternatives and searchable model selectors

### DIFF
--- a/electron/ai/studySynonyms.ts
+++ b/electron/ai/studySynonyms.ts
@@ -72,13 +72,13 @@ export function buildStudySynonymPrompt(request: StudySynonymRequest): { system:
   const markedSentence = `${request.sentence.slice(0, request.selectionFrom)}<<<SELECCIÓN>>>${request.selectedText}<<<FIN_SELECCIÓN>>>${request.sentence.slice(request.selectionTo)}`;
   const excluded = (request.previousAlternatives ?? []).slice(-50);
   return {
-    system: `Actúas como tesauro contextual y asistente de redacción de Nodus.
+    system: `Actúas como asistente de redacción contextual de Nodus. Propones alternativas: distintas formas naturales de expresar lo mismo. No te limites a sinónimos palabra por palabra; la selección puede ser una palabra, una expresión o una frase completa.
 
 Devuelve exclusivamente JSON válido con esta forma exacta:
 {"alternatives":[{"target":"fragmento original exacto","replacement":"alternativa"}]}
 
 REGLAS:
-- Devuelve ${CANDIDATE_COUNT} alternativas naturales, distintas entre sí y distintas del original. El servidor seleccionará las cinco primeras válidas.
+- Devuelve ${CANDIDATE_COUNT} alternativas de redacción naturales, distintas entre sí y distintas del original. El servidor seleccionará las cinco primeras válidas.
 - Detecta el idioma de la frase y escribe TODAS las alternativas en ese mismo idioma. Nunca traduzcas.
 - Conserva significado, registro, género, número, tiempo verbal, datos, citas y fuerza de la afirmación.
 - "target" debe ser una subcadena literal y contigua de la frase original que contenga toda la selección.
@@ -94,16 +94,37 @@ REGLAS:
   };
 }
 
-export async function suggestStudySynonyms(request: StudySynonymRequest): Promise<StudySynonymResult> {
+function normalizedSynonymRequest(request: StudySynonymRequest): StudySynonymRequest {
   const sentence = request.sentence.replace(/\r\n/g, '\n');
   const selectedText = request.selectedText;
-  if (!selectedText.trim()) throw new Error('Selecciona una o varias palabras.');
+  if (!selectedText.trim()) throw new Error('Selecciona una palabra, expresión o frase.');
   if (sentence.length > MAX_SENTENCE_CHARS) throw new Error(`La frase supera el límite de ${MAX_SENTENCE_CHARS.toLocaleString('es-ES')} caracteres.`);
   if (request.selectionFrom < 0 || request.selectionTo > sentence.length || request.selectionFrom >= request.selectionTo
     || sentence.slice(request.selectionFrom, request.selectionTo) !== selectedText) {
     throw new Error('La selección ya no coincide con la frase. Vuelve a seleccionar el texto.');
   }
-  const normalizedRequest = { ...request, sentence };
+  return { ...request, sentence };
+}
+
+async function generateAlternatives(request: StudySynonymRequest, model: ModelRef): Promise<StudySynonymAlternative[]> {
+  const prompt = buildStudySynonymPrompt(request);
+  const raw = await completeTextNeutral({
+    system: prompt.system,
+    user: prompt.user,
+    temperature: 0.65,
+    maxTokens: 1_200,
+    reasoning: 'off',
+    plainContext: true,
+  }, model);
+  const alternatives = normalizeAlternatives(request, parsePayload(raw));
+  if (alternatives.length !== ALTERNATIVE_COUNT) {
+    throw new Error('La IA no pudo proponer cinco alternativas distintas. Regenera para intentarlo de nuevo.');
+  }
+  return alternatives;
+}
+
+export async function suggestStudySynonyms(request: StudySynonymRequest): Promise<StudySynonymResult> {
+  const normalizedRequest = normalizedSynonymRequest(request);
   const initialPrompt = buildStudySynonymPrompt(normalizedRequest);
   const completed = await runStudyAiTask({
     task: 'improve',
@@ -112,24 +133,31 @@ export async function suggestStudySynonyms(request: StudySynonymRequest): Promis
     inputChars: initialPrompt.system.length + initialPrompt.user.length,
     outputChars: (value: StudySynonymAlternative[]) => JSON.stringify(value).length,
     externalConsentModelKey: '*',
-  }, async (model) => {
-    const raw = await completeTextNeutral({
-      system: initialPrompt.system,
-      user: initialPrompt.user,
-      temperature: 0.65,
-      maxTokens: 1_200,
-      reasoning: 'off',
-      plainContext: true,
-    }, model);
-    const alternatives = normalizeAlternatives(normalizedRequest, parsePayload(raw));
-    if (alternatives.length !== ALTERNATIVE_COUNT) {
-      throw new Error('La IA no pudo proponer cinco alternativas distintas. Regenera para intentarlo de nuevo.');
-    }
-    return alternatives;
-  });
+  }, (model) => generateAlternatives(normalizedRequest, model));
   return {
     alternatives: completed.value,
     modelProvider: completed.model.provider,
     modelName: completed.model.model,
+  };
+}
+
+/**
+ * Word's AI Edition is an explicit, user-triggered writing action and talks to
+ * its selected model directly. Alternatives follow that same contract instead
+ * of being blocked by the separate Study-AI enablement, budget and subject
+ * policy; only their structured five-option output differs.
+ */
+export async function suggestCopilotAlternatives(
+  request: StudySynonymRequest & { model: ModelRef },
+): Promise<StudySynonymResult> {
+  const normalizedRequest = normalizedSynonymRequest(request);
+  if (!request.model?.provider || !request.model.model) {
+    throw new Error('No hay un modelo de IA configurado. Elige uno en Ajustes de Nodus.');
+  }
+  const alternatives = await generateAlternatives(normalizedRequest, request.model);
+  return {
+    alternatives,
+    modelProvider: request.model.provider,
+    modelName: request.model.model,
   };
 }

--- a/electron/copilot/server.ts
+++ b/electron/copilot/server.ts
@@ -31,7 +31,7 @@ import { embeddedIdeaCount } from '../db/ideasRepo';
 import { getStudyStyle, listStudyStyles } from '../db/studyStylesRepo';
 import { getDb } from '../db/database';
 import { applyCopilotPromptStyle } from '../ai/copilotPromptStyles';
-import { suggestStudySynonyms } from '../ai/studySynonyms';
+import { suggestCopilotAlternatives } from '../ai/studySynonyms';
 import {
   normalizeOfficeChatRequest,
   streamOfficeChat,
@@ -104,7 +104,7 @@ function copilotError(error: unknown): string {
     'El estilo seleccionado no está disponible.': 'The selected style is not available.',
     'No hay un modelo de IA configurado. Elige uno en Ajustes de Nodus.':
       'No AI model is configured. Choose one in Nodus Settings.',
-    'Selecciona una o varias palabras.': 'Select one or more words.',
+    'Selecciona una palabra, expresión o frase.': 'Select a word, expression, or phrase.',
     'La selección ya no coincide con la frase. Vuelve a seleccionar el texto.':
       'The selection no longer matches the sentence. Select the text again.',
     'La IA no pudo proponer cinco alternativas distintas. Regenera para intentarlo de nuevo.':
@@ -407,7 +407,19 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
     }
     if (urlPath === '/api/synonyms' && req.method === 'POST') {
       const body = (await readJsonBody(req)) as Partial<StudySynonymRequest>;
-      const result = await suggestStudySynonyms({
+      const requestedModel = modelRef(body.model);
+      if (!requestedModel) {
+        sendJson(res, 400, { error: copilotText('El modelo seleccionado no es válido.', 'The selected model is invalid.') });
+        return;
+      }
+      const allowed = copilotPromptCatalogue().models.some((entry) => (
+        entry.provider === requestedModel.provider && entry.model === requestedModel.model
+      ));
+      if (!allowed) {
+        sendJson(res, 400, { error: copilotText('El modelo ya no está disponible en Nodus.', 'The model is no longer available in Nodus.') });
+        return;
+      }
+      const result = await suggestCopilotAlternatives({
         documentId: 'office-addin',
         sentence: String(body.sentence ?? ''),
         selectedText: String(body.selectedText ?? ''),
@@ -416,7 +428,7 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, p
         previousAlternatives: Array.isArray(body.previousAlternatives)
           ? body.previousAlternatives.map(String).slice(-50)
           : [],
-        model: modelRef(body.model),
+        model: requestedModel,
       });
       sendJson(res, 200, result);
       return;

--- a/scripts/test-copilot-addin.mjs
+++ b/scripts/test-copilot-addin.mjs
@@ -75,6 +75,7 @@ try {
   const taskpaneJs = fs.readFileSync(path.join(repoRoot, 'word-addin/taskpane.js'), 'utf8');
   const referencesJs = fs.readFileSync(path.join(repoRoot, 'word-addin/references.js'), 'utf8');
   const chatJs = fs.readFileSync(path.join(repoRoot, 'word-addin/chat.js'), 'utf8');
+  const modelPickerJs = fs.readFileSync(path.join(repoRoot, 'word-addin/model-picker.js'), 'utf8');
   const taskpaneCss = fs.readFileSync(path.join(repoRoot, 'word-addin/taskpane.css'), 'utf8');
   const wordIconBuilder = fs.readFileSync(path.join(repoRoot, 'scripts/build-word-addin-icons.mjs'), 'utf8');
   assert.match(taskpaneHtml, /<html lang="en">/);
@@ -120,6 +121,15 @@ try {
     assert.match(taskpaneHtml, new RegExp(`id="${id}"`), `Chat UI must contain ${id}`);
   }
   assert.match(taskpaneHtml, /<script src="\/addin\/chat\.js"><\/script>/);
+  assert.match(taskpaneHtml, /<script src="\/addin\/model-picker\.js"><\/script>/);
+  for (const selectId of ['searchModel', 'promptModel', 'synonymModel']) {
+    assert.match(taskpaneJs, new RegExp(`NodusModelPicker\\.enhance\\([\\s\\S]*${selectId}|\\[els\\.searchModel, els\\.promptModel, els\\.synonymModel\\]`), `${selectId} must use the searchable model picker`);
+  }
+  assert.match(chatJs, /NodusModelPicker\.enhance\(els\.model/);
+  assert.match(modelPickerJs, /input\.type = 'search'/);
+  assert.match(modelPickerJs, /setAttribute\('role', 'combobox'\)/);
+  assert.match(modelPickerJs, /normalizeSearch\(label\)\.indexOf\(normalized\)/, 'model options must be filtered by the search box');
+  assert.match(modelPickerJs, /event\.key === 'ArrowDown'/, 'the searchable picker must remain keyboard accessible');
   assert.equal((taskpaneHtml.match(/class="prompt-typing-dot"/g) || []).length, 6, 'both writing generators must use the Nodi-style three-dot indicator');
   for (const id of ['referenceStyle', 'referenceStyleSearch', 'referenceLocale', 'referencePlacement', 'selectedReferences', 'insertCitation', 'insertBibliography', 'refreshReferences', 'unlinkReferences']) {
     assert.match(taskpaneHtml, new RegExp(`id="${id}"`), `References UI must contain ${id}`);
@@ -292,10 +302,12 @@ try {
   assert.match(copilotChatSource, /completeTextStreamNeutral/, 'global promptLanguage must not override the question language');
   assert.match(copilotChatSource, /No inventes contenido ausente del contexto/, 'chat must stay grounded in the selected Word context');
   assert.match(referencesJs, /fingerprint === externalStateFingerprint/, 'identical Writer polling snapshots must not rebuild the citation composer');
-  assert.match(serverSource, /suggestStudySynonyms\(\{/, 'the Word endpoint must reuse the workspace synonym engine');
+  assert.match(serverSource, /suggestCopilotAlternatives\(\{/, 'the Word endpoint must use the direct AI Edition-style alternatives engine');
   assert.match(serverSource, /composeFromSelection\(\{[\s\S]*?model: modelRef\(body\.model\)/, 'selection actions must honor the Ideas/Passages model selector');
   assert.match(serverSource, /composeCopilotIdeaInsertion\(\{[\s\S]*?model: modelRef\(body\.model\)/, 'Insert with AI must honor the Ideas model selector');
-  assert.match(serverSource, /suggestStudySynonyms\(\{[\s\S]*?model: modelRef\(body\.model\)/, 'synonyms must honor their model selector');
+  assert.match(serverSource, /var requestedModel|const requestedModel = modelRef\(body\.model\)/, 'alternatives must validate their model selector');
+  assert.match(serverSource, /suggestCopilotAlternatives\(\{[\s\S]*?model: requestedModel/, 'alternatives must honor their validated model selector');
+  assert.doesNotMatch(taskpaneJs, /if \(synonymMode\) \{[\s\S]*?generateSynonymRound\(\);[\s\S]*?startPromptSelectionPolling\(\);/, 'opening Alternatives must never spend tokens automatically');
   assert.match(serverSource, /destination: 'ideas'/);
   assert.match(serverSource, /destination === 'citation-styles'[\s\S]*destination: 'library-citation-styles'/);
   assert.match(appSource, /target\.destination === 'library-citation-styles'[\s\S]*citationStyles: true[\s\S]*setView\('library'\)/);

--- a/scripts/test-study-improve.mjs
+++ b/scripts/test-study-improve.mjs
@@ -163,12 +163,29 @@ try {
     previousAlternatives: [],
     model: { provider: 'ollama', model: 'controlled-local-verifier' },
   });
-  assert.equal(synonymResult.alternatives.length, 5, 'the contextual thesaurus always returns five alternatives');
+  assert.equal(synonymResult.alternatives.length, 5, 'the contextual writing assistant always returns five alternatives');
   assert.deepEqual(synonymResult.alternatives.at(-1), { target: 'es sólido', replacement: 'está bien fundamentado', from: 13, to: 22 }, 'an alternative may expand the exact replacement target');
   assert.equal(synonymGenerationCalls, 1, 'over-generation fills five alternatives without an extra provider call');
   const synonymPrompt = synonyms.buildStudySynonymPrompt({ sentence: sentenceContext.sentence, selectedText: 'sólido', selectionFrom: sentenceContext.selectionFrom, selectionTo: sentenceContext.selectionTo });
+  assert.match(synonymPrompt.system, /No te limites a sinónimos palabra por palabra/);
+  assert.match(synonymPrompt.system, /una palabra, una expresión o una frase completa/);
   assert.match(synonymPrompt.user, /<<<SELECCIÓN>>>sólido<<<FIN_SELECCIÓN>>>/);
   assert.equal(JSON.parse(synonymPrompt.user).originalSentence, sentenceContext.sentence, 'the model can copy an exact target from an unmarked sentence');
+
+  settingsRepo.updateSettings({ studyAiEnabled: false });
+  const wordAlternatives = await synonyms.suggestCopilotAlternatives({
+    documentId: 'office-addin',
+    sentence: sentenceContext.sentence,
+    selectedText: 'sólido',
+    selectionFrom: sentenceContext.selectionFrom,
+    selectionTo: sentenceContext.selectionTo,
+    previousAlternatives: [],
+    model: { provider: 'ollama', model: 'controlled-local-verifier' },
+  });
+  assert.equal(wordAlternatives.alternatives.length, 5, 'Word alternatives use the explicit AI Edition model directly');
+  assert.equal(wordAlternatives.modelName, 'controlled-local-verifier');
+  assert.equal(synonymGenerationCalls, 2, 'the Word path reaches the selected model even when Study AI is disabled');
+  settingsRepo.updateSettings({ studyAiEnabled: true });
 
   const exported = styles.exportStudyStyles([custom.id]);
   assert.equal(exported.format, 'nodus-study-styles');

--- a/word-addin/README.md
+++ b/word-addin/README.md
@@ -5,7 +5,7 @@ Nodus provides one writing assistant and reference workflow in Microsoft Word an
 - **Ideas** relates the current paragraph to the active Nodus vault.
 - **Passages** searches indexed full text and inserts quotations or AI-assisted prose.
 - **References** searches the Nodus global library and manages live citations and bibliographies.
-- **Synonyms** reads the complete sentence around the Word selection, proposes five contextual alternatives, applies the chosen replacement, and can regenerate without repeating earlier suggestions.
+- **Alternatives** reads the complete sentence around a selected word, expression, or phrase, proposes five contextual ways to express the same meaning, applies the chosen replacement, and can regenerate without repeating earlier suggestions.
 - **AI Edition** loads the active workspace writing styles, applies one to the current Word selection with a configured Nodus model, and keeps the proposal in the pane until the user copies it or explicitly replaces the selection.
 - **Chat** mirrors the Nodus for Zotero conversation design. Each question uses either the current Word page or the full document as context, prioritizes any selected text, streams the answer, and supports per-document history, editing, copying, stopping, and regenerating replies.
 
@@ -66,7 +66,7 @@ The macro is installed in the current user's LibreOffice Python scripts director
 ## Architecture
 
 - `manifest.xml` defines the persistent Word ribbon and task-pane commands.
-- `taskpane.html`, `taskpane.css`, `taskpane.js`, and `chat.js` provide Ideas, Passages, contextual synonyms, AI Edition, and the grounded document chat.
+- `taskpane.html`, `taskpane.css`, `model-picker.js`, `taskpane.js`, and `chat.js` provide Ideas, Passages, contextual writing alternatives, searchable model selectors, AI Edition, and the grounded document chat.
 - `references.js` provides the shared reference composer and Word live-field adapter.
 - `scripts/nodus_copilot.py` provides the LibreOffice bridge and Writer live-field adapter.
 - `electron/copilot/server.ts` serves the pane and authenticated local API.

--- a/word-addin/chat.js
+++ b/word-addin/chat.js
@@ -22,6 +22,7 @@
       copy: 'Copiar', edit: 'Editar', regenerate: 'Regenerar', remove: 'Eliminar',
       copied: 'Copiado', copyError: 'No se pudo copiar la respuesta.',
       noModels: 'No hay modelos configurados en Nodus.', loadingModels: 'Cargando modelos…',
+      modelSearch: 'Buscar modelos', noModelMatches: 'No hay modelos que coincidan.',
       modelError: 'No se pudieron cargar los modelos: ', responseEmpty: 'Nodus no devolvió una respuesta.',
       stopped: 'Respuesta detenida.', contextReading: 'Leyendo el contexto del documento…',
       contextReady: '{label} · {chars} caracteres enviados',
@@ -41,6 +42,7 @@
       copy: 'Copy', edit: 'Edit', regenerate: 'Regenerate', remove: 'Delete',
       copied: 'Copied', copyError: 'The response could not be copied.',
       noModels: 'There are no models configured in Nodus.', loadingModels: 'Loading models…',
+      modelSearch: 'Search models', noModelMatches: 'No matching models.',
       modelError: 'Could not load models: ', responseEmpty: 'Nodus returned no response.',
       stopped: 'Response stopped.', contextReading: 'Reading document context…',
       contextReady: '{label} · {chars} characters sent',
@@ -628,6 +630,7 @@
         var wanted = modelKey((conversation && conversation.model) || defaultModel);
         if (wanted && models.some(function (model) { return modelKey(model) === wanted; })) els.model.value = wanted;
       }
+      if (window.NodusModelPicker) window.NodusModelPicker.refresh(els.model);
       setBusy(false);
     }
 
@@ -671,6 +674,13 @@
       els.history = document.getElementById('chatHistory');
       els.historyList = document.getElementById('chatHistoryList');
       els.historyClose = document.getElementById('chatHistoryClose');
+      if (window.NodusModelPicker) {
+        window.NodusModelPicker.enhance(els.model, {
+          searchPlaceholder: t('modelSearch'),
+          showOptionsLabel: t('modelSearch'),
+          noResults: t('noModelMatches'),
+        });
+      }
       applyLabels();
       if (!options.pageSupported) {
         els.scopePage.disabled = true;

--- a/word-addin/manifest.xml
+++ b/word-addin/manifest.xml
@@ -166,7 +166,7 @@
         <bt:String id="Nodus.Group.Label" DefaultValue="Nodus" />
         <bt:String id="Nodus.Taskpane.Label" DefaultValue="Nodus Copilot" />
         <bt:String id="Nodus.AiEdit.Label" DefaultValue="AI Edit"><bt:Override Locale="es-ES" Value="AI Edit" /></bt:String>
-        <bt:String id="Nodus.Synonyms.Label" DefaultValue="Synonyms"><bt:Override Locale="es-ES" Value="Sinónimos" /></bt:String>
+        <bt:String id="Nodus.Synonyms.Label" DefaultValue="Alternatives"><bt:Override Locale="es-ES" Value="Alternativas" /></bt:String>
         <bt:String id="Nodus.Chat.Label" DefaultValue="Chat"><bt:Override Locale="es-ES" Value="Chat" /></bt:String>
         <bt:String id="Nodus.Citation.Label" DefaultValue="Add/Edit Citation"><bt:Override Locale="es-ES" Value="Añadir/editar cita" /></bt:String>
         <bt:String id="Nodus.Bibliography.Label" DefaultValue="Add/Edit Bibliography"><bt:Override Locale="es-ES" Value="Añadir/editar bibliografía" /></bt:String>
@@ -182,7 +182,7 @@
           <bt:Override Locale="es-ES" Value="Relaciona el párrafo actual con tu biblioteca de Nodus e inserta ideas citadas." />
         </bt:String>
         <bt:String id="Nodus.AiEdit.Tooltip" DefaultValue="Transform the current selection with a saved Nodus writing prompt."><bt:Override Locale="es-ES" Value="Transforma la selección actual con un prompt de escritura guardado en Nodus." /></bt:String>
-        <bt:String id="Nodus.Synonyms.Tooltip" DefaultValue="Suggest contextual synonyms and rephrasings for the current selection."><bt:Override Locale="es-ES" Value="Sugiere sinónimos y reformulaciones contextuales para la selección actual." /></bt:String>
+        <bt:String id="Nodus.Synonyms.Tooltip" DefaultValue="Suggest different contextual ways to express the current selection."><bt:Override Locale="es-ES" Value="Sugiere distintas alternativas contextuales para expresar la selección actual." /></bt:String>
         <bt:String id="Nodus.Chat.Tooltip" DefaultValue="Chat with the current page or the complete Word document."><bt:Override Locale="es-ES" Value="Chatea con la página actual o con todo el documento de Word." /></bt:String>
         <bt:String id="Nodus.Citation.Tooltip" DefaultValue="Search the Nodus global library and add or edit a live citation."><bt:Override Locale="es-ES" Value="Busca en la biblioteca global de Nodus y añade o edita una cita viva." /></bt:String>
         <bt:String id="Nodus.Bibliography.Tooltip" DefaultValue="Insert or update the live bibliography for this document."><bt:Override Locale="es-ES" Value="Inserta o actualiza la bibliografía viva de este documento." /></bt:String>

--- a/word-addin/model-picker.js
+++ b/word-addin/model-picker.js
@@ -1,0 +1,214 @@
+/* Searchable model selector shared by every Word add-in surface. */
+(function () {
+  'use strict';
+
+  var instances = [];
+
+  function normalizeSearch(value) {
+    var normalized = String(value || '').toLocaleLowerCase();
+    try { normalized = normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, ''); } catch (error) { /* older webviews */ }
+    return normalized.trim().replace(/\s+/g, ' ');
+  }
+
+  function dispatchChange(select) {
+    var event;
+    try {
+      event = new Event('change', { bubbles: true });
+    } catch (error) {
+      event = document.createEvent('Event');
+      event.initEvent('change', true, false);
+    }
+    select.dispatchEvent(event);
+  }
+
+  function enhance(select, options) {
+    if (!select) return null;
+    if (select.__nodusModelPicker) return select.__nodusModelPicker;
+    options = options || {};
+
+    var root = document.createElement('div');
+    root.className = 'model-picker';
+    var input = document.createElement('input');
+    input.id = select.id + 'Search';
+    input.className = 'model-picker-search';
+    input.type = 'search';
+    input.autocomplete = 'off';
+    input.placeholder = options.searchPlaceholder || 'Search models';
+    input.setAttribute('aria-label', options.searchPlaceholder || 'Search models');
+    input.setAttribute('role', 'combobox');
+    input.setAttribute('aria-autocomplete', 'list');
+    input.setAttribute('aria-expanded', 'false');
+    var toggle = document.createElement('button');
+    toggle.className = 'model-picker-toggle';
+    toggle.type = 'button';
+    toggle.setAttribute('aria-label', options.showOptionsLabel || input.placeholder);
+    toggle.innerHTML = '<span aria-hidden="true"></span>';
+    var list = document.createElement('div');
+    list.id = select.id + 'Options';
+    list.className = 'model-picker-options';
+    list.setAttribute('role', 'listbox');
+    list.hidden = true;
+    input.setAttribute('aria-controls', list.id);
+    toggle.setAttribute('aria-controls', list.id);
+    toggle.setAttribute('aria-expanded', 'false');
+    root.appendChild(input);
+    root.appendChild(toggle);
+    root.appendChild(list);
+    select.parentNode.insertBefore(root, select.nextSibling);
+    select.hidden = true;
+    select.tabIndex = -1;
+    select.setAttribute('aria-hidden', 'true');
+
+    var visibleOptions = [];
+    var activeIndex = -1;
+
+    function selectedLabel() {
+      var selected = select.options[select.selectedIndex];
+      return selected ? selected.textContent : '';
+    }
+
+    function setExpanded(expanded) {
+      root.classList.toggle('open', expanded);
+      list.hidden = !expanded;
+      input.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      if (!expanded) {
+        activeIndex = -1;
+        input.removeAttribute('aria-activedescendant');
+        input.value = selectedLabel();
+      }
+    }
+
+    function setActive(index) {
+      if (!visibleOptions.length) return;
+      activeIndex = Math.max(0, Math.min(visibleOptions.length - 1, index));
+      visibleOptions.forEach(function (button, buttonIndex) {
+        button.classList.toggle('active', buttonIndex === activeIndex);
+      });
+      var active = visibleOptions[activeIndex];
+      input.setAttribute('aria-activedescendant', active.id);
+      if (active.scrollIntoView) active.scrollIntoView({ block: 'nearest' });
+    }
+
+    function choose(value) {
+      if (select.value !== value) {
+        select.value = value;
+        dispatchChange(select);
+      }
+      setExpanded(false);
+      input.focus();
+      input.select();
+    }
+
+    function render(query) {
+      var normalized = normalizeSearch(query);
+      var selectedVisibleIndex = -1;
+      list.innerHTML = '';
+      visibleOptions = [];
+      activeIndex = -1;
+      Array.prototype.forEach.call(select.options, function (option, index) {
+        var label = String(option.textContent || '');
+        if (normalized && normalizeSearch(label).indexOf(normalized) < 0) return;
+        var button = document.createElement('button');
+        button.id = select.id + 'Option' + index;
+        button.type = 'button';
+        button.className = 'model-picker-option';
+        button.setAttribute('role', 'option');
+        button.setAttribute('aria-selected', option.value === select.value ? 'true' : 'false');
+        button.textContent = label;
+        button.disabled = option.disabled;
+        button.onmousedown = function (event) { event.preventDefault(); };
+        button.onclick = function () { choose(option.value); };
+        list.appendChild(button);
+        visibleOptions.push(button);
+        if (option.value === select.value) selectedVisibleIndex = visibleOptions.length - 1;
+      });
+      if (!visibleOptions.length) {
+        var empty = document.createElement('div');
+        empty.className = 'model-picker-empty';
+        empty.textContent = options.noResults || 'No matching models';
+        list.appendChild(empty);
+      } else {
+        setActive(selectedVisibleIndex >= 0 ? selectedVisibleIndex : 0);
+      }
+    }
+
+    function openPicker(showAll) {
+      if (select.disabled || !select.options.length) return;
+      if (showAll) input.value = '';
+      render(input.value);
+      setExpanded(true);
+    }
+
+    function refresh() {
+      input.disabled = select.disabled;
+      toggle.disabled = select.disabled;
+      input.value = selectedLabel();
+      input.placeholder = options.searchPlaceholder || input.placeholder;
+      if (!list.hidden) render(input.value);
+    }
+
+    input.onfocus = function () {
+      openPicker(true);
+      input.select();
+    };
+    input.onclick = function () {
+      if (list.hidden) openPicker(true);
+      input.select();
+    };
+    input.oninput = function () {
+      render(input.value);
+      setExpanded(true);
+    };
+    input.onkeydown = function (event) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (list.hidden) openPicker(true);
+        setActive(activeIndex + 1);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        if (list.hidden) openPicker(true);
+        setActive(activeIndex < 0 ? visibleOptions.length - 1 : activeIndex - 1);
+      } else if (event.key === 'Enter' && !list.hidden && activeIndex >= 0) {
+        event.preventDefault();
+        visibleOptions[activeIndex].click();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        setExpanded(false);
+      }
+    };
+    toggle.onclick = function () {
+      if (list.hidden) {
+        openPicker(true);
+        input.focus();
+      } else {
+        setExpanded(false);
+      }
+    };
+    select.addEventListener('change', refresh);
+    document.addEventListener('mousedown', function (event) {
+      if (!root.contains(event.target)) setExpanded(false);
+    });
+
+    var observer = typeof MutationObserver !== 'undefined'
+      ? new MutationObserver(refresh)
+      : null;
+    if (observer) observer.observe(select, { childList: true, subtree: true, attributes: true });
+
+    var instance = { refresh: refresh, root: root, input: input, list: list };
+    select.__nodusModelPicker = instance;
+    instances.push(instance);
+    refresh();
+    return instance;
+  }
+
+  function refresh(select) {
+    if (select && select.__nodusModelPicker) select.__nodusModelPicker.refresh();
+  }
+
+  window.NodusModelPicker = {
+    enhance: enhance,
+    refresh: refresh,
+    refreshAll: function () { instances.forEach(function (instance) { instance.refresh(); }); },
+  };
+})();

--- a/word-addin/taskpane.css
+++ b/word-addin/taskpane.css
@@ -864,6 +864,88 @@ input[type="radio"] { accent-color: var(--primary); }
   box-shadow: 0 0 0 3px var(--primary-soft);
 }
 .prompt-field select option { background: var(--panel); color: var(--control-text); }
+
+/* Searchable model dropdown shared by Ideas, Alternatives, AI Edition and Chat. */
+.model-picker { position: relative; width: 100%; min-width: 0; color: var(--control-text); }
+.model-picker-search {
+  width: 100%;
+  min-width: 0;
+  min-height: 34px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--primary-line);
+  border-radius: 9px;
+  padding: 6px 32px 6px 9px;
+  background: var(--panel);
+  color: var(--control-text);
+  font: inherit;
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  transition: border-color .16s ease, box-shadow .16s ease;
+}
+.model-picker-search:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
+}
+.model-picker-search:disabled { cursor: not-allowed; opacity: .65; }
+.model-picker-toggle {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 30px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-left: 1px solid var(--border);
+  border-radius: 0 8px 8px 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.model-picker-toggle span {
+  width: 7px;
+  height: 7px;
+  margin-top: -3px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg);
+}
+.model-picker.open .model-picker-toggle span { margin-top: 3px; transform: rotate(225deg); }
+.model-picker-options {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 210px;
+  overflow-y: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  padding: 4px;
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
+}
+.model-picker-option {
+  width: 100%;
+  display: block;
+  border: 0;
+  border-radius: 6px;
+  padding: 7px 8px;
+  background: transparent;
+  color: var(--control-text);
+  font: inherit;
+  font-size: 10.5px;
+  line-height: 1.35;
+  text-align: left;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+}
+.model-picker-option:hover,
+.model-picker-option.active { background: var(--primary-soft); color: var(--primary); }
+.model-picker-option[aria-selected="true"] { color: var(--primary); font-weight: 650; }
+.model-picker-empty { padding: 10px 8px; color: var(--muted); font-size: 10.5px; text-align: center; }
 .prompt-description {
   min-height: 0;
   margin: -3px 2px 0;
@@ -1138,18 +1220,19 @@ input[type="radio"] { accent-color: var(--primary); }
 .word-chat-icon-btn:hover { border-color: var(--primary-line); background: var(--primary-soft); color: var(--primary); }
 .word-chat-model { min-width: 0; flex: 1 1 auto; display: flex; align-items: center; gap: 6px; }
 .word-chat-model > span { color: var(--muted); font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
-.word-chat-model select {
+.word-chat-model .model-picker {
   flex: 1 1 auto;
   min-width: 0;
+}
+.word-chat-model .model-picker-search {
   height: 28px;
+  min-height: 28px;
   border: 1px solid var(--border);
   border-radius: 7px;
-  padding: 3px 7px;
-  background: var(--panel);
-  color: var(--control-text);
-  font: inherit;
+  padding: 3px 29px 3px 7px;
   font-size: 10.5px;
 }
+.word-chat-model .model-picker-toggle { width: 27px; height: 26px; border-radius: 0 6px 6px 0; }
 .word-chat-scope {
   display: flex;
   align-items: center;

--- a/word-addin/taskpane.html
+++ b/word-addin/taskpane.html
@@ -54,9 +54,9 @@
             <svg class="seg-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 5h11a3 3 0 0 1 3 3v11H8a3 3 0 0 1-3-3zM8 8h7M8 12h7M8 16h4M5 16a3 3 0 0 1 3-3h11"/></svg>
             <span class="seg-label">References</span>
           </button>
-          <button class="seg" data-mode="synonyms" type="button" role="tab" aria-selected="false" aria-label="Synonyms" title="Synonyms">
+          <button class="seg" data-mode="synonyms" type="button" role="tab" aria-selected="false" aria-label="Alternatives" title="Alternatives">
             <svg class="seg-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H11a2 2 0 0 1 2 2v16a2.5 2.5 0 0 0-2-2H6.5A2.5 2.5 0 0 0 4 21.5zM13 5a2 2 0 0 1 2-2h2M7 8h3M7 12h3M16 12h3M19 2l.5 1.5L21 4l-1.5.5L19 6l-.5-1.5L17 4l1.5-.5zM13 21a2.5 2.5 0 0 1 2-2h4a2 2 0 0 1 2 2v-9"/></svg>
-            <span class="seg-label">Synonyms</span>
+            <span class="seg-label">Alternatives</span>
           </button>
           <button class="seg" data-mode="prompts" type="button" role="tab" aria-selected="false" aria-label="AI Edition" title="AI Edition">
             <svg class="seg-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m14 4 1-2 1 2 2 1-2 1-1 2-1-2-2-1zM5 17l9-9 3 3-9 9H5zM12.5 9.5l3 3M18 16l.8-1.8.8 1.8 1.8.8-1.8.8-.8 1.8-.8-1.8-1.8-.8z"/></svg>
@@ -72,7 +72,7 @@
           <button id="searchBtn" class="btn icon" type="button" title="Search">⌕</button>
         </div>
         <div id="analysisControls">
-          <label class="prompt-field mode-model-field"><span data-model-label>Model</span><select id="searchModel"></select></label>
+          <div class="prompt-field mode-model-field"><span data-model-label>Model</span><select id="searchModel"></select></div>
           <div class="toolbar">
             <label class="auto"><input type="checkbox" id="autoToggle" checked /> Auto</label>
             <button id="analyzeBtn" class="btn primary" type="button">Analyze paragraph</button>
@@ -139,7 +139,7 @@
           </div>
           <label class="prompt-field"><span data-prompt-label="style">Saved prompt</span><select id="promptStyle"></select></label>
           <p id="promptDescription" class="prompt-description"></p>
-          <label class="prompt-field"><span data-prompt-label="model">Model</span><select id="promptModel"></select></label>
+          <div class="prompt-field"><span data-prompt-label="model">Model</span><select id="promptModel"></select></div>
           <div class="prompt-selection-block">
             <span class="prompt-block-label">Selected text in Word</span>
             <div id="promptSelection" class="prompt-selection">Select text in Word to transform it.</div>
@@ -164,15 +164,15 @@
           </div>
         </section>
 
-        <section id="synonymControls" class="synonym-controls" hidden aria-label="Contextual synonyms">
+        <section id="synonymControls" class="synonym-controls" hidden aria-label="Contextual alternatives">
           <div class="synonym-heading">
-            <div><strong>Synonyms and rephrasings</strong><small>Select one or more words. Nodus uses the complete sentence to preserve meaning and grammar.</small></div>
+            <div><strong>Writing alternatives</strong><small>Select a word, expression, or phrase. Nodus suggests different ways to express the same meaning in context.</small></div>
             <button id="refreshSynonymSelection" class="btn tiny" type="button" title="Refresh selected text" aria-label="Refresh selected text">↻</button>
           </div>
-          <label class="prompt-field"><span data-model-label>Model</span><select id="synonymModel"></select></label>
+          <div class="prompt-field"><span data-model-label>Model</span><select id="synonymModel"></select></div>
           <div class="synonym-selection-block">
             <span class="synonym-block-label">Sentence context</span>
-            <div id="synonymContext" class="synonym-context placeholder">Select one or more words in Word.</div>
+            <div id="synonymContext" class="synonym-context placeholder">Select a word, expression, or phrase in Word.</div>
           </div>
           <button id="generateSynonyms" class="btn primary synonym-generate" type="button" disabled>
             <span id="synonymGenerateLabel">Generate 5 alternatives</span>
@@ -192,7 +192,7 @@
               <button id="chatNew" class="word-chat-icon-btn" type="button" title="New conversation" aria-label="New conversation">＋</button>
               <button id="chatHistoryButton" class="word-chat-icon-btn" type="button" title="Conversations" aria-label="Conversations">↶</button>
             </div>
-            <label class="word-chat-model"><span>Model</span><select id="chatModel"></select></label>
+            <div class="word-chat-model"><span>Model</span><select id="chatModel"></select></div>
           </div>
           <div id="chatScope" class="word-chat-scope" role="radiogroup" aria-label="Context">
             <span class="word-chat-scope-label">Context</span>
@@ -224,6 +224,7 @@
       <div id="empty" class="empty">Place the cursor in a paragraph to see related ideas.</div>
     </main>
 
+    <script src="/addin/model-picker.js"></script>
     <script src="/addin/references.js"></script>
     <script src="/addin/chat.js"></script>
     <script src="/addin/taskpane.js"></script>

--- a/word-addin/taskpane.js
+++ b/word-addin/taskpane.js
@@ -87,7 +87,7 @@
       modeIdeas: 'Ideas',
       modePassages: 'Pasajes',
       modeReferences: 'Referencias',
-      modeSynonyms: 'Sinónimos',
+      modeSynonyms: 'Alternativas',
       modePrompts: 'AI Edition',
       modeChat: 'Chat',
       selectionLabel: 'Selección',
@@ -131,12 +131,14 @@
       promptLoadError: 'No se pudieron cargar los prompts: ',
       promptNoStyles: 'No hay prompts activos en este workspace.',
       promptNoModels: 'No hay modelos configurados en Nodus.',
+      modelSearch: 'Buscar modelos',
+      modelNoMatches: 'No hay modelos que coincidan.',
       promptGeneratedWith: 'Generado con ',
       promptWarnings: 'Revisa: ',
-      synonymTitle: 'Sinónimos y reformulaciones',
-      synonymHint: 'Selecciona una o varias palabras. Nodus usa la frase completa para conservar el sentido y la gramática.',
+      synonymTitle: 'Alternativas de redacción',
+      synonymHint: 'Selecciona una palabra, expresión o frase. Nodus propone distintas formas de expresar lo mismo respetando el contexto.',
       synonymContextLabel: 'Contexto de la frase',
-      synonymSelectionEmpty: 'Selecciona una o varias palabras en Word.',
+      synonymSelectionEmpty: 'Selecciona una palabra, expresión o frase en Word.',
       synonymRefresh: 'Actualizar selección',
       synonymGenerate: 'Generar 5 alternativas',
       synonymRegenerate: 'Regenerar alternativas',
@@ -195,7 +197,7 @@
       modeIdeas: 'Ideas',
       modePassages: 'Passages',
       modeReferences: 'References',
-      modeSynonyms: 'Synonyms',
+      modeSynonyms: 'Alternatives',
       modePrompts: 'AI Edition',
       modeChat: 'Chat',
       selectionLabel: 'Selection',
@@ -239,12 +241,14 @@
       promptLoadError: 'Could not load prompts: ',
       promptNoStyles: 'There are no active prompts in this workspace.',
       promptNoModels: 'There are no models configured in Nodus.',
+      modelSearch: 'Search models',
+      modelNoMatches: 'No matching models.',
       promptGeneratedWith: 'Generated with ',
       promptWarnings: 'Review: ',
-      synonymTitle: 'Synonyms and rephrasings',
-      synonymHint: 'Select one or more words. Nodus uses the complete sentence to preserve meaning and grammar.',
+      synonymTitle: 'Writing alternatives',
+      synonymHint: 'Select a word, expression, or phrase. Nodus suggests different ways to express the same meaning in context.',
       synonymContextLabel: 'Sentence context',
-      synonymSelectionEmpty: 'Select one or more words in Word.',
+      synonymSelectionEmpty: 'Select a word, expression, or phrase in Word.',
       synonymRefresh: 'Refresh selection',
       synonymGenerate: 'Generate 5 alternatives',
       synonymRegenerate: 'Regenerate alternatives',
@@ -1256,6 +1260,7 @@
         noModel.textContent = T('promptNoModels');
         select.appendChild(noModel);
         select.disabled = true;
+        if (window.NodusModelPicker) window.NodusModelPicker.refresh(select);
         return;
       }
       select.disabled = false;
@@ -1269,6 +1274,7 @@
         ? previousModel
         : promptModelValue(data.defaultModel);
       if (wantedModel) select.value = wantedModel;
+      if (window.NodusModelPicker) window.NodusModelPicker.refresh(select);
     }
     [els.promptModel, els.searchModel, els.synonymModel].forEach(fillModelSelect);
     renderPromptDescription();
@@ -1631,9 +1637,9 @@
       return;
     }
     if (synonymMode) {
-      refreshSynonymSelection().then(function (context) {
-        if (context && selectedModelFrom(els.synonymModel) && !synonymRequestContext && !synonymGenerating) generateSynonymRound();
-      });
+      // Reading and showing the selection is free. Alternatives are generated
+      // only after the user explicitly presses the button.
+      refreshSynonymSelection();
       startPromptSelectionPolling();
       return;
     }
@@ -1752,6 +1758,16 @@
     els.synonymRounds = document.getElementById('synonymRounds');
     els.synonymTab = document.querySelector('.seg[data-mode="synonyms"]');
     els.chatControls = document.getElementById('chatControls');
+
+    if (window.NodusModelPicker) {
+      [els.searchModel, els.promptModel, els.synonymModel].forEach(function (select) {
+        window.NodusModelPicker.enhance(select, {
+          searchPlaceholder: T('modelSearch'),
+          showOptionsLabel: T('modelSearch'),
+          noResults: T('modelNoMatches'),
+        });
+      });
+    }
 
     document.documentElement.lang = LANG;
     els.status.textContent = T('connecting');


### PR DESCRIPTION
## Summary

- add a shared searchable, keyboard-accessible model picker to Ideas/Passages, AI Edition, Alternatives, and Chat in the Word add-in
- rename the contextual synonyms surface to Alternatives and broaden the prompt to support words, expressions, and complete phrases
- stop generation from running automatically when the Alternatives tab opens
- align Word alternatives with AI Edition by validating and using the explicitly selected model directly
- add regression coverage for model selection, explicit generation, prompt behavior, and operation while Study AI is disabled

## Validation

- `npm run typecheck`
- `npx eslint electron/ai/studySynonyms.ts electron/copilot/server.ts`
- `node scripts/test-copilot-addin.mjs`
- `node scripts/test-study-improve.mjs`
- `node --test scripts/test-study-improve-ui.mjs`
- headless Chrome interaction check for filtering, Enter selection, change propagation, and no-results state
- `git diff --check`

Closes #629