### PR TITLE
Fix Research Assistant citation previews and reading flow

### DIFF
--- a/scripts/test-chat-typing-indicator.mjs
+++ b/scripts/test-chat-typing-indicator.mjs
@@ -25,3 +25,21 @@ test('Nodi and the research assistant share the Zotero-style waiting indicator',
   assert.match(assistant, /message\.id === streamingId \? \(\s*<ChatTypingIndicator/);
   assert.doesNotMatch(nodi, /escribiendo…<\/span>/);
 });
+
+test('the research assistant holds the start of a streaming answer like Nodi', async () => {
+  const assistant = await read('src/views/ResearchAssistantModal.tsx');
+  const generate = assistant.slice(
+    assistant.indexOf('const generate = async'),
+    assistant.indexOf('const send = async'),
+  );
+
+  assert.equal(
+    (generate.match(/scrollToBottom\('auto'\)/g) ?? []).length,
+    1,
+    'a new turn scrolls into view once, before streaming begins',
+  );
+  assert.match(generate, /setStreamingId\(assistantId\)[\s\S]*?setTimeout\(\(\) => scrollToBottom\('auto'\), 0\)[\s\S]*?researchChatStream/);
+  assert.doesNotMatch(generate, /onDelta:[\s\S]*?scrollToBottom/, 'stream deltas never chase the bottom');
+  assert.doesNotMatch(assistant, /stickToBottomRef/, 'there is no latent stream-following mode');
+  assert.match(generate, /onDelta:[\s\S]*?setTimeout\(updateJumpIndicator, 0\)/, 'growth still exposes the manual jump-to-bottom control');
+});

--- a/scripts/test-citation-preview.mjs
+++ b/scripts/test-citation-preview.mjs
@@ -5,7 +5,7 @@
 // rules the hover-card relies on to never render a blank or overflowing card.
 import assert from 'node:assert/strict';
 import { build } from 'esbuild';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -76,6 +76,22 @@ try {
   assert.equal(capped.snippet.length, CITATION_PREVIEW_SNIPPET_MAX);
   assert.ok(capped.title.endsWith('…') && capped.subtitle.endsWith('…') && capped.snippet.endsWith('…'));
   assert.equal(capped.kind, 'contradiction');
+
+  // The card lives inside `.citation-group`, whose nowrap keeps a citation pill
+  // together. Both renderers must explicitly reset that inherited value or long
+  // preview prose spills out of the bounded card (the overlay has its own CSS).
+  for (const stylesheet of ['src/index.css', 'src/components/nodi/companion.css']) {
+    const css = await readFile(path.join(repoRoot, stylesheet), 'utf8');
+    const selector = stylesheet.endsWith('index.css')
+      ? '.citation-card {'
+      : '.nodi-companion .citation-card {';
+    const start = css.indexOf(selector);
+    assert.ok(start >= 0, `${stylesheet} defines the citation hover-card`);
+    const rule = css.slice(start, css.indexOf('}', start) + 1);
+    assert.match(rule, /white-space:\s*normal/, `${stylesheet} lets preview prose wrap`);
+    assert.match(rule, /overflow-wrap:\s*anywhere/, `${stylesheet} contains long unbroken text`);
+    assert.match(rule, /max-width:\s*min\([^;]*100vw/, `${stylesheet} keeps the card inside narrow windows`);
+  }
 
   console.log('test-citation-preview: OK');
 } finally {

--- a/src/components/nodi/companion.css
+++ b/src/components/nodi/companion.css
@@ -1051,7 +1051,8 @@
   flex-direction: column;
   gap: 3px;
   width: max-content;
-  max-width: 300px;
+  max-width: min(300px, calc(100vw - 24px));
+  box-sizing: border-box;
   padding: 8px 10px;
   border-radius: 10px;
   border: 0.5px solid rgba(212, 175, 55, 0.35);
@@ -1060,6 +1061,10 @@
   pointer-events: none;
   font-size: 12px;
   line-height: 1.35;
+  /* The enclosing citation group deliberately uses nowrap for the pill. The
+     preview must opt out or its prose overflows the fixed-width card. */
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: #cbd3df;
   animation: nodi-panel-pop 0.14s ease-out;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4297,7 +4297,8 @@ body:has(.library-document-reader [data-testid="library-reader-sidebar"]) .app-t
   flex-direction: column;
   gap: 3px;
   width: max-content;
-  max-width: 320px;
+  max-width: min(320px, calc(100vw - 24px));
+  box-sizing: border-box;
   padding: 8px 10px;
   border-radius: 8px;
   border: 1px solid rgb(64 64 64);
@@ -4306,6 +4307,11 @@ body:has(.library-document-reader [data-testid="library-reader-sidebar"]) .app-t
   pointer-events: none;
   font-size: 12px;
   line-height: 1.35;
+  /* Citation groups stay on one line, but the preview is nested inside that
+     group. Reset the inherited value so long titles and snippets wrap inside
+     the card instead of painting beyond its background. */
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: rgb(212 212 212);
   animation: fade-in 0.12s ease-out;
 }

--- a/src/views/ResearchAssistantModal.tsx
+++ b/src/views/ResearchAssistantModal.tsx
@@ -241,9 +241,6 @@ export function ResearchAssistantModal({
   const contextTriggerRef = useRef<HTMLButtonElement>(null);
   const focusTriggerRef = useRef<HTMLButtonElement>(null);
   const contextPanelRef = useRef<HTMLDivElement>(null);
-  // Whether new stream deltas should keep the view pinned to the bottom. Starts
-  // true on send and flips off as soon as the user scrolls up to read back.
-  const stickToBottomRef = useRef(true);
   const lastInitialTargetRef = useRef<number | null>(null);
   // Mirrors `messages` so async stream callbacks can persist the final array without
   // racing React state updates.
@@ -355,10 +352,6 @@ export function ResearchAssistantModal({
     const el = scrollRef.current;
     if (!el) return;
     const onScroll = () => {
-      // The user driving the scrollbar decides whether we keep following the
-      // stream: reading back (scrolling up) releases the pin; returning to the
-      // bottom re-engages it.
-      stickToBottomRef.current = isNearBottom();
       updateJumpIndicator();
     };
     el.addEventListener('scroll', onScroll, { passive: true });
@@ -500,7 +493,10 @@ export function ResearchAssistantModal({
     setMessages([...priorMessages, userMessage, { id: assistantId, role: 'assistant', content: '', selectionKey }]);
     setSending(true);
     setStreamingId(assistantId);
-    stickToBottomRef.current = true;
+    // Reveal the question and the beginning of the answer once. Streaming
+    // deltas must not chase the bottom: keeping this position stable lets the
+    // user read from the start and scroll through the reply at their own pace,
+    // matching Nodi's chat behaviour.
     window.setTimeout(() => scrollToBottom('auto'), 0);
 
     try {
@@ -514,8 +510,7 @@ export function ResearchAssistantModal({
                 message.id === assistantId ? { ...message, content: message.content + delta } : message
               )
             );
-            if (stickToBottomRef.current) scrollToBottom('auto');
-            else window.setTimeout(updateJumpIndicator, 0);
+            window.setTimeout(updateJumpIndicator, 0);
           },
           onReasoning: (delta) => {
             if (activeIdRef.current !== conversationId) return;


### PR DESCRIPTION
## Summary

- wrap citation preview content inside viewport-safe cards in the main Research Assistant and Nodi companion
- stop following every streaming delta so the Research Assistant holds the beginning of a new answer in view, matching Nodi
- retain the explicit jump-to-bottom control and add regression coverage for both behaviors

## Testing

- `node --test scripts/test-chat-typing-indicator.mjs`
- `node scripts/test-citation-preview.mjs`
- `npm run typecheck`

Closes #733