### PR TITLE
fix(graph): keep Context toggle in place when enabled

### DIFF
--- a/src/stellarGraph/CorpusContext.tsx
+++ b/src/stellarGraph/CorpusContext.tsx
@@ -61,11 +61,6 @@ export function CorpusContextControls({ context, onFit }: {
   onFit(): void;
 }) {
   return <div className="stellar-context-controls">
-    <button type="button" role="switch" aria-checked={context.enabled}
-      title={t("Mostrar el corpus tenue alrededor de las ideas de esta pestaña")}
-      onClick={() => context.setEnabled(!context.enabled)}>
-      <i aria-hidden="true" />{t("Contexto")}
-    </button>
     {context.enabled && <>
       <input type="range" min="5" max="40" step="1" value={Math.round(context.opacity * 100)}
         aria-label={t("Intensidad del contexto")} title={t("Intensidad del contexto")}
@@ -75,6 +70,11 @@ export function CorpusContextControls({ context, onFit }: {
           ? tx("{n} ideas · {edges} conexiones en el corpus", { n: context.layer.data.nodes.length.toLocaleString(), edges: context.layer.data.edges.length.toLocaleString() })
           : undefined}>{t("Ver corpus")}</button>}
     </>}
+    <button type="button" role="switch" aria-checked={context.enabled}
+      title={t("Mostrar el corpus tenue alrededor de las ideas de esta pestaña")}
+      onClick={() => context.setEnabled(!context.enabled)}>
+      <i aria-hidden="true" />{t("Contexto")}
+    </button>
   </div>;
 }
 


### PR DESCRIPTION
## Summary

Enabling **Context** in the graph moved the toggle left because the opacity slider and **View corpus** button appeared to its right. Render those conditional controls before the toggle so they appear on its left and the toggle keeps its position beside the zoom controls.

## Related issue

Closes #706

## Type of change

- [x] Bug fix

## Validation

- [x] `npm run typecheck`
- [x] `git diff --check`

## Screenshots

Before: `Context | opacity slider | View corpus | zoom controls`

After: `opacity slider | View corpus | Context | zoom controls`

Screenshots of the updated application have not been captured.

## Privacy and data review

This change only reorders existing controls. It introduces no network access, data handling, database changes, or new UI strings.

## Contributor checklist

- [x] I preserved local-first behavior and existing privacy boundaries.
- [x] I have read and followed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
