### PR TITLE
Nodus 5.1.7: the Dictionary no longer reports a failure while it works

### DIFF
--- a/.github/workflows/nodus-server-image.yml
+++ b/.github/workflows/nodus-server-image.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Build smoke-test image
-        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.6 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
+        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.7 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
 
       - name: Run image health smoke test
         shell: bash
@@ -114,7 +114,7 @@ jobs:
           scripts/test-server-vectors.mjs
 
       - name: Build smoke-test image
-        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.6 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
+        run: docker build -f server/Dockerfile --build-arg NODUS_VERSION=5.1.7 --build-arg NODUS_REVISION="$GITHUB_SHA" --tag nodus-server:ci .
 
       - name: Run image health smoke test
         shell: bash
@@ -164,7 +164,7 @@ jobs:
             org.opencontainers.image.description=Experimental self-hosted Nodus MCP server
             org.opencontainers.image.source=https://github.com/Drakonis96/nodus
             org.opencontainers.image.licenses=AGPL-3.0-only
-            org.opencontainers.image.version=5.1.6
+            org.opencontainers.image.version=5.1.7
             org.opencontainers.image.revision=${{ github.sha }}
             app.nodus.stability=experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 5.1.7 — 2026-09-04
+
+Nodus 5.1.7 is a single-fix release for the Dictionary, which reported a failure
+while the definition was being written correctly.
+
+- Stopped the main-process localizer from rewriting the Dictionary generation
+  status as the generic "the operation could not be completed" notice. The
+  queued, corpus-analysis and definition-generation lines travel in a `message`
+  field, so they were localized as failures in every interface language other
+  than Spanish while the definition itself came out fine. They now reach
+  `DictionaryView` untouched and are translated where they are rendered.
+- Added regression coverage pinning the Dictionary progress catalogue to the
+  renderer-translated allowlist in all seven non-Spanish languages.
+
 ## 5.1.6 — 2026-09-03
 
 Nodus 5.1.6 adds a custom OpenAI-compatible AI provider in Settings and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,12 +12,12 @@ authors:
     orcid: "https://orcid.org/0000-0002-1150-1930"
   - name: "Nodus contributors"
 type: software
-version: "5.1.6"
-date-released: "2026-09-03"
+version: "5.1.7"
+date-released: "2026-09-04"
 license: "AGPL-3.0-only"
 repository-code: "https://github.com/Drakonis96/nodus"
 url: "https://nodusresearch.com/"
-# Zenodo assigns the immutable v5.1.6 DOI after the stable GitHub release is archived.
+# Zenodo assigns the immutable v5.1.7 DOI after the stable GitHub release is archived.
 # Until then the concept DOI is 10.5281/zenodo.21515531 for Nodus over time.
 doi: "10.5281/zenodo.21515531"
 keywords:

--- a/SOURCE_CODE.md
+++ b/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.1.6 is licensed exclusively under the GNU Affero General Public
+Nodus 5.1.7 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.1.6 release is available
+The preferred form for modifying the official Nodus 5.1.7 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.6
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.6
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.6.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.6.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.7
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.7
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.7.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.7.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.1.6 is free software distributed exclusively under the GNU Affero
+Nodus 5.1.7 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/electron/ai/clientIdentity.ts
+++ b/electron/ai/clientIdentity.ts
@@ -18,7 +18,7 @@ export function registerNodusClientVersion(version: string): void {
   if (trimmed) clientVersion = trimmed;
 }
 
-/** `Nodus/5.1.6`. Product name and running version — nothing about the user. */
+/** `Nodus/5.1.7`. Product name and running version — nothing about the user. */
 export function nodusUserAgent(): string {
   return `Nodus/${clientVersion}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodus",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodus",
-      "version": "5.1.6",
+      "version": "5.1.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Local-first desktop app that turns a Zotero library into a navigable graph of ideas and authors.",
   "author": {
     "name": "Jorge Pérez Burgueño",
@@ -13,7 +13,7 @@
     "url": "https://github.com/Drakonis96/nodus.git"
   },
   "releaseMetadata": {
-    "dateReleased": "2026-09-03",
+    "dateReleased": "2026-09-04",
     "conceptDoi": "10.5281/zenodo.21515531",
     "versionDoi": null
   },

--- a/scripts/e2e-browser-connector.mjs
+++ b/scripts/e2e-browser-connector.mjs
@@ -138,7 +138,7 @@ async function exerciseMultiCapture() {
       scripting: { executeScript: async () => [{ result: nextSnapshot }] },
       storage: { local: { get: async (defaults) => ({ ...defaults, ...values }), set: async (input) => Object.assign(values, input), remove: async (keys) => { for (const key of keys) delete values[key]; } } },
       permissions: { request: async () => true, contains: async () => false, remove: async () => true },
-      runtime: { getManifest: () => ({ version: '5.1.6' }), getURL: (path = '') => `chrome-extension://ilcclajjhofhieoljdjmikmfopfbamej/${path}`, openOptionsPage: async () => undefined },
+      runtime: { getManifest: () => ({ version: '5.1.7' }), getURL: (path = '') => `chrome-extension://ilcclajjhofhieoljdjmikmfopfbamej/${path}`, openOptionsPage: async () => undefined },
     };
   }, { messages: english, snapshot: detected });
   let saves = 0;

--- a/scripts/test-agpl-release.mjs
+++ b/scripts/test-agpl-release.mjs
@@ -14,7 +14,7 @@ const json = async (relative) => JSON.parse(await read(relative));
 
 const AGPL_SHA256 = '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0';
 const LICENSE_ID = 'AGPL-3.0-only';
-const VERSION = '5.1.6';
+const VERSION = '5.1.7';
 
 test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   const license = await read('LICENSE');
@@ -23,7 +23,7 @@ test('Nodus 5 carries the unmodified GNU AGPL v3 license text', async () => {
   assert.match(license, /13\. Remote Network Interaction/);
 });
 
-test('all first-party release metadata identifies 5.1.6 as AGPL-3.0-only', async () => {
+test('all first-party release metadata identifies 5.1.7 as AGPL-3.0-only', async () => {
   const [pkg, lock, serverPkg, plugin, citation] = await Promise.all([
     json('package.json'),
     json('package-lock.json'),

--- a/scripts/test-localize-ipc-payload.mjs
+++ b/scripts/test-localize-ipc-payload.mjs
@@ -35,7 +35,7 @@ execFileSync(
 
 const require = createRequire(import.meta.url);
 const mod = require(bundle);
-const { localizeIpcPayload, localizeRuntimeError } = mod;
+const { DICTIONARY_PROGRESS_MESSAGES, localizeIpcPayload, localizeRuntimeError } = mod;
 
 /**
  * The original implementation, kept as the correctness oracle. It needs the
@@ -196,6 +196,18 @@ try {
     const payload = { ok: false, message: 'Algo salió mal en el proceso.' };
     const out = localizeIpcPayload(payload, 'es');
     assert.deepEqual(out, payload, 'Spanish output must be unchanged in value');
+  }
+
+  // --- 8. Dictionary progress is UI copy, not a runtime failure -----------
+  for (const language of LANGUAGES) {
+    for (const message of DICTIONARY_PROGRESS_MESSAGES) {
+      const payload = { message };
+      assert.equal(
+        localizeIpcPayload(payload, language),
+        payload,
+        `Dictionary progress must reach DictionaryView intact in ${language}: ${message}`
+      );
+    }
   }
 
   console.log('# localize IPC payload tests passed');

--- a/scripts/test-nodus-server-deployment.mjs
+++ b/scripts/test-nodus-server-deployment.mjs
@@ -76,7 +76,7 @@ test('every remote user receives the exact AGPL license and Corresponding Source
       const response = await fetch(`${origin}${endpoint}`);
       assert.equal(response.status, 200);
       const info = await response.json();
-      assert.equal(info.version, '5.1.6');
+      assert.equal(info.version, '5.1.7');
       assert.equal(info.license, 'AGPL-3.0-only');
       assert.equal(info.sourceCodeUrl, sourceCodeUrl);
     }

--- a/scripts/test-release-notes.mjs
+++ b/scripts/test-release-notes.mjs
@@ -24,16 +24,28 @@ try {
   );
 
   const { RELEASE_NOTES, releaseNotesForMajor, compareVersions } = await import(pathToFileURL(bundlePath).href);
+  // 5.1.7 is a single-fix release: the Dictionary status line reported a failure
+  // while the definition was being written correctly, because its progress copy
+  // travelled in a `message` field the main-process localizer rewrote.
+  const currentRelease = RELEASE_NOTES[0];
+  assert.equal(currentRelease?.version, '5.1.7');
+  assert.equal(currentRelease?.date, '2026-09-04');
+  assert.equal(currentRelease?.highlights.length, 1);
+  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), ['languages']);
+  for (const phrase of [
+    /Generating a dictionary definition no longer looks like a failure/,
+    /queued, analysing corpus and generating definition/,
+  ]) assert.ok(currentRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
+
   // 5.1.6 stands alone with the three changes that are actually new: a custom
   // OpenAI-compatible provider plus the progress-bar and main-process error
   // translations. The scope order below is also the rendered order, because the
   // modal puts the largest scope cluster first and `languages` carries two of
   // the three.
-  const currentRelease = RELEASE_NOTES[0];
-  assert.equal(currentRelease?.version, '5.1.6');
-  assert.equal(currentRelease?.date, '2026-09-03');
-  assert.equal(currentRelease?.highlights.length, 3);
-  assert.deepEqual(currentRelease?.highlights.map((highlight) => highlight.scope), [
+  const release516 = RELEASE_NOTES.find((note) => note.version === '5.1.6');
+  assert.equal(release516?.date, '2026-09-03');
+  assert.equal(release516?.highlights.length, 3);
+  assert.deepEqual(release516?.highlights.map((highlight) => highlight.scope), [
     'languages', 'languages', 'ai',
   ]);
   for (const phrase of [
@@ -43,7 +55,7 @@ try {
     /More than a thousand messages/,
     /Settings gains a custom provider compatible with the OpenAI API/,
     /adding nothing to the path/,
-  ]) assert.ok(currentRelease?.highlights.some((highlight) => phrase.test(highlight.en)));
+  ]) assert.ok(release516?.highlights.some((highlight) => phrase.test(highlight.en)));
 
   // 5.1.5 deliberately duplicated the 5.1.4 modal for its focused hotfix.
   const release515 = RELEASE_NOTES.find((note) => note.version === '5.1.5');

--- a/scripts/test-v4-release-readiness.mjs
+++ b/scripts/test-v4-release-readiness.mjs
@@ -38,7 +38,7 @@ try {
   assert.match(backup, /const supportedVersions = \[1, 2, 3, 4, 5, 6\]/, 'Nodus 4 still opens released 3.x backup formats');
   assert.match(backup, /if \(!descriptor\) return null/, 'a 3.x backup without a Global Library preserves the current local one');
 
-  assert.equal(pluginManifest.version, '5.1.6');
+  assert.equal(pluginManifest.version, '5.1.7');
   assert.match(readerPlugin, /X-Nodus-Zotero-Protocol": "4"/);
   assert.match(readerPlugin, /capabilities\.globalLibrary/, 'plugin v4 omits v4-only Library controls with desktop v3');
   assert.match(readerPlugin, /\/api\/z\/chat/, 'ordinary plugin chat remains available across protocol versions');
@@ -54,10 +54,10 @@ try {
     maxMutationBytes: 1024, maxMutationBatchBytes: 4096, maxMutationBatch: 12,
   });
 
-  assert.match(serverVersion, /export const NODUS_VERSION = '5\.1.6'/);
+  assert.match(serverVersion, /export const NODUS_VERSION = '5\.1.7'/);
   assert.match(serverVersion, /tree\/v\$\{NODUS_VERSION\}/);
-  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.1.6\.tar\.gz/);
-  assert.match(citation, /^date-released: "2026-09-03"$/m);
+  assert.match(sourceOffer, /archive\/refs\/tags\/v5\.1.7\.tar\.gz/);
+  assert.match(citation, /^date-released: "2026-09-04"$/m);
   for (const phrase of ['pre-v4', '3.2.7', 'may not open', '50,000', '10,000']) {
     assert.match(`${guide}\n${acceptance}`, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `release documentation is missing ${phrase}`);
   }

--- a/scripts/test-zotero-plugin.mjs
+++ b/scripts/test-zotero-plugin.mjs
@@ -1627,9 +1627,9 @@ test('#9: build-zotero-xpi produces a valid xpi + updates.json', () => {
   ]) {
     assert.ok(names.includes(need), `xpi contains ${need}`);
   }
-  assert.equal(manifest.version, '5.1.6', 'the add-on shares the Nodus 5 release version');
+  assert.equal(manifest.version, '5.1.7', 'the add-on shares the Nodus 5 release version');
   assert.equal(manifest.license, 'AGPL-3.0-only');
-  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.1.6/);
+  assert.match(zip.readAsText('SOURCE_CODE.md'), /releases\/tag\/v5\.1.7/);
   assert.equal(manifest.icons['64'], 'icons/nodus.svg');
   assert.match(zip.readAsText('icons/nodus.svg'), /M18 48V16L46 48V16/, 'Zotero keeps the normal Nodus N');
   assert.ok(!names.includes('icons/zotero-z.svg'), 'the rotated release-note mark is not shipped as Zotero UI');

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -15,13 +15,13 @@ RUN npm run build:server-web
 
 FROM node:22-alpine
 
-ARG NODUS_VERSION=5.1.6
+ARG NODUS_VERSION=5.1.7
 ARG NODUS_REVISION=unknown
 LABEL org.opencontainers.image.title="Nodus Server" \
       org.opencontainers.image.description="Experimental self-hosted Nodus MCP server" \
       org.opencontainers.image.source="https://github.com/Drakonis96/nodus" \
       org.opencontainers.image.url="https://github.com/Drakonis96/nodus" \
-      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v5.1.6/server/README.md" \
+      org.opencontainers.image.documentation="https://github.com/Drakonis96/nodus/blob/v5.1.7/server/README.md" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.version="${NODUS_VERSION}" \
       org.opencontainers.image.revision="${NODUS_REVISION}" \
@@ -45,7 +45,7 @@ COPY --from=web-build /src/server/dist/web ./dist/web
 ENV NODUS_DATA_DIR=/data \
     NODUS_HOST=0.0.0.0 \
     NODUS_PORT=7443 \
-    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v5.1.6
+    NODUS_SOURCE_URL=https://github.com/Drakonis96/nodus/tree/v5.1.7
 
 RUN mkdir -p /data && chown -R node:node /app /data
 USER node

--- a/server/SOURCE_CODE.md
+++ b/server/SOURCE_CODE.md
@@ -5,18 +5,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Corresponding source for Nodus
 
-Nodus 5.1.6 is licensed exclusively under the GNU Affero General Public
+Nodus 5.1.7 is licensed exclusively under the GNU Affero General Public
 License v3.0 (`AGPL-3.0-only`). The complete, unmodified license text is in
 [`LICENSE`](LICENSE). Versions published through Nodus 3.2.7 remain available
 under the MIT license that accompanied those releases.
 
-The preferred form for modifying the official Nodus 5.1.6 release is available
+The preferred form for modifying the official Nodus 5.1.7 release is available
 from the immutable release tag and its source archives:
 
-- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.6
-- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.6
-- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.6.tar.gz
-- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.6.zip
+- Tag and release: https://github.com/Drakonis96/nodus/releases/tag/v5.1.7
+- Source tree: https://github.com/Drakonis96/nodus/tree/v5.1.7
+- Tar archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.7.tar.gz
+- ZIP archive: https://github.com/Drakonis96/nodus/archive/refs/tags/v5.1.7.zip
 
 The source includes the desktop app, Nodus Server, the Zotero add-on, build
 scripts, lockfile and the material needed to rebuild the distributed work.

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Nodus third-party notices
 
-Nodus 5.1.6 is free software distributed exclusively under the GNU Affero
+Nodus 5.1.7 is free software distributed exclusively under the GNU Affero
 General Public License v3.0 (`AGPL-3.0-only`). Versions through 3.2.7 remain
 available under MIT. Nodus includes or interoperates with the components and
 data described below. Those components keep their own licenses and their

--- a/server/docker-compose.cloudflared.yml
+++ b/server/docker-compose.cloudflared.yml
@@ -36,7 +36,7 @@ services:
       # With the pair, the account is created on first boot and its password is rotated
       # whenever you change the value here.
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.6}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.7}
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       # Optional ceilings. Unset they default to 8 MiB per image, 2 GiB of images per

--- a/server/docker-compose.source.yml
+++ b/server/docker-compose.source.yml
@@ -26,7 +26,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.6}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.7}
       # Optional ceilings. Left unset they default to 8 MiB per image, 2 GiB of images per
       # space, and the snapshot limits documented in the README.
       NODUS_MAX_ASSET_BYTES: ${NODUS_MAX_ASSET_BYTES:-}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.6}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.7}
     volumes:
       - nodus_data:/data
       # Mount a versioned 0600 keyring outside /data and set NODUS_AI_KEYRING_FILE to

--- a/server/lib/version.mjs
+++ b/server/lib/version.mjs
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2026 Jorge Pérez Burgueño and Nodus contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export const NODUS_VERSION = '5.1.6';
+export const NODUS_VERSION = '5.1.7';
 export const NODUS_LICENSE = 'AGPL-3.0-only';
 
 const OFFICIAL_SOURCE_URL = `https://github.com/Drakonis96/nodus/tree/v${NODUS_VERSION}`;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/server/portainer-stack.yml
+++ b/server/portainer-stack.yml
@@ -16,7 +16,7 @@ services:
       NODUS_ADMIN_EMAIL: ${NODUS_ADMIN_EMAIL:-}
       NODUS_ADMIN_PASSWORD: ${NODUS_ADMIN_PASSWORD:-}
       NODUS_SETUP_TOKEN: ${NODUS_SETUP_TOKEN:-}
-      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.6}
+      NODUS_SOURCE_URL: ${NODUS_SOURCE_URL:-https://github.com/Drakonis96/nodus/tree/v5.1.7}
     volumes:
       - nodus_data:/data
     expose:

--- a/shared/releaseNotes.it.ts
+++ b/shared/releaseNotes.it.ts
@@ -166,6 +166,9 @@ const RELEASE_5_1_0_IT = [
 ];
 
 export const RELEASE_NOTES_IT: Record<string, string[]> = {
+  "5.1.7": [
+    "Generare una definizione del dizionario non sembra più un errore. La riga di stato annunciava che l’operazione non poteva essere completata mentre la definizione veniva scritta senza problemi. Ora mostra l’avanzamento reale nella tua lingua: in coda, analisi del corpus e generazione della definizione.",
+  ],
   "5.1.6": [
     "Le barre di avanzamento parlano ora la tua lingua. Le righe di indicizzazione, embedding, passaggi, coda e importazione di Zotero appaiono tradotte nelle otto lingue. I falsi avvisi di errore non compaiono più quando va tutto bene e i nomi delle tue biblioteche e opere restano esattamente come sono.",
     "Gli errori del processo principale arrivano ora tradotti nella tua lingua. Più di mille messaggi che apparivano in spagnolo o come avviso generico spiegano ora la loro causa reale. Il test di connessione lo mostra bene. Se Ollama non risponde, vedrai il suo indirizzo, il codice HTTP e la domanda se è in esecuzione.",

--- a/shared/releaseNotes.tr.ts
+++ b/shared/releaseNotes.tr.ts
@@ -106,6 +106,9 @@ const RELEASE_5_1_0_TR = [
 ];
 
 export const RELEASE_NOTES_TR: Record<string, string[]> = {
+  "5.1.7": [
+    "Sözlük tanımı oluşturmak artık bir hata gibi görünmüyor. Durum satırı, tanım sorunsuz yazılırken işlemin tamamlanamadığını duyuruyordu. Artık gerçek ilerlemeyi dilinizde gösteriyor: kuyrukta, derlem inceleniyor ve tanım oluşturuluyor.",
+  ],
   "5.1.6": [
     "İlerleme çubukları artık dilinizi konuşuyor. Dizin oluşturma, embedding, pasaj, kuyruk ve Zotero içe aktarma satırları sekiz dilde çevrilmiş görünüyor. Her şey yolundayken hatalı hata uyarıları artık görünmüyor ve kitaplık ile eser adlarınız aynen korunuyor.",
     "Ana işlem hataları artık dilinize çevrilmiş olarak geliyor. Eskiden İspanyolca veya genel bir uyarı olarak görünen binden fazla ileti artık gerçek nedenini açıklıyor. Bağlantı testi bunu açıkça gösteriyor. Ollama yanıt vermezse adresini, HTTP kodunu ve çalışıp çalışmadığı sorusunu göreceksiniz.",

--- a/shared/releaseNotes.ts
+++ b/shared/releaseNotes.ts
@@ -2481,6 +2481,25 @@ const RELEASE_5_1_4_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 /**
+ * v5.1.7 carries a single repair: the Dictionary status line announced a
+ * failure while the definition was being written correctly. Its progress copy
+ * travelled in a `message` field, so the main-process localizer rewrote it as
+ * the generic "the operation could not be completed" notice in every language
+ * other than Spanish. The sentences are now handed to the renderer untouched.
+ */
+const RELEASE_5_1_7_HIGHLIGHTS: RawReleaseHighlight[] = [
+  {
+    scope: 'languages',
+    es: 'Generar una definici\u00f3n del diccionario ya no parece un fallo. La l\u00ednea de estado anunciaba que la operaci\u00f3n no se pudo completar mientras la definici\u00f3n se escrib\u00eda sin problemas. Ahora muestra el progreso real en tu idioma: en cola, analizando corpus y generando definici\u00f3n.',
+    en: 'Generating a dictionary definition no longer looks like a failure. The status line announced that the operation could not be completed while the definition was being written just fine. It now shows the real progress in your language: queued, analysing corpus and generating definition.',
+    fr: 'G\u00e9n\u00e9rer une d\u00e9finition du dictionnaire ne ressemble plus \u00e0 un \u00e9chec. La ligne d\u2019\u00e9tat annon\u00e7ait que l\u2019op\u00e9ration n\u2019avait pas pu aboutir alors que la d\u00e9finition s\u2019\u00e9crivait sans probl\u00e8me. Elle affiche maintenant la progression r\u00e9elle dans votre langue : en file d\u2019attente, analyse du corpus et g\u00e9n\u00e9ration de la d\u00e9finition.',
+    de: 'Das Erzeugen einer W\u00f6rterbuchdefinition sieht nicht l\u00e4nger nach einem Fehler aus. Die Statuszeile meldete, der Vorgang habe nicht abgeschlossen werden k\u00f6nnen, w\u00e4hrend die Definition einwandfrei geschrieben wurde. Jetzt zeigt sie den echten Fortschritt in Ihrer Sprache: in der Warteschlange, Korpus wird analysiert und Definition wird erzeugt.',
+    pt: 'Gerar uma defini\u00e7\u00e3o do dicion\u00e1rio j\u00e1 n\u00e3o parece uma falha. A linha de estado anunciava que a opera\u00e7\u00e3o n\u00e3o p\u00f4de ser conclu\u00edda enquanto a defini\u00e7\u00e3o se escrevia sem problemas. Agora mostra o progresso real no seu idioma: em fila, a analisar o corpus e a gerar a defini\u00e7\u00e3o.',
+    'pt-BR': 'Gerar uma defini\u00e7\u00e3o do dicion\u00e1rio n\u00e3o parece mais uma falha. A linha de status anunciava que a opera\u00e7\u00e3o n\u00e3o p\u00f4de ser conclu\u00edda enquanto a defini\u00e7\u00e3o era escrita sem problemas. Agora ela mostra o progresso real no seu idioma: na fila, analisando o corpus e gerando a defini\u00e7\u00e3o.',
+  },
+];
+
+/**
  * v5.1.6 stands on its own with the three changes that are actually new: a
  * custom OpenAI-compatible provider in Settings, and the two translation
  * repairs for progress bars and main-process errors. The order below is the
@@ -2518,6 +2537,11 @@ const RELEASE_5_1_6_HIGHLIGHTS: RawReleaseHighlight[] = [
 ];
 
 const RAW_RELEASE_NOTES: RawReleaseNote[] = [
+  {
+    version: '5.1.7',
+    date: '2026-09-04',
+    highlights: RELEASE_5_1_7_HIGHLIGHTS,
+  },
   {
     version: '5.1.6',
     date: '2026-09-03',

--- a/shared/uiLanguage.ts
+++ b/shared/uiLanguage.ts
@@ -695,6 +695,16 @@ export const PROGRESS_STATE_MESSAGES = [
   'La obra ya no existe.',
 ];
 
+/** Dictionary generation status copy is translated by DictionaryView. */
+export const DICTIONARY_PROGRESS_MESSAGES = [
+  'En cola',
+  'Analizando corpus',
+  'Generando definición',
+  'Definición generada',
+  'La síntesis necesita revisión',
+  'Error al generar',
+];
+
 /**
  * The Zotero import readout, exactly as `electron/library/zoteroLibraryImport.ts`
  * writes it.
@@ -733,6 +743,7 @@ const RENDERER_TRANSLATED_MESSAGES = new Set([
   ...IMAGE_GENERATION_ERROR_MESSAGES,
   ...ZOTERO_IMPORT_PROGRESS_MESSAGES,
   ...PROGRESS_STATE_MESSAGES,
+  ...DICTIONARY_PROGRESS_MESSAGES,
   'Bóveda no encontrada.',
   'No se encontró la bóveda de origen de las claves API.',
   'Esta bóveda ya está cargada.',

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -86,9 +86,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.6",
-      "datePublished": "2026-09-03",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.6",
+      "softwareVersion": "5.1.7",
+      "datePublished": "2026-09-04",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.7",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -103,7 +103,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.6"
+          "value": "v5.1.7"
         }
       ],
       "sameAs": [

--- a/site/cite/index.html
+++ b/site/cite/index.html
@@ -87,9 +87,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.6",
-      "datePublished": "2026-09-03",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.6",
+      "softwareVersion": "5.1.7",
+      "datePublished": "2026-09-04",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.7",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -104,7 +104,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.6"
+          "value": "v5.1.7"
         }
       ],
       "sameAs": [
@@ -170,9 +170,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 <dl class="citation-meta reveal">
       <div><dt>Project</dt><dd>Nodus Research</dd></div>
       <div><dt>Software</dt><dd>Nodus</dd></div>
-      <div><dt>Version</dt><dd>5.1.6</dd></div>
-      <div><dt>Released</dt><dd>3 September 2026</dd></div>
-      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.6" target="_blank" rel="noopener">v5.1.6</a></dd></div>
+      <div><dt>Version</dt><dd>5.1.7</dd></div>
+      <div><dt>Released</dt><dd>4 September 2026</dd></div>
+      <div><dt>Release tag</dt><dd><a href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.7" target="_blank" rel="noopener">v5.1.7</a></dd></div>
       <div><dt>Author</dt><dd><a href="https://orcid.org/0000-0002-1150-1930" target="_blank" rel="noopener">Jorge Pérez Burgueño · ORCID</a></dd></div>
       <div><dt>Licence</dt><dd><a href="https://spdx.org/licenses/AGPL-3.0-only.html" target="_blank" rel="noopener">AGPL-3.0-only</a></dd></div>
     </dl>
@@ -197,10 +197,10 @@ SPDX-License-Identifier: AGPL-3.0-only
         <a class="doi-value" href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">10.5281/zenodo.21515531</a>
       </article>
       <article class="card lit doi-card reveal" style="--delay:80ms">
-        <span class="kicker">Nodus 5.1.6 · archive pending</span>
+        <span class="kicker">Nodus 5.1.7 · archive pending</span>
         <h3>Version DOI pending</h3>
-        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.1.6 release tag shown here.</p>
-        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.6" target="_blank" rel="noopener">v5.1.6</a>
+        <p>Zenodo assigns the immutable DOI after this release is archived. Until then, cite the conceptual DOI and the v5.1.7 release tag shown here.</p>
+        <a class="doi-value" href="https://github.com/Drakonis96/nodus/releases/tag/v5.1.7" target="_blank" rel="noopener">v5.1.7</a>
       </article>
     </div>
 <!-- generated:citation-dois:end -->
@@ -218,7 +218,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- generated:citation-formats:start -->
 <div class="citation-block reveal">
       <h3>APA</h3>
-      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.1.6) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
+      <p>Pérez Burgueño, J., &amp; Nodus contributors. (2026). <i>Nodus: Open-Source Research Workspace</i> (Version 5.1.7) [Computer software]. Zenodo. <a href="https://doi.org/10.5281/zenodo.21515531" target="_blank" rel="noopener">https://doi.org/10.5281/zenodo.21515531</a></p>
     </div>
 
     <div class="citation-block reveal">
@@ -226,11 +226,11 @@ SPDX-License-Identifier: AGPL-3.0-only
       <pre><code>@software{perez_burgueno_nodus_2026,
   author    = {Pérez Burgueño, Jorge and Nodus contributors},
   title     = {Nodus: Open-Source Research Workspace},
-  version   = {5.1.6},
+  version   = {5.1.7},
   year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.21515531},
-  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.1.6},
+  url       = {https://github.com/Drakonis96/nodus/releases/tag/v5.1.7},
   license   = {AGPL-3.0-only}
 }</code></pre>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -97,9 +97,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       "applicationSubCategory": "Academic research workspace",
       "operatingSystem": "macOS, Windows, Linux",
       "description": "Nodus is a free, open-source, local-first desktop workspace for academic research. It connects sources, ideas and evidence, supports Zotero libraries and semantic search, and keeps the research corpus on the researcher’s own computer.",
-      "softwareVersion": "5.1.6",
-      "datePublished": "2026-09-03",
-      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.6",
+      "softwareVersion": "5.1.7",
+      "datePublished": "2026-09-04",
+      "releaseNotes": "https://github.com/Drakonis96/nodus/releases/tag/v5.1.7",
       "license": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "codeRepository": "https://github.com/Drakonis96/nodus",
       "isAccessibleForFree": true,
@@ -114,7 +114,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         {
           "@type": "PropertyValue",
           "propertyID": "Release tag",
-          "value": "v5.1.6"
+          "value": "v5.1.7"
         }
       ],
       "sameAs": [

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nodusresearch.com/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/about/</loc>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/app/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/apps/</loc>
@@ -30,7 +30,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/zotero-plugin/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/ai-research/</loc>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/cite/</loc>
-    <lastmod>2026-09-03</lastmod>
+    <lastmod>2026-09-04</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/demo/</loc>

--- a/zotero-plugin/manifest.json
+++ b/zotero-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Nodus for Zotero",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "license": "AGPL-3.0-only",
   "description": "Evidence-grounded research assistant for Zotero with full-text semantic retrieval, audited citations, OCR and visual document understanding.",
   "author": "Nodus",


### PR DESCRIPTION
Generating a dictionary definition showed **"The operation could not be completed."** while the definition was in fact being written correctly.

## Cause

The Dictionary generation queue reports its state in a `message` field (`En cola`, `Analizando corpus`, `Generando definición`). Every IPC payload passes through `localizeIpcPayload`, which treats `message`/`error` fields as main-process failures, so those three progress lines were rewritten as the generic failure notice in every interface language other than Spanish.

## Fix

- `DICTIONARY_PROGRESS_MESSAGES` is added to the renderer-translated allowlist in `shared/uiLanguage.ts`, so the sentences reach `DictionaryView` untouched. `dictionaryProgressText` already translates each one where it is rendered.
- `scripts/test-localize-ipc-payload.mjs` pins the whole catalogue across the seven non-Spanish languages.

## Release

Second commit is the 5.1.7 bump: desktop app, server, browser extension and Zotero plugin, citation and source-offer metadata, the Docker image labels and the server-image workflow, the regenerated `site/` release metadata, the CHANGELOG entry, and one What's New highlight in all eight interface languages.

## Verification

- `npm test` — 2862 tests, all passing (the three e2e suites need `npm run build` first, which was run).
- `npm run site:verify` — 74 passing.
- `npm run typecheck`, `npm run citation:check` — clean.