### PR TITLE
Release v5.1.2

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Build smoke-test image
-        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.1 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
+        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.2 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
 
       - name: Run image health smoke test
         shell: bash
@@ -114,7 +114,7 @@ jobs:
           scripts/test-server-vectors.mjs
 
       - name: Build smoke-test image
-        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.1 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
+        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.2 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
 
       - name: Run image health smoke test
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## 5.1.2 — 2026-08-31
+
+Nodus 5.1.2 improves Word model selection and fixes local analysis, Zotero
+titles, summary diagnostics and the first-vault password flow.
+
+- Replaced Synonyms with explicit, phrase-aware Alternatives in the Word add-in,
+  stopped automatic generation on tab entry and added one searchable,
+  keyboard-accessible model picker across all five Copilot tasks.
+- Let local embedding models process inputs beyond the previous 512-token
+  physical batch limit while remaining inside the configured context window.
+- Preserved completed summaries when optional provenance or embedding work
+  fails, and persisted actionable errors when summary generation itself fails.
+- Rendered Zotero rich-text titles as clean text throughout the interface while
+  retaining their original markup for stable change detection.
+- Unified the master-password policy across first-vault setup, Settings, IPC and
+  recovery creation, with immediate translated feedback for short or mismatched
+  passwords.
+- Kept every 5.1.1 entry in the What's New modal and added these corrections in
+  all eight interface languages.
+
 ## 5.1.1 — 2026-08-31
 
 Nodus 5.1.1 is a Zotero hotfix that keeps the header refresh limited to the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "5.1.1"
+version: "5.1.2"
 date-released: "2026-08-31"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://nodusresearch.com/"
-# Zenodo assigns the immutable v5.1.1 DOI after the GitHub release is archived.
+# Zenodo assigns the immutable v5.1.2 DOI after the GitHub release is archived.
 # Until then the concept DOI is 10.5281/zenodo.21515531 for Nodus over time.
 doi: "10.5281/zenodo.21515531"
 keywords:

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.1.1 is licensed exclusively under the GNU Affero General Public
+Nodus 5.1.2 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.1.1 release is available
+The preferred form for modifying the official Nodus 5.1.2 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.1
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.1
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.2
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.2
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.2.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.2.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.1.1 is free software distributed exclusively under the GNU Affero
+Nodus 5.1.2 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": {
     "name": "Jorge Pérez Burgueño",

--- a/scripts/e2e-browser-connector.mjs
+++ b/scripts/e2e-browser-connector.mjs
@@ -138,7 +138,7 @@ async function exerciseMultiCapture() {
       scripting: { executeScript: async () => [{ result: nextSnapshot }] },
       storage: { local: { get: async (defaults) => ({ ...defaults, ...values }), set: async (input) => Object.assign(values, input), remove: async (keys) => { for (const key of keys) delete values[key]; } } },
       permissions: { request: async () => true, contains: async () => false, remove: async () => true },
-      runtime: { getManifest: () => ({ version: '5.1.1' }), getURL: (path = '') => `chrome-extension://ilcclajjhofhieoljdjmikmfopfbamej/${path}`, openOptionsPage: async () => undefined },
+      runtime: { getManifest: () => ({ version: '5.1.2' }), getURL: (path = '') => `chrome-extension://ilcclajjhofhieoljdjmikmfopfbamej/${path}`, openOptionsPage: async () => undefined },
     };
   }, { messages: english, snapshot: detected });
   let saves = 0;

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '5.1.1';
+const VERSION = '5.1.2';
 
 test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 5.1.1 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 5.1.2 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -76,7 +76,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '5.1.1');
+      assert.equal(info.version, '5.1.2');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -24,14 +24,15 @@ try {
   );
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
-  // 5.1.1 preserves the complete 5.1.0 announcement and adds the catalog-only
-  // Zotero header refresh hotfix in every interface language.
+  // 5.1.2 preserves the complete 5.1.1 announcement and adds every repair
+  // merged afterwards in all eight interface languages.
   const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '5.1.1');
+  assert.equal(currentRelease?.version, '5.1.2');
   assert.equal(currentRelease?.date, '2026-08-31');
-  assert.equal(currentRelease?.highlights.length, 9);
+  assert.equal(currentRelease?.highlights.length, 13);
   assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), [
     'ai', 'ai', 'zotero', 'server', 'library', 'databases', 'word', 'connector', 'zotero',
+    'word', 'ai', 'zotero', 'general',
   ]);
   for (const phrase of [
     /more than twice as fast/,
@@ -44,12 +45,22 @@ try {
     /Nodus Research Connector/,
     /without starting or queuing analysis/,
     /entire library appear to have changed at once/,
+    /replaces Synonyms with Alternatives/,
+    /without failing above 512 tokens/,
+    /saves and shows the reason/,
+    /appear as clean text/,
+    /at least eight characters/,
   ]) assert.ok(currentRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
+
+  const previousPatchRelease = RELEASE_NOTES.find((note) => note.version === '5.1.1');
+  assert.equal(previousPatchRelease?.date, '2026-08-31');
+  assert.equal(previousPatchRelease?.highlights.length, 9);
+  assert.deepEqual(currentRelease?.highlights.slice(0, 9), previousPatchRelease?.highlights);
 
   const minorRelease = RELEASE_NOTES.find((note) => note.version === '5.1.0');
   assert.equal(minorRelease?.date, '2026-08-30');
   assert.equal(minorRelease?.highlights.length, 8);
-  assert.deepEqual(currentRelease?.highlights.slice(0, 8), minorRelease?.highlights);
+  assert.deepEqual(previousPatchRelease?.highlights.slice(0, 8), minorRelease?.highlights);
 
   // 5.0.6 remains intact beneath the new hotfix and minor release.
   const previousStableRelease = RELEASE_NOTES.find((note) => note.version === '5.0.6');
@@ -91,9 +102,9 @@ try {
   assert.equal(compassRelease?.highlights.length, 6);
 
   // 5.0.1 keeps the seven repair highlights it shipped with underneath 5.0.4.
-  const previousPatchRelease = RELEASE_NOTES.find((note) => note.version === '5.0.1');
-  assert.equal(previousPatchRelease?.date, '2026-08-25');
-  assert.equal(previousPatchRelease?.highlights.length, 7);
+  const previousMajorPatchRelease = RELEASE_NOTES.find((note) => note.version === '5.0.1');
+  assert.equal(previousMajorPatchRelease?.date, '2026-08-25');
+  assert.equal(previousMajorPatchRelease?.highlights.length, 7);
 
   // 5.0.0 keeps the eight highlights it shipped with underneath this repair release.
   const majorRelease = RELEASE_NOTES.find((note) => note.version === '5.0.0');

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '5.1.1');
+  assert.equal(pluginManifest.version, '5.1.2');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,9 +54,9 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '5\.1\.1'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '5\.1\.2'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.1\.1\.tar\.gz/);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.1\.2\.tar\.gz/);
   assert.match(citation, /^date-released: "2026-08-31"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1563,9 +1563,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '5.1.1', 'the add-on shares the Nodus 5 release version');
+  assert.equal(manifest.version, '5.1.2', 'the add-on shares the Nodus 5 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.1\.1/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.1\.2/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -15,13 +15,13 @@ RUN npm run build:server-web
 
 FROM node:22-alpine
 
-ARG NODUS_VERSION=5.1.1
+ARG NODUS_VERSION=5.1.2
 ARG NODUS_REVISION=unknown
 LABEL org.opencontainers.image.title="Nodus Server" \
       org.opencontainers.image.description="Experimental self-hosted Nodus MCP server" \
       org.opencontainers.image.source="https://github.com/Drakonis96/nodus" \
       org.opencontainers.image.url="https://github.com/Drakonis96/nodus" \
-      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v5.1.1/server/README.md" \
+      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v5.1.2/server/README.md" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.version="${NODUS_VERSION}" \
       org.opencontainers.image.revision="${NODUS_REVISION}" \
@@ -45,7 +45,7 @@ COPY --from=web-build /src/server/dist/web ./dist/web
 ENV NODUS_DATA_DIR=/data \
     NODUS_HOST=0.0.0.0 \
     NODUS_PORT=7443 \
-    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v5.1.1
+    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v5.1.2
 
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.1.1 is licensed exclusively under the GNU Affero General Public
+Nodus 5.1.2 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.1.1 release is available
+The preferred form for modifying the official Nodus 5.1.2 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.1
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.1
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.1.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.2
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.2
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.2.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.2.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.1.1 is free software distributed exclusively under the GNU Affero
+Nodus 5.1.2 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -36,7 +36,7 @@ services:
       # With the pair, the account is created on first boot and its password is rotated
       # whenever you change the value here.
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.2}
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       # Optional ceilings. Unset they default to 8 MiB per image, 2 GiB of images per

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -26,7 +26,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.2}
       # Optional ceilings. Left unset they default to 8 MiB per image, 2 GiB of images per
       # space, and the snapshot limits documented in the README.
       NODUS_MAX_ASSET_BYTES: ${NODUS_MAX_ASSET_BYTES:-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.2}
     volumes:
       - nodus_data:/data
       # Mount a versioned 0600 keyring outside /data and set NODUS_AI_KEYRING_FILE to

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '5.1.1';
+export const NODUS_VERSION = '5.1.2';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/server/portainer-stack.yml
+++ b/server/portainer-stack.yml
@@ -16,7 +16,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.1}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.2}
     volumes:
       - nodus_data:/data
     expose:

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -166,6 +166,14 @@ const RELEASE_5_1_0_IT = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "5.1.2": [
+    ...RELEASE_5_1_0_IT,
+    "Il pulsante Aggiorna nell’intestazione ora aggiorna soltanto il catalogo delle collezioni Zotero monitorate. I nuovi elementi compaiono nella Libreria senza avviare né accodare analisi. Questa versione gestisce anche il valore zero restituito da Zotero 10, che poteva far apparire modificata tutta la libreria in una sola volta.",
+    "Nodus Copilot per Word sostituisce Sinonimi con Alternative per lavorare anche con espressioni e frasi complete. La scheda attende che tu prema Genera e rispetta il modello scelto. Idee, Passaggi, Modifica con IA, Alternative e Chat condividono ora un selettore di modelli ricercabile e controllabile da tastiera.",
+    "I modelli locali possono ora creare embedding di passaggi lunghi entro il proprio limite di contesto senza fallire oltre 512 token. I riassunti completati restano disponibili se un’attività facoltativa successiva fallisce. Quando fallisce il riassunto stesso, Nodus salva e mostra il motivo per permetterti di correggerlo e riprovare.",
+    "I titoli Zotero con corsivo, apici, pedici o altra formattazione avanzata appaiono ora come testo pulito nella Libreria, nella ricerca e nei messaggi di avanzamento. Nodus conserva il markup originale quando verifica le modifiche reali, così un titolo formattato non destabilizza più la sincronizzazione.",
+    "Il primo deposito e le Impostazioni spiegano ora la stessa regola per la password principale. Deve contenere almeno otto caratteri e può essere una passphrase lunga senza numeri o simboli obbligatori. La convalida segnala subito una conferma troppo corta o diversa, e la stessa regola viene applicata quando si crea la copia protetta.",
+  ],
   "5.1.1": [
     ...RELEASE_5_1_0_IT,
     "Il pulsante Aggiorna nell’intestazione ora aggiorna soltanto il catalogo delle collezioni Zotero monitorate. I nuovi elementi compaiono nella Libreria senza avviare né accodare analisi. Questa versione gestisce anche il valore zero restituito da Zotero 10, che poteva far apparire modificata tutta la libreria in una sola volta.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -106,6 +106,14 @@ const RELEASE_5_1_0_TR = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "5.1.2": [
+    ...RELEASE_5_1_0_TR,
+    "Başlıktaki Güncelle düğmesi artık yalnızca izlediğiniz Zotero koleksiyonlarının kataloğunu yeniliyor. Yeni öğeler analiz başlatılmadan veya kuyruğa eklenmeden Kitaplıkta görünüyor. Bu sürüm ayrıca Zotero 10’un döndürdüğü sıfır öğe sürümünü düzeltiyor. Bu değer daha önce tüm kitaplığı bir anda değişmiş gibi gösterebiliyordu.",
+    "Word için Nodus Copilot, ifadeler ve tam cümlelerle de çalışabilmek için Eş Anlamlılar özelliğini Alternatifler olarak değiştiriyor. Sekme siz Oluştur düğmesine basana kadar bekliyor ve seçtiğiniz modeli kullanıyor. Fikirler, Pasajlar, Yapay Zeka ile Düzenleme, Alternatifler ve Sohbet artık aranabilen ve klavyeyle kullanılabilen ortak bir model seçiciye sahip.",
+    "Yerel modeller artık bağlam sınırları içindeki uzun pasajların embeddinglerini 512 token üzerinde hata vermeden oluşturabiliyor. Tamamlanmış özetler, isteğe bağlı sonraki bir görev başarısız olsa bile kullanılabilir kalıyor. Özetin kendisi başarısız olduğunda Nodus nedeni kaydedip gösteriyor, böylece sorunu düzeltip yeniden deneyebiliyorsunuz.",
+    "İtalik, üst simge, alt simge veya başka zengin biçimlendirme içeren Zotero başlıkları artık Kitaplıkta, aramada ve ilerleme iletilerinde temiz metin olarak görünüyor. Nodus gerçek değişiklikleri denetlerken özgün işaretlemeyi koruyor, böylece biçimlendirilmiş bir başlık eşitlemeyi artık kararsız hâle getirmiyor.",
+    "İlk kasa ve Ayarlar artık ana parola için aynı kuralı açıklıyor. Parola en az sekiz karakter içermeli ve zorunlu sayı ya da simge olmadan uzun bir parola ifadesi olabilir. Doğrulama kısa veya eşleşmeyen onayı hemen gösteriyor ve korumalı kopya oluşturulurken de aynı kural uygulanıyor.",
+  ],
   "5.1.1": [
     ...RELEASE_5_1_0_TR,
     "Başlıktaki Güncelle düğmesi artık yalnızca izlediğiniz Zotero koleksiyonlarının kataloğunu yeniliyor. Yeni öğeler analiz başlatılmadan veya kuyruğa eklenmeden Kitaplıkta görünüyor. Bu sürüm ayrıca Zotero 10’un döndürdüğü sıfır öğe sürümünü düzeltiyor. Bu değer daha önce tüm kitaplığı bir anda değişmiş gibi gösterebiliyordu.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -1877,6 +1877,51 @@ const RELEASE_5_1_1_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 /**
+ * v5.1.2 keeps the complete v5.1.1 announcement and appends the fixes merged
+ * afterwards. The patch remains self-contained for anyone updating from an
+ * earlier 5.1 release.
+ */
+const RELEASE_5_1_2_HIGHLIGHTS: RawReleaseHighlight[] = [
+  ...RELEASE_5_1_1_HIGHLIGHTS,
+  {
+    scope: 'word',
+    es: 'Nodus Copilot para Word cambia Sinónimos por Alternativas para trabajar también con expresiones y frases completas. La pestaña espera a que pulses Generar y respeta el modelo elegido. Ideas, Pasajes, Edición con IA, Alternativas y Chat comparten ahora un selector de modelos con búsqueda y control por teclado.',
+    en: 'Nodus Copilot for Word replaces Synonyms with Alternatives so it can also work with expressions and complete phrases. The tab waits for you to press Generate and respects the model you choose. Ideas, Passages, AI Edit, Alternatives, and Chat now share a searchable model picker with keyboard control.',
+    fr: 'Nodus Copilot pour Word remplace Synonymes par Alternatives afin de traiter aussi les expressions et les phrases complètes. L’onglet attend que vous appuyiez sur Générer et respecte le modèle choisi. Idées, Passages, Édition par IA, Alternatives et Chat partagent désormais un sélecteur de modèles avec recherche et contrôle au clavier.',
+    de: 'Nodus Copilot für Word ersetzt Synonyme durch Alternativen, damit auch Ausdrücke und vollständige Sätze bearbeitet werden können. Die Registerkarte wartet auf einen Klick auf Erzeugen und verwendet das gewählte Modell. Ideen, Passagen, KI-Bearbeitung, Alternativen und Chat teilen sich jetzt eine durchsuchbare Modellauswahl mit Tastatursteuerung.',
+    pt: 'O Nodus Copilot para Word substitui Sinónimos por Alternativas para trabalhar também com expressões e frases completas. O separador espera que carregue em Gerar e respeita o modelo escolhido. Ideias, Passagens, Edição com IA, Alternativas e Chat partilham agora um seletor de modelos com pesquisa e controlo por teclado.',
+    'pt-BR': 'O Nodus Copilot para Word substitui Sinônimos por Alternativas para trabalhar também com expressões e frases completas. A aba espera você clicar em Gerar e respeita o modelo escolhido. Ideias, Passagens, Edição com IA, Alternativas e Chat agora compartilham um seletor de modelos com busca e controle pelo teclado.',
+  },
+  {
+    scope: 'ai',
+    es: 'Los modelos locales ya pueden vectorizar pasajes largos dentro de su límite de contexto sin fallar al superar 512 tokens. Los resúmenes terminados siguen disponibles si falla una tarea opcional posterior. Cuando el propio resumen falla, Nodus guarda y muestra el motivo para que puedas corregirlo y reintentar.',
+    en: 'Local models can now embed long passages within their context limit without failing above 512 tokens. Completed summaries remain available if an optional follow-up task fails. When the summary itself fails, Nodus saves and shows the reason so you can correct it and try again.',
+    fr: 'Les modèles locaux peuvent désormais vectoriser de longs passages dans leur limite de contexte sans échouer au-delà de 512 jetons. Les résumés terminés restent disponibles si une tâche facultative ultérieure échoue. Lorsque le résumé lui-même échoue, Nodus enregistre et affiche la raison afin de pouvoir la corriger et réessayer.',
+    de: 'Lokale Modelle können jetzt lange Passagen innerhalb ihres Kontextlimits einbetten, ohne oberhalb von 512 Token fehlzuschlagen. Fertige Zusammenfassungen bleiben verfügbar, wenn eine optionale Folgeaufgabe scheitert. Schlägt die Zusammenfassung selbst fehl, speichert und zeigt Nodus den Grund, damit Sie ihn beheben und es erneut versuchen können.',
+    pt: 'Os modelos locais já podem criar embeddings de passagens longas dentro do respetivo limite de contexto sem falhar acima de 512 tokens. Os resumos concluídos continuam disponíveis se uma tarefa opcional posterior falhar. Quando o próprio resumo falha, o Nodus guarda e mostra o motivo para que possa corrigi-lo e tentar novamente.',
+    'pt-BR': 'Os modelos locais agora podem criar embeddings de passagens longas dentro do limite de contexto sem falhar acima de 512 tokens. Os resumos concluídos continuam disponíveis se uma tarefa opcional posterior falhar. Quando o próprio resumo falha, o Nodus salva e mostra o motivo para você corrigi-lo e tentar novamente.',
+  },
+  {
+    scope: 'zotero',
+    es: 'Los títulos de Zotero con cursivas, superíndices, subíndices u otro formato enriquecido vuelven a mostrarse como texto limpio en la Biblioteca, la búsqueda y los mensajes de progreso. Nodus conserva el marcado original para reconocer cambios reales y evita que un título formateado desestabilice la sincronización.',
+    en: 'Zotero titles with italics, superscripts, subscripts, or other rich formatting now appear as clean text in the Library, search, and progress messages. Nodus preserves the original markup when checking for real changes so a formatted title no longer destabilizes synchronization.',
+    fr: 'Les titres Zotero contenant de l’italique, des exposants, des indices ou d’autres mises en forme enrichies s’affichent désormais comme du texte propre dans la Bibliothèque, la recherche et les messages de progression. Nodus conserve le balisage d’origine pour détecter les changements réels et empêcher un titre formaté de déstabiliser la synchronisation.',
+    de: 'Zotero-Titel mit Kursivschrift, Hochstellung, Tiefstellung oder anderer Rich-Text-Formatierung erscheinen jetzt als sauberer Text in Bibliothek, Suche und Fortschrittsmeldungen. Nodus bewahrt die ursprüngliche Auszeichnung zur Erkennung echter Änderungen, damit ein formatierter Titel die Synchronisierung nicht mehr destabilisiert.',
+    pt: 'Os títulos do Zotero com itálico, sobrescrito, subscrito ou outra formatação enriquecida passam a aparecer como texto limpo na Biblioteca, na pesquisa e nas mensagens de progresso. O Nodus conserva a marcação original ao verificar alterações reais para que um título formatado deixe de desestabilizar a sincronização.',
+    'pt-BR': 'Os títulos do Zotero com itálico, sobrescrito, subscrito ou outra formatação enriquecida agora aparecem como texto limpo na Biblioteca, na busca e nas mensagens de progresso. O Nodus preserva a marcação original ao verificar mudanças reais para que um título formatado não desestabilize mais a sincronização.',
+  },
+  {
+    scope: 'general',
+    es: 'La primera bóveda y los Ajustes explican ahora la misma regla para la contraseña maestra. Debe tener al menos ocho caracteres y puede ser una frase larga sin números ni símbolos obligatorios. La validación señala enseguida si falta longitud o si la confirmación no coincide, y la misma regla se aplica al crear la copia protegida.',
+    en: 'Your first vault and Settings now explain the same master-password rule. It must contain at least eight characters and can be a long passphrase without mandatory numbers or symbols. Validation immediately identifies a short or mismatched confirmation, and the same rule is enforced when the protected copy is created.',
+    fr: 'Le premier coffre et les Paramètres expliquent désormais la même règle pour le mot de passe principal. Il doit comporter au moins huit caractères et peut être une longue phrase sans chiffres ni symboles obligatoires. La validation signale immédiatement une longueur insuffisante ou une confirmation différente, et la même règle est appliquée lors de la création de la copie protégée.',
+    de: 'Der erste Tresor und die Einstellungen erklären jetzt dieselbe Regel für das Masterpasswort. Es muss mindestens acht Zeichen enthalten und darf eine lange Passphrase ohne vorgeschriebene Zahlen oder Symbole sein. Die Prüfung zeigt eine zu kurze oder abweichende Bestätigung sofort an, und beim Erstellen der geschützten Kopie gilt dieselbe Regel.',
+    pt: 'O primeiro cofre e as Definições passam a explicar a mesma regra para a palavra-passe mestra. Deve ter pelo menos oito caracteres e pode ser uma frase longa sem números nem símbolos obrigatórios. A validação identifica de imediato uma confirmação curta ou diferente, e a mesma regra é aplicada ao criar a cópia protegida.',
+    'pt-BR': 'O primeiro cofre e as Configurações agora explicam a mesma regra para a senha mestra. Ela deve ter pelo menos oito caracteres e pode ser uma frase longa sem números nem símbolos obrigatórios. A validação identifica imediatamente uma confirmação curta ou diferente, e a mesma regra é aplicada ao criar a cópia protegida.',
+  },
+];
+
+/**
  * v5.0.6 — every user-visible change merged after v5.0.5, excluding the
  * independent server-web parity branch. Keep this list aligned by index with
  * the Italian and Turkish tables so all eight interface languages receive the
@@ -2331,6 +2376,11 @@ const RELEASE_5_0_0_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '5.1.2',
+    date: '2026-08-31',
+    highlights: RELEASE_5_1_2_HIGHLIGHTS,
+  },
   {
     version: '5.1.1',
     date: '2026-08-31',

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.1",
+      "softwareVersion": "5.1.2",
       "datePublished": "2026-08-31",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.1",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.2",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -103,7 +103,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.1"
+          "value": "v5.1.2"
         }
       ],
       "sameAs": [

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -87,9 +87,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.1",
+      "softwareVersion": "5.1.2",
       "datePublished": "2026-08-31",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.1",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.2",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -104,7 +104,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.1"
+          "value": "v5.1.2"
         }
       ],
       "sameAs": [
@@ -170,9 +170,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 <dl class="citation-meta reveal">
       <div><dt>Project</dt><dd>Nodus Research</dd></div>
       <div><dt>Software</dt><dd>Nodus</dd></div>
-      <div><dt>Version</dt><dd>5.1.1</dd></div>
+      <div><dt>Version</dt><dd>5.1.2</dd></div>
       <div><dt>Released</dt><dd>31 August 2026</dd></div>
-      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.1" target="_blank" rel="noopener">v5.1.1</a></dd></div>
+      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.2" target="_blank" rel="noopener">v5.1.2</a></dd></div>
       <div><dt>Author</dt><dd><a href="https://orcid.org/0000-0002-1150-1930" target="_blank" rel="noopener">Jorge Pérez Burgueño · ORCID</a></dd></div>
       <div><dt>Licence</dt><dd><a href="https://spdx.org/licenses/AGPL-3.0-only.html" target="_blank" rel="noopener">AGPL-3.0-only</a></dd></div>
     </dl>
@@ -197,10 +197,10 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a class="doi-value" href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">10.5281/zenodo.21515531</a>
       </article>
       <article class="card lit doi-card reveal" style="--delay:80ms">
-        <span class="kicker">Nodus 5.1.1 · archive pending</span>
+        <span class="kicker">Nodus 5.1.2 · archive pending</span>
         <h3>Version DOI pending</h3>
-        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.1.1 release tag shown here.</p>
-        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.1" target="_blank" rel="noopener">v5.1.1</a>
+        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.1.2 release tag shown here.</p>
+        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.2" target="_blank" rel="noopener">v5.1.2</a>
       </article>
     </div>
 <!-- generated:citation-dois:end -->
@@ -218,7 +218,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- generated:citation-formats:start -->
 <div class="citation-block reveal">
       <h3>APA</h3>
-      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.1.1) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
+      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.1.2) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
     </div>
 
     <div class="citation-block reveal">
@@ -226,11 +226,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       <pre><code>@software{perez_burgueno_nodus_2026,
   author    = {Pérez Burgueño, Jorge and Nodus contributors},
   title     = {Nodus: Open-Source Research Workspace},
-  version   = {5.1.1},
+  version   = {5.1.2},
   year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.21515531},
-  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.1.1},
+  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.1.2},
   license   = {AGPL-3.0-only}
 }</code></pre>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -97,9 +97,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.1",
+      "softwareVersion": "5.1.2",
       "datePublished": "2026-08-31",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.1",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.2",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -114,7 +114,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.1"
+          "value": "v5.1.2"
         }
       ],
       "sameAs": [

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
## Summary

- release Nodus 5.1.2 with the Word, local-analysis, Zotero-title, summary-diagnostics, and first-vault password fixes merged after 5.1.1
- keep every v5.1.1 What's New highlight and append four user-facing groups in all eight interface languages
- synchronize Desktop, Server, browser connector, Zotero plugin, source-offer, citation, website, and container metadata

## Verification

- `npm run lint`
- `npm run build`
- `npm run build:server-web`
- `npm test` (2,695 passed, 0 failed, 1 skipped)
- `npm run test:e2e`
- `npm run citation:check`
- `npm run release:verify-source`
- `node scripts/verify-release-channel.mjs latest v5.1.2`
- release-notes, i18n coverage, Zotero, AGPL, Server deployment, version agreement, and release-readiness contract tests
