### PR TITLE
Fix model-specific OpenAI and Anthropic request parameters

### DIFF
--- a/electron/ai/aiClient.ts
+++ b/electron/ai/aiClient.ts
@@ -5,6 +5,7 @@ import {
   supportsJsonMode,
   reasoningBody,
   samplingTemperatureBody,
+  completionTokensBody,
   openRouterRoutingBody,
   OPENROUTER_HEADERS,
   isLocalProvider,
@@ -774,15 +775,6 @@ function openAiClientHeaders(model: Pick<ModelRef, 'provider'>): Record<string, 
   };
 }
 
-/** Cerebras documents the current Chat Completions token cap as
- * `max_completion_tokens`; the other compatible providers used here accept the
- * legacy OpenAI `max_tokens` field. Keep the difference at the transport seam. */
-function completionTokensBody(model: ModelRef, maxTokens: number): Record<string, number> {
-  return model.provider === 'cerebras'
-    ? { max_completion_tokens: maxTokens }
-    : { max_tokens: maxTokens };
-}
-
 /**
  * Only retry a 400 when the provider explicitly names an unsupported optional
  * transport field. A generic 400 can be an ambiguous timeout or rejected payload;
@@ -1053,7 +1045,7 @@ async function rawCompleteTransport(
       const res = await scheduleProviderRequest(model, opts, key, 'anthropic', () => client.messages.create({
         model: model.model,
         max_tokens: opts.maxTokens ?? 8000,
-        temperature: opts.temperature ?? 0.15,
+        ...samplingTemperatureBody(model.provider, model.model, opts.temperature ?? 0.15, reasoning),
         system: opts.system,
         messages: [
           { role: 'user', content: opts.images?.length ? (anthropicVisionContent(opts.user, opts.images) as any) : opts.user },
@@ -1162,8 +1154,8 @@ async function rawCompleteTransport(
     });
   const baseBody = {
     model: model.model,
-    ...samplingTemperatureBody(model.provider, model.model, opts.temperature ?? 0.15),
-    ...completionTokensBody(model, maxTokens),
+    ...samplingTemperatureBody(model.provider, model.model, opts.temperature ?? 0.15, reasoning),
+    ...completionTokensBody(model.provider, model.model, maxTokens),
     messages: [
       { role: 'system' as const, content: opts.system },
       { role: 'user' as const, content: opts.images?.length ? (openAiVisionContent(opts.user, opts.images) as any) : opts.user },
@@ -1652,7 +1644,7 @@ async function rawCompleteStreamTransport(
         const stream = await (client.messages.create as any)({
           model: model.model,
           max_tokens: opts.maxTokens ?? 8000,
-          temperature: opts.temperature ?? 0.15,
+          ...samplingTemperatureBody(model.provider, model.model, opts.temperature ?? 0.15, reasoning),
           system: opts.system,
           stream: true,
           messages: [{ role: 'user', content: opts.user }],
@@ -1699,8 +1691,8 @@ async function rawCompleteStreamTransport(
   });
   const baseBody = {
     model: model.model,
-    ...samplingTemperatureBody(model.provider, model.model, opts.temperature ?? 0.15),
-    ...completionTokensBody(model, maxTokens),
+    ...samplingTemperatureBody(model.provider, model.model, opts.temperature ?? 0.15, reasoning),
+    ...completionTokensBody(model.provider, model.model, maxTokens),
     stream: true as const,
     messages: [
       { role: 'system' as const, content: opts.system },

--- a/electron/ai/providers.ts
+++ b/electron/ai/providers.ts
@@ -116,6 +116,28 @@ function isGemini3Model(modelId: string | undefined): boolean {
   return Boolean(modelId && /^gemini-3(?:[.-]|$)/i.test(modelId));
 }
 
+/** Anthropic deprecated sampling controls for Claude 4.7+ (including the 5.x
+ * families) and Mythos Preview. Those models reject a non-default value with
+ * HTTP 400, so prompt wording is the only portable creativity control. */
+function isAnthropicSamplingDeprecatedModel(modelId: string | undefined): boolean {
+  if (!modelId) return false;
+  if (/mythos/i.test(modelId)) return true;
+  const version = modelId.match(/^claude-[a-z]+-(\d+)[.-](\d+)(?:[.-]|$)/i);
+  if (!version) return false;
+  const major = Number(version[1]);
+  const minor = Number(version[2]);
+  return major > 4 || (major === 4 && minor >= 7);
+}
+
+function isOpenAiSamplingUnsupportedModel(modelId: string, effort: ReasoningEffort): boolean {
+  if (/^o(?:1|3|4)(?:[.-]|$)/i.test(modelId) || /^gpt-6(?:[.-]|$)/i.test(modelId)) return true;
+  if (/^gpt-5(?:$|-mini(?:[.-]|$)|-nano(?:[.-]|$)|-pro(?:[.-]|$)|-codex(?:[.-]|$)|-20\d{2})/i.test(modelId)) {
+    return true;
+  }
+  // GPT-5.1+ sampling is available only with reasoning disabled.
+  return /^gpt-5\.\d+(?:[.-]|$)/i.test(modelId) && effort !== 'off';
+}
+
 /** OpenRouter models whose endpoint requires reasoning and rejects
  * `reasoning.enabled=false`. Their minimum supported effort is the only safe mapping
  * for Nodus' `off`: omitting the field can select a `max` default that spends the
@@ -126,17 +148,37 @@ function isOpenRouterMandatoryReasoningModel(modelId: string | undefined): boole
 }
 
 /**
- * Sampling controls are deliberately absent for Gemini 3.x. Google recommends the
- * model defaults for the whole family and, starting with 3.5 Flash-Lite / 3.6,
- * rejects deprecated temperature/top-p/top-k fields with HTTP 400. Keeping this
- * decision at the transport seam makes non-streaming and streaming calls identical.
+ * Sampling controls are deliberately absent for model families that reject them.
+ * Keeping this decision at the transport seam makes non-streaming and streaming
+ * calls identical while older models and all other providers keep their current
+ * request shape.
  */
 export function samplingTemperatureBody(
   provider: AiProvider,
   modelId: string,
   temperature: number,
+  reasoningEffort: ReasoningEffort = 'off',
 ): Record<string, number> {
-  return provider === 'gemini' && isGemini3Model(modelId) ? {} : { temperature };
+  return (provider === 'gemini' && isGemini3Model(modelId)) ||
+    (provider === 'anthropic' && isAnthropicSamplingDeprecatedModel(modelId)) ||
+    (provider === 'openai' && isOpenAiSamplingUnsupportedModel(modelId, reasoningEffort))
+    ? {}
+    : { temperature };
+}
+
+/** OpenAI reasoning models use `max_completion_tokens`; legacy OpenAI models and
+ * other OpenAI-compatible providers still receive `max_tokens`. Cerebras already
+ * documents the newer field for its own compatible endpoint. */
+export function completionTokensBody(
+  provider: AiProvider,
+  modelId: string,
+  maxTokens: number,
+): Record<string, number> {
+  const openAiReasoningModel = provider === 'openai' &&
+    (/^gpt-[56](?:[.-]|$)/i.test(modelId) || /^o(?:1|3|4)(?:[.-]|$)/i.test(modelId));
+  return provider === 'cerebras' || openAiReasoningModel
+    ? { max_completion_tokens: maxTokens }
+    : { max_tokens: maxTokens };
 }
 
 export function reasoningBody(

--- a/scripts/test-free-tier-and-extraction.mjs
+++ b/scripts/test-free-tier-and-extraction.mjs
@@ -106,6 +106,45 @@ test('Gemini 3 transport omits rejected sampling and impossible thinking-off con
   );
 });
 
+test('provider/model transport preserves legacy fields and adapts only incompatible models', async () => {
+  const m = await load('electron/ai/providers.ts');
+
+  assert.deepEqual(m.samplingTemperatureBody('anthropic', 'claude-fable-5-1', 0.3), {});
+  assert.deepEqual(m.samplingTemperatureBody('anthropic', 'claude-opus-4-8', 0.3), {});
+  assert.deepEqual(
+    m.samplingTemperatureBody('anthropic', 'claude-sonnet-4-5', 0.3),
+    { temperature: 0.3 },
+    'older Claude models keep temperature',
+  );
+  assert.deepEqual(
+    m.samplingTemperatureBody('deepseek', 'deepseek-chat', 0.3),
+    { temperature: 0.3 },
+    'unrelated providers keep their sampling contract',
+  );
+  assert.deepEqual(m.samplingTemperatureBody('openai', 'gpt-5-mini', 0.3), {});
+  assert.deepEqual(m.samplingTemperatureBody('openai', 'o4-mini', 0.3), {});
+  assert.deepEqual(m.samplingTemperatureBody('openai', 'gpt-5.4', 0.3, 'high'), {});
+  assert.deepEqual(
+    m.samplingTemperatureBody('openai', 'gpt-5.4', 0.3, 'off'),
+    { temperature: 0.3 },
+    'GPT-5.4 keeps sampling when reasoning is disabled',
+  );
+
+  assert.deepEqual(m.completionTokensBody('openai', 'gpt-5.4', 8000), { max_completion_tokens: 8000 });
+  assert.deepEqual(m.completionTokensBody('openai', 'o4-mini', 8000), { max_completion_tokens: 8000 });
+  assert.deepEqual(m.completionTokensBody('openai', 'gpt-6-astra', 8000), { max_completion_tokens: 8000 });
+  assert.deepEqual(
+    m.completionTokensBody('openai', 'gpt-4.1-mini', 8000),
+    { max_tokens: 8000 },
+    'legacy OpenAI models keep max_tokens',
+  );
+  assert.deepEqual(
+    m.completionTokensBody('openrouter', 'openai/gpt-5.4', 8000),
+    { max_tokens: 8000 },
+    'other compatible providers retain their own established contract',
+  );
+});
+
 test('OpenRouter omits thinking-off only for endpoints with mandatory reasoning', async () => {
   const m = await load('electron/ai/providers.ts');
   assert.deepEqual(


### PR DESCRIPTION
## Summary

- omit deprecated sampling controls for Claude 4.7+ and other models that reject them
- send max_completion_tokens to OpenAI GPT-5/GPT-6 and o-series models
- preserve max_tokens and temperature for legacy models and unaffected compatible providers
- apply the same request shaping to buffered and streaming completions
- add regression coverage for the provider/model compatibility matrix

## Validation

- node --test scripts/test-free-tier-and-extraction.mjs
- npm run typecheck
- npx eslint electron/ai/providers.ts electron/ai/aiClient.ts
- git diff --check

Closes #683