### PR TITLE
Keep marketplace categories in built-in skill metadata

### DIFF
--- a/scripts/sync-skill-marketplace.mjs
+++ b/scripts/sync-skill-marketplace.mjs
@@ -23,8 +23,8 @@ try {
     // Keep the separately curated PR700 packages and their required native capabilities.
     if (skill.builtin === 'genomics' || skill.builtin === 'legal') continue;
     const id = skill.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-    const category = ({ svg: 'Visual creation', image: 'Visual creation', chemistry: 'Science', socratic: 'Learning' })[skill.builtin] ?? 'Thinking and writing';
-    const manifest = { schemaVersion: 1, id, name: skill.name, version: skill.version ?? '1.0.0', author: 'Drakonis96', description: skill.description, category, license: 'AGPL-3.0-only', instructions: 'SKILL.md', capabilities: ['svg','image','chemistry'].includes(skill.builtin) ? [skill.builtin] : [], tools: [] };
+    if (!skill.category) throw new Error(`Built-in skill ${skill.name} needs a marketplace category.`);
+    const manifest = { schemaVersion: 1, id, name: skill.name, version: skill.version ?? '1.0.0', author: 'Drakonis96', description: skill.description, category: skill.category, license: 'AGPL-3.0-only', instructions: 'SKILL.md', capabilities: ['svg','image','chemistry'].includes(skill.builtin) ? [skill.builtin] : [], tools: [] };
     const dir = path.join(target, id); fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'skill.json'), JSON.stringify(manifest, null, 2) + '\n');
     fs.writeFileSync(path.join(dir, 'SKILL.md'), skill.instructions + '\n');

--- a/scripts/test-chat-skills.mjs
+++ b/scripts/test-chat-skills.mjs
@@ -480,6 +480,8 @@ test('every built-in is published under the identifier the marketplace export pr
     const id = skill.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     assert.equal(lib.BUILTIN_SKILL_PACKAGES[id], skill.id, `${skill.name} is not published as ${id}`);
     assert.equal(lib.builtinSkillForPackage(id).name, skill.name);
+    assert.match(skill.version ?? '', /^\d+\.\d+\.\d+$/, `${skill.name} needs a marketplace version`);
+    assert.ok(skill.category, `${skill.name} needs a marketplace category`);
   }
   assert.equal(Object.keys(lib.BUILTIN_SKILL_PACKAGES).length, lib.DEFAULT_CHAT_SKILLS.length, 'two built-ins share one package identifier');
   assert.equal(lib.builtinSkillForPackage('descriptive-statistics'), undefined);

--- a/shared/chatSkills.ts
+++ b/shared/chatSkills.ts
@@ -42,7 +42,7 @@ Prefer a finished, useful artifact over instructions describing how the user cou
 
 export const DEFAULT_CHAT_SKILLS: ChatSkill[] = [
   {
-    id: 'builtin-svg', name: 'SVG Studio', builtin: 'svg', capabilities: ['nodus:svg'], version: '1.0.1',
+    id: 'builtin-svg', name: 'SVG Studio', builtin: 'svg', capabilities: ['nodus:svg'], version: '1.0.1', category: 'Design and visual communication',
     description: 'Precise diagrams, explanatory drawings, maps, timelines and visual systems.',
     enabled: { assistant: true, nodi: true },
     instructions: `Use this skill when the user asks to draw, diagram, map, visualize, or explain spatial relationships, or when a precise visual would substantially clarify the answer. It applies across science, humanities, engineering, education, business, and creative work. Prefer SVG when exact labels, relationships, geometry, or editable line work matter. Honor an explicit request for SVG.
@@ -53,7 +53,7 @@ Choose domain-appropriate conventions: circuit symbols for circuits; arrows and 
 Before returning, audit semantic correctness, counts, units, arrow direction, connectivity, label collisions, clipping, contrast, and completeness of XML. A missing source illustration is not a reason to withhold an original drawing. Cite any source-supported explanation outside the SVG; describe the figure as your own construction when appropriate.`,
   },
   {
-    id: 'builtin-chemistry', name: 'Chemistry Studio', builtin: 'chemistry', capabilities: ['nodus:chemistry'], version: '1.0.1',
+    id: 'builtin-chemistry', name: 'Chemistry Studio', builtin: 'chemistry', capabilities: ['nodus:chemistry'], version: '1.0.1', category: 'Physical sciences',
     description: 'Reference-backed molecular structures, Fischer/Haworth/Newman projections and bounded reaction mechanisms with validated ChemFig export.',
     enabled: { assistant: false, nodi: false },
     instructions: `CHEMISTRY STUDIO — VERIFIED IDENTITY FIRST
@@ -78,7 +78,7 @@ When there is no chemical identity in the request, ask for the complete name, Pu
 This validation establishes agreement with the stated reference graph and supported projection/rule, not infallibility of chemical databases, all visual layout details, experimental kinetics or product dominance. Do not claim success before the tool result.`,
   },
   {
-    id: 'builtin-image', name: 'Image Atelier', builtin: 'image', capabilities: ['nodus:image'],
+    id: 'builtin-image', name: 'Image Atelier', builtin: 'image', capabilities: ['nodus:image'], version: '1.0.1', category: 'Design and visual communication',
     description: 'Original illustrations, concept art and visual scenes using your image model.',
     enabled: { assistant: true, nodi: true },
     instructions: `Use this skill to fulfill requests for original images, illustrations, photographs, concept art, visual metaphors, or rich scenes. You write the creative brief; Nodus sends it to the image provider and model selected by the user in Settings. Do not claim the text model itself rendered an image. Use SVG Studio for exact diagrams or extensive labels unless the user specifically requests a generated image.
@@ -87,7 +87,7 @@ Build a self-contained brief of roughly 100–250 words: first the purpose and s
 Invoke generation by emitting a fenced code block labeled nodus-image containing ONLY a JSON object with string fields "title", "alt", and "prompt", plus an optional "aspectRatio" chosen from 1:1, 16:9, 9:16, 4:3, 3:4, 3:2, or 2:3. Choose the requested aspect ratio or the closest supported one; use a composition-appropriate format when unspecified. title and alt should be in the user's language; prompt must be in English. Example: {"title":"A quiet observatory","alt":"An astronomer working beneath an open dome at dusk","prompt":"Create an editorial illustration ..."}. This is an executable image request, not an example to quote. Emit it only when you intend to generate, at most once per answer. Never fabricate a URL or replace generation with a description of an imaginary result. Nodus replaces the request with the actual image card, stores the prompt and chosen model, and reports any failure. Keep surrounding prose short and do not claim success before the image arrives.`,
   },
   {
-    id: 'builtin-socratic-tutor', name: 'Socratic Tutor', builtin: 'socratic',
+    id: 'builtin-socratic-tutor', name: 'Socratic Tutor', builtin: 'socratic', version: '1.0.1', category: 'Learning and teaching',
     description: 'Guided learning through focused questions, progressive hints and personalized feedback.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill when the user wants to learn, practice, test their understanding, or work through a problem with guidance. It applies across disciplines and levels. Do not turn unrelated requests into lessons. Speak in the user's language and match their terminology, confidence and goals.
@@ -97,10 +97,10 @@ Give specific feedback: identify what is correct, explain any misconception resp
 Use relevant vault evidence accurately and cite source-dependent claims. Distinguish supplied evidence from general knowledge, original examples and assumptions. Do not invent facts or citations, or demand that the sources contain a worked answer before teaching the underlying concept. Use an enabled visual skill only when a diagram would clarify the current learning step; do not reveal a whole solution through a visual while inviting the learner to discover it.
 When the learner demonstrates understanding, summarize the key idea in a few sentences and offer one short transfer exercise or a natural stopping point. Treat success as the learner being able to explain or apply the idea, not merely agreeing with you.`,
   },
-  { id: 'builtin-genomics', name: 'AlphaGenome', builtin: 'genomics', capabilities: ['nodus:genomics'],
+  { id: 'builtin-genomics', name: 'AlphaGenome', builtin: 'genomics', capabilities: ['nodus:genomics'], version: '1.1.1', category: 'Life sciences',
     description: 'AlphaGenome regulatory variant predictions for non-commercial research, with local plots and attributed exports. Requires a personal API key.',
     enabled: { assistant: false, nodi: false }, instructions: GENOMICS_INSTRUCTIONS },
-  { id: 'builtin-legal', name: 'Legalize', builtin: 'legal', capabilities: ['nodus:legal'], description: 'Busca legislación por país en legalize-dev, con texto, fuente oficial, versión y atribuciones.', enabled: { assistant: false, nodi: false }, instructions: LEGALIZE_INSTRUCTIONS },
+  { id: 'builtin-legal', name: 'Legalize', builtin: 'legal', capabilities: ['nodus:legal'], version: '1.1.1', category: 'Law and public policy', description: 'Busca legislación por país en legalize-dev, con texto, fuente oficial, versión y atribuciones.', enabled: { assistant: false, nodi: false }, instructions: LEGALIZE_INSTRUCTIONS },
   ...GENERAL_CHAT_SKILLS,
 ];
 

--- a/shared/generalChatSkills.ts
+++ b/shared/generalChatSkills.ts
@@ -3,7 +3,7 @@ import type { ChatSkill } from './chatSkills';
 /** Optional methods for the existing chat model; these grant no extra tools. */
 export const GENERAL_CHAT_SKILLS: ChatSkill[] = [
   {
-    id: 'builtin-thought-partner', name: 'Thought Partner', builtin: 'general',
+    id: 'builtin-thought-partner', name: 'Thought Partner', builtin: 'general', version: '1.0.1', category: 'Thinking and decision-making',
     description: 'Develop an unfinished idea, surface assumptions and find a useful way forward.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill when the user wants to think through an idea, untangle a problem or develop an uncertain direction. Respond in their language and preserve what makes their idea distinctive.
@@ -12,7 +12,7 @@ Offer two or three meaningfully different ways forward and explain what each wou
 Use relevant vault evidence with accurate attribution. Ask one focused question only if its answer would materially change the next step; otherwise proceed with an explicit working assumption. Finish with a sharper formulation, a practical next move or one useful question. Support the user's thinking without taking over their decision.`,
   },
   {
-    id: 'builtin-brainstorm-studio', name: 'Brainstorm Studio', builtin: 'general',
+    id: 'builtin-brainstorm-studio', name: 'Brainstorm Studio', builtin: 'general', version: '1.0.1', category: 'Thinking and decision-making',
     description: 'Generate distinct ideas, then select and develop the most promising ones.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill for ideation, alternative approaches, naming, concepts or creative problem solving. Respond in the user's language. Establish the purpose, audience and explicit constraints from the request; ask only for a missing detail that would substantially change the direction.
@@ -21,7 +21,7 @@ Select two or three promising candidates using the user's criteria, explaining t
 Treat invented concepts as proposals, not facts. Do not claim uniqueness, legal availability, proven results or market validation without evidence. Build on supplied material while respecting its attribution and the user's constraints.`,
   },
   {
-    id: 'builtin-make-it-simple', name: 'Make It Simple', builtin: 'general',
+    id: 'builtin-make-it-simple', name: 'Make It Simple', builtin: 'general', version: '1.0.1', category: 'Writing and communication',
     description: 'Explain complex material clearly with concrete examples and useful analogies.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill when the user wants a clearer or more accessible explanation of a concept, passage or process. Adapt to their audience and knowledge level; otherwise start with an intelligent beginner. Respond in their language without sounding patronizing.
@@ -30,7 +30,7 @@ Simplify the presentation, not the truth. Preserve meaningful distinctions, unce
 Keep optional technical detail separate. Use an enabled visual skill only when it adds clarity. Provide a direct explanation rather than a quiz unless the user asks to practice. Aim for an explanation the reader can restate in their own words.`,
   },
   {
-    id: 'builtin-action-planner', name: 'Action Planner', builtin: 'general',
+    id: 'builtin-action-planner', name: 'Action Planner', builtin: 'general', version: '1.0.1', category: 'Planning and productivity',
     description: 'Turn a goal into priorities, concrete steps and an achievable first action.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill to turn a goal, idea or problem into an actionable plan. Respond in the user's language. Identify the desired outcome and observable completion criteria, using their deadlines, resources and constraints. Make assumptions explicit rather than inventing commitments or availability.
@@ -39,7 +39,7 @@ Give time or effort estimates only with a reasonable basis and label approximate
 This skill produces a plan: never claim to have created tasks, sent messages, scheduled reminders or changed external systems unless an available tool actually completed the authorized action.`,
   },
   {
-    id: 'builtin-compare-and-choose', name: 'Compare & Choose', builtin: 'general',
+    id: 'builtin-compare-and-choose', name: 'Compare & Choose', builtin: 'general', version: '1.0.1', category: 'Thinking and decision-making',
     description: 'Compare alternatives against explicit criteria and recommend a choice suited to your needs.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill when the user is choosing among alternatives, approaches or proposals. Respond in their language. Frame the decision around their goal, constraints and priorities. Use their options; add another only when it fills a meaningful gap.
@@ -48,7 +48,7 @@ Explain practical tradeoffs and what the user gives up with each option. Avoid a
 Recommend the best fit with a concise rationale and the condition under which another option would win. If evidence is insufficient, give a conditional recommendation and one concrete way to resolve the uncertainty. Preserve the user's agency rather than treating preference as objective fact.`,
   },
   {
-    id: 'builtin-constructive-critic', name: 'Constructive Critic', builtin: 'general',
+    id: 'builtin-constructive-critic', name: 'Constructive Critic', builtin: 'general', version: '1.0.1', category: 'Thinking and decision-making',
     description: 'Review a text, design or proposal and prioritize specific, practical improvements.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill for reviews, critiques, stress tests and improvements of texts, designs, arguments or proposals. Respond in the user's language. Judge the work against its intended purpose, audience and constraints. Base comments on supplied material; do not pretend to inspect an unavailable image or document.
@@ -57,7 +57,7 @@ Be candid without being dismissive. Critique the work, not the person. Do not in
 Finish with an ordered improvement sequence or the highest-value change. If the user asks for the revised artifact, deliver it rather than stopping at advice.`,
   },
   {
-    id: 'builtin-writing-partner', name: 'Writing Partner', builtin: 'general',
+    id: 'builtin-writing-partner', name: 'Writing Partner', builtin: 'general', version: '1.0.1', category: 'Writing and communication',
     description: 'Draft and refine clear, purposeful writing while preserving your voice and intent.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill to draft, rewrite or polish emails, documents, presentations, posts and other prose. Match the user's language, audience, purpose, format and tone. Infer reasonable defaults; ask only if a missing detail would materially change the message.
@@ -66,7 +66,7 @@ Retain intended meaning, factual details, qualifications, names and commitments.
 Scale the intervention to the request: proofreading should not become a wholesale rewrite. Explain only consequential changes unless a detailed review is requested. Offer alternatives when they provide a useful difference in tone or emphasis. Preparing a message does not authorize sending or publishing it.`,
   },
   {
-    id: 'builtin-perspective-switcher', name: 'Perspective Switcher', builtin: 'general',
+    id: 'builtin-perspective-switcher', name: 'Perspective Switcher', builtin: 'general', version: '1.0.1', category: 'Thinking and decision-making',
     description: 'Explore different viewpoints and see which assumptions change the conclusions.',
     enabled: { assistant: false, nodi: false },
     instructions: `Use this skill to examine a question from several viewpoints, understand disagreement or challenge one interpretation. Respond in the user's language. Choose three to five relevant perspectives: stakeholders, disciplines, time horizons or value priorities. Avoid artificial viewpoints added merely for symmetry.


### PR DESCRIPTION
## Summary

Keep the built-in skill metadata aligned with the category structure merged in NodusResearch/nodus-research-skill-marketplace#6.

Each built-in now carries its marketplace category and explicit package version. The marketplace synchronizer exports that metadata directly and fails when a built-in has no category, so future synchronization cannot restore the former `Science`, `Thinking and writing`, `Visual creation` or `Learning` labels.

## Related issue

Follow-up to NodusResearch/nodus-research-skill-marketplace#6.

## Type of change

- [x] New feature or improvement
- [x] Refactor or maintenance

## Validation

- [x] `npm run typecheck`
- [x] `node --test scripts/test-chat-skills.mjs scripts/test-skill-marketplace.mjs` (39 tests passed)
- [x] Ran `scripts/sync-skill-marketplace.mjs` against a clean checkout of the merged marketplace; all 15 standalone manifests retained their merged categories and versions.
- [x] `git diff --check`

The full `npm test`, lint, build and E2E suites were not run because this change is limited to built-in metadata and the export guard.

## Privacy and data review

- [x] No secrets, credentials, private vault content, personal data, student data, or confidential documents are included.
- [x] No network access was added or changed.
- [x] The change does not send protected data to AI providers.
- [x] The change does not grade, rank, profile or evaluate students.
- [x] No database, backup, synchronization or migration behavior changed.

## Contributor checklist

- [x] I added a focused regression assertion for marketplace versions and categories.
- [x] No static UI text or translation changed.
- [x] Local-first behavior and existing privacy boundaries are unchanged.
- [x] I have read and followed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.