### PR TITLE
fix(assistant): render the Assistant context picker with the light theme

### DIFF
--- a/src/views/researchAssistant.css
+++ b/src/views/researchAssistant.css
@@ -61,3 +61,12 @@
   font-size: 12px;
   line-height: 1.5;
 }
+
+/* The picker portals to <body>, so its own dark surface survives the light
+   theme unless it is overridden here, exactly like the Skills balloon. */
+:is(.light, .nodi-theme-light) .research-context-panel {
+  background: #fff;
+  border-color: color-mix(in srgb, var(--vault-accent, #6366f1) 55%, white);
+  box-shadow: 0 24px 80px #27272a26;
+  color: #27272a;
+}


### PR DESCRIPTION
## Summary

The **Assistant context** balloon of the Research assistant kept its hardcoded dark surface (`#18191f` background, `#e4e4e7` text) while the app was in the light theme. The panel is portaled to `<body>`, so the dark surface declared by `.research-context-panel` in `src/views/researchAssistant.css` never received the `.light` override that the sibling Skills balloon gets in `src/components/chatSkills.css`.

This adds the missing override with the same treatment as `.chat-skills-panel`: white surface, dark text, softer shadow and an accent-tinted border. Dark theme is untouched because the rule is scoped to `:is(.light, .nodi-theme-light)`.

## Related issue

Closes #738

## Type of change

- [x] Bug fix

## Validation

- `npm run build` (includes `npm run typecheck`) — passes.
- `npm run lint` — passes.
- Real app verification on a throwaway `NODUS_USERDATA` with the seeded demo corpus and light theme: opened the Research assistant and the context picker and asserted the panel's computed style. Before the fix: `background: rgb(24, 25, 31)`, text `rgb(228, 228, 231)`. After: `background: rgb(255, 255, 255)`, text `rgb(39, 39, 42)`, with `<html class="light">`.
- Before/after captured through the same build pipeline and profile seed; only the CSS override differs.
- No unit or e2e test renders CSS theming, so no focused test was added.

## Screenshots

| Before | After |
| --- | --- |
| ![Assistant context before the fix](https://raw.githubusercontent.com/Drakonis96/nodus/screenshots-assistant-context-light/assistant-context-light-before.png) | ![Assistant context after the fix](https://raw.githubusercontent.com/Drakonis96/nodus/screenshots-assistant-context-light/assistant-context-light-after.png) |

The captures live on the `screenshots-assistant-context-light` branch so they stay out of the diff; that branch can be deleted after merging.

## Privacy and data review

- [x] No secrets, credentials, private vault content, personal data, student data, or confidential documents are included. Captures and fixtures use the seeded demo corpus on a throwaway profile.
- [x] The change does not send rosters, grades, student answers, or other protected data to AI providers.
- [x] The change does not use AI to grade, rank, profile, or evaluate students.
- [x] Database, backup, synchronization, and migration effects are documented and tested. Not applicable: the change is CSS only.
- [x] New network access is explicit, documented, and initiated by the user. Not applicable: no network access is added.

## Contributor checklist

- [x] I have read [CLA.md](https://github.com/Drakonis96/nodus/blob/main/CLA.md) and accepted it through the **CLA / signature** check. Every author and coauthor must accept separately; this checkbox alone is not acceptance.
- [ ] I added or updated focused tests. The repository has no CSS-rendering test harness; the manual computed-style assertions are described above.
- [ ] I updated documentation where behavior changed. No documented behavior changes; visual-only fix.
- [ ] I updated every language table for new static UI text. No UI text was added.
- [x] I preserved local-first behavior and existing privacy boundaries.
- [x] I have read and followed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
