### PR TITLE
Fix Windows file imports failing with EPERM on fsync

### DIFF
--- a/electron/library/libraryOperations.ts
+++ b/electron/library/libraryOperations.ts
@@ -104,7 +104,8 @@ function copyImmutable(source: string, destination: string): void {
   const temporary = `${destination}.tmp-${process.pid}-${randomUUID()}`;
   try {
     fs.copyFileSync(source, temporary, fs.constants.COPYFILE_EXCL);
-    const descriptor = fs.openSync(temporary, 'r');
+    // Windows requires write access to flush the copied file to disk.
+    const descriptor = fs.openSync(temporary, 'r+');
     try { fs.fsyncSync(descriptor); } finally { fs.closeSync(descriptor); }
     fs.renameSync(temporary, destination);
   } finally {

--- a/electron/library/zoteroLibraryImport.ts
+++ b/electron/library/zoteroLibraryImport.ts
@@ -253,7 +253,8 @@ async function copyImmutable(source: string, destination: string, signal?: Abort
       fs.createWriteStream(temporary, { flags: 'wx' }),
       { signal },
     );
-    const descriptor = await fsp.open(temporary, 'r');
+    // Windows requires write access to flush the copied file to disk.
+    const descriptor = await fsp.open(temporary, 'r+');
     try { await descriptor.sync(); } finally { await descriptor.close(); }
     signal?.throwIfAborted();
     await fsp.rename(temporary, destination);


### PR DESCRIPTION
## Summary

File imports on Windows can fail with `EPERM: operation not permitted, fsync` because both the local and Zotero import paths reopen the copied temporary file in read-only mode before flushing it. Windows requires write access for `FlushFileBuffers`, which backs `fsync`.

Open the temporary file with `r+` in both paths so the flush can succeed without truncating the copied contents. Preserve the existing flush, close, atomic rename, and cleanup sequence, and explain the Windows requirement in a short comment.

## Related issue

Closes #702

## Type of change

- [x] Bug fix

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `node --test scripts/test-global-library-operations.mjs scripts/test-library-storage.mjs scripts/test-zotero-library-import.mjs` — all three suites passed.
- [x] `git diff --check`

Local validation ran on macOS. Native Windows reproduction and verification remain pending. The full test suite, build, and E2E checks were not run locally.

## Privacy and data review

The change only adjusts access to Nodus's temporary import copies. It adds no network access, migrations, or changes to source files, and includes no private data or credentials.

## Contributor checklist

- [x] Preserved local-first behavior and existing privacy boundaries.
- [x] Read and followed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
- Existing integration suites cover the affected import paths; no new tests or UI strings were added.
