### PR TITLE
test(ai): assert the body deadline by ordering, not wall clock

### DIFF
--- a/scripts/test-ai-json-retry.mjs
+++ b/scripts/test-ai-json-retry.mjs
@@ -34,6 +34,9 @@ installRuntimeHooks(root);
  */
 let queue = [];
 let seen = [];
+/** Flips when the fake server actually flushes a delayed body, so ordering can be asserted. */
+let bodyFlushed = false;
+let announceBodyFlush = () => undefined;
 const server = createServer((req, res) => {
   let body = '';
   req.on('data', (chunk) => { body += chunk; });
@@ -48,7 +51,11 @@ const server = createServer((req, res) => {
       // Reproduce the SDK edge case: headers arrive within its timeout, while the
       // response body remains pending beyond the complete-operation deadline.
       res.flushHeaders();
-      setTimeout(() => res.end(payload), reply.bodyDelayMs);
+      setTimeout(() => {
+        bodyFlushed = true;
+        announceBodyFlush();
+        res.end(payload);
+      }, reply.bodyDelayMs);
     } else {
       res.end(payload);
     }
@@ -69,7 +76,7 @@ try {
   const opts = { system: 'system', user: 'user', maxTokens: 256 };
   /** Demands a field the model may omit — the realistic schema-mismatch shape. */
   const guard = (v) => !!v && typeof v === 'object' && Array.isArray(v.ideas);
-  const run = (replies) => { queue = replies; seen = []; };
+  const run = (replies) => { queue = replies; seen = []; bodyFlushed = false; };
 
   // 1. Happy path: one well-formed, schema-valid response costs exactly one call.
   run(['{"ideas":["a"]}']);
@@ -208,12 +215,17 @@ try {
   // SDK timeout stops at that boundary, which allowed a 180s request to occupy a Nodus
   // slot for 267s when DeepSeek stalled while delivering the body.
   run([{ content: '{"ideas":["late"]}', finish_reason: 'stop', bodyDelayMs: 200 }]);
-  const timeoutStarted = Date.now();
+  // Ordering, not milliseconds: an unarmed deadline can only surface after the body
+  // lands, so a rejection that beats the flush is the property itself under any load.
+  const bodyDelivered = new Promise((resolve) => { announceBodyFlush = resolve; });
   await assert.rejects(() => aiClient.completeJson({ ...opts, timeoutMs: 40 }, guard, model), (e) => {
     assert.equal(e.code, 'timeout');
     return true;
   });
-  assert.ok(Date.now() - timeoutStarted < 180, 'body delivery is bounded by the caller deadline');
+  assert.equal(bodyFlushed, false, 'the caller deadline fires before the stalled body is ever delivered');
+  // Waiting for the flush proves the delayed path really ran, so the check above is not vacuous.
+  await bodyDelivered;
+  assert.equal(bodyFlushed, true, 'the fake server did stall the body, so the ordering check had something to beat');
   assert.equal(seen.length, 1, 'an ambiguous body timeout is not replayed blindly');
 
   // 10. Deterministic Gemini extraction uses the native GenerationConfig contract:


### PR DESCRIPTION
Closes #650.

## What this changes

The stalled-body case in `scripts/test-ai-json-retry.mjs` guarded the post-header AI deadline with a wall-clock budget:

```js
assert.ok(Date.now() - timeoutStarted < 180, 'body delivery is bounded by the caller deadline');
```

It now asserts ordering instead. The fake server records the moment it actually flushes the delayed body, and the case asserts that the timeout rejection arrives before that flush:

```js
const bodyDelivered = new Promise((resolve) => { announceBodyFlush = resolve; });
await assert.rejects(() => aiClient.completeJson({ ...opts, timeoutMs: 40 }, guard, model), …);
assert.equal(bodyFlushed, false, 'the caller deadline fires before the stalled body is ever delivered');
await bodyDelivered;
assert.equal(bodyFlushed, true, 'the fake server did stall the body, so the ordering check had something to beat');
```

`bodyFlushed` resets per `run()`, alongside the existing `queue` and `seen`.

## Why ordering rather than a bigger number

The property under test is that the complete-operation deadline stays armed after the HTTP headers arrive — the edge case that once let a 180 s request occupy a Nodus slot for 267 s when DeepSeek stalled mid-body. An un-bounded path can only surface *after* the body lands, so a rejection that beats the flush **is** that property, and it holds under any amount of scheduler pressure. Raising the constant would have kept the guard hostage to machine speed; this version has no timing constant left.

The trailing `await bodyDelivered` plus its assertion keeps the check honest: if the fake server ever stopped stalling the body, the test fails instead of passing vacuously.

## Verification

- `node --test scripts/test-ai-json-retry.mjs` — pass.
- **Mutation check** (throwaway copy, since deleted): the call was wrapped so the timeout error only surfaces 400 ms later, i.e. after the body lands — exactly the un-bounded behaviour this guards. The new assertion failed with `actual: true, expected: false`. It catches the regression, not just the clock.
- Full `node --test scripts/test-*.mjs` — exit 0, 2808 tests, 2807 pass, 0 fail, 1 skipped (~294 s), with this file passing inside the parallel run that produced the original flake.

Test-only change; no runtime code is touched.
