### PR TITLE
Carry Chemistry Studio 2.2.0 in the build

### DIFF
--- a/electron/capabilities/bootstrap.json
+++ b/electron/capabilities/bootstrap.json
@@ -3,14 +3,14 @@
   "packages": [
     {
       "id": "chemistry-studio",
-      "version": "2.0.1",
-      "releaseUrl": "https://github.com/NodusResearch/nodus-research-skill-marketplace/releases/download/chemistry-studio-v2.0.1",
+      "version": "2.2.0",
+      "releaseUrl": "https://github.com/NodusResearch/nodus-research-skill-marketplace/releases/download/chemistry-studio-v2.2.0",
       "assets": [
         {
           "target": "any",
-          "asset": "chemistry-studio-2.0.1-any.nodus-plugin",
-          "bytes": 21412941,
-          "sha256": "a0f4836cfd4de4fdbf55ac50f115d1a2789272053fc4c295835ef75e5c9765f8"
+          "asset": "chemistry-studio-2.2.0-any.nodus-plugin",
+          "bytes": 21418041,
+          "sha256": "9615dd1626a33a04d383d4493e4efdf0e90fb639bf72cd415e3265a6afdbf95e"
         }
       ]
     },


### PR DESCRIPTION
`electron/capabilities/bootstrap.json` is what a profile upgrading from 5.3.1 adopts when it has no network, so it should pin the current package rather than the one that happened to exist when the list was written. Chemistry Studio moves 2.0.1 → 2.2.0.

Nothing about the mechanism changes: the entry is pinned by asset name, size and SHA-256, and the bundled bytes are verified exactly like a download before anything is opened.

**Verified before pinning**

- The published archive verifies against the public key committed to the application: `chemistry-studio 2.2.0 verifies against the published key nr02`.
- A local rebuild of the merged marketplace source reproduces the published digest byte for byte — `21418041 bytes  sha256:9615dd16…dbf95e` — so the signed bytes correspond to the code that was reviewed, not merely to something that was signed.
- `scripts/prepare-capability-bootstrap.mjs` downloads and re-verifies against the new pin; the bundled file's digest matches.
- `scripts/verify-capability-migration-e2e.mjs` passes all 16 scenarios against the new pin, including the three refusals (wrong key, tampered archive, corrupt package) and the offline/online, interruption, rollback and removal paths.