### PR TITLE
feat(ai): OpenCode Go session header and a custom OpenAI-compatible provider

### DIFF
--- a/electron/ai/aiClient.ts
+++ b/electron/ai/aiClient.ts
@@ -11,6 +11,7 @@ import {
   localContextWindow,
   localContextCapabilities,
   localBaseUrl,
+  customBaseUrl,
   FREE_TIER_PROVIDERS,
   freeTierMaxTokens,
   groqFreeTpm,
@@ -42,6 +43,7 @@ import { classifyProviderError } from './providerErrors';
 import { completeWithChatGptSubscription } from './codexSubscription';
 import { completeWithGitHubCopilotSubscription } from './githubCopilotSubscription';
 import { completeWithOpenCodeGo, OUTPUT_TRUNCATED_MARKER } from './openCodeGoCompletion';
+import { nodusUserAgent, openCodeGoSessionId } from './clientIdentity';
 import { recordOpenCodeGoUsage } from './openCodeGoUsage';
 import { AI_MODEL_REQUIRED_ERROR_CODE } from '@shared/aiModelRequired';
 import { createHash } from 'node:crypto';
@@ -249,10 +251,17 @@ function withJsonModeDirective(system: string, jsonMode: boolean): string {
 /** Stored key for a provider, or a harmless placeholder for local providers
  *  (Ollama / LM Studio need no key; the OpenAI SDK still requires a non-empty
  *  string). A user-supplied token for a secured local instance takes precedence. */
+const CUSTOM_ENDPOINT_MISSING =
+  'Falta la dirección del servidor compatible con OpenAI. Configúrala en Ajustes → Proveedores.';
+
 function resolveProviderKey(provider: AiProvider): string | null {
   const stored = getApiKey(provider);
   if (stored) return stored;
-  return isLocalProvider(provider) || provider === 'nodus' ? 'local' : null;
+  // A gateway on the user's own machine usually authenticates nobody, and the
+  // OpenAI SDK refuses to construct without an apiKey — so these providers get the
+  // same placeholder bearer the local ones have always sent. A real key, when the
+  // user stores one, is returned above and takes its place.
+  return isLocalProvider(provider) || provider === 'nodus' || provider === 'custom' ? 'local' : null;
 }
 
 // ── Local model context budgeting ────────────────────────────────────────────
@@ -744,8 +753,22 @@ function freeTierBudget(model: ModelRef, opts: CallOpts, localMax: number): numb
   return budget;
 }
 
-function openAiClientHeaders(model: ModelRef): Record<string, string> | undefined {
-  return model.provider === 'openrouter' ? OPENROUTER_HEADERS : undefined;
+/**
+ * Headers every OpenAI-compatible client sends: this one seam covers OpenAI,
+ * Groq, Cerebras, DeepSeek, Xiaomi, Gemini's compatible surface and OpenRouter,
+ * for chat and embeddings alike.
+ *
+ * None of them require the User-Agent — unlike OpenCode Go, see
+ * electron/ai/clientIdentity.ts — but announcing the app and version costs
+ * nothing and beats appearing in their logs as an anonymous "node". It carries no
+ * user data, and the API key already identifies the account far more precisely.
+ * OpenRouter additionally gets the attribution pair it uses for ranking.
+ */
+function openAiClientHeaders(model: Pick<ModelRef, 'provider'>): Record<string, string> {
+  return {
+    'User-Agent': nodusUserAgent(),
+    ...(model.provider === 'openrouter' ? OPENROUTER_HEADERS : {}),
+  };
 }
 
 /** Cerebras documents the current Chat Completions token cap as
@@ -977,6 +1000,12 @@ async function rawCompleteTransport(
   }
   const key = resolveProviderKey(model.provider);
   if (!key) throw new AiError(`Falta la clave de IA para ${model.provider}. Configúrala en Ajustes.`, false, true);
+  // Refuse an unconfigured custom endpoint here: further down the base URL becomes
+  // `baseURL ?? undefined`, and an undefined baseURL sends the request to
+  // api.openai.com — the user's prompt would leave for a provider they never chose.
+  if (model.provider === 'custom' && !customBaseUrl()) {
+    throw new AiError(CUSTOM_ENDPOINT_MISSING, false, true);
+  }
 
   if (model.provider === 'opencode-go') {
     try {
@@ -992,6 +1021,7 @@ async function rawCompleteTransport(
         timeoutMs: opts.timeoutMs,
         images: opts.images,
         signal: opts.signal,
+        sessionId: openCodeGoSessionId(opts.jobId),
       }));
       await recordOpenCodeGoUsage(model.model, result.usage);
       return result.text;
@@ -1569,6 +1599,12 @@ async function rawCompleteStreamTransport(
 
   const key = resolveProviderKey(model.provider);
   if (!key) throw new AiError(`Falta la clave de IA para ${model.provider}. Configúrala en Ajustes.`, false, true);
+  // Refuse an unconfigured custom endpoint here: further down the base URL becomes
+  // `baseURL ?? undefined`, and an undefined baseURL sends the request to
+  // api.openai.com — the user's prompt would leave for a provider they never chose.
+  if (model.provider === 'custom' && !customBaseUrl()) {
+    throw new AiError(CUSTOM_ENDPOINT_MISSING, false, true);
+  }
 
   if (isLocalProvider(model.provider)) {
     const native = await tryLocalNativeStreaming(model, opts, key, scheduleOpts.signal, (delta, kind) => {
@@ -1594,6 +1630,7 @@ async function rawCompleteStreamTransport(
         signal,
         onDelta: emitContent,
         onReasoningDelta: emitReasoning,
+        sessionId: openCodeGoSessionId(opts.jobId),
       }));
       await recordOpenCodeGoUsage(model.model, result.usage);
       if (!full && result.text) emitContent(result.text);
@@ -1876,13 +1913,7 @@ async function requestEmbeddings(
   const client = new OpenAI({
     apiKey: key,
     baseURL: endpoint,
-    defaultHeaders:
-      provider === 'openrouter'
-        ? {
-            'HTTP-Referer': 'https://github.com/Drakonis96/nodus',
-            'X-Title': 'Nodus',
-          }
-        : undefined,
+    defaultHeaders: openAiClientHeaders({ provider }),
   });
   try {
     const res = await withProviderRetries(freeTier, () => runEmbeddingRequest(async () => {

--- a/electron/ai/clientIdentity.ts
+++ b/electron/ai/clientIdentity.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from 'node:crypto';
+
+/**
+ * How Nodus identifies itself to third-party HTTP APIs.
+ *
+ * The version is registered once from `app.getVersion()` instead of importing
+ * `electron` here: this module is reached from `electron/ai/providers.ts`, which
+ * the `node --test` harnesses bundle as an esbuild entry point, and there
+ * `electron` resolves to a path string with no `app` on it. Hard-coding the
+ * number is not an option either — `libraryCslStyles.ts` announced `Nodus/4.2.3`
+ * to GitHub for eleven releases because the string was typed in by hand.
+ */
+let clientVersion = process.env.npm_package_version?.trim() || '0.0.0-dev';
+
+/** Called once at startup from main.ts, so the User-Agent tracks package.json. */
+export function registerNodusClientVersion(version: string): void {
+  const trimmed = version.trim();
+  if (trimmed) clientVersion = trimmed;
+}
+
+/** `Nodus/5.1.5`. Product name and running version — nothing about the user. */
+export function nodusUserAgent(): string {
+  return `Nodus/${clientVersion}`;
+}
+
+/**
+ * `x-opencode-session`: the grouping key OpenCode Go asks every client to send so
+ * it can optimise its service. Requests missing it may be rejected from
+ * 2026-09-06, which would take down the whole OpenCode Go provider — inference on
+ * all three protocols plus the unauthenticated catalogue call in Settings.
+ *
+ * Nodus has no chat conversations, so the closest equivalent is a unit of work:
+ * one deep scan of a work, one Deep Research report, one Nodi thread. Job ids are
+ * shaped `<root>:<stage>:<chunk>…`, so the root is what groups a run's many
+ * chunked calls under a single session; calls with no job id share one id for the
+ * running process.
+ *
+ * What travels is always a fresh random UUID, never the job id itself: job ids are
+ * content-free but they still spell out which Nodus pipeline is running, and that
+ * is not OpenCode's business. Nothing is persisted, so no id survives a restart
+ * and none can act as a stable identifier for the user.
+ */
+const SESSION_LIMIT = 256;
+const sessions = new Map<string, string>();
+const processSession = randomUUID();
+
+export function openCodeGoSessionId(jobId?: string | null): string {
+  const root = jobId?.split(':')[0]?.trim();
+  if (!root) return processSession;
+  const existing = sessions.get(root);
+  if (existing) return existing;
+  const id = randomUUID();
+  sessions.set(root, id);
+  // Bounded: a corpus-wide run opens one root per work.
+  if (sessions.size > SESSION_LIMIT) {
+    const oldest = sessions.keys().next().value;
+    if (oldest !== undefined) sessions.delete(oldest);
+  }
+  return id;
+}

--- a/electron/ai/openCodeGoCompletion.ts
+++ b/electron/ai/openCodeGoCompletion.ts
@@ -1,5 +1,6 @@
 import type { ReasoningEffort } from '@shared/types';
 import type { VisionImagePart } from '@shared/imageAnalysis';
+import { nodusUserAgent, openCodeGoSessionId } from './clientIdentity';
 
 /**
  * Prefix that marks an output-ceiling cutoff. aiClient re-types errors carrying it as
@@ -34,6 +35,8 @@ export interface OpenCodeGoCompletionOptions {
   onReasoningDelta?: (delta: string) => void;
   /** Test seam; production always uses the documented OpenCode Go endpoint. */
   baseUrl?: string;
+  /** `x-opencode-session` grouping key. Defaults to the per-process session. */
+  sessionId?: string;
 }
 
 export interface OpenCodeGoCompletionResult {
@@ -53,6 +56,22 @@ export function openCodeGoProtocol(model: string): OpenCodeGoProtocol {
   return ANTHROPIC_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix))
     ? 'anthropic'
     : 'openai';
+}
+
+/**
+ * Headers every OpenCode Go request carries, whichever protocol it speaks.
+ *
+ * `x-opencode-session` is required by OpenCode: without it they may reject the
+ * request outright from 2026-09-06. The User-Agent is courtesy — their logs saw
+ * only "Node fetch" and could not tell which client was calling.
+ */
+function goHeaders(options: OpenCodeGoCompletionOptions, auth: Record<string, string>): Record<string, string> {
+  return {
+    ...auth,
+    'Content-Type': 'application/json',
+    'User-Agent': nodusUserAgent(),
+    'x-opencode-session': options.sessionId ?? openCodeGoSessionId(),
+  };
 }
 
 function apiError(status: number, payload: unknown): Error & { status: number } {
@@ -232,7 +251,7 @@ async function completeResponses(options: OpenCodeGoCompletionOptions, url: stri
   const streaming = Boolean(options.onDelta);
   const response = await postWithOptionalExtras(
     `${url}/v1/responses`,
-    { Authorization: `Bearer ${options.apiKey}`, 'Content-Type': 'application/json' },
+    goHeaders(options, { Authorization: `Bearer ${options.apiKey}` }),
     signal,
     {
       model: options.model,
@@ -289,7 +308,7 @@ async function completeOpenAi(options: OpenCodeGoCompletionOptions, url: string,
   const streaming = Boolean(options.onDelta);
   const response = await postWithOptionalExtras(
     `${url}/v1/chat/completions`,
-    { Authorization: `Bearer ${options.apiKey}`, 'Content-Type': 'application/json' },
+    goHeaders(options, { Authorization: `Bearer ${options.apiKey}` }),
     signal,
     {
       model: options.model,
@@ -348,11 +367,7 @@ async function completeAnthropic(options: OpenCodeGoCompletionOptions, url: stri
   const isQwen = options.model.toLowerCase().startsWith('qwen');
   const response = await fetch(`${url}/v1/messages`, {
     method: 'POST',
-    headers: {
-      'x-api-key': options.apiKey,
-      'anthropic-version': '2023-06-01',
-      'Content-Type': 'application/json',
-    },
+    headers: goHeaders(options, { 'x-api-key': options.apiKey, 'anthropic-version': '2023-06-01' }),
     signal,
     body: JSON.stringify({
       model: options.model,

--- a/electron/ai/providers.ts
+++ b/electron/ai/providers.ts
@@ -6,16 +6,28 @@ import type {
   ModelInfo,
 } from '@shared/types';
 import { getSettings } from '../db/settingsRepo';
-import { DEFAULT_LOCAL_BASE_URLS } from '@shared/providers';
+import { DEFAULT_LOCAL_BASE_URLS, normalizeCustomBaseUrl, normalizeCustomModels } from '@shared/providers';
 import { listNodusLocalChatModels, listNodusLocalEmbeddingModels } from './nodusLocalAi';
+import { nodusUserAgent, openCodeGoSessionId } from './clientIdentity';
 
 export { AI_PROVIDERS, PROVIDER_LABELS, LOCAL_PROVIDERS, isLocalProvider } from '@shared/providers';
+export { normalizeCustomBaseUrl, normalizeCustomModels, normalizeCustomProviderConfig } from '@shared/providers';
 export { FREE_TIER_PROVIDERS } from '@shared/providers';
 
 /** The configured base URL for a local provider, without a trailing slash. */
 export function localBaseUrl(provider: LocalProvider): string {
   const configured = getSettings().localProviders?.[provider]?.baseUrl?.trim();
   return (configured || DEFAULT_LOCAL_BASE_URLS[provider]).replace(/\/+$/, '');
+}
+
+/** The user's configured endpoint, or '' when unset. See normalizeCustomBaseUrl. */
+export function customBaseUrl(): string {
+  return normalizeCustomBaseUrl(getSettings().customProvider?.baseUrl ?? '');
+}
+
+/** The model slugs the user typed by hand for that endpoint. */
+export function customManualModels(): string[] {
+  return normalizeCustomModels(getSettings().customProvider?.models);
 }
 
 /** Optional bearer header when a local instance is secured with a token. */
@@ -49,6 +61,11 @@ export function openAiCompatBase(provider: AiProvider): string | null {
     case 'lmstudio':
       // Local servers expose an OpenAI-compatible surface under {baseUrl}/v1.
       return `${localBaseUrl(provider)}/v1`;
+    case 'custom':
+      // Whatever the user configured, used verbatim. Null when unset so callers
+      // refuse with an actionable error instead of silently falling back to
+      // api.openai.com, which is what an undefined baseURL would do.
+      return customBaseUrl() || null;
     case 'anthropic':
     case 'codex':
     case 'github-copilot':
@@ -75,6 +92,10 @@ export function supportsJsonMode(provider: AiProvider): boolean {
     provider === 'gemini' ||
     provider === 'xiaomi' ||
     provider === 'nodus' ||
+    // The user's own gateway: response_format is part of the OpenAI contract it
+    // claims to implement. A backend that ignores or rejects it is caught by the
+    // caller's 400 retry, which strips the optional params and sends again.
+    provider === 'custom' ||
     // Ollama and LM Studio both accept OpenAI's response_format on their compat
     // surface. A small model that ignores it is caught by the caller's 400 retry.
     provider === 'ollama' ||
@@ -177,6 +198,10 @@ export function reasoningBody(
     case 'opencode-go':
       // Go serves a mixed OpenAI/Anthropic catalogue through dedicated paths.
       return {};
+    case 'custom':
+      // Nodus cannot know what sits behind the user's gateway, and an unsupported
+      // reasoning field is a 400 the caller would have to retry past. Send none.
+      return {};
   }
 }
 
@@ -277,8 +302,65 @@ export async function listModels(provider: AiProvider, key: string | null): Prom
       return listOllama(key);
     case 'lmstudio':
       return listLmStudio(key, false);
+    case 'custom':
+      return listCustom(key);
     case 'nodus':
       return listNodusLocalChatModels();
+  }
+}
+
+/**
+ * The union of what the user typed and what their endpoint reports.
+ *
+ * The remote half is best-effort ON PURPOSE. A gateway that serves inference
+ * without implementing GET /models is precisely the case this provider exists
+ * for, and throwing here would empty every model picker in the app for a setup
+ * that works perfectly well. The failure is surfaced by testCustomProvider
+ * instead — where the user actually asked a question and can act on the answer.
+ *
+ * Manual slugs come first (the user's own list is the one they are looking for)
+ * and win on collision; the remote half stays sorted as listOpenAiStyle returns it.
+ */
+async function listCustom(key: string | null): Promise<ModelInfo[]> {
+  const manual: ModelInfo[] = customManualModels().map((id) => ({ id, name: id }));
+  const base = customBaseUrl();
+  if (!base) return manual;
+  let remote: ModelInfo[] = [];
+  try {
+    remote = await listOpenAiStyle(`${base}/models`, key, false, { keyRequired: false, timeoutMs: 8000 });
+  } catch {
+    // Endpoint has no catalogue, is unreachable, or rejects the key: the manual
+    // list still selects and still runs inference.
+    remote = [];
+  }
+  const typed = new Set(manual.map((model) => model.id));
+  return [...manual, ...remote.filter((model) => !typed.has(model.id))];
+}
+
+/**
+ * "Test connection" for the custom endpoint, in the spirit of testLocalProvider.
+ *
+ * A catalogue failure is reported as such, but the message says the manual list
+ * still works: for many gateways a missing /models is normal, not broken.
+ */
+export async function testCustomProvider(key: string | null): Promise<LocalProviderTestResult> {
+  const base = customBaseUrl();
+  if (!base) return { ok: false, message: 'Falta la dirección del servidor.' };
+  const manual = customManualModels().length;
+  try {
+    const models = await listOpenAiStyle(`${base}/models`, key, false, { keyRequired: false, timeoutMs: 8000 });
+    const typed = new Set(customManualModels());
+    return { ok: true, modelCount: models.filter((model) => !typed.has(model.id)).length + manual };
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      message: manual > 0
+        ? `${base}: ${detail}. ${manual === 1
+            ? 'El modelo escrito a mano sigue disponible.'
+            : `Los ${manual} modelos escritos a mano siguen disponibles.`}`
+        : `${base}: ${detail}`,
+    };
   }
 }
 
@@ -317,7 +399,12 @@ const OPENCODE_GO_MODEL_NAMES: Record<string, string> = {
  * for inference, so Settings can show what the subscription offers before a key
  * is pasted. The response intentionally carries no inferred vision capability. */
 async function listOpenCodeGo(): Promise<ModelInfo[]> {
-  const res = await fetch('https://opencode.ai/zen/go/v1/models');
+  // Unauthenticated, but still an OpenCode Go request: it needs the session
+  // header like any other or it may start being rejected, which would empty the
+  // model picker in Settings before a key is even pasted.
+  const res = await fetch('https://opencode.ai/zen/go/v1/models', {
+    headers: { 'User-Agent': nodusUserAgent(), 'x-opencode-session': openCodeGoSessionId() },
+  });
   if (!res.ok) throw new Error(`OpenCode Go /models HTTP ${res.status}`);
   const data = (await res.json()) as { data?: { id?: string }[] };
   return (data.data ?? [])
@@ -353,9 +440,32 @@ async function listAnthropic(key: string | null): Promise<ModelInfo[]> {
   return (data.data ?? []).map((m) => ({ id: m.id, name: m.display_name })).sort(byId);
 }
 
-async function listOpenAiStyle(url: string, key: string | null, filterChat: boolean): Promise<ModelInfo[]> {
-  if (!key) throw new Error('Falta la clave del proveedor.');
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${key}` } });
+/**
+ * GET {url} in OpenAI's /models shape.
+ *
+ * `keyRequired` exists for the custom provider, whose endpoint is frequently a
+ * gateway on the user's own machine that needs no credential at all; `timeoutMs`
+ * likewise, so a mistyped host fails fast instead of hanging the Settings button
+ * the way an untimed fetch against a black-holed IP would.
+ */
+async function listOpenAiStyle(
+  url: string,
+  key: string | null,
+  filterChat: boolean,
+  options: { keyRequired?: boolean; timeoutMs?: number } = {},
+): Promise<ModelInfo[]> {
+  if (!key && options.keyRequired !== false) throw new Error('Falta la clave del proveedor.');
+  const controller = new AbortController();
+  const timer = options.timeoutMs ? setTimeout(() => controller.abort(), options.timeoutMs) : null;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: key ? { Authorization: `Bearer ${key}` } : {},
+      signal: timer ? controller.signal : undefined,
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
   if (!res.ok) throw new Error(`/models HTTP ${res.status}`);
   const data = (await res.json()) as {
     data?: {

--- a/electron/db/appPrefs.ts
+++ b/electron/db/appPrefs.ts
@@ -88,6 +88,10 @@ export type GlobalPrefKey = (typeof GLOBAL_PREF_KEYS)[number];
 export const SHARED_MODEL_KEYS = [
   'codexReasoningEfforts',
   'localProviders',
+  // The user's own OpenAI-compatible endpoint. App-level like the local base URLs:
+  // one gateway serves every vault, and re-typing the URL per vault is nobody's idea
+  // of a preference.
+  'customProvider',
   'providerFreeTier',
   'extractionModel',
   'visionModel',

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -1,6 +1,11 @@
 import { getDb } from './database';
 import type { AppSettings, ModelRef } from '@shared/types';
-import { DEFAULT_EMBEDDING_MODELS, DEFAULT_LOCAL_BASE_URLS, normalizeEmbeddingProvider } from '@shared/providers';
+import {
+  DEFAULT_EMBEDDING_MODELS,
+  DEFAULT_LOCAL_BASE_URLS,
+  normalizeCustomProviderConfig,
+  normalizeEmbeddingProvider,
+} from '@shared/providers';
 import { isOpenAiStudySttModel } from '@shared/sttModels';
 import { NODI_ORB_DEFAULT_COLOR } from '@shared/nodiOrb';
 import { NODI_DEFAULT_SCALE, normalizeNodiScale } from '@shared/nodiSize';
@@ -22,6 +27,9 @@ const DEFAULT_LOCAL_PROVIDERS: AppSettings['localProviders'] = {
   ollama: { baseUrl: DEFAULT_LOCAL_BASE_URLS.ollama, contextMode: 'auto' },
   lmstudio: { baseUrl: DEFAULT_LOCAL_BASE_URLS.lmstudio, contextMode: 'auto' },
 };
+
+/** No default endpoint exists for someone else's gateway: unconfigured means off. */
+const DEFAULT_CUSTOM_PROVIDER: AppSettings['customProvider'] = { baseUrl: '', models: [] };
 
 function sanitizeCodexReasoningEfforts(value: unknown): AppSettings['codexReasoningEfforts'] {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
@@ -50,6 +58,7 @@ const DEFAULTS: Omit<AppSettings, 'providerKeys' | 'lockedProviderKeys'> = {
   embeddingProvider: 'openai',
   embeddingModel: DEFAULT_EMBEDDING_MODELS.openai,
   localProviders: DEFAULT_LOCAL_PROVIDERS,
+  customProvider: DEFAULT_CUSTOM_PROVIDER,
   favorites: [],
   defaultModel: null,
   modelSettingsMode: 'basic',
@@ -333,6 +342,10 @@ export function getSettings(): AppSettings {
   if (!['ask', 'always', 'never'].includes(merged.studyKnowledgeAutoProcess)) merged.studyKnowledgeAutoProcess = 'ask';
   // Deep-merge local-provider config so a stored partial (or a newly added
   // provider absent from an older settings blob) keeps its default base URL.
+  // Normalise on the way OUT as well as in: a blob written by an older build (or by
+  // hand) can carry a trailing slash or duplicate slugs, and every consumer reads
+  // this value rather than re-normalising for itself.
+  merged.customProvider = normalizeCustomProviderConfig(parsed.customProvider ?? merged.customProvider);
   merged.localProviders = {
     ollama: { ...DEFAULT_LOCAL_PROVIDERS.ollama, ...parsed.localProviders?.ollama },
     lmstudio: { ...DEFAULT_LOCAL_PROVIDERS.lmstudio, ...parsed.localProviders?.lmstudio },
@@ -500,6 +513,12 @@ export function updateSettings(patch: Partial<AppSettings>): AppSettings {
   }
   if (patch.customEventTypes !== undefined) {
     patch = { ...patch, customEventTypes: sanitizeCustomEventTypes(patch.customEventTypes) };
+  }
+  if (patch.customProvider !== undefined) {
+    // Normalise on the way IN as well as out: the stored blob is what Settings
+    // renders back, and a trailing slash the user pasted should not survive to be
+    // shown to them (nor to be diffed against the next value they type).
+    patch = { ...patch, customProvider: normalizeCustomProviderConfig(patch.customProvider) };
   }
   if (patch.codexReasoningEfforts !== undefined) {
     patch = { ...patch, codexReasoningEfforts: sanitizeCodexReasoningEfforts(patch.codexReasoningEfforts) };

--- a/electron/ipc/platform.ts
+++ b/electron/ipc/platform.ts
@@ -14,7 +14,7 @@ import { ensureCopilotCert } from '../copilot/certs';
 import { installCopilotAddin, installLibreOfficeCopilot } from '../copilot/install';
 import { setApiKey, clearApiKey, getApiKey, getLocalServerAdminPassword } from '../secrets/secretStore';
 import { recoverLegacyApiKeys } from '../secrets/legacySecretRecovery';
-import { listEmbeddingModels, listModels, testLocalProvider } from '../ai/providers';
+import { listEmbeddingModels, listModels, testCustomProvider, testLocalProvider } from '../ai/providers';
 import { cancelChatGptSubscriptionLogin, getChatGptSubscriptionStatus, listChatGptSubscriptionModels, logoutChatGptSubscription, startChatGptSubscriptionLogin } from '../ai/codexSubscription';
 import { cancelGitHubCopilotSubscriptionLogin, getGitHubCopilotSubscriptionStatus, listGitHubCopilotSubscriptionModels, logoutGitHubCopilotSubscription, startGitHubCopilotSubscriptionLogin } from '../ai/githubCopilotSubscription';
 import { getOpenCodeGoUsageStatus } from '../ai/openCodeGoUsage';
@@ -232,6 +232,7 @@ export function registerPlatformIpc({ h, getWindow }: IpcContext): void {
     listEmbeddingModels(provider, getApiKey(provider))
   );
   h('ai:testLocalProvider', async (_e, provider: LocalProvider) => testLocalProvider(provider, getApiKey(provider)));
+  h('ai:testCustomProvider', async () => testCustomProvider(getApiKey('custom')));
   h('ai:localDiagnostics', async () => listLocalAiDiagnostics());
   h('ai:listImageModels', async () => listImageModels());
   h('ai:nodusLocal:status', async () => getNodusLocalAiStatus());

--- a/electron/library/libraryCslStyles.ts
+++ b/electron/library/libraryCslStyles.ts
@@ -23,6 +23,7 @@ import type {
 } from '@shared/officeCitationTypes';
 import { atomicWriteFile, atomicWriteJson, configuredLibraryRootOrThrow, readJsonFile, safeLibraryFolderName } from './libraryPaths';
 import { bundledOfficialCslStyle } from './bundledOfficialCslStyles';
+import { nodusUserAgent } from '../ai/clientIdentity';
 
 type StoredStyleSource = Extract<LibraryCitationStyleRecord['source'], 'zotero' | 'file' | 'repository'>;
 interface StoredStyleEntry { id: string; source: StoredStyleSource; fileName: string; importedAt: string }
@@ -155,7 +156,7 @@ function repositoryStyleTitle(id: string): string {
 async function officialRepositoryIndex(): Promise<LibraryCitationStyleRepositoryEntry[]> {
   if (!repositoryIndexPromise) {
     repositoryIndexPromise = fetch(OFFICIAL_STYLES_TREE_URL, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Nodus/4.2.3' },
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': nodusUserAgent() },
     }).then(async (response) => {
       if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
       const payload = await response.json() as { tree?: Array<{ path?: string; type?: string }>; truncated?: boolean };
@@ -246,7 +247,7 @@ export async function installRepositoryCitationStyle(rawId: string): Promise<Lib
   const id = repositoryIdFromUrl(rawId) ?? rawId.trim().toLowerCase().replace(/\.csl$/i, '');
   if (!/^[a-z0-9][a-z0-9._-]{1,199}$/.test(id)) throw new Error('Introduce el identificador de un estilo del repositorio oficial de CSL.');
   const response = await fetch(`${OFFICIAL_STYLES_RAW_URL}/${encodeURIComponent(id)}.csl`, {
-    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': 'Nodus/4.2.3' },
+    headers: { Accept: 'application/vnd.citationstyles.style+xml, application/xml;q=0.9', 'User-Agent': nodusUserAgent() },
   });
   if (!response.ok) throw new Error(`El repositorio oficial de CSL respondió ${response.status}.`);
   const declaredLength = Number(response.headers.get('content-length') || 0);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -64,6 +64,7 @@ import { setBrowserTheme } from './browser/tabs';
 import { destroyBrowserSubsystem } from './browser/lifecycle';
 import { ensurePreV4Recovery } from './recovery/preV4Recovery';
 import { applyUpdateChannel, availableUpdateVersion, isPrereleaseVersion } from './updateChannel';
+import { registerNodusClientVersion } from './ai/clientIdentity';
 import {
   upgradeWorldbuildingDemoDynasties,
   upgradeWorldbuildingDemoImageQuality,
@@ -83,6 +84,11 @@ const { autoUpdater } = require('electron-updater') as typeof import('electron-u
 // server and Bridge credentials in the macOS Keychain. It is a compatibility identifier, not a
 // user-facing product name.
 app.setName('Nodus');
+
+// The version every outbound API request announces in its User-Agent. Registered
+// here rather than imported where it is used, because those modules are bundled
+// by the node --test harnesses, where `electron` has no `app` on it.
+registerNodusClientVersion(app.getVersion());
 
 // Deeplink for OAuth: nodus://authorize?code=XYZ
 // Google blocks OAuth in embedded webviews; the correct pattern is

--- a/electron/preload/platform.ts
+++ b/electron/preload/platform.ts
@@ -109,6 +109,7 @@ export const platformApi: PlatformApi = {
   listModels: (provider) => ipcRenderer.invoke('ai:listModels', provider),
   listEmbeddingModels: (provider) => ipcRenderer.invoke('ai:listEmbeddingModels', provider),
   testLocalProvider: (provider) => ipcRenderer.invoke('ai:testLocalProvider', provider),
+  testCustomProvider: () => ipcRenderer.invoke('ai:testCustomProvider'),
   getLocalAiDiagnostics: () => ipcRenderer.invoke('ai:localDiagnostics'),
   listImageModels: () => ipcRenderer.invoke('ai:listImageModels'),
   getNodusLocalAiStatus: () => ipcRenderer.invoke('ai:nodusLocal:status'),

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -677,6 +677,23 @@ try {
   await page.getByText(/Anthropic no permite que aplicaciones de terceros ofrezcan inicio de sesión de Claude\.ai/).waitFor();
   console.log('[e2e] provider UI exposes subscriptions, usage limits and real light/dark surfaces');
 
+  // The custom OpenAI-compatible provider: its whole reason to exist is that the
+  // user can name models a gateway never publishes, so the row must offer both the
+  // URL field and the manual-model list, and must store what it captured. Placed
+  // after the OpenCode assertions on purpose: this accordion shows one provider at
+  // a time, so expanding a row here collapses whatever the previous block opened.
+  const customProvider = page.getByTestId('provider-row-custom');
+  await customProvider.waitFor();
+  await customProvider.locator('button').first().click();
+  await customProvider.getByTestId('custom-provider-url').fill('http://127.0.0.1:8317/v1/');
+  await customProvider.getByTestId('custom-provider-model-input').fill('gateway-model-a');
+  await customProvider.getByRole('button', { name: 'Añadir', exact: true }).click();
+  await customProvider.getByTestId('custom-provider-manual-models').getByText('gateway-model-a', { exact: true }).waitFor();
+  const storedCustomProvider = await page.evaluate(async () => (await window.nodus.getSettings()).customProvider);
+  assert.deepEqual(storedCustomProvider, { baseUrl: 'http://127.0.0.1:8317/v1', models: ['gateway-model-a'] },
+    'the custom endpoint is stored normalised, with the hand-typed model');
+  console.log('[e2e] custom OpenAI-compatible provider accepts a URL and hand-typed models');
+
   // ── ChatGPT MCP connector: every semantic surface must work in both themes ──
   await page.getByRole('button', { name: 'Integraciones', exact: true }).click();
   const mcpSettingsCard = page.getByTestId('mcp-settings-card');

--- a/scripts/test-ai-json-retry.mjs
+++ b/scripts/test-ai-json-retry.mjs
@@ -39,7 +39,7 @@ const server = createServer((req, res) => {
   req.on('data', (chunk) => { body += chunk; });
   req.on('end', () => {
     if (!req.url.includes('/chat/completions')) { res.writeHead(404).end('{}'); return; }
-    seen.push({ url: req.url, body: JSON.parse(body || '{}') });
+    seen.push({ url: req.url, headers: req.headers, body: JSON.parse(body || '{}') });
     const next = queue.shift() ?? '{}';
     const reply = typeof next === 'string' ? { content: next, finish_reason: 'stop' } : next;
     res.writeHead(200, { 'content-type': 'application/json' });
@@ -75,6 +75,12 @@ try {
   run(['{"ideas":["a"]}']);
   assert.deepEqual((await aiClient.completeJson(opts, guard, model)).ideas, ['a']);
   assert.equal(seen.length, 1, 'a valid first response costs a single provider call');
+  // Every OpenAI-compatible provider (OpenAI, Groq, Cerebras, DeepSeek, Xiaomi,
+  // Gemini-compat, OpenRouter) is built through this one client, so proving the
+  // User-Agent survives the SDK here proves it for all of them. `defaultHeaders`
+  // must WIN over the SDK's own UA, which is the part worth pinning down.
+  assert.match(seen[0].headers['user-agent'], /^Nodus\/\d+\.\d+/, 'requests announce the app and its version');
+  assert.doesNotMatch(seen[0].headers['user-agent'], /OpenAI/i, 'the SDK User-Agent is replaced, not appended to');
 
   /** A repair prompt would ship the bad text back under this key. It is forbidden here. */
   const isRepairCall = (hit) => JSON.stringify(hit.body).includes('invalid_json');

--- a/scripts/test-custom-provider.mjs
+++ b/scripts/test-custom-provider.mjs
@@ -1,0 +1,239 @@
+// The "Custom (OpenAI-compatible)" provider: the user's own gateway (LiteLLM, vLLM,
+// llama.cpp server, a proxy) instead of a vendor API.
+//
+// Drives the REAL electron/ai/providers.ts against a fake OpenAI-compatible server,
+// with only the settings repository stubbed. Three properties matter and none of
+// them is obvious:
+//
+//  1. The base URL is used verbatim. Every other provider in Nodus appends "/v1";
+//     these gateways mount the API wherever they like, so appending anything would
+//     break as many installs as it fixed.
+//  2. The model list is the UNION of what the user typed and what the endpoint
+//     reports — the manual half exists precisely for endpoints that report nothing.
+//  3. An endpoint without GET /models must not break model selection. That is the
+//     normal shape of several proxies, not an error state, so a throw there would
+//     empty every model picker in the app for a setup that works fine.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'nodus-custom-provider-'));
+test.after(() => rm(tmp, { recursive: true, force: true }));
+
+// The settings stub reads a mutable global so each test can reconfigure the
+// provider the way Settings would, without rebuilding the bundle.
+const settingsStub = path.join(tmp, 'settings-stub.mjs');
+await writeFile(settingsStub, 'export function getSettings() { return globalThis.__NODUS_SETTINGS__ ?? {}; }\n');
+const localAiStub = path.join(tmp, 'nodusLocalAi-stub.mjs');
+await writeFile(localAiStub, 'export async function listNodusLocalChatModels() { return []; }\nexport async function listNodusLocalEmbeddingModels() { return []; }\n');
+
+const outfile = path.join(tmp, 'providers.mjs');
+await build({
+  entryPoints: [path.join(repoRoot, 'electron/ai/providers.ts')],
+  outfile,
+  bundle: true,
+  format: 'esm',
+  platform: 'node',
+  logLevel: 'silent',
+  alias: { '@shared': path.join(repoRoot, 'shared') },
+  plugins: [{
+    name: 'stub-deps',
+    setup(b) {
+      b.onResolve({ filter: /db\/settingsRepo$/ }, () => ({ path: settingsStub }));
+      b.onResolve({ filter: /nodusLocalAi$/ }, () => ({ path: localAiStub }));
+    },
+  }],
+});
+const {
+  customBaseUrl,
+  customManualModels,
+  listModels,
+  normalizeCustomBaseUrl,
+  normalizeCustomModels,
+  normalizeCustomProviderConfig,
+  openAiCompatBase,
+  supportsJsonMode,
+  testCustomProvider,
+} = await import(pathToFileURL(outfile).href);
+
+/** Configure the provider the way Settings → Providers would. */
+function configure(baseUrl, models = []) {
+  globalThis.__NODUS_SETTINGS__ = { customProvider: { baseUrl, models } };
+}
+
+/** A gateway. `catalogue: null` models the very common proxy with no GET /models. */
+async function fakeGateway({ catalogue }) {
+  const seen = [];
+  const server = createServer((request, response) => {
+    seen.push({ url: request.url, auth: request.headers.authorization ?? null });
+    if (!request.url.endsWith('/models') || catalogue === null) {
+      response.writeHead(404, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: { message: 'not found' } }));
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ data: catalogue.map((id) => ({ id })) }));
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    seen,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+test('the base URL is taken verbatim: only the trailing slash is normalised', () => {
+  assert.equal(normalizeCustomBaseUrl('  http://localhost:8317/v1  '), 'http://localhost:8317/v1');
+  assert.equal(normalizeCustomBaseUrl('http://localhost:8317/v1///'), 'http://localhost:8317/v1');
+  // The path is the user's business: a gateway mounted at the root stays at the root,
+  // and one under /openai/v1 keeps that prefix. Nodus must never append "/v1".
+  assert.equal(normalizeCustomBaseUrl('http://gateway.lan:4000/'), 'http://gateway.lan:4000');
+  assert.equal(normalizeCustomBaseUrl('https://proxy.example.com/openai/v1'), 'https://proxy.example.com/openai/v1');
+  assert.equal(normalizeCustomBaseUrl(''), '');
+  assert.equal(normalizeCustomBaseUrl(undefined), '');
+
+  configure('http://localhost:8317/v1/');
+  assert.equal(customBaseUrl(), 'http://localhost:8317/v1');
+  assert.equal(openAiCompatBase('custom'), 'http://localhost:8317/v1', 'inference uses the configured base as-is');
+
+  // Unconfigured must be null, NOT undefined: `new OpenAI({ baseURL: undefined })`
+  // silently talks to api.openai.com, which is a provider the user never chose.
+  configure('');
+  assert.equal(openAiCompatBase('custom'), null);
+  assert.equal(supportsJsonMode('custom'), true, 'JSON mode is part of the contract it claims to implement');
+});
+
+test('manual model slugs are trimmed, de-duplicated and keep their order', () => {
+  assert.deepEqual(normalizeCustomModels(['  gemini-3.1-flash ', 'qwen3', 'gemini-3.1-flash', '', '   ']),
+    ['gemini-3.1-flash', 'qwen3']);
+  assert.deepEqual(normalizeCustomModels(undefined), []);
+  assert.deepEqual(
+    normalizeCustomProviderConfig({ baseUrl: 'http://x:1/v1/', models: ['a', 'a', ' b '] }),
+    { baseUrl: 'http://x:1/v1', models: ['a', 'b'] },
+  );
+  assert.deepEqual(normalizeCustomProviderConfig(undefined), { baseUrl: '', models: [] });
+});
+
+test('listModels returns the union of the manual list and the endpoint catalogue', async () => {
+  const gateway = await fakeGateway({ catalogue: ['served-a', 'served-b', 'typed-first'] });
+  try {
+    configure(`${gateway.origin}/v1`, ['typed-first', 'typed-only']);
+    const models = await listModels('custom', null);
+    assert.deepEqual(models.map((m) => m.id), ['typed-first', 'typed-only', 'served-a', 'served-b'],
+      'manual slugs come first and win on collision; the remote half follows');
+    assert.equal(gateway.seen.at(-1).url, '/v1/models', 'the catalogue is read from {baseUrl}/models');
+    assert.equal(gateway.seen.at(-1).auth, null, 'no key configured means no Authorization header');
+
+    const result = await testCustomProvider(null);
+    assert.equal(result.ok, true);
+    assert.equal(result.modelCount, 4, 'the reported count is the union, not just the catalogue');
+  } finally {
+    await gateway.close();
+  }
+});
+
+test('an endpoint without GET /models still selects models and says why', async () => {
+  const gateway = await fakeGateway({ catalogue: null });
+  try {
+    configure(`${gateway.origin}/v1`, ['gemini-3.1-flash', 'qwen3-max']);
+    // The whole point: a 404 catalogue is a normal proxy, not a broken provider.
+    const models = await listModels('custom', null);
+    assert.deepEqual(models.map((m) => m.id), ['gemini-3.1-flash', 'qwen3-max'],
+      'model selection survives an endpoint with no catalogue');
+
+    const result = await testCustomProvider(null);
+    assert.equal(result.ok, false, 'the test reports the catalogue failure honestly');
+    assert.match(result.message, /404/);
+    assert.match(result.message, /2 modelos escritos a mano/, 'and says the manual list still works');
+  } finally {
+    await gateway.close();
+  }
+});
+
+test('an unreachable or unconfigured endpoint never throws out of listModels', async () => {
+  // Nothing is listening here; the manual list must still reach the pickers.
+  configure('http://127.0.0.1:1/v1', ['typed-anyway']);
+  assert.deepEqual((await listModels('custom', null)).map((m) => m.id), ['typed-anyway']);
+
+  configure('', ['typed-anyway']);
+  assert.deepEqual(customManualModels(), ['typed-anyway']);
+  assert.deepEqual((await listModels('custom', null)).map((m) => m.id), ['typed-anyway'],
+    'with no URL at all the manual list is the whole catalogue');
+  assert.deepEqual(await testCustomProvider(null), { ok: false, message: 'Falta la dirección del servidor.' });
+
+  configure('', []);
+  assert.deepEqual(await listModels('custom', null), []);
+});
+
+test('a configured key travels as a bearer token', async () => {
+  const gateway = await fakeGateway({ catalogue: ['served'] });
+  try {
+    configure(`${gateway.origin}/v1`, []);
+    await listModels('custom', 'secret-token');
+    assert.equal(gateway.seen.at(-1).auth, 'Bearer secret-token');
+  } finally {
+    await gateway.close();
+  }
+});
+
+test('the endpoint is stored app-level, normalised on write, and shared by every vault', async () => {
+  // Requires the real settings repository (SQLite + app-prefs.json), so it runs in
+  // an Electron child the way test-model-prefs-recovery does. Two things are being
+  // pinned: that what gets STORED is already normalised — Settings renders the
+  // stored value straight back, and a trailing slash the user pasted should not
+  // survive to be shown to them — and that the gateway is app-level, so configuring
+  // it once does not have to be repeated in every vault.
+  const workspace = await mkdtemp(path.join(os.tmpdir(), 'nodus-custom-persist-'));
+  const userData = await mkdtemp(path.join(os.tmpdir(), 'nodus-custom-userdata-'));
+  try {
+    const entry = path.join(workspace, 'entry.ts');
+    const bundle = path.join(workspace, 'entry.cjs');
+    await writeFile(entry, [
+      `export * as registry from ${JSON.stringify(path.join(repoRoot, 'electron/vaults/vaultRegistry.ts'))};`,
+      `export * as settingsRepo from ${JSON.stringify(path.join(repoRoot, 'electron/db/settingsRepo.ts'))};`,
+    ].join('\n'));
+    execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
+      entry, '--bundle', '--platform=node', '--format=cjs', '--target=es2022', `--outfile=${bundle}`,
+      `--alias:electron=${path.join(repoRoot, 'scripts/stub-electron.mjs')}`, '--external:better-sqlite3',
+    ], { cwd: repoRoot, stdio: 'inherit' });
+
+    const child = path.join(workspace, 'child.cjs');
+    const resultFile = path.join(workspace, 'result.json');
+    await writeFile(child, `
+      const assert = require('node:assert/strict');
+      const fs = require('node:fs');
+      const path = require('node:path');
+      const Module = require('node:module');
+      process.env.NODE_PATH = ${JSON.stringify(path.join(repoRoot, 'node_modules'))};
+      Module._initPaths();
+      const { registry, settingsRepo } = require(${JSON.stringify(bundle)});
+      settingsRepo.updateSettings({ customProvider: { baseUrl: '  http://gateway.lan:4000/openai/v1//  ', models: [' a ', 'a', '', 'b'] } });
+      const stored = settingsRepo.getSettings().customProvider;
+      const prefs = JSON.parse(fs.readFileSync(path.join(${JSON.stringify(userData)}, 'app-prefs.json'), 'utf8'));
+      registry.createVault('Second vault');
+      const inSecondVault = settingsRepo.getSettings().customProvider;
+      fs.writeFileSync(${JSON.stringify(resultFile)}, JSON.stringify({ stored, inPrefsFile: prefs.customProvider, inSecondVault }));
+    `);
+    execFileSync(path.join(repoRoot, 'node_modules/.bin/electron'), [child], {
+      cwd: repoRoot,
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', NODUS_TEST_USERDATA: userData },
+      stdio: 'inherit',
+    });
+
+    const result = JSON.parse(await readFile(resultFile, 'utf8'));
+    const expected = { baseUrl: 'http://gateway.lan:4000/openai/v1', models: ['a', 'b'] };
+    assert.deepEqual(result.stored, expected, 'the stored value is already normalised');
+    assert.deepEqual(result.inPrefsFile, expected, 'it lands in app-prefs.json, not only in the vault');
+    assert.deepEqual(result.inSecondVault, expected, 'a newly created vault inherits the same gateway');
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+    await rm(userData, { recursive: true, force: true });
+  }
+});

--- a/scripts/test-subscription-providers.mjs
+++ b/scripts/test-subscription-providers.mjs
@@ -15,6 +15,7 @@ const entry = path.join(outDir, 'entry.ts');
 fs.writeFileSync(entry, [
   `export * from ${JSON.stringify(path.join(repoRoot, 'electron/ai/openCodeGoCompletion.ts'))};`,
   `export * from ${JSON.stringify(path.join(repoRoot, 'electron/ai/openCodeGoPricing.ts'))};`,
+  `export * from ${JSON.stringify(path.join(repoRoot, 'electron/ai/clientIdentity.ts'))};`,
   `export * from ${JSON.stringify(path.join(repoRoot, 'electron/ai/githubCopilotCompletion.ts'))};`,
 ].join('\n'));
 execFileSync(path.join(repoRoot, 'node_modules/.bin/esbuild'), [
@@ -30,6 +31,9 @@ const {
   completeWithOpenCodeGo,
   estimateOpenCodeGoCostUsd,
   openCodeGoProtocol,
+  openCodeGoSessionId,
+  registerNodusClientVersion,
+  nodusUserAgent,
   runIsolatedGitHubCopilotCompletion,
 } = require(bundle);
 
@@ -143,6 +147,8 @@ test('OpenCode Go selects its three documented protocols and normalizes usage', 
     const openaiCall = fake.calls[0];
     assert.equal(openaiCall.url, '/v1/chat/completions');
     assert.equal(openaiCall.headers.authorization, 'Bearer go-key');
+    assert.match(openaiCall.headers['user-agent'], /^Nodus\//);
+    assert.ok(openaiCall.headers['x-opencode-session'], 'Chat Completions carries the session header');
     assert.deepEqual(openaiCall.payload.response_format, { type: 'json_object' });
 
     const anthropic = await completeWithOpenCodeGo({
@@ -154,6 +160,8 @@ test('OpenCode Go selects its three documented protocols and normalizes usage', 
     assert.equal(anthropicCall.url, '/v1/messages');
     assert.equal(anthropicCall.headers['x-api-key'], 'go-key');
     assert.equal(anthropicCall.headers['anthropic-version'], '2023-06-01');
+    assert.match(anthropicCall.headers['user-agent'], /^Nodus\//);
+    assert.ok(anthropicCall.headers['x-opencode-session'], 'Messages carries the session header');
     assert.deepEqual(anthropicCall.payload.thinking, { type: 'disabled' });
 
     const responses = await completeWithOpenCodeGo({
@@ -164,9 +172,49 @@ test('OpenCode Go selects its three documented protocols and normalizes usage', 
     const responsesCall = fake.calls[2];
     assert.equal(responsesCall.url, '/v1/responses');
     assert.equal(responsesCall.headers.authorization, 'Bearer go-key');
+    assert.match(responsesCall.headers['user-agent'], /^Nodus\//);
+    assert.ok(responsesCall.headers['x-opencode-session'], 'Responses carries the session header');
     assert.match(responsesCall.payload.instructions, /valid JSON/);
   } finally {
     await fake.close();
+  }
+});
+
+test('OpenCode Go sends an opaque session per unit of work and a named User-Agent', async () => {
+  // OpenCode rejects requests without x-opencode-session from 2026-09-06, so the
+  // header is a contract, not a nicety. What it carries must stay opaque: a job id
+  // is content-free but still names the pipeline, and nothing may persist across
+  // restarts or the "session" becomes a stable identifier for the user.
+  const first = openCodeGoSessionId('WORK123:deep:0:1:abc');
+  assert.match(first, /^[0-9a-f-]{36}$/, 'the session is a random UUID, not the job id');
+  assert.equal(openCodeGoSessionId('WORK123:deep:7:1:def'), first, 'chunks of one run share a session');
+  assert.notEqual(openCodeGoSessionId('WORK456:deep:0:1:abc'), first, 'a different work is a different session');
+  const processScoped = openCodeGoSessionId();
+  assert.equal(openCodeGoSessionId(null), processScoped, 'job-less calls share the process session');
+  assert.notEqual(processScoped, first);
+
+  registerNodusClientVersion('9.9.9');
+  assert.equal(nodusUserAgent(), 'Nodus/9.9.9', 'the User-Agent names the app and tracks package.json');
+
+  const fake = await fakeOpenCodeGo();
+  try {
+    await completeWithOpenCodeGo({
+      apiKey: 'go-key', model: 'kimi-k3', system: 's', user: 'u', baseUrl: fake.baseUrl, sessionId: first,
+    });
+    assert.equal(fake.calls[0].headers['x-opencode-session'], first, 'the caller-supplied session is what travels');
+    assert.equal(fake.calls[0].headers['user-agent'], 'Nodus/9.9.9');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('the app version reaching third parties is read, never typed in', () => {
+  // A hand-written Nodus/4.2.3 kept going out to GitHub for eleven releases.
+  const main = fs.readFileSync(path.join(repoRoot, 'electron/main.ts'), 'utf8');
+  assert.match(main, /registerNodusClientVersion\(app\.getVersion\(\)\)/, 'main.ts registers the running version');
+  for (const file of ['electron/ai/openCodeGoCompletion.ts', 'electron/ai/providers.ts', 'electron/library/libraryCslStyles.ts']) {
+    const source = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+    assert.doesNotMatch(source, /Nodus\/\d+\.\d+/, `${file} must not hard-code a version`);
   }
 });
 

--- a/shared/api/platform.ts
+++ b/shared/api/platform.ts
@@ -190,6 +190,9 @@ export interface PlatformApi {
   deleteNodusLocalImageModel(model: string): Promise<NodusLocalImageStatus>;
   /** Ping a local provider (Ollama / LM Studio) to verify its base URL is reachable. */
   testLocalProvider(provider: LocalProvider): Promise<LocalProviderTestResult>;
+  /** Ping the user's own OpenAI-compatible endpoint. Reuses LocalProviderTestResult:
+   *  the question ("is it reachable, how many models?") is the same one. */
+  testCustomProvider(): Promise<LocalProviderTestResult>;
   getLocalAiDiagnostics(): Promise<LocalAiRequestDiagnostic[]>;
   getDecorativeImage(entityKind: DecorativeImageEntityKind, entityId: string): Promise<DecorativeImage | null>;
   getDecorativeImageDataUrl(entityKind: DecorativeImageEntityKind, entityId: string, thumbnail?: boolean): Promise<string | null>;

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -1,4 +1,4 @@
-import type { AiProvider, EmbeddingProvider, ImageProvider, LocalProvider, ModelRef } from './types';
+import type { AiProvider, CustomProviderConfig, EmbeddingProvider, ImageProvider, LocalProvider, ModelRef } from './types';
 
 // Single source of truth for provider identity, labels and defaults, shared by
 // the main process (electron/) and the renderer (src/). Adding a provider to
@@ -20,6 +20,7 @@ export const AI_PROVIDERS: AiProvider[] = [
   'xiaomi',
   'ollama',
   'lmstudio',
+  'custom',
 ];
 
 /** Providers whose credentials are Nodus-managed API keys/tokens. ChatGPT's
@@ -36,6 +37,7 @@ export const SECRET_PROVIDERS: Exclude<AiProvider, 'codex' | 'github-copilot' | 
   'xiaomi',
   'ollama',
   'lmstudio',
+  'custom',
 ];
 
 /**
@@ -69,6 +71,10 @@ export const PROVIDER_LABELS: Record<AiProvider, string> = {
   xiaomi: 'Xiaomi MiMo',
   ollama: 'Ollama',
   lmstudio: 'LM Studio',
+  // Not a brand: the endpoint is whatever the user runs. Kept in English like the
+  // rest of this record because it is rendered raw by modelLabel() in every model
+  // picker; the descriptive prose around it in Settings is translated normally.
+  custom: 'Custom (OpenAI-compatible)',
   nodus: 'Nodus local',
 };
 
@@ -138,6 +144,44 @@ export const DEFAULT_LOCAL_BASE_URLS: Record<LocalProvider, string> = {
   ollama: 'http://localhost:11434',
   lmstudio: 'http://localhost:1234',
 };
+
+// ── Custom (OpenAI-compatible) provider ──────────────────────────────────────
+// Pure normalisers, kept here rather than in electron/ai/providers.ts so that the
+// settings repository can call them without importing the module that reads
+// settings — that pair imports each other and the cycle is real.
+
+/**
+ * The endpoint exactly as typed, minus any trailing slash.
+ *
+ * Deliberately NOT `${url}/v1` the way the local providers build theirs: these
+ * gateways mount the OpenAI API wherever they please (LiteLLM at the root, vLLM
+ * at /v1, proxies under /openai/v1), so guessing the suffix would break as many
+ * installs as it fixed. The user pastes the complete base.
+ */
+export function normalizeCustomBaseUrl(raw: string): string {
+  return String(raw ?? '').trim().replace(/\/+$/, '');
+}
+
+/** Model slugs typed by hand: trimmed, de-duplicated, order preserved. */
+export function normalizeCustomModels(models: readonly string[] | undefined): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of models ?? []) {
+    const id = String(raw ?? '').trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+/** Normalise a whole stored or incoming config blob. */
+export function normalizeCustomProviderConfig(config: Partial<CustomProviderConfig> | undefined): CustomProviderConfig {
+  return {
+    baseUrl: normalizeCustomBaseUrl(config?.baseUrl ?? ''),
+    models: normalizeCustomModels(config?.models),
+  };
+}
 
 /** Embedding-capable providers, in the order the Settings selector shows them. */
 export const EMBEDDING_PROVIDERS: EmbeddingProvider[] = ['openai', 'gemini', 'openrouter', 'ollama', 'lmstudio', 'nodus'];

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1267,6 +1267,7 @@ export type AiProvider =
   | 'xiaomi'
   | 'ollama'
   | 'lmstudio'
+  | 'custom'
   | 'nodus';
 /** Providers that run on the user's machine (or LAN) via a configurable base URL.
  *  They need no API key (an optional token is supported for secured instances). */
@@ -1282,6 +1283,25 @@ export interface LocalProviderConfig {
    * task's output ceiling; it only controls the total prompt+completion window. */
   contextMode?: 'auto' | 'manual';
   manualContextTokens?: 4096 | 8192 | 16384 | 32768 | 65536 | 131072;
+}
+
+/**
+ * The user's own OpenAI-compatible endpoint (LiteLLM, vLLM, llama.cpp server, a
+ * proxy such as CLIProxyAPI or codex-lb). App-level, not per vault.
+ *
+ * Unlike LocalProviderConfig, `baseUrl` is used EXACTLY as typed apart from the
+ * trailing slash: these gateways mount their API on wildly different paths
+ * ("/v1", "/openai/v1", the root), so appending "/v1" would break as many setups
+ * as it fixed. The user pastes the full base, e.g. "http://localhost:8317/v1".
+ */
+export interface CustomProviderConfig {
+  baseUrl: string;
+  /**
+   * Model slugs typed by the user. Kept independently of anything GET /models
+   * returns, because plenty of gateways serve inference without implementing
+   * that endpoint at all — the manual list is what keeps those usable.
+   */
+  models: string[];
 }
 
 /** Result of pinging a local provider from Settings ("Test connection"). */
@@ -1758,6 +1778,9 @@ export interface AppSettings {
   // Connection settings for local providers (Ollama, LM Studio). The base URL is
   // user-editable; an optional access token, when set, is stored like an API key.
   localProviders: Record<LocalProvider, LocalProviderConfig>;
+  // The user's own OpenAI-compatible endpoint: base URL and manually typed model
+  // slugs. An optional API key travels the ordinary secret path, never this blob.
+  customProvider: CustomProviderConfig;
   // Favorite models the user pinned. This list is app-wide and shared across vaults.
   // Workload and feature selectors below remain deliberately independent: changing
   // one must never retarget another flow.

--- a/src/i18n.de.ts
+++ b/src/i18n.de.ts
@@ -8328,4 +8328,18 @@ export const DE: Record<string, string> = {
   "La clave o el dato no son válidos.": "Der Schlüssel oder die Daten sind ungültig.",
   "Conversación no encontrada.": "Unterhaltung nicht gefunden.",
   "Informe sin título": "Bericht ohne Titel",
+
+  // Custom (OpenAI-compatible) provider — Settings → Providers.
+  "(tu servidor)": "(dein Server)",
+  "Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.": "Verbinde Nodus mit jedem Server, der die OpenAI-API spricht: LiteLLM, vLLM, den llama.cpp-Server oder einen eigenen Proxy.",
+  "Dirección del servidor (URL completa)": "Serveradresse (vollständige URL)",
+  "Nodus no añade \"/v1\" por su cuenta: escribe la ruta exacta que sirve tu servidor.": "Nodus hängt „/v1\" nicht von selbst an: Gib genau den Pfad ein, den dein Server bereitstellt.",
+  "•••••••• clave guardada (opcional)": "•••••••• Schlüssel gespeichert (optional)",
+  "clave de API (opcional)": "API-Schlüssel (optional)",
+  "Modelos escritos a mano": "Manuell eingetragene Modelle",
+  "Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.": "Wenn dein Server keinen Katalog veröffentlicht, trage die Bezeichner hier ein. Sie werden gespeichert und lassen sich in jeder Modellauswahl wählen.",
+  "identificador del modelo": "Modellbezeichner",
+  "Quitar modelo": "Modell entfernen",
+  "Ni el servidor publica modelos ni has escrito ninguno todavía.": "Der Server veröffentlicht keine Modelle und du hast noch keines eingetragen.",
+  "Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.": "Dieser Anbieter erzeugt Text, keine Embeddings. Wähle für die semantische Suche in den Einstellungen einen anderen Anbieter.",
 };

--- a/src/i18n.en.ts
+++ b/src/i18n.en.ts
@@ -8556,4 +8556,18 @@ export const EN: Record<string, string> = {
   "La clave o el dato no son válidos.": "The key or data is invalid.",
   "Conversación no encontrada.": "Conversation not found.",
   "Informe sin título": "Untitled report",
+
+  // Custom (OpenAI-compatible) provider — Settings → Providers.
+  "(tu servidor)": "(your server)",
+  "Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.": "Connect Nodus to any server that speaks the OpenAI API: LiteLLM, vLLM, the llama.cpp server or a proxy of your own.",
+  "Dirección del servidor (URL completa)": "Server address (full URL)",
+  "Nodus no añade \"/v1\" por su cuenta: escribe la ruta exacta que sirve tu servidor.": "Nodus does not add \"/v1\" on its own: type the exact path your server serves.",
+  "•••••••• clave guardada (opcional)": "•••••••• key saved (optional)",
+  "clave de API (opcional)": "API key (optional)",
+  "Modelos escritos a mano": "Hand-typed models",
+  "Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.": "If your server publishes no catalogue, type the identifiers here. They are saved and can be picked in any model selector.",
+  "identificador del modelo": "model identifier",
+  "Quitar modelo": "Remove model",
+  "Ni el servidor publica modelos ni has escrito ninguno todavía.": "The server publishes no models and you have not typed any yet.",
+  "Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.": "This provider generates text, not embeddings. For semantic search, pick another provider in Settings.",
 };

--- a/src/i18n.fr.ts
+++ b/src/i18n.fr.ts
@@ -8319,4 +8319,18 @@ export const FR: Record<string, string> = {
   "La clave o el dato no son válidos.": "La clé ou la donnée n’est pas valide.",
   "Conversación no encontrada.": "Conversation introuvable.",
   "Informe sin título": "Rapport sans titre",
+
+  // Custom (OpenAI-compatible) provider — Settings → Providers.
+  "(tu servidor)": "(votre serveur)",
+  "Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.": "Connectez Nodus à n'importe quel serveur qui parle l'API OpenAI : LiteLLM, vLLM, le serveur llama.cpp ou votre propre proxy.",
+  "Dirección del servidor (URL completa)": "Adresse du serveur (URL complète)",
+  "Nodus no añade \"/v1\" por su cuenta: escribe la ruta exacta que sirve tu servidor.": "Nodus n'ajoute pas « /v1 » de lui-même : saisissez le chemin exact servi par votre serveur.",
+  "•••••••• clave guardada (opcional)": "•••••••• clé enregistrée (facultatif)",
+  "clave de API (opcional)": "clé d'API (facultatif)",
+  "Modelos escritos a mano": "Modèles saisis à la main",
+  "Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.": "Si votre serveur ne publie pas de catalogue, saisissez ici les identifiants. Ils sont enregistrés et peuvent être choisis dans n'importe quel sélecteur de modèle.",
+  "identificador del modelo": "identifiant du modèle",
+  "Quitar modelo": "Retirer le modèle",
+  "Ni el servidor publica modelos ni has escrito ninguno todavía.": "Le serveur ne publie aucun modèle et vous n'en avez saisi aucun pour l'instant.",
+  "Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.": "Ce fournisseur génère du texte, pas des embeddings. Pour la recherche sémantique, choisissez un autre fournisseur dans les Réglages.",
 };

--- a/src/i18n.it.ts
+++ b/src/i18n.it.ts
@@ -7733,4 +7733,18 @@ export const IT: Record<string, string> = {
   "La clave o el dato no son válidos.": "La chiave o il dato non sono validi.",
   "Conversación no encontrada.": "Conversazione non trovata.",
   "Informe sin título": "Rapporto senza titolo",
+
+  // Custom (OpenAI-compatible) provider — Settings → Providers.
+  "(tu servidor)": "(il tuo server)",
+  "Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.": "Collega Nodus a qualsiasi server che parli l’API di OpenAI: LiteLLM, vLLM, il server di llama.cpp o un proxy tuo.",
+  "Dirección del servidor (URL completa)": "Indirizzo del server (URL completo)",
+  "Nodus no añade \"/v1\" por su cuenta: escribe la ruta exacta que sirve tu servidor.": "Nodus non aggiunge \"/v1\" da sé: scrivi il percorso esatto che serve il tuo server.",
+  "•••••••• clave guardada (opcional)": "•••••••• chiave salvata (facoltativa)",
+  "clave de API (opcional)": "chiave API (facoltativa)",
+  "Modelos escritos a mano": "Modelli scritti a mano",
+  "Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.": "Se il tuo server non pubblica un catalogo, scrivi qui gli identificatori. Restano salvati e si possono scegliere in qualunque selettore di modello.",
+  "identificador del modelo": "identificatore del modello",
+  "Quitar modelo": "Rimuovi modello",
+  "Ni el servidor publica modelos ni has escrito ninguno todavía.": "Il server non pubblica modelli e non ne hai ancora scritto nessuno.",
+  "Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.": "Questo fornitore genera testo, non embedding. Per la ricerca semantica scegli un altro fornitore nelle Impostazioni.",
 };

--- a/src/i18n.pt-BR.ts
+++ b/src/i18n.pt-BR.ts
@@ -8278,4 +8278,18 @@ export const PT_BR: Record<string, string> = {
   "La clave o el dato no son válidos.": "A chave ou o dado não são válidos.",
   "Conversación no encontrada.": "Conversa não encontrada.",
   "Informe sin título": "Relatório sem título",
+
+  // Custom (OpenAI-compatible) provider — Settings → Providers.
+  "(tu servidor)": "(seu servidor)",
+  "Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.": "Conecte o Nodus a qualquer servidor que fale a API da OpenAI: LiteLLM, vLLM, o servidor do llama.cpp ou um proxy seu.",
+  "Dirección del servidor (URL completa)": "Endereço do servidor (URL completa)",
+  "Nodus no añade \"/v1\" por su cuenta: escribe la ruta exacta que sirve tu servidor.": "O Nodus não acrescenta \"/v1\" sozinho: digite o caminho exato que o seu servidor serve.",
+  "•••••••• clave guardada (opcional)": "•••••••• chave salva (opcional)",
+  "clave de API (opcional)": "chave de API (opcional)",
+  "Modelos escritos a mano": "Modelos digitados à mão",
+  "Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.": "Se o seu servidor não publica catálogo, digite aqui os identificadores. Eles ficam salvos e podem ser escolhidos em qualquer seletor de modelo.",
+  "identificador del modelo": "identificador do modelo",
+  "Quitar modelo": "Remover modelo",
+  "Ni el servidor publica modelos ni has escrito ninguno todavía.": "O servidor não publica modelos e você ainda não digitou nenhum.",
+  "Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.": "Este provedor gera texto, não embeddings. Para a busca semântica escolha outro provedor nas Configurações.",
 };

--- a/src/i18n.pt.ts
+++ b/src/i18n.pt.ts
@@ -8270,4 +8270,18 @@ export const PT: Record<string, string> = {
   "La clave o el dato no son válidos.": "A chave ou o dado não são válidos.",
   "Conversación no encontrada.": "Conversa não encontrada.",
   "Informe sin título": "Relatório sem título",
+
+  // Custom (OpenAI-compatible) provider — Settings → Providers.
+  "(tu servidor)": "(o teu servidor)",
+  "Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.": "Liga o Nodus a qualquer servidor que fale a API da OpenAI: LiteLLM, vLLM, o servidor do llama.cpp ou um proxy teu.",
+  "Dirección del servidor (URL completa)": "Endereço do servidor (URL completo)",
+  "Nodus no añade \"/v1\" por su cuenta: escribe la ruta exacta que sirve tu servidor.": "O Nodus não acrescenta \"/v1\" por si: escreve o caminho exato que o teu servidor serve.",
+  "•••••••• clave guardada (opcional)": "•••••••• chave guardada (opcional)",
+  "clave de API (opcional)": "chave de API (opcional)",
+  "Modelos escritos a mano": "Modelos escritos à mão",
+  "Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.": "Se o teu servidor não publica catálogo, escreve aqui os identificadores. Ficam guardados e podem ser escolhidos em qualquer seletor de modelo.",
+  "identificador del modelo": "identificador do modelo",
+  "Quitar modelo": "Remover modelo",
+  "Ni el servidor publica modelos ni has escrito ninguno todavía.": "O servidor não publica modelos e ainda não escreveste nenhum.",
+  "Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.": "Este fornecedor gera texto, não embeddings. Para a pesquisa semântica escolhe outro fornecedor nas Definições.",
 };

--- a/src/i18n.tr.ts
+++ b/src/i18n.tr.ts
@@ -8078,4 +8078,18 @@ export const TR: Record<string, string> = {
   "La clave o el dato no son válidos.": "Anahtar veya veri geçersiz.",
   "Conversación no encontrada.": "Konuşma bulunamadı.",
   "Informe sin título": "Başlıksız rapor",
+
+  // Custom (OpenAI-compatible) provider — Settings → Providers.
+  "(tu servidor)": "(sunucunuz)",
+  "Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.": "Nodus’u OpenAI API’sini konuşan herhangi bir sunucuya bağlayın: LiteLLM, vLLM, llama.cpp sunucusu ya da kendi proxy’niz.",
+  "Dirección del servidor (URL completa)": "Sunucu adresi (tam URL)",
+  "Nodus no añade \"/v1\" por su cuenta: escribe la ruta exacta que sirve tu servidor.": "Nodus \"/v1\" ekini kendiliğinden eklemez: sunucunuzun sunduğu yolu birebir yazın.",
+  "•••••••• clave guardada (opcional)": "•••••••• anahtar kaydedildi (isteğe bağlı)",
+  "clave de API (opcional)": "API anahtarı (isteğe bağlı)",
+  "Modelos escritos a mano": "Elle yazılan modeller",
+  "Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.": "Sunucunuz katalog yayımlamıyorsa tanımlayıcıları buraya yazın. Kaydedilir ve her model seçicide seçilebilir.",
+  "identificador del modelo": "model tanımlayıcısı",
+  "Quitar modelo": "Modeli kaldır",
+  "Ni el servidor publica modelos ni has escrito ninguno todavía.": "Sunucu model yayımlamıyor ve henüz hiçbirini yazmadınız.",
+  "Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.": "Bu sağlayıcı metin üretir, gömme (embedding) üretmez. Anlamsal arama için Ayarlar’dan başka bir sağlayıcı seçin.",
 };

--- a/src/views/ProvidersSettings.tsx
+++ b/src/views/ProvidersSettings.tsx
@@ -15,7 +15,12 @@ import type {
   OpenCodeGoUsageStatus,
 } from '@shared/types';
 import { DECORATIVE_IMAGE_STYLES } from '@shared/imageStyles';
-import { DEFAULT_LOCAL_BASE_URLS, supportsFreeTierShaping } from '@shared/providers';
+import {
+  DEFAULT_LOCAL_BASE_URLS,
+  normalizeCustomBaseUrl,
+  normalizeCustomModels,
+  supportsFreeTierShaping,
+} from '@shared/providers';
 import { AI_PROVIDERS, PROVIDER_LABELS, Icon, isLocalAiProvider, modelLabel, sameModel } from '../components/ui';
 import { IMAGE_PROVIDER_LABELS } from '@shared/providers';
 import { SettingsModelDot, SettingsModelList, settingsModelRowClass } from '../components/SettingsModelList';
@@ -125,6 +130,16 @@ export function ProvidersSettings({
               key={p}
               expanded={open === p}
               onToggle={() => setOpen(open === p ? null : p)}
+              isFav={isFav}
+              toggleFav={toggleFav}
+            />
+          ) : p === 'custom' ? (
+            <CustomProviderRow
+              key={p}
+              settings={settings}
+              expanded={open === p}
+              onToggle={() => setOpen(open === p ? null : p)}
+              onChange={onChange}
               isFav={isFav}
               toggleFav={toggleFav}
             />
@@ -861,6 +876,243 @@ function OpenCodeObservedCard({
         cap: cap.toFixed(0),
       })}</div>
       {period.unpricedRequests > 0 && <div className="text-amber-700 dark:text-amber-400">{tx('{n} sin precio estimable', { n: period.unpricedRequests })}</div>}
+    </div>
+  );
+}
+
+/**
+ * The user's own OpenAI-compatible endpoint.
+ *
+ * Not a LocalProviderRow: that one owns a context-window planner and a diagnostics
+ * panel that only mean something for Ollama/LM Studio, and it appends nothing to the
+ * URL — whereas the whole point here is that Nodus must not guess the path. What
+ * this row adds instead is the hand-written model list, which is what keeps a
+ * gateway without GET /models usable.
+ */
+function CustomProviderRow({
+  settings,
+  expanded,
+  onToggle,
+  onChange,
+  isFav,
+  toggleFav,
+}: {
+  settings: AppSettings;
+  expanded: boolean;
+  onToggle: () => void;
+  onChange: () => Promise<unknown>;
+  isFav: (m: ModelRef) => boolean;
+  toggleFav: (m: ModelRef) => Promise<void>;
+}) {
+  const config = settings.customProvider ?? { baseUrl: '', models: [] };
+  const savedUrl = config.baseUrl ?? '';
+  const manualModels = config.models ?? [];
+  const [urlInput, setUrlInput] = useState(savedUrl);
+  const [modelInput, setModelInput] = useState('');
+  const [keyInput, setKeyInput] = useState('');
+  const [models, setModels] = useState<ModelInfo[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [test, setTest] = useState<LocalProviderTestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const hasKey = settings.providerKeys?.custom;
+
+  // Keep the field in sync when the saved value changes elsewhere (vault switch).
+  useEffect(() => setUrlInput(savedUrl), [savedUrl]);
+
+  const persist = async (patch: { baseUrl?: string; models?: string[] }) => {
+    await window.nodus.updateSettings({
+      customProvider: {
+        baseUrl: normalizeCustomBaseUrl(patch.baseUrl ?? savedUrl),
+        models: normalizeCustomModels(patch.models ?? manualModels),
+      },
+    });
+    await onChange();
+  };
+
+  const persistUrl = async () => {
+    const next = normalizeCustomBaseUrl(urlInput);
+    setUrlInput(next);
+    if (next !== savedUrl) await persist({ baseUrl: next });
+  };
+
+  const addModel = async () => {
+    const id = modelInput.trim();
+    if (!id) return;
+    setModelInput('');
+    await persist({ models: [...manualModels, id] });
+  };
+
+  const removeModel = async (id: string) => {
+    await persist({ models: manualModels.filter((model) => model !== id) });
+  };
+
+  const saveKey = async () => {
+    if (!keyInput.trim()) return;
+    await window.nodus.setApiKey('custom', keyInput.trim());
+    setKeyInput('');
+    await onChange();
+  };
+
+  const runTest = async () => {
+    setTesting(true);
+    setTest(null);
+    setError(null);
+    try {
+      await persistUrl();
+      setTest(await window.nodus.testCustomProvider());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const loadModels = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await persistUrl();
+      setModels(await window.nodus.listModels('custom'));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filtered = (models ?? []).filter((m) => {
+    const q = search.toLowerCase();
+    return !q || (m.id ?? '').toLowerCase().includes(q) || (m.name ?? '').toLowerCase().includes(q);
+  });
+  const shown = filtered.slice(0, 300);
+
+  return (
+    <div className="border border-neutral-800 rounded-lg" data-testid="provider-row-custom">
+      <button className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm" onClick={onToggle}>
+        <span className="text-neutral-500">{expanded ? '▾' : '▸'}</span>
+        <span className="font-medium">{PROVIDER_LABELS.custom}</span>
+        <span className="text-xs text-neutral-600">{t('(tu servidor)')}</span>
+        <span className="ml-auto truncate font-mono text-[10px] text-neutral-500" title={savedUrl}>{savedUrl}</span>
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2">
+          <p className="text-xs leading-5 text-neutral-500">
+            {t('Conecta Nodus con cualquier servidor que hable la API de OpenAI: LiteLLM, vLLM, el servidor de llama.cpp o un proxy propio.')}
+          </p>
+
+          <label className="block text-xs text-neutral-500">
+            {t('Dirección del servidor (URL completa)')}
+            <div className="mt-1 flex gap-2 items-center">
+              <input
+                className="input flex-1 font-mono"
+                data-testid="custom-provider-url"
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                onBlur={() => void persistUrl()}
+                placeholder="http://localhost:8317/v1"
+                spellCheck={false}
+              />
+              <button className="btn btn-ghost border border-neutral-700" onClick={() => void runTest()} disabled={testing}>
+                {testing ? t('Probando…') : t('Probar conexión')}
+              </button>
+            </div>
+          </label>
+          <p className="text-xs leading-5 text-neutral-500">
+            {t('Nodus no añade "/v1" por su cuenta: escribe la ruta exacta que sirve tu servidor.')}
+          </p>
+
+          {test && (
+            <div className={`text-xs ${test.ok ? 'text-emerald-400' : 'text-red-400'}`} data-testid="custom-provider-test">
+              {test.ok
+                ? tx('Conectado{version} · {n} modelos disponibles', { version: '', n: test.modelCount ?? 0 })
+                : tx('Sin conexión: {msg}', { msg: test.message ?? '' })}
+            </div>
+          )}
+
+          <div className="flex gap-2 items-center">
+            <input
+              type="password"
+              className="input flex-1"
+              placeholder={hasKey ? t('•••••••• clave guardada (opcional)') : t('clave de API (opcional)')}
+              value={keyInput}
+              onChange={(e) => setKeyInput(e.target.value)}
+            />
+            <button className="btn btn-primary" onClick={saveKey}>{t('Guardar')}</button>
+            {hasKey && (
+              <button className="btn btn-ghost text-red-400" onClick={() => window.nodus.clearApiKey('custom').then(onChange)}>
+                {t('Borrar')}
+              </button>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-neutral-800 p-3 text-xs text-neutral-500">
+            <div className="font-medium text-neutral-300">{t('Modelos escritos a mano')}</div>
+            <p className="mt-1 leading-5">
+              {t('Si tu servidor no publica catálogo, escribe aquí los identificadores. Quedan guardados y se pueden elegir en cualquier selector de modelo.')}
+            </p>
+            <div className="mt-2 flex gap-2 items-center">
+              <input
+                className="input flex-1 font-mono"
+                data-testid="custom-provider-model-input"
+                value={modelInput}
+                onChange={(e) => setModelInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void addModel(); } }}
+                placeholder={t('identificador del modelo')}
+                spellCheck={false}
+              />
+              <button className="btn btn-ghost border border-neutral-700" onClick={() => void addModel()}>{t('Añadir')}</button>
+            </div>
+            {manualModels.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1" data-testid="custom-provider-manual-models">
+                {manualModels.map((id) => (
+                  <span key={id} className="flex items-center gap-1 rounded bg-neutral-800 px-2 py-0.5 text-xs text-neutral-300">
+                    <span className="font-mono">{id}</span>
+                    <button
+                      className="ml-0.5 grid h-4 w-4 shrink-0 place-items-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-red-400"
+                      title={t('Quitar modelo')}
+                      aria-label={t('Quitar modelo')}
+                      onClick={() => void removeModel(id)}
+                    >
+                      <Icon name="x" size={10} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-2 items-center">
+            <button className="btn btn-ghost border border-neutral-700" onClick={loadModels} disabled={loading}>
+              {loading ? t('Cargando…') : t('Cargar modelos')}
+            </button>
+            {models && (
+              <input className="input flex-1" placeholder={t('Buscar modelo…')} value={search} onChange={(e) => setSearch(e.target.value)} />
+            )}
+            {models && <span className="text-xs text-neutral-500">{filtered.length}</span>}
+          </div>
+
+          {error && <div className="text-xs text-red-400">{error}</div>}
+
+          {models && (
+            <SettingsModelList className="max-h-64 overflow-y-auto" data-testid="provider-model-list-custom">
+              <ModelList provider="custom" models={shown} isFav={isFav} toggleFav={toggleFav} />
+              {models.length === 0 && (
+                <div className="p-3 text-xs text-neutral-500">{t('Ni el servidor publica modelos ni has escrito ninguno todavía.')}</div>
+              )}
+              {filtered.length > shown.length && (
+                <div className="text-xs text-neutral-600 p-2">{tx('Mostrando {n}; refina la búsqueda para ver más.', { n: shown.length })}</div>
+              )}
+            </SettingsModelList>
+          )}
+
+          <p className="text-xs leading-5 text-neutral-500">
+            {t('Este proveedor genera texto, no embeddings. Para la búsqueda semántica elige otro proveedor en Ajustes.')}
+          </p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #652.

Two changes to how Nodus reaches AI providers. They are independent; they share a branch because both land in the provider transport layer.

## OpenCode Go: the required session header, and saying who we are

All four calls to `opencode.ai/zen/go` — the three inference protocols and the unauthenticated catalogue — now carry `x-opencode-session` and a `User-Agent`.

The session groups by unit of work. Nodus has no conversations, so the closest equivalent is a job: one deep scan, one Deep Research report, one Nodi thread. Job ids are shaped `<root>:<stage>:<chunk>`, so the root is what ties a scan's many chunked calls together. What travels is always a fresh random UUID, **never the job id itself** — job ids are content-free but still spell out which pipeline is running — and nothing is persisted, so no id survives a restart or can act as a stable identifier for the user.

The version is registered once from `app.getVersion()` instead of being typed in, so it follows `package.json` with no manual step at release time. `libraryCslStyles.ts` had been announcing a hard-coded `Nodus/4.2.3` to GitHub since that release; it now reads the running version too, and a test fails if anyone hard-codes one again.

No other provider requires the session header and none receives it. The `User-Agent` does reach the shared OpenAI-compatible client seam (`openAiClientHeaders`), which covers OpenAI, Groq, Cerebras, DeepSeek, Xiaomi, Gemini's compatible surface and OpenRouter, for chat and embeddings alike. The embeddings client had OpenRouter's attribution headers inlined as a copy and now goes through that same seam, so the two can no longer drift.

## A custom OpenAI-compatible provider

For users who run their own gateway (LiteLLM, vLLM, the llama.cpp server, proxies such as CLIProxyAPI or codex-lb) instead of holding a vendor key.

- **The base URL is used verbatim**, apart from the trailing slash. Every other provider here appends `/v1`; these gateways mount the API at the root, at `/v1`, or under `/openai/v1`, so guessing the suffix would break as many installs as it fixed.
- Stored **app-level**, like the local base URLs: one gateway serves every vault.
- Optional API key through the ordinary secret path.
- Model selection is the **union** of hand-typed slugs and whatever `GET {base}/models` reports. The remote half is best-effort on purpose: a gateway that serves inference without a catalogue is precisely the case this provider exists for, and throwing there would empty every model picker in the app for a setup that works fine. "Test connection" is where that failure gets reported instead.
- An **unconfigured endpoint is refused before the request leaves**. Further down the base URL becomes `baseURL ?? undefined`, and an undefined `baseURL` sends the prompt to `api.openai.com` — a provider the user never chose.
- **Embeddings are explicitly unsupported**, not half-supported. The transport would work, but `EmbeddingProvider` requires a default model and no honest default exists for someone else's endpoint; an empty one is the run-time failure this was meant to avoid. Leaving `custom` out of the union makes it a compile error instead. The Settings row says so.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` (2817 tests, 2816 pass, 1 skip) and `npm run test:e2e` all pass locally.
- New `scripts/test-custom-provider.mjs` drives the real `electron/ai/providers.ts` against a fake gateway: base-URL normalisation, the manual + remote union, a `/models` 404 not breaking selection, an unreachable endpoint never throwing, the bearer token, and an Electron child proving the config is stored normalised in `app-prefs.json` and inherited by a new vault.
- `test-ai-json-retry.mjs` now asserts on the wire that `defaultHeaders` **wins** over the OpenAI SDK's own User-Agent rather than being appended to.
- `test-subscription-providers.mjs` covers the session header on all three OpenCode protocols and pins the opaque-id contract.
- Live checks against the real endpoints with the user's stored keys: DeepSeek, Gemini-compat and OpenRouter (chat and embeddings) all answered 200 with `Nodus/5.1.5`, and OpenCode Go's catalogue answered 200 with the new header.
- Live check of the custom provider against a dependency-free `node:http` gateway, through the real `settingsRepo` → `providers` → `aiClient` path: models load, a JSON-mode extraction returns valid JSON, and with the catalogue returning 404 the manual list still selects **and** still infers.
- `e2e-smoke.mjs` gained a check for the new Settings row. Note for future edits: the provider accordion shows one row at a time, so a block that expands a row collapses whatever the previous block opened — that is why the new assertions sit after the OpenCode ones.

## Not included

No version bump or changelog entry: this follows the recent feature PRs on this repo, and release preparation is its own step.
