### PR TITLE
Fix CI Electron bootstrap race and stale legal-page sitemap date

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "npm run build:cloudflare && npm run typecheck && vite build",
     "build:cloudflare": "node scripts/build-cloudflare-worker.mjs",
     "build:server-web": "vite build --config vite.server-web.config.ts",
+    "pretest": "node scripts/prepare-electron-tests.mjs",
     "test": "node --test scripts/test-*.mjs",
     "test:cloudflare": "node --test scripts/test-cloudflare-contract.mjs",
     "blog:pages": "node scripts/build-blog-pages.mjs",

--- a/scripts/prepare-electron-tests.mjs
+++ b/scripts/prepare-electron-tests.mjs
@@ -1,0 +1,18 @@
+// Electron 43 downloads its binary lazily. Resolve and launch it once, before
+// node --test starts parallel workers that would otherwise extract the same app.
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+
+const require = createRequire(import.meta.url);
+const expectedVersion = require('electron/package.json').version;
+const executable = require('electron');
+const actualVersion = execFileSync(executable, ['-p', 'process.versions.electron'], {
+  env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'inherit'],
+  timeout: 30_000,
+}).trim();
+if (actualVersion !== expectedVersion) {
+  throw new Error(`Electron runtime mismatch: expected ${expectedVersion}, received ${actualVersion}. Reinstall the Electron binary before running tests.`);
+}
+console.log(`[test setup] Electron ${actualVersion} is installed and can start.`);

--- a/scripts/test-electron-bootstrap.mjs
+++ b/scripts/test-electron-bootstrap.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const require = createRequire(import.meta.url);
+const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const bootstrap = () => spawnSync(process.execPath, ['scripts/prepare-electron-tests.mjs'], {
+  cwd: root, encoding: 'utf8', timeout: 60_000,
+});
+
+test('npm test prepares and verifies Electron before launching parallel test workers', () => {
+  assert.equal(packageJson.scripts.pretest, 'node scripts/prepare-electron-tests.mjs');
+  const result = bootstrap();
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(result.stdout.includes(`Electron ${require('electron/package.json').version} is installed and can start.`));
+});
+
+test('an unusable Electron distribution fails the prerequisite instead of starting tests', () => {
+  const missing = fs.mkdtempSync(path.join(os.tmpdir(), 'nodus-electron-bootstrap-'));
+  try {
+    const result = spawnSync(process.execPath, ['scripts/prepare-electron-tests.mjs'], {
+      cwd: root, encoding: 'utf8', timeout: 30_000,
+      env: { ...process.env, ELECTRON_OVERRIDE_DIST_PATH: missing },
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ENOENT/);
+    assert.doesNotMatch(result.stdout, /installed and can start/);
+  } finally { fs.rmSync(missing, { recursive: true, force: true }); }
+});

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -38,7 +38,7 @@
   </url>
   <url>
     <loc>https://nodusresearch.com/open-source/</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-09</lastmod>
   </url>
   <url>
     <loc>https://nodusresearch.com/cite/</loc>


### PR DESCRIPTION
## Summary

The `CI / test (push)` run after #700 failed for two reasons:

1. Electron 43 installs its binary lazily. Several parallel test workers entered that download/extraction path together, and four suites launched an incomplete macOS framework (`segment '__TEXT' load command content extends beyond end of file`).
2. The sitemap still dated `/open-source/` as 2026-09-02 after its privacy source changed on 2026-09-09.

Add an npm `pretest` step that resolves Electron once, launches it as Node, and checks its version before the parallel suite starts. An unusable runtime stops the prerequisite instead of allowing workers to proceed. Regenerate the sitemap using the existing source-date generator; do not weaken the freshness assertion or serialize the test suite itself.

## Related issue

Follow-up to #700 and #699.
Failed run: https://github.com/Drakonis96/nodus/actions/runs/34376265626

## Type of change

- [x] Bug fix
- [x] Refactor or maintenance

## Validation

Passed all nine tests in the focused rerun, including the five original failures and the new bootstrap checks:

```sh
node --test scripts/test-electron-bootstrap.mjs scripts/test-site-sitemap.mjs scripts/test-ai-json-retry.mjs scripts/test-archive-discovery.mjs scripts/test-archive.mjs scripts/test-argument-map-graph.mjs
```

- `node scripts/prepare-electron-tests.mjs` verified the installed Electron 43.4.0 runtime.
- `npm run build:server-web` passed (prerequisite for the full suite).
- `git diff --check` passed.
- `npm test` is running; its final result will be recorded here.

No application behavior, credential handling, licence terms or user preferences are changed. No secrets or personal data are included. No new dependencies are introduced.

## Contributor checklist

- [x] Added focused regression checks for a usable and an unusable Electron distribution.
- [x] Preserved existing test assertions and parallel execution.
- [x] Regenerated the derived sitemap rather than editing its expected test value.
- [ ] CLA acceptance is determined by the CLA check; this PR does not sign on anyone's behalf.

Do not merge as part of this fix. No automatic merge is requested.
