### PR TITLE
Carry Chemistry Studio 2.2.0, and stop two tests failing on things that are not the code

### DIFF
--- a/electron/capabilities/bootstrap.json
+++ b/electron/capabilities/bootstrap.json
@@ -3,14 +3,14 @@
   "packages": [
     {
       "id": "chemistry-studio",
-      "version": "2.0.1",
-      "releaseUrl": "https://github.com/NodusResearch/nodus-research-skill-marketplace/releases/download/chemistry-studio-v2.0.1",
+      "version": "2.2.0",
+      "releaseUrl": "https://github.com/NodusResearch/nodus-research-skill-marketplace/releases/download/chemistry-studio-v2.2.0",
       "assets": [
         {
           "target": "any",
-          "asset": "chemistry-studio-2.0.1-any.nodus-plugin",
-          "bytes": 21412941,
-          "sha256": "a0f4836cfd4de4fdbf55ac50f115d1a2789272053fc4c295835ef75e5c9765f8"
+          "asset": "chemistry-studio-2.2.0-any.nodus-plugin",
+          "bytes": 21418041,
+          "sha256": "9615dd1626a33a04d383d4493e4efdf0e90fb639bf72cd415e3265a6afdbf95e"
         }
       ]
     },

--- a/scripts/lib/vectorSearchProbe.mjs
+++ b/scripts/lib/vectorSearchProbe.mjs
@@ -38,9 +38,11 @@ const set = corpus();
 // could have answered somebody else while this search was in flight.
 //
 // The count alone is a throughput number, and throughput depends on the machine — a busy
-// build runner turns "how many" into a coin toss. So the gaps between beats are recorded
-// too: the longest one is how long the server went unable to answer, which is the thing the
-// defect was about, and it can be compared against the arm that blocks outright.
+// build runner turns "how many" into a coin toss. The gaps between beats are recorded too,
+// and so is what this loop manages with nothing running. Neither is a threshold: both were
+// tried as one and both failed on a healthy tree, for reasons the test sets out. They are
+// reported so that a failure of the one thing that is exact — blocked is zero, off-thread is
+// not — can be read without guessing at the machine it happened on.
 let ticks = 0;
 let beating = true;
 let last = performance.now();

--- a/scripts/test-database-deep-research-integration.mjs
+++ b/scripts/test-database-deep-research-integration.mjs
@@ -3,7 +3,7 @@
 // deterministic.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import fs from "node:fs";
+import fs, { mkdtempSync, rmSync } from "node:fs";
 import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import os from "node:os";
@@ -17,21 +17,43 @@ const repoRoot = path.resolve(
 const require = createRequire(import.meta.url);
 
 if (!process.argv.includes("--electron-database-deep-research-test")) {
-  execFileSync(
-    path.join(repoRoot, "node_modules/.bin/electron"),
-    [
-      path.join(
-        repoRoot,
-        "scripts/test-database-deep-research-integration.mjs",
-      ),
-      "--electron-database-deep-research-test",
-    ],
-    {
-      cwd: repoRoot,
-      env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
-      stdio: "inherit",
-    },
-  );
+  // The child gets a temporary directory of its own.
+  //
+  // It checks that the private SQLite snapshot is cleaned up by listing the system
+  // temporary directory before and after, which is only a statement about this code if
+  // nothing else writes there. Under `node --test` several files run at once, and three
+  // sibling harnesses create scratch directories under the very prefix this one filters
+  // on -- `nodus-db-research-model-`, `-privacy-` and `-luna-runtime-`. A sibling's
+  // mkdtemp landing between the two listings is read here as a leak: the run that found
+  // this was holding `nodus-db-research-privacy-3s3mnZ`, a directory belonging to
+  // another test file. Giving the child its own root makes the listing exact instead of
+  // a race, and costs nothing else: `os.tmpdir()` is all the code under test asks for.
+  const childTemp = mkdtempSync(path.join(os.tmpdir(), "nodus-dbr-electron-"));
+  try {
+    execFileSync(
+      path.join(repoRoot, "node_modules/.bin/electron"),
+      [
+        path.join(
+          repoRoot,
+          "scripts/test-database-deep-research-integration.mjs",
+        ),
+        "--electron-database-deep-research-test",
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          ELECTRON_RUN_AS_NODE: "1",
+          TMPDIR: childTemp,
+          TMP: childTemp,
+          TEMP: childTemp,
+        },
+        stdio: "inherit",
+      },
+    );
+  } finally {
+    rmSync(childTemp, { recursive: true, force: true });
+  }
   process.exit(0);
 }
 

--- a/scripts/test-server-vector-pool.mjs
+++ b/scripts/test-server-vector-pool.mjs
@@ -43,33 +43,36 @@ test('a search on worker threads leaves the event loop free, and inline does not
   assert.equal(inline.pool.threads, 0, 'NODUS_VECTOR_WORKERS=0 must not start a thread');
 
   assert.ok(pooled.pool.threads >= 1, 'the pooled arm must actually have used a thread');
-  assert.ok(pooled.ticks > 0, 'the pooled search must leave the loop running at all');
 
-  // Not a tick count: how many times a loop comes around in a given window is a property of
-  // the machine, and on a loaded build runner the same healthy loop manages a fraction of
-  // what an idle laptop does — which is how a threshold of ten came to fail at eight.
+  // No threshold on how much of the loop was left, because there is no honest one.
   //
-  // What the fix was actually for is that the server keeps answering, so that is what is
-  // measured: the longest the loop went unable to run anything. Compared against the arm
-  // that blocks outright, on the same machine in the same run, so a slow host slows both.
-  // Against what this machine manages with nothing running, not against a number written
-  // here. How many times a loop comes around in a given window belongs to the host: an idle
-  // laptop and a build runner sharing its cores differ by more than the margin any fixed
-  // threshold can hold, which is how "at least ten" came to fail at eight on a green tree.
+  // Two have now been tried and both failed on a healthy tree. "At least ten ticks" failed
+  // at eight. Its replacement compared the search against what the same machine manages
+  // idle, on the reasoning that a ratio survives a slow host -- and it failed at 8% on a
+  // macOS runner whose longest pause was 3.9 ms, which is a loop answering every four
+  // milliseconds reported as a defect.
   //
-  // The ratio does not have that problem. Blocked is zero however slow the host is, and a
-  // loop that is merely busy keeps a large share of its own capacity: measured at 0.84 idle
-  // and 0.43 with four of these running at once, against a tenth required here.
-  const shareOf = arm => arm.ticks / Math.max(arm.idleTicks, 1);
-  // The control for the threshold, from the arm that is the defect: it is zero, and stays
-  // zero on any host, because no macrotask runs while synchronous code holds the thread.
-  assert.equal(shareOf(inline), 0, 'the blocked arm is what this threshold is drawn to exclude');
-
-  const share = shareOf(pooled);
+  // The ratio was wrong for a specific reason worth keeping: the two windows are not
+  // comparable. The search window has a worker saturating a core and the idle window has
+  // nothing, so where cores are already spoken for the ratio measures how many are free
+  // rather than whether the loop was blocked. The longest pause is no better -- measured
+  // here under deliberate oversubscription it reached 72.8 ms on a run whose loop ticked
+  // 883 times, because the operating system descheduled the whole process, which is not a
+  // property of this code. Under that same load the share ranged from 0.26 to 1.33.
+  //
+  // What is exact on every host is the boundary, and it is asserted above in both
+  // directions: blocked is zero ticks, and it is zero because no macrotask can run while
+  // synchronous code holds the thread -- not nearly zero, not usually zero. Off the thread
+  // is more than zero. That is the defect and its fix, and it is the whole of what a shared
+  // build runner can be asked. The numbers below travel with a failure so a real regression
+  // can be read, and they are reported rather than thresholded.
+  const shareOfIdle = pooled.ticks / Math.max(pooled.idleTicks, 1);
   assert.ok(
-    share >= 0.1,
-    `the pooled search left the loop ${(share * 100).toFixed(0)}% of the capacity it has when idle`
-    + ` (${pooled.ticks} ticks against ${pooled.idleTicks}, longest pause ${pooled.longestGapMs.toFixed(1)} ms)`,
+    pooled.ticks > 0,
+    `the pooled search blocked the loop as completely as the inline one:`
+    + ` ${pooled.ticks} ticks against ${pooled.idleTicks} idle`
+    + ` (${(shareOfIdle * 100).toFixed(0)}% of idle capacity, longest pause`
+    + ` ${pooled.longestGapMs.toFixed(1)} ms, search ${pooled.elapsedMs.toFixed(0)} ms)`,
   );
 });
 


### PR DESCRIPTION
Two commits that have to land together. The second is the one that was wanted; the first is what it took to get a green tree.

---

## Carry Chemistry Studio 2.2.0 in the build

`electron/capabilities/bootstrap.json` is what a profile upgrading from 5.3.1 adopts when it has no network, so it should pin the current package rather than the one that happened to exist when the list was written. Chemistry Studio moves 2.0.1 → 2.2.0.

Nothing about the mechanism changes: the entry is pinned by asset name, size and SHA-256, and the bundled bytes are verified exactly like a download before anything is opened.

This is not optional now that the marketplace publishes 2.2.0 — `verify-cross-repo` fails on every branch off `main` until it lands, which is the guard working:

```
FAIL chemistry-studio: the pinned version is the one the marketplace publishes
     the bootstrap pins a version the marketplace does not publish
'2.0.1' !== '2.2.0'
```

**Verified before pinning**

- The published archive verifies against the public key committed to the application: `chemistry-studio 2.2.0 verifies against the published key nr02`.
- A local rebuild of the merged marketplace source reproduces the published digest byte for byte — `21418041 bytes  sha256:9615dd16…dbf95e` — so the signed bytes correspond to the code that was reviewed, not merely to something that was signed.
- `scripts/prepare-capability-bootstrap.mjs` downloads and re-verifies against the new pin; the bundled file's digest matches.
- `scripts/verify-capability-migration-e2e.mjs` passes all 16 scenarios against the new pin, including the three refusals (wrong key, tampered archive, corrupt package) and the offline/online, interruption, rollback and removal paths.

---

## Stop two tests failing on things that are not the code

Two failures blocked that pin this morning, in consecutive runs of the same branch. Neither was a defect in the application, and neither test was measuring what it claimed.

### A leak check that was reading other tests' directories

`test-database-deep-research-integration.mjs` proves the private SQLite snapshot is cleaned up by listing the system temporary directory before and after its work and asserting the set is unchanged. That is a statement about this code only if nothing else writes there — and under `node --test` several files run at once. Three sibling harnesses create scratch directories under the very prefix it filters on:

| creator | prefix |
| --- | --- |
| `electron/ai/databaseDeepResearch.ts` (the code under test) | `nodus-db-research-` |
| `test-database-deep-research-model-contract.mjs` | `nodus-db-research-model-` |
| `test-database-deep-research-privacy.mjs` | `nodus-db-research-privacy-` |
| `verify-database-deep-research-live-luna.mjs` | `nodus-db-research-luna-runtime-` |

A sibling's `mkdtemp` landing between the two listings is read as a leak. The failing run reported exactly one leftover, `nodus-db-research-privacy-3s3mnZ` — another test file's directory, not one this code could have made.

The Electron child now gets a temporary directory of its own, so the listing is exact instead of a race. `os.tmpdir()` is all the code under test asks for, so nothing about the production path changes.

Verified in both directions:

- With a sibling churning the real temporary directory: the old code reproduces the CI failure, the new code passes.
- With the `rmSync` removed from `withPrivateSqliteSnapshot`: the new code still fails with `private SQLite snapshot is cleaned after processing`. The check still checks.

### A threshold that measured the runner, not the loop

`test-server-vector-pool.mjs` asserted that a pooled search leaves the event loop at least a tenth of the capacity it has when idle. It failed at 8% — on a run whose longest pause was 3.9 ms, which is a loop answering every four milliseconds being reported as a defect.

This is the second threshold this test has had and the second to fail on healthy code; the first was "at least ten ticks" and it failed at eight. The ratio was meant to fix that by comparing the machine against itself, but the two windows are not comparable: the search window has a worker thread saturating a core and the idle window has nothing, so on a host whose cores are already spoken for the ratio measures how many cores are free rather than whether the loop was blocked.

The longest pause is no better as a threshold. Measured here under deliberate oversubscription (8 CPU burners, 12 concurrent probes), one pooled run reached a **72.8 ms** worst pause while its loop ticked 883 times — the operating system descheduling the whole process, which is not a property of this code. The share over the same runs ranged from 0.26 to 1.33.

What is exact on every host is the boundary, and it was always asserted in both directions:

- blocked is **zero** ticks, deterministically, because no macrotask can run while synchronous code holds the thread;
- off the thread is **more than zero**.

That is the defect and its fix. The capacity share, the longest pause and the search duration now travel with a failure so a real regression can be read, rather than being thresholded.

Verified: the assertion still fires when the pooled arm is forced back onto the main thread —

```
the pooled search blocked the loop as completely as the inline one: 0 ticks against 2143 idle
(0% of idle capacity, longest pause 0.0 ms, search 32 ms)
```

— and three consecutive runs pass under the 8-burner load that produced the 72.8 ms pause.