### PR TITLE
fix(cla): skip PRs closed during verification

### DIFF
--- a/docs/cla-maintenance.md
+++ b/docs/cla-maintenance.md
@@ -33,6 +33,11 @@ while reporting a missing signature. Its **Details** link opens the workflow
 summary, including the exact agreement and statement to post. No bot comments
 are posted to PR discussions.
 
+If a PR closes or merges during verification, the scan skips publishing its
+result instead of failing the workflow. Its pending status does not grant
+acceptance; reopening triggers a fresh check. Open PRs sharing its head SHA
+still determine that SHA's final status using their own contributors.
+
 Runs are serialized. Each run scans every open PR so concurrent acceptances are
 found even if GitHub replaces a pending run, and signing on one PR unblocks other
 covered PRs. New PRs, pushes to PR branches, reopening, closing, retargeting, new acceptance

--- a/scripts/cla.mjs
+++ b/scripts/cla.mjs
@@ -198,6 +198,13 @@ export async function run({ github, context, core, document }) {
         const missing = [];
         for (const user of result.users) if (!await getRecord(user.id)) missing.push(`@${user.login}`);
         const { data: latest } = await github.rest.pulls.get({ ...repo, pull_number: pr.number });
+        if (latest.state === 'closed') {
+          // A merge/close during this scan is normal, not a signature failure.
+          // Do not grant success or alter outcomes for open PRs sharing this SHA.
+          // The pending status stays unapproved; reopening triggers a fresh scan.
+          summary.push(`\n### PR #${pr.number}\nClosed during verification; skipped. Reopening triggers a new check.`);
+          continue;
+        }
         if (latest.head.sha !== pr.head.sha || latest.state !== 'open') {
           throw new Error('PR changed before publication; a new workflow run must verify it.');
         }

--- a/scripts/test-cla.mjs
+++ b/scripts/test-cla.mjs
@@ -50,6 +50,7 @@ function harness(prs, options = {}) {
         get: async ({ pull_number }) => ({ data: {
           ...prs.find(pr => pr.number === pull_number),
           ...(options.changedHead ? { head: { sha: 'changed' } } : {}),
+          ...(options.closedPrs?.includes(pull_number) ? { state: 'closed' } : {}),
         } }),
       },
       git: { getRef: async () => ({ data: {} }) },
@@ -203,6 +204,40 @@ test('API failures, persistence failures, corrupt records, and changed heads fai
     assert.equal(h.statuses[0].state, 'pending');
     assert.equal(h.statuses.at(-1).state, 'failure');
     assert.ok(h.errors.length);
+  }
+});
+
+test('closing or merging a PR during verification does not fail the workflow or grant acceptance', async () => {
+  const closing = fixture();
+  const open = fixture(2, bob);
+  open.comments = [signingComment(bob)];
+  const h = harness([closing, open], { closedPrs: [1] });
+  await h.execute();
+  assert.deepEqual(h.errors, []);
+  assert.deepEqual(h.statuses.filter(s => s.sha === closing.head.sha).map(s => s.state), ['pending']);
+  assert.equal(h.statuses.filter(s => s.sha === open.head.sha).at(-1).state, 'success');
+  assert.match(h.summary(), /PR #1\nClosed during verification; skipped/);
+
+  // A reopened PR must still obtain its own acceptance.
+  const reopened = harness([closing], { files: h.files });
+  await reopened.execute();
+  assert.equal(reopened.statuses.at(-1).state, 'failure');
+  assert.match(reopened.statuses.at(-1).description, /@alice/);
+});
+
+test('a PR closing during verification cannot override the gate of an open PR sharing its SHA', async () => {
+  for (const signed of [false, true]) {
+    for (const closedFirst of [false, true]) {
+      const closing = fixture(1);
+      const open = fixture(2, bob);
+      open.head.sha = closing.head.sha;
+      if (signed) open.comments = [signingComment(bob)];
+      const h = harness(closedFirst ? [closing, open] : [open, closing], { closedPrs: [1] });
+      await h.execute();
+      assert.deepEqual(h.errors, []);
+      assert.equal(h.statuses.at(-1).state, signed ? 'success' : 'failure');
+      if (!signed) assert.match(h.statuses.at(-1).description, /@bob/);
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

A PR merged during a CLA scan made the workflow fail with “PR changed before publication”, even when its contributors had already accepted the agreement (observed in PR #668).

Skip publishing the result for a PR that closes during verification. Reopening triggers a fresh check, and open PRs sharing its commit SHA still determine that SHA's status. Existing signature reuse and failures for unsigned contributors, API/storage errors, and changed heads remain enforced.

## Validation

- `node --test scripts/test-cla.mjs scripts/test-agpl-release.mjs` — 20 tests passed.
- Added regression coverage for closing/merging during a scan, reopening without acceptance, and signed/unsigned open PRs sharing a SHA in either scan order.
- `git diff --check` — passed.
- Updated the CLA maintenance guide.
