### PR TITLE
Make browser bookmark cards compact and resolve favicons

### DIFF
--- a/electron/browser/favicon.ts
+++ b/electron/browser/favicon.ts
@@ -5,6 +5,7 @@ import { browserSession } from './session';
 import { sanitizeFaviconDataUrl, sanitizeBookmarkUrl } from '@shared/browserBookmarks';
 
 const MAX_FAVICON_BYTES = 64 * 1024;
+const MAX_FAVICON_DOCUMENT_BYTES = 256 * 1024;
 const MAX_CACHE_ENTRIES = 256;
 const TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/x-icon', 'image/vnd.microsoft.icon']);
 const cache = new Map<string, Promise<string | null>>();
@@ -37,6 +38,79 @@ async function boundedBody(response: Response): Promise<Buffer | null> {
   return Buffer.concat(chunks, bytes);
 }
 
+async function boundedPrefix(response: Response, maxBytes: number): Promise<Buffer | null> {
+  const reader = (response.body as unknown as { getReader?: () => Reader } | null)?.getReader?.();
+  if (!reader) return null;
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  try {
+    while (bytes < maxBytes) {
+      const part = await reader.read();
+      if (part.done) break;
+      const chunk = Buffer.from(part.value ?? []);
+      const remaining = maxBytes - bytes;
+      chunks.push(chunk.subarray(0, remaining));
+      bytes += Math.min(chunk.length, remaining);
+      if (chunk.length > remaining || bytes === maxBytes) await reader.cancel();
+    }
+  } catch {
+    return null;
+  }
+  return Buffer.concat(chunks, bytes);
+}
+
+function decodeHtmlAttribute(value: string): string {
+  return value.replace(/&(?:amp|quot|apos|lt|gt|#(\d+)|#x([\da-f]+));/gi, (entity, decimal, hexadecimal) => {
+    if (decimal) return String.fromCodePoint(Number(decimal));
+    if (hexadecimal) return String.fromCodePoint(Number.parseInt(hexadecimal, 16));
+    return ({ '&amp;': '&', '&quot;': '"', '&apos;': "'", '&lt;': '<', '&gt;': '>' } as Record<string, string>)[entity.toLowerCase()] ?? entity;
+  });
+}
+
+function linkAttribute(tag: string, name: string): string {
+  const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i'));
+  return decodeHtmlAttribute(match?.[1] ?? match?.[2] ?? match?.[3] ?? '');
+}
+
+async function discoverFaviconUrls(pageUrl: string): Promise<string[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 4_000);
+  try {
+    const response = await browserSession().fetch(pageUrl, {
+      signal: controller.signal,
+      credentials: 'omit',
+      redirect: 'follow',
+      headers: { accept: 'text/html,application/xhtml+xml' },
+    });
+    const finalUrl = sanitizeBookmarkUrl(response.url);
+    const type = String(response.headers.get('content-type') ?? '').split(';', 1)[0].trim().toLowerCase();
+    if (!response.ok || !finalUrl || (type !== 'text/html' && type !== 'application/xhtml+xml')) return [];
+    const body = await boundedPrefix(response, MAX_FAVICON_DOCUMENT_BYTES);
+    if (!body?.length) return [];
+    const candidates: string[] = [];
+    for (const match of body.toString('utf8').matchAll(/<link\b[^>]*>/gi)) {
+      const tag = match[0];
+      const rel = linkAttribute(tag, 'rel').toLowerCase().split(/\s+/);
+      if (!rel.some((value) => value === 'icon' || value === 'apple-touch-icon')) continue;
+      const href = linkAttribute(tag, 'href');
+      if (!href) continue;
+      try {
+        const resolved = new URL(href, finalUrl).href;
+        const declaredType = linkAttribute(tag, 'type').toLowerCase();
+        // SVG is intentionally not embedded as a data URL in the trusted app
+        // renderer; keep looking for a raster alternative from the same site.
+        if (declaredType === 'image/svg+xml' || new URL(resolved).pathname.toLowerCase().endsWith('.svg')) continue;
+        if (sanitizeBookmarkUrl(resolved)) candidates.push(resolved);
+      } catch { /* Ignore malformed link elements from remote pages. */ }
+    }
+    return candidates;
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function fetchOne(url: string): Promise<string | null> {
   const safe = sanitizeBookmarkUrl(url);
   if (!safe) return null;
@@ -64,8 +138,8 @@ async function fetchOne(url: string): Promise<string | null> {
 /** Fetch at most four Chromium-discovered candidates, cached and size-limited. */
 export function cachePageFavicon(urls: string[]): Promise<string | null> {
   const candidates = [...new Set(urls.map(String).filter((url) => sanitizeBookmarkUrl(url)))].slice(0, 4);
-  const key = candidates.join('\n');
-  if (!key) return Promise.resolve(null);
+  if (!candidates.length) return Promise.resolve(null);
+  const key = `icons:${candidates.join('\n')}`;
   const existing = cache.get(key);
   if (existing) return existing;
   const pending = (async () => {
@@ -74,6 +148,29 @@ export function cachePageFavicon(urls: string[]): Promise<string | null> {
       if (data) return data;
     }
     return null;
+  })();
+  cache.set(key, pending);
+  if (cache.size > MAX_CACHE_ENTRIES) cache.delete(cache.keys().next().value ?? '');
+  return pending;
+}
+
+/** Resolve a bookmark icon even when it was imported or saved before Chromium reported one. */
+export function cacheWebsiteFavicon(pageUrl: string): Promise<string | null> {
+  const safe = sanitizeBookmarkUrl(pageUrl);
+  if (!safe) return Promise.resolve(null);
+  const origin = new URL(safe).origin;
+  const key = `website:${origin}`;
+  const existing = cache.get(key);
+  if (existing) return existing;
+  const pending = (async () => {
+    const discovered = await discoverFaviconUrls(safe);
+    const linked = await cachePageFavicon(discovered);
+    if (linked) return linked;
+    return cachePageFavicon([
+      new URL('/favicon.ico', origin).href,
+      new URL('/favicon.png', origin).href,
+      new URL('/apple-touch-icon.png', origin).href,
+    ]);
   })();
   cache.set(key, pending);
   if (cache.size > MAX_CACHE_ENTRIES) cache.delete(cache.keys().next().value ?? '');

--- a/electron/ipc/browser.ts
+++ b/electron/ipc/browser.ts
@@ -65,6 +65,7 @@ import {
 import { destroyBrowserSubsystem, restartBrowserSubsystem } from '../browser/lifecycle';
 import { addGlobalLibraryAttachments, createGlobalLibraryItem } from '../library/libraryService';
 import { clearAllBrowserData, clearBrowserData, measureBrowserStorage } from '../browser/storage';
+import { cacheWebsiteFavicon } from '../browser/favicon';
 import { setNodiQuoteSelection, setNodiViewContext } from '../ai/nodiChat';
 import { localizeIpcPayload } from '@shared/uiLanguage';
 import { getSettings } from '../db/settingsRepo';
@@ -182,6 +183,41 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     window.webContents.send('browser:bookmarks', store);
   };
   bookmarks.setNotifier(broadcastBookmarks);
+
+  // Favicon discovery is deliberately bounded and queued: opening a folder may
+  // expose many imported bookmarks at once, but should never create a request
+  // burst or block rendering the local bookmarks page.
+  const faviconQueue: string[] = [];
+  const queuedFavicons = new Set<string>();
+  let activeFaviconJobs = 0;
+  const pumpFaviconQueue = () => {
+    while (activeFaviconJobs < 4) {
+      const id = faviconQueue.shift();
+      if (!id) return;
+      activeFaviconJobs += 1;
+      void (async () => {
+        const bookmark = bookmarks.snapshot().bookmarks.find((entry) => entry.id === id);
+        if (!bookmark || bookmark.faviconDataUrl) return;
+        const faviconDataUrl = await cacheWebsiteFavicon(bookmark.url);
+        if (!faviconDataUrl) return;
+        const current = bookmarks.snapshot().bookmarks.find((entry) => entry.id === id);
+        if (!current || current.faviconDataUrl || current.url !== bookmark.url) return;
+        await bookmarks.editBookmark(id, { faviconDataUrl });
+      })().catch(() => undefined).finally(() => {
+        activeFaviconJobs -= 1;
+        queuedFavicons.delete(id);
+        pumpFaviconQueue();
+      });
+    }
+  };
+  const enqueueFavicons = (ids: string[]) => {
+    for (const id of ids) {
+      if (queuedFavicons.has(id)) continue;
+      queuedFavicons.add(id);
+      faviconQueue.push(id);
+    }
+    pumpFaviconQueue();
+  };
 
   const history = browserHistoryRepository();
   const broadcastHistory = (store: BrowserHistoryStore) => {
@@ -681,6 +717,13 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
     return bookmarks.snapshot();
   });
 
+  h('browser:bookmarks:resolveFavicons', async (event, rawIds: unknown) => {
+    assertUiSender(event, getWindow);
+    if (!Array.isArray(rawIds)) return;
+    const ids = [...new Set(rawIds.filter((id): id is string => typeof id === 'string' && id.length > 0 && id.length <= 100))].slice(0, 500);
+    enqueueFavicons(ids);
+  });
+
   h('browser:bookmarks:candidate', async (event) => {
     assertUiSender(event, getWindow);
     const tab = activeTabSummary();
@@ -698,13 +741,18 @@ export function registerBrowserIpc({ h, getWindow }: IpcContext): void {
   h('browser:bookmarks:create', async (event, raw: unknown) => {
     assertUiSender(event, getWindow);
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('El marcador no es válido.');
-    return bookmarks.createBookmark(raw as BrowserBookmarkDraft);
+    const result = await bookmarks.createBookmark(raw as BrowserBookmarkDraft);
+    if (!result.bookmark.faviconDataUrl) enqueueFavicons([result.bookmark.id]);
+    return result;
   });
 
   h('browser:bookmarks:update', async (event, id: string, raw: unknown) => {
     assertUiSender(event, getWindow);
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('Los cambios del marcador no son válidos.');
-    return bookmarks.editBookmark(String(id), raw as Partial<BrowserBookmarkDraft>);
+    const store = await bookmarks.editBookmark(String(id), raw as Partial<BrowserBookmarkDraft>);
+    const bookmark = store.bookmarks.find((entry) => entry.id === String(id));
+    if (bookmark && !bookmark.faviconDataUrl) enqueueFavicons([bookmark.id]);
+    return store;
   });
 
   h('browser:bookmarks:createFolder', async (event, raw: unknown) => {

--- a/electron/preload/browser.ts
+++ b/electron/preload/browser.ts
@@ -148,6 +148,8 @@ export const browserApi = {
     ipcRenderer.invoke('browser:clearData', categories, origins ?? null),
   clearAllBrowserData: (): Promise<BrowserStorageReport> => ipcRenderer.invoke('browser:clearAllData'),
   getBrowserBookmarks: (): Promise<BrowserBookmarkStore> => ipcRenderer.invoke('browser:bookmarks:get'),
+  resolveBrowserBookmarkFavicons: (ids: string[]): Promise<void> =>
+    ipcRenderer.invoke('browser:bookmarks:resolveFavicons', ids).then(() => undefined),
   getCurrentBrowserBookmarkCandidate: (): Promise<BrowserBookmarkCandidate | null> =>
     ipcRenderer.invoke('browser:bookmarks:candidate'),
   createBrowserBookmark: (draft: BrowserBookmarkDraft): Promise<{ store: BrowserBookmarkStore; bookmark: BrowserBookmark; duplicate: boolean }> =>

--- a/scripts/test-browser-bookmarks.mjs
+++ b/scripts/test-browser-bookmarks.mjs
@@ -143,6 +143,7 @@ test('trusted Bookmarks UI reuses Atlas styling and avoids native prompt dialogs
   const pages = readFileSync(path.join(repoRoot, 'src/components/browser/NodusStartPages.tsx'), 'utf8');
   const manager = readFileSync(path.join(repoRoot, 'src/components/browser/BrowserBookmarksManager.tsx'), 'utf8');
   const browserView = readFileSync(path.join(repoRoot, 'src/views/NodusBrowserView.tsx'), 'utf8');
+  const ipc = readFileSync(path.join(repoRoot, 'electron/ipc/browser.ts'), 'utf8');
   assert.match(styles, /@import url\([^)]*research-atlas\.css/);
   assert.match(pages, /site\/assets\/js\/organism\.js/,
     'the local start pages must load the exact Nodus Research organism engine');
@@ -168,6 +169,17 @@ test('trusted Bookmarks UI reuses Atlas styling and avoids native prompt dialogs
     'bookmark rows must not stretch short cards to match taller neighbours');
   assert.match(styles, /\.bookmarks-main \.atlas-card\s*\{\s*min-height:0;\s*padding:20px/,
     'bookmark cards must override the Atlas minimum height and excess padding');
+  assert.match(styles, /\.bookmarks-main \.bookmark-card\s*\{\s*height:171px/,
+    'website and folder cards must keep the same compact desktop height');
+  assert.match(styles, /\.bookmark-card \.atlas-description[\s\S]{0,180}text-overflow:ellipsis/,
+    'long bookmark copy must truncate instead of making one card taller');
+  assert.match(pages, /resolveBrowserBookmarkFavicons\(missingFaviconKey\.split\('\\n'\)\)/,
+    'visible bookmarks must ask the trusted browser process to fill missing favicons');
+  assert.match(ipc, /browser:bookmarks:resolveFavicons/);
+  const favicon = readFileSync(path.join(repoRoot, 'electron/browser/favicon.ts'), 'utf8');
+  assert.match(favicon, /discoverFaviconUrls/);
+  assert.match(favicon, /new URL\('\/favicon\.ico', origin\)/,
+    'favicon discovery must retain the conventional site icon fallback');
   assert.match(pages, /className="card lit atlas-card bookmark-card"[\s\S]{0,260}openBrowserTab\(entry\.url\)/,
     'clicking a website card must open its bookmark');
   assert.match(pages, /className=\{`card lit atlas-card bookmark-card[\s\S]{0,300}setFolderId\(entry\.id\)/,
@@ -184,7 +196,6 @@ test('trusted Bookmarks UI reuses Atlas styling and avoids native prompt dialogs
     'Atlas and Bookmarks must render inside the same Nodus Research site shell');
   assert.match(pages, /navigateBrowserStartPage\('atlas'\)/);
   assert.match(pages, /navigateBrowserStartPage\('bookmarks'\)/);
-  const ipc = readFileSync(path.join(repoRoot, 'electron/ipc/browser.ts'), 'utf8');
   const localNavigation = ipc.indexOf("h('browser:navigateStartPage'");
   assert.ok(localNavigation >= 0);
   assert.match(ipc.slice(localNavigation, localNavigation + 550), /assertUiSender\(event, getWindow\)/);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -8753,6 +8753,7 @@ export interface BrowserApi {
   clearAllBrowserData(): Promise<import('./browser').BrowserStorageReport>;
   /** Global Nodus data. Never exposed to the untrusted Browser-page preload. */
   getBrowserBookmarks(): Promise<import('./browserBookmarks').BrowserBookmarkStore>;
+  resolveBrowserBookmarkFavicons(ids: string[]): Promise<void>;
   getCurrentBrowserBookmarkCandidate(): Promise<import('./browserBookmarks').BrowserBookmarkCandidate | null>;
   createBrowserBookmark(draft: import('./browserBookmarks').BrowserBookmarkDraft): Promise<{
     store: import('./browserBookmarks').BrowserBookmarkStore;

--- a/src/components/browser/BrowserBookmarkModal.tsx
+++ b/src/components/browser/BrowserBookmarkModal.tsx
@@ -48,7 +48,13 @@ export function BrowserBookmarkModal({ target, store, onClose, onSaved }: {
     setBusy(true); setError('');
     try {
       if (target.mode === 'edit') {
-        const next = await window.nodus.updateBrowserBookmark(target.bookmark.id, { title, url, description, parentId });
+        const next = await window.nodus.updateBrowserBookmark(target.bookmark.id, {
+          title,
+          url,
+          description,
+          parentId,
+          faviconDataUrl: url === target.bookmark.url ? target.bookmark.faviconDataUrl : null,
+        });
         onSaved(next, false);
       } else {
         const result = await window.nodus.createBrowserBookmark({ title, url, description, parentId, faviconDataUrl: target.candidate.faviconDataUrl });

--- a/src/components/browser/BrowserBookmarksManager.tsx
+++ b/src/components/browser/BrowserBookmarksManager.tsx
@@ -26,6 +26,10 @@ export function BrowserBookmarksManager({ store, onClose, onEdit, onCreate, onNo
   }, [busy, onClose]);
 
   const visibleIds = useMemo(() => new Set(searchBrowserBookmarks(store, query).map((hit) => hit.bookmark.id)), [query, store]);
+  const missingFaviconKey = store.bookmarks.filter((bookmark) => !bookmark.faviconDataUrl).map((bookmark) => bookmark.id).join('\n');
+  useEffect(() => {
+    if (missingFaviconKey) void window.nodus.resolveBrowserBookmarkFavicons(missingFaviconKey.split('\n'));
+  }, [missingFaviconKey]);
   const saveFolder = async () => {
     if (!folderEditor?.name.trim()) return;
     setBusy(true);

--- a/src/components/browser/NodusBookmarks.css
+++ b/src/components/browser/NodusBookmarks.css
@@ -99,13 +99,23 @@
 .nodus-start-page .atlas-card-actions .is-saved { color:#fbbf24; border-color:rgba(251,191,36,.3); }
 .nodus-start-page.bookmarks-main .atlas-grid { align-items:start; }
 .nodus-start-page.bookmarks-main .atlas-card { min-height:0; padding:20px; }
-.nodus-start-page.bookmarks-main .bookmark-card { cursor:pointer; }
+.nodus-start-page.bookmarks-main .bookmark-card { height:171px; cursor:pointer; }
 .nodus-start-page.bookmarks-main .atlas-card-actions { margin-top:14px; }
 .nodus-start-page.bookmarks-main .bookmark-delete { color:#fca5a5; border-color:rgba(248,113,113,.2); }
 .nodus-start-page.bookmarks-main .bookmark-delete:hover { color:#fecaca; border-color:rgba(248,113,113,.45); background:rgba(127,29,29,.2); }
 .nodus-start-page .bookmark-favicon { width:22px; height:22px; object-fit:contain; border-radius:5px; }
 .nodus-start-page .bookmark-folder-icon { display:grid; place-items:center; width:36px; height:36px; border:1px solid rgba(167,139,250,.25); border-radius:11px; background:rgba(139,92,246,.12); color:var(--violet-3); }
-.nodus-start-page .bookmark-heading { display:flex; align-items:center; gap:11px; min-width:0; }
+.nodus-start-page .bookmark-favicon,
+.nodus-start-page .bookmark-folder-icon,
+.nodus-start-page .bookmark-heading > svg { flex:0 0 auto; }
+.nodus-start-page .bookmark-heading { display:flex; flex:1 1 auto; align-items:center; gap:11px; min-width:0; }
+.nodus-start-page .bookmark-heading h2 { min-width:0; }
+.nodus-start-page .bookmark-heading h2 button,
+.nodus-start-page.bookmarks-main .bookmark-card .atlas-geo,
+.nodus-start-page.bookmarks-main .bookmark-card .atlas-description {
+  display:block; overflow:hidden; width:100%; white-space:nowrap; text-overflow:ellipsis;
+}
+.nodus-start-page .bookmark-heading h2 button { border:0; padding:0; background:transparent; color:inherit; text-align:left; cursor:pointer; }
 .nodus-start-page .bookmark-breadcrumbs { display:flex; justify-content:center; align-items:center; flex-wrap:wrap; gap:5px; margin-top:16px; color:var(--ink-3); font:600 11px/1 var(--mono); }
 .nodus-start-page .bookmark-breadcrumbs button { border:0; background:transparent; color:inherit; cursor:pointer; }
 .nodus-start-page .bookmark-breadcrumbs button:hover { color:var(--violet-3); }
@@ -138,6 +148,7 @@
 @media (max-width:560px) {
   .nodus-start-page .nodus-site-foot-grid { grid-template-columns:1fr; }
   .nodus-start-page .nodus-site-foot-brand { grid-column:auto; }
+  .nodus-start-page.bookmarks-main .bookmark-card { height:auto; min-height:171px; }
 }
 @media (max-width:760px) {
   .nodus-start-page .atlas-searchbar.is-bookmarks { grid-template-columns:minmax(0,1fr) 46px; }

--- a/src/components/browser/NodusStartPages.tsx
+++ b/src/components/browser/NodusStartPages.tsx
@@ -244,6 +244,10 @@ export function NodusBookmarksPage({ store, onEditBookmark, onNewBookmark, onNew
   const bookmarks = query
     ? results.map((entry) => entry.bookmark)
     : childRefs.filter((ref) => ref.kind === 'bookmark').map((ref) => store.bookmarks.find((entry) => entry.id === ref.id)!).filter(Boolean);
+  const missingFaviconKey = bookmarks.filter((entry) => !entry.faviconDataUrl).map((entry) => entry.id).join('\n');
+  useEffect(() => {
+    if (missingFaviconKey) void window.nodus.resolveBrowserBookmarkFavicons(missingFaviconKey.split('\n'));
+  }, [missingFaviconKey]);
   const pathFolders = useMemo(() => {
     const entries = [];
     let cursor = folder;
@@ -302,7 +306,7 @@ export function NodusBookmarksPage({ store, onEditBookmark, onNewBookmark, onNew
           onDragLeave={() => setDropId(null)}
           onDrop={(event) => { event.preventDefault(); void move(entry.id); }}
         >
-          <div className="bookmark-heading"><span className="bookmark-folder-icon"><Icon name="folder" size={19} /></span><h2><button type="button" onClick={() => setFolderId(entry.id)}>{entry.name}</button></h2></div>
+          <div className="bookmark-heading"><span className="bookmark-folder-icon"><Icon name="folder" size={19} /></span><h2><button type="button" title={entry.name} onClick={() => setFolderId(entry.id)}>{entry.name}</button></h2></div>
           <div className="atlas-geo">Folder · {browserBookmarkChildren(store, entry.id).length} items</div>
           <p className="atlas-description">Open this folder to browse its saved research resources and nested folders.</p>
           <div className="atlas-card-actions"><button className="atlas-open" type="button" onClick={() => setFolderId(entry.id)}>Open folder <Icon name="chevronRight" size={13} /></button><button className="atlas-open bookmark-delete" type="button" data-testid="browser-bookmark-card-delete" onClick={() => setDeleteConfirmation({ ref: { kind: 'folder', id: entry.id }, label: entry.name })}><Icon name="trash" size={13} /> Delete</button></div>
@@ -312,9 +316,9 @@ export function NodusBookmarksPage({ store, onEditBookmark, onNewBookmark, onNew
         const location = browserBookmarkFolderPath(store, entry.parentId);
         return (
           <article key={entry.id} className="card lit atlas-card bookmark-card" draggable onClick={(event) => { if (!(event.target as Element).closest('button')) void window.nodus.openBrowserTab(entry.url); }} onDragStart={() => setDragging({ kind: 'bookmark', id: entry.id })}>
-            <div className="atlas-card-top"><div className="bookmark-heading">{entry.faviconDataUrl ? <img className="bookmark-favicon" src={entry.faviconDataUrl} alt="" /> : <Icon name="globe" size={22} />}<h2><button type="button" onClick={() => void window.nodus.openBrowserTab(entry.url)}>{entry.title}</button></h2></div><span className="atlas-access">Saved</span></div>
-            <div className="atlas-geo">{new URL(entry.url).hostname}{location.length ? ` · ${location.join(' › ')}` : ''}</div>
-            <p className="atlas-description">{entry.description || 'A website saved privately in Nodus Bookmarks.'}</p>
+            <div className="atlas-card-top"><div className="bookmark-heading">{entry.faviconDataUrl ? <img className="bookmark-favicon" src={entry.faviconDataUrl} alt="" /> : <Icon name="globe" size={22} />}<h2><button type="button" title={entry.title} onClick={() => void window.nodus.openBrowserTab(entry.url)}>{entry.title}</button></h2></div><span className="atlas-access">Saved</span></div>
+            <div className="atlas-geo" title={`${new URL(entry.url).hostname}${location.length ? ` · ${location.join(' › ')}` : ''}`}>{new URL(entry.url).hostname}{location.length ? ` · ${location.join(' › ')}` : ''}</div>
+            <p className="atlas-description" title={entry.description || 'A website saved privately in Nodus Bookmarks.'}>{entry.description || 'A website saved privately in Nodus Bookmarks.'}</p>
             <div className="atlas-card-actions">
               <button className="atlas-open" type="button" onClick={() => void window.nodus.openBrowserTab(entry.url)}>Open <Icon name="external" size={13} /></button>
               <button className="atlas-open" type="button" onClick={() => onEditBookmark(entry)}>Edit</button>


### PR DESCRIPTION
## Summary

- keep bookmark and folder cards at a uniform compact desktop height
- truncate long titles, paths, and descriptions while exposing full text through native tooltips
- discover, validate, cache, and persist missing raster favicons in the trusted browser process
- queue favicon resolution with bounded concurrency and preserve the globe fallback
- refresh favicons when an edited bookmark changes URL

## Testing

- `npm run typecheck`
- `node --test scripts/test-browser-bookmarks.mjs`
- `npx eslint electron/browser/favicon.ts electron/ipc/browser.ts electron/preload/browser.ts shared/types.ts src/components/browser/NodusStartPages.tsx src/components/browser/BrowserBookmarksManager.tsx src/components/browser/BrowserBookmarkModal.tsx`

Closes #743