### PR TITLE
fix(graph): guard the stellar render loop against an unmounted host

### DIFF
--- a/src/stellarGraph/StellarCanvas.tsx
+++ b/src/stellarGraph/StellarCanvas.tsx
@@ -237,10 +237,15 @@ export function StellarCanvas(props: Props) {
     let lastAnimatedEdge: string | null | undefined;
     const reduce = matchMedia("(prefers-reduced-motion: reduce)");
     const render = () => {
+      // Unmount detaches the ref during commit but this loop's rAF is only
+      // cancelled by the passive cleanup after paint, so one in-flight frame
+      // can still run with host.current === null.
+      const hostEl = host.current;
+      if (!hostEl) return;
       const p = live.current,
         dpr = Math.min(devicePixelRatio, 2),
-        w = host.current!.clientWidth,
-        h = host.current!.clientHeight;
+        w = hostEl.clientWidth,
+        h = hostEl.clientHeight;
       el.width = Math.round(w * dpr);
       el.height = Math.round(h * dpr);
       const screen = (pos: StellarPosition) => ({


### PR DESCRIPTION
## Summary

- guard the Stellar canvas render loop so a frame that outlives unmount returns early instead of dereferencing `host.current === null`
- fixes the intermittent `main` CI failure introduced after #716 was merged

## Root cause

`src/stellarGraph/StellarCanvas.tsx` runs a self-scheduling `requestAnimationFrame` loop that read `host.current!.clientWidth`. On unmount React detaches the ref during commit, but the loop is only cancelled by the passive `useEffect` cleanup after paint. One in-flight frame can therefore run between ref detach and cleanup and throw:

```
TypeError: Cannot read properties of null (reading 'clientWidth')
```

The Graph tabs E2E collects `pageerror`s and asserts none (`scripts/e2e-stellar-tabs.mjs:342`), so the race surfaced there as a flaky failure on `main` (`run 34460630638`). It is a long-standing latent race (introduced in #674), not caused by #716: the #716 merge only touched Nodi skills CSS and tests.

## Verification

- `npm run build` — passes (includes typecheck)
- `node scripts/e2e-stellar-tabs.mjs` — passes
- `npm run lint` — clean