### PR TITLE
Fix Nodi Skills styles and theme overlay scrollbars

### DIFF
--- a/scripts/test-chat-skills.mjs
+++ b/scripts/test-chat-skills.mjs
@@ -436,3 +436,14 @@ test('a built-in can be uninstalled and reinstalled alone, keeping every other s
   assert.throws(() => lib.installBuiltinChatSkill('descriptive-statistics'), /not a built-in/);
   lib.deleteChatSkill(personal.id);
 });
+
+test('the panel reset never outranks the switch track color', () => {
+  // The standalone Nodi window has no Tailwind base reset, so the shared panel
+  // normalizes its own buttons. A bare `.chat-skills-panel button` rule beats the
+  // later `.chat-skill-switch` class and blanks the unchecked #45454f track; the
+  // reset must stay at the class specificity via :where(button).
+  const css = fs.readFileSync(path.join(root, 'src/components/chatSkills.css'), 'utf8');
+  assert.match(css, /\.chat-skills-panel :where\(button\)\s*\{/, 'the button reset must not outrank component classes');
+  assert.doesNotMatch(css, /\.chat-skills-panel button\s*\{[^}]*background:\s*transparent/, 'a bare .chat-skills-panel button reset would blank the unchecked switch track');
+  assert.match(css, /\.chat-skill-switch \{[^}]*background:\s*#45454f/, 'the unchecked switch keeps an explicit track color');
+});

--- a/scripts/test-nodi-assistant.mjs
+++ b/scripts/test-nodi-assistant.mjs
@@ -204,8 +204,11 @@ test('Nodi chat keeps model selection inside settings and exposes deletable hist
   assert.match(component, /clearNodiConversations\(\)/);
   assert.match(component, /role="dialog" aria-modal="true"/);
   assert.match(component, /<ModelPicker[^>]* menu /);
-  assert.match(css, /nodi-chat-msgs::-webkit-scrollbar/);
-  assert.match(css, /nodi-chat-input::-webkit-scrollbar/);
+  // Scrollbars are themed once for the whole companion instead of per element,
+  // so every present and future scroll container inherits the same tokens.
+  assert.match(css, /\.nodi-companion \*::-webkit-scrollbar \{/);
+  assert.match(css, /scrollbar-color: var\(--nodi-scrollbar-thumb\) var\(--nodi-scrollbar-track\)/);
+  assert.match(css, /\.nodi-theme-light \{\s*\n\s*--nodi-scrollbar-track: #eef2f7;/);
   assert.match(css, /\.nodi-msg \.md table/);
   assert.match(css, /\.nodi-history-delete:hover/);
   assert.match(css, /\.nodi-confirm-overlay/);

--- a/scripts/verify-nodi-overlay.mjs
+++ b/scripts/verify-nodi-overlay.mjs
@@ -336,11 +336,13 @@ try {
     const close = panel.querySelector('.chat-skills-heading > button');
     const search = panel.querySelector('.chat-skills-search input');
     const toggle = panel.querySelector('.chat-skill-switch');
+    const uncheckedToggle = panel.querySelector('.chat-skill-switch[aria-checked="false"]');
     const knob = panel.querySelector('.chat-skill-switch span');
     const style = (element) => {
       if (!(element instanceof HTMLElement)) throw new Error('missing Skills control');
       const computed = getComputedStyle(element);
       return {
+        background: computed.backgroundColor,
         border: computed.borderWidth,
         fontFamily: computed.fontFamily,
         fontSize: computed.fontSize,
@@ -360,6 +362,7 @@ try {
       close: style(close),
       search: style(search),
       toggle: style(toggle),
+      uncheckedToggle: style(uncheckedToggle),
       knob: style(knob),
     };
   });
@@ -367,6 +370,11 @@ try {
   assert.equal(skillAppearance.close.border, '0px');
   assert.equal(skillAppearance.search.border, '0px');
   assert.equal(skillAppearance.toggle.border, '0px');
+  assert.equal(
+    skillAppearance.uncheckedToggle.background,
+    'rgb(69, 69, 79)',
+    'an unchecked Skills switch keeps its #45454f track instead of inheriting the reset transparent background',
+  );
   assert.equal(skillAppearance.tab.fontFamily, skillAppearance.panelFont);
   assert.equal(skillAppearance.search.fontFamily, skillAppearance.panelFont);
   assert.deepEqual(

--- a/scripts/verify-nodi-overlay.mjs
+++ b/scripts/verify-nodi-overlay.mjs
@@ -323,6 +323,102 @@ try {
     opacity: '1',
   }, 'quoted document text must retain the readable foreground of the user bubble');
   await overlay.screenshot({ path: `${shots}/overlay-4-chat-quote.png` });
+
+  // Skills is shared with the main Assistant, but the standalone mascot entry
+  // does not load Tailwind's base reset. Verify the panel supplies its own
+  // control normalization instead of inheriting Chromium's native borders and
+  // oversized form typography in this window.
+  await overlay.getByTestId('chat-skills-nodi').click();
+  const skillsPanel = overlay.getByRole('region', { name: 'Skills', exact: true });
+  await skillsPanel.waitFor();
+  const skillAppearance = await skillsPanel.evaluate((panel) => {
+    const tab = panel.querySelector('.skill-marketplace-tabs button');
+    const close = panel.querySelector('.chat-skills-heading > button');
+    const search = panel.querySelector('.chat-skills-search input');
+    const toggle = panel.querySelector('.chat-skill-switch');
+    const knob = panel.querySelector('.chat-skill-switch span');
+    const style = (element) => {
+      if (!(element instanceof HTMLElement)) throw new Error('missing Skills control');
+      const computed = getComputedStyle(element);
+      return {
+        border: computed.borderWidth,
+        fontFamily: computed.fontFamily,
+        fontSize: computed.fontSize,
+        height: computed.height,
+        margin: computed.margin,
+        width: computed.width,
+      };
+    };
+    return {
+      panelFont: getComputedStyle(panel).fontFamily,
+      scrollbar: {
+        standard: getComputedStyle(panel).scrollbarColor,
+        track: getComputedStyle(panel, '::-webkit-scrollbar-track').backgroundColor,
+        thumb: getComputedStyle(panel, '::-webkit-scrollbar-thumb').backgroundColor,
+      },
+      tab: style(tab),
+      close: style(close),
+      search: style(search),
+      toggle: style(toggle),
+      knob: style(knob),
+    };
+  });
+  assert.equal(skillAppearance.tab.border, '0px');
+  assert.equal(skillAppearance.close.border, '0px');
+  assert.equal(skillAppearance.search.border, '0px');
+  assert.equal(skillAppearance.toggle.border, '0px');
+  assert.equal(skillAppearance.tab.fontFamily, skillAppearance.panelFont);
+  assert.equal(skillAppearance.search.fontFamily, skillAppearance.panelFont);
+  assert.deepEqual(
+    [skillAppearance.toggle.width, skillAppearance.toggle.height, skillAppearance.knob.width, skillAppearance.knob.height],
+    ['29px', '17px', '13px', '13px'],
+    'Nodi rendered the Skills switch with native button geometry',
+  );
+  assert.equal(skillAppearance.tab.margin, '0px');
+  assert.deepEqual(skillAppearance.scrollbar, {
+    standard: 'rgb(203, 213, 225) rgb(238, 242, 247)',
+    track: 'rgb(238, 242, 247)',
+    thumb: 'rgb(203, 213, 225)',
+  });
+  console.log('[verify] Nodi Skills normalized controls ->', JSON.stringify(skillAppearance));
+  await overlay.screenshot({ path: `${shots}/overlay-4-chat-skills-light.png` });
+  await skillsPanel.getByRole('button', { name: 'Marketplace', exact: true }).click();
+  await skillsPanel.locator('.skill-marketplace').waitFor();
+  await overlay.screenshot({ path: `${shots}/overlay-4-chat-skills-marketplace-light.png` });
+  await skillsPanel.getByRole('button', { name: 'My skills', exact: true }).click();
+  await page.evaluate(() => window.nodus.updateSettings({ theme: 'dark' }));
+  await overlay.waitForFunction(() => !document.querySelector('.nodi-companion')?.classList.contains('nodi-theme-light'));
+  await overlay.waitForTimeout(250);
+  // Re-render the tab content after Chromium repaints the transparent native
+  // window's theme; this keeps the visual artifact deterministic on macOS.
+  await skillsPanel.getByRole('button', { name: 'Marketplace', exact: true }).click();
+  await skillsPanel.getByRole('button', { name: 'My skills', exact: true }).click();
+  await overlay.mouse.move(0, 0);
+  await overlay.waitForTimeout(50);
+  const darkAppearance = await skillsPanel.evaluate((panel) => {
+    const tab = panel.querySelector('.skill-marketplace-tabs button[aria-pressed="true"]');
+    if (!(tab instanceof HTMLElement)) throw new Error('missing active Skills tab');
+    return {
+      activeTab: { text: tab.textContent, color: getComputedStyle(tab).color },
+      scrollbar: {
+        standard: getComputedStyle(panel).scrollbarColor,
+        track: getComputedStyle(panel, '::-webkit-scrollbar-track').backgroundColor,
+        thumb: getComputedStyle(panel, '::-webkit-scrollbar-thumb').backgroundColor,
+      },
+    };
+  });
+  assert.deepEqual(darkAppearance, {
+    activeTab: { text: 'My skills', color: 'rgb(255, 255, 255)' },
+    scrollbar: {
+      standard: 'rgb(89, 101, 121) rgb(17, 24, 36)',
+      track: 'rgb(17, 24, 36)',
+      thumb: 'rgb(89, 101, 121)',
+    },
+  });
+  await overlay.screenshot({ path: `${shots}/overlay-4-chat-skills-dark.png` });
+  await page.evaluate(() => window.nodus.updateSettings({ theme: 'light' }));
+  await overlay.waitForFunction(() => document.querySelector('.nodi-companion')?.classList.contains('nodi-theme-light'));
+  await skillsPanel.getByRole('button', { name: 'Cerrar', exact: true }).click();
   await overlay.locator('.nodi-panel textarea').first().fill('Hola Nodi');
   await overlay.waitForFunction(() => {
     const send = document.querySelector('.nodi-chat-send');

--- a/src/components/chatSkills.css
+++ b/src/components/chatSkills.css
@@ -12,7 +12,7 @@
   letter-spacing: inherit;
   color: inherit;
 }
-.chat-skills-panel button {
+.chat-skills-panel :where(button) {
   appearance: none;
   -webkit-appearance: none;
   border: 0;

--- a/src/components/chatSkills.css
+++ b/src/components/chatSkills.css
@@ -1,4 +1,25 @@
 .chat-skills-control,.chat-skills-control * { box-sizing: border-box; }
+/*
+ * The standalone Nodi window intentionally does not load the application's
+ * Tailwind base layer. Keep this shared panel independent from that global
+ * reset so native button borders, form fonts and block margins cannot leak
+ * into the compact Nodi rendering.
+ */
+.chat-skills-panel :where(h1,h2,h3,h4,p,pre,fieldset) { margin: 0; }
+.chat-skills-panel :where(button,input,select,textarea) {
+  margin: 0;
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+}
+.chat-skills-panel button {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+.chat-skills-panel :where(img,svg) { display: block; }
 .chat-skills-panel { font-weight: 400; font-size: 12px; line-height: 1.5; }
 .chat-skills-control { position: relative; flex-shrink: 0; color: #e4e4e7; }
 .chat-skills-trigger { display: flex; align-items: center; gap: 7px; padding: 7px 10px; border: 1px solid color-mix(in srgb, var(--vault-accent, #6366f1) 27.1%, transparent); background: color-mix(in srgb, var(--vault-accent, #6366f1) 5.5%, transparent); border-radius: 9px; font-size: 12px; color: color-mix(in srgb, var(--vault-accent, #6366f1) 55%, white); }

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -1,8 +1,33 @@
 .nodi-companion {
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --nodi-scrollbar-track: #111824;
+  --nodi-scrollbar-thumb: #596579;
+  --nodi-scrollbar-thumb-hover: #748198;
 }
 .nodi-companion,
 .nodi-companion * { box-sizing: border-box; }
+.nodi-companion,
+.nodi-companion * {
+  scrollbar-width: thin;
+  scrollbar-color: var(--nodi-scrollbar-thumb) var(--nodi-scrollbar-track);
+}
+.nodi-companion::-webkit-scrollbar,
+.nodi-companion *::-webkit-scrollbar { width: 8px; height: 8px; }
+.nodi-companion::-webkit-scrollbar-track,
+.nodi-companion *::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: var(--nodi-scrollbar-track);
+}
+.nodi-companion::-webkit-scrollbar-thumb,
+.nodi-companion *::-webkit-scrollbar-thumb {
+  border: 2px solid var(--nodi-scrollbar-track);
+  border-radius: 999px;
+  background: var(--nodi-scrollbar-thumb);
+}
+.nodi-companion::-webkit-scrollbar-thumb:hover,
+.nodi-companion *::-webkit-scrollbar-thumb:hover { background: var(--nodi-scrollbar-thumb-hover); }
+.nodi-companion::-webkit-scrollbar-corner,
+.nodi-companion *::-webkit-scrollbar-corner { background: var(--nodi-scrollbar-track); }
 .nodi-anchor { position: absolute; }
 
 .nodi-figure {
@@ -590,31 +615,6 @@
   cursor: pointer;
 }
 .nodi-open-settings:hover { background: rgba(212,175,55,.14); }
-.nodi-chat-msgs,
-.nodi-chat-input,
-.nodi-history,
-.nodi-panel-body,
-.nodi-msg .md pre { scrollbar-width: thin; scrollbar-color: #596579 #111824; }
-.nodi-chat-msgs::-webkit-scrollbar,
-.nodi-chat-input::-webkit-scrollbar,
-.nodi-history::-webkit-scrollbar,
-.nodi-panel-body::-webkit-scrollbar,
-.nodi-msg .md pre::-webkit-scrollbar { width: 8px; height: 8px; }
-.nodi-chat-msgs::-webkit-scrollbar-track,
-.nodi-chat-input::-webkit-scrollbar-track,
-.nodi-history::-webkit-scrollbar-track,
-.nodi-panel-body::-webkit-scrollbar-track,
-.nodi-msg .md pre::-webkit-scrollbar-track { background: #111824; border-radius: 999px; }
-.nodi-chat-msgs::-webkit-scrollbar-thumb,
-.nodi-chat-input::-webkit-scrollbar-thumb,
-.nodi-history::-webkit-scrollbar-thumb,
-.nodi-panel-body::-webkit-scrollbar-thumb,
-.nodi-msg .md pre::-webkit-scrollbar-thumb { background: #596579; border: 2px solid #111824; border-radius: 999px; }
-.nodi-chat-msgs::-webkit-scrollbar-thumb:hover,
-.nodi-chat-input::-webkit-scrollbar-thumb:hover,
-.nodi-history::-webkit-scrollbar-thumb:hover,
-.nodi-panel-body::-webkit-scrollbar-thumb:hover,
-.nodi-msg .md pre::-webkit-scrollbar-thumb:hover { background: #748198; }
 /* Quick notes ───────────────────────────────────────────────────────────── */
 .nodi-panel.nodi-notes-panel { width: 372px; max-height: 480px; }
 
@@ -779,21 +779,13 @@
 .nodi-note-foot { display: flex; align-items: center; justify-content: center; flex: 0 0 auto; padding: 8px; border-top: 0.5px solid rgba(255, 255, 255, 0.08); }
 .nodi-note-state { font-size: 10px; color: #7a8598; text-align: center; }
 
-.nodi-notes-list,
-.nodi-note-textarea,
-.nodi-note-preview { scrollbar-width: thin; scrollbar-color: #596579 #111824; }
-.nodi-notes-list::-webkit-scrollbar,
-.nodi-note-textarea::-webkit-scrollbar,
-.nodi-note-preview::-webkit-scrollbar { width: 8px; height: 8px; }
-.nodi-notes-list::-webkit-scrollbar-track,
-.nodi-note-textarea::-webkit-scrollbar-track,
-.nodi-note-preview::-webkit-scrollbar-track { background: #111824; border-radius: 999px; }
-.nodi-notes-list::-webkit-scrollbar-thumb,
-.nodi-note-textarea::-webkit-scrollbar-thumb,
-.nodi-note-preview::-webkit-scrollbar-thumb { background: #596579; border: 2px solid #111824; border-radius: 999px; }
-
 /* Shared light mode — driven by Nodus' resolved theme and the active vault accent.
  * Dark mode deliberately keeps the original navy/gold Nodi identity above. */
+.nodi-theme-light {
+  --nodi-scrollbar-track: #eef2f7;
+  --nodi-scrollbar-thumb: #cbd5e1;
+  --nodi-scrollbar-thumb-hover: #94a3b8;
+}
 .nodi-theme-light .nodi-node {
   border-color: var(--nodi-vault-accent, #6366f1);
   background: #ffffff;
@@ -871,26 +863,6 @@
   opacity: 1;
 }
 .nodi-theme-light .nodi-msg.user .md blockquote + p { color: inherit; }
-.nodi-theme-light .nodi-chat-msgs,
-.nodi-theme-light .nodi-chat-input,
-.nodi-theme-light .nodi-history,
-.nodi-theme-light .nodi-panel-body,
-.nodi-theme-light .nodi-msg .md pre { scrollbar-color: #cbd5e1 #eef2f7; }
-.nodi-theme-light .nodi-chat-msgs::-webkit-scrollbar-track,
-.nodi-theme-light .nodi-chat-input::-webkit-scrollbar-track,
-.nodi-theme-light .nodi-history::-webkit-scrollbar-track,
-.nodi-theme-light .nodi-panel-body::-webkit-scrollbar-track,
-.nodi-theme-light .nodi-msg .md pre::-webkit-scrollbar-track { background: #eef2f7; }
-.nodi-theme-light .nodi-chat-msgs::-webkit-scrollbar-thumb,
-.nodi-theme-light .nodi-chat-input::-webkit-scrollbar-thumb,
-.nodi-theme-light .nodi-history::-webkit-scrollbar-thumb,
-.nodi-theme-light .nodi-panel-body::-webkit-scrollbar-thumb,
-.nodi-theme-light .nodi-msg .md pre::-webkit-scrollbar-thumb { background: #cbd5e1; border-color: #eef2f7; }
-.nodi-theme-light .nodi-chat-msgs::-webkit-scrollbar-thumb:hover,
-.nodi-theme-light .nodi-chat-input::-webkit-scrollbar-thumb:hover,
-.nodi-theme-light .nodi-history::-webkit-scrollbar-thumb:hover,
-.nodi-theme-light .nodi-panel-body::-webkit-scrollbar-thumb:hover,
-.nodi-theme-light .nodi-msg .md pre::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
 .nodi-theme-light .nodi-chat-foot { border-top-color: rgba(15, 23, 42, .08); }
 .nodi-theme-light .nodi-chat-quote { background: rgba(15, 23, 42, .045); color: #475569; }
 .nodi-theme-light .nodi-chat-quote button { color: #64748b; }
@@ -1015,16 +987,6 @@
 .nodi-theme-light .nodi-notes-panel .nodi-note-preview .md a { color: var(--nodi-vault-accent, #6366f1); }
 .nodi-theme-light .nodi-notes-panel .nodi-note-foot { border-top-color: rgba(15, 23, 42, 0.08); }
 .nodi-theme-light .nodi-notes-panel .nodi-note-state { color: #94a3b8; }
-.nodi-theme-light .nodi-notes-panel .nodi-notes-list,
-.nodi-theme-light .nodi-notes-panel .nodi-note-textarea,
-.nodi-theme-light .nodi-notes-panel .nodi-note-preview { scrollbar-color: #cbd5e1 #eef2f7; }
-.nodi-theme-light .nodi-notes-panel .nodi-notes-list::-webkit-scrollbar-track,
-.nodi-theme-light .nodi-notes-panel .nodi-note-textarea::-webkit-scrollbar-track,
-.nodi-theme-light .nodi-notes-panel .nodi-note-preview::-webkit-scrollbar-track { background: #eef2f7; }
-.nodi-theme-light .nodi-notes-panel .nodi-notes-list::-webkit-scrollbar-thumb,
-.nodi-theme-light .nodi-notes-panel .nodi-note-textarea::-webkit-scrollbar-thumb,
-.nodi-theme-light .nodi-notes-panel .nodi-note-preview::-webkit-scrollbar-thumb { background: #cbd5e1; border-color: #eef2f7; }
-
 /* Corpus starters on an empty chat ─────────────────────────────────────────── */
 .nodi-chat-welcome { display: flex; flex-direction: column; align-items: center; gap: 12px; padding: 18px 12px; text-align: center; }
 .nodi-chat-welcome .nodi-empty { padding: 0; }
@@ -1154,11 +1116,6 @@
 .nodi-cite-btn:hover { background: rgba(255, 255, 255, 0.1); }
 .nodi-cite-btn.primary { border-color: rgba(212, 175, 55, 0.5); background: rgba(212, 175, 55, 0.14); color: #f3d67a; }
 .nodi-cite-btn.primary:hover { background: rgba(212, 175, 55, 0.22); }
-.nodi-cite-body { scrollbar-width: thin; scrollbar-color: #596579 #111824; }
-.nodi-cite-body::-webkit-scrollbar { width: 8px; }
-.nodi-cite-body::-webkit-scrollbar-track { background: #111824; border-radius: 999px; }
-.nodi-cite-body::-webkit-scrollbar-thumb { background: #596579; border: 2px solid #111824; border-radius: 999px; }
-
 /* Light theme — driven by Nodus' resolved theme + active vault accent. */
 .nodi-theme-light .nodi-starter {
   border-color: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 40%, transparent);
@@ -1217,10 +1174,6 @@
   color: var(--nodi-vault-accent, #6366f1);
 }
 .nodi-theme-light .nodi-cite-btn.primary:hover { background: color-mix(in srgb, var(--nodi-vault-accent, #6366f1) 18%, transparent); }
-.nodi-theme-light .nodi-cite-body { scrollbar-color: #cbd5e1 #eef2f7; }
-.nodi-theme-light .nodi-cite-body::-webkit-scrollbar-track { background: #eef2f7; }
-.nodi-theme-light .nodi-cite-body::-webkit-scrollbar-thumb { background: #cbd5e1; border-color: #eef2f7; }
-
 @keyframes nodi-badge-pop { 0% { transform: scale(0); } 70% { transform: scale(1.3); } 100% { transform: scale(1); } }
 @keyframes nodi-bubble-pop { 0% { opacity: 0; transform: scale(0.6) translateY(8px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
 @keyframes nodi-panel-pop { 0% { opacity: 0; transform: scale(0.85) translateY(8px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }


### PR DESCRIPTION
## Summary

- make the shared Skills panel independent from the main renderer Tailwind reset by normalizing its buttons, form controls, block spacing and inline media within the panel scope
- replace Nodi scrollbar container allowlists with light/dark theme tokens inherited by every scrollable descendant, including track, thumb, hover and corner styling
- extend the real Electron overlay verification with computed-style assertions for Skills controls and both scrollbar themes, plus light, dark and Marketplace screenshots

## Compatibility with #714

This branch is rebased directly on `80641a69`, the merge commit for #714. The rebase completed without conflicts.

#714 adds installed-skill management behavior in the React components and five Marketplace rules at the end of `chatSkills.css`. This change does not alter that behavior: its panel reset is at the start of `chatSkills.css`, while the scrollbar implementation is scoped to `nodi/companion.css`. The post-rebase Skills suite includes and passes #714 tests for built-in publication identifiers, uninstall/reinstall, official built-in restoration and legacy duplicate consolidation.

## Verification

- `npm run build`
- `node --test scripts/test-chat-skills.mjs scripts/test-chat-skills-surfaces.mjs scripts/test-skill-marketplace.mjs` — 36 passed, 0 failed
- `NODUS_VERIFY_SHOTS=artifacts/nodi-skills-fix node scripts/verify-nodi-overlay.mjs` — passed against the real standalone Electron overlay, including exact light/dark scrollbar colors and switch geometry

Closes #715