### PR TITLE
Refresh the academic vault onboarding tour

### DIFF
--- a/scripts/capture-academic-tour.mjs
+++ b/scripts/capture-academic-tour.mjs
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { _electron as electron } from 'playwright-core';
+import sharp from 'sharp';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const appVersion = require(path.join(repoRoot, 'package.json')).version;
+const outputRoot = path.resolve(process.argv[2] || path.join(repoRoot, 'artifacts', 'academic-tour'));
+const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-academic-tour-'));
+
+const languages = [
+  ['es', 'Español'],
+  ['en', 'English'],
+  ['fr', 'Français'],
+  ['de', 'Deutsch'],
+  ['pt', 'Português'],
+  ['pt-BR', 'Português (Brasil)'],
+  ['it', 'Italiano'],
+  ['tr', 'Türkçe'],
+];
+
+const expectedTargets = [null, 'vault-badge', 'nav-library', 'library-scope', null, 'nav-ideas', 'nav-graph', 'nav-workspace', null];
+const viewport = { width: 1440, height: 900 };
+const thumb = { width: 456, height: 285 };
+const captionHeight = 46;
+
+async function makeContactSheet(language, files, titles) {
+  const width = thumb.width * 3;
+  const height = (thumb.height + captionHeight) * 3;
+  const composites = [];
+  for (let index = 0; index < files.length; index += 1) {
+    const left = (index % 3) * thumb.width;
+    const top = Math.floor(index / 3) * (thumb.height + captionHeight);
+    const image = await sharp(files[index]).resize(thumb.width, thumb.height, { fit: 'cover' }).png().toBuffer();
+    const safeTitle = titles[index].replace(/[&<>]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[char]);
+    const caption = Buffer.from(`<svg width="${thumb.width}" height="${captionHeight}" xmlns="http://www.w3.org/2000/svg">
+      <rect width="100%" height="100%" fill="#111827"/>
+      <text x="14" y="18" fill="#818cf8" font-family="Inter, Arial, sans-serif" font-size="11" font-weight="700">${language.toUpperCase()} · ${index + 1}/9</text>
+      <text x="14" y="36" fill="#f3f4f6" font-family="Inter, Arial, sans-serif" font-size="13">${safeTitle}</text>
+    </svg>`);
+    composites.push({ input: image, left, top }, { input: caption, left, top: top + thumb.height });
+  }
+  const destination = path.join(outputRoot, `${language}-contact-sheet.png`);
+  await sharp({ create: { width, height, channels: 4, background: '#030712' } }).composite(composites).png().toFile(destination);
+  return destination;
+}
+
+let app;
+try {
+  assert.ok(existsSync(path.join(repoRoot, 'dist', 'index.html')), 'Run the production build before capturing');
+  await mkdir(outputRoot, { recursive: true });
+  const childEnv = {
+    ...process.env,
+    NODUS_USERDATA: userData,
+    NODUS_DISABLE_AUTO_UPDATE: '1',
+    NODUS_E2E_UPDATE_STATUS: 'not-available',
+    NODUS_E2E_DISABLE_STUDY_BACKGROUND_AI: '1',
+  };
+  delete childEnv.ELECTRON_RUN_AS_NODE;
+  app = await electron.launch({ executablePath: require('electron'), args: [repoRoot], env: childEnv });
+  const page = await app.firstWindow();
+  page.setDefaultTimeout(30_000);
+  await page.setViewportSize(viewport);
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+  await page.waitForFunction(() => Boolean(window.nodus));
+  await page.evaluate(async ({ version }) => {
+    localStorage.setItem('nodus.libraryTutorialSeen.v1', '1');
+    localStorage.setItem('nodus.lastSeenVersion', version);
+    localStorage.setItem(`nodus.mobileTeaserSeen.${version}`, '1');
+    localStorage.setItem('nodus.platformHighlightsSeen.2026-07', '1');
+    localStorage.setItem('nodus.toolkitBetaGuideSeen.2.4.0', '1');
+    localStorage.setItem('nodus.tutorialVideosAnnouncementSeen.2026-07', '1');
+    sessionStorage.setItem('nodus.startupUpdateChecked', '1');
+    const vaults = await window.nodus.listVaults();
+    if (vaults[0]) await window.nodus.setVaultType(vaults[0].id, 'academic');
+    await window.nodus.updateSettings({
+      onboardingComplete: true,
+      basicsTutorialVersion: 999,
+      firstVaultVersion: 999,
+      recoverySetupVersion: 999,
+      tourComplete: false,
+      advancedTourComplete: true,
+      mascotEnabled: false,
+      mascotStyleChosen: true,
+      theme: 'dark',
+      libraryGlobalEnabled: false,
+      libraryScope: 'vault',
+      sidebarCustomized: false,
+    });
+  }, { version: appVersion });
+
+  const contactSheets = [];
+  for (const [language, label] of languages) {
+    await page.evaluate(async (uiLanguage) => {
+      await window.nodus.updateSettings({ uiLanguage, promptLanguage: uiLanguage, tourComplete: false, advancedTourComplete: true });
+    }, language);
+    await page.reload();
+    await page.getByTestId('app-shell').waitFor();
+    const card = page.getByTestId('tour-card');
+    await card.waitFor();
+
+    const languageDir = path.join(outputRoot, language);
+    await mkdir(languageDir, { recursive: true });
+    const files = [];
+    const titles = [];
+    for (let index = 0; index < 9; index += 1) {
+      if (index === 1) await card.getByTestId('tour-start-walkthrough').click();
+      else if (index > 1) await card.getByTestId('tour-next').click();
+
+      await page.waitForFunction((expected) => {
+        const eyebrow = document.querySelector('[data-testid="tour-card"] [aria-live="polite"]');
+        return eyebrow?.textContent?.includes(expected);
+      }, `${index + 1}/9`);
+
+      const target = expectedTargets[index];
+      if (target) {
+        await page.locator(`[data-tour="${target}"]`).first().waitFor({ state: 'visible' });
+        await page.getByTestId('tour-spotlight').waitFor({ state: 'visible' });
+      }
+      await page.waitForTimeout(260);
+      const title = (await card.locator('h3').innerText()).trim();
+      titles.push(title);
+      const box = await card.boundingBox();
+      assert.ok(box && box.x >= 0 && box.y >= 0 && box.x + box.width <= viewport.width && box.y + box.height <= viewport.height,
+        `${language} step ${index + 1} card must stay inside the viewport: ${JSON.stringify(box)}`);
+      const file = path.join(languageDir, `${String(index + 1).padStart(2, '0')}.png`);
+      await page.screenshot({ path: file });
+      files.push(file);
+    }
+    contactSheets.push(await makeContactSheet(language, files, titles));
+    process.stdout.write(`[academic-tour] ${label}: 9/9 steps captured\n`);
+  }
+
+  assert.equal(pageErrors.length, 0, pageErrors.map((error) => error.stack || error.message).join('\n'));
+  process.stdout.write(`${JSON.stringify({ outputRoot, contactSheets }, null, 2)}\n`);
+} finally {
+  if (app) await app.close().catch(() => undefined);
+  await rm(userData, { recursive: true, force: true });
+}

--- a/scripts/test-vault-onboarding-ui.mjs
+++ b/scripts/test-vault-onboarding-ui.mjs
@@ -149,6 +149,34 @@ test('academic onboarding offers Nodus Library or optional Zotero while dedicate
   assert.match(onboarding, /Construye un mundo de ficción coherente a partir de tu propio canon/);
 });
 
+test('academic first-run tour stays focused on the current evidence workflow in every language', async () => {
+  const [tour, engine, library, translations] = await Promise.all([
+    read('src/views/Tour.tsx'),
+    read('src/views/tourEngine.tsx'),
+    read('src/views/GlobalLibraryView.tsx'),
+    read('src/i18n.academicTour.ts'),
+  ]);
+
+  assert.match(tour, /export const ACADEMIC_TOUR_STEPS/);
+  assert.equal(tour.match(/^\s{4}title:/gm)?.length, 9, 'the essential tour should remain a nine-step path');
+  assert.match(tour, /Biblioteca → Ideas → Grafo/);
+  assert.match(tour, /La fuente sigue siendo la autoridad|la fuente sigue siendo la autoridad/);
+  for (const target of ['vault-badge', 'nav-library', 'library-scope', 'nav-ideas', 'nav-graph', 'nav-workspace']) {
+    assert.match(tour, new RegExp(`target: '${target}'`), `missing current tour target ${target}`);
+  }
+  for (const obsoleteTarget of ['sync', 'model', 'nav-notes', 'nav-search']) {
+    assert.doesNotMatch(tour, new RegExp(`target: '${obsoleteTarget}'`), `obsolete tour target ${obsoleteTarget}`);
+  }
+
+  assert.match(library, /data-tour="library-scope"/);
+  assert.match(engine, /scrollIntoView\(\{ block: 'center', inline: 'nearest' \}\)/);
+  assert.match(engine, /data-testid="tour-next"/);
+  for (const language of ['en', 'fr', 'de', 'pt', 'pt-BR', 'it', 'tr']) {
+    const key = language === 'pt-BR' ? `'pt-BR'` : language;
+    assert.match(translations, new RegExp(`^  ${key}: \\{`, 'm'), `missing academic tour copy for ${language}`);
+  }
+});
+
 test('a failed Zotero check names the setting that fixes it', async () => {
   const [client, helper, onboarding, translate, en] = await Promise.all([
     read('electron/zotero/zoteroClient.ts'),

--- a/src/i18n.academicTour.ts
+++ b/src/i18n.academicTour.ts
@@ -1,0 +1,215 @@
+import type { AppLanguage } from '@shared/types';
+
+type TourLanguage = Exclude<AppLanguage, 'es'>;
+
+/**
+ * Copy for the academic vault's essential tour.
+ *
+ * Keeping the seven translations beside the source flow makes product changes easy
+ * to review as one unit. The Spanish keys are the canonical copy in Tour.tsx.
+ */
+export const ACADEMIC_TOUR_TRANSLATIONS: Record<TourLanguage, Record<string, string>> = {
+  en: {
+    'Bienvenido a tu vault académico': 'Welcome to your academic vault',
+    'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.':
+      'Although there are many options, you only need one path to get started: Library → Ideas → Graph. This one-minute tour follows that path; you can skip it or replay it from Settings at any time.',
+    'Empieza por una sola ruta': 'Start with one simple path',
+    'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.':
+      'This badge shows which vault you are in. Each vault keeps one project separate, so its sources, analyses and drafts do not get mixed with others. Use it only when you want to switch projects or create another one.',
+    'Biblioteca: dos ámbitos, una decisión': 'Library: two scopes, one choice',
+    'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.':
+      'Global stores sources available to all your projects; “This vault” shows only those used here. You can add files, DOIs, ISBNs or manual references, or sync Zotero. You do not need to configure every option to begin.',
+    'Analiza solo lo que necesites': 'Analyze only what you need',
+    'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.':
+      'Add a source to the vault and switch to “This vault”. Select one or more works there and click “Analyze”. Nodus will extract themes, ideas, evidence and relationships. Start with one source; you can always analyze more later.',
+    'La cola te cuenta qué ocurre': 'The queue tells you what is happening',
+    'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.':
+      'The bottom bar shows analysis progress. You can keep using Nodus while it works. If an AI model or key is missing, the task pauses and tells you what to check in Settings, so you never have to guess what failed.',
+    'Comprueba antes de confiar': 'Check before you trust',
+    'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.':
+      'Ideas brings together what was extracted from your reading. Open an idea and review the quotation or passage supporting it. AI helps you read, but the source remains the authority: this check is the most important habit in an academic vault.',
+    'Las conexiones aparecen después': 'Connections come later',
+    'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.':
+      'Graph shows each idea as a node and its relationships as links. It may be empty or small at first; that is normal. It becomes useful as you analyze verified sources, not before.',
+    'Escribe sin salir del corpus': 'Write without leaving your corpus',
+    'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.':
+      'Workspace brings together notes, drafts and writing projects. It preserves internal links to sources and ideas so you can return to the evidence while writing. You do not need it until you have something to develop.',
+    'Lo demás puede esperar': 'Everything else can wait',
+    'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.':
+      'The menu groups features by purpose: Explore, Analyze, Write and Tools. Open them when your research needs them; Settings lets you hide or reorder sections. Your first mission is simple: add one source, analyze it and verify one idea.',
+  },
+  fr: {
+    'Bienvenido a tu vault académico': 'Bienvenue dans votre vault académique',
+    'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.':
+      'Même si de nombreuses options sont affichées, un seul parcours suffit pour commencer : Bibliothèque → Idées → Graphe. Cette visite d’une minute suit ce chemin ; vous pouvez la passer ou la relancer depuis les Paramètres.',
+    'Empieza por una sola ruta': 'Commencez par un parcours simple',
+    'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.':
+      'Ce badge indique dans quel vault vous vous trouvez. Chaque vault isole un projet afin que ses sources, analyses et brouillons ne se mélangent pas aux autres. Utilisez-le seulement pour changer de projet ou en créer un autre.',
+    'Biblioteca: dos ámbitos, una decisión': 'Bibliothèque : deux espaces, un choix',
+    'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.':
+      'Global conserve les sources disponibles pour tous vos projets ; « Ce vault » affiche uniquement celles utilisées ici. Vous pouvez ajouter des fichiers, DOI, ISBN ou références manuelles, ou synchroniser Zotero. Il n’est pas nécessaire de tout configurer pour commencer.',
+    'Analiza solo lo que necesites': 'Analysez uniquement ce dont vous avez besoin',
+    'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.':
+      'Ajoutez une source au vault puis passez à « Ce vault ». Sélectionnez-y une ou plusieurs œuvres et cliquez sur « Analyser ». Nodus extraira thèmes, idées, preuves et relations. Commencez par une source ; vous pourrez toujours en analyser davantage.',
+    'La cola te cuenta qué ocurre': 'La file indique ce qui se passe',
+    'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.':
+      'La barre inférieure affiche la progression des analyses. Vous pouvez continuer à utiliser Nodus pendant ce temps. Si un modèle ou une clé d’IA manque, la tâche se met en pause et indique quoi vérifier dans les Paramètres.',
+    'Comprueba antes de confiar': 'Vérifiez avant de faire confiance',
+    'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.':
+      'Idées rassemble ce qui a été extrait de vos lectures. Ouvrez une idée et vérifiez la citation ou le passage qui l’étaye. L’IA aide à lire, mais la source reste l’autorité : cette vérification est l’habitude la plus importante du vault académique.',
+    'Las conexiones aparecen después': 'Les connexions apparaissent ensuite',
+    'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.':
+      'Graphe affiche chaque idée comme un nœud et ses relations comme des liens. Il peut être vide ou modeste au début : c’est normal. Il devient utile à mesure que vous analysez des sources vérifiées.',
+    'Escribe sin salir del corpus': 'Écrivez sans quitter votre corpus',
+    'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.':
+      'Espace de travail réunit notes, brouillons et projets d’écriture. Il conserve les liens internes vers les sources et les idées afin de revenir aux preuves pendant la rédaction. Vous n’en avez pas besoin avant d’avoir quelque chose à développer.',
+    'Lo demás puede esperar': 'Le reste peut attendre',
+    'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.':
+      'Le menu regroupe les fonctions par intention : Explorer, Analyser, Écrire et Outils. Ouvrez-les lorsque votre recherche en a besoin ; les Paramètres permettent de masquer ou réorganiser des sections. Première mission : ajoutez une source, analysez-la et vérifiez une idée.',
+  },
+  de: {
+    'Bienvenido a tu vault académico': 'Willkommen in deinem akademischen Vault',
+    'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.':
+      'Auch wenn viele Optionen sichtbar sind, brauchst du zum Einstieg nur einen Weg: Bibliothek → Ideen → Graph. Diese einminütige Tour folgt diesem Weg; du kannst sie überspringen oder jederzeit in den Einstellungen erneut starten.',
+    'Empieza por una sola ruta': 'Beginne mit einem einfachen Weg',
+    'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.':
+      'Dieses Abzeichen zeigt, in welchem Vault du dich befindest. Jeder Vault hält ein Projekt getrennt, damit Quellen, Analysen und Entwürfe nicht vermischt werden. Nutze es nur, um das Projekt zu wechseln oder ein neues anzulegen.',
+    'Biblioteca: dos ámbitos, una decisión': 'Bibliothek: zwei Bereiche, eine Entscheidung',
+    'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.':
+      'Global speichert Quellen für alle Projekte; „Dieser Vault“ zeigt nur die hier verwendeten. Du kannst Dateien, DOIs, ISBNs oder manuelle Referenzen hinzufügen oder Zotero synchronisieren. Für den Einstieg musst du nicht alles konfigurieren.',
+    'Analiza solo lo que necesites': 'Analysiere nur, was du brauchst',
+    'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.':
+      'Füge dem Vault eine Quelle hinzu und wechsle zu „Dieser Vault“. Wähle dort ein oder mehrere Werke und klicke auf „Analysieren“. Nodus extrahiert Themen, Ideen, Belege und Beziehungen. Beginne mit einer Quelle; weitere kannst du später analysieren.',
+    'La cola te cuenta qué ocurre': 'Die Warteschlange zeigt, was passiert',
+    'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.':
+      'Die untere Leiste zeigt den Fortschritt der Analysen. Du kannst Nodus währenddessen weiter nutzen. Fehlt ein KI-Modell oder Schlüssel, pausiert die Aufgabe und zeigt, was in den Einstellungen geprüft werden muss.',
+    'Comprueba antes de confiar': 'Prüfe, bevor du vertraust',
+    'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.':
+      'Ideen bündelt, was aus deinen Lektüren extrahiert wurde. Öffne eine Idee und prüfe das Zitat oder die Passage, die sie stützt. KI hilft beim Lesen, doch die Quelle bleibt maßgeblich: Diese Prüfung ist die wichtigste Gewohnheit im akademischen Vault.',
+    'Las conexiones aparecen después': 'Verbindungen entstehen später',
+    'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.':
+      'Graph zeigt jede Idee als Knoten und ihre Beziehungen als Verbindungen. Anfangs kann er leer oder klein sein; das ist normal. Nützlich wird er, sobald du geprüfte Quellen analysierst.',
+    'Escribe sin salir del corpus': 'Schreibe, ohne den Korpus zu verlassen',
+    'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.':
+      'Arbeitsbereich vereint Notizen, Entwürfe und Schreibprojekte. Interne Links zu Quellen und Ideen bleiben erhalten, damit du beim Schreiben zu den Belegen zurückkehren kannst. Du brauchst ihn erst, wenn du etwas ausarbeiten möchtest.',
+    'Lo demás puede esperar': 'Alles andere kann warten',
+    'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.':
+      'Das Menü gruppiert Funktionen nach Zweck: Erkunden, Analysieren, Schreiben und Werkzeuge. Öffne sie erst, wenn deine Forschung sie braucht; in den Einstellungen kannst du Bereiche ausblenden oder neu ordnen. Erste Aufgabe: eine Quelle hinzufügen, analysieren und eine Idee prüfen.',
+  },
+  pt: {
+    'Bienvenido a tu vault académico': 'Bem-vindo ao seu vault académico',
+    'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.':
+      'Embora veja muitas opções, para começar só precisa de um percurso: Biblioteca → Ideias → Grafo. Esta visita de um minuto segue esse caminho; pode ignorá-la ou repeti-la nas Definições quando quiser.',
+    'Empieza por una sola ruta': 'Comece por um percurso simples',
+    'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.':
+      'Este distintivo indica em que vault está. Cada vault mantém um projeto separado, para que fontes, análises e rascunhos não se misturem. Use-o apenas quando quiser mudar de projeto ou criar outro.',
+    'Biblioteca: dos ámbitos, una decisión': 'Biblioteca: dois âmbitos, uma decisão',
+    'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.':
+      'Global guarda as fontes disponíveis para todos os projetos; «Este vault» mostra apenas as usadas aqui. Pode adicionar ficheiros, DOI, ISBN ou referências manuais, ou sincronizar o Zotero. Não precisa de configurar todas as opções para começar.',
+    'Analiza solo lo que necesites': 'Analise apenas o que precisa',
+    'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.':
+      'Adicione uma fonte ao vault e mude para «Este vault». Aí, selecione uma ou várias obras e prima «Analisar». O Nodus extrairá temas, ideias, evidências e relações. Comece com uma fonte; poderá analisar mais depois.',
+    'La cola te cuenta qué ocurre': 'A fila mostra o que está a acontecer',
+    'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.':
+      'A barra inferior mostra o progresso das análises. Pode continuar a usar o Nodus enquanto trabalha. Se faltar um modelo ou uma chave de IA, a tarefa pausa e indica o que deve verificar nas Definições.',
+    'Comprueba antes de confiar': 'Verifique antes de confiar',
+    'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.':
+      'Ideias reúne o que foi extraído das suas leituras. Abra uma ideia e verifique a citação ou passagem que a sustenta. A IA ajuda a ler, mas a fonte continua a ser a autoridade: esta verificação é o hábito mais importante do vault académico.',
+    'Las conexiones aparecen después': 'As ligações aparecem depois',
+    'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.':
+      'Grafo mostra cada ideia como um nó e as suas relações como ligações. No início pode estar vazio ou ser pequeno; é normal. Torna-se útil à medida que analisa fontes verificadas.',
+    'Escribe sin salir del corpus': 'Escreva sem sair do corpus',
+    'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.':
+      'Espaço de trabalho reúne notas, rascunhos e projetos de escrita. Mantém as ligações internas a fontes e ideias para poder regressar às evidências enquanto escreve. Só precisa dele quando tiver algo para desenvolver.',
+    'Lo demás puede esperar': 'O resto pode esperar',
+    'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.':
+      'O menu agrupa funções por objetivo: Explorar, Analisar, Escrever e Ferramentas. Abra-as quando a sua investigação precisar; nas Definições pode ocultar ou reordenar secções. Primeira missão: adicione uma fonte, analise-a e verifique uma ideia.',
+  },
+  'pt-BR': {
+    'Bienvenido a tu vault académico': 'Boas-vindas ao seu vault acadêmico',
+    'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.':
+      'Mesmo com tantas opções, você só precisa de um caminho para começar: Biblioteca → Ideias → Grafo. Este tour de um minuto segue esse caminho; você pode pulá-lo ou repeti-lo em Configurações quando quiser.',
+    'Empieza por una sola ruta': 'Comece por um caminho simples',
+    'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.':
+      'Este selo indica em qual vault você está. Cada vault mantém um projeto separado para que fontes, análises e rascunhos não se misturem. Use-o apenas para trocar de projeto ou criar outro.',
+    'Biblioteca: dos ámbitos, una decisión': 'Biblioteca: dois escopos, uma escolha',
+    'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.':
+      'Global guarda as fontes disponíveis para todos os projetos; “Este vault” mostra apenas as usadas aqui. Você pode adicionar arquivos, DOI, ISBN ou referências manuais, ou sincronizar o Zotero. Não é preciso configurar tudo para começar.',
+    'Analiza solo lo que necesites': 'Analise apenas o que você precisa',
+    'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.':
+      'Adicione uma fonte ao vault e mude para “Este vault”. Selecione uma ou mais obras e clique em “Analisar”. O Nodus extrairá temas, ideias, evidências e relações. Comece com uma fonte; você sempre poderá analisar mais depois.',
+    'La cola te cuenta qué ocurre': 'A fila mostra o que está acontecendo',
+    'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.':
+      'A barra inferior mostra o progresso das análises. Você pode continuar usando o Nodus enquanto ele trabalha. Se faltar um modelo ou uma chave de IA, a tarefa pausa e informa o que revisar em Configurações.',
+    'Comprueba antes de confiar': 'Confira antes de confiar',
+    'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.':
+      'Ideias reúne o que foi extraído das suas leituras. Abra uma ideia e confira a citação ou o trecho que a sustenta. A IA ajuda na leitura, mas a fonte continua sendo a autoridade: essa verificação é o hábito mais importante do vault acadêmico.',
+    'Las conexiones aparecen después': 'As conexões aparecem depois',
+    'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.':
+      'Grafo mostra cada ideia como um nó e suas relações como conexões. No começo ele pode estar vazio ou pequeno; isso é normal. Ele se torna útil à medida que você analisa fontes verificadas.',
+    'Escribe sin salir del corpus': 'Escreva sem sair do corpus',
+    'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.':
+      'Espaço de trabalho reúne notas, rascunhos e projetos de escrita. Ele preserva links internos para fontes e ideias, permitindo voltar às evidências durante a redação. Você só precisa usá-lo quando tiver algo para desenvolver.',
+    'Lo demás puede esperar': 'O restante pode esperar',
+    'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.':
+      'O menu agrupa recursos por objetivo: Explorar, Analisar, Escrever e Ferramentas. Abra-os quando sua pesquisa precisar; em Configurações você pode ocultar ou reordenar seções. Primeira missão: adicione uma fonte, analise-a e verifique uma ideia.',
+  },
+  it: {
+    'Bienvenido a tu vault académico': 'Benvenuto nel tuo vault accademico',
+    'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.':
+      'Anche se vedi molte opzioni, per iniziare ti basta un percorso: Biblioteca → Idee → Grafo. Questo tour di un minuto segue quel percorso; puoi saltarlo o ripeterlo dalle Impostazioni in qualsiasi momento.',
+    'Empieza por una sola ruta': 'Inizia con un percorso semplice',
+    'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.':
+      'Questo distintivo indica in quale vault ti trovi. Ogni vault mantiene separato un progetto, così fonti, analisi e bozze non si mescolano. Usalo solo per cambiare progetto o crearne un altro.',
+    'Biblioteca: dos ámbitos, una decisión': 'Biblioteca: due ambiti, una scelta',
+    'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.':
+      'Globale conserva le fonti disponibili per tutti i progetti; “Questo vault” mostra solo quelle usate qui. Puoi aggiungere file, DOI, ISBN o riferimenti manuali, oppure sincronizzare Zotero. Non serve configurare tutto per iniziare.',
+    'Analiza solo lo que necesites': 'Analizza solo ciò che ti serve',
+    'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.':
+      'Aggiungi una fonte al vault e passa a “Questo vault”. Seleziona una o più opere e premi “Analizza”. Nodus estrarrà temi, idee, prove e relazioni. Inizia con una fonte; potrai sempre analizzarne altre in seguito.',
+    'La cola te cuenta qué ocurre': 'La coda mostra cosa sta succedendo',
+    'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.':
+      'La barra inferiore mostra l’avanzamento delle analisi. Puoi continuare a usare Nodus mentre lavora. Se manca un modello o una chiave IA, l’attività si mette in pausa e indica cosa controllare nelle Impostazioni.',
+    'Comprueba antes de confiar': 'Controlla prima di fidarti',
+    'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.':
+      'Idee raccoglie ciò che è stato estratto dalle tue letture. Apri un’idea e controlla la citazione o il passaggio che la sostiene. L’IA aiuta a leggere, ma la fonte resta l’autorità: questa verifica è l’abitudine più importante del vault accademico.',
+    'Las conexiones aparecen después': 'Le connessioni arrivano dopo',
+    'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.':
+      'Grafo mostra ogni idea come un nodo e le sue relazioni come collegamenti. All’inizio può essere vuoto o piccolo: è normale. Diventa utile man mano che analizzi fonti verificate.',
+    'Escribe sin salir del corpus': 'Scrivi senza uscire dal corpus',
+    'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.':
+      'Spazio di lavoro riunisce note, bozze e progetti di scrittura. Mantiene i collegamenti interni a fonti e idee, così puoi tornare alle prove mentre scrivi. Non serve usarlo finché non hai qualcosa da sviluppare.',
+    'Lo demás puede esperar': 'Il resto può aspettare',
+    'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.':
+      'Il menu raggruppa le funzioni per scopo: Esplora, Analizza, Scrivi e Strumenti. Aprile quando servono alla tua ricerca; nelle Impostazioni puoi nascondere o riordinare le sezioni. Prima missione: aggiungi una fonte, analizzala e verifica un’idea.',
+  },
+  tr: {
+    'Bienvenido a tu vault académico': 'Akademik vault’una hoş geldin',
+    'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.':
+      'Birçok seçenek görsen de başlamak için tek bir yol yeter: Kütüphane → Fikirler → Grafik. Bu bir dakikalık tur o yolu izler; turu atlayabilir veya Ayarlar’dan istediğin zaman yeniden başlatabilirsin.',
+    'Empieza por una sola ruta': 'Tek ve basit bir yolla başla',
+    'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.':
+      'Bu rozet hangi vault’ta olduğunu gösterir. Her vault bir projeyi diğerlerinden ayırır; böylece kaynaklar, analizler ve taslaklar karışmaz. Rozeti yalnızca proje değiştirmek veya yeni bir proje oluşturmak istediğinde kullan.',
+    'Biblioteca: dos ámbitos, una decisión': 'Kütüphane: iki kapsam, tek seçim',
+    'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.':
+      'Global, tüm projelerde kullanılabilen kaynakları saklar; “Bu vault” yalnızca burada kullanılanları gösterir. Dosya, DOI, ISBN veya elle referans ekleyebilir ya da Zotero’yu eşitleyebilirsin. Başlamak için her seçeneği yapılandırman gerekmez.',
+    'Analiza solo lo que necesites': 'Yalnızca ihtiyacın olanı analiz et',
+    'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.':
+      'Vault’a bir kaynak ekle ve “Bu vault”a geç. Burada bir veya daha fazla eser seçip “Analiz et”e tıkla. Nodus temaları, fikirleri, kanıtları ve ilişkileri çıkarır. Tek bir kaynakla başla; daha fazlasını sonra analiz edebilirsin.',
+    'La cola te cuenta qué ocurre': 'Kuyruk neler olduğunu gösterir',
+    'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.':
+      'Alt çubuk analizlerin ilerlemesini gösterir. Nodus çalışırken uygulamayı kullanmaya devam edebilirsin. Bir yapay zekâ modeli veya anahtarı eksikse görev duraklar ve Ayarlar’da neyi kontrol etmen gerektiğini söyler.',
+    'Comprueba antes de confiar': 'Güvenmeden önce kontrol et',
+    'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.':
+      'Fikirler, okumalarından çıkarılanları bir araya getirir. Bir fikri açıp onu destekleyen alıntıyı veya bölümü kontrol et. Yapay zekâ okumaya yardımcı olur, ancak yetkili olan kaynaktır: Bu kontrol akademik vault’taki en önemli alışkanlıktır.',
+    'Las conexiones aparecen después': 'Bağlantılar daha sonra oluşur',
+    'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.':
+      'Grafik her fikri bir düğüm, ilişkilerini ise bağlantı olarak gösterir. Başta boş veya küçük olabilir; bu normaldir. Doğrulanmış kaynakları analiz ettikçe faydalı hâle gelir.',
+    'Escribe sin salir del corpus': 'Korpustan ayrılmadan yaz',
+    'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.':
+      'Çalışma Alanı notları, taslakları ve yazı projelerini bir araya getirir. Yazarken kanıtlara dönebilmen için kaynaklara ve fikirlere giden iç bağlantıları korur. Geliştirecek bir şeyin olana kadar kullanman gerekmez.',
+    'Lo demás puede esperar': 'Geri kalan her şey bekleyebilir',
+    'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.':
+      'Menü özellikleri amaca göre gruplar: Keşfet, Analiz et, Yaz ve Araçlar. Araştırman gerektiğinde bunları aç; Ayarlar’da bölümleri gizleyebilir veya yeniden sıralayabilirsin. İlk görevin basit: bir kaynak ekle, analiz et ve bir fikri doğrula.',
+  },
+};

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -53,8 +53,10 @@ import { DEEP_RESEARCH_QUALITY_TRANSLATIONS } from './i18n.deepResearchQuality';
 import { MODEL_SETTINGS_TRANSLATIONS } from './i18n.modelSettings';
 import { ADAPTIVE_CONCURRENCY_TRANSLATIONS } from './i18n.adaptiveConcurrency';
 import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch';
+import { ACADEMIC_TOUR_TRANSLATIONS } from './i18n.academicTour';
 
 export const DE: Record<string, string> = {
+  ...ACADEMIC_TOUR_TRANSLATIONS.de,
   ...ADAPTIVE_CONCURRENCY_TRANSLATIONS.de,
   ...DATABASE_DEEP_RESEARCH_TRANSLATIONS.de,
   ...MODEL_SETTINGS_TRANSLATIONS.de,

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -47,6 +47,7 @@ import { DEEP_RESEARCH_QUALITY_TRANSLATIONS } from './i18n.deepResearchQuality';
 import { MODEL_SETTINGS_TRANSLATIONS } from './i18n.modelSettings';
 import { ADAPTIVE_CONCURRENCY_TRANSLATIONS } from './i18n.adaptiveConcurrency';
 import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch';
+import { ACADEMIC_TOUR_TRANSLATIONS } from './i18n.academicTour';
 
 /**
  * English translations keyed by the Spanish source string (see {@link ../i18n}).
@@ -54,6 +55,7 @@ import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch
  * every non-Spanish interface language.
  */
 export const EN: Record<string, string> = {
+  ...ACADEMIC_TOUR_TRANSLATIONS.en,
   ...ADAPTIVE_CONCURRENCY_TRANSLATIONS.en,
   ...DATABASE_DEEP_RESEARCH_TRANSLATIONS.en,
   ...MODEL_SETTINGS_TRANSLATIONS.en,

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -53,8 +53,10 @@ import { DEEP_RESEARCH_QUALITY_TRANSLATIONS } from './i18n.deepResearchQuality';
 import { MODEL_SETTINGS_TRANSLATIONS } from './i18n.modelSettings';
 import { ADAPTIVE_CONCURRENCY_TRANSLATIONS } from './i18n.adaptiveConcurrency';
 import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch';
+import { ACADEMIC_TOUR_TRANSLATIONS } from './i18n.academicTour';
 
 export const FR: Record<string, string> = {
+  ...ACADEMIC_TOUR_TRANSLATIONS.fr,
   ...ADAPTIVE_CONCURRENCY_TRANSLATIONS.fr,
   ...DATABASE_DEEP_RESEARCH_TRANSLATIONS.fr,
   ...MODEL_SETTINGS_TRANSLATIONS.fr,

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -47,9 +47,11 @@ import { DEEP_RESEARCH_QUALITY_TRANSLATIONS } from './i18n.deepResearchQuality';
 import { MODEL_SETTINGS_TRANSLATIONS } from './i18n.modelSettings';
 import { ADAPTIVE_CONCURRENCY_TRANSLATIONS } from './i18n.adaptiveConcurrency';
 import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch';
+import { ACADEMIC_TOUR_TRANSLATIONS } from './i18n.academicTour';
 
 /** Complete static Italian interface table; coverage prohibits runtime fallbacks. */
 export const IT: Record<string, string> = {
+  ...ACADEMIC_TOUR_TRANSLATIONS.it,
   ...ADAPTIVE_CONCURRENCY_TRANSLATIONS.it,
   ...DATABASE_DEEP_RESEARCH_TRANSLATIONS.it,
   ...MODEL_SETTINGS_TRANSLATIONS.it,

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -53,8 +53,10 @@ import { DEEP_RESEARCH_QUALITY_TRANSLATIONS } from './i18n.deepResearchQuality';
 import { MODEL_SETTINGS_TRANSLATIONS } from './i18n.modelSettings';
 import { ADAPTIVE_CONCURRENCY_TRANSLATIONS } from './i18n.adaptiveConcurrency';
 import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch';
+import { ACADEMIC_TOUR_TRANSLATIONS } from './i18n.academicTour';
 
 export const PT_BR: Record<string, string> = {
+  ...ACADEMIC_TOUR_TRANSLATIONS['pt-BR'],
   ...ADAPTIVE_CONCURRENCY_TRANSLATIONS['pt-BR'],
   ...DATABASE_DEEP_RESEARCH_TRANSLATIONS['pt-BR'],
   ...MODEL_SETTINGS_TRANSLATIONS['pt-BR'],

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -53,8 +53,10 @@ import { DEEP_RESEARCH_QUALITY_TRANSLATIONS } from './i18n.deepResearchQuality';
 import { MODEL_SETTINGS_TRANSLATIONS } from './i18n.modelSettings';
 import { ADAPTIVE_CONCURRENCY_TRANSLATIONS } from './i18n.adaptiveConcurrency';
 import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch';
+import { ACADEMIC_TOUR_TRANSLATIONS } from './i18n.academicTour';
 
 export const PT: Record<string, string> = {
+  ...ACADEMIC_TOUR_TRANSLATIONS.pt,
   ...ADAPTIVE_CONCURRENCY_TRANSLATIONS.pt,
   ...DATABASE_DEEP_RESEARCH_TRANSLATIONS.pt,
   ...MODEL_SETTINGS_TRANSLATIONS.pt,

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -47,9 +47,11 @@ import { DEEP_RESEARCH_QUALITY_TRANSLATIONS } from './i18n.deepResearchQuality';
 import { MODEL_SETTINGS_TRANSLATIONS } from './i18n.modelSettings';
 import { ADAPTIVE_CONCURRENCY_TRANSLATIONS } from './i18n.adaptiveConcurrency';
 import { DATABASE_DEEP_RESEARCH_TRANSLATIONS } from './i18n.databaseDeepResearch';
+import { ACADEMIC_TOUR_TRANSLATIONS } from './i18n.academicTour';
 
 /** Complete static Turkish interface table; coverage prohibits runtime fallbacks. */
 export const TR: Record<string, string> = {
+  ...ACADEMIC_TOUR_TRANSLATIONS.tr,
   ...ADAPTIVE_CONCURRENCY_TRANSLATIONS.tr,
   ...DATABASE_DEEP_RESEARCH_TRANSLATIONS.tr,
   ...MODEL_SETTINGS_TRANSLATIONS.tr,

--- a/src/views/GlobalLibraryView.tsx
+++ b/src/views/GlobalLibraryView.tsx
@@ -764,6 +764,7 @@ function LibraryScopeControls({
   return (
     <div
       data-testid="library-scope-switcher"
+      data-tour="library-scope"
       data-scope-placement="content-header"
       className="library-scope-switcher"
       role="group"

--- a/src/views/Tour.tsx
+++ b/src/views/Tour.tsx
@@ -1,93 +1,66 @@
 import { TourOverlay, type TourStep } from './tourEngine';
 
-type ViewId = 'library' | 'graph' | 'gaps' | 'reading' | 'settings' | 'search' | 'ideas' | 'notes';
+type ViewId = 'library' | 'graph' | 'ideas' | 'workspace';
 
 /**
  * First-run usage tour. Distinct from the setup Onboarding: this teaches how to
  * *use* the app on the real UI — most importantly, how to add a work to the graph.
  * Steps spotlight live elements tagged with `data-tour`; target-less steps are centered.
  */
-const STEPS: TourStep[] = [
+export const ACADEMIC_TOUR_STEPS: TourStep[] = [
   {
-    title: '¡Bienvenido a Nodus!',
-    body: '¿Es tu primera vez? En menos de un minuto te enseño cómo convertir la Biblioteca de Nodus o tu biblioteca de Zotero en un grafo de ideas. Puedes saltártelo cuando quieras.',
+    title: 'Bienvenido a tu vault académico',
+    body: 'Aunque veas muchas opciones, para empezar solo necesitas una ruta: Biblioteca → Ideas → Grafo. En un minuto harás ese recorrido; puedes saltarlo o repetirlo desde Ajustes cuando quieras.',
   },
   {
     target: 'vault-badge',
-    title: 'Bóvedas independientes',
-    body: 'Cada bóveda es un espacio separado: biblioteca, grafo, notas, proyectos, chats, ajustes, embeddings y claves API pueden vivir aislados. Pulsa esta insignia para crear otra, cambiar de bóveda o cargar claves desde una bóveda anterior.',
-  },
-  {
-    target: 'nav-graph',
-    view: 'graph',
-    title: 'El grafo de ideas',
-    body: 'Es el corazón de Nodus. Cada nodo es una idea extraída de tus lecturas y cada arista una relación entre ellas. Empieza vacío: se llena a medida que escaneas obras a fondo.',
-  },
-  {
-    target: 'sync',
-    title: 'Dos formas de añadir obras',
-    body: 'Biblioteca acepta archivos, DOI, ISBN, referencias manuales e importaciones. Si ya usas Zotero, este botón sincroniza tus colecciones monitorizadas en modo solo lectura.',
-  },
-  {
-    // Sin ancla: Colecciones ya no tiene icono propio en la cabecera. Se abre desde la
-    // paleta de comandos, que no es un elemento que se pueda señalar en pantalla.
-    title: 'Organiza a tu manera',
-    body: 'Crea colecciones y subcolecciones propias dentro de Biblioteca. También puedes mantener la estructura de Zotero como fuente de solo lectura y combinar ambos sistemas sin perder tus cambios de Nodus.',
+    title: 'Empieza por una sola ruta',
+    body: 'Este distintivo indica en qué vault estás. Cada vault separa un proyecto de los demás, para que sus fuentes, análisis y borradores no se mezclen. Úsalo solo cuando quieras cambiar de proyecto o crear otro.',
   },
   {
     target: 'nav-library',
     view: 'library',
-    title: 'Tu biblioteca',
-    body: 'Global reúne referencias, archivos y colecciones de todos tus vaults. Este vault conserva el corpus tradicional y sus estados de análisis. Puedes usar solo Nodus, solo Zotero o combinar ambos.',
+    title: 'Biblioteca: dos ámbitos, una decisión',
+    body: 'Global guarda las fuentes disponibles para todos tus proyectos; «Este vault» muestra solo las que participan aquí. Puedes añadir archivos, DOI, ISBN o referencias manuales, o sincronizar Zotero. No necesitas configurar todas las opciones para comenzar.',
   },
   {
-    target: 'library-actions',
+    target: 'library-scope',
     view: 'library',
-    title: 'Añadir una obra al grafo',
-    body: 'Pulsa «Analizar» en la fila de una obra, o selecciona varias y analízalas juntas. Nodus lee el texto, extrae temas padre, ideas con evidencia y relaciones, y las añade al grafo. La columna Estado te dice en qué punto va cada obra.',
+    title: 'Analiza solo lo que necesites',
+    body: 'Añade una fuente al vault y cambia a «Este vault». Allí selecciona una o varias obras y pulsa «Analizar». Nodus extraerá temas, ideas, evidencia y relaciones. Empieza con una sola fuente: siempre podrás analizar más después.',
+  },
+  {
+    title: 'La cola te cuenta qué ocurre',
+    body: 'La barra inferior muestra el progreso de los análisis. Puedes seguir usando Nodus mientras trabaja. Si falta un modelo o una clave de IA, la tarea se pausa y te indica qué revisar en Ajustes; no tienes que adivinar qué falló.',
   },
   {
     target: 'nav-ideas',
     view: 'ideas',
-    title: 'Verificar ideas extraídas',
-    body: 'Cada idea aparece con su tipo (afirmación, hallazgo, constructo, método o marco), la obra de la que procede y la cita textual que la sostiene. Abre el detalle para comprobar si la lectura automática coincide con la tuya.',
+    title: 'Comprueba antes de confiar',
+    body: 'Ideas reúne lo extraído de tus lecturas. Abre una idea y revisa la cita o el pasaje que la sostiene. La IA ayuda a leer, pero la fuente sigue siendo la autoridad: esta comprobación es el hábito más importante del vault académico.',
   },
   {
-    target: 'queue',
-    title: 'La cola de escaneo',
-    body: 'Sigue aquí el progreso. Si falta el modelo de IA o la clave, la cola se pausa y te avisa en vez de fallar en silencio: lo arreglas en Ajustes y pulsas «Reanudar».',
+    target: 'nav-graph',
+    view: 'graph',
+    title: 'Las conexiones aparecen después',
+    body: 'Grafo muestra cada idea como un nodo y sus relaciones como enlaces. Al principio puede estar vacío o ser pequeño: es normal. Se vuelve útil a medida que analizas fuentes verificadas, no antes.',
   },
   {
-    target: 'model',
-    title: 'Modelo de IA',
-    body: 'Comprueba que hay un modelo seleccionado: sin él, Nodus no puede escanear. Puedes cambiarlo aquí o en Ajustes, y marcar tus favoritos.',
+    target: 'nav-workspace',
+    view: 'workspace',
+    title: 'Escribe sin salir del corpus',
+    body: 'Espacio de trabajo reúne notas, borradores y proyectos de escritura. Conserva los enlaces internos a fuentes e ideas para que puedas volver a la evidencia mientras redactas. No hace falta usarlo hasta que tengas algo que desarrollar.',
   },
   {
-    target: 'nav-search',
-    view: 'search',
-    title: 'Búsqueda global',
-    body: 'Busca por palabras clave a través de ideas, obras, huecos, temas, autores y notas. Los resultados te llevan directamente al detalle correspondiente en cada vista.',
-  },
-  {
-    target: 'nav-notes',
-    view: 'notes',
-    title: 'Tu espacio de notas',
-    body: 'Crea carpetas y notas en Markdown. Captura respuestas del asistente, borradores del taller de escritura, síntesis de debates e ideas individuales. Las citas internas (nodus://) permanecen clicables.',
-  },
-  {
-    title: 'Y hay mucho más',
-    body: 'Esto es solo la mecánica básica. Nodus incluye también Autores (fichas y matriz de síntesis), un Laboratorio de hipótesis, Mapa de argumentos, Debates, Cobertura de tu pregunta, Ruta de lectura, un Taller de escritura con Deep Research y Proyectos de manuscrito con verificador de citas. ¿Quieres el recorrido completo de este flujo? Lánzalo desde Ajustes → Ayuda → Tutorial avanzado.',
-  },
-  {
-    title: '¡Listo para empezar!',
-    body: 'Explora el grafo, descubre huecos de investigación y sigue la ruta de lectura sugerida. Podrás volver a ver este recorrido desde Ajustes cuando quieras.',
+    title: 'Lo demás puede esperar',
+    body: 'El menú agrupa funciones por intención: Explorar, Analizar, Escribir y Herramientas. Ábrelas cuando tu investigación las necesite; en Ajustes puedes ocultar o reordenar secciones. Tu primera misión es sencilla: añade una fuente, analízala y verifica una idea.',
   },
 ];
 
 export function Tour({ onClose, onNavigate }: { onClose: () => void; onNavigate: (v: ViewId) => void }) {
   return (
     <TourOverlay
-      steps={STEPS}
+      steps={ACADEMIC_TOUR_STEPS}
       vaultType="academic"
       onClose={onClose}
       onNavigate={(v) => onNavigate(v as ViewId)}

--- a/src/views/tourEngine.tsx
+++ b/src/views/tourEngine.tsx
@@ -117,12 +117,22 @@ export function TourOverlay({
     }
     let cancelled = false;
     let timer = 0;
+    let scrolledIntoView = false;
     const deadline = Date.now() + 5_000;
     const measure = () => {
       if (cancelled) return;
       const el = document.querySelector<HTMLElement>(`[data-tour="${activeTarget}"]`);
       const r = el?.getBoundingClientRect();
       if (r && r.width > 0 && r.height > 0) {
+        // Long sidebars can contain a perfectly valid target below their own scroll
+        // viewport. A spotlight around those off-screen coordinates teaches nothing,
+        // so bring the item into view once and measure again after the scroll settles.
+        if (!scrolledIntoView && (r.bottom < 0 || r.top > window.innerHeight || r.right < 0 || r.left > window.innerWidth)) {
+          scrolledIntoView = true;
+          el?.scrollIntoView({ block: 'center', inline: 'nearest' });
+          timer = window.setTimeout(measure, 120);
+          return;
+        }
         setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
         return; // found — the resize listener keeps it fresh from here
       }
@@ -311,6 +321,7 @@ export function TourOverlay({
                   </button>
                 )}
                 <button
+                  data-testid="tour-start-walkthrough"
                   className={`w-full ${video ? 'btn btn-ghost border border-neutral-700' : 'btn btn-primary'}`}
                   onClick={() => {
                     setStarted(true);
@@ -324,11 +335,11 @@ export function TourOverlay({
                 </button>
               </>
             ) : isLast ? (
-              <button className="btn btn-primary" onClick={onClose}>
+              <button data-testid="tour-finish" className="btn btn-primary" onClick={onClose}>
                 {t('Empezar')}
               </button>
             ) : (
-              <button className="btn btn-primary" onClick={() => setI((n) => n + 1)}>
+              <button data-testid="tour-next" className="btn btn-primary" onClick={() => setI((n) => n + 1)}>
                 {t('Siguiente')}
               </button>
             )}


### PR DESCRIPTION
## Summary\n\n- replace the outdated 14-step academic vault tour with a calm nine-step Library → Ideas → Graph workflow\n- explain Global versus This vault, one-source analysis, evidence verification, Graph growth, and optional Workspace use\n- remove stale Sync, Model, Notes, and Search targets and make long-sidebar targets scroll into view\n- provide complete copy for all eight supported interface languages\n- add regression coverage and a reusable real-Electron capture script\n\n## Related issue\n\nCloses #640\n\n## Type of change\n\n- [ ] Bug fix\n- [x] New feature or improvement\n- [x] Documentation or translation\n- [ ] Refactor or maintenance\n- [ ] Database, privacy, security, or infrastructure change\n\n## Validation\n\n- [x] npm run citation:check\n- [x] npm run lint\n- [x] npm run typecheck\n- [x] npm run build\n- [x] npm run build:server-web\n- [x] node --test scripts/test-i18n-coverage.mjs scripts/test-vault-onboarding-ui.mjs\n- [x] Server Web tests that require the compiled bundle\n- [x] Real Electron visual QA: 9 steps × 8 locales, 72 full-size screenshots and 8 contact sheets\n- [ ] npm run test:e2e when relevant — delegated to the required macOS CI job\n\nThe initial unsequenced full test run exposed two Server Web failures because its compiled bundle was absent. After reproducing the CI order with npm run build:server-web, both affected suites passed.\n\n## Screenshots\n\nThe real-Electron capture script generated and validated all nine steps in Spanish, English, French, German, European Portuguese, Brazilian Portuguese, Italian, and Turkish. The 72 screenshots and eight contact sheets were reviewed locally and kept out of Git as generated QA artifacts.\n\n## Privacy and data review\n\n- [x] No secrets, credentials, private vault content, personal data, student data, or confidential documents are included.\n- [x] No new network access is introduced.\n- [x] The change does not send rosters, grades, student answers, or other protected data to AI providers.\n- [x] The change does not use AI to grade, rank, profile, or evaluate students.\n- [x] No database, backup, synchronization, or migration behavior changes.\n\n## Contributor checklist\n\n- [x] I added or updated focused tests.\n- [x] No external documentation change is required for this in-app tutorial refresh.\n- [x] I updated every language table for new static UI text.\n- [x] I preserved local-first behavior and existing privacy boundaries.\n- [x] I have read and followed CONTRIBUTING.md and CODE_OF_CONDUCT.md.