### PR TITLE
Fix document search CPU regression with indexed profile joins

### DIFF
--- a/electron/db/documentProfilesRepo.ts
+++ b/electron/db/documentProfilesRepo.ts
@@ -598,11 +598,13 @@ export async function findSimilarDocuments(
   queryEmbedding: number[], threshold = 0.24, limit = 20
 ): Promise<DocumentSearchHit[]> {
   const config = currentEmbeddingConfig();
+  // Join state by its indexed work key as well as version: a version-only
+  // join scans every profile state for each candidate vector.
   const ranked = await scanSimilar<{ vector_id: string; rid: number; similarity: number }>({
     table: 'document_vectors',
     sql: `SELECT dv.vector_id, dv.rowid rid, vec_scan(dv.embedding) similarity
             FROM document_vectors dv
-            JOIN document_profile_state dps ON dps.current_version_id=dv.version_id
+            JOIN document_profile_state dps ON dps.nodus_id=dv.nodus_id AND dps.current_version_id=dv.version_id
             JOIN works w ON w.nodus_id=dv.nodus_id
            WHERE dv.rowid>? AND dv.rowid<=? AND dv.embedding IS NOT NULL
              AND w.archived=0 AND dv.embedding_provider=? AND dv.embedding_model=?
@@ -618,7 +620,7 @@ export async function findSimilarDocuments(
     `SELECT dv.vector_id,dv.nodus_id,dv.version_id,dv.kind,dv.source_id,dv.text,dv.weight,
             w.title,w.authors_json,w.year,dps.status
        FROM document_vectors dv JOIN works w ON w.nodus_id=dv.nodus_id
-       JOIN document_profile_state dps ON dps.current_version_id=dv.version_id
+       JOIN document_profile_state dps ON dps.nodus_id=dv.nodus_id AND dps.current_version_id=dv.version_id
       WHERE dv.vector_id IN (${ranked.map(() => '?').join(',')})`
   ).all(...ranked.map((item) => item.vector_id)) as Record<string, unknown>[];
   const bestBySource = new Map<string, DocumentSearchHit>();

--- a/scripts/test-document-profile-scale.mjs
+++ b/scripts/test-document-profile-scale.mjs
@@ -113,6 +113,21 @@ try {
   })();
 
   const repo = require(bundle);
+  // Inspect the actual production statements, not a copied query. Both the
+  // paged scan and winner hydration must look up profile state by its work key.
+  const prepare = db.prepare.bind(db);
+  const profilePlans = [];
+  db.prepare = (sql) => {
+    const statement = prepare(sql);
+    if (/JOIN document_profile_state dps/.test(sql)) {
+      const all = statement.all.bind(statement);
+      statement.all = (...params) => {
+        profilePlans.push(prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params));
+        return all(...params);
+      };
+    }
+    return statement;
+  };
   let ticks = 0;
   const tick = () => { ticks += 1; timer = setImmediate(tick); };
   let timer = setImmediate(tick);
@@ -123,7 +138,16 @@ try {
   const semanticCpu = process.cpuUsage(semanticCpuStart);
   const semanticCpuMs = (semanticCpu.user + semanticCpu.system) / 1_000;
   clearImmediate(timer);
+  assert.ok(profilePlans.length > 1, 'inspect paged scanning and winner hydration');
+  for (const plan of profilePlans) {
+    assert.ok(plan.some((row) => /SEARCH dps USING INDEX .*\(nodus_id=\?\)/.test(row.detail)),
+      `profile state must use its work-key index: ${JSON.stringify(plan)}`);
+    assert.ok(!plan.some((row) => /SCAN dps\b/.test(row.detail)), 'never rescan all profile states per vector');
+  }
   assert.ok(semantic.some((hit) => hit.nodusId === `work-${WORKS - 1}`), 'the strongest document survives the 16k-vector scan');
+  assert.equal(semantic.length, 20);
+  assert.equal(semantic[0].nodusId, `work-${WORKS - 1}`);
+  assert.equal(semantic[0].similarity, 1);
   assert.ok(ticks >= 5, `the semantic scan yielded only ${ticks} times`);
   // `npm test` runs hundreds of files concurrently. Wall time there includes
   // time this isolated Electron child was not scheduled, so keep the release
@@ -151,6 +175,19 @@ try {
   assert.equal(statuses.length, WORKS);
   assert.ok(statusCpuMs < 1_000, `2k profile statuses used ${statusCpuMs.toFixed(1)} ms of CPU`);
   assert.ok(statusMs < 5_000, `2k profile statuses stalled for ${statusMs.toFixed(1)} ms wall time`);
+
+  // The indexed join still filters archived works and superseded versions,
+  // and cannot borrow another work's current-version pointer.
+  db.prepare('UPDATE works SET archived=1 WHERE nodus_id=?').run(`work-${WORKS - 1}`);
+  assert.ok(!(await repo.findSimilarDocuments(query, -1, 20))
+    .some((hit) => hit.nodusId === `work-${WORKS - 1}`));
+  db.prepare('UPDATE works SET archived=0 WHERE nodus_id=?').run(`work-${WORKS - 1}`);
+  db.prepare('UPDATE document_profile_state SET current_version_id=? WHERE nodus_id=?')
+    .run('superseding-version', `work-${WORKS - 1}`);
+  db.prepare('UPDATE document_profile_state SET current_version_id=? WHERE nodus_id=?')
+    .run(`version-${WORKS - 1}`, 'work-0');
+  assert.ok(!(await repo.findSimilarDocuments(query, -1, 20))
+    .some((hit) => hit.nodusId === `work-${WORKS - 1}`), 'a different work cannot activate an obsolete version');
   db.close();
   console.log(`document profile scale passed: ${WORKS} works/${WORKS * VECTORS_PER_WORK} vectors; semantic ${semanticMs.toFixed(1)} ms wall/${semanticCpuMs.toFixed(1)} ms CPU, FTS ${lexicalMs.toFixed(1)}/${lexicalCpuMs.toFixed(1)} ms, statuses ${statusMs.toFixed(1)}/${statusCpuMs.toFixed(1)} ms`);
 } finally {


### PR DESCRIPTION
## Summary
Fix the document-profile performance failure seen in the post-merge CI run for #689: https://github.com/Drakonis96/nodus/actions/runs/34267623044.

The semantic scan joined profile state only by current_version_id, which has no matching index. EXPLAIN QUERY PLAN showed SCAN dps for every candidate vector. Join by the existing indexed nodus_id as well as current_version_id in both candidate scanning and winner hydration. This also prevents a different work from activating an obsolete version.

## Regression coverage
- Inspect the actual executed production statements with EXPLAIN QUERY PLAN; require indexed work-key lookups and reject profile-state table scans.
- The new query-plan assertion fails against the old implementation and passes with this fix.
- Preserve top-result identity and score, result count, event-loop yielding, archived-work exclusion and current-version ownership.
- Keep every existing CPU and wall-time limit unchanged.

## Validation
- Before: six local runs around 1,100 ms CPU for 16,000 vectors; failed main CI measured 3,790 ms against the 3,000 ms budget.
- After: focused run 41 ms CPU; full-suite run 74 ms CPU. These are local measurements, not a guarantee for every machine.
- Focused document-profile tests: 13 passed.
- Full npm test: 3,028 passed, zero failed, one skipped.
- npm run lint: passed.
- npm run build including TypeScript checks: passed.
- npm run test:e2e: passed, no renderer errors.
- git diff --check: passed.

## Compatibility and privacy
No migration, new index, stored-data rewrite, UI change, dependency change or network access. Existing similarity scoring is unchanged. All test data is synthetic.

This is a separate follow-up PR; remote CI must pass before merging.