### PR TITLE
fix(zotero): release semantic retrieval memory

### DIFF
--- a/scripts/test-zotero-memory-lifecycle.mjs
+++ b/scripts/test-zotero-memory-lifecycle.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readSource = (relativePath) => readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+function loadContentScript(relativePath, extraGlobals = {}) {
+  const sandbox = {
+    window: {},
+    Zotero: { logError() {} },
+    ChromeUtils: { importESModule: () => ({ Zotero: { logError() {} } }) },
+    console,
+    ...extraGlobals,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(readSource(relativePath), sandbox, { filename: relativePath });
+  return sandbox.window;
+}
+
+test('evidence cache compaction removes coordinate-heavy duplicate maps', () => {
+  const { NodusStore: store } = loadContentScript('zotero-plugin/content/store.js');
+  const index = {
+    pages: [{ text: 'alpha', rawText: 'alpha', spans: [{ start: 0, end: 5, rect: [1, 2, 3, 4], text: 'alpha' }] }],
+    chunks: [{ text: 'alpha', positions: [{ start: 0, end: 5, rect: [1, 2, 3, 4], text: 'alpha' }] }],
+  };
+
+  assert.equal(store.compactEvidenceIndex(index), true);
+  assert.equal(index.pages[0].rawText, undefined);
+  assert.equal(index.pages[0].spans, undefined);
+  assert.equal(index.chunks[0].positions, undefined);
+  assert.equal(index.pages[0].text, 'alpha');
+  assert.equal(store.compactEvidenceIndex(index), false);
+});
+
+test('embedding worker terminates after idle and on sidebar unload', async () => {
+  const workers = [];
+  const timers = new Map();
+  let nextTimer = 0;
+  let unload = null;
+
+  class FakeWorker {
+    constructor() { this.listeners = {}; this.terminated = false; workers.push(this); }
+    addEventListener(type, listener) { this.listeners[type] = listener; }
+    postMessage(message) { this.message = message; }
+    terminate() { this.terminated = true; }
+    reply(result) { this.listeners.message({ data: { type: 'result', id: this.message.id, result } }); }
+  }
+
+  const fakeWindow = {
+    addEventListener(type, listener) { if (type === 'unload') unload = listener; },
+  };
+  const { NodusLocalEmbeddings: embeddings } = loadContentScript('zotero-plugin/content/local-embeddings.js', {
+    window: fakeWindow,
+    ChromeWorker: FakeWorker,
+    DOMException,
+    setTimeout(listener, ms) { const id = ++nextTimer; timers.set(id, { listener, ms }); return id; },
+    clearTimeout(id) { timers.delete(id); },
+  });
+
+  const completed = embeddings.embedPassages(['alpha']);
+  workers[0].reply([[0.1, 0.2]]);
+  await completed;
+  const idle = [...timers.values()].find((timer) => timer.ms === 5 * 60 * 1000);
+  assert.ok(idle);
+  idle.listener();
+  assert.equal(workers[0].terminated, true);
+
+  const pending = embeddings.warmup();
+  unload();
+  await assert.rejects(pending, /local-embedding-reset/);
+  assert.equal(workers[1].terminated, true);
+});
+
+test('library identity sync does not load every full index a second time', () => {
+  const sidebar = readSource('zotero-plugin/content/sidebar.js');
+  const start = sidebar.indexOf('async function syncLibraryIdentityBeforeSend()');
+  const end = sidebar.indexOf('\nfunction availableContextTokens()', start);
+  const body = sidebar.slice(start, end);
+  assert.ok(body.includes('NS.listEvidenceRecords'));
+  assert.ok(!body.includes('buildSelectedIndexes'));
+});
+
+test('sidebar and bootstrap release long-lived resources on unload', () => {
+  const sidebar = readSource('zotero-plugin/content/sidebar.js');
+  const bootstrap = readSource('zotero-plugin/bootstrap.js');
+  assert.match(sidebar, /if \(NL && NL\.reset\) NL\.reset\(\)/);
+  assert.match(sidebar, /NS\.closeEvidenceDb\(\)/);
+  assert.match(sidebar, /clearTimeout\(refreshTimer\)/);
+  assert.match(bootstrap, /_popupMods = null/);
+});

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -518,6 +518,20 @@ test('store: evidence cache separates compressed metadata from Float32 vectors',
   assert.ok(Math.abs(restored.chunks[2].embedding[2] + 1) < 1e-6);
 });
 
+test('store: evidence cache drops unused duplicate layout maps', () => {
+  const { NodusStore: S } = loadModule('store.js');
+  const index = {
+    pages: [{ text: 'alpha', rawText: 'alpha', spans: [{ start: 0, end: 5, rect: [1, 2, 3, 4], text: 'alpha' }] }],
+    chunks: [{ text: 'alpha', positions: [{ start: 0, end: 5, rect: [1, 2, 3, 4], text: 'alpha' }] }],
+  };
+  assert.equal(S.compactEvidenceIndex(index), true);
+  assert.equal(index.pages[0].rawText, undefined);
+  assert.equal(index.pages[0].spans, undefined);
+  assert.equal(index.chunks[0].positions, undefined);
+  assert.equal(index.pages[0].text, 'alpha', 'retrieval text remains intact');
+  assert.equal(S.compactEvidenceIndex(index), false, 'migration is idempotent');
+});
+
 test('evidence: layout extraction removes repeated margins, orders columns and retains exact coordinates', () => {
   const { NodusEvidence: E } = loadModule('evidence.js');
   const item = (str, x, y, width = 90) => ({ str, x, y, width, height: 10 });
@@ -1251,9 +1265,59 @@ test('local retrieval: E5 is pinned, isolated in a worker and requires no embedd
   assert.match(worker, /env\.useCustomCache = true/);
   assert.ok(worker.includes('createIndexedDbCache') && worker.includes("indexedDB.open(CACHE_DB, 1)"));
   assert.ok(bridge.includes('ChromeWorker') && bridge.includes('embedQueries'));
+  assert.ok(bridge.includes('IDLE_TERMINATE_MS') && bridge.includes('scheduleIdleTermination'));
+  assert.match(bridge, /addEventListener\("unload", reset/);
   assert.ok(sidebar.includes('NL.embedPassages') && sidebar.includes('NL.embedQuery'));
   assert.ok(!sidebar.includes('NP.embed('), 'retrieval no longer calls a provider embedding API');
   assert.ok(!html.includes('nd-embedding-model'), 'embedding configuration was removed');
+});
+
+test('local retrieval: completed workers terminate when idle and pending work terminates on unload', async () => {
+  const workers = [];
+  const timers = new Map();
+  let nextTimer = 0;
+  let unload = null;
+  class FakeWorker {
+    constructor() { this.listeners = {}; this.terminated = false; workers.push(this); }
+    addEventListener(type, listener) { this.listeners[type] = listener; }
+    postMessage(message) { this.message = message; }
+    terminate() { this.terminated = true; }
+    reply(result) { this.listeners.message({ data: { type: 'result', id: this.message.id, result } }); }
+  }
+  const fakeWindow = {
+    addEventListener(type, listener) { if (type === 'unload') unload = listener; },
+  };
+  const { NodusLocalEmbeddings: embeddings } = loadModule('local-embeddings.js', {
+    window: fakeWindow,
+    ChromeWorker: FakeWorker,
+    DOMException,
+    setTimeout(listener, ms) { const id = ++nextTimer; timers.set(id, { listener, ms }); return id; },
+    clearTimeout(id) { timers.delete(id); },
+  });
+
+  const completed = embeddings.embedPassages(['alpha']);
+  workers[0].reply([[0.1, 0.2]]);
+  await completed;
+  const idle = [...timers.values()].find((timer) => timer.ms === 5 * 60 * 1000);
+  assert.ok(idle, 'the heavyweight worker gets an idle deadline');
+  idle.listener();
+  assert.equal(workers[0].terminated, true);
+  assert.equal(embeddings.getBackend(), null);
+
+  const pending = embeddings.warmup();
+  assert.equal(workers.length, 2, 'work after the deadline creates a fresh worker');
+  unload();
+  await assert.rejects(pending, /local-embedding-reset/);
+  assert.equal(workers[1].terminated, true);
+});
+
+test('library scope computes identity from metadata and loads full indexes only for retrieval', () => {
+  const sidebar = readSource('zotero-plugin/content/sidebar.js');
+  const start = sidebar.indexOf('async function syncLibraryIdentityBeforeSend()');
+  const end = sidebar.indexOf('\nfunction availableContextTokens()', start);
+  const body = sidebar.slice(start, end);
+  assert.ok(body.includes('NS.listEvidenceRecords'));
+  assert.ok(!body.includes('buildSelectedIndexes'), 'identity sync must not duplicate the full-index allocation');
 });
 
 test('agentic retrieval: both modes use a validated two-round planner', () => {

--- a/zotero-plugin/bootstrap.js
+++ b/zotero-plugin/bootstrap.js
@@ -81,10 +81,16 @@ function shutdown() {
   try { eachMainWindow((w) => { removeLibraryButton(w); removeSidebar(w); }); } catch (e) {}
   if (Nodus.readerToolbarListener) {
     try { Zotero.Reader.unregisterEventListener("renderToolbar", Nodus.readerToolbarListener); } catch (e) {}
+    Nodus.readerToolbarListener = null;
   }
   if (Nodus.selectionListener) {
     try { Zotero.Reader.unregisterEventListener("renderTextSelectionPopup", Nodus.selectionListener); } catch (e) {}
+    Nodus.selectionListener = null;
   }
+  try {
+    if (_popupMods && _popupMods.NS && _popupMods.NS.closeEvidenceDb) _popupMods.NS.closeEvidenceDb().catch(() => {});
+  } catch (e) {}
+  _popupMods = null;
   if (chromeHandle) { try { chromeHandle.destruct(); } catch (e) {} chromeHandle = null; }
   Nodus.rootURI = null;
 }

--- a/zotero-plugin/content/local-embeddings.js
+++ b/zotero-plugin/content/local-embeddings.js
@@ -15,18 +15,47 @@
     fingerprint: "Xenova/multilingual-e5-small@761b726dd34fb83930e26aab4e9ac3899aa1fa78:q8:mean:l2:v1",
   });
   const WORKER_URL = "chrome://nodus/content/runtime/local-embedding-worker.js";
+  // Keeping the WASM model alive costs hundreds of MiB. A short grace period
+  // avoids reloading it between related questions, while still returning that
+  // memory to Zotero after the user stops using semantic retrieval.
+  const IDLE_TERMINATE_MS = 5 * 60 * 1000;
 
   let worker = null;
+  let idleTimer = null;
   let seq = 0;
   let lastBackend = null;
   const pending = new Map();
   const progressListeners = new Set();
 
+  function clearIdleTermination() {
+    if (idleTimer == null) return;
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+
+  function terminateWorker() {
+    clearIdleTermination();
+    const current = worker;
+    worker = null;
+    lastBackend = null;
+    if (current) { try { current.terminate(); } catch (e) {} }
+  }
+
+  function scheduleIdleTermination() {
+    clearIdleTermination();
+    if (!worker || pending.size) return;
+    idleTimer = setTimeout(() => {
+      idleTimer = null;
+      if (!pending.size) terminateWorker();
+    }, IDLE_TERMINATE_MS);
+  }
+
   function makeWorker() {
     if (worker) return worker;
     const WorkerImpl = typeof ChromeWorker !== "undefined" ? ChromeWorker : Worker;
-    worker = new WorkerImpl(WORKER_URL);
-    worker.addEventListener("message", (event) => {
+    const instance = new WorkerImpl(WORKER_URL);
+    worker = instance;
+    instance.addEventListener("message", (event) => {
       const message = event && event.data ? event.data : {};
       if (message.type === "progress") {
         for (const listener of progressListeners) {
@@ -44,29 +73,36 @@
       if (job.cleanup) job.cleanup();
       if (message.type === "error") job.reject(new Error(String(message.error || "local-embedding-failed")));
       else job.resolve(message.result);
+      scheduleIdleTermination();
     });
-    worker.addEventListener("error", (event) => {
+    instance.addEventListener("error", (event) => {
       const error = new Error(String(event && (event.message || event.error) || "local-embedding-worker-failed"));
       for (const job of pending.values()) {
         if (job.cleanup) job.cleanup();
         job.reject(error);
       }
       pending.clear();
-      try { worker.terminate(); } catch (e) {}
-      worker = null;
+      if (worker === instance) terminateWorker();
+      else { try { instance.terminate(); } catch (e) {} }
     });
     return worker;
   }
 
   function request(type, payload, signal) {
     if (signal && signal.aborted) return Promise.reject(new DOMException("Aborted", "AbortError"));
+    clearIdleTermination();
     const id = "le_" + Date.now() + "_" + (++seq);
     return new Promise((resolve, reject) => {
       const onAbort = () => {
         const job = pending.get(id);
         if (!job) return;
         pending.delete(id);
+        if (job.cleanup) job.cleanup();
         reject(new DOMException("Aborted", "AbortError"));
+        // The worker API cannot cancel an individual inference. If this was
+        // the final request, terminate it so an aborted long document does not
+        // keep consuming CPU and RAM in the background.
+        if (!pending.size) terminateWorker();
       };
       const cleanup = signal ? () => signal.removeEventListener("abort", onAbort) : null;
       if (signal) signal.addEventListener("abort", onAbort, { once: true });
@@ -76,6 +112,7 @@
         pending.delete(id);
         if (cleanup) cleanup();
         reject(error);
+        scheduleIdleTermination();
       }
     });
   }
@@ -105,14 +142,15 @@
     return lastBackend;
   }
   function reset() {
-    if (worker) { try { worker.terminate(); } catch (e) {} }
-    worker = null;
+    terminateWorker();
     for (const job of pending.values()) {
       if (job.cleanup) job.cleanup();
       job.reject(new Error("local-embedding-reset"));
     }
     pending.clear();
   }
+
+  window.addEventListener("unload", reset, { once: true });
 
   window.NodusLocalEmbeddings = {
     MODEL,

--- a/zotero-plugin/content/sidebar.js
+++ b/zotero-plugin/content/sidebar.js
@@ -1273,13 +1273,13 @@ async function buildSelectedIndexes(force, signal) {
 }
 async function syncLibraryIdentityBeforeSend() {
   if (state.sourceScope !== "library") return;
-  const indexes = await buildSelectedIndexes(false, null);
-  const nextIdentity = await librarySourceIdentity(indexes);
+  // Identity only depends on the cache catalogue. prepareEvidence() validates
+  // and loads the full indexes immediately afterwards; doing that here as well
+  // doubled the largest allocation on every library-scoped message.
+  const records = NS.listEvidenceRecords ? await NS.listEvidenceRecords() : [];
+  const nextIdentity = await librarySourceIdentity(records);
   const changed = !!state.sourceIdentity && state.sourceIdentity !== nextIdentity;
-  if (changed) {
-    await resetSourceContext(false);
-    state.indexes = indexes;
-  }
+  if (changed) await resetSourceContext(false);
   state.sourceIdentity = nextIdentity;
   state.lastItemKey = nextIdentity;
   if (state.conv && !state.conv.messages.length) state.conv.sourceIdentity = nextIdentity;
@@ -2736,11 +2736,20 @@ function registerNotifier() {
     };
     state.notifierID = Zotero.Notifier.registerObserver(observer, ["item", "tab", "collection"], "nodus-sidebar");
     window.addEventListener("unload", () => {
+      try { if (state.abort) state.abort.abort(); } catch (e) {}
       try { if (state.notifierID) Zotero.Notifier.unregisterObserver(state.notifierID); } catch (e) {}
       try { if (state.pollTimer) clearInterval(state.pollTimer); } catch (e) {}
+      try { if (refreshTimer) clearTimeout(refreshTimer); } catch (e) {}
       try { if (evidencePruneTimer) clearTimeout(evidencePruneTimer); } catch (e) {}
+      try { if (toastTimer) clearTimeout(toastTimer); } catch (e) {}
+      try { window.removeEventListener("focus", retryConnectionNow); } catch (e) {}
       try { stopConnectionWatch(); } catch (e) {}
       cancelBackgroundEmbeddings(false).catch(() => {});
+      try { if (NL && NL.reset) NL.reset(); } catch (e) {}
+      try { if (NS.closeEvidenceDb) NS.closeEvidenceDb().catch(() => {}); } catch (e) {}
+      state.indexes = [];
+      state.evidence = new Map();
+      state.visuals = [];
     });
   } catch (e) { try { Zotero.logError(e); } catch (x) {} }
 }

--- a/zotero-plugin/content/store.js
+++ b/zotero-plugin/content/store.js
@@ -303,6 +303,7 @@
   }
   const EVIDENCE_CACHE_VERSION = 1;
   let evidenceDbPromise = null;
+  let evidenceDbClosed = false;
 
   function legacyIndexDir() {
     const dir = Services.dirsvc.get("ProfD", Components.interfaces.nsIFile).path;
@@ -328,6 +329,31 @@
   function evidenceVectorPath(libraryID, attachmentKey) {
     return PathUtils.join(evidenceDir(), evidenceStem(libraryID, attachmentKey) + ".f32");
   }
+  // Layout extraction used to persist the same coordinate map twice: once as
+  // page spans and again as chunk positions. Nothing in retrieval, citation
+  // navigation or highlighting consumes either persisted map; Zotero resolves
+  // the live page when the user opens a citation. On large PDFs these millions
+  // of tiny objects dominate both JSON size and JS heap usage.
+  function compactEvidenceIndex(index) {
+    let changed = false;
+    for (const chunk of Array.isArray(index && index.chunks) ? index.chunks : []) {
+      if (Object.prototype.hasOwnProperty.call(chunk, "positions")) {
+        delete chunk.positions;
+        changed = true;
+      }
+    }
+    for (const page of Array.isArray(index && index.pages) ? index.pages : []) {
+      if (Object.prototype.hasOwnProperty.call(page, "rawText")) {
+        delete page.rawText;
+        changed = true;
+      }
+      if (Object.prototype.hasOwnProperty.call(page, "spans")) {
+        delete page.spans;
+        changed = true;
+      }
+    }
+    return changed;
+  }
   async function gzipText(value) {
     const bytes = new TextEncoder().encode(String(value || ""));
     if (typeof CompressionStream === "undefined") throw new Error("gzip-unavailable");
@@ -340,6 +366,7 @@
     return new TextDecoder().decode(await new Response(stream).arrayBuffer());
   }
   function detachEmbeddings(index) {
+    compactEvidenceIndex(index);
     const copy = { ...(index || {}) };
     const chunks = [];
     let totalFloats = 0;
@@ -389,6 +416,7 @@
     return copy;
   }
   async function evidenceDb() {
+    if (evidenceDbClosed) throw new Error("evidence-db-closed");
     if (evidenceDbPromise) return evidenceDbPromise;
     evidenceDbPromise = (async () => {
       await IOUtils.makeDirectory(evidenceDir(), { ignoreExisting: true });
@@ -409,6 +437,16 @@
     });
     return evidenceDbPromise;
   }
+  async function closeEvidenceDb() {
+    evidenceDbClosed = true;
+    const pending = evidenceDbPromise;
+    evidenceDbPromise = null;
+    if (!pending) return;
+    try {
+      const db = await pending;
+      if (db && db.closeDatabase) await db.closeDatabase(true);
+    } catch (e) { try { Zotero.logError(e); } catch (x) {} }
+  }
   async function loadEvidenceIndex(libraryID, attachmentKey) {
     let dataPath = evidenceDataPath(libraryID, attachmentKey);
     let vectorPath = evidenceVectorPath(libraryID, attachmentKey);
@@ -428,7 +466,12 @@
     try {
       const packed = await IOUtils.read(dataPath);
       const vectors = await IOUtils.read(vectorPath);
-      return attachEmbeddings(JSON.parse(await gunzipText(packed)), vectors);
+      const index = attachEmbeddings(JSON.parse(await gunzipText(packed)), vectors);
+      // One-time in-place migration of old, coordinate-heavy sidecars. The
+      // first read releases the duplicate objects immediately and rewrites a
+      // compact cache so subsequent Zotero sessions never parse them again.
+      if (compactEvidenceIndex(index)) await saveEvidenceIndex(index);
+      return index;
     } catch (e) {}
     // One-way lazy migration from the v0.1 JSON cache.  The old file is left in
     // place until the new cache has been written successfully.
@@ -593,8 +636,8 @@
     getAgent, setAgent, getAgentAuto, setAgentAuto,
     getHistoryEnabled, setHistoryEnabled, getHistoryRetention, setHistoryRetention,
     getManual, setManual, loadConversations, saveConversations, deleteConversationHistory, compactAudit, compactConversations,
-    EVIDENCE_CACHE_VERSION, gzipText, gunzipText, detachEmbeddings, attachEmbeddings,
+    EVIDENCE_CACHE_VERSION, gzipText, gunzipText, compactEvidenceIndex, detachEmbeddings, attachEmbeddings,
     loadEvidenceIndex, saveEvidenceIndex, deleteEvidenceIndex, listEvidenceRecords, loadEvidenceIndexes,
-    pruneEvidenceIndexes, clearEvidenceIndexes, evidenceCacheStats, newId,
+    pruneEvidenceIndexes, clearEvidenceIndexes, evidenceCacheStats, closeEvidenceDb, newId,
   };
 })();


### PR DESCRIPTION
## Summary

- terminate the heavyweight local embedding worker after five minutes of inactivity and immediately on final-request abort or plugin unload
- compact legacy evidence sidecars on first read by removing unused duplicate coordinate maps while preserving retrieval text, vectors, OCR state, citations, and page navigation
- avoid loading every full evidence index twice before library-scoped retrieval
- close the evidence SQLite connection and clear timers, listeners, popup modules, and in-memory references during teardown
- add focused regression coverage for worker and cache lifecycle behavior

On the diagnosed profile, the equivalent uncompressed evidence JSON falls from 167.8 MiB to approximately 13.1 MiB after compaction. The migration is idempotent and retains stored embeddings.

Fixes #636

## Verification

- node --test scripts/test-zotero-memory-lifecycle.mjs
- node --check on all modified Zotero runtime scripts
- git diff --check

The broader Zotero test file could not be started locally because this worktree does not have its node_modules dependencies installed, including adm-zip; remote checks are expected to exercise the repository environment.