### PR TITLE
Add pinned Toolkit shortcuts and fix citation, Dictionary, and queue UI states

### DIFF
--- a/electron/db/appPrefs.ts
+++ b/electron/db/appPrefs.ts
@@ -33,6 +33,9 @@ export const GLOBAL_PREF_KEYS = [
   'highContrast',
   'reduceMotion',
   'readingFocusMode',
+  // Toolkit pins are a user preference, not vault content. Their position stays
+  // in each vault's sidebarOrder, but the chosen shortcuts follow vault switches.
+  'toolkitPinnedPages',
   'announcementsEnabled',
   'betaUpdates',
   'favorites',

--- a/electron/db/settingsRepo.ts
+++ b/electron/db/settingsRepo.ts
@@ -13,6 +13,7 @@ import { lockedApiKeyProviders, providerKeyMap } from '../secrets/secretStore';
 import { GRANULAR_MODEL_KEYS, migrateModelSettings } from '@shared/modelSettings';
 import { DEFAULT_NODUS_IMAGE_QUALITY, isNodusImageQuality } from '@shared/localImageModels';
 import { EMPTY_CUSTOM_EVENT_TYPES, sanitizeCustomEventTypes } from '@shared/eventTypes';
+import { normalizeToolkitToolPages } from '@shared/toolkitNavigation';
 import { recoverV23SharedModelPrefs, recoverV23VaultEmbeddingSelection } from './modelPrefsRecovery';
 import {
   GLOBAL_PREF_KEYS,
@@ -229,6 +230,7 @@ const DEFAULTS: Omit<AppSettings, 'providerKeys' | 'lockedProviderKeys'> = {
   sidebarOrder: [],
   sidebarHidden: [],
   sidebarCustomized: false,
+  toolkitPinnedPages: [],
   treeFrame: 'oak',
   treeFocusPersonId: null,
   treeOrientation: 'ancestors_top',
@@ -333,6 +335,7 @@ export function getSettings(): AppSettings {
   merged.mascotScale = normalizeNodiScale(parsed.mascotScale);
   merged.studyImproveToolbarStyleIds = [...new Set((Array.isArray(merged.studyImproveToolbarStyleIds) ? merged.studyImproveToolbarStyleIds : [])
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0))].slice(0, 4);
+  merged.toolkitPinnedPages = normalizeToolkitToolPages(parsed.toolkitPinnedPages);
   merged.customEventTypes = sanitizeCustomEventTypes(parsed.customEventTypes);
   // Pre-2.3 builds called the Transformers.js worker simply "local".
   if ((parsed as { sttProvider?: string }).sttProvider === 'local') merged.sttProvider = 'transformers';
@@ -387,8 +390,9 @@ export function getSettings(): AppSettings {
   // The global preferences file is user-editable, so validate the shared size again
   // after it has overlaid the vault defaults.
   merged.mascotScale = normalizeNodiScale(merged.mascotScale);
-  // Global preferences are user-editable JSON on disk. Fail closed to the v3-safe
-  // vault scope if those three values are missing or malformed.
+  // Global preferences are user-editable JSON on disk; discard unknown pin ids.
+  merged.toolkitPinnedPages = normalizeToolkitToolPages(merged.toolkitPinnedPages);
+  // Fail closed to the v3-safe vault scope if these three values are malformed.
   if (merged.libraryScope !== 'global' && merged.libraryScope !== 'vault') merged.libraryScope = 'vault';
   if (typeof merged.libraryGlobalEnabled !== 'boolean') merged.libraryGlobalEnabled = false;
   if (!Number.isInteger(merged.libraryScopeOnboardingVersion) || merged.libraryScopeOnboardingVersion < 0) {
@@ -525,6 +529,9 @@ export function updateSettings(patch: Partial<AppSettings>): AppSettings {
   }
   if (patch.studyImproveToolbarStyleIds) {
     patch = { ...patch, studyImproveToolbarStyleIds: [...new Set(patch.studyImproveToolbarStyleIds.filter((value) => typeof value === 'string' && value.trim()))].slice(0, 4) };
+  }
+  if (patch.toolkitPinnedPages !== undefined) {
+    patch = { ...patch, toolkitPinnedPages: normalizeToolkitToolPages(patch.toolkitPinnedPages) };
   }
   if (patch.transcriptionModel !== undefined) {
     patch = { ...patch, transcriptionModel: sanitizeTranscriptionModel(patch.transcriptionModel) };

--- a/electron/pipeline/scanQueue.ts
+++ b/electron/pipeline/scanQueue.ts
@@ -162,6 +162,28 @@ class ScanQueue {
     this.items.push(item);
   }
 
+  /**
+   * The queue is an operational view, not an attempt log. Starting the same step
+   * again supersedes its completed/failed/cancelled row; keeping those rows made a
+   * successful third attempt still look like two actionable failures.
+   */
+  private dropSupersededAttempts(nodusId: string, kind: QueueKind): void {
+    const staleIds = this.items
+      .filter((item) =>
+        item.nodus_id === nodusId
+        && item.kind === kind
+        && (item.state === 'done' || item.state === 'failed' || item.state === 'cancelled')
+      )
+      .map((item) => item.id);
+    if (staleIds.length === 0) return;
+    const stale = new Set(staleIds);
+    this.items = this.items.filter((item) => !stale.has(item.id));
+    for (const id of stale) {
+      this.retries.delete(id);
+      this.notifiedTerminalIds.delete(id);
+    }
+  }
+
   enqueue(nodusId: string, title: string, kind: QueueKind, model?: ModelRef | null, opts?: { chain?: boolean; refresh?: boolean }): void {
     // Avoid duplicate pending/running jobs for the same work+kind.
     const existing = this.items.find(
@@ -173,6 +195,7 @@ class ScanQueue {
       if (opts?.refresh) existing.refresh = true;
       return;
     }
+    this.dropSupersededAttempts(nodusId, kind);
     this.beginTask();
     if (kind === 'deep') setDeepPending(nodusId);
     this.insertPending({
@@ -200,6 +223,7 @@ class ScanQueue {
       else if (existing.scopeNodusIds) existing.scopeNodusIds = [...new Set([...existing.scopeNodusIds, ...scopeNodusIds])];
       return;
     }
+    this.dropSupersededAttempts('', 'bridge');
     this.beginTask();
     this.insertPending({
       id: uuid(),

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -1147,6 +1147,25 @@ try {
     assert.equal(centring.square, true, `${testId} icon tile is square`);
     assert.ok(centring.dx <= 0.5 && centring.dy <= 0.5, `${testId} icon is centred (dx ${centring.dx}, dy ${centring.dy})`);
   }
+  // A card pin creates a real direct shortcut, using the exact same catalogue
+  // icon, and that shortcut opens the nested page without turning it into a View.
+  const ocrPin = page.getByTestId('toolkit-card-aiocr-pin');
+  assert.equal(await ocrPin.getAttribute('aria-pressed'), 'false', 'OCR starts unpinned');
+  await ocrPin.click();
+  await page.waitForFunction(() => document.querySelector('[data-tour="nav-toolkit:ocr"]'));
+  assert.equal(await ocrPin.getAttribute('aria-pressed'), 'true', 'the card reflects its saved pin');
+  const ocrShortcut = page.locator('[data-tour="nav-toolkit:ocr"]');
+  assert.equal(
+    await ocrShortcut.locator('svg').innerHTML(),
+    await page.getByTestId('toolkit-card-aiocr').locator('span svg').first().innerHTML(),
+    'the shortcut reuses the OCR catalogue icon',
+  );
+  await ocrShortcut.click();
+  await page.getByTestId('aiocr-home').waitFor({ timeout: 10_000 });
+  await page.getByTestId('toolkit-aiocr-back').click();
+  await page.getByTestId('toolkit-home').waitFor();
+  await page.getByTestId('toolkit-card-aiocr-pin').click();
+  await ocrShortcut.waitFor({ state: 'detached' });
   // Nodus Apps opens its beginner-facing catalogue and executes both curated
   // multilingual apps in the real sandbox before exercising app management.
   assert.equal(await page.getByTestId('toolkit-card-apps').isDisabled(), false, 'Nodus Apps opens');

--- a/scripts/test-dictionary-ui.mjs
+++ b/scripts/test-dictionary-ui.mjs
@@ -270,6 +270,21 @@ assert.match(
 );
 assert.match(
   view,
+  /jobs\s*\.filter\(\(job\) => job\.phase !== ["']done["']\)/,
+  "a completed job does not permanently cover the entry lifecycle status after remounting",
+);
+assert.match(
+  view,
+  /progress\.phase === ["']done["'][\s\S]*reload\(false\)\.then\(\(reloaded\)[\s\S]*next\.delete\(progress\.entryId\)/,
+  "the generated confirmation yields to the saved Active status after a successful reload",
+);
+assert.match(
+  view,
+  /progress\.phase === ["']done["'] && status !== ["']draft["'][\s\S]*<StatusPill status=\{status\}/,
+  "stale successful progress cannot replace an already-persisted lifecycle status",
+);
+assert.match(
+  view,
   /const hasEvidence = detail\.coverage\.included > 0/,
   "generation eligibility uses the live included selection, not a nonexistent draft version",
 );

--- a/scripts/test-progress-bars-lifecycle.mjs
+++ b/scripts/test-progress-bars-lifecycle.mjs
@@ -23,6 +23,13 @@ test('finished lower bars use semantic SVG status icons instead of destructive t
   }
 });
 
+test('the scan queue reaches 100% only when its dismiss tick is available', async () => {
+  const queue = await source('QueueBar.tsx');
+  assert.match(queue, /const pct = maintenanceRunning \? \(total \? Math\.min\(itemPct, 99\) : 99\) : itemPct/);
+  assert.match(queue, /const terminal = !active && !maintenanceError/);
+  assert.match(queue, /\{terminal && \([\s\S]*?<Icon name=\{failed > 0 \? 'warning' : 'check'\}/);
+});
+
 test('every persistent processing rail exposes total time and its current item time where applicable', async () => {
   const names = [
     'QueueBar.tsx',

--- a/scripts/test-scan-queue-lifecycle.mjs
+++ b/scripts/test-scan-queue-lifecycle.mjs
@@ -15,6 +15,7 @@ globalThis.__scanQueueLife = {
   reprocessStarted: false,
   releaseReprocess: null,
   releaseBridge: null,
+  deepFailures: 0,
 };
 
 await build({
@@ -40,7 +41,7 @@ await build({
       `);
       stub(/\.\.\/db\/settingsRepo$/, 'settings', `export function getSettings(){return {aiConcurrencyMode:'manual',concurrency:1,autoBridgeAfterQueue:false,autoSummaryAfterDeep:false,embeddingProvider:'openai',providerKeys:{openai:false},zoteroUserId:'',zoteroStoragePath:'',unpaywallEmail:'',preferZoteroFulltext:false,ocrEnabled:false,ocrLanguages:[],ocrMaxPages:0,themesLocked:false,synthesisModel:null}}`);
       stub(/\.\.\/ai\/lightScan$/, 'light', `export async function runLightScan(){}`);
-      stub(/\.\.\/ai\/deepScan$/, 'deep', `export function issueDeepScanPublicationOrdinal(){return 1}export function finishDeepScanPublicationOrdinal(){}export async function runDeepScan(){}`);
+      stub(/\.\.\/ai\/deepScan$/, 'deep', `export function issueDeepScanPublicationOrdinal(){return 1}export function finishDeepScanPublicationOrdinal(){}export async function runDeepScan(){if(globalThis.__scanQueueLife.deepFailures>0){globalThis.__scanQueueLife.deepFailures-=1;throw new Error('temporary fusion failure')}}`);
       stub(/\.\.\/ai\/summaryScan$/, 'summary', `export async function runSummaryScan(){}`);
       stub(/\.\.\/ai\/reprocessConnections$/, 'reprocess', `export async function reprocessConnections(_options,_model,onProgress){globalThis.__scanQueueLife.reprocessStarted=true;onProgress?.({phase:'themes',label:'Agrupando ideas en temas',current:1,total:1});await new Promise(resolve=>{globalThis.__scanQueueLife.releaseReprocess=resolve});return {relationsAdded:0,newThemes:0}}`);
       stub(/\.\.\/db\/themesRepo$/, 'themes', `export function listThemeLabels(){return []}`);
@@ -78,6 +79,28 @@ test('required graph maintenance remains active after the paper itself finishes'
   globalThis.__scanQueueLife.releaseReprocess();
   await waitFor(() => !scanQueue.snapshot().maintenanceRunning, 'maintenance settles');
   assert.ok(scanQueue.snapshot().finishedAt, 'the task finishes only after its required post-processing');
+});
+
+test('retrying one work replaces its failed attempt instead of accumulating failures', async () => {
+  scanQueue.clear();
+  globalThis.__scanQueueLife.deepFailures = 1;
+  scanQueue.enqueue('paper-1', 'Paper one', 'deep');
+  await waitFor(() => scanQueue.snapshot().failed === 1, 'first attempt fails');
+  const failedId = scanQueue.snapshot().items.find((item) => item.state === 'failed').id;
+
+  globalThis.__scanQueueLife.reprocessStarted = false;
+  scanQueue.enqueue('paper-1', 'Paper one', 'deep');
+  const retrying = scanQueue.snapshot();
+  assert.equal(retrying.items.some((item) => item.id === failedId), false, 'the superseded failure leaves the operational queue');
+  assert.equal(retrying.failed, 0, 'the retry control counts current failures, not attempt history');
+
+  await waitFor(() => globalThis.__scanQueueLife.reprocessStarted, 'successful retry reaches graph maintenance');
+  globalThis.__scanQueueLife.releaseReprocess();
+  await waitFor(() => !scanQueue.snapshot().maintenanceRunning, 'retry maintenance settles');
+  const completed = scanQueue.snapshot();
+  assert.equal(completed.failed, 0);
+  assert.equal(completed.done, 1);
+  assert.equal(completed.items.filter((item) => item.kind === 'deep').length, 1, 'only the successful current attempt remains');
 });
 
 test('stopping an accepted provider operation never hides it while it is still running', async () => {

--- a/scripts/test-server-web-model-provider-parity.mjs
+++ b/scripts/test-server-web-model-provider-parity.mjs
@@ -45,7 +45,7 @@ function profileWithFavorites(favorites) {
       },
     },
     workspace: {
-      sidebarOrder: [], sidebarHidden: [], sidebarCustomized: false, concurrency: 2,
+      sidebarOrder: [], sidebarHidden: [], sidebarCustomized: false, toolkitPinnedPages: [], concurrency: 2,
       deepContextMode: 'standard', standardChunkWords: 1800, longChunkWords: 30000,
     },
   };

--- a/scripts/test-toolkit-ui.mjs
+++ b/scripts/test-toolkit-ui.mjs
@@ -59,9 +59,9 @@ test('every sidebar icon stays unique so a collapsed sidebar keeps sections apar
   assert.equal(icons.filter((icon) => icon === 'tools').length, 1, 'the tools icon belongs to the toolkit alone');
 });
 
-test('the toolkit icons exist in the shared catalogue', async () => {
+test('the toolkit and pin icons exist in the shared catalogue', async () => {
   const ui = await read('src/components/ui.tsx');
-  for (const icon of ['tools', 'swap', 'shield', 'scanText', 'presentation', 'languages', 'chevronLeft']) {
+  for (const icon of ['tools', 'swap', 'shield', 'scanText', 'presentation', 'languages', 'chevronLeft', 'pin']) {
     assert.match(ui, new RegExp(`\\n\\s{2}${icon}: '`), `${icon} is defined in ICON_PATHS`);
   }
 });
@@ -87,6 +87,52 @@ test('the toolkit shows in every vault type, including databases and study', () 
   assert.deepEqual(tools.items.map((n) => n.id), ['browser', 'radar', 'compass', 'toolkit']);
 });
 
+test('pinned Toolkit pages become reorderable sidebar shortcuts with their catalogue icons', () => {
+  const pinned = navigation.pinnedToolkitSidebarItems(['apps', 'ocr', 'apps', 'unknown']);
+  assert.deepEqual(
+    pinned.map(({ id, label, icon, toolkitPage }) => ({ id, label, icon, toolkitPage })),
+    [
+      { id: 'toolkit:apps', label: 'Nodus Apps', icon: 'grid', toolkitPage: 'apps' },
+      { id: 'toolkit:ocr', label: 'OCR Workspace', icon: 'scanText', toolkitPage: 'ocr' },
+    ],
+  );
+
+  const defaultTools = navigation.groupedNav([], [], ['apps', 'ocr']).find((group) => group.id === 'tools');
+  assert.deepEqual(
+    defaultTools.items.map((item) => item.id),
+    ['browser', 'radar', 'compass', 'toolkit', 'toolkit:apps', 'toolkit:ocr'],
+    'new pins start beside the Nodus Tools catalogue',
+  );
+
+  const reordered = navigation.groupedNav(
+    ['browser', 'toolkit:ocr', 'radar', 'toolkit', 'toolkit:apps', 'compass'],
+    [],
+    ['apps', 'ocr'],
+  ).find((group) => group.id === 'tools');
+  assert.deepEqual(
+    reordered.items.map((item) => item.id),
+    ['browser', 'toolkit:ocr', 'radar', 'toolkit', 'toolkit:apps', 'compass'],
+    'the Settings order applies to parent sections and pinned tools together',
+  );
+});
+
+test('the Toolkit hub, real sidebar and Settings editor share the pin contract', async () => {
+  const [view, app, settings, defaults, appPrefs] = await Promise.all([
+    read('src/views/ToolkitView.tsx'),
+    read('src/App.tsx'),
+    read('src/views/Settings.tsx'),
+    read('electron/db/settingsRepo.ts'),
+    read('electron/db/appPrefs.ts'),
+  ]);
+  assert.match(view, /onTogglePinned=\{\(\) => void togglePinned\(tool\.page\)\}/);
+  assert.match(app, /settings\?\.toolkitPinnedPages \?\? \[\]/, 'the real sidebar resolves the saved pins');
+  assert.match(app, /setToolkitPage\(n\.toolkitPage\)[\s\S]*?setView\('toolkit'\)/, 'a shortcut opens its nested Toolkit page');
+  assert.match(settings, /groupedNav\(sidebarOrder, \[\], toolkitPinnedPages\)/, 'Settings uses the real Tools group');
+  assert.match(settings, /toolkitPinnedPages=\{settings\.toolkitPinnedPages\}/, 'Settings receives the persistent pin set');
+  assert.match(defaults, /toolkitPinnedPages: \[\]/, 'existing profiles start with no pinned tools');
+  assert.match(appPrefs, /'toolkitPinnedPages'/, 'pins follow the user when switching vaults');
+});
+
 test('the hub renders every built tool including Nodus Translate', async () => {
   const view = await read('src/views/ToolkitView.tsx');
   assert.ok(view.includes('data-testid="toolkit-home"'), 'the hub is addressable');
@@ -107,6 +153,10 @@ test('the hub renders every built tool including Nodus Translate', async () => {
   );
   assert.match(view, /name=\{tool\.name\}/, 'the card shows the brand name verbatim, never through t()');
   assert.match(view, /description=\{t\(tool\.description\)\}/, 'only the description is translated');
+  assert.match(view, /data-testid=\{`\$\{testid\}-pin`\}/, 'every card exposes its pin control');
+  assert.match(view, /aria-pressed=\{pinned\}/, 'pin state is accessible');
+  assert.match(view, /toolkitPinnedPages:/, 'pinning persists the selected Toolkit page');
+  assert.match(view, /sidebarOrder: isPinned/, 'unpinning retires stale order entries');
 
   // Every tool is built and openable; none is coming soon.
   assert.deepEqual(
@@ -205,24 +255,19 @@ test('Protect exposes the complete local workflow and the secure preload boundar
   }
 });
 
-test('the toolkit has one sidebar entry and keeps its tools in the catalogue', async () => {
+test('Toolkit tools remain nested destinations even when pinned into the sidebar', async () => {
   const app = await read('@shell');
-  // The tools are NOT views: they must never enter NAV_ITEMS, or they would show
-  // up in sidebarOrder, the reordering UI and the vault-type allow-lists.
+  // The tools are NOT views: the optional shortcuts are namespaced ids and open
+  // the existing nested page, so vault-type allow-lists never need to grow.
   const toolPages = new Set(navigation.TOOLKIT_TOOLS.map((tool) => tool.page));
   assert.ok(
     !navigation.NAV_ITEMS.some((n) => toolPages.has(n.id)),
     'the tools stay out of the canonical nav table'
   );
   assert.doesNotMatch(app, /toolkitSubNav/, 'the sidebar does not render nested tool buttons');
-  assert.doesNotMatch(app, /nav-toolkit-/, 'tools are only addressable from the catalogue');
   assert.match(app, /if \(n\.id === 'toolkit'\) setToolkitPage\('home'\);/, 'the section button opens the catalogue');
-  // The section is highlighted only while its catalogue is on screen.
-  assert.match(
-    app,
-    /view === n\.id && \(n\.id !== 'toolkit' \|\| toolkitPage === 'home'\)/,
-    'the section and its open tool never highlight at once'
-  );
+  assert.match(app, /'toolkitPage' in n[\s\S]*?toolkitPage === n\.toolkitPage/, 'only the shortcut for the open tool is highlighted');
+  assert.match(app, /n\.id !== 'toolkit' \|\| toolkitPage === 'home'/, 'the catalogue entry is inactive inside a tool');
 });
 
 test('the hub cards share one shape and omit development labels', async () => {
@@ -230,7 +275,7 @@ test('the hub cards share one shape and omit development labels', async () => {
   // One ToolCard component renders every card, so they cannot drift apart.
   assert.equal((view.match(/<ToolCard\b/g) ?? []).length, 1, 'a single ToolCard renders the whole catalogue');
   assert.match(view, /grid gap-4 sm:grid-cols-2/, 'the cards use a two-column grid when space permits');
-  assert.match(view, /className=\{`flex h-full flex-col/, 'each card fills its grid cell');
+  assert.match(view, /className=\{`flex h-full w-full flex-col/, 'each card fills its grid cell');
   assert.match(view, /h-12 w-12 shrink-0 items-center justify-center/, 'the card icon sits in a fixed centred tile');
   assert.doesNotMatch(view, /t\('En desarrollo'\)/, 'available apps do not show a development label');
   assert.match(view, /disabled && \(/, 'only unavailable tools render a status label');

--- a/scripts/test-view-registry.mjs
+++ b/scripts/test-view-registry.mjs
@@ -48,10 +48,12 @@ test('every view has a renderer and every renderer is a view', () => {
 
 test('App.tsx renders through the registry and holds no view chain of its own', () => {
   const app = readSource('src/App.tsx');
-  assert.match(app, /\{VIEW_REGISTRY\[view\]\(viewContext\)\}/);
-  // The four that remain are sidebar active-state checks, not dispatch.
-  const branches = [...app.matchAll(/view === /g)].length;
-  assert.ok(branches <= 6, `App.tsx still dispatches on view ${branches} times`);
+  const main = app.match(/^\s*<main\b[^>]*>([\s\S]*?)<\/main>/m)?.[1];
+  assert.ok(main, 'App.tsx must have a main content region');
+  // Sidebar active states and browser effects legitimately compare views. Check
+  // the content region instead of imposing a global budget on those comparisons.
+  assert.doesNotMatch(main, /\bview\s*===|===\s*view\b|switch\s*\(\s*view\s*\)/);
+  assert.match(main, /<AppErrorBoundary key=\{view\}>\s*\{VIEW_REGISTRY\[view\]\(viewContext\)\}\s*<\/AppErrorBoundary>/);
   // The crash boundary and the lazy fallback stay around the registry, not inside it.
   assert.match(app, /<AppErrorBoundary key=\{view\}>/);
   assert.match(app, /<Suspense fallback=/);

--- a/scripts/test-view-snapshots.mjs
+++ b/scripts/test-view-snapshots.mjs
@@ -57,6 +57,7 @@ const store = bundleOf('src/app/viewSnapshots.ts', 'viewSnapshots.cjs');
 const preferences = bundleOf('src/app/filterPreferences.ts', 'filterPreferences.cjs');
 const { topAnchorId } = bundleOf('src/listPlacement.ts', 'listPlacement.cjs');
 const { readingBlocks, topBlockIndex } = bundleOf('src/readingPlace.ts', 'readingPlace.cjs');
+const { groupParenthesizedCitations } = bundleOf('src/markdownCitationGroups.ts', 'markdownCitationGroups.cjs');
 
 test.after(async () => { await rm(bundleDir, { recursive: true, force: true }); });
 
@@ -547,11 +548,63 @@ test('Deep Research restores its gallery, the report it was left in and the plac
   }
 });
 
+test('parentheses and a citation pill wrap as one unit', () => {
+  const citation = {
+    type: 'element',
+    tagName: 'a',
+    properties: { href: 'nodus://idea/cita-1' },
+    children: [{ type: 'text', value: 'Moreno Garrido, A. (2012)' }],
+  };
+  const tree = {
+    type: 'root',
+    children: [
+      { type: 'element', tagName: 'p', properties: {}, children: [
+        { type: 'text', value: 'Texto anterior (' },
+        citation,
+        { type: 'text', value: '), texto posterior' },
+      ] },
+    ],
+  };
+
+  groupParenthesizedCitations(tree);
+
+  assert.equal(tree.children[0].children[0].value, 'Texto anterior ');
+  assert.equal(tree.children[0].children[2].value, ', texto posterior');
+  assert.deepEqual(tree.children[0].children[1], {
+    type: 'element',
+    tagName: 'span',
+    properties: { className: ['citation-group'] },
+    children: [
+      { type: 'text', value: '(' },
+      citation,
+      { type: 'text', value: ')' },
+    ],
+  });
+});
+
+test('the citation grouping transform leaves ordinary links and bare citations untouched', () => {
+  for (const [href, before, after] of [
+    ['https://example.com', '(', ')'],
+    ['nodus://idea/cita-1', 'sin paréntesis ', ' al final'],
+  ]) {
+    const tree = { type: 'p', children: [
+      { type: 'text', value: before },
+      { type: 'element', tagName: 'a', properties: { href }, children: [] },
+      { type: 'text', value: after },
+    ] };
+    const original = structuredClone(tree);
+    groupParenthesizedCitations(tree);
+    assert.deepEqual(tree, original);
+  }
+});
+
 test('the Deep Research reader has persistent typography and a live report outline', async () => {
-  const [view, css, shared] = await Promise.all([
+  const [view, css, shared, markdown, citationGroups] = await Promise.all([
     readSource('src/views/DeepResearchView.tsx'),
     readSource('src/index.css'),
     readSource('src/views/writingShared.tsx'),
+    readSource('src/components/Markdown.tsx'),
+    readSource('src/markdownCitationGroups.ts'),
   ]);
   assert.match(view, /READER_FONT_STORAGE_KEY = 'nodus\.deepResearch\.readerFontSize'/);
   assert.match(view, /data-testid="deep-research-font-decrease"/);
@@ -567,6 +620,9 @@ test('the Deep Research reader has persistent typography and a live report outli
   assert.match(css, /\.deep-research-reader-document \.md \{[\s\S]*?font-size: var\(--deep-research-font-size, 16px\)/);
   assert.match(css, /overflow-wrap: normal;\s*word-break: normal;\s*hyphens: none;/);
   assert.match(css, /\.deep-research-reader-document \.md :is\(a, code, \.citation-link\)[\s\S]*?overflow-wrap: anywhere/);
+  assert.match(citationGroups, /function groupParenthesizedCitations\(tree:[\s\S]*?className: \['citation-group'\]/, 'citation punctuation is grouped with its pill');
+  assert.match(markdown, /rehypePlugins=\{\[rehypeKatex, rehypeGroupParenthesizedCitations\]\}/, 'the citation grouping transform runs in rendered Markdown');
+  assert.match(css, /\.md \.citation-group \{\s*display: inline-block;\s*white-space: nowrap;/, 'a parenthesized citation wraps as one inline unit');
   assert.doesNotMatch(shared, /text-justify hyphens-auto/, 'justified report prose does not hyphenate words behind the reader');
   assert.match(shared, /icon="copyText"\s*label=\{t\('Copiar sin referencias'\)\}/, 'plain-text copy uses a text-copy mark');
   assert.doesNotMatch(shared, /icon="volume"\s*label=\{t\('Copiar sin referencias'\)\}/, 'plain-text copy is not presented as audio');

--- a/server/test/userProfilePreferences.integration.test.mjs
+++ b/server/test/userProfilePreferences.integration.test.mjs
@@ -27,6 +27,7 @@ function desktopSettings(overrides = {}) {
     studyAiMaxOutputTokens: 4000, studyAiTemperature: 0.15, studyAiRetryCount: 1,
     studentPseudonymsEnabled: true, sidebarOrder: ['home', 'ideas'], sidebarHidden: ['tools'],
     sidebarCustomized: true, concurrency: 2, deepContextMode: 'standard', deepStandardChunkWords: 1800,
+    toolkitPinnedPages: ['apps', 'ocr'],
     deepLongChunkWords: 30000,
     // These values prove that the exporter is an allowlist rather than a broad object copy.
     providerKeys: { openai: true }, lockedProviderKeys: ['openai'], embeddingProvider: 'openai',
@@ -58,6 +59,7 @@ test('Desktop profile preferences persist per user without secrets or embedding 
   }
   assert.equal(portable.ai.models.assistant.model, 'gpt-5.4');
   assert.equal(portable.appearance.interfaceScale, 1.1);
+  assert.deepEqual(portable.workspace.toolkitPinnedPages, ['apps', 'ocr']);
 
   await withServer({ label: 'user-profile-preferences', ai: true }, async (ctx) => {
     const spaceId = await ctx.createSpace('Shared preferences vault');

--- a/shared/serverProfilePreferences.d.mts
+++ b/shared/serverProfilePreferences.d.mts
@@ -22,7 +22,7 @@ export type ServerProfilePreferences = {
     audio: { provider: string; voice: string; speed: number; pending?: boolean };
     studyPolicy: { enabled: boolean; privacyMode: AppSettings['studyAiPrivacyMode']; confirmExternal: boolean; monthlyBudgetUsd: number; budgetWarningPercent: number; maxInputChars: number; maxOutputTokens: number; temperature: number; retryCount: number; studentPseudonyms: boolean };
   };
-  workspace: { sidebarOrder: string[]; sidebarHidden: string[]; sidebarCustomized: boolean; aiConcurrencyMode: AppSettings['aiConcurrencyMode']; aiConcurrencyVersion: number; concurrency: number; deepContextMode: AppSettings['deepContextMode']; standardChunkWords: number; longChunkWords: number };
+  workspace: { sidebarOrder: string[]; sidebarHidden: string[]; sidebarCustomized: boolean; toolkitPinnedPages: AppSettings['toolkitPinnedPages']; aiConcurrencyMode: AppSettings['aiConcurrencyMode']; aiConcurrencyVersion: number; concurrency: number; deepContextMode: AppSettings['deepContextMode']; standardChunkWords: number; longChunkWords: number };
 };
 
 export class ServerProfilePreferenceError extends Error { code: string }

--- a/shared/serverProfilePreferences.mjs
+++ b/shared/serverProfilePreferences.mjs
@@ -59,7 +59,7 @@ const STUDY_KEYS = new Set([
   'maxInputChars', 'maxOutputTokens', 'temperature', 'retryCount', 'studentPseudonyms',
 ]);
 const WORKSPACE_KEYS = new Set([
-  'sidebarOrder', 'sidebarHidden', 'sidebarCustomized', 'aiConcurrencyMode', 'aiConcurrencyVersion', 'concurrency', 'deepContextMode',
+  'sidebarOrder', 'sidebarHidden', 'sidebarCustomized', 'toolkitPinnedPages', 'aiConcurrencyMode', 'aiConcurrencyVersion', 'concurrency', 'deepContextMode',
   'standardChunkWords', 'longChunkWords',
 ]);
 const PROVIDER_PATTERN = /^[a-z][a-z0-9-]{0,47}$/;
@@ -232,6 +232,7 @@ export function extractServerProfilePreferences(settings) {
       sidebarOrder: Array.isArray(settings.sidebarOrder) ? settings.sidebarOrder : [],
       sidebarHidden: Array.isArray(settings.sidebarHidden) ? settings.sidebarHidden : [],
       sidebarCustomized: settings.sidebarCustomized,
+      toolkitPinnedPages: Array.isArray(settings.toolkitPinnedPages) ? settings.toolkitPinnedPages : [],
       aiConcurrencyMode: settings.aiConcurrencyMode,
       aiConcurrencyVersion: settings.aiConcurrencyVersion,
       concurrency: settings.concurrency,
@@ -305,6 +306,7 @@ export function desktopSettingsPatchFromServerProfile(value) {
     sidebarOrder: [...profile.workspace.sidebarOrder],
     sidebarHidden: [...profile.workspace.sidebarHidden],
     sidebarCustomized: profile.workspace.sidebarCustomized,
+    toolkitPinnedPages: [...profile.workspace.toolkitPinnedPages],
     aiConcurrencyMode: profile.workspace.aiConcurrencyMode,
     aiConcurrencyVersion: profile.workspace.aiConcurrencyVersion,
     concurrency: profile.workspace.concurrency,
@@ -414,6 +416,7 @@ export function sanitizeServerProfilePreferences(value) {
     workspace: {
       sidebarOrder: strings(workspace.sidebarOrder), sidebarHidden: strings(workspace.sidebarHidden),
       sidebarCustomized: bool(workspace.sidebarCustomized),
+      toolkitPinnedPages: workspace.toolkitPinnedPages === undefined ? [] : strings(workspace.toolkitPinnedPages),
       // Version 1 records an explicit selector choice. Older/missing values are
       // the pre-release opt-in default and graduate once to production automatic.
       aiConcurrencyMode: workspace.aiConcurrencyVersion !== undefined

--- a/shared/toolkitNavigation.ts
+++ b/shared/toolkitNavigation.ts
@@ -1,0 +1,14 @@
+/** Stable Toolkit destinations that may be pinned into the main sidebar. */
+export const TOOLKIT_TOOL_PAGES = ['apps', 'convert', 'protect', 'translate', 'presenter', 'ocr'] as const;
+
+export type ToolkitToolPage = (typeof TOOLKIT_TOOL_PAGES)[number];
+
+const TOOLKIT_TOOL_PAGE_SET = new Set<string>(TOOLKIT_TOOL_PAGES);
+
+/** Settings are user-editable JSON, so keep only known, unique destinations. */
+export function normalizeToolkitToolPages(value: unknown): ToolkitToolPage[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter(
+    (page): page is ToolkitToolPage => typeof page === 'string' && TOOLKIT_TOOL_PAGE_SET.has(page),
+  ))];
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -19,6 +19,7 @@ import type { LibraryApi } from './api/library';
 import type { RadarApi } from './api/radar';
 import type { CompassApi } from './api/compass';
 import type { LibraryAttachmentRecord } from './libraryTypes';
+import type { ToolkitToolPage } from './toolkitNavigation';
 
 export type {
   LibraryAttachmentRecord,
@@ -2153,6 +2154,8 @@ export interface AppSettings {
    * `sidebarHidden` and this flips true, so their choice is respected thereafter.
    */
   sidebarCustomized: boolean;
+  /** Toolkit destinations explicitly pinned as independent sidebar shortcuts. */
+  toolkitPinnedPages: ToolkitToolPage[];
   /** Default wooden frame design for the genealogy tree (per-person overrides win). */
   treeFrame: string;
   /** Person used as the relative centre for every displayed and AI-visible kinship tag. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ import type {
   PendingGraphNavigationTarget,
   PendingIdeaNavigationTarget,
   PendingLibraryNavigationTarget,
+  SidebarNavItem,
   View,
 } from './navigation';
 import { dedicatedVaultNavIds, groupedNav, NAV_ITEMS, NAV_GROUPS } from './navigation';
@@ -478,8 +479,12 @@ export function App() {
     const outsideDedicatedWorkspace = dedicatedIds
       ? NAV_ITEMS.filter((item) => item.id !== 'home' && item.id !== 'settings' && !dedicatedIds.includes(item.id)).map((item) => item.id)
       : [];
-    return groupedNav(settings?.sidebarOrder ?? [], ['library', ...activeSidebarHidden, ...disallowed, ...outsideDedicatedWorkspace]);
-  }, [settings?.sidebarOrder, activeSidebarHidden, activeVault?.type]);
+    return groupedNav(
+      settings?.sidebarOrder ?? [],
+      ['library', ...activeSidebarHidden, ...disallowed, ...outsideDedicatedWorkspace],
+      settings?.toolkitPinnedPages ?? [],
+    );
+  }, [settings?.sidebarOrder, settings?.toolkitPinnedPages, activeSidebarHidden, activeVault?.type]);
 
   // If the active vault type doesn't allow the current view (e.g. switching from a
   // primary-source vault to an academic one while on Personas), fall back to Home.
@@ -1569,7 +1574,7 @@ export function App() {
           >
             <div data-testid="sidebar-scroll-region" className="vault-sidebar-scroll mr-[6px] flex h-full min-h-0 flex-col gap-1 overflow-y-auto p-2">
               {(() => {
-              const navButton = (n: { id: View; icon: string; label: string }, disabled = false) => (
+              const navButton = (n: SidebarNavItem, disabled = false) => (
                 <button
                   key={n.id}
                   data-tour={`nav-${n.id}`}
@@ -1579,6 +1584,11 @@ export function App() {
                   title={disabled ? `${t(n.label)} · ${t('Próximamente')}` : sidebarCompact ? t(n.label) : undefined}
                   onClick={() => {
                     if (disabled) return;
+                    if ('toolkitPage' in n) {
+                      setToolkitPage(n.toolkitPage);
+                      setView('toolkit');
+                      return;
+                    }
                     // La sección Herramientas siempre entra por el catálogo.
                     if (n.id === 'toolkit') setToolkitPage('home');
                     setView(n.id);
@@ -1586,7 +1596,9 @@ export function App() {
                   className={`flex items-center rounded-lg py-2 text-sm text-left transition-colors ${sidebarCompact ? 'justify-center px-2' : 'gap-2 px-3'} ${
                     disabled
                       ? 'cursor-not-allowed text-neutral-700 opacity-65'
-                      : view === n.id && (n.id !== 'toolkit' || toolkitPage === 'home')
+                      : ('toolkitPage' in n
+                          ? view === 'toolkit' && toolkitPage === n.toolkitPage
+                          : view === n.id && (n.id !== 'toolkit' || toolkitPage === 'home'))
                         ? 'bg-indigo-600 text-white'
                         : 'text-neutral-400 hover:bg-neutral-900'
                   }`}
@@ -1617,7 +1629,9 @@ export function App() {
               );
               const renderGroup = (group: (typeof navGroups)[number]) => {
                 const collapsed = !sidebarCompact && collapsedGroups.has(group.id);
-                const hasActive = group.items.some((n) => n.id === view);
+                const hasActive = group.items.some((n) => 'toolkitPage' in n
+                  ? view === 'toolkit' && toolkitPage === n.toolkitPage
+                  : n.id === view);
                 return (
                   <div key={group.id} className={`${sidebarCompact ? 'mt-1 border-t border-neutral-800/70 pt-1' : 'mt-2'} flex flex-col gap-1`}>
                     {!sidebarCompact && <div className="flex items-center px-3">{groupHeaderButton(group.id, group.label, collapsed, hasActive)}</div>}

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -9,6 +9,7 @@ import { parseTestimonyLink, type TestimonyDeepLink } from '@shared/testimonyDee
 import { t } from '../i18n';
 import { VERIFY_DEBOUNCE_MS, planCitationVerification } from '../citationVerification';
 import { parsePrimarySourceExcerptDeepLink } from '@shared/primarySourceDeepLink';
+import { rehypeGroupParenthesizedCitations } from '../markdownCitationGroups';
 
 const nodusUrlTransform = (value: string) => {
   if (value.startsWith('nodus://')) return value;
@@ -152,7 +153,7 @@ function MarkdownComponent({
     <div className={`md ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
-        rehypePlugins={[rehypeKatex]}
+        rehypePlugins={[rehypeKatex, rehypeGroupParenthesizedCitations]}
         urlTransform={(value, key) => {
           if (allowDataImages && key === 'src' && /^data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,/i.test(value)) return value;
           return nodusUrlTransform(value);

--- a/src/components/QueueBar.tsx
+++ b/src/components/QueueBar.tsx
@@ -49,7 +49,11 @@ export function QueueBar() {
     maintenanceRunning, maintenanceDetail, startedAt, finishedAt, items,
   } = progress;
   const terminalItems = items.filter((item) => item.state === 'done' || item.state === 'failed' || item.state === 'cancelled').length;
-  const pct = total ? Math.round((terminalItems / total) * 100) : maintenanceRunning ? 99 : 0;
+  const itemPct = total ? Math.round((terminalItems / total) * 100) : 0;
+  // Finished scan rows are followed by required graph maintenance. Holding at
+  // 99% makes it clear that semantic validation is still live; 100% and the
+  // dismiss tick arrive together only after the whole pipeline has settled.
+  const pct = maintenanceRunning ? (total ? Math.min(itemPct, 99) : 99) : itemPct;
   const workActive = items.some((item) => item.state === 'queued' || item.state === 'running' || item.state === 'paused');
   const active = workActive || maintenanceRunning;
   const terminal = !active && !maintenanceError;

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -59,6 +59,7 @@ const ICON_PATHS: Record<string, string> = {
   flag: '<path d="M5 21V4"/><path d="M5 4h11l-2 3.5L16 11H5"/>',
   ruler: '<path d="M3 15 15 3l6 6L9 21z"/><path d="m7 11 2 2"/><path d="m10 8 2 2"/><path d="m13 5 2 2"/>',
   mapPin: '<path d="M12 21s7-6.2 7-11a7 7 0 1 0-14 0c0 4.8 7 11 7 11Z"/><circle cx="12" cy="10" r="2.6"/>',
+  pin: '<path d="M12 17v5"/><path d="M5 17h14"/><path d="M7 17V9l-2-2V5h14v2l-2 2v8"/><path d="M9 5V2h6v3"/>',
   scissors: '<circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><path d="M8.1 7.7 20 18"/><path d="M8.1 16.3 20 6"/>',
   truck: '<path d="M3 6h11v10H3z"/><path d="M14 9h4l3 3v4h-7z"/><circle cx="7" cy="18" r="1.6"/><circle cx="17.5" cy="18" r="1.6"/>',
   anchor: '<circle cx="12" cy="5" r="2.5"/><path d="M12 7.5V21"/><path d="M8 11H5a7 7 0 0 0 14 0h-3"/>',

--- a/src/index.css
+++ b/src/index.css
@@ -3819,6 +3819,10 @@ body:has(.library-document-reader [data-testid="library-reader-sidebar"]) .app-t
 
 /* NotebookLM-style inline source citation. Rendered as a small pill that opens a
    source modal instead of navigating. */
+.md .citation-group {
+  display: inline-block;
+  white-space: nowrap;
+}
 .md .citation-link {
   display: inline-flex;
   align-items: center;

--- a/src/markdownCitationGroups.ts
+++ b/src/markdownCitationGroups.ts
@@ -1,0 +1,61 @@
+export interface MarkdownHastNode {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: MarkdownHastNode[];
+}
+
+const NODUS_CITATION_HREF = /^nodus:\/\/(?:idea|work|gap|contradiction|passage|reader)\//;
+const OPENING_CITATION_PARENTHESIS = /\(\s*$/u;
+const CLOSING_CITATION_PARENTHESIS = /^\s*\)/u;
+
+/**
+ * Keep a parenthesized citation's punctuation and pill in the same inline box.
+ * Markdown parses `([Author](nodus://idea/id))` as three siblings, which lets the
+ * browser leave either parenthesis behind when a line wraps.
+ */
+export function groupParenthesizedCitations(tree: MarkdownHastNode): void {
+  const children = tree.children;
+  if (!children) return;
+
+  // Visit the existing descendants first. A group created below must not be
+  // visited again, or its deliberately adjacent parentheses would be rewrapped.
+  for (const child of children) groupParenthesizedCitations(child);
+
+  for (let index = 1; index < children.length - 1; index += 1) {
+    const previous = children[index - 1];
+    const citation = children[index];
+    const next = children[index + 1];
+    const href = citation.type === 'element' && citation.tagName === 'a'
+      ? citation.properties?.href
+      : undefined;
+    if (
+      previous.type !== 'text'
+      || next.type !== 'text'
+      || typeof previous.value !== 'string'
+      || typeof next.value !== 'string'
+      || typeof href !== 'string'
+      || !NODUS_CITATION_HREF.test(href)
+    ) continue;
+
+    const opening = previous.value.match(OPENING_CITATION_PARENTHESIS)?.[0];
+    const closing = next.value.match(CLOSING_CITATION_PARENTHESIS)?.[0];
+    if (!opening || !closing) continue;
+
+    previous.value = previous.value.slice(0, -opening.length);
+    next.value = next.value.slice(closing.length);
+    children[index] = {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['citation-group'] },
+      children: [
+        { type: 'text', value: opening },
+        citation,
+        { type: 'text', value: closing },
+      ],
+    };
+  }
+}
+
+export const rehypeGroupParenthesizedCitations = () => groupParenthesizedCitations;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,6 +1,7 @@
 import type { CorpusHealthBucketId, ResearchContextSelection } from '@shared/types';
 import type { LibraryScope } from '@shared/libraryTypes';
 import { type VaultType, normalizeVaultType } from '@shared/vaultTypes';
+import type { ToolkitToolPage } from '@shared/toolkitNavigation';
 
 export type View = 'home' | 'search' | 'testimonyInterviews' | 'testimonyParticipants' | 'testimonyContrasts' | 'library' | 'graph' | 'argument' | 'ideas' | 'dictionary' | 'authors' | 'persons' | 'prosopSearch' | 'prosopPopulation' | 'prosopPersons' | 'prosopSources' | 'prosopAnalysis' | 'prosopNetworks' | 'encyclopedia' | 'continuity' | 'conflicts' | 'arcs' | 'rules' | 'questions' | 'worldChat' | 'manuscript' | 'characters' | 'places' | 'factions' | 'cultures' | 'dynasties' | 'scenes' | 'timeline' | 'tree' | 'relations' | 'map' | 'archive' | 'pages' | 'databases' | 'dbSearch' | 'dbAnalysis' | 'dbChat' | 'dbDeepResearch' | 'studyCourses' | 'studySchedule' | 'studyCalendar' | 'studySearch' | 'studyLibrary' | 'studyRecordings' | 'studyChat' | 'studyIdeas' | 'studyGraph' | 'studyQuestions' | 'studyReview' | 'studyDeepResearch' | 'teachingGroups' | 'teachingGrades' | 'teachingExams' | 'teachingRubrics' | 'teachingUnits' | 'immersion' | 'gaps' | 'debate' | 'research' | 'hypothesis' | 'reading' | 'writing' | 'deepResearch' | 'projects' | 'notes' | 'workspace' | 'browser' | 'radar' | 'compass' | 'toolkit' | 'settings';
 
@@ -143,13 +144,12 @@ export const NAV_ITEMS: NavItem[] = [
 ];
 
 /** Pages inside the Herramientas section. The toolkit keeps a SINGLE entry in the
- * View union — its tools are addressed by this id instead — so that adding a tool
- * never turns into a new top-level view (and never leaks into sidebarOrder, the
- * per-vault-type allow-lists or the reordering UI). 'home' is the catalogue. */
-export type ToolkitPage = 'home' | 'apps' | 'convert' | 'translate' | 'protect' | 'presenter' | 'ocr';
+ * View union — pinned tools use namespaced sidebar shortcut ids instead — so that
+ * adding a tool never expands the vault-type allow-lists. 'home' is the catalogue. */
+export type ToolkitPage = 'home' | ToolkitToolPage;
 
 export interface ToolkitToolDef {
-  page: Exclude<ToolkitPage, 'home'>;
+  page: ToolkitToolPage;
   /** Marca de la herramienta; NO se traduce. */
   name: string;
   /** Clave i18n (español) de la descripción de la tarjeta. */
@@ -213,6 +213,37 @@ export const TOOLKIT_TOOLS: ToolkitToolDef[] = [
   },
 ];
 
+export type ToolkitSidebarId = `toolkit:${ToolkitToolPage}`;
+
+/** A pinned Toolkit page behaves like a sidebar item without becoming a View. */
+export interface ToolkitSidebarNavItem {
+  id: ToolkitSidebarId;
+  label: string;
+  icon: string;
+  group: 'tools';
+  toolkitPage: ToolkitToolPage;
+}
+
+export type SidebarNavItem = NavItem | ToolkitSidebarNavItem;
+
+export function toolkitSidebarId(page: ToolkitToolPage): ToolkitSidebarId {
+  return `toolkit:${page}`;
+}
+
+/** Derive sidebar shortcuts from the canonical Toolkit catalogue (including icons). */
+export function pinnedToolkitSidebarItems(pages: unknown): ToolkitSidebarNavItem[] {
+  const pinned = new Set(Array.isArray(pages) ? pages : []);
+  return TOOLKIT_TOOLS
+    .filter((tool) => pinned.has(tool.page))
+    .map((tool) => ({
+      id: toolkitSidebarId(tool.page),
+      label: tool.name,
+      icon: tool.icon,
+      group: 'tools' as const,
+      toolkitPage: tool.page,
+    }));
+}
+
 const VAULT_TYPE_LABELS: Partial<Record<VaultType, Partial<Record<View, string>>>> = {
   docencia: {
     studyChat: 'Chat',
@@ -250,6 +281,10 @@ export function orderedNav(sidebarOrder: string[]): NavItem[] {
 }
 
 export interface NavGroup extends NavGroupDef {
+  items: SidebarNavItem[];
+}
+
+export interface StandardNavGroup extends NavGroupDef {
   items: NavItem[];
 }
 
@@ -316,19 +351,32 @@ export function orderSidebarItems<T extends { id: string }>(items: readonly T[],
  * order. Home and Settings are pinned outside groups and are not returned here.
  * Empty groups (all sections hidden) are dropped.
  */
-export function groupedNav(sidebarOrder: string[], sidebarHidden: string[]): NavGroup[] {
+export function groupedNav(sidebarOrder: string[], sidebarHidden: string[]): StandardNavGroup[];
+export function groupedNav(
+  sidebarOrder: string[],
+  sidebarHidden: string[],
+  toolkitPinnedPages: unknown,
+): NavGroup[];
+export function groupedNav(
+  sidebarOrder: string[],
+  sidebarHidden: string[],
+  toolkitPinnedPages?: unknown,
+): NavGroup[] {
   const hidden = new Set(sidebarHidden);
-  const ordered = orderedNav(sidebarOrder).filter(
-    (n) => n.id !== 'home' && n.id !== 'settings' && !hidden.has(n.id),
-  );
-  const toolsOrder = new Map<View, number>([['browser', 0], ['radar', 1], ['compass', 2], ['toolkit', 3]]);
+  const base = orderedNav(sidebarOrder).filter((n) => n.id !== 'home' && n.id !== 'settings');
+  const pinned = pinnedToolkitSidebarItems(toolkitPinnedPages ?? []);
+  const toolkitIndex = base.findIndex((item) => item.id === 'toolkit');
+  const combined: SidebarNavItem[] = [...base];
+  combined.splice(toolkitIndex >= 0 ? toolkitIndex + 1 : combined.length, 0, ...pinned);
+  // Once a shortcut has been moved in Settings its saved position wins. A newly
+  // pinned shortcut has no saved position yet and starts directly after Nodus Tools.
+  const ordered = pinned.some((item) => sidebarOrder.includes(item.id))
+    ? orderSidebarItems(combined, sidebarOrder)
+    : combined;
   return NAV_GROUPS.map((g) => ({
     ...g,
     items: ordered
-      .filter((n) => n.group === g.id)
-      .sort((a, b) => g.id === 'tools'
-        ? (toolsOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (toolsOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER)
-        : 0),
+      .filter((n) => n.group === g.id && !hidden.has(n.id)),
   })).filter((g) => g.items.length > 0);
 }
 

--- a/src/serverWeb/settings/ServerSettingsView.tsx
+++ b/src/serverWeb/settings/ServerSettingsView.tsx
@@ -244,6 +244,7 @@ function blankProfile(
       sidebarOrder: [],
       sidebarHidden: [],
       sidebarCustomized: false,
+      toolkitPinnedPages: [],
       aiConcurrencyMode: "automatic",
       aiConcurrencyVersion: 1,
       concurrency: 2,

--- a/src/serverWeb/types.ts
+++ b/src/serverWeb/types.ts
@@ -179,6 +179,7 @@ export type PortableProfileValues = {
     sidebarOrder: string[];
     sidebarHidden: string[];
     sidebarCustomized: boolean;
+    toolkitPinnedPages: string[];
     aiConcurrencyMode: 'automatic' | 'manual';
     aiConcurrencyVersion: number;
     concurrency: number;

--- a/src/views/DictionaryView.tsx
+++ b/src/views/DictionaryView.tsx
@@ -1098,8 +1098,10 @@ export function DictionaryView({
         setEntries(page.items);
         setTotal(page.total);
         setFacets(nextFacets);
+        return true;
       } catch (reason) {
         setError(message(reason));
+        return false;
       } finally {
         if (foreground) setLoading(false);
       }
@@ -1146,11 +1148,18 @@ export function DictionaryView({
       .then((jobs) => {
         if (!alive) return;
         setGenerationJobs((current) => {
-          const next = new Map(jobs.map((job) => [job.entryId, job]));
+          // A successful job has already committed the entry's persistent
+          // lifecycle status. Rehydrating that terminal progress would cover
+          // "Active" with "Generated" for the rest of the app session.
+          const next = new Map(
+            jobs
+              .filter((job) => job.phase !== "done")
+              .map((job) => [job.entryId, job]),
+          );
           // Events received while the IPC round-trip was in flight are newer than
           // the returned snapshot and must win.
           for (const [entryId, progress] of current) {
-            next.set(entryId, progress);
+            if (progress.phase !== "done") next.set(entryId, progress);
           }
           return next;
         });
@@ -1175,7 +1184,21 @@ export function DictionaryView({
           next.set(progress.entryId, progress);
           return next;
         });
-        if (["done", "degraded"].includes(progress.phase)) void reload(false);
+        if (progress.phase === "done") {
+          // Keep the completion tick only until the saved entry has been read
+          // back. Afterwards its real status (normally Active) owns the column.
+          void reload(false).then((reloaded) => {
+            if (!reloaded) return;
+            setGenerationJobs((current) => {
+              if (current.get(progress.entryId)?.phase !== "done") return current;
+              const next = new Map(current);
+              next.delete(progress.entryId);
+              return next;
+            });
+          });
+        } else if (progress.phase === "degraded") {
+          void reload(false);
+        }
       }),
     [reload],
   );
@@ -1679,7 +1702,11 @@ function DictionaryGenerationState({
   progress?: DictionaryProgress;
   status: DictionaryEntryStatus;
 }) {
-  if (!progress) return <StatusPill status={status} />;
+  // Defensively prefer the persisted lifecycle once a successful generation has
+  // already activated (or preserved the archived state of) the entry.
+  if (!progress || (progress.phase === "done" && status !== "draft")) {
+    return <StatusPill status={status} />;
+  }
   if (progress.phase === "failed") {
     return (
       <span

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -50,7 +50,7 @@ import { LocalAiModelsSettings } from '../components/LocalAiModelsSettings';
 import { LocalImageModelSettings } from '../components/LocalImageModelSettings';
 import { McpConnectionModal } from '../components/McpConnectionModal';
 import { CloudflareDeployModal } from '../components/CloudflareDeployModal';
-import { dedicatedVaultNavIds, NAV_GROUPS, navItemLabel, orderSidebarItems, orderedNav } from '../navigation';
+import { dedicatedVaultNavIds, groupedNav, NAV_GROUPS, navItemLabel, orderSidebarItems, orderedNav } from '../navigation';
 import { teachingItemId, TEACHING_GROUPS } from '../components/TeachingSidebar';
 import { WORLDBUILDING_GROUPS } from '../components/WorldbuildingSidebar';
 import { TESTIMONY_GROUPS } from '../components/TestimonySidebar';
@@ -1326,6 +1326,7 @@ export function Settings({
             <SidebarOrderEditor
               sidebarOrder={settings.sidebarOrder}
               sidebarHidden={effectiveSidebarHidden(settings.sidebarHidden, settings.sidebarCustomized, activeVault?.type)}
+              toolkitPinnedPages={settings.toolkitPinnedPages}
               vaultType={activeVault?.type}
               onReorder={(ids) => void patch({ sidebarOrder: ids })}
               onToggleHidden={(hidden) => void patch({ sidebarHidden: hidden, sidebarCustomized: true })}
@@ -3589,12 +3590,14 @@ function NodusServerGuideModal({ onOpenGuide, onClose }: { onOpenGuide: () => vo
 function SidebarOrderEditor({
   sidebarOrder,
   sidebarHidden,
+  toolkitPinnedPages,
   vaultType,
   onReorder,
   onToggleHidden,
 }: {
   sidebarOrder: string[];
   sidebarHidden: string[];
+  toolkitPinnedPages: AppSettings['toolkitPinnedPages'];
   vaultType: VaultType | undefined;
   onReorder: (ids: string[]) => void;
   onToggleHidden: (hidden: string[]) => void;
@@ -3602,7 +3605,11 @@ function SidebarOrderEditor({
   type EditorItem = { id: string; label: string; icon: string; group: string };
   type EditorGroup = { id: string; label: string; items: EditorItem[] };
 
-  const toolkit = orderedNav(sidebarOrder).find((item) => item.id === 'toolkit');
+  // Use the exact same resolved Tools group as the real sidebar. Pinned Toolkit
+  // pages therefore inherit the catalogue's icon/name and can be hidden, dragged,
+  // or moved with the arrow controls like every other sidebar entry.
+  const universalTools = groupedNav(sidebarOrder, [], toolkitPinnedPages)
+    .find((group) => group.id === 'tools');
   let groups: EditorGroup[];
   if (vaultType === 'docencia') {
     groups = TEACHING_GROUPS.map((group) => ({
@@ -3647,11 +3654,12 @@ function SidebarOrderEditor({
         .map((item) => ({ ...item, label: navItemLabel(item, vaultType), group: group.id })),
     }));
   }
-  if ((vaultType === 'docencia' || vaultType === 'worldbuilding' || vaultType === 'testimonios') && toolkit) {
-    const tools = NAV_GROUPS.find((group) => group.id === 'tools')!;
+  groups = groups.filter((group) => group.id !== 'tools');
+  if (universalTools?.items.length) {
     groups.push({
-      ...tools,
-      items: [{ ...toolkit, group: tools.id }],
+      id: universalTools.id,
+      label: universalTools.label,
+      items: universalTools.items.map((item) => ({ ...item, group: universalTools.id })),
     });
   }
   groups = groups.filter((group) => group.items.length > 0);

--- a/src/views/ToolkitView.tsx
+++ b/src/views/ToolkitView.tsx
@@ -1,12 +1,14 @@
 // Nodus Toolkit — el hub de Herramientas: utilidades locales de proceso de
 // archivos (conversión, protección, presentación de PDFs y OCR asistido). La navegación
-// interna (catálogo ↔ herramienta) no añade ids a la union View: el sidebar
-// tiene una única entrada de sección con las herramientas anidadas debajo, y la
-// página activa la controla App (así el estado sobrevive a salir de la sección).
+// interna (catálogo ↔ herramienta) no añade ids a la union View: los accesos
+// fijados del sidebar apuntan a estas páginas anidadas, y la página activa la
+// controla App (así el estado sobrevive a salir de la sección).
+import { useState } from 'react';
 import type { AppSettings } from '@shared/types';
+import { normalizeToolkitToolPages, type ToolkitToolPage } from '@shared/toolkitNavigation';
 import { Icon } from '../components/ui';
 import { t } from '../i18n';
-import { TOOLKIT_TOOLS, type ToolkitPage } from '../navigation';
+import { TOOLKIT_TOOLS, toolkitSidebarId, type ToolkitPage } from '../navigation';
 import { ToolkitConvertView } from './ToolkitConvertView';
 import { ToolkitProtectView } from './ToolkitProtectView';
 import { ToolkitPresenterView } from './ToolkitPresenterView';
@@ -22,39 +24,60 @@ interface ToolCardProps {
   description: string;
   /** 'wip' = navegable pero en construcción; 'soon' = tarjeta deshabilitada. */
   state: 'wip' | 'soon';
+  pinned: boolean;
+  pinBusy: boolean;
   onOpen?: () => void;
+  onTogglePinned: () => void;
 }
 
 /** Tarjeta del hub. Todas se renderizan con la MISMA estructura y altura
  *  (grid + h-full); el icono va en una loseta cuadrada fija para que quede
  *  perfectamente centrado. Solo las herramientas aún no disponibles muestran
  *  estado: las aplicaciones navegables no necesitan una etiqueta de desarrollo. */
-function ToolCard({ testid, icon, name, description, state, onOpen }: ToolCardProps) {
+function ToolCard({ testid, icon, name, description, state, pinned, pinBusy, onOpen, onTogglePinned }: ToolCardProps) {
   const disabled = state === 'soon';
   return (
-    <button
-      data-testid={testid}
-      disabled={disabled}
-      aria-disabled={disabled}
-      title={disabled ? t('Próximamente') : undefined}
-      onClick={disabled ? undefined : onOpen}
-      className={`flex h-full flex-col items-start gap-3 rounded-xl border p-5 text-left transition-colors ${
-        disabled
-          ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 opacity-60 dark:border-neutral-800 dark:bg-neutral-900/20'
-          : 'border-neutral-200 bg-white hover:border-amber-400 dark:border-neutral-800 dark:bg-neutral-900/40 dark:hover:border-amber-500/60'
-      }`}
-    >
-      <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
-        <Icon name={icon} size={22} />
-      </span>
-      <span className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{name}</span>
-      <span className="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">{description}</span>
-      {disabled && (
-        <span className="mt-auto inline-flex items-center gap-1 rounded-md bg-neutral-200 px-2 py-0.5 text-xs text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
-          {t('Próximamente')}
+    <div className="relative h-full">
+      <button
+        data-testid={testid}
+        disabled={disabled}
+        aria-disabled={disabled}
+        title={disabled ? t('Próximamente') : undefined}
+        onClick={disabled ? undefined : onOpen}
+        className={`flex h-full w-full flex-col items-start gap-3 rounded-xl border p-5 pr-16 text-left transition-colors ${
+          disabled
+            ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 opacity-60 dark:border-neutral-800 dark:bg-neutral-900/20'
+            : 'border-neutral-200 bg-white hover:border-amber-400 dark:border-neutral-800 dark:bg-neutral-900/40 dark:hover:border-amber-500/60'
+        }`}
+      >
+        <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
+          <Icon name={icon} size={22} />
         </span>
-      )}
-    </button>
+        <span className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{name}</span>
+        <span className="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">{description}</span>
+        {disabled && (
+          <span className="mt-auto inline-flex items-center gap-1 rounded-md bg-neutral-200 px-2 py-0.5 text-xs text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+            {t('Próximamente')}
+          </span>
+        )}
+      </button>
+      <button
+        type="button"
+        data-testid={`${testid}-pin`}
+        aria-pressed={pinned}
+        aria-label={`${name} · ${t(pinned ? 'Desfijar' : 'Fijar')}`}
+        title={t(pinned ? 'Desfijar' : 'Fijar')}
+        disabled={disabled || pinBusy}
+        onClick={onTogglePinned}
+        className={`absolute right-4 top-4 z-10 flex h-9 w-9 items-center justify-center rounded-lg border transition-colors disabled:cursor-wait disabled:opacity-50 ${
+          pinned
+            ? 'border-amber-300 bg-amber-100 text-amber-700 dark:border-amber-500/50 dark:bg-amber-500/20 dark:text-amber-300'
+            : 'border-neutral-200 bg-white/90 text-neutral-400 hover:border-amber-300 hover:text-amber-600 dark:border-neutral-700 dark:bg-neutral-900/90 dark:hover:border-amber-500/50 dark:hover:text-amber-300'
+        }`}
+      >
+        <Icon name="pin" size={17} />
+      </button>
+    </div>
   );
 }
 
@@ -67,6 +90,34 @@ export function ToolkitView({
   onNavigate: (page: ToolkitPage) => void;
   settings: AppSettings | null;
 }) {
+  const [pinBusy, setPinBusy] = useState<ToolkitToolPage | null>(null);
+  const pinnedPages = normalizeToolkitToolPages(settings?.toolkitPinnedPages);
+  const pinned = new Set(pinnedPages);
+
+  const togglePinned = async (toolPage: ToolkitToolPage) => {
+    if (!settings || pinBusy) return;
+    setPinBusy(toolPage);
+    const id = toolkitSidebarId(toolPage);
+    const isPinned = pinned.has(toolPage);
+    try {
+      await window.nodus.updateSettings({
+        toolkitPinnedPages: isPinned
+          ? pinnedPages.filter((pageId) => pageId !== toolPage)
+          : [...pinnedPages, toolPage],
+        // A fresh pin must be visible. Unpinning also retires its ordering and
+        // visibility residue so pinning it again starts beside Nodus Tools.
+        sidebarHidden: settings.sidebarHidden.filter((itemId) => itemId !== id),
+        sidebarOrder: isPinned
+          ? settings.sidebarOrder.filter((itemId) => itemId !== id)
+          : settings.sidebarOrder,
+      });
+    } catch (error) {
+      console.error('[toolkit] no se pudo actualizar la chincheta', error);
+    } finally {
+      setPinBusy(null);
+    }
+  };
+
   return (
     <div className="h-full overflow-y-auto px-6 py-6 max-md:px-4">
       {/* Las herramientas tienen página propia; cualquier otra página
@@ -105,7 +156,10 @@ export function ToolkitView({
                 name={tool.name}
                 description={t(tool.description)}
                 state={tool.state}
+                pinned={pinned.has(tool.page)}
+                pinBusy={pinBusy === tool.page}
                 onOpen={() => onNavigate(tool.page)}
+                onTogglePinned={() => void togglePinned(tool.page)}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary

Add a pin button to each Nodus Tools card. Pinned tools appear as direct sidebar shortcuts using the catalogue's existing names and icons, and can be reordered or hidden in Settings. Pins persist across vaults and portable profile sync.

Fix three reported UI inconsistencies: keep citation parentheses with their reference buttons, restore the saved Dictionary status after generation, and replace superseded scan attempts so successful retries no longer leave historical failures in the queue. Required semantic maintenance remains below 100% until it finishes.

Closes #659

## Type of change

- [x] Bug fix
- [x] New feature or improvement

## Validation

- TypeScript checks and production build passed locally.
- 36 focused Toolkit, navigation, vault, and profile integration checks passed.
- Queue lifecycle and citation/Dictionary regression checks passed.
- Focused real Electron Toolkit smoke passed, including pinning OCR, comparing its sidebar SVG with its card icon, opening the shortcut, and unpinning it.
- Full CI is required before merge.

## Persistence and privacy

Pins use app preferences; sidebar order and visibility retain their existing storage. The portable profile accepts the new optional field and defaults older profiles to no pins. No user screenshots, private vault content, credentials, or new network services are included.

The queue fix covers retry bookkeeping and progress presentation; it does not claim to diagnose the original provider failures from screenshots alone.
