### PR TITLE
Pin Chemistry Studio 2.0.1

### DIFF
--- a/.github/marketplace-ref
+++ b/.github/marketplace-ref
@@ -1,1 +1,0 @@
-feature/capability-api-v2-plugins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,25 @@ jobs:
       # the marketplace's default branch, which is what a released Nodus installs from. So
       # a paired change that merges here before it merges there fails on main, loudly,
       # instead of being carried by a pairing nobody remembered to remove.
+      # A pairing outlives its purpose silently. `.github/marketplace-ref` reached main with
+      # the change it was paired to, and every pull request afterwards was checked against a
+      # marketplace branch frozen at that moment — still comparing, still green, no longer
+      # meaning anything. It surfaced only because a bootstrap pinned a version that branch
+      # had never heard of, and it read as a version mismatch rather than as a stale pairing.
+      #
+      # The rule that prevents it is the one the file already implies: a pairing is for the
+      # pull request that needs it, so it must be gone before that pull request merges.
+      - name: A pairing never reaches main
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          if [ -f .github/marketplace-ref ]; then
+            echo ".github/marketplace-ref is a pull-request-only pairing and is still here on $GITHUB_REF_NAME." >&2
+            echo "Delete it in the pull request that paired the two repositories; until then every" >&2
+            echo "later pull request is checked against a marketplace branch that has stopped moving." >&2
+            exit 1
+          fi
+
       - name: Use the paired marketplace branch on a pull request
         if: github.event_name == 'pull_request'
         working-directory: .marketplace

--- a/electron/capabilities/bootstrap.json
+++ b/electron/capabilities/bootstrap.json
@@ -3,32 +3,14 @@
   "packages": [
     {
       "id": "chemistry-studio",
-      "version": "2.0.0",
-      "releaseUrl": "https://github.com/NodusResearch/nodus-research-skill-marketplace/releases/download/chemistry-studio-v2.0.0",
+      "version": "2.0.1",
+      "releaseUrl": "https://github.com/NodusResearch/nodus-research-skill-marketplace/releases/download/chemistry-studio-v2.0.1",
       "assets": [
         {
-          "target": "darwin-arm64",
-          "asset": "chemistry-studio-2.0.0-darwin-arm64.nodus-plugin",
-          "bytes": 21412815,
-          "sha256": "48be65a8b258e14ceccbbcc4649f79effb53412107a5e2d80459ca4581ab3ede"
-        },
-        {
-          "target": "darwin-x64",
-          "asset": "chemistry-studio-2.0.0-darwin-x64.nodus-plugin",
-          "bytes": 21412815,
-          "sha256": "48be65a8b258e14ceccbbcc4649f79effb53412107a5e2d80459ca4581ab3ede"
-        },
-        {
-          "target": "linux-x64",
-          "asset": "chemistry-studio-2.0.0-linux-x64.nodus-plugin",
-          "bytes": 21412235,
-          "sha256": "16d1463fc090da247eaabd890338ebf0b686325974132696b634185655d56c20"
-        },
-        {
-          "target": "win32-x64",
-          "asset": "chemistry-studio-2.0.0-win32-x64.nodus-plugin",
-          "bytes": 21412815,
-          "sha256": "14e069214f000e9106ede5c2632866ca46fa0125f27f7caf49ba6749f51c1514"
+          "target": "any",
+          "asset": "chemistry-studio-2.0.1-any.nodus-plugin",
+          "bytes": 21412941,
+          "sha256": "a0f4836cfd4de4fdbf55ac50f115d1a2789272053fc4c295835ef75e5c9765f8"
         }
       ]
     },


### PR DESCRIPTION
2.0.0 shipped three MIT libraries on Linux without their required licence text, and published byte-identical code under four targets. 2.0.1 fixes both.

The pin is one `any` asset where it was four, read from the signed manifest after its signature verified against this application's trust store. Verified: `NODUS_REQUIRE_BOOTSTRAP=1` fetched and digest-matched it, cross-repo agrees on the version, and the 5.3.1 migration runs from it offline.

The published digest is the one this machine produced before the PR was opened — CI built on Ubuntu, this was macOS.