### PR TITLE
macOS: stop flagging a vendor's cross-platform binaries as a foreign architecture

### DIFF
--- a/scripts/test-packaged-native-runtime.mjs
+++ b/scripts/test-packaged-native-runtime.mjs
@@ -12,16 +12,56 @@ const {
   assertBinaryArchitecture,
   findForeignRuntimePaths,
   findUniquePackagedBinary,
+  topLevelPackage,
 } = require(path.join(repoRoot, 'scripts/verify-packaged-native-runtime.cjs'));
 
 test('packaged runtime audit rejects the other architecture, whichever is being packed', () => {
   const paths = [
     '/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node',
     '/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex',
-    '/node_modules/@koromix/koffi-darwin_x64/darwin_x64/koffi.node',
+    '/node_modules/@img/sharp-libvips-darwin-x64/lib/libvips-cpp.8.18.6.dylib',
+    '/node_modules/better-sqlite3/build/Release/better_sqlite3.node',
   ];
-  assert.deepEqual(findForeignRuntimePaths('arm64', paths), [paths[0], paths[2]]);
-  assert.deepEqual(findForeignRuntimePaths('x64', paths), [paths[1]]);
+  assert.deepEqual(findForeignRuntimePaths('arm64', paths), [
+    '@img/sharp-libvips-darwin-x64',
+    '@napi-rs/canvas-darwin-x64',
+  ]);
+  assert.deepEqual(findForeignRuntimePaths('x64', paths), ['@openai/codex-darwin-arm64']);
+});
+
+test('THE REGRESSION: a vendor shipping every platform inside the right package is not foreign', () => {
+  // These four paths failed the first Intel build ever attempted. They are
+  // helper binaries vendored by @github/copilot-darwin-x64 — the CORRECT
+  // package for that build — whose paths merely contain the other architecture.
+  // The arm64 package does not vendor them, so a substring match over the path
+  // passed on Apple silicon for months and then failed on Intel.
+  const vendored = [
+    '/node_modules/@github/copilot-darwin-x64/ripgrep/bin/darwin-arm64',
+    '/node_modules/@github/copilot-darwin-x64/ripgrep/bin/darwin-arm64/rg',
+    '/node_modules/@github/copilot-darwin-x64/tgrep/bin/darwin-arm64',
+    '/node_modules/@github/copilot-darwin-x64/tgrep/bin/darwin-arm64/tgrep',
+  ];
+  assert.deepEqual(findForeignRuntimePaths('x64', vendored), []);
+
+  // Same shape on Apple silicon: a nested per-architecture dependency inside
+  // the correct package is the vendor's business, not a mixed tree.
+  assert.deepEqual(findForeignRuntimePaths('arm64', [
+    '/node_modules/@github/copilot-darwin-arm64/clipboard/node_modules/@teddyzhu/clipboard/clipboard.darwin-x64.node',
+    '/node_modules/@github/copilot-darwin-arm64/clipboard/node_modules/@teddyzhu/clipboard-darwin-x64/clipboard.darwin-x64.node',
+  ]), []);
+
+  // But the package that would actually break at launch is still caught.
+  assert.deepEqual(
+    findForeignRuntimePaths('x64', ['/node_modules/@github/copilot-darwin-arm64/copilot']),
+    ['@github/copilot-darwin-arm64'],
+  );
+});
+
+test('the top-level package is read, and only the top level', () => {
+  assert.equal(topLevelPackage('/node_modules/@img/sharp-darwin-x64/lib/x.node'), '@img/sharp-darwin-x64');
+  assert.equal(topLevelPackage('node_modules/better-sqlite3/build/x.node'), 'better-sqlite3');
+  assert.equal(topLevelPackage('/node_modules/a/node_modules/b-darwin-arm64/x'), null);
+  assert.equal(topLevelPackage('/dist/renderer-darwin-arm64.js'), null);
 });
 
 test('packaged runtime audit requires the slice being packed', () => {

--- a/scripts/verify-packaged-native-runtime.cjs
+++ b/scripts/verify-packaged-native-runtime.cjs
@@ -43,14 +43,26 @@ const REQUIRED_BINARY_PATTERNS = {
   ],
 };
 
-// The markers of the OTHER macOS architecture. These are matched against the
-// asar listing only: some vendored packages legitimately carry every platform's
-// prebuild (@github/copilot bundles a clipboard addon for all six targets), and
-// those live in app.asar.unpacked, outside this listing.
-const FOREIGN_PACKAGE_MARKERS = {
-  arm64: [/darwin-x64/i, /darwin_x64/i, /x86_64-apple-darwin/i],
-  x64: [/darwin-arm64/i, /darwin_arm64/i, /aarch64-apple-darwin/i],
-};
+// npm names an architecture-specific package with the target as a suffix, so
+// what has to be absent is a TOP-LEVEL package of the other architecture:
+// `@img/sharp-darwin-arm64` inside the Intel app is what breaks at first launch.
+//
+// This deliberately reads the package name and not the whole path. Vendored
+// binaries for every platform live inside the correct package and are perfectly
+// legitimate — @github/copilot-darwin-x64 ships ripgrep and tgrep for
+// darwin-arm64 among others — and a substring match over the path flagged those
+// and failed the first Intel build ever attempted. Nested node_modules are the
+// vendor's own business for the same reason, so only the top level is read.
+const FOREIGN_PACKAGE_SUFFIXES = { arm64: '-darwin-x64', x64: '-darwin-arm64' };
+
+/** The top-level package an asar entry belongs to, or null if it is nested. */
+function topLevelPackage(entry) {
+  const segments = entry.split('node_modules/');
+  if (segments.length !== 2) return null; // not in node_modules, or vendored deeper
+  const parts = segments[1].split('/');
+  if (parts.length === 0) return null;
+  return parts[0].startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+}
 
 function assertSupportedArchitecture(architecture) {
   if (!SUPPORTED_ARCHITECTURES.includes(architecture)) {
@@ -62,8 +74,13 @@ function assertSupportedArchitecture(architecture) {
 
 function findForeignRuntimePaths(architecture, entries) {
   assertSupportedArchitecture(architecture);
-  const markers = FOREIGN_PACKAGE_MARKERS[architecture];
-  return entries.filter((entry) => markers.some((marker) => marker.test(entry)));
+  const suffix = FOREIGN_PACKAGE_SUFFIXES[architecture];
+  const foreign = new Set();
+  for (const entry of entries) {
+    const packageName = topLevelPackage(entry);
+    if (packageName && packageName.endsWith(suffix)) foreign.add(packageName);
+  }
+  return [...foreign].sort();
 }
 
 function getArchitectures(filename) {
@@ -104,10 +121,10 @@ function verifyPackagedNativeRuntime(appPath, architecture, options = {}) {
   if (!existsSync(asarPath)) throw new Error(`Missing packaged application archive: ${asarPath}`);
 
   const archiveEntries = (options.listPackage || asar.listPackage)(asarPath);
-  const foreignEntries = findForeignRuntimePaths(architecture, archiveEntries);
-  if (foreignEntries.length > 0) {
+  const foreignPackages = findForeignRuntimePaths(architecture, archiveEntries);
+  if (foreignPackages.length > 0) {
     throw new Error(
-      `macOS runtime packages for the other architecture were bundled into the ${architecture} app:\n${foreignEntries.slice(0, 20).join('\n')}`,
+      `macOS runtime packages for the other architecture were bundled into the ${architecture} app:\n${foreignPackages.join('\n')}`,
     );
   }
 
@@ -139,6 +156,7 @@ module.exports = {
   SUPPORTED_ARCHITECTURES,
   REQUIRED_BINARIES,
   REQUIRED_BINARY_PATTERNS,
+  topLevelPackage,
   assertBinaryArchitecture,
   findUniquePackagedBinary,
   findForeignRuntimePaths,


### PR DESCRIPTION
The first Intel build ever attempted ([run 33802505652](https://github.com/Drakonis96/nodus/actions/runs/33802505652)) failed its own packaging audit, before signing and before touching the release:

```
⨯ macOS runtime packages for the other architecture were bundled into the x64 app:
/node_modules/@github/copilot-darwin-x64/ripgrep/bin/darwin-arm64/rg
/node_modules/@github/copilot-darwin-x64/tgrep/bin/darwin-arm64/tgrep
```

Those four paths live inside `@github/copilot-darwin-x64` — the **correct** package for an Intel build — which vendors ripgrep and tgrep for every platform it might shell out on, `darwin-arm64` included. The audit matched the architecture marker as a substring of any path in the asar, so a vendor shipping every platform inside the right package read as a mixed dependency tree.

The arm64 copilot package does not vendor those binaries. That asymmetry is why the check passed on Apple silicon for months and could only fail once an Intel build existed to run it.

## The fix

What actually has to be absent is a **top-level package of the other architecture**. npm names architecture-specific packages with the target as a suffix, and `@img/sharp-darwin-arm64` sitting in the Intel app is what breaks at first launch — a helper binary vendored three directories down inside the right package is dead weight, not a hazard.

So the audit now reads the package name rather than the whole path, and ignores nested `node_modules` entirely: what a vendor bundles inside its own package is its business. The `lipo` check on every required native binary is unchanged and remains the real guarantee that each slice is the right architecture.

The four real paths from the failed run are pinned as a regression fixture, alongside the equivalent Apple silicon shape (`@teddyzhu/clipboard-darwin-x64` nested inside `@github/copilot-darwin-arm64`), and the case that must still fail — `@github/copilot-darwin-arm64` at the top level of an x64 build.

## Verification

- `npm test` 2861/2861, lint and typecheck clean.
- Reverted to the substring match to confirm the regression test fails on it.
- Still packaging-only: `verify-backfill-parity.mjs` reports 23 files changed since `v5.1.6`, none reaching the app bundle, so the 5.1.6 backfill route stays open.

The failed run left the release untouched — 13 assets, unchanged, credentials cleaned up — so this can simply be re-dispatched once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
