### PR TITLE
fix(i18n): offer Italian in the writing workshop language picker

### DIFF
--- a/scripts/test-prompt-language-pickers.mjs
+++ b/scripts/test-prompt-language-pickers.mjs
@@ -1,0 +1,60 @@
+// Regression guard for the AI prompt-language pickers. Every composer used to spell
+// the language list out by hand and they drifted: the Writing Workshop (and, before
+// it, Deep Research) offered seven of the eight supported languages, so an Italian
+// draft was reachable over MCP — whose schema enumerates PROMPT_LANGUAGES — but not
+// from the app. Every picker must render the shared PROMPT_LANGUAGE_OPTIONS, and that
+// list must cover every PromptLanguage.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const buildDir = await mkdtemp(path.join(os.tmpdir(), 'nodus-prompt-language-'));
+
+function loadModule(source, name) {
+  const output = path.join(buildDir, `${name}.cjs`);
+  execFileSync(
+    path.join(repoRoot, 'node_modules/.bin/esbuild'),
+    [path.join(repoRoot, source), '--bundle', '--platform=node', '--format=cjs', '--target=es2022', `--outfile=${output}`],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  return require(output);
+}
+
+const source = (relative) => readFile(path.join(repoRoot, relative), 'utf8');
+
+test.after(() => rm(buildDir, { recursive: true, force: true }));
+
+test('the shared prompt-language list covers every supported language, Italian included', () => {
+  const { PROMPT_LANGUAGES } = loadModule('shared/types.ts', 'types');
+  const { PROMPT_LANGUAGE_OPTIONS } = loadModule('shared/promptLanguageOptions.ts', 'promptLanguageOptions');
+
+  assert.deepEqual(
+    PROMPT_LANGUAGE_OPTIONS.map((option) => option.id).sort(),
+    [...PROMPT_LANGUAGES].sort(),
+    'every prompt language must be offered exactly once',
+  );
+  assert.equal(new Set(PROMPT_LANGUAGE_OPTIONS.map((option) => option.id)).size, PROMPT_LANGUAGES.length);
+  for (const option of PROMPT_LANGUAGE_OPTIONS) {
+    assert.ok(option.label.trim().length > 0, `${option.id} has no endonym label`);
+  }
+  assert.equal(PROMPT_LANGUAGE_OPTIONS.find((option) => option.id === 'it')?.label, 'Italiano');
+});
+
+for (const file of [
+  'src/views/WritingWorkshopView.tsx',
+  'src/views/DeepResearchView.tsx',
+  'src/views/DatabaseDeepResearchView.tsx',
+]) {
+  test(`${file} renders the shared prompt-language list instead of a hand-written one`, async () => {
+    const text = await source(file);
+    assert.ok(text.includes('PROMPT_LANGUAGE_OPTIONS'), `${file} must use the shared prompt-language options`);
+    assert.ok(!/<option value="pt">/.test(text), `${file} must not spell the language list by hand`);
+  });
+}

--- a/src/views/WritingWorkshopView.tsx
+++ b/src/views/WritingWorkshopView.tsx
@@ -18,6 +18,7 @@ import type {
   WritingWorkshopThemeCandidate,
   WritingWorkshopWorkCandidate,
 } from '@shared/types';
+import { PROMPT_LANGUAGE_OPTIONS } from '@shared/promptLanguageOptions';
 import { Badge, EDGE_LABELS, Icon, NODE_LABELS, modelLabel } from '../components/ui';
 import { ModelPicker } from '../components/ModelPicker';
 import { confirm } from '../components/feedback';
@@ -379,13 +380,9 @@ export function WritingWorkshopView({
           value={brief.language ?? 'es'}
           onChange={(e) => setBrief((current) => ({ ...current, language: e.target.value as WritingWorkshopBrief['language'] }))}
         >
-          <option value="es">Español</option>
-          <option value="en">English</option>
-          <option value="fr">Français</option>
-          <option value="de">Deutsch</option>
-          <option value="pt">Português (Portugal)</option>
-          <option value="pt-BR">Português (Brasil)</option>
-          <option value="tr">Türkçe</option>
+          {PROMPT_LANGUAGE_OPTIONS.map((option) => (
+            <option key={option.id} value={option.id}>{option.label}</option>
+          ))}
         </select>
         <ModelPicker settings={settings} value={selectedModel} onChange={setSelectedModel} compact menu />
         <div className="flex-1" />


### PR DESCRIPTION
Closes #728

### Problem

The Writing Workshop language dropdown was spelled out by hand and offered only seven of the eight supported prompt languages, omitting **Italiano**. Italian drafts were reachable over MCP but not from the app. This is the same drift fixed for the Deep Research and database research pickers in #727; the workshop picker was left out of that scope.

### Change

- Render the Writing Workshop selector from the shared `PROMPT_LANGUAGE_OPTIONS` (`shared/promptLanguageOptions.ts`) instead of a hand-written `<option>` list, matching the other composers. This adds Italian and keeps the picker tied to the single source of truth `PROMPT_LANGUAGES`.
- Add `scripts/test-prompt-language-pickers.mjs`: a contract test that `PROMPT_LANGUAGE_OPTIONS` covers exactly `PROMPT_LANGUAGES` (Italian included) and that every composer picker renders the shared list rather than a hand-written one.

### Checks run

- `npm run lint`
- `npm run typecheck`
- `node --test scripts/test-prompt-language-pickers.mjs`
- `node --test scripts/test-i18n-coverage.mjs`

No migrations, no network access, no privacy impact. UI-only change (the dropdown gains one option).