### PR TITLE
feat(assistant): open the corpus context picker as a balloon

### DIFF
--- a/scripts/test-research-context-popover.mjs
+++ b/scripts/test-research-context-popover.mjs
@@ -1,0 +1,30 @@
+// The assistant's context picker ("Síntesis" and friends) used to open as a
+// centered modal that covered the conversation. It now behaves like the Skills
+// menu: a balloon anchored to its header trigger. This guards the regression.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (file) => readFile(path.join(root, file), 'utf8');
+
+test('the assistant context picker opens as an anchored balloon, not a modal', async () => {
+  const [assistant, styles] = await Promise.all([
+    read('src/views/ResearchAssistantModal.tsx'),
+    read('src/views/researchAssistant.css'),
+  ]);
+
+  assert.match(assistant, /import \{ createPortal \} from 'react-dom'/, 'the balloon renders through a portal');
+  assert.match(assistant, /className="research-context-panel"/, 'the panel carries the balloon class');
+  assert.match(assistant, /contextPanelRef/, 'the panel is tracked for outside-click dismissal');
+  assert.match(assistant, /setShowContext\(\(value\) => !value\)/, 'both triggers toggle the picker');
+
+  // The old centered dialog is gone: no full-screen backdrop. Only the outer
+  // research-assistant window remains a modal; the picker is not one.
+  assert.doesNotMatch(assistant, /fixed inset-0 z-\[60\]/, 'the modal backdrop was removed');
+  assert.equal((assistant.match(/aria-modal="true"/g) ?? []).length, 1, 'only the assistant window is a modal');
+
+  assert.match(styles, /\.research-context-panel\s*\{/, 'the balloon class is styled');
+});

--- a/src/views/ResearchAssistantModal.tsx
+++ b/src/views/ResearchAssistantModal.tsx
@@ -1,6 +1,7 @@
 import { ChatMarkdown } from '../components/ChatMarkdown';
 import { ChatSkillsControl } from '../components/ChatSkillsControl';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import type {
   AppSettings,
   ChatConversationSummary,
@@ -229,11 +230,17 @@ export function ResearchAssistantModal({
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [showContext, setShowContext] = useState(false);
+  // The context picker opens as a balloon anchored to its header trigger (like
+  // Skills) instead of a centered modal, so the corpus selection stays in reach.
+  const [contextPanelStyle, setContextPanelStyle] = useState<CSSProperties>({});
   // Id of the assistant message currently streaming — drives the live caret and
   // the "stop" affordance. Null when nothing is in flight.
   const [streamingId, setStreamingId] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const contextTriggerRef = useRef<HTMLButtonElement>(null);
+  const focusTriggerRef = useRef<HTMLButtonElement>(null);
+  const contextPanelRef = useRef<HTMLDivElement>(null);
   // Whether new stream deltas should keep the view pinned to the bottom. Starts
   // true on send and flips off as soon as the user scrolls up to read back.
   const stickToBottomRef = useRef(true);
@@ -276,6 +283,62 @@ export function ResearchAssistantModal({
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, 224)}px`;
   }, [input]);
+
+  // Anchor the context balloon to its trigger, flipping above when there is no
+  // room below. Mirrors the Skills popover so both header menus feel the same.
+  useLayoutEffect(() => {
+    if (!showContext) return;
+    const place = () => {
+      const rect = (contextTriggerRef.current ?? focusTriggerRef.current)?.getBoundingClientRect();
+      if (!rect) return;
+      const width = Math.min(420, window.innerWidth - 24);
+      const below = window.innerHeight - rect.bottom - 20;
+      const above = rect.top - 20;
+      const upwards = below < 360 && above > below;
+      setContextPanelStyle({
+        position: 'fixed',
+        width,
+        left: Math.max(12, Math.min(rect.right - width, window.innerWidth - width - 12)),
+        top: upwards ? 'auto' : rect.bottom + 8,
+        bottom: upwards ? window.innerHeight - rect.top + 8 : 'auto',
+        maxHeight: Math.min(720, Math.max(200, upwards ? above : below)),
+        zIndex: 10050,
+      });
+    };
+    place();
+    window.addEventListener('resize', place);
+    window.addEventListener('scroll', place, true);
+    return () => {
+      window.removeEventListener('resize', place);
+      window.removeEventListener('scroll', place, true);
+    };
+  }, [showContext]);
+
+  useEffect(() => {
+    if (!showContext) return;
+    const close = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        !contextTriggerRef.current?.contains(target) &&
+        !focusTriggerRef.current?.contains(target) &&
+        !contextPanelRef.current?.contains(target)
+      ) {
+        setShowContext(false);
+      }
+    };
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopImmediatePropagation();
+        setShowContext(false);
+      }
+    };
+    document.addEventListener('mousedown', close);
+    document.addEventListener('keydown', escape, true);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('keydown', escape, true);
+    };
+  }, [showContext]);
 
   const isNearBottom = useCallback(() => {
     const el = scrollRef.current;
@@ -583,12 +646,13 @@ export function ResearchAssistantModal({
           ) : (
             <button
               type="button"
+              ref={contextTriggerRef}
               data-testid="research-context-trigger"
               className="btn btn-ghost border border-neutral-700 gap-1.5 text-xs py-1"
               title={t('Elegir qué partes del corpus ve el asistente')}
               aria-haspopup="dialog"
               aria-expanded={showContext}
-              onClick={() => setShowContext(true)}
+              onClick={() => setShowContext((value) => !value)}
             >
               <Icon name="layers" size={15} className="text-indigo-300" />
               <span className="hidden sm:inline">{activeMode ? t(activeMode.label) : t('Contexto')}</span>
@@ -599,12 +663,13 @@ export function ResearchAssistantModal({
           {!isGenealogy && contextTitle && (
             <button
               type="button"
+              ref={focusTriggerRef}
               data-testid="research-focus-trigger"
               className="hidden md:inline-flex items-center gap-1.5 rounded-md border border-indigo-900/70 bg-indigo-950/25 px-2 py-1 text-xs text-indigo-200"
               title={t('Elegir qué partes del corpus ve el asistente')}
               aria-haspopup="dialog"
               aria-expanded={showContext}
-              onClick={() => setShowContext(true)}
+              onClick={() => setShowContext((value) => !value)}
             >
               <Icon name="fit" size={15} />
               <span className="truncate">{contextTitle}</span>
@@ -842,16 +907,14 @@ export function ResearchAssistantModal({
         </div>
       </div>
 
-      {showContext && (
-        <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4"
-          onClick={() => setShowContext(false)}
-        >
+      {showContext &&
+        createPortal(
           <div
+            ref={contextPanelRef}
             role="dialog"
-            aria-modal="true"
-            className="flex max-h-[86vh] w-full max-w-lg flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
+            aria-label={t('Contexto del asistente')}
+            style={contextPanelStyle}
+            className="research-context-panel"
           >
             <header className="flex items-center gap-2 border-b border-neutral-800 px-4 py-3">
               <Icon name="layers" className="text-indigo-300" />
@@ -962,9 +1025,9 @@ export function ResearchAssistantModal({
                 {t('Listo')}
               </button>
             </footer>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body
+        )}
 
       {pendingDelete && (
         <ConfirmModal

--- a/src/views/researchAssistant.css
+++ b/src/views/researchAssistant.css
@@ -45,3 +45,19 @@
   outline: 2px solid var(--vault-accent, #6366f1);
   outline-offset: 2px;
 }
+
+/* Context picker balloon: the same anchored treatment as the Skills menu,
+   instead of a centered modal that covers the conversation. */
+.research-context-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 18px;
+  background: #18191f;
+  border: 1px solid color-mix(in srgb, var(--vault-accent, #6366f1) 22.7%, transparent);
+  box-shadow: 0 24px 80px #0009;
+  color: #e4e4e7;
+  text-align: left;
+  font-size: 12px;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Summary

The research assistant's context picker (the panel behind the **Síntesis** button in the chat header) opened as a centered, full-screen modal that covered the conversation. This changes it to the same anchored balloon treatment as the **Skills** menu:

- Renders through a portal to `document.body`, positioned against the trigger's bounding box.
- Flips above the trigger when there is not enough room below, and clamps to the viewport.
- Dismisses on outside click and `Escape`; both the mode trigger and the focused-context trigger toggle it.

No behavioral change to the corpus selection or the modes themselves.

## Related issue

Closes #718

## Type of change

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation or translation
- [ ] Refactor or maintenance
- [ ] Database, privacy, security, or infrastructure change

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `node --test scripts/test-research-context-popover.mjs scripts/test-chat-typing-indicator.mjs scripts/test-model-independence.mjs`
- [x] `npm run build` (via `npx vite build`)
- [x] Manual verification in the real Electron app: the balloon opens anchored under **Síntesis**, above when space is short, and closes on outside click / `Escape`.

## Screenshots

Before: centered modal covering the conversation. After: the context balloon anchored to the **Síntesis** trigger, matching **Skills**. (Captured from the real app on a throwaway demo profile.)

## Privacy and data review

- [x] No secrets, credentials, private vault content, personal data, student data, or confidential documents are included.
- [x] New network access is explicit, documented, and initiated by the user.
- [x] The change does not send rosters, grades, student answers, or other protected data to AI providers.
- [x] The change does not use AI to grade, rank, profile, or evaluate students.
- [x] Database, backup, synchronization, and migration effects are documented and tested.

## Contributor checklist

- [x] I have read [CLA.md](https://github.com/Drakonis96/nodus/blob/main/CLA.md) and accepted it through the **CLA / signature** check. Every author and coauthor must accept separately; this checkbox alone is not acceptance.
- [x] I added or updated focused tests.
- [ ] I updated documentation where behavior changed. (No user-facing docs describe this popover.)
- [x] I updated every language table for new static UI text. (No new static UI text.)
- [x] I preserved local-first behavior and existing privacy boundaries.
- [x] I have read and followed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.