### PR TITLE
A comment in a drawing is not a reason to lose the drawing

### DIFF
--- a/scripts/verify-chat-svg-runtime.mjs
+++ b/scripts/verify-chat-svg-runtime.mjs
@@ -26,6 +26,14 @@ await build({
       const clean = await probe.webContents.executeJavaScript('(' + sanitizeChatSvg.toString() + ')(' + JSON.stringify(hostile) + ')');
       assert.doesNotMatch(clean.svg, /script|foreignObject|onclick|https:|file:|@import/);
       assert.match(clean.svg, /Safe/);
+      // A model writing a divider comment emits two dashes inside it, which XML forbids:
+      // the parser rejected the whole drawing over a decoration that never renders.
+      // Checked in a real parser, because that is the only place the rejection happens.
+      const commented = svg('<!-- ---- section ---- --><text x="10" y="30">Kept</text>');
+      const survived = await probe.webContents.executeJavaScript('(' + sanitizeChatSvg.toString() + ')(' + JSON.stringify(commented) + ')');
+      assert.ok(survived, 'a dashed comment must not take the drawing with it');
+      assert.match(survived.svg, /Kept/);
+      assert.doesNotMatch(survived.svg, /section/, 'and the comment itself is gone');
       probe.destroy();
       // Reproduce Electron's generic "Script failed to execute" rejection. A
       // failed optional layout review must not replace the chat answer with it.

--- a/shared/chatSvg.ts
+++ b/shared/chatSvg.ts
@@ -12,11 +12,19 @@ interface SvgDom {
   XMLSerializer: new () => { serializeToString(document: SvgDocument): string };
 }
 
-/** Static SVG allowlist. Even sanitized SVG is rendered as an image, never live DOM. */
+/** Static SVG allowlist. Even sanitized SVG is rendered as an image, never live DOM.
+ *
+ *  Self-contained on purpose: this function is stringified and evaluated inside an isolated
+ *  window, so anything it called by name would be undefined there. A helper extracted from
+ *  it does not fail at build time — it fails in the one place the sanitizer actually runs. */
 export function sanitizeChatSvg(source: string): { svg: string; title: string } | null {
   if (source.length > 300_000 || /<!DOCTYPE|<!ENTITY/i.test(source)) return null;
   const dom = globalThis as unknown as SvgDom;
-  const doc = new dom.DOMParser().parseFromString(source, 'image/svg+xml');
+  // XML forbids `--` inside a comment, and a model writing a divider — `<!-- ---- -->` —
+  // produces one routinely. The parser rejects the whole document for it, so a drawing
+  // correct in every other respect disappears because of a decoration that never renders.
+  // Comments survive nothing below this line anyway.
+  const doc = new dom.DOMParser().parseFromString(source.replace(/<!--[\s\S]*?-->/g, ''), 'image/svg+xml');
   if (doc.querySelector('parsererror') || doc.documentElement.localName !== 'svg') return null;
   const allowed = new Set(['svg', 'g', 'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon', 'text', 'tspan', 'title', 'desc', 'defs', 'linearGradient', 'radialGradient', 'stop', 'clipPath', 'mask', 'marker', 'use', 'style']);
   const safeCss = (value: string) => !/@|expression|javascript:|https?:|data:|\/\/|\\|behavior|binding/i.test(value)


### PR DESCRIPTION
XML forbids two dashes inside a comment, and a model writing a divider comment produces one every time. The parser rejected the whole document for it, so a drawing correct in every other respect disappeared over a decoration that renders nothing.

Not a chemistry fix — it applies to every SVG the application accepts.

Written inline rather than as a helper: `sanitizeChatSvg` is stringified and evaluated inside an isolated window, so a helper it called by name would be undefined exactly where the sanitizer runs.

Verified in a real parser and checked both ways — with the strip removed, the drawing is lost and the check fails.

Reported by Avi.